### PR TITLE
fix: Standardize logos, fix ESLint errors, upgrade to @conduction/nextcloud-vue@0.1.0-beta.3

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,9 +24,6 @@ module.exports = defineConfig([{
 				extensions: ['.js', '.ts', '.vue', '.json'],
 			},
 		},
-		// @conduction/nextcloud-vue is resolved at build time via webpack alias to
-		// local source; skip all import validation for this package in ESLint.
-		'import/ignore': ['@conduction/nextcloud-vue'],
 	},
 
 	rules: {
@@ -38,8 +35,5 @@ module.exports = defineConfig([{
 		'import/default': 'off',
 		'import/no-named-as-default': 'off',
 		'import/no-named-as-default-member': 'off',
-		// @conduction/nextcloud-vue is resolved via webpack alias at build time;
-		// ESLint resolves against the published npm package which may lag behind.
-		'import/no-unresolved': ['error', { ignore: ['^@conduction/nextcloud-vue'] }],
 	},
 }])

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "EUPL-1.2",
       "dependencies": {
-        "@conduction/nextcloud-vue": "^0.1.0-beta.1",
+        "@conduction/nextcloud-vue": "^0.1.0-beta.3",
         "@nextcloud/axios": "^2.5.0",
         "@nextcloud/dialogs": "^3.2.0",
         "@nextcloud/initial-state": "^2.2.0",
@@ -312,9 +312,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "0.1.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-0.1.0-beta.1.tgz",
-      "integrity": "sha512-8ZaWbm7QKcXmsQ+zdW5Z+BXxA84zv+V4Sq5cEjU6B35VH+/TQkETHGoNvSrj97XBoSmIdz8I2VNpCfFtoZ0IIg==",
+      "version": "0.1.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-0.1.0-beta.3.tgz",
+      "integrity": "sha512-+B02z2vUgN8BTZ0ZRd9mtrIVo55KMETzvEsyt7g0AW50hNU44xd9ILBHjKvZlKQclsLWzT36K0+RWIbcC22QVA==",
       "license": "EUPL-1.2",
       "peerDependencies": {
         "@nextcloud/l10n": "^2.0.0 || ^3.0.0",
@@ -15219,9 +15219,9 @@
       }
     },
     "@conduction/nextcloud-vue": {
-      "version": "0.1.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-0.1.0-beta.1.tgz",
-      "integrity": "sha512-8ZaWbm7QKcXmsQ+zdW5Z+BXxA84zv+V4Sq5cEjU6B35VH+/TQkETHGoNvSrj97XBoSmIdz8I2VNpCfFtoZ0IIg==",
+      "version": "0.1.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-0.1.0-beta.3.tgz",
+      "integrity": "sha512-+B02z2vUgN8BTZ0ZRd9mtrIVo55KMETzvEsyt7g0AW50hNU44xd9ILBHjKvZlKQclsLWzT36K0+RWIbcC22QVA==",
       "requires": {}
     },
     "@csstools/css-parser-algorithms": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "extends @nextcloud/browserslist-config"
   ],
   "dependencies": {
-    "@conduction/nextcloud-vue": "^0.1.0-beta.1",
+    "@conduction/nextcloud-vue": "^0.1.0-beta.3",
     "@nextcloud/axios": "^2.5.0",
     "@nextcloud/dialogs": "^3.2.0",
     "@nextcloud/initial-state": "^2.2.0",


### PR DESCRIPTION
## Summary

- Updated app logo to blue hexagon `app-store.svg` in README
- Fixed `vue/no-mutating-props` error in `UserSettings.vue` (replaced `.sync` with explicit `@update:open` emit)
- Applied ESLint auto-fix for indentation across all Vue components
- Upgraded `@conduction/nextcloud-vue` to `0.1.0-beta.3` which ships `css/index.css` at package root
- Removed temporary `import/ignore` and `import/no-unresolved` ESLint workarounds — no longer needed

## Test plan

- [ ] CI Code Quality (PHP + Frontend) passes on this PR
- [ ] `npm run lint` shows 0 errors locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)