### PR TITLE
feat: Enhance My Work — case type, a11y, responsive

### DIFF
--- a/openspec/changes/my-work/delta-spec.md
+++ b/openspec/changes/my-work/delta-spec.md
@@ -1,0 +1,17 @@
+## Delta Spec: my-work
+
+### REQ-MYWORK-001: Case Type Name Display — IMPLEMENTED
+- Case items in My Work now show the case type name as subtitle text
+- Case types are fetched on mount and cached for lookup
+
+### Accessibility — IMPLEMENTED
+- All items have `tabindex="0"` for keyboard focus
+- Items have `aria-label` announcing entity type, title, and urgency status
+- Filter tabs use `role="tablist"` / `role="tab"` pattern with `aria-selected`
+- Section headers have `role="heading"` with appropriate level
+- Keyboard activation via Enter/Space on items and tabs
+
+### Responsiveness — IMPLEMENTED
+- At viewport <= 768px, item rows stack vertically
+- Reduced padding for mobile readability
+- Priority and deadline info stack below title

--- a/openspec/changes/my-work/design.md
+++ b/openspec/changes/my-work/design.md
@@ -1,0 +1,28 @@
+## Architecture
+
+### Case Type Name Resolution
+
+Fetch case types via `objectStore.fetchCollection('caseType')` on mount, build a lookup map `caseTypeId -> title`, display on case items as subtitle.
+
+### Accessibility (WCAG AA)
+
+- Add `role="list"` and `role="listitem"` to sections and items
+- Add `aria-label` to filter tabs with active state announcement
+- Add `role="tablist"` to filter tab container
+- Items: `tabindex="0"` for keyboard focus, `aria-label` with entity type + title + urgency
+- Overdue text: `aria-live="polite"` for dynamic announcements
+
+### Keyboard Navigation
+
+- Items respond to `Enter` and `Space` keypress for activation
+- Filter tabs respond to `Enter` and `Space`
+
+### Responsive Layout
+
+- At `max-width: 768px`: stack item content vertically, reduce padding
+- Hide reference/deadline columns, show as stacked info
+
+## Decisions
+
+1. **Case type fetched once** — all case types loaded at mount, cached in component data
+2. **Keyboard handlers on items** — `@keydown.enter` and `@keydown.space` on each row

--- a/openspec/changes/my-work/proposal.md
+++ b/openspec/changes/my-work/proposal.md
@@ -1,0 +1,19 @@
+## Why
+
+My Work is substantially implemented but missing several quality improvements: case type name display on case items, keyboard navigation, ARIA labels for accessibility, and responsive mobile layout. These are non-functional requirements specified in the my-work spec.
+
+## What Changes
+
+- **REQ-MYWORK-001**: Display case type name on case items in My Work
+- **Accessibility**: Add ARIA labels to items, section headers, and filter tabs
+- **Keyboard navigation**: Add tabindex and keyboard event handlers for item navigation
+- **Responsiveness**: Add CSS for narrow viewports
+
+## Capabilities
+
+### Modified Capabilities
+- `my-work-view`: Enhanced with case type display, accessibility, keyboard nav, responsive layout
+
+## Impact
+
+- **Frontend**: `src/views/MyWork.vue` — add case type resolution, ARIA attributes, keyboard handlers, responsive CSS

--- a/openspec/changes/my-work/tasks.md
+++ b/openspec/changes/my-work/tasks.md
@@ -1,0 +1,21 @@
+## Tasks
+
+### TASK-1: Add case type name to case items
+- **Spec ref**: REQ-MYWORK-001
+- **Files**: `src/views/MyWork.vue`
+- **Acceptance**: Case items show case type name (e.g., "Omgevingsvergunning") below title
+
+### TASK-2: Add ARIA attributes for accessibility
+- **Spec ref**: Non-functional (Accessibility)
+- **Files**: `src/views/MyWork.vue`
+- **Acceptance**: Screen readers announce entity type, title, urgency on item focus
+
+### TASK-3: Add keyboard navigation
+- **Spec ref**: Non-functional (Accessibility)
+- **Files**: `src/views/MyWork.vue`
+- **Acceptance**: Tab through items, Enter/Space to activate
+
+### TASK-4: Add responsive CSS
+- **Spec ref**: Non-functional (Responsiveness)
+- **Files**: `src/views/MyWork.vue`
+- **Acceptance**: Readable layout at 768px viewport width

--- a/src/utils/dashboardHelpers.js
+++ b/src/utils/dashboardHelpers.js
@@ -252,6 +252,7 @@ export function getGroupedMyWorkItems(cases, normalizedTasks) {
 			isCompleted: false,
 			priority: c.priority || 'normal',
 			status: c.status || null,
+			caseType: c.caseType || null,
 		})
 	}
 

--- a/src/views/MyWork.vue
+++ b/src/views/MyWork.vue
@@ -8,13 +8,17 @@
 		</div>
 
 		<!-- Filter tabs -->
-		<div class="my-work__tabs">
+		<div class="my-work__tabs" role="tablist" :aria-label="t('procest', 'Filter by type')">
 			<button
 				v-for="tab in tabs"
 				:key="tab.key"
+				role="tab"
+				:aria-selected="activeTab === tab.key"
 				class="my-work__tab"
 				:class="{ 'my-work__tab--active': activeTab === tab.key }"
-				@click="activeTab = tab.key">
+				@click="activeTab = tab.key"
+				@keydown.enter="activeTab = tab.key"
+				@keydown.space.prevent="activeTab = tab.key">
 				{{ tab.label }} ({{ tab.count }})
 			</button>
 
@@ -62,12 +66,18 @@
 					v-for="item in filteredGroups.overdue"
 					:key="`${item.type}-${item.id}`"
 					class="my-work__row my-work__row--overdue"
-					@click="onItemClick(item)">
+					tabindex="0"
+					role="listitem"
+					:aria-label="`${item.type === 'case' ? t('procest', 'Case') : t('procest', 'Task')}: ${item.title}, ${item.daysText}`"
+					@click="onItemClick(item)"
+					@keydown.enter="onItemClick(item)"
+					@keydown.space.prevent="onItemClick(item)">
 					<span class="my-work__badge" :class="`my-work__badge--${item.type}`">
 						{{ item.type === 'case' ? t('procest', 'CASE') : t('procest', 'TASK') }}
 					</span>
 					<div class="my-work__info">
 						<span class="my-work__item-title">{{ item.title }}</span>
+						<span v-if="item.type === 'case' && getCaseTypeName(item.caseType)" class="my-work__reference my-work__case-type">{{ getCaseTypeName(item.caseType) }}</span>
 						<span v-if="item.reference" class="my-work__reference">{{ item.reference }}</span>
 					</div>
 					<div class="my-work__deadline">
@@ -89,12 +99,18 @@
 					v-for="item in filteredGroups.dueThisWeek"
 					:key="`${item.type}-${item.id}`"
 					class="my-work__row"
-					@click="onItemClick(item)">
+					tabindex="0"
+					role="listitem"
+					:aria-label="`${item.type === 'case' ? t('procest', 'Case') : t('procest', 'Task')}: ${item.title}, ${item.daysText}`"
+					@click="onItemClick(item)"
+					@keydown.enter="onItemClick(item)"
+					@keydown.space.prevent="onItemClick(item)">
 					<span class="my-work__badge" :class="`my-work__badge--${item.type}`">
 						{{ item.type === 'case' ? t('procest', 'CASE') : t('procest', 'TASK') }}
 					</span>
 					<div class="my-work__info">
 						<span class="my-work__item-title">{{ item.title }}</span>
+						<span v-if="item.type === 'case' && getCaseTypeName(item.caseType)" class="my-work__reference my-work__case-type">{{ getCaseTypeName(item.caseType) }}</span>
 						<span v-if="item.reference" class="my-work__reference">{{ item.reference }}</span>
 					</div>
 					<div class="my-work__deadline">
@@ -116,12 +132,18 @@
 					v-for="item in filteredGroups.upcoming"
 					:key="`${item.type}-${item.id}`"
 					class="my-work__row"
-					@click="onItemClick(item)">
+					tabindex="0"
+					role="listitem"
+					:aria-label="`${item.type === 'case' ? t('procest', 'Case') : t('procest', 'Task')}: ${item.title}, ${item.daysText}`"
+					@click="onItemClick(item)"
+					@keydown.enter="onItemClick(item)"
+					@keydown.space.prevent="onItemClick(item)">
 					<span class="my-work__badge" :class="`my-work__badge--${item.type}`">
 						{{ item.type === 'case' ? t('procest', 'CASE') : t('procest', 'TASK') }}
 					</span>
 					<div class="my-work__info">
 						<span class="my-work__item-title">{{ item.title }}</span>
+						<span v-if="item.type === 'case' && getCaseTypeName(item.caseType)" class="my-work__reference my-work__case-type">{{ getCaseTypeName(item.caseType) }}</span>
 						<span v-if="item.reference" class="my-work__reference">{{ item.reference }}</span>
 					</div>
 					<div class="my-work__deadline">
@@ -143,12 +165,18 @@
 					v-for="item in filteredGroups.noDeadline"
 					:key="`${item.type}-${item.id}`"
 					class="my-work__row"
-					@click="onItemClick(item)">
+					tabindex="0"
+					role="listitem"
+					:aria-label="`${item.type === 'case' ? t('procest', 'Case') : t('procest', 'Task')}: ${item.title}`"
+					@click="onItemClick(item)"
+					@keydown.enter="onItemClick(item)"
+					@keydown.space.prevent="onItemClick(item)">
 					<span class="my-work__badge" :class="`my-work__badge--${item.type}`">
 						{{ item.type === 'case' ? t('procest', 'CASE') : t('procest', 'TASK') }}
 					</span>
 					<div class="my-work__info">
 						<span class="my-work__item-title">{{ item.title }}</span>
+						<span v-if="item.type === 'case' && getCaseTypeName(item.caseType)" class="my-work__reference my-work__case-type">{{ getCaseTypeName(item.caseType) }}</span>
 						<span v-if="item.reference" class="my-work__reference">{{ item.reference }}</span>
 					</div>
 					<div class="my-work__deadline">
@@ -212,6 +240,7 @@ export default {
 			normalizedTasks: [],
 			completedCases: [],
 			completedTasks: [],
+			caseTypeMap: {},
 		}
 	},
 	computed: {
@@ -289,10 +318,21 @@ export default {
 		await this.fetchData()
 	},
 	methods: {
+		getCaseTypeName(caseTypeId) {
+			return this.caseTypeMap[caseTypeId] || ''
+		},
 		async fetchData() {
 			this.loading = true
 			try {
 				const currentUser = OC?.currentUser || ''
+
+				// Fetch case types for name resolution.
+				const caseTypes = await this.objectStore.fetchCollection('caseType', { _limit: 100 })
+				const map = {}
+				for (const ct of (caseTypes || [])) {
+					map[ct.id] = ct.title
+				}
+				this.caseTypeMap = map
 
 				// Fetch active cases assigned to current user.
 				const caseResults = await this.objectStore.fetchCollection('case', {
@@ -552,5 +592,44 @@ export default {
 .my-work__priority {
 	color: var(--color-warning);
 	font-weight: bold;
+}
+
+.my-work__case-type {
+	font-size: 11px;
+	color: var(--color-text-maxcontrast);
+	font-style: italic;
+}
+
+/* Focus outline for keyboard navigation */
+.my-work__row:focus {
+	outline: 2px solid var(--color-primary-element);
+	outline-offset: -2px;
+	border-radius: var(--border-radius);
+}
+
+/* Responsive layout */
+@media (max-width: 768px) {
+	.my-work {
+		padding: 12px;
+	}
+
+	.my-work__tabs {
+		flex-wrap: wrap;
+	}
+
+	.my-work__row {
+		flex-wrap: wrap;
+		gap: 6px;
+		padding: 12px 10px;
+	}
+
+	.my-work__info {
+		width: calc(100% - 60px);
+	}
+
+	.my-work__deadline {
+		width: 100%;
+		padding-left: 56px;
+	}
 }
 </style>


### PR DESCRIPTION
## Summary

- Display case type name on case items in My Work
- Add ARIA attributes (tablist, tab, listitem, aria-label, aria-selected)
- Add keyboard navigation (Tab, Enter, Space) on all items and filter tabs
- Add responsive CSS for narrow viewports (< 768px)
- Pass caseType ID through grouped work items for name resolution

Closes #42

## Test plan

- [ ] Verify case type name appears below case title (e.g., "Omgevingsvergunning")
- [ ] Tab through items with keyboard — verify focus outline visible
- [ ] Press Enter on focused item — verify navigation to case detail
- [ ] Use screen reader — verify entity type, title, and urgency announced
- [ ] Resize to 768px — verify items stack properly