### PR TITLE
chore: add missing generated artifact entries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 /docusaurus/node_modules/
 /docusaurus/build/
 /docusaurus/.docusaurus/
+
+.phpunit.cache/
+coverage/
+phpmetrics/


### PR DESCRIPTION
Adds `.phpunit.cache/`, `coverage/`, and `phpmetrics/` to `.gitignore` to prevent generated test and quality tool artifacts from being tracked. These cause unnecessary dirty-submodule noise in the parent repo.