### PR TITLE
feat: AWB-compliant bezwaar/beroep workflow

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -76,6 +76,7 @@ Vrij en open source onder de AGPL-licentie.
         <post-migration>
             <step>OCA\Procest\Repair\InitializeSettings</step>
             <step>OCA\Procest\Repair\LoadDefaultZgwMappings</step>
+            <step>OCA\Procest\Repair\SeedBezwaarBeroepData</step>
         </post-migration>
     </repair-steps>
 

--- a/docs/features/bezwaar-beroep-workflow.md
+++ b/docs/features/bezwaar-beroep-workflow.md
@@ -1,0 +1,51 @@
+# Bezwaar/Beroep Workflow
+
+**Issue:** #86
+**Branch:** `feature/86/bezwaar-beroep-workflow`
+**PR:** #97
+
+## Overview
+
+Implements AWB-compliant (Algemene wet bestuursrecht) bezwaar (objection) and beroep (appeal) workflows for Dutch municipal case management. Includes pre-seeded case types with all required status types, role types, and workflow templates.
+
+## Architecture
+
+### Backend
+
+**`lib/Service/SeedDataService`**
+- Seeds bezwaar/beroep case types from `lib/Settings/bezwaar_seed_data.json`
+- Idempotent: checks for existing objects by `identifier` before creating
+- Resolves name-to-UUID references in workflow steps/transitions after creation
+- Returns a summary with counts: `caseTypes`, `statusTypes`, `roleTypes`, `workflows`, `skipped`
+
+**`lib/Repair/SeedBezwaarBeroepData`**
+- `IRepairStep` executed during app installation or upgrade
+- Delegates to `SeedDataService::seedBezwaarBeroepData()`
+- Skips if OpenRegister is not available (`SettingsService::isOpenRegisterAvailable`)
+- Exceptions are caught and logged — never propagated
+
+**`lib/Settings/bezwaar_seed_data.json`**
+- Pre-defined case types: `bezwaar` and `beroep`
+- Each includes: status types (e.g. `ontvangen`, `in-behandeling`, `beslissing-genomen`), role types, and a workflow template with steps, transitions, and guards
+
+### Frontend (Vue)
+
+- Pinia store: `src/store/modules/bezwaar.js`
+- Case detail components: `BezwaarIntakeForm`, `BezwaarTimeline`, `BezwaarDecisionForm`, `HearingPanel`, `AdvisoryReportPanel`, `DeadlineIndicator`
+- Beroep escalation: `BeroepEscalationPanel`, `CourtProceedingsPanel`
+
+## AWB Timeline
+
+| Phase | Status types | Key deadlines |
+|-------|-------------|---------------|
+| Ontvangst | `ontvangen` | 14-day acknowledgement |
+| In behandeling | `in-behandeling` | 6-week standard, 12-week extended |
+| Hoorzitting | `hoorzitting-gepland`, `hoorzitting-gehouden` | Date from case |
+| Beslissing | `beslissing-concept`, `beslissing-genomen` | Within deadline |
+| Beroep | `beroep-ingediend`, `bij-rechtbank` | 6-week filing window |
+
+## Testing
+
+Unit tests are in:
+- `tests/Unit/Service/SeedDataServiceTest.php` — ObjectService unavailable → failure, missing config → failure, happy path summary structure, idempotency (existing → skipped), seed data file integrity
+- `tests/Unit/Repair/SeedBezwaarBeroepDataTest.php` — getName, skip when OpenRegister unavailable, call seed service, info output on success, exception handling

--- a/lib/Repair/SeedBezwaarBeroepData.php
+++ b/lib/Repair/SeedBezwaarBeroepData.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * Procest Seed Bezwaar/Beroep Data Repair Step
+ *
+ * Repair step that seeds pre-defined bezwaar and beroep case types
+ * with status types, role types, and workflow templates.
+ *
+ * @category Repair
+ * @package  OCA\Procest\Repair
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Repair;
+
+use OCA\Procest\Service\SeedDataService;
+use OCA\Procest\Service\SettingsService;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Repair step that seeds bezwaar and beroep case types into OpenRegister.
+ */
+class SeedBezwaarBeroepData implements IRepairStep
+{
+    /**
+     * Constructor for SeedBezwaarBeroepData.
+     *
+     * @param SeedDataService $seedDataService The seed data service
+     * @param SettingsService $settingsService The settings service
+     * @param LoggerInterface $logger          The logger interface
+     *
+     * @return void
+     */
+    public function __construct(
+        private SeedDataService $seedDataService,
+        private SettingsService $settingsService,
+        private LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Get the name of this repair step.
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'Seed Bezwaar and Beroep case types for Procest';
+    }//end getName()
+
+    /**
+     * Run the repair step to seed bezwaar/beroep data.
+     *
+     * @param IOutput $output The output interface for progress reporting
+     *
+     * @return void
+     */
+    public function run(IOutput $output): void
+    {
+        $output->info('Seeding bezwaar and beroep case types...');
+
+        if ($this->settingsService->isOpenRegisterAvailable() === false) {
+            $output->warning(
+                'OpenRegister is not available. Skipping bezwaar/beroep seed.'
+            );
+            return;
+        }
+
+        try {
+            $result = $this->seedDataService->seedBezwaarBeroepData();
+
+            if ($result['success'] === true) {
+                $output->info(
+                    'Bezwaar/beroep seed complete: '
+                    .$result['caseTypes'].' case types, '
+                    .$result['statusTypes'].' status types, '
+                    .$result['roleTypes'].' role types, '
+                    .$result['workflows'].' workflows created ('
+                    .$result['skipped'].' skipped)'
+                );
+                return;
+            }
+
+            $message = ($result['message'] ?? 'unknown error');
+            $output->warning('Bezwaar/beroep seed issue: '.$message);
+        } catch (\Throwable $e) {
+            $output->warning(
+                'Could not seed bezwaar/beroep data: '.$e->getMessage()
+            );
+            $this->logger->error(
+                'Procest bezwaar/beroep seed failed',
+                ['exception' => $e->getMessage()]
+            );
+        }//end try
+    }//end run()
+}//end class

--- a/lib/Service/SeedDataService.php
+++ b/lib/Service/SeedDataService.php
@@ -1,0 +1,506 @@
+<?php
+
+/**
+ * Procest Seed Data Service
+ *
+ * Service for seeding pre-defined case types, status types, role types,
+ * and workflow templates into OpenRegister.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service;
+
+use OCA\Procest\AppInfo\Application;
+use OCP\IAppConfig;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Service for seeding bezwaar/beroep case types and related configuration.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) — needs OpenRegister service access
+ */
+class SeedDataService
+{
+    /**
+     * Constructor for the SeedDataService.
+     *
+     * @param IAppConfig         $appConfig The app configuration service
+     * @param ContainerInterface $container The DI container
+     * @param LoggerInterface    $logger    The logger interface
+     *
+     * @return void
+     */
+    public function __construct(
+        private IAppConfig $appConfig,
+        private ContainerInterface $container,
+        private LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Seed the bezwaar and beroep case types with all related objects.
+     *
+     * This method is idempotent — it checks for existing objects by identifier
+     * before creating new ones.
+     *
+     * @return array Result summary with counts of created and skipped objects
+     */
+    public function seedBezwaarBeroepData(): array
+    {
+        $seedPath = __DIR__.'/../Settings/bezwaar_seed_data.json';
+        if (file_exists($seedPath) === false) {
+            $this->logger->error('Procest: Seed data file not found at '.$seedPath);
+            return ['success' => false, 'message' => 'Seed data file not found'];
+        }
+
+        $seedContent = file_get_contents($seedPath);
+        $seedData    = json_decode($seedContent, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            $this->logger->error('Procest: Invalid JSON in seed data file');
+            return ['success' => false, 'message' => 'Invalid JSON in seed data file'];
+        }
+
+        $objectService = $this->getObjectService();
+        if ($objectService === null) {
+            return ['success' => false, 'message' => 'ObjectService not available'];
+        }
+
+        $registerId       = $this->getConfigValue(key: 'register');
+        $caseTypeSchema   = $this->getConfigValue(key: 'case_type_schema');
+        $statusTypeSchema = $this->getConfigValue(key: 'status_type_schema');
+        $roleTypeSchema   = $this->getConfigValue(key: 'role_type_schema');
+        $workflowSchema   = $this->getConfigValue(key: 'workflow_template_schema');
+
+        if ($registerId === '' || $caseTypeSchema === '') {
+            $this->logger->warning('Procest: Register or case type schema not configured, skipping seed');
+            return ['success' => false, 'message' => 'Register or schemas not configured'];
+        }
+
+        $summary = [
+            'success'     => true,
+            'caseTypes'   => 0,
+            'statusTypes' => 0,
+            'roleTypes'   => 0,
+            'workflows'   => 0,
+            'skipped'     => 0,
+        ];
+
+        foreach (($seedData['caseTypes'] ?? []) as $caseTypeData) {
+            $result = $this->seedCaseType(
+                objectService: $objectService,
+                caseTypeData: $caseTypeData,
+                registerId: $registerId,
+                caseTypeSchema: $caseTypeSchema,
+                statusTypeSchema: $statusTypeSchema,
+                roleTypeSchema: $roleTypeSchema,
+                workflowSchema: $workflowSchema,
+            );
+
+            $summary['caseTypes']   += $result['caseTypes'];
+            $summary['statusTypes'] += $result['statusTypes'];
+            $summary['roleTypes']   += $result['roleTypes'];
+            $summary['workflows']   += $result['workflows'];
+            $summary['skipped']     += $result['skipped'];
+        }
+
+        $this->logger->info('Procest: Seed data complete', $summary);
+
+        return $summary;
+    }//end seedBezwaarBeroepData()
+
+    /**
+     * Seed a single case type with its status types, role types, and workflow.
+     *
+     * @param object $objectService    The OpenRegister ObjectService
+     * @param array  $caseTypeData     The case type seed data
+     * @param string $registerId       The register UUID
+     * @param string $caseTypeSchema   The case type schema UUID
+     * @param string $statusTypeSchema The status type schema UUID
+     * @param string $roleTypeSchema   The role type schema UUID
+     * @param string $workflowSchema   The workflow template schema UUID
+     *
+     * @return array Counts of created and skipped objects
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList) — all schema IDs are needed
+     */
+    private function seedCaseType(
+        object $objectService,
+        array $caseTypeData,
+        string $registerId,
+        string $caseTypeSchema,
+        string $statusTypeSchema,
+        string $roleTypeSchema,
+        string $workflowSchema,
+    ): array {
+        $counts = [
+            'caseTypes'   => 0,
+            'statusTypes' => 0,
+            'roleTypes'   => 0,
+            'workflows'   => 0,
+            'skipped'     => 0,
+        ];
+
+        $identifier = ($caseTypeData['identifier'] ?? '');
+
+        // Check if case type already exists by identifier.
+        $existing = $this->findByFilter(
+            objectService: $objectService,
+            registerId: $registerId,
+            schemaId: $caseTypeSchema,
+            filters: ['identifier' => $identifier],
+        );
+
+        if ($existing !== null) {
+            $this->logger->info(
+                'Procest: Case type already exists, skipping seed',
+                ['identifier' => $identifier]
+            );
+            $counts['skipped']++;
+            return $counts;
+        }
+
+        // Extract nested data before creating the case type.
+        $statusTypesData = ($caseTypeData['statusTypes'] ?? []);
+        $roleTypesData   = ($caseTypeData['roleTypes'] ?? []);
+        $workflowData    = ($caseTypeData['workflowTemplate'] ?? null);
+
+        unset(
+            $caseTypeData['statusTypes'],
+            $caseTypeData['roleTypes'],
+            $caseTypeData['workflowTemplate']
+        );
+
+        // Create the case type.
+        $caseType = $this->createObject(
+            objectService: $objectService,
+            registerId: $registerId,
+            schemaId: $caseTypeSchema,
+            data: $caseTypeData,
+        );
+
+        if ($caseType === null) {
+            $this->logger->error(
+                'Procest: Failed to create case type',
+                ['identifier' => $identifier]
+            );
+            return $counts;
+        }
+
+        $caseTypeId = $this->getObjectId(object: $caseType);
+        $counts['caseTypes']++;
+
+        $this->logger->info(
+            'Procest: Created case type',
+            ['identifier' => $identifier, 'id' => $caseTypeId]
+        );
+
+        // Create status types and build a name-to-ID map.
+        $statusNameToId = [];
+        foreach ($statusTypesData as $statusData) {
+            $statusData['caseType'] = $caseTypeId;
+            $statusObj = $this->createObject(
+                objectService: $objectService,
+                registerId: $registerId,
+                schemaId: $statusTypeSchema,
+                data: $statusData,
+            );
+
+            if ($statusObj !== null) {
+                $statusId = $this->getObjectId(object: $statusObj);
+                $statusNameToId[$statusData['name']] = $statusId;
+                $counts['statusTypes']++;
+            }
+        }
+
+        // Create role types and build a name-to-ID map.
+        $roleNameToId = [];
+        if ($roleTypeSchema !== '') {
+            foreach ($roleTypesData as $roleData) {
+                $roleData['caseType'] = $caseTypeId;
+                $roleObj = $this->createObject(
+                    objectService: $objectService,
+                    registerId: $registerId,
+                    schemaId: $roleTypeSchema,
+                    data: $roleData,
+                );
+
+                if ($roleObj !== null) {
+                    $roleId = $this->getObjectId(object: $roleObj);
+                    $roleNameToId[$roleData['name']] = $roleId;
+                    $counts['roleTypes']++;
+                }
+            }
+        }
+
+        // Create workflow template with resolved status/role references.
+        if ($workflowData !== null && $workflowSchema !== '') {
+            $resolvedWorkflow = $this->resolveWorkflowReferences(
+                workflowData: $workflowData,
+                statusNameMap: $statusNameToId,
+                roleNameMap: $roleNameToId,
+                caseTypeId: $caseTypeId,
+            );
+
+            $workflowObj = $this->createObject(
+                objectService: $objectService,
+                registerId: $registerId,
+                schemaId: $workflowSchema,
+                data: $resolvedWorkflow,
+            );
+
+            if ($workflowObj !== null) {
+                $counts['workflows']++;
+            }
+        }
+
+        return $counts;
+    }//end seedCaseType()
+
+    /**
+     * Resolve workflow step and transition references from names to UUIDs.
+     *
+     * @param array  $workflowData  The raw workflow template data
+     * @param array  $statusNameMap Status name to UUID mapping
+     * @param array  $roleNameMap   Role name to UUID mapping
+     * @param string $caseTypeId    The case type UUID
+     *
+     * @return array The workflow data with resolved references
+     */
+    private function resolveWorkflowReferences(
+        array $workflowData,
+        array $statusNameMap,
+        array $roleNameMap,
+        string $caseTypeId,
+    ): array {
+        $workflowData['caseType'] = $caseTypeId;
+
+        // Resolve steps: map statusName to status UUID.
+        $resolvedSteps = [];
+        foreach (($workflowData['steps'] ?? []) as $step) {
+            $statusName = ($step['statusName'] ?? '');
+            unset($step['statusName']);
+
+            $step['id']     = $this->generateUUID();
+            $step['status'] = ($statusNameMap[$statusName] ?? '');
+
+            $resolvedSteps[] = $step;
+        }
+
+        $workflowData['steps'] = json_encode($resolvedSteps);
+
+        // Resolve transitions: map statusName to UUID, roleName to UUID.
+        $resolvedTransitions = [];
+        foreach (($workflowData['transitions'] ?? []) as $transition) {
+            $fromName = ($transition['fromStatusName'] ?? '');
+            $toName   = ($transition['toStatusName'] ?? '');
+            unset($transition['fromStatusName'], $transition['toStatusName']);
+
+            $transition['id'] = $this->generateUUID();
+
+            // Handle wildcard "*" for "any active status".
+            if ($fromName === '*') {
+                $transition['fromStatus'] = '*';
+            } else {
+                $transition['fromStatus'] = ($statusNameMap[$fromName] ?? '');
+            }
+
+            $transition['toStatus'] = ($statusNameMap[$toName] ?? '');
+
+            // Resolve role guards.
+            $resolvedGuards = [];
+            foreach (($transition['guards'] ?? []) as $guard) {
+                if ($guard['type'] === 'roleGuard' && isset($guard['config']['roleName']) === true) {
+                    $roleName = $guard['config']['roleName'];
+                    $guard['config']['roleId'] = ($roleNameMap[$roleName] ?? '');
+                }
+
+                $resolvedGuards[] = $guard;
+            }
+
+            $transition['guards'] = $resolvedGuards;
+
+            // Resolve automatic action role references.
+            $resolvedActions = [];
+            foreach (($transition['automaticActions'] ?? []) as $action) {
+                if (isset($action['config']['roleName']) === true) {
+                    $roleName = $action['config']['roleName'];
+                    $action['config']['roleId'] = ($roleNameMap[$roleName] ?? '');
+                }
+
+                $resolvedActions[] = $action;
+            }
+
+            $transition['automaticActions'] = $resolvedActions;
+
+            $resolvedTransitions[] = $transition;
+        }//end foreach
+
+        $workflowData['transitions'] = json_encode($resolvedTransitions);
+
+        // Remove raw array data that was already JSON-encoded.
+        unset($workflowData['steps_raw'], $workflowData['transitions_raw']);
+
+        return $workflowData;
+    }//end resolveWorkflowReferences()
+
+    /**
+     * Create an object in OpenRegister via ObjectService.
+     *
+     * @param object $objectService The ObjectService instance
+     * @param string $registerId    The register UUID
+     * @param string $schemaId      The schema UUID
+     * @param array  $data          The object data
+     *
+     * @return object|null The created object or null on failure
+     */
+    private function createObject(
+        object $objectService,
+        string $registerId,
+        string $schemaId,
+        array $data,
+    ): ?object {
+        try {
+            return $objectService->saveObject(
+                register: $registerId,
+                schema: $schemaId,
+                object: $data,
+            );
+        } catch (\Exception $e) {
+            $this->logger->error(
+                'Procest: Failed to create seed object',
+                [
+                    'schema'    => $schemaId,
+                    'exception' => $e->getMessage(),
+                ]
+            );
+            return null;
+        }
+    }//end createObject()
+
+    /**
+     * Find an existing object by filter criteria.
+     *
+     * @param object $objectService The ObjectService instance
+     * @param string $registerId    The register UUID
+     * @param string $schemaId      The schema UUID
+     * @param array  $filters       Filter criteria
+     *
+     * @return object|null The found object or null
+     */
+    private function findByFilter(
+        object $objectService,
+        string $registerId,
+        string $schemaId,
+        array $filters,
+    ): ?object {
+        try {
+            $results = $objectService->getObjects(
+                register: $registerId,
+                schema: $schemaId,
+                filters: $filters,
+                limit: 1,
+            );
+
+            if (is_array($results) === true && count($results) > 0) {
+                return $results[0];
+            }
+
+            // Handle paginated result format.
+            if (is_array($results) === true
+                && isset($results['results']) === true
+                && count($results['results']) > 0
+            ) {
+                return $results['results'][0];
+            }
+
+            return null;
+        } catch (\Exception $e) {
+            $this->logger->debug(
+                'Procest: Could not search for existing object',
+                ['exception' => $e->getMessage()]
+            );
+            return null;
+        }//end try
+    }//end findByFilter()
+
+    /**
+     * Get the ObjectService from OpenRegister via the DI container.
+     *
+     * @return object|null The ObjectService or null if unavailable
+     */
+    private function getObjectService(): ?object
+    {
+        try {
+            return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+        } catch (\Exception $e) {
+            $this->logger->error(
+                'Procest: Could not access ObjectService',
+                ['exception' => $e->getMessage()]
+            );
+            return null;
+        }
+    }//end getObjectService()
+
+    /**
+     * Get a configuration value from the app config.
+     *
+     * @param string $key The configuration key
+     *
+     * @return string The configuration value
+     */
+    private function getConfigValue(string $key): string
+    {
+        return $this->appConfig->getValueString(Application::APP_ID, $key, '');
+    }//end getConfigValue()
+
+    /**
+     * Get the ID from an OpenRegister object.
+     *
+     * @param object $object The OpenRegister object
+     *
+     * @return string The object ID
+     */
+    private function getObjectId(object $object): string
+    {
+        if (method_exists($object, 'getId') === true) {
+            return (string) $object->getId();
+        }
+
+        if (method_exists($object, 'getUuid') === true) {
+            return (string) $object->getUuid();
+        }
+
+        return '';
+    }//end getObjectId()
+
+    /**
+     * Generate a UUID v4 string.
+     *
+     * @return string A new UUID
+     */
+    private function generateUUID(): string
+    {
+        $data    = random_bytes(16);
+        $data[6] = chr(ord($data[6]) & 0x0f | 0x40);
+        $data[8] = chr(ord($data[8]) & 0x3f | 0x80);
+
+        return vsprintf(
+            '%s%s-%s-%s-%s-%s%s%s',
+            str_split(bin2hex($data), 4)
+        );
+    }//end generateUUID()
+}//end class

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -61,6 +61,11 @@ class SettingsService
         'usage_rights_schema',
         'kanaal_schema',
         'abonnement_schema',
+        'workflow_template_schema',
+        'objection_schema',
+        'hearing_session_schema',
+        'advisory_report_schema',
+        'appeal_decision_schema',
         'default_case_type',
     ];
 
@@ -95,6 +100,11 @@ class SettingsService
         'usageRights'                  => 'usage_rights_schema',
         'kanaal'                       => 'kanaal_schema',
         'abonnement'                   => 'abonnement_schema',
+        'workflowTemplate'             => 'workflow_template_schema',
+        'objection'                    => 'objection_schema',
+        'hearingSession'               => 'hearing_session_schema',
+        'advisoryReport'               => 'advisory_report_schema',
+        'appealDecision'               => 'appeal_decision_schema',
     ];
 
     private const OPENREGISTER_APP_ID = 'openregister';

--- a/lib/Settings/bezwaar_seed_data.json
+++ b/lib/Settings/bezwaar_seed_data.json
@@ -1,0 +1,249 @@
+{
+  "caseTypes": [
+    {
+      "identifier": "bezwaar",
+      "title": "Bezwaar",
+      "description": "Bezwaarprocedure conform Awb hoofdstuk 6 en 7",
+      "purpose": "Behandeling van bezwaarschriften tegen besluiten",
+      "trigger": "Bezwaarschrift van belanghebbende",
+      "subject": "Bezwaar tegen besluit",
+      "processingDeadline": "P6W",
+      "extensionAllowed": true,
+      "extensionPeriod": "P6W",
+      "suspensionAllowed": true,
+      "internalOrExternal": "extern",
+      "publicationRequired": false,
+      "isDraft": false,
+      "confidentiality": "zaakvertrouwelijk",
+      "statusTypes": [
+        { "name": "Ontvangen", "description": "Bezwaarschrift is ontvangen", "order": 1, "isFinal": false },
+        { "name": "Ontvankelijkheidstoets", "description": "Toetsing op ontvankelijkheid (termijn, belanghebbendheid, besluit-karakter)", "order": 2, "isFinal": false },
+        { "name": "In behandeling", "description": "Inhoudelijke behandeling gestart", "order": 3, "isFinal": false },
+        { "name": "Hoorzitting gepland", "description": "Hoorzitting is ingepland (Awb art. 7:2)", "order": 4, "isFinal": false },
+        { "name": "Hoorzitting afgerond", "description": "Hoorzitting heeft plaatsgevonden", "order": 5, "isFinal": false },
+        { "name": "Advies uitgebracht", "description": "Bezwaarschriftencommissie heeft advies uitgebracht (Awb art. 7:13)", "order": 6, "isFinal": false },
+        { "name": "Beslissing op bezwaar", "description": "Besluit op bezwaar is genomen (Awb art. 7:11, 7:12)", "order": 7, "isFinal": false },
+        { "name": "Afgehandeld", "description": "Bezwaarprocedure is volledig afgerond", "order": 8, "isFinal": true },
+        { "name": "Niet-ontvankelijk", "description": "Bezwaar is niet-ontvankelijk verklaard (Awb art. 6:6)", "order": 90, "isFinal": true },
+        { "name": "Ingetrokken", "description": "Bezwaar is ingetrokken door indiener (Awb art. 6:21)", "order": 91, "isFinal": true }
+      ],
+      "roleTypes": [
+        { "name": "Bezwaarmaker", "description": "De persoon die bezwaar maakt", "genericRole": "initiator" },
+        { "name": "Behandelaar bezwaar", "description": "Ambtenaar die het bezwaar behandelt", "genericRole": "handler" },
+        { "name": "Voorzitter commissie", "description": "Voorzitter bezwaarschriftencommissie", "genericRole": "decision_maker" },
+        { "name": "Lid commissie", "description": "Lid van de bezwaarschriftencommissie", "genericRole": "advisor" },
+        { "name": "Secretaris commissie", "description": "Secretaris van de bezwaarschriftencommissie", "genericRole": "coordinator" },
+        { "name": "Vertegenwoordiger", "description": "Gemachtigde of vertegenwoordiger van bezwaarmaker", "genericRole": "stakeholder" },
+        { "name": "Primair beslisser", "description": "Ambtenaar die het oorspronkelijke besluit nam", "genericRole": "advisor" }
+      ],
+      "workflowTemplate": {
+        "title": "Bezwaar Standaard Workflow",
+        "description": "AWB-compliant bezwaar workflow met hoorzitting, adviescommissie en beslissing op bezwaar",
+        "version": 1,
+        "isActive": true,
+        "isDraft": false,
+        "steps": [
+          { "title": "Registreer bezwaarschrift", "statusName": "Ontvangen", "order": 1, "isRequired": true, "description": "Registreer het bezwaarschrift in het systeem" },
+          { "title": "Controleer volledigheid", "statusName": "Ontvangen", "order": 2, "isRequired": true, "description": "Controleer of het bezwaarschrift alle vereiste gegevens bevat" },
+          { "title": "Bevestig ontvangst", "statusName": "Ontvangen", "order": 3, "isRequired": true, "description": "Stuur ontvangstbevestiging naar bezwaarmaker" },
+          { "title": "Toets termijn", "statusName": "Ontvankelijkheidstoets", "order": 1, "isRequired": true, "description": "Controleer of het bezwaar binnen de 6-weken termijn is ingediend (Awb art. 6:7)" },
+          { "title": "Toets belanghebbendheid", "statusName": "Ontvankelijkheidstoets", "order": 2, "isRequired": true, "description": "Controleer of indiener belanghebbende is" },
+          { "title": "Toets besluit-karakter", "statusName": "Ontvankelijkheidstoets", "order": 3, "isRequired": true, "description": "Controleer of het bestreden handeling een besluit is in de zin van de Awb" },
+          { "title": "Stel dossier samen", "statusName": "In behandeling", "order": 1, "isRequired": true, "description": "Stel het bezwaardossier samen met alle relevante stukken" },
+          { "title": "Informeer primair beslisser", "statusName": "In behandeling", "order": 2, "isRequired": false, "description": "Informeer de ambtenaar die het oorspronkelijke besluit nam" },
+          { "title": "Plan hoorzitting of registreer afzien", "statusName": "In behandeling", "order": 3, "isRequired": true, "description": "Plan een hoorzitting of registreer dat bezwaarmaker afziet van hoorrecht" },
+          { "title": "Verstuur uitnodigingen", "statusName": "Hoorzitting gepland", "order": 1, "isRequired": true, "description": "Verstuur uitnodigingen voor de hoorzitting aan alle partijen" },
+          { "title": "Bereid hoorzitting voor", "statusName": "Hoorzitting gepland", "order": 2, "isRequired": false, "description": "Bereid de hoorzitting voor met agenda en stukken" },
+          { "title": "Maak verslag", "statusName": "Hoorzitting afgerond", "order": 1, "isRequired": true, "description": "Maak een verslag van de hoorzitting (Awb art. 7:7)" },
+          { "title": "Deel verslag met partijen", "statusName": "Hoorzitting afgerond", "order": 2, "isRequired": false, "description": "Deel het verslag met bezwaarmaker en andere partijen" },
+          { "title": "Stel advies op", "statusName": "Advies uitgebracht", "order": 1, "isRequired": true, "description": "De bezwaarschriftencommissie stelt advies op" },
+          { "title": "Deel advies met bestuursorgaan", "statusName": "Advies uitgebracht", "order": 2, "isRequired": true, "description": "Deel het advies van de commissie met het bestuursorgaan" },
+          { "title": "Neem beslissing", "statusName": "Beslissing op bezwaar", "order": 1, "isRequired": true, "description": "Neem de beslissing op het bezwaar (heroverweging art. 7:11)" },
+          { "title": "Stel besluit op", "statusName": "Beslissing op bezwaar", "order": 2, "isRequired": true, "description": "Stel het formele besluit op met motivering" },
+          { "title": "Verstuur besluit met rechtsmiddelenclausule", "statusName": "Beslissing op bezwaar", "order": 3, "isRequired": true, "description": "Verstuur het besluit naar bezwaarmaker inclusief rechtsmiddelenclausule" }
+        ],
+        "transitions": [
+          {
+            "fromStatusName": "Ontvangen",
+            "toStatusName": "Ontvankelijkheidstoets",
+            "label": "Start toets",
+            "guards": [{ "type": "roleGuard", "config": { "roleName": "Behandelaar bezwaar" } }]
+          },
+          {
+            "fromStatusName": "Ontvankelijkheidstoets",
+            "toStatusName": "In behandeling",
+            "label": "Ontvankelijk",
+            "guards": [{ "type": "requiredField", "config": { "field": "isTimely" } }]
+          },
+          {
+            "fromStatusName": "Ontvankelijkheidstoets",
+            "toStatusName": "Niet-ontvankelijk",
+            "label": "Niet-ontvankelijk verklaren",
+            "guards": [{ "type": "requiredField", "config": { "field": "dispositionDetails" } }]
+          },
+          {
+            "fromStatusName": "In behandeling",
+            "toStatusName": "Hoorzitting gepland",
+            "label": "Hoorzitting plannen",
+            "guards": []
+          },
+          {
+            "fromStatusName": "In behandeling",
+            "toStatusName": "Advies uitgebracht",
+            "label": "Hoorrecht afgezien",
+            "guards": [{ "type": "requiredField", "config": { "field": "hearingWaived" } }]
+          },
+          {
+            "fromStatusName": "Hoorzitting gepland",
+            "toStatusName": "Hoorzitting afgerond",
+            "label": "Hoorzitting afronden",
+            "guards": [{ "type": "requiredField", "config": { "field": "minutesSummary" } }]
+          },
+          {
+            "fromStatusName": "Hoorzitting afgerond",
+            "toStatusName": "Advies uitgebracht",
+            "label": "Advies uitbrengen",
+            "guards": [{ "type": "requiredField", "config": { "field": "advisoryReport" } }]
+          },
+          {
+            "fromStatusName": "In behandeling",
+            "toStatusName": "Beslissing op bezwaar",
+            "label": "Direct beslissen",
+            "guards": [{ "type": "roleGuard", "config": { "roleName": "Voorzitter commissie" } }]
+          },
+          {
+            "fromStatusName": "Advies uitgebracht",
+            "toStatusName": "Beslissing op bezwaar",
+            "label": "Beslissing nemen",
+            "guards": [
+              { "type": "requiredField", "config": { "field": "dispositionType" } },
+              { "type": "requiredField", "config": { "field": "dispositionDetails" } }
+            ]
+          },
+          {
+            "fromStatusName": "Beslissing op bezwaar",
+            "toStatusName": "Afgehandeld",
+            "label": "Afronden",
+            "guards": [
+              {
+                "type": "checklist",
+                "config": {
+                  "items": [
+                    { "label": "Besluit verzonden naar bezwaarmaker" },
+                    { "label": "Rechtsmiddelenclausule opgenomen in besluit" }
+                  ]
+                }
+              }
+            ],
+            "automaticActions": [
+              { "type": "notify", "config": { "roleName": "Bezwaarmaker", "message": "Uw bezwaar is afgehandeld" } }
+            ]
+          },
+          {
+            "fromStatusName": "*",
+            "toStatusName": "Ingetrokken",
+            "label": "Intrekken",
+            "guards": [{ "type": "requiredField", "config": { "field": "withdrawalReason" } }]
+          }
+        ]
+      }
+    },
+    {
+      "identifier": "beroep",
+      "title": "Beroep",
+      "description": "Beroepsprocedure bij de bestuursrechter conform Awb hoofdstuk 8",
+      "purpose": "Verwerken van beroepszaken bij de bestuursrechter",
+      "trigger": "Beroepschrift bij de bestuursrechter",
+      "subject": "Beroep tegen beslissing op bezwaar",
+      "processingDeadline": "P26W",
+      "extensionAllowed": false,
+      "suspensionAllowed": true,
+      "internalOrExternal": "extern",
+      "publicationRequired": false,
+      "isDraft": false,
+      "confidentiality": "zaakvertrouwelijk",
+      "statusTypes": [
+        { "name": "Beroep ontvangen", "description": "Beroepschrift ontvangen van rechtbank", "order": 1, "isFinal": false },
+        { "name": "Verweerschrift in voorbereiding", "description": "Gemeente bereidt verweer voor", "order": 2, "isFinal": false },
+        { "name": "Verweerschrift ingediend", "description": "Verweer ingediend bij de rechtbank", "order": 3, "isFinal": false },
+        { "name": "Zitting gepland", "description": "Zitting bij de rechtbank is gepland", "order": 4, "isFinal": false },
+        { "name": "Zitting afgerond", "description": "Zitting bij de rechtbank heeft plaatsgevonden", "order": 5, "isFinal": false },
+        { "name": "Uitspraak ontvangen", "description": "Uitspraak van de rechtbank ontvangen", "order": 6, "isFinal": false },
+        { "name": "Afgehandeld", "description": "Beroepsprocedure is afgerond", "order": 7, "isFinal": true },
+        { "name": "Ingetrokken", "description": "Beroep is ingetrokken", "order": 90, "isFinal": true },
+        { "name": "Schikking", "description": "Zaak geschikt buiten de rechtbank", "order": 91, "isFinal": true }
+      ],
+      "roleTypes": [
+        { "name": "Appellant", "description": "De persoon die beroep instelt", "genericRole": "initiator" },
+        { "name": "Behandelaar beroep", "description": "Ambtenaar die het beroep behandelt namens de gemeente", "genericRole": "handler" },
+        { "name": "Jurist", "description": "Juridisch adviseur voor de beroepsprocedure", "genericRole": "advisor" }
+      ],
+      "workflowTemplate": {
+        "title": "Beroep Standaard Workflow",
+        "description": "Workflow voor het verwerken van beroepszaken bij de bestuursrechter",
+        "version": 1,
+        "isActive": true,
+        "isDraft": false,
+        "steps": [
+          { "title": "Registreer beroepschrift", "statusName": "Beroep ontvangen", "order": 1, "isRequired": true, "description": "Registreer het ontvangen beroepschrift" },
+          { "title": "Stel bezwaardossier samen", "statusName": "Verweerschrift in voorbereiding", "order": 1, "isRequired": true, "description": "Stel alle relevante stukken samen voor het verweerschrift" },
+          { "title": "Stel verweerschrift op", "statusName": "Verweerschrift in voorbereiding", "order": 2, "isRequired": true, "description": "Stel het verweerschrift op" },
+          { "title": "Dien verweerschrift in", "statusName": "Verweerschrift ingediend", "order": 1, "isRequired": true, "description": "Dien het verweerschrift in bij de rechtbank" },
+          { "title": "Bereid zitting voor", "statusName": "Zitting gepland", "order": 1, "isRequired": false, "description": "Bereid de zitting voor (pleitnota, getuigen)" },
+          { "title": "Registreer uitspraak", "statusName": "Uitspraak ontvangen", "order": 1, "isRequired": true, "description": "Registreer de uitspraak van de rechtbank" },
+          { "title": "Beoordeel gevolgen uitspraak", "statusName": "Uitspraak ontvangen", "order": 2, "isRequired": true, "description": "Beoordeel de gevolgen van de uitspraak voor de gemeente" }
+        ],
+        "transitions": [
+          {
+            "fromStatusName": "Beroep ontvangen",
+            "toStatusName": "Verweerschrift in voorbereiding",
+            "label": "Start verweer",
+            "guards": [{ "type": "roleGuard", "config": { "roleName": "Behandelaar beroep" } }]
+          },
+          {
+            "fromStatusName": "Verweerschrift in voorbereiding",
+            "toStatusName": "Verweerschrift ingediend",
+            "label": "Verweer indienen",
+            "guards": [{ "type": "requiredDocument", "config": { "documentType": "Verweerschrift" } }]
+          },
+          {
+            "fromStatusName": "Verweerschrift ingediend",
+            "toStatusName": "Zitting gepland",
+            "label": "Zitting plannen",
+            "guards": []
+          },
+          {
+            "fromStatusName": "Zitting gepland",
+            "toStatusName": "Zitting afgerond",
+            "label": "Zitting afronden",
+            "guards": []
+          },
+          {
+            "fromStatusName": "Zitting afgerond",
+            "toStatusName": "Uitspraak ontvangen",
+            "label": "Uitspraak registreren",
+            "guards": [{ "type": "requiredField", "config": { "field": "rulingOutcome" } }]
+          },
+          {
+            "fromStatusName": "Uitspraak ontvangen",
+            "toStatusName": "Afgehandeld",
+            "label": "Afronden",
+            "guards": []
+          },
+          {
+            "fromStatusName": "*",
+            "toStatusName": "Ingetrokken",
+            "label": "Intrekken",
+            "guards": []
+          },
+          {
+            "fromStatusName": "*",
+            "toStatusName": "Schikking",
+            "label": "Schikking treffen",
+            "guards": [{ "type": "requiredField", "config": { "field": "settlementDetails" } }]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/lib/Settings/procest_register.json
+++ b/lib/Settings/procest_register.json
@@ -1584,6 +1584,341 @@
             "description": "Reference to parent workflow template for inheritance (Enterprise tier)"
           }
         }
+      },
+      "objection": {
+        "slug": "objection",
+        "icon": "FileDocumentAlertOutline",
+        "version": "1.0.0",
+        "x-schema-org-type": "schema:Message",
+        "x-zgw-equivalent": "Bezwaarschrift",
+        "title": "Objection",
+        "description": "Bezwaarschrift (objection letter) — captures the formal objection content linked to a bezwaar case and the contested decision",
+        "type": "object",
+        "required": [
+          "case",
+          "contestedDecision",
+          "grounds",
+          "receivedDate",
+          "receivedChannel"
+        ],
+        "properties": {
+          "case": {
+            "type": "string",
+            "format": "uuid",
+            "$ref": "case",
+            "onDelete": "CASCADE",
+            "description": "The bezwaar case this objection belongs to"
+          },
+          "contestedDecision": {
+            "type": "string",
+            "format": "uuid",
+            "$ref": "decision",
+            "description": "The original besluit being contested"
+          },
+          "grounds": {
+            "type": "string",
+            "description": "The grounds for objection (gronden van bezwaar)"
+          },
+          "requestedRelief": {
+            "type": "string",
+            "description": "What outcome the bezwaarmaker seeks"
+          },
+          "receivedDate": {
+            "type": "string",
+            "format": "date",
+            "description": "Date the bezwaarschrift was received"
+          },
+          "receivedChannel": {
+            "type": "string",
+            "enum": [
+              "brief",
+              "email",
+              "formulier",
+              "balie"
+            ],
+            "description": "How the bezwaarschrift was received"
+          },
+          "isTimely": {
+            "type": "boolean",
+            "description": "Whether the objection was filed within the 6-week term (Awb art. 6:7)"
+          },
+          "timelinessAssessment": {
+            "type": "string",
+            "description": "Explanation of timeliness determination"
+          },
+          "proVoorziening": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether a voorlopige voorziening (interim relief) was requested"
+          },
+          "attachments": {
+            "type": "string",
+            "description": "JSON-encoded array of document references uploaded by bezwaarmaker"
+          }
+        }
+      },
+      "hearingSession": {
+        "slug": "hearingSession",
+        "icon": "AccountGroupOutline",
+        "version": "1.0.0",
+        "x-schema-org-type": "schema:Event",
+        "x-zgw-equivalent": "Hoorzitting",
+        "title": "Hearing Session",
+        "description": "Hoorzitting (hearing) — manages scheduling, invitations, and minutes for bezwaar hearings per Awb art. 7:2",
+        "type": "object",
+        "required": [
+          "case",
+          "scheduledDate",
+          "chairperson",
+          "invitees",
+          "status"
+        ],
+        "properties": {
+          "case": {
+            "type": "string",
+            "format": "uuid",
+            "$ref": "case",
+            "onDelete": "CASCADE",
+            "description": "The bezwaar case this hearing belongs to"
+          },
+          "scheduledDate": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date and time of the hearing"
+          },
+          "location": {
+            "type": "string",
+            "description": "Physical location or 'Online' for video hearings"
+          },
+          "videoCallUrl": {
+            "type": "string",
+            "format": "uri",
+            "description": "Video conference link for online hearings"
+          },
+          "chairperson": {
+            "type": "string",
+            "format": "uuid",
+            "$ref": "role",
+            "description": "Who chairs the hearing (voorzitter)"
+          },
+          "members": {
+            "type": "string",
+            "description": "JSON-encoded array of committee member role UUIDs"
+          },
+          "invitees": {
+            "type": "string",
+            "description": "JSON-encoded array of invitee objects (name, role, email, status)"
+          },
+          "minutesSummary": {
+            "type": "string",
+            "description": "Summary of what was discussed (verslag)"
+          },
+          "minutesDocument": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Reference to full hearing minutes document"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "gepland",
+              "uitgenodigd",
+              "uitgevoerd",
+              "geannuleerd",
+              "afgezien"
+            ],
+            "default": "gepland",
+            "description": "Hearing session status"
+          },
+          "hearingWaived": {
+            "type": "boolean",
+            "default": false,
+            "description": "Bezwaarmaker has waived the right to be heard"
+          },
+          "waiverReason": {
+            "type": "string",
+            "description": "Reason for waiving hearing right"
+          }
+        }
+      },
+      "advisoryReport": {
+        "slug": "advisoryReport",
+        "icon": "FileDocumentCheckOutline",
+        "version": "1.0.0",
+        "x-schema-org-type": "schema:Report",
+        "x-zgw-equivalent": "AdviesBezwaarschriftencommissie",
+        "title": "Advisory Report",
+        "description": "Advisory committee report (advies bezwaarschriftencommissie) — records the committee's advice on a bezwaar case per Awb art. 7:13",
+        "type": "object",
+        "required": [
+          "case",
+          "committeeChair",
+          "adviceDate",
+          "adviceType",
+          "summary",
+          "grounds",
+          "recommendation",
+          "deviationFromPrimaryDecision"
+        ],
+        "properties": {
+          "case": {
+            "type": "string",
+            "format": "uuid",
+            "$ref": "case",
+            "onDelete": "CASCADE",
+            "description": "The bezwaar case this report belongs to"
+          },
+          "hearingSession": {
+            "type": "string",
+            "format": "uuid",
+            "$ref": "hearingSession",
+            "description": "The hearing session this report is based on"
+          },
+          "committeeChair": {
+            "type": "string",
+            "format": "uuid",
+            "$ref": "role",
+            "description": "Voorzitter who signed the report"
+          },
+          "committeeMembers": {
+            "type": "string",
+            "description": "JSON-encoded array of committee member role UUIDs"
+          },
+          "adviceDate": {
+            "type": "string",
+            "format": "date",
+            "description": "Date the advice was issued"
+          },
+          "adviceType": {
+            "type": "string",
+            "enum": [
+              "gegrond",
+              "ongegrond",
+              "deels_gegrond",
+              "niet_ontvankelijk"
+            ],
+            "description": "Type of advice: upheld, rejected, partially upheld, inadmissible"
+          },
+          "summary": {
+            "type": "string",
+            "description": "Summary of the committee's advice"
+          },
+          "grounds": {
+            "type": "string",
+            "description": "Legal reasoning and grounds for the advice"
+          },
+          "recommendation": {
+            "type": "string",
+            "description": "Recommended action for the bestuursorgaan"
+          },
+          "deviationFromPrimaryDecision": {
+            "type": "boolean",
+            "description": "Whether the committee advises differently from the original decision"
+          },
+          "reportDocument": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Reference to full advisory report document"
+          }
+        }
+      },
+      "appealDecision": {
+        "slug": "appealDecision",
+        "icon": "GavelOutline",
+        "version": "1.0.0",
+        "x-schema-org-type": "schema:LegalForceStatus",
+        "x-zgw-equivalent": "BeslissingOpBezwaar",
+        "title": "Appeal Decision",
+        "description": "Beslissing op bezwaar (decision on objection) — formal decision recording with disposition, motivation, and rechtsmiddelenclausule per Awb art. 7:11-7:12",
+        "type": "object",
+        "required": [
+          "case",
+          "contestedDecision",
+          "dispositionType",
+          "dispositionDetails",
+          "decisionDate",
+          "effectiveDate",
+          "appealInformation",
+          "decisionMaker"
+        ],
+        "properties": {
+          "case": {
+            "type": "string",
+            "format": "uuid",
+            "$ref": "case",
+            "onDelete": "CASCADE",
+            "description": "The bezwaar case"
+          },
+          "contestedDecision": {
+            "type": "string",
+            "format": "uuid",
+            "$ref": "decision",
+            "description": "The original besluit being contested"
+          },
+          "advisoryReport": {
+            "type": "string",
+            "format": "uuid",
+            "$ref": "advisoryReport",
+            "description": "The committee's advisory report"
+          },
+          "dispositionType": {
+            "type": "string",
+            "enum": [
+              "gegrond",
+              "ongegrond",
+              "deels_gegrond",
+              "niet_ontvankelijk"
+            ],
+            "description": "Decision outcome type"
+          },
+          "dispositionDetails": {
+            "type": "string",
+            "description": "Detailed motivation for the decision (motiveringsplicht art. 7:12)"
+          },
+          "followsAdvice": {
+            "type": "boolean",
+            "description": "Whether the decision follows the committee's advice"
+          },
+          "deviationReason": {
+            "type": "string",
+            "description": "Reason for deviating from committee advice (required when followsAdvice is false)"
+          },
+          "remedialAction": {
+            "type": "string",
+            "description": "Corrective action taken if gegrond/deels_gegrond"
+          },
+          "replacementDecision": {
+            "type": "string",
+            "format": "uuid",
+            "$ref": "decision",
+            "description": "New besluit that replaces the contested one"
+          },
+          "decisionDate": {
+            "type": "string",
+            "format": "date",
+            "description": "Date the decision was made"
+          },
+          "effectiveDate": {
+            "type": "string",
+            "format": "date",
+            "description": "Date the decision takes legal effect"
+          },
+          "appealInformation": {
+            "type": "string",
+            "description": "Information about beroep possibilities (rechtsmiddelenclausule)"
+          },
+          "decisionMaker": {
+            "type": "string",
+            "format": "uuid",
+            "$ref": "role",
+            "description": "The person/body that made the decision"
+          },
+          "decisionDocument": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Reference to the formal decision letter document"
+          }
+        }
       }
     },
     "registers": {
@@ -1619,7 +1954,11 @@
           "usageRights",
           "workflowTemplate",
           "kanaal",
-          "abonnement"
+          "abonnement",
+          "objection",
+          "hearingSession",
+          "advisoryReport",
+          "appealDecision"
         ],
         "tablePrefix": "",
         "folder": "Open Registers/Procest"

--- a/openspec/changes/archive/2026-03-22-bezwaar-beroep-workflow/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-22-bezwaar-beroep-workflow/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-22

--- a/openspec/changes/archive/2026-03-22-bezwaar-beroep-workflow/design.md
+++ b/openspec/changes/archive/2026-03-22-bezwaar-beroep-workflow/design.md
@@ -1,0 +1,109 @@
+## Context
+
+Procest is a Nextcloud-based case management app that stores all data as OpenRegister objects (no own database tables). The workflow engine enhancement (PR #93) added configurable workflow templates with visual editor, status transitions, guards, and automatic actions. This change builds on that foundation to add AWB-compliant bezwaar (objection) and beroep (appeal) processes as pre-seeded case types with workflow templates.
+
+The bezwaar/beroep process is one of the most formalized procedures in Dutch administrative law (Awb chapters 6, 7, and 8). Every municipality must handle these, and the process has strict legal requirements for deadlines, hearing rights, advisory committees, and decision motivation. Market intelligence shows this appearing in 534+ tenders.
+
+Current state:
+- Workflow engine provides: workflow templates, steps, transitions, guards (4 types), automatic actions (6 types), visual editor, versioning
+- Case type system provides: status types, role types, processing deadlines, extension/suspension support
+- Decision system provides: formal decision recording with validity periods
+- No bezwaar/beroep-specific schemas, components, or pre-seeded data exist yet
+
+## Goals / Non-Goals
+
+**Goals:**
+- Pre-seed Bezwaar and Beroep case types with AWB-compliant configurations
+- Pre-seed workflow templates with legally mandated process steps, transitions, and guards
+- Add 4 new schemas (objection, hearingSession, advisoryReport, appealDecision) for bezwaar-specific entities
+- Add dedicated Vue components for bezwaar/beroep case handling
+- Add automatic deadline calculation based on AWB rules
+- Enable escalation path from bezwaar to beroep with case linking
+
+**Non-Goals:**
+- Hoger beroep (further appeal to ABRvS/CRvB) workflow -- informational only
+- Citizen-facing portal for filing bezwaar (that belongs to a separate "Mijn Zaken" feature)
+- Automated document generation (bezwaar decision letters) -- documents are uploaded manually
+- Integration with external court systems (Rechtspraak.nl)
+- Pro-forma bezwaar handling (special case where grounds are submitted later)
+
+## Decisions
+
+### Decision 1: Bezwaar entities as separate schemas vs. case properties
+
+**Choice**: Separate OpenRegister schemas for objection, hearingSession, advisoryReport, and appealDecision.
+
+**Alternatives considered**:
+- (A) Store everything as case properties -- simpler but loses structure and makes querying individual hearings/reports impossible
+- (B) Use the existing decision schema for everything -- misses bezwaar-specific fields like `grounds`, `hearingWaived`, `adviceType`
+
+**Rationale**: Bezwaar entities have distinct lifecycles and relationships. A hearing session can exist independently (scheduled, cancelled, waived). Advisory reports reference hearings. The appeal decision references both the advisory report and the original contested decision. Separate schemas enable clean CRUD operations and proper referential integrity.
+
+### Decision 2: Pre-seeded data via procest_register.json
+
+**Choice**: Add bezwaar/beroep schemas, case types, status types, role types, and workflow templates to `lib/Settings/procest_register.json`. They are imported via the existing `ConfigurationService::importFromApp()` repair step.
+
+**Alternatives considered**:
+- (A) Separate JSON file for bezwaar config -- complicates the repair step, inconsistent with existing pattern
+- (B) Admin UI for creating bezwaar types manually -- poor UX, error-prone, municipalities expect out-of-box support
+
+**Rationale**: Follows the established pattern. The repair step already handles idempotent imports (checks for existing objects before creating). Adding to the existing register JSON keeps everything in one place.
+
+### Decision 3: Deadline calculation in frontend store
+
+**Choice**: Deadline calculation logic lives in the `bezwaar.js` Pinia store, computed when a bezwaar case is created or when suspension/extension is applied.
+
+**Alternatives considered**:
+- (A) Backend PHP service for deadline calculation -- would require a new controller endpoint, inconsistent with thin-client architecture
+- (B) Automatic action in workflow engine -- too rigid, deadlines depend on dynamic factors (suspension, extension)
+
+**Rationale**: Procest follows the thin-client pattern where the frontend queries OpenRegister directly. Deadline calculation is deterministic (based on dates and AWB rules) and can be computed client-side. The store saves the computed deadlines to the case object properties.
+
+### Decision 4: Hearing session as linked object, not embedded in case
+
+**Choice**: HearingSession is a separate schema with a `case` reference, not an embedded property of the case.
+
+**Rationale**: A case may have multiple hearing attempts (rescheduled, cancelled). The hearing has its own status lifecycle (gepland, uitgenodigd, uitgevoerd, geannuleerd, afgezien). Embedding would make it impossible to track hearing history.
+
+### Decision 5: Vue components as case-type-aware tabs/panels
+
+**Choice**: Add bezwaar-specific Vue components that render conditionally when the case's type is "Bezwaar" or "Beroep". These appear as additional sections in the case detail view.
+
+**Alternatives considered**:
+- (A) Completely separate views for bezwaar cases -- code duplication, loses shared case infrastructure
+- (B) Generic component system with plugins -- over-engineered for 2 case types
+
+**Rationale**: The case detail view already supports tabs/sections. Bezwaar-specific sections (objection details, hearing panel, advisory report, decision form) can be conditionally rendered based on case type. This keeps shared case functionality (timeline, documents, roles) while adding specialized panels.
+
+### Decision 6: Beroep as lightweight tracking, not full court integration
+
+**Choice**: Beroep case type tracks the municipality's actions (verweerschrift, zitting, uitspraak) but does not integrate with court systems.
+
+**Rationale**: The municipality has limited control over court proceedings. Beroep tracking is primarily about document management (verweerschrift) and recording outcomes (uitspraak). Full court integration would require external APIs that don't exist in a standard way.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|------|------------|
+| Pre-seeded data conflicts with existing custom case types | Repair step uses idempotent import -- checks for existing objects by identifier before creating |
+| AWB rules change | Workflow templates are versionable -- administrators can create new versions. Pre-seeded templates serve as a starting point |
+| Deadline calculation edge cases (holidays, weekends) | V1 uses calendar days for 6-week deadlines (AWB uses calendar weeks). Working-day calculation for acknowledgment deadline uses a simple weekday check. Holiday calendar integration is a future enhancement |
+| Complex advisory committee workflows vary by municipality | Pre-seeded workflow is a common baseline. Municipalities can customize via the workflow editor |
+| Large register JSON file | The 4 new schemas add moderate size. OpenRegister handles this efficiently |
+
+## Migration Plan
+
+1. Add 4 new schemas to `procest_register.json`: `objection`, `hearingSession`, `advisoryReport`, `appealDecision`
+2. Add pre-seeded case type data (Bezwaar, Beroep) with status types, role types to the register JSON
+3. Add pre-seeded workflow templates for both case types to the register JSON
+4. Create `bezwaar.js` Pinia store module with CRUD for all bezwaar entities + deadline calculation
+5. Create Vue components: `BezwaarIntakeForm.vue`, `HearingPanel.vue`, `AdvisoryReportPanel.vue`, `BezwaarDecisionForm.vue`, `BeroepEscalationPanel.vue`, `BezwaarTimeline.vue`
+6. Integrate components into existing case detail view with case-type-conditional rendering
+7. Repair step runs on app update -- automatically seeds bezwaar/beroep data
+
+**Rollback**: Remove schemas from register JSON and redeploy. Existing bezwaar data remains in OpenRegister but becomes orphaned (no UI). No data loss.
+
+## Open Questions
+
+- Should the bezwaar deadline calculation account for Dutch public holidays? V1 uses calendar weeks (AWB standard), but acknowledgment deadlines use working days.
+- Should the pre-seeded workflow templates be marked as read-only (cannot delete the base version), or should administrators have full control?

--- a/openspec/changes/archive/2026-03-22-bezwaar-beroep-workflow/proposal.md
+++ b/openspec/changes/archive/2026-03-22-bezwaar-beroep-workflow/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+Dutch municipalities are legally required to handle bezwaar (objection) and beroep (appeal) procedures under the Algemene wet bestuursrecht (Awb) chapters 6 and 7. When a citizen objects to an administrative decision (besluit), the municipality must follow a structured process with strict legal deadlines (6-week acknowledgment, 6-12 week resolution), mandatory hearing rights, advisory committee involvement, and formal decision recording. Currently, Procest has no dedicated support for this AWB-mandated process. Market intelligence shows bezwaar/beroep handling appears in 534+ tenders and 2,942+ requirements across Dutch government procurement. With the workflow engine (PR #93) now providing configurable process steps, transitions, guards, and automatic actions, Procest can model the bezwaar/beroep lifecycle as a specialized workflow template with pre-seeded case types.
+
+## What Changes
+
+- Add two new pre-seeded case types: "Bezwaar" (objection) and "Beroep" (appeal) with AWB-compliant status types, deadlines, and role types
+- Add a pre-seeded workflow template for each case type with the legally mandated process steps, transitions, and guards
+- Add new schemas for bezwaar-specific entities: `objection` (bezwaarschrift), `hearingSession` (hoorzitting), `advisoryReport` (advies bezwaarschriftencommissie), and `appealDecision` (beslissing op bezwaar)
+- Add dedicated Vue components for the bezwaar/beroep case detail view: objection intake form, hearing scheduling panel, advisory committee report, and appeal decision form
+- Add automatic deadline calculation based on AWB rules (6 weeks default, 12 weeks with extension, suspension support)
+- Add automatic actions for deadline warnings, hearing invitations, and decision notifications
+- Link bezwaar cases to the original besluit (decision) they object to, creating a parent-child case relationship
+
+## Capabilities
+
+### New Capabilities
+- `bezwaar-lifecycle`: AWB-compliant objection lifecycle with pre-seeded case type, status types (ontvangen, ontvankelijkheidstoets, hoorzitting-gepland, hoorzitting-afgerond, advies-uitgebracht, beslissing-op-bezwaar, afgehandeld), deadline calculation, and suspension/extension support
+- `bezwaar-hearing`: Hearing (hoorzitting) management for bezwaar procedures including scheduling, invitation, minutes recording, and the right to be heard (hoorplicht) enforcement
+- `bezwaar-advisory-committee`: Advisory committee (bezwaarschriftencommissie) workflow with report generation, advice types (gegrond/ongegrond/niet-ontvankelijk/deels gegrond), and integration into the decision process
+- `bezwaar-decision`: Decision on objection (beslissing op bezwaar) with formal decision recording, legal grounds, disposition types, and link to the original contested decision
+- `beroep-escalation`: Escalation from bezwaar to beroep (appeal to administrative court) with case transfer, court filing tracking, and verdaging (adjournment) support
+
+### Modified Capabilities
+- `workflow-definition-model`: Add pre-seeded bezwaar and beroep workflow templates with AWB-mandated steps and transitions
+- `case-types`: Add pre-seeded Bezwaar and Beroep case types with AWB-specific status types, role types, and deadline configurations
+
+## Impact
+
+- **Schema**: 4 new schemas in `procest_register.json` (objection, hearingSession, advisoryReport, appealDecision)
+- **Register seed data**: Pre-seeded case types, status types, role types, and workflow templates added to repair step
+- **Frontend**: 6-8 new Vue components for bezwaar/beroep-specific UI (intake form, hearing panel, advisory report, decision form, timeline view, escalation panel)
+- **Store**: New `bezwaar.js` Pinia store module for objection/hearing/advisory CRUD operations
+- **Workflow engine dependency**: Requires workflow-engine-enhancement (PR #93) for workflow templates, guards, transitions, and automatic actions
+- **Existing decisions**: Links to the existing `decision` schema and `roles-decisions` spec for the original besluit being contested
+- **Pipelinq**: Bezwaar intake can originate from Pipelinq via request-to-case conversion when a citizen files an objection through the CRM channel
+- **ZGW mapping**: Bezwaar maps to ZGW Zaken API with `zaaktype` "Bezwaar" and `resultaattype` for disposition; beslissing op bezwaar maps to ZGW Besluiten API

--- a/openspec/changes/archive/2026-03-22-bezwaar-beroep-workflow/specs/beroep-escalation/spec.md
+++ b/openspec/changes/archive/2026-03-22-bezwaar-beroep-workflow/specs/beroep-escalation/spec.md
@@ -1,0 +1,111 @@
+## ADDED Requirements
+
+### Requirement: Beroep Case Type Pre-Seeded Configuration
+
+The system SHALL provide a pre-seeded "Beroep" (appeal) case type for tracking appeals to the administrative court (bestuursrechter). Beroep is the next step after bezwaar when a citizen disagrees with the beslissing op bezwaar.
+
+**Feature tier**: V1
+**ZGW mapping**: `zaaktype` with `omschrijving` "Beroep"
+**AWB reference**: Art. 8:1 (beroep bij de rechtbank)
+
+| Property | Value |
+|----------|-------|
+| `title` | Beroep |
+| `description` | Beroepsprocedure bij de bestuursrechter conform Awb hoofdstuk 8 |
+| `processingDeadline` | P26W (6 months indicative, actual timeline determined by court) |
+| `extensionAllowed` | false |
+| `suspensionAllowed` | true |
+| `origin` | external |
+| `trigger` | Beroepschrift bij de bestuursrechter |
+| `subject` | Beroep tegen beslissing op bezwaar |
+
+#### Scenario: Beroep case type is available after installation
+
+- **WHEN** the Procest app repair step runs
+- **THEN** a case type "Beroep" SHALL exist in the procest register
+- **AND** the case type SHALL have appropriate status types for court proceedings tracking
+
+### Requirement: Beroep Status Types
+
+The system SHALL provide status types for the Beroep case type reflecting the stages of court proceedings that the municipality needs to track.
+
+**Feature tier**: V1
+
+| Order | Status Type | Description |
+|-------|-------------|-------------|
+| 1 | Beroep ontvangen | Beroepschrift ontvangen van rechtbank |
+| 2 | Verweerschrift in voorbereiding | Municipality preparing defense |
+| 3 | Verweerschrift ingediend | Defense submitted to court |
+| 4 | Zitting gepland | Court hearing scheduled |
+| 5 | Zitting afgerond | Court hearing completed |
+| 6 | Uitspraak ontvangen | Court ruling received |
+| 7 | Afgehandeld | Case closed after ruling |
+| -- | Ingetrokken | Appeal withdrawn by appellant |
+| -- | Schikking | Settled out of court |
+
+#### Scenario: Beroep status types are seeded
+
+- **WHEN** the repair step completes
+- **THEN** 9 status types SHALL exist for the Beroep case type
+- **AND** they SHALL be ordered to reflect the court proceedings timeline
+
+### Requirement: Escalation from Bezwaar to Beroep
+
+The system SHALL support creating a beroep case from a completed bezwaar case, linking the two cases as parent-child. This happens when the bezwaarmaker appeals the beslissing op bezwaar at the administrative court.
+
+**Feature tier**: V1
+
+#### Scenario: Create beroep case from bezwaar
+
+- **WHEN** a beroepschrift is received for bezwaar case BZ-2026-0042
+- **AND** the bezwaar case has status "Beslissing op bezwaar" or "Afgehandeld"
+- **THEN** the behandelaar SHALL be able to create a beroep case linked to the bezwaar case
+- **AND** the beroep case SHALL reference the bezwaar case as its parent
+- **AND** the beroep case SHALL reference the beslissing op bezwaar as the contested decision
+- **AND** the bezwaar case SHALL display a link to the beroep case in its timeline
+
+#### Scenario: Beroep case inherits relevant data from bezwaar
+
+- **WHEN** a beroep case is created from bezwaar BZ-2026-0042
+- **THEN** the system SHALL pre-fill:
+  - Bezwaarmaker becomes the appellant (initiator) on the beroep case
+  - The contested decision references the beslissing op bezwaar
+  - The case description references the original bezwaar grounds
+- **AND** the behandelaar SHALL be able to modify pre-filled data before saving
+
+#### Scenario: Voorlopige voorziening tracking
+
+- **WHEN** the appellant has also requested a voorlopige voorziening (interim relief) alongside the beroep
+- **THEN** the beroep case SHALL have a boolean `voorzieningRequested` property set to `true`
+- **AND** the system SHALL display a flag on the case indicating urgency due to the interim relief request
+
+### Requirement: Court Proceedings Document Management
+
+The system SHALL support tracking key court documents within the beroep case.
+
+**Feature tier**: V1
+
+#### Scenario: Upload verweerschrift (defense document)
+
+- **WHEN** the municipality prepares its defense for beroep case BR-2026-0015
+- **THEN** the behandelaar SHALL be able to upload the verweerschrift as a case document
+- **AND** the case status SHALL transition to "Verweerschrift ingediend"
+
+#### Scenario: Record court ruling
+
+- **WHEN** the court issues its ruling (uitspraak) on beroep case BR-2026-0015
+- **THEN** the behandelaar SHALL record the ruling outcome: beroep_gegrond, beroep_ongegrond, deels_gegrond, niet_ontvankelijk
+- **AND** the case status SHALL transition to "Uitspraak ontvangen"
+- **AND** if the ruling requires the municipality to take a new decision, the system SHALL allow creating a follow-up task
+
+### Requirement: Hoger Beroep Awareness
+
+The system SHALL inform users about the possibility of hoger beroep (further appeal) after a court ruling, but SHALL NOT implement a full hoger beroep workflow.
+
+**Feature tier**: V1
+
+#### Scenario: Display hoger beroep information after ruling
+
+- **WHEN** a court ruling is recorded on a beroep case
+- **THEN** the system SHALL display informational text: "Na de uitspraak van de rechtbank kan hoger beroep worden ingesteld bij de Afdeling bestuursrechtspraak van de Raad van State (ABRvS) of de Centrale Raad van Beroep (CRvB)"
+- **AND** the system SHALL NOT create an automated hoger beroep case (this is a non-goal for this change)

--- a/openspec/changes/archive/2026-03-22-bezwaar-beroep-workflow/specs/bezwaar-advisory-committee/spec.md
+++ b/openspec/changes/archive/2026-03-22-bezwaar-beroep-workflow/specs/bezwaar-advisory-committee/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+### Requirement: Advisory Committee Report Schema
+
+The system SHALL support recording advisory reports from the bezwaarschriftencommissie (objection advisory committee) as OpenRegister objects. Under AWB art. 7:13, many municipalities use an independent advisory committee to advise on bezwaar cases.
+
+**Feature tier**: V1
+**Schema.org mapping**: `schema:Report` with `schema:about` referencing the bezwaar case
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `case` | reference (UUID) | Yes | The bezwaar case this report belongs to |
+| `hearingSession` | reference (UUID) | No | The hearing session this report is based on |
+| `committeeChair` | reference (UUID to role) | Yes | Voorzitter who signed the report |
+| `committeeMembers` | array of references | No | Committee members involved |
+| `adviceDate` | date | Yes | Date the advice was issued |
+| `adviceType` | enum | Yes | gegrond, ongegrond, deels_gegrond, niet_ontvankelijk |
+| `summary` | string (text) | Yes | Summary of the committee's advice |
+| `grounds` | string (text) | Yes | Legal reasoning and grounds for the advice |
+| `recommendation` | string (text) | Yes | Recommended action for the bestuursorgaan |
+| `deviationFromPrimaryDecision` | boolean | Yes | Whether the committee advises differently from the original decision |
+| `reportDocument` | reference (UUID) | No | Full advisory report document |
+
+#### Scenario: Create advisory committee report
+
+- **WHEN** the bezwaarschriftencommissie has completed its review of bezwaar BZ-2026-0042
+- **THEN** the commissie secretaris SHALL create an advisory report with `adviceType` and `recommendation`
+- **AND** the case status SHALL transition to "Advies uitgebracht"
+- **AND** the report SHALL reference the hearing session if one was held
+
+#### Scenario: Advisory report recommends overturning original decision
+
+- **WHEN** the committee issues advice with `adviceType: gegrond` and `deviationFromPrimaryDecision: true`
+- **THEN** the system SHALL flag the case as requiring attention from the decision maker
+- **AND** a notification SHALL be sent to the user with the "Beslisser" role on the case
+
+#### Scenario: Advisory report with partial upholding
+
+- **WHEN** the committee issues advice with `adviceType: deels_gegrond`
+- **THEN** the `recommendation` field SHALL specify which grounds are upheld and which are rejected
+- **AND** the `grounds` field SHALL contain the legal reasoning for each determination
+
+### Requirement: Committee Composition Tracking
+
+The system SHALL track which committee members participated in each bezwaar case to ensure independence and prevent conflicts of interest.
+
+**Feature tier**: V1
+
+#### Scenario: Committee member was involved in original decision
+
+- **WHEN** a user with role "Lid commissie" on the bezwaar case is also the "Primair beslisser" on the contested original case
+- **THEN** the system SHALL display a warning: "Commissielid was betrokken bij het primaire besluit"
+- **AND** the warning SHALL be visible to the voorzitter commissie
+- **AND** the system SHALL NOT block the assignment (it is an advisory warning, not an enforcement)
+
+#### Scenario: Minimum committee composition
+
+- **WHEN** an advisory report is being created
+- **THEN** the system SHALL require at least a `committeeChair` to be assigned
+- **AND** the system SHALL display a recommendation to have at least 3 committee members (voorzitter + 2 leden) per municipal best practice

--- a/openspec/changes/archive/2026-03-22-bezwaar-beroep-workflow/specs/bezwaar-decision/spec.md
+++ b/openspec/changes/archive/2026-03-22-bezwaar-beroep-workflow/specs/bezwaar-decision/spec.md
@@ -1,0 +1,87 @@
+## ADDED Requirements
+
+### Requirement: Decision on Objection Schema
+
+The system SHALL support recording the beslissing op bezwaar (decision on objection) as a formal decision object linked to the bezwaar case. This extends the existing `decision` schema with bezwaar-specific properties.
+
+**Feature tier**: V1
+**ZGW mapping**: `besluit` with `besluittype` "Beslissing op bezwaar"
+**AWB reference**: Art. 7:11 (heroverweging), Art. 7:12 (motivering)
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `case` | reference (UUID) | Yes | The bezwaar case |
+| `contestedDecision` | reference (UUID) | Yes | The original besluit being contested |
+| `advisoryReport` | reference (UUID) | No | The committee's advisory report |
+| `dispositionType` | enum | Yes | gegrond, ongegrond, deels_gegrond, niet_ontvankelijk |
+| `dispositionDetails` | string (text) | Yes | Detailed motivation for the decision (motiveringsplicht art. 7:12) |
+| `followsAdvice` | boolean | No | Whether the decision follows the committee's advice |
+| `deviationReason` | string (text) | No | Reason for deviating from committee advice (required when followsAdvice is false) |
+| `remedialAction` | string (text) | No | What corrective action is taken if gegrond/deels_gegrond |
+| `replacementDecision` | reference (UUID) | No | New besluit that replaces the contested one |
+| `decisionDate` | date | Yes | Date the decision was made |
+| `effectiveDate` | date | Yes | Date the decision takes legal effect |
+| `appealInformation` | string (text) | Yes | Information about beroep possibilities (rechtsmiddelenclausule) |
+| `decisionMaker` | reference (UUID to role) | Yes | The person/body that made the decision |
+| `decisionDocument` | reference (UUID) | No | The formal decision letter document |
+
+#### Scenario: Record gegrond (upheld) decision on bezwaar
+
+- **WHEN** the beslisser records a decision with `dispositionType: gegrond` on bezwaar BZ-2026-0042
+- **THEN** the decision object SHALL be created with required `dispositionDetails` explaining the reconsideration
+- **AND** the case status SHALL transition to "Beslissing op bezwaar"
+- **AND** `remedialAction` SHALL describe what corrective action is taken
+- **AND** `appealInformation` SHALL be populated with information about beroep at the administrative court
+
+#### Scenario: Decision deviates from advisory committee advice
+
+- **WHEN** the beslisser records a decision that does not follow the committee's advice
+- **AND** `followsAdvice` is set to `false`
+- **THEN** the system SHALL require `deviationReason` to be filled in
+- **AND** the deviation SHALL be recorded in the case audit trail
+- **AND** per art. 7:13 lid 7, the deviationReason SHALL be included in the decision letter
+
+#### Scenario: Decision includes rechtsmiddelenclausule
+
+- **WHEN** a beslissing op bezwaar is recorded
+- **THEN** `appealInformation` SHALL include:
+  - The option to file beroep at the rechtbank (administrative court)
+  - The 6-week term for filing beroep (art. 6:7)
+  - The name of the competent court
+- **AND** if `appealInformation` is left empty, the system SHALL display a warning: "Rechtsmiddelenclausule ontbreekt"
+
+#### Scenario: Niet-ontvankelijk declaration
+
+- **WHEN** the beslisser records a decision with `dispositionType: niet_ontvankelijk`
+- **THEN** the case status SHALL transition to "Niet-ontvankelijk"
+- **AND** `dispositionDetails` SHALL explain why the bezwaar is inadmissible (e.g., termijn overschreden, geen belanghebbende, geen besluit)
+
+### Requirement: Decision Notification
+
+The system SHALL notify the bezwaarmaker when a decision on their objection has been made.
+
+**Feature tier**: V1
+
+#### Scenario: Notify bezwaarmaker of decision
+
+- **WHEN** a beslissing op bezwaar is recorded and the case transitions to "Beslissing op bezwaar"
+- **THEN** the system SHALL trigger an automatic action to notify the bezwaarmaker
+- **AND** the notification SHALL reference the case number and decision type
+- **AND** if a gemachtigde (representative) is registered on the case, the gemachtigde SHALL also be notified
+
+### Requirement: Heroverweging (Full Reconsideration)
+
+The beslissing op bezwaar SHALL be based on a complete reconsideration (heroverweging) of the original decision, not just a review of the bezwaarmaker's arguments. This is mandated by AWB art. 7:11.
+
+**Feature tier**: V1
+
+#### Scenario: Reconsideration scope includes new facts
+
+- **WHEN** the behandelaar prepares the beslissing op bezwaar
+- **THEN** the decision form SHALL include a field for ex nunc (current situation) assessment
+- **AND** the system SHALL display guidance: "De heroverweging betreft een volledige heroverweging, inclusief feiten en omstandigheden ten tijde van de beslissing op bezwaar"
+
+#### Scenario: Reformatio in peius warning
+
+- **WHEN** the reconsideration could lead to a worse outcome for the bezwaarmaker than the original decision
+- **THEN** the system SHALL display a warning: "Let op: reformatio in peius -- het bezwaar mag in beginsel niet leiden tot een voor de bezwaarmaker nadeliger besluit"

--- a/openspec/changes/archive/2026-03-22-bezwaar-beroep-workflow/specs/bezwaar-hearing/spec.md
+++ b/openspec/changes/archive/2026-03-22-bezwaar-beroep-workflow/specs/bezwaar-hearing/spec.md
@@ -1,0 +1,84 @@
+## ADDED Requirements
+
+### Requirement: Hearing Session Management
+
+The system SHALL support scheduling and managing hoorzittingen (hearings) as part of the bezwaar process. The hearing is a legal right under AWB art. 7:2 -- the bezwaarmaker MUST be offered the opportunity to be heard before a decision on the objection is made.
+
+**Feature tier**: V1
+**CMMN mapping**: HumanTask within bezwaar CasePlanModel
+**Schema.org mapping**: `schema:Event` with `schema:about` referencing the bezwaar case
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `case` | reference (UUID) | Yes | The bezwaar case this hearing belongs to |
+| `scheduledDate` | datetime | Yes | Date and time of the hearing |
+| `location` | string | No | Physical location or "Online" for video hearings |
+| `videoCallUrl` | string (URL) | No | Video conference link for online hearings |
+| `chairperson` | reference (UUID to role) | Yes | Who chairs the hearing (voorzitter) |
+| `members` | array of references | No | Committee members present |
+| `invitees` | array of objects | Yes | Persons invited (bezwaarmaker, gemachtigde, primair beslisser) |
+| `minutesSummary` | string (text) | No | Summary of what was discussed (verslag) |
+| `minutesDocument` | reference (UUID) | No | Full hearing minutes document |
+| `status` | enum | Yes | gepland, uitgenodigd, uitgevoerd, geannuleerd, afgezien |
+| `hearingWaived` | boolean | No | Bezwaarmaker has waived the right to be heard |
+| `waiverReason` | string | No | Reason for waiving hearing right |
+
+#### Scenario: Schedule a hearing for a bezwaar case
+
+- **WHEN** the behandelaar schedules a hearing for bezwaar case BZ-2026-0042
+- **THEN** a hearingSession object SHALL be created with status "gepland"
+- **AND** the case status SHALL transition to "Hoorzitting gepland"
+- **AND** the system SHALL validate that the hearing date is at least 5 working days in the future (to allow preparation time)
+
+#### Scenario: Send hearing invitations
+
+- **WHEN** a hearing is scheduled with status "gepland"
+- **AND** the behandelaar triggers the invitation action
+- **THEN** the system SHALL create a notification for each invitee
+- **AND** the hearing status SHALL change to "uitgenodigd"
+- **AND** the invitation SHALL include: date, time, location, subject of the bezwaar, and the right to bring witnesses (art. 7:8)
+
+#### Scenario: Record hearing minutes
+
+- **WHEN** the hearing has taken place
+- **AND** the chairperson marks the hearing as "uitgevoerd"
+- **THEN** the system SHALL require a `minutesSummary` to be filled in
+- **AND** optionally allow uploading a full minutes document
+- **AND** the case status SHALL transition to "Hoorzitting afgerond"
+
+### Requirement: Hearing Waiver (Afzien van Hoorrecht)
+
+The system SHALL allow the bezwaarmaker to waive their right to a hearing, as permitted under AWB art. 7:3. When the right is waived, the hearing steps SHALL be skipped.
+
+**Feature tier**: V1
+
+#### Scenario: Bezwaarmaker waives hearing right
+
+- **WHEN** the bezwaarmaker indicates they do not wish to be heard
+- **THEN** the behandelaar SHALL record this by creating a hearingSession with `hearingWaived: true` and `waiverReason`
+- **AND** the case SHALL be able to skip the "Hoorzitting gepland" and "Hoorzitting afgerond" statuses
+- **AND** the waiver SHALL be recorded in the case audit trail
+
+#### Scenario: Hearing waiver cannot be recorded after hearing is completed
+
+- **WHEN** a hearing has already been held (status "uitgevoerd")
+- **THEN** the system SHALL NOT allow setting `hearingWaived` to true
+- **AND** an error message SHALL display: "Hoorzitting heeft reeds plaatsgevonden"
+
+### Requirement: Hearing Participants and Access Rights
+
+The system SHALL manage hearing participants with appropriate access rights as defined in AWB art. 7:4 through 7:8.
+
+**Feature tier**: V1
+
+#### Scenario: Bezwaarmaker may bring a representative
+
+- **WHEN** the bezwaarmaker is invited to a hearing
+- **THEN** the invitation SHALL state that they may bring a gemachtigde (authorized representative)
+- **AND** the system SHALL allow adding a "Vertegenwoordiger" role to the case for the gemachtigde
+
+#### Scenario: Bezwaarmaker may inspect case documents before hearing
+
+- **WHEN** a hearing is scheduled for bezwaar case BZ-2026-0042
+- **THEN** the bezwaarmaker SHALL have the right to inspect all case documents for at least 1 week before the hearing (art. 7:4 lid 2)
+- **AND** the system SHALL track which documents are part of the bezwaardossier

--- a/openspec/changes/archive/2026-03-22-bezwaar-beroep-workflow/specs/bezwaar-lifecycle/spec.md
+++ b/openspec/changes/archive/2026-03-22-bezwaar-beroep-workflow/specs/bezwaar-lifecycle/spec.md
@@ -1,0 +1,155 @@
+## ADDED Requirements
+
+### Requirement: Bezwaar Case Type Pre-Seeded Configuration
+
+The system SHALL provide a pre-seeded "Bezwaar" (objection) case type with AWB chapter 6/7 compliant configuration. The case type SHALL be imported via the repair step alongside existing case types.
+
+**Feature tier**: V1
+**ZGW mapping**: `zaaktype` with `omschrijving` "Bezwaar"
+**CMMN mapping**: CaseDefinition with TimerEventListeners for legal deadlines
+
+| Property | Value |
+|----------|-------|
+| `title` | Bezwaar |
+| `description` | Bezwaarprocedure conform Awb hoofdstuk 6 en 7 |
+| `processingDeadline` | P6W (6 weeks, Awb art. 7:10 lid 1) |
+| `extensionAllowed` | true |
+| `extensionPeriod` | P6W (6 weeks extension, Awb art. 7:10 lid 3) |
+| `suspensionAllowed` | true |
+| `origin` | external |
+| `trigger` | Bezwaarschrift van belanghebbende |
+| `subject` | Bezwaar tegen besluit |
+
+#### Scenario: Bezwaar case type is available after installation
+
+- **WHEN** the Procest app repair step runs
+- **THEN** a case type "Bezwaar" SHALL exist in the procest register
+- **AND** the case type SHALL have `processingDeadline` set to `P6W`
+- **AND** the case type SHALL have `extensionAllowed` set to `true` with `extensionPeriod` `P6W`
+- **AND** the case type SHALL have `suspensionAllowed` set to `true`
+
+### Requirement: Bezwaar Status Types
+
+The system SHALL provide pre-seeded status types for the Bezwaar case type that reflect the AWB-mandated process phases. Status types SHALL be ordered to enforce the legal process sequence.
+
+**Feature tier**: V1
+**ZGW mapping**: `statustype` linked to bezwaar `zaaktype`
+
+| Order | Status Type | Description | AWB Reference |
+|-------|-------------|-------------|---------------|
+| 1 | Ontvangen | Bezwaarschrift is ontvangen | Art. 6:4 |
+| 2 | Ontvankelijkheidstoets | Toetsing op ontvankelijkheid | Art. 6:5, 6:6 |
+| 3 | In behandeling | Inhoudelijke behandeling gestart | Art. 7:2 |
+| 4 | Hoorzitting gepland | Hoorzitting is ingepland | Art. 7:2 |
+| 5 | Hoorzitting afgerond | Hoorzitting heeft plaatsgevonden | Art. 7:7 |
+| 6 | Advies uitgebracht | Bezwaarschriftencommissie heeft advies uitgebracht | Art. 7:13 |
+| 7 | Beslissing op bezwaar | Besluit op bezwaar is genomen | Art. 7:11, 7:12 |
+| 8 | Afgehandeld | Bezwaarprocedure is volledig afgerond | -- |
+| -- | Niet-ontvankelijk | Bezwaar is niet-ontvankelijk verklaard | Art. 6:6 |
+| -- | Ingetrokken | Bezwaar is ingetrokken door indiener | Art. 6:21 |
+
+#### Scenario: All bezwaar status types are seeded
+
+- **WHEN** the repair step completes
+- **THEN** 10 status types SHALL exist for the Bezwaar case type
+- **AND** they SHALL be ordered from 1 (Ontvangen) through 8 (Afgehandeld) with Niet-ontvankelijk and Ingetrokken as terminal statuses
+
+#### Scenario: Skip hearing when right is waived
+
+- **WHEN** the bezwaarmaker waives the right to a hearing (afzien van hoorrecht)
+- **THEN** the case SHALL be able to transition from "Ontvankelijkheidstoets" or "In behandeling" directly to "Advies uitgebracht" or "Beslissing op bezwaar"
+- **AND** the skip SHALL be recorded in the case audit trail with reason "Belanghebbende heeft afgezien van het recht te worden gehoord"
+
+### Requirement: Bezwaar Role Types
+
+The system SHALL provide pre-seeded role types for the Bezwaar case type covering all participants in the objection process.
+
+**Feature tier**: V1
+**ZGW mapping**: `roltype` linked to bezwaar `zaaktype`
+
+| Role Type | Generic Role | Description |
+|-----------|-------------|-------------|
+| Bezwaarmaker | initiator | De persoon die bezwaar maakt |
+| Behandelaar bezwaar | handler | Ambtenaar die het bezwaar behandelt |
+| Voorzitter commissie | decision_maker | Voorzitter bezwaarschriftencommissie |
+| Lid commissie | advisor | Lid van de bezwaarschriftencommissie |
+| Secretaris commissie | coordinator | Secretaris van de bezwaarschriftencommissie |
+| Vertegenwoordiger | stakeholder | Gemachtigde of vertegenwoordiger van bezwaarmaker |
+| Primair beslisser | advisor | Ambtenaar die het oorspronkelijke besluit nam |
+
+#### Scenario: All bezwaar role types are seeded
+
+- **WHEN** the repair step completes
+- **THEN** 7 role types SHALL exist for the Bezwaar case type
+- **AND** each role type SHALL map to a standard generic role
+
+### Requirement: Bezwaar Deadline Calculation
+
+The system SHALL automatically calculate legal deadlines when a bezwaar case is created, based on AWB articles 6:7, 6:8, 7:10, and 7:24.
+
+**Feature tier**: V1
+
+#### Scenario: Standard deadline calculation on case creation
+
+- **WHEN** a bezwaar case is created with `ontvangstdatum` 2026-03-01 (Monday)
+- **THEN** the system SHALL calculate:
+  - `ontvangstbevestigingDeadline`: within 1 week (2026-03-08)
+  - `afhandelDeadline`: 6 weeks from ontvangstdatum (2026-04-12)
+  - `verdagingMogelijk`: true (6-week extension available per art. 7:10 lid 3)
+- **AND** these deadlines SHALL be stored as properties on the case object
+
+#### Scenario: Extended deadline after verdaging
+
+- **WHEN** the behandelaar extends the deadline (verdaging) on a bezwaar case with original deadline 2026-04-12
+- **THEN** the new `afhandelDeadline` SHALL be 2026-05-24 (original + 6 weeks)
+- **AND** the extension SHALL be recorded in the audit trail
+- **AND** the bezwaarmaker SHALL be notified of the extension per art. 7:10 lid 3
+
+#### Scenario: Deadline suspension (opschorting)
+
+- **WHEN** the behandelaar suspends the deadline because additional information is requested from the bezwaarmaker
+- **THEN** the deadline clock SHALL stop
+- **AND** the suspension SHALL be recorded with start date and reason
+- **AND** when the bezwaarmaker provides the information, the deadline clock SHALL resume with the remaining days added
+
+#### Scenario: Deadline warning notification
+
+- **WHEN** a bezwaar case is within 5 working days of its `afhandelDeadline`
+- **AND** the case status is not "Afgehandeld", "Niet-ontvankelijk", or "Ingetrokken"
+- **THEN** the system SHALL create a warning notification for the bezwaar behandelaar
+- **AND** the case SHALL appear in the dashboard overdue/at-risk section
+
+### Requirement: Bezwaar Objection Object Schema
+
+The system SHALL store bezwaarschrift (objection letter) details as an OpenRegister object linked to the bezwaar case. This captures the formal objection content separately from the case metadata.
+
+**Feature tier**: V1
+**Schema.org mapping**: `schema:Message` with `schema:about` referencing the contested decision
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `case` | reference (UUID) | Yes | The bezwaar case this objection belongs to |
+| `contestedDecision` | reference (UUID) | Yes | The original besluit being contested |
+| `grounds` | string (text) | Yes | The grounds for objection (gronden van bezwaar) |
+| `requestedRelief` | string (text) | No | What outcome the bezwaarmaker seeks |
+| `receivedDate` | date | Yes | Date the bezwaarschrift was received |
+| `receivedChannel` | enum | Yes | How it was received (brief, email, formulier, balie) |
+| `isTimely` | boolean | No | Whether the objection was filed within the 6-week term (art. 6:7) |
+| `timelinessAssessment` | string | No | Explanation of timeliness determination |
+| `proVoorziening` | boolean | No | Whether a voorlopige voorziening (interim relief) was requested |
+| `attachments` | array of references | No | Supporting documents uploaded by bezwaarmaker |
+
+#### Scenario: Create objection linked to contested decision
+
+- **WHEN** an intake worker creates a bezwaar case
+- **THEN** an objection object SHALL be created linking the case to the original besluit
+- **AND** the `contestedDecision` field SHALL reference the UUID of the besluit being contested
+- **AND** the `grounds` field SHALL contain the bezwaarmaker's stated reasons
+
+#### Scenario: Timeliness check (ontvankelijkheidstoets)
+
+- **WHEN** the behandelaar performs the ontvankelijkheidstoets
+- **AND** the bezwaarschrift was received more than 6 weeks after the besluit publication date
+- **THEN** the `isTimely` field SHALL default to `false`
+- **AND** the system SHALL display a warning: "Bezwaartermijn mogelijk overschreden"
+- **AND** the behandelaar SHALL be able to override with a `timelinessAssessment` explanation (e.g., verschoonbare termijnoverschrijding)

--- a/openspec/changes/archive/2026-03-22-bezwaar-beroep-workflow/specs/case-types/spec.md
+++ b/openspec/changes/archive/2026-03-22-bezwaar-beroep-workflow/specs/case-types/spec.md
@@ -1,0 +1,32 @@
+## MODIFIED Requirements
+
+### Requirement: Case Type Pre-Seeded Data
+
+The system SHALL provide pre-seeded case types that are imported via the repair step. In addition to any existing pre-seeded case types, the system SHALL now include Bezwaar and Beroep case types with their associated status types, role types, and workflow templates.
+
+**Feature tier**: V1
+
+The repair step SHALL import the following new case types alongside existing ones:
+
+| Case Type | Processing Deadline | Extension | Suspension | Origin |
+|-----------|-------------------|-----------|------------|--------|
+| Bezwaar | P6W | P6W | Yes | external |
+| Beroep | P26W | No | Yes | external |
+
+Each case type SHALL include its associated:
+- Status types (see bezwaar-lifecycle and beroep-escalation specs)
+- Role types (see bezwaar-lifecycle spec)
+- Workflow template (see workflow-definition-model spec)
+
+#### Scenario: Bezwaar and Beroep case types are available after installation
+
+- **WHEN** the Procest app repair step runs for the first time or after an update
+- **THEN** case types "Bezwaar" and "Beroep" SHALL exist in the procest register
+- **AND** each SHALL have its complete set of status types, role types, and an active workflow template
+- **AND** existing case types SHALL NOT be affected by the addition
+
+#### Scenario: Pre-seeded case types are not duplicated on re-run
+
+- **WHEN** the repair step runs again on an installation that already has Bezwaar and Beroep case types
+- **THEN** the system SHALL NOT create duplicate case types
+- **AND** existing customizations to the case types SHALL be preserved

--- a/openspec/changes/archive/2026-03-22-bezwaar-beroep-workflow/specs/workflow-definition-model/spec.md
+++ b/openspec/changes/archive/2026-03-22-bezwaar-beroep-workflow/specs/workflow-definition-model/spec.md
@@ -1,0 +1,74 @@
+## ADDED Requirements
+
+### Requirement: Pre-Seeded Bezwaar Workflow Template
+
+The system SHALL provide a pre-seeded workflow template for the Bezwaar case type that encodes the AWB-mandated process steps, transitions, and guards. The template SHALL be imported via the repair step alongside the bezwaar case type.
+
+**Feature tier**: V1
+
+The bezwaar workflow template SHALL define the following transitions:
+
+| From Status | To Status | Label | Guards |
+|-------------|-----------|-------|--------|
+| Ontvangen | Ontvankelijkheidstoets | Start toets | roleGuard: Behandelaar bezwaar |
+| Ontvankelijkheidstoets | In behandeling | Ontvankelijk | requiredField: isTimely assessment |
+| Ontvankelijkheidstoets | Niet-ontvankelijk | Niet-ontvankelijk verklaren | requiredField: dispositionDetails |
+| In behandeling | Hoorzitting gepland | Hoorzitting plannen | -- |
+| In behandeling | Advies uitgebracht | Hoorrecht afgezien | requiredField: hearingWaived=true |
+| Hoorzitting gepland | Hoorzitting afgerond | Hoorzitting afronden | requiredField: minutesSummary |
+| Hoorzitting afgerond | Advies uitgebracht | Advies uitbrengen | requiredField: advisoryReport |
+| In behandeling | Beslissing op bezwaar | Direct beslissen | roleGuard: Beslisser (when no committee) |
+| Advies uitgebracht | Beslissing op bezwaar | Beslissing nemen | requiredField: dispositionType, dispositionDetails |
+| Beslissing op bezwaar | Afgehandeld | Afronden | checklist: decision letter sent, rechtsmiddelenclausule included |
+| Any active | Ingetrokken | Intrekken | requiredField: withdrawal reason |
+
+The workflow template SHALL include workflow steps for each status phase:
+
+| Status Phase | Steps |
+|-------------|-------|
+| Ontvangen | Registreer bezwaarschrift, Controleer volledigheid, Bevestig ontvangst |
+| Ontvankelijkheidstoets | Toets termijn, Toets belanghebbendheid, Toets besluit-karakter |
+| In behandeling | Stel dossier samen, Informeer primair beslisser, Plan hoorzitting of registreer afzien |
+| Hoorzitting gepland | Verstuur uitnodigingen, Bereid hoorzitting voor |
+| Hoorzitting afgerond | Maak verslag, Deel verslag met partijen |
+| Advies uitgebracht | Stel advies op, Deel advies met bestuursorgaan |
+| Beslissing op bezwaar | Neem beslissing, Stel besluit op, Verstuur besluit met rechtsmiddelenclausule |
+
+#### Scenario: Bezwaar workflow template is seeded after repair
+
+- **WHEN** the Procest app repair step runs
+- **THEN** a workflow template SHALL exist for the Bezwaar case type
+- **AND** the template SHALL contain all defined transitions with their guards
+- **AND** the template SHALL contain all defined steps per status phase
+- **AND** the template SHALL be published (isDraft: false, isActive: true)
+
+#### Scenario: Administrator can customize the bezwaar workflow
+
+- **WHEN** an administrator opens the Bezwaar case type in the admin settings
+- **THEN** the pre-seeded workflow template SHALL be visible in the workflow tab
+- **AND** the administrator SHALL be able to create a new version to customize steps and transitions
+- **AND** the original pre-seeded template SHALL remain as a base version
+
+### Requirement: Pre-Seeded Beroep Workflow Template
+
+The system SHALL provide a pre-seeded workflow template for the Beroep case type with transitions for tracking court proceedings.
+
+**Feature tier**: V1
+
+| From Status | To Status | Label | Guards |
+|-------------|-----------|-------|--------|
+| Beroep ontvangen | Verweerschrift in voorbereiding | Start verweer | roleGuard: Behandelaar |
+| Verweerschrift in voorbereiding | Verweerschrift ingediend | Verweer indienen | requiredDocument: Verweerschrift |
+| Verweerschrift ingediend | Zitting gepland | Zitting plannen | -- |
+| Zitting gepland | Zitting afgerond | Zitting afronden | -- |
+| Zitting afgerond | Uitspraak ontvangen | Uitspraak registreren | requiredField: ruling outcome |
+| Uitspraak ontvangen | Afgehandeld | Afronden | -- |
+| Any active | Ingetrokken | Intrekken | -- |
+| Any active | Schikking | Schikking treffen | requiredField: settlement details |
+
+#### Scenario: Beroep workflow template is seeded after repair
+
+- **WHEN** the Procest app repair step runs
+- **THEN** a workflow template SHALL exist for the Beroep case type
+- **AND** the template SHALL contain all defined transitions
+- **AND** the template SHALL be published (isDraft: false, isActive: true)

--- a/openspec/changes/archive/2026-03-22-bezwaar-beroep-workflow/tasks.md
+++ b/openspec/changes/archive/2026-03-22-bezwaar-beroep-workflow/tasks.md
@@ -1,0 +1,72 @@
+## 1. Schema Definitions
+
+- [x] 1.1 Add `objection` schema to `procest_register.json` with all properties from bezwaar-lifecycle spec (case, contestedDecision, grounds, requestedRelief, receivedDate, receivedChannel, isTimely, timelinessAssessment, proVoorziening, attachments)
+- [x] 1.2 Add `hearingSession` schema to `procest_register.json` with all properties from bezwaar-hearing spec (case, scheduledDate, location, videoCallUrl, chairperson, members, invitees, minutesSummary, minutesDocument, status, hearingWaived, waiverReason)
+- [x] 1.3 Add `advisoryReport` schema to `procest_register.json` with all properties from bezwaar-advisory-committee spec (case, hearingSession, committeeChair, committeeMembers, adviceDate, adviceType, summary, grounds, recommendation, deviationFromPrimaryDecision, reportDocument)
+- [x] 1.4 Add `appealDecision` schema to `procest_register.json` with all properties from bezwaar-decision spec (case, contestedDecision, advisoryReport, dispositionType, dispositionDetails, followsAdvice, deviationReason, remedialAction, replacementDecision, decisionDate, effectiveDate, appealInformation, decisionMaker, decisionDocument)
+
+## 2. Pre-Seeded Case Types and Status Types
+
+- [x] 2.1 Add Bezwaar case type definition to `procest_register.json` with AWB-compliant properties (P6W deadline, extension P6W, suspension allowed, external origin)
+- [x] 2.2 Add 10 Bezwaar status types to `procest_register.json` (Ontvangen, Ontvankelijkheidstoets, In behandeling, Hoorzitting gepland, Hoorzitting afgerond, Advies uitgebracht, Beslissing op bezwaar, Afgehandeld, Niet-ontvankelijk, Ingetrokken)
+- [x] 2.3 Add 7 Bezwaar role types to `procest_register.json` (Bezwaarmaker, Behandelaar bezwaar, Voorzitter commissie, Lid commissie, Secretaris commissie, Vertegenwoordiger, Primair beslisser)
+- [x] 2.4 Add Beroep case type definition to `procest_register.json` with properties (P26W deadline, no extension, suspension allowed, external origin)
+- [x] 2.5 Add 9 Beroep status types to `procest_register.json` (Beroep ontvangen, Verweerschrift in voorbereiding, Verweerschrift ingediend, Zitting gepland, Zitting afgerond, Uitspraak ontvangen, Afgehandeld, Ingetrokken, Schikking)
+
+## 3. Pre-Seeded Workflow Templates
+
+- [x] 3.1 Add Bezwaar workflow template to `procest_register.json` with all transitions from workflow-definition-model spec (11 transitions with guards)
+- [x] 3.2 Add Bezwaar workflow steps per status phase to the workflow template (7 phases, ~20 steps total)
+- [x] 3.3 Add Beroep workflow template to `procest_register.json` with all transitions from workflow-definition-model spec (8 transitions)
+- [x] 3.4 Add automatic actions to bezwaar workflow transitions (deadline warning notifications, hearing invitations, decision notifications)
+
+## 4. Frontend Store
+
+- [x] 4.1 Create `src/store/modules/bezwaar.js` Pinia store with CRUD operations for objection objects (list, get, create, update, delete via OpenRegister API)
+- [x] 4.2 Add hearing session CRUD operations to bezwaar store (create, update, list by case)
+- [x] 4.3 Add advisory report CRUD operations to bezwaar store (create, update, get by case)
+- [x] 4.4 Add appeal decision CRUD operations to bezwaar store (create, update, get by case)
+- [x] 4.5 Add deadline calculation logic to bezwaar store (compute afhandelDeadline, ontvangstbevestigingDeadline, handle extension/suspension)
+- [x] 4.6 Add escalation action to bezwaar store (create beroep case from bezwaar with pre-filled data)
+- [x] 4.7 Register bezwaar store module in `src/store/store.js`
+
+## 5. Frontend Components — Bezwaar
+
+- [x] 5.1 Create `src/components/bezwaar/BezwaarIntakeForm.vue` — objection intake form with contested decision selector, grounds, received date/channel, timeliness check
+- [x] 5.2 Create `src/components/bezwaar/HearingPanel.vue` — hearing session management with scheduling, invitation trigger, minutes recording, waiver option
+- [x] 5.3 Create `src/components/bezwaar/AdvisoryReportPanel.vue` — committee advisory report form with advice type selector, grounds, recommendation, committee composition
+- [x] 5.4 Create `src/components/bezwaar/BezwaarDecisionForm.vue` — decision on objection form with disposition type, motivation, follows-advice toggle, rechtsmiddelenclausule, reformatio in peius warning
+- [x] 5.5 Create `src/components/bezwaar/BezwaarTimeline.vue` — bezwaar-specific timeline showing legal deadlines, hearing dates, advisory dates, decision date alongside case status transitions
+- [x] 5.6 Create `src/components/bezwaar/DeadlineIndicator.vue` — visual deadline indicator showing days remaining, at-risk/overdue state, suspension status
+
+## 6. Frontend Components — Beroep
+
+- [x] 6.1 Create `src/components/beroep/BeroepEscalationPanel.vue` — panel to create beroep case from bezwaar with pre-filled data, voorlopige voorziening flag
+- [x] 6.2 Create `src/components/beroep/CourtProceedingsPanel.vue` — verweerschrift upload, zitting tracking, uitspraak recording with outcome type
+
+## 7. Case Detail Integration
+
+- [x] 7.1 Add conditional rendering in case detail view to show bezwaar-specific sections when case type is "Bezwaar" (intake form, hearing panel, advisory report, decision form, timeline)
+- [x] 7.2 Add conditional rendering in case detail view to show beroep-specific sections when case type is "Beroep" (court proceedings panel)
+- [x] 7.3 Add bezwaar-to-beroep escalation link in bezwaar case detail when status is "Beslissing op bezwaar" or "Afgehandeld"
+- [x] 7.4 Add parent case link display in beroep case detail showing the originating bezwaar case
+
+## 8. Validation and Guards
+
+- [x] 8.1 Add timeliness validation in BezwaarIntakeForm — auto-calculate whether bezwaar was filed within 6-week term, display warning when late
+- [x] 8.2 Add hearing waiver validation — prevent waiver after hearing is completed
+- [x] 8.3 Add advisory report committee composition recommendation — display warning when fewer than 3 members
+- [x] 8.4 Add committee conflict-of-interest warning — detect when a committee member was the original decision maker
+- [x] 8.5 Add decision form validation — require deviationReason when followsAdvice is false, require rechtsmiddelenclausule, display reformatio in peius warning
+- [x] 8.6 Add deadline warning logic — trigger notification when bezwaar case is within 5 working days of afhandelDeadline
+
+## 9. Testing and Verification
+
+- [x] 9.1 Verify all 4 new schemas are imported correctly via repair step (create objects, validate required fields)
+- [x] 9.2 Verify Bezwaar and Beroep case types are seeded with correct status types, role types
+- [x] 9.3 Verify workflow templates are seeded and functional (transitions, guards, steps)
+- [x] 9.4 Test complete bezwaar happy path: intake -> ontvankelijkheidstoets -> hoorzitting -> advies -> beslissing -> afgehandeld
+- [x] 9.5 Test bezwaar path with hearing waiver: intake -> ontvankelijkheidstoets -> direct to advies/beslissing
+- [x] 9.6 Test bezwaar-to-beroep escalation: create beroep from completed bezwaar, verify data pre-fill
+- [x] 9.7 Test deadline calculation: verify 6-week deadline, extension, suspension/resume
+- [x] 9.8 Verify pre-seeded data is not duplicated on repair step re-run

--- a/openspec/specs/beroep-escalation/spec.md
+++ b/openspec/specs/beroep-escalation/spec.md
@@ -1,0 +1,111 @@
+## ADDED Requirements
+
+### Requirement: Beroep Case Type Pre-Seeded Configuration
+
+The system SHALL provide a pre-seeded "Beroep" (appeal) case type for tracking appeals to the administrative court (bestuursrechter). Beroep is the next step after bezwaar when a citizen disagrees with the beslissing op bezwaar.
+
+**Feature tier**: V1
+**ZGW mapping**: `zaaktype` with `omschrijving` "Beroep"
+**AWB reference**: Art. 8:1 (beroep bij de rechtbank)
+
+| Property | Value |
+|----------|-------|
+| `title` | Beroep |
+| `description` | Beroepsprocedure bij de bestuursrechter conform Awb hoofdstuk 8 |
+| `processingDeadline` | P26W (6 months indicative, actual timeline determined by court) |
+| `extensionAllowed` | false |
+| `suspensionAllowed` | true |
+| `origin` | external |
+| `trigger` | Beroepschrift bij de bestuursrechter |
+| `subject` | Beroep tegen beslissing op bezwaar |
+
+#### Scenario: Beroep case type is available after installation
+
+- **WHEN** the Procest app repair step runs
+- **THEN** a case type "Beroep" SHALL exist in the procest register
+- **AND** the case type SHALL have appropriate status types for court proceedings tracking
+
+### Requirement: Beroep Status Types
+
+The system SHALL provide status types for the Beroep case type reflecting the stages of court proceedings that the municipality needs to track.
+
+**Feature tier**: V1
+
+| Order | Status Type | Description |
+|-------|-------------|-------------|
+| 1 | Beroep ontvangen | Beroepschrift ontvangen van rechtbank |
+| 2 | Verweerschrift in voorbereiding | Municipality preparing defense |
+| 3 | Verweerschrift ingediend | Defense submitted to court |
+| 4 | Zitting gepland | Court hearing scheduled |
+| 5 | Zitting afgerond | Court hearing completed |
+| 6 | Uitspraak ontvangen | Court ruling received |
+| 7 | Afgehandeld | Case closed after ruling |
+| -- | Ingetrokken | Appeal withdrawn by appellant |
+| -- | Schikking | Settled out of court |
+
+#### Scenario: Beroep status types are seeded
+
+- **WHEN** the repair step completes
+- **THEN** 9 status types SHALL exist for the Beroep case type
+- **AND** they SHALL be ordered to reflect the court proceedings timeline
+
+### Requirement: Escalation from Bezwaar to Beroep
+
+The system SHALL support creating a beroep case from a completed bezwaar case, linking the two cases as parent-child. This happens when the bezwaarmaker appeals the beslissing op bezwaar at the administrative court.
+
+**Feature tier**: V1
+
+#### Scenario: Create beroep case from bezwaar
+
+- **WHEN** a beroepschrift is received for bezwaar case BZ-2026-0042
+- **AND** the bezwaar case has status "Beslissing op bezwaar" or "Afgehandeld"
+- **THEN** the behandelaar SHALL be able to create a beroep case linked to the bezwaar case
+- **AND** the beroep case SHALL reference the bezwaar case as its parent
+- **AND** the beroep case SHALL reference the beslissing op bezwaar as the contested decision
+- **AND** the bezwaar case SHALL display a link to the beroep case in its timeline
+
+#### Scenario: Beroep case inherits relevant data from bezwaar
+
+- **WHEN** a beroep case is created from bezwaar BZ-2026-0042
+- **THEN** the system SHALL pre-fill:
+  - Bezwaarmaker becomes the appellant (initiator) on the beroep case
+  - The contested decision references the beslissing op bezwaar
+  - The case description references the original bezwaar grounds
+- **AND** the behandelaar SHALL be able to modify pre-filled data before saving
+
+#### Scenario: Voorlopige voorziening tracking
+
+- **WHEN** the appellant has also requested a voorlopige voorziening (interim relief) alongside the beroep
+- **THEN** the beroep case SHALL have a boolean `voorzieningRequested` property set to `true`
+- **AND** the system SHALL display a flag on the case indicating urgency due to the interim relief request
+
+### Requirement: Court Proceedings Document Management
+
+The system SHALL support tracking key court documents within the beroep case.
+
+**Feature tier**: V1
+
+#### Scenario: Upload verweerschrift (defense document)
+
+- **WHEN** the municipality prepares its defense for beroep case BR-2026-0015
+- **THEN** the behandelaar SHALL be able to upload the verweerschrift as a case document
+- **AND** the case status SHALL transition to "Verweerschrift ingediend"
+
+#### Scenario: Record court ruling
+
+- **WHEN** the court issues its ruling (uitspraak) on beroep case BR-2026-0015
+- **THEN** the behandelaar SHALL record the ruling outcome: beroep_gegrond, beroep_ongegrond, deels_gegrond, niet_ontvankelijk
+- **AND** the case status SHALL transition to "Uitspraak ontvangen"
+- **AND** if the ruling requires the municipality to take a new decision, the system SHALL allow creating a follow-up task
+
+### Requirement: Hoger Beroep Awareness
+
+The system SHALL inform users about the possibility of hoger beroep (further appeal) after a court ruling, but SHALL NOT implement a full hoger beroep workflow.
+
+**Feature tier**: V1
+
+#### Scenario: Display hoger beroep information after ruling
+
+- **WHEN** a court ruling is recorded on a beroep case
+- **THEN** the system SHALL display informational text: "Na de uitspraak van de rechtbank kan hoger beroep worden ingesteld bij de Afdeling bestuursrechtspraak van de Raad van State (ABRvS) of de Centrale Raad van Beroep (CRvB)"
+- **AND** the system SHALL NOT create an automated hoger beroep case (this is a non-goal for this change)

--- a/openspec/specs/bezwaar-advisory-committee/spec.md
+++ b/openspec/specs/bezwaar-advisory-committee/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+### Requirement: Advisory Committee Report Schema
+
+The system SHALL support recording advisory reports from the bezwaarschriftencommissie (objection advisory committee) as OpenRegister objects. Under AWB art. 7:13, many municipalities use an independent advisory committee to advise on bezwaar cases.
+
+**Feature tier**: V1
+**Schema.org mapping**: `schema:Report` with `schema:about` referencing the bezwaar case
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `case` | reference (UUID) | Yes | The bezwaar case this report belongs to |
+| `hearingSession` | reference (UUID) | No | The hearing session this report is based on |
+| `committeeChair` | reference (UUID to role) | Yes | Voorzitter who signed the report |
+| `committeeMembers` | array of references | No | Committee members involved |
+| `adviceDate` | date | Yes | Date the advice was issued |
+| `adviceType` | enum | Yes | gegrond, ongegrond, deels_gegrond, niet_ontvankelijk |
+| `summary` | string (text) | Yes | Summary of the committee's advice |
+| `grounds` | string (text) | Yes | Legal reasoning and grounds for the advice |
+| `recommendation` | string (text) | Yes | Recommended action for the bestuursorgaan |
+| `deviationFromPrimaryDecision` | boolean | Yes | Whether the committee advises differently from the original decision |
+| `reportDocument` | reference (UUID) | No | Full advisory report document |
+
+#### Scenario: Create advisory committee report
+
+- **WHEN** the bezwaarschriftencommissie has completed its review of bezwaar BZ-2026-0042
+- **THEN** the commissie secretaris SHALL create an advisory report with `adviceType` and `recommendation`
+- **AND** the case status SHALL transition to "Advies uitgebracht"
+- **AND** the report SHALL reference the hearing session if one was held
+
+#### Scenario: Advisory report recommends overturning original decision
+
+- **WHEN** the committee issues advice with `adviceType: gegrond` and `deviationFromPrimaryDecision: true`
+- **THEN** the system SHALL flag the case as requiring attention from the decision maker
+- **AND** a notification SHALL be sent to the user with the "Beslisser" role on the case
+
+#### Scenario: Advisory report with partial upholding
+
+- **WHEN** the committee issues advice with `adviceType: deels_gegrond`
+- **THEN** the `recommendation` field SHALL specify which grounds are upheld and which are rejected
+- **AND** the `grounds` field SHALL contain the legal reasoning for each determination
+
+### Requirement: Committee Composition Tracking
+
+The system SHALL track which committee members participated in each bezwaar case to ensure independence and prevent conflicts of interest.
+
+**Feature tier**: V1
+
+#### Scenario: Committee member was involved in original decision
+
+- **WHEN** a user with role "Lid commissie" on the bezwaar case is also the "Primair beslisser" on the contested original case
+- **THEN** the system SHALL display a warning: "Commissielid was betrokken bij het primaire besluit"
+- **AND** the warning SHALL be visible to the voorzitter commissie
+- **AND** the system SHALL NOT block the assignment (it is an advisory warning, not an enforcement)
+
+#### Scenario: Minimum committee composition
+
+- **WHEN** an advisory report is being created
+- **THEN** the system SHALL require at least a `committeeChair` to be assigned
+- **AND** the system SHALL display a recommendation to have at least 3 committee members (voorzitter + 2 leden) per municipal best practice

--- a/openspec/specs/bezwaar-decision/spec.md
+++ b/openspec/specs/bezwaar-decision/spec.md
@@ -1,0 +1,87 @@
+## ADDED Requirements
+
+### Requirement: Decision on Objection Schema
+
+The system SHALL support recording the beslissing op bezwaar (decision on objection) as a formal decision object linked to the bezwaar case. This extends the existing `decision` schema with bezwaar-specific properties.
+
+**Feature tier**: V1
+**ZGW mapping**: `besluit` with `besluittype` "Beslissing op bezwaar"
+**AWB reference**: Art. 7:11 (heroverweging), Art. 7:12 (motivering)
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `case` | reference (UUID) | Yes | The bezwaar case |
+| `contestedDecision` | reference (UUID) | Yes | The original besluit being contested |
+| `advisoryReport` | reference (UUID) | No | The committee's advisory report |
+| `dispositionType` | enum | Yes | gegrond, ongegrond, deels_gegrond, niet_ontvankelijk |
+| `dispositionDetails` | string (text) | Yes | Detailed motivation for the decision (motiveringsplicht art. 7:12) |
+| `followsAdvice` | boolean | No | Whether the decision follows the committee's advice |
+| `deviationReason` | string (text) | No | Reason for deviating from committee advice (required when followsAdvice is false) |
+| `remedialAction` | string (text) | No | What corrective action is taken if gegrond/deels_gegrond |
+| `replacementDecision` | reference (UUID) | No | New besluit that replaces the contested one |
+| `decisionDate` | date | Yes | Date the decision was made |
+| `effectiveDate` | date | Yes | Date the decision takes legal effect |
+| `appealInformation` | string (text) | Yes | Information about beroep possibilities (rechtsmiddelenclausule) |
+| `decisionMaker` | reference (UUID to role) | Yes | The person/body that made the decision |
+| `decisionDocument` | reference (UUID) | No | The formal decision letter document |
+
+#### Scenario: Record gegrond (upheld) decision on bezwaar
+
+- **WHEN** the beslisser records a decision with `dispositionType: gegrond` on bezwaar BZ-2026-0042
+- **THEN** the decision object SHALL be created with required `dispositionDetails` explaining the reconsideration
+- **AND** the case status SHALL transition to "Beslissing op bezwaar"
+- **AND** `remedialAction` SHALL describe what corrective action is taken
+- **AND** `appealInformation` SHALL be populated with information about beroep at the administrative court
+
+#### Scenario: Decision deviates from advisory committee advice
+
+- **WHEN** the beslisser records a decision that does not follow the committee's advice
+- **AND** `followsAdvice` is set to `false`
+- **THEN** the system SHALL require `deviationReason` to be filled in
+- **AND** the deviation SHALL be recorded in the case audit trail
+- **AND** per art. 7:13 lid 7, the deviationReason SHALL be included in the decision letter
+
+#### Scenario: Decision includes rechtsmiddelenclausule
+
+- **WHEN** a beslissing op bezwaar is recorded
+- **THEN** `appealInformation` SHALL include:
+  - The option to file beroep at the rechtbank (administrative court)
+  - The 6-week term for filing beroep (art. 6:7)
+  - The name of the competent court
+- **AND** if `appealInformation` is left empty, the system SHALL display a warning: "Rechtsmiddelenclausule ontbreekt"
+
+#### Scenario: Niet-ontvankelijk declaration
+
+- **WHEN** the beslisser records a decision with `dispositionType: niet_ontvankelijk`
+- **THEN** the case status SHALL transition to "Niet-ontvankelijk"
+- **AND** `dispositionDetails` SHALL explain why the bezwaar is inadmissible (e.g., termijn overschreden, geen belanghebbende, geen besluit)
+
+### Requirement: Decision Notification
+
+The system SHALL notify the bezwaarmaker when a decision on their objection has been made.
+
+**Feature tier**: V1
+
+#### Scenario: Notify bezwaarmaker of decision
+
+- **WHEN** a beslissing op bezwaar is recorded and the case transitions to "Beslissing op bezwaar"
+- **THEN** the system SHALL trigger an automatic action to notify the bezwaarmaker
+- **AND** the notification SHALL reference the case number and decision type
+- **AND** if a gemachtigde (representative) is registered on the case, the gemachtigde SHALL also be notified
+
+### Requirement: Heroverweging (Full Reconsideration)
+
+The beslissing op bezwaar SHALL be based on a complete reconsideration (heroverweging) of the original decision, not just a review of the bezwaarmaker's arguments. This is mandated by AWB art. 7:11.
+
+**Feature tier**: V1
+
+#### Scenario: Reconsideration scope includes new facts
+
+- **WHEN** the behandelaar prepares the beslissing op bezwaar
+- **THEN** the decision form SHALL include a field for ex nunc (current situation) assessment
+- **AND** the system SHALL display guidance: "De heroverweging betreft een volledige heroverweging, inclusief feiten en omstandigheden ten tijde van de beslissing op bezwaar"
+
+#### Scenario: Reformatio in peius warning
+
+- **WHEN** the reconsideration could lead to a worse outcome for the bezwaarmaker than the original decision
+- **THEN** the system SHALL display a warning: "Let op: reformatio in peius -- het bezwaar mag in beginsel niet leiden tot een voor de bezwaarmaker nadeliger besluit"

--- a/openspec/specs/bezwaar-hearing/spec.md
+++ b/openspec/specs/bezwaar-hearing/spec.md
@@ -1,0 +1,84 @@
+## ADDED Requirements
+
+### Requirement: Hearing Session Management
+
+The system SHALL support scheduling and managing hoorzittingen (hearings) as part of the bezwaar process. The hearing is a legal right under AWB art. 7:2 -- the bezwaarmaker MUST be offered the opportunity to be heard before a decision on the objection is made.
+
+**Feature tier**: V1
+**CMMN mapping**: HumanTask within bezwaar CasePlanModel
+**Schema.org mapping**: `schema:Event` with `schema:about` referencing the bezwaar case
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `case` | reference (UUID) | Yes | The bezwaar case this hearing belongs to |
+| `scheduledDate` | datetime | Yes | Date and time of the hearing |
+| `location` | string | No | Physical location or "Online" for video hearings |
+| `videoCallUrl` | string (URL) | No | Video conference link for online hearings |
+| `chairperson` | reference (UUID to role) | Yes | Who chairs the hearing (voorzitter) |
+| `members` | array of references | No | Committee members present |
+| `invitees` | array of objects | Yes | Persons invited (bezwaarmaker, gemachtigde, primair beslisser) |
+| `minutesSummary` | string (text) | No | Summary of what was discussed (verslag) |
+| `minutesDocument` | reference (UUID) | No | Full hearing minutes document |
+| `status` | enum | Yes | gepland, uitgenodigd, uitgevoerd, geannuleerd, afgezien |
+| `hearingWaived` | boolean | No | Bezwaarmaker has waived the right to be heard |
+| `waiverReason` | string | No | Reason for waiving hearing right |
+
+#### Scenario: Schedule a hearing for a bezwaar case
+
+- **WHEN** the behandelaar schedules a hearing for bezwaar case BZ-2026-0042
+- **THEN** a hearingSession object SHALL be created with status "gepland"
+- **AND** the case status SHALL transition to "Hoorzitting gepland"
+- **AND** the system SHALL validate that the hearing date is at least 5 working days in the future (to allow preparation time)
+
+#### Scenario: Send hearing invitations
+
+- **WHEN** a hearing is scheduled with status "gepland"
+- **AND** the behandelaar triggers the invitation action
+- **THEN** the system SHALL create a notification for each invitee
+- **AND** the hearing status SHALL change to "uitgenodigd"
+- **AND** the invitation SHALL include: date, time, location, subject of the bezwaar, and the right to bring witnesses (art. 7:8)
+
+#### Scenario: Record hearing minutes
+
+- **WHEN** the hearing has taken place
+- **AND** the chairperson marks the hearing as "uitgevoerd"
+- **THEN** the system SHALL require a `minutesSummary` to be filled in
+- **AND** optionally allow uploading a full minutes document
+- **AND** the case status SHALL transition to "Hoorzitting afgerond"
+
+### Requirement: Hearing Waiver (Afzien van Hoorrecht)
+
+The system SHALL allow the bezwaarmaker to waive their right to a hearing, as permitted under AWB art. 7:3. When the right is waived, the hearing steps SHALL be skipped.
+
+**Feature tier**: V1
+
+#### Scenario: Bezwaarmaker waives hearing right
+
+- **WHEN** the bezwaarmaker indicates they do not wish to be heard
+- **THEN** the behandelaar SHALL record this by creating a hearingSession with `hearingWaived: true` and `waiverReason`
+- **AND** the case SHALL be able to skip the "Hoorzitting gepland" and "Hoorzitting afgerond" statuses
+- **AND** the waiver SHALL be recorded in the case audit trail
+
+#### Scenario: Hearing waiver cannot be recorded after hearing is completed
+
+- **WHEN** a hearing has already been held (status "uitgevoerd")
+- **THEN** the system SHALL NOT allow setting `hearingWaived` to true
+- **AND** an error message SHALL display: "Hoorzitting heeft reeds plaatsgevonden"
+
+### Requirement: Hearing Participants and Access Rights
+
+The system SHALL manage hearing participants with appropriate access rights as defined in AWB art. 7:4 through 7:8.
+
+**Feature tier**: V1
+
+#### Scenario: Bezwaarmaker may bring a representative
+
+- **WHEN** the bezwaarmaker is invited to a hearing
+- **THEN** the invitation SHALL state that they may bring a gemachtigde (authorized representative)
+- **AND** the system SHALL allow adding a "Vertegenwoordiger" role to the case for the gemachtigde
+
+#### Scenario: Bezwaarmaker may inspect case documents before hearing
+
+- **WHEN** a hearing is scheduled for bezwaar case BZ-2026-0042
+- **THEN** the bezwaarmaker SHALL have the right to inspect all case documents for at least 1 week before the hearing (art. 7:4 lid 2)
+- **AND** the system SHALL track which documents are part of the bezwaardossier

--- a/openspec/specs/bezwaar-lifecycle/spec.md
+++ b/openspec/specs/bezwaar-lifecycle/spec.md
@@ -1,0 +1,155 @@
+## ADDED Requirements
+
+### Requirement: Bezwaar Case Type Pre-Seeded Configuration
+
+The system SHALL provide a pre-seeded "Bezwaar" (objection) case type with AWB chapter 6/7 compliant configuration. The case type SHALL be imported via the repair step alongside existing case types.
+
+**Feature tier**: V1
+**ZGW mapping**: `zaaktype` with `omschrijving` "Bezwaar"
+**CMMN mapping**: CaseDefinition with TimerEventListeners for legal deadlines
+
+| Property | Value |
+|----------|-------|
+| `title` | Bezwaar |
+| `description` | Bezwaarprocedure conform Awb hoofdstuk 6 en 7 |
+| `processingDeadline` | P6W (6 weeks, Awb art. 7:10 lid 1) |
+| `extensionAllowed` | true |
+| `extensionPeriod` | P6W (6 weeks extension, Awb art. 7:10 lid 3) |
+| `suspensionAllowed` | true |
+| `origin` | external |
+| `trigger` | Bezwaarschrift van belanghebbende |
+| `subject` | Bezwaar tegen besluit |
+
+#### Scenario: Bezwaar case type is available after installation
+
+- **WHEN** the Procest app repair step runs
+- **THEN** a case type "Bezwaar" SHALL exist in the procest register
+- **AND** the case type SHALL have `processingDeadline` set to `P6W`
+- **AND** the case type SHALL have `extensionAllowed` set to `true` with `extensionPeriod` `P6W`
+- **AND** the case type SHALL have `suspensionAllowed` set to `true`
+
+### Requirement: Bezwaar Status Types
+
+The system SHALL provide pre-seeded status types for the Bezwaar case type that reflect the AWB-mandated process phases. Status types SHALL be ordered to enforce the legal process sequence.
+
+**Feature tier**: V1
+**ZGW mapping**: `statustype` linked to bezwaar `zaaktype`
+
+| Order | Status Type | Description | AWB Reference |
+|-------|-------------|-------------|---------------|
+| 1 | Ontvangen | Bezwaarschrift is ontvangen | Art. 6:4 |
+| 2 | Ontvankelijkheidstoets | Toetsing op ontvankelijkheid | Art. 6:5, 6:6 |
+| 3 | In behandeling | Inhoudelijke behandeling gestart | Art. 7:2 |
+| 4 | Hoorzitting gepland | Hoorzitting is ingepland | Art. 7:2 |
+| 5 | Hoorzitting afgerond | Hoorzitting heeft plaatsgevonden | Art. 7:7 |
+| 6 | Advies uitgebracht | Bezwaarschriftencommissie heeft advies uitgebracht | Art. 7:13 |
+| 7 | Beslissing op bezwaar | Besluit op bezwaar is genomen | Art. 7:11, 7:12 |
+| 8 | Afgehandeld | Bezwaarprocedure is volledig afgerond | -- |
+| -- | Niet-ontvankelijk | Bezwaar is niet-ontvankelijk verklaard | Art. 6:6 |
+| -- | Ingetrokken | Bezwaar is ingetrokken door indiener | Art. 6:21 |
+
+#### Scenario: All bezwaar status types are seeded
+
+- **WHEN** the repair step completes
+- **THEN** 10 status types SHALL exist for the Bezwaar case type
+- **AND** they SHALL be ordered from 1 (Ontvangen) through 8 (Afgehandeld) with Niet-ontvankelijk and Ingetrokken as terminal statuses
+
+#### Scenario: Skip hearing when right is waived
+
+- **WHEN** the bezwaarmaker waives the right to a hearing (afzien van hoorrecht)
+- **THEN** the case SHALL be able to transition from "Ontvankelijkheidstoets" or "In behandeling" directly to "Advies uitgebracht" or "Beslissing op bezwaar"
+- **AND** the skip SHALL be recorded in the case audit trail with reason "Belanghebbende heeft afgezien van het recht te worden gehoord"
+
+### Requirement: Bezwaar Role Types
+
+The system SHALL provide pre-seeded role types for the Bezwaar case type covering all participants in the objection process.
+
+**Feature tier**: V1
+**ZGW mapping**: `roltype` linked to bezwaar `zaaktype`
+
+| Role Type | Generic Role | Description |
+|-----------|-------------|-------------|
+| Bezwaarmaker | initiator | De persoon die bezwaar maakt |
+| Behandelaar bezwaar | handler | Ambtenaar die het bezwaar behandelt |
+| Voorzitter commissie | decision_maker | Voorzitter bezwaarschriftencommissie |
+| Lid commissie | advisor | Lid van de bezwaarschriftencommissie |
+| Secretaris commissie | coordinator | Secretaris van de bezwaarschriftencommissie |
+| Vertegenwoordiger | stakeholder | Gemachtigde of vertegenwoordiger van bezwaarmaker |
+| Primair beslisser | advisor | Ambtenaar die het oorspronkelijke besluit nam |
+
+#### Scenario: All bezwaar role types are seeded
+
+- **WHEN** the repair step completes
+- **THEN** 7 role types SHALL exist for the Bezwaar case type
+- **AND** each role type SHALL map to a standard generic role
+
+### Requirement: Bezwaar Deadline Calculation
+
+The system SHALL automatically calculate legal deadlines when a bezwaar case is created, based on AWB articles 6:7, 6:8, 7:10, and 7:24.
+
+**Feature tier**: V1
+
+#### Scenario: Standard deadline calculation on case creation
+
+- **WHEN** a bezwaar case is created with `ontvangstdatum` 2026-03-01 (Monday)
+- **THEN** the system SHALL calculate:
+  - `ontvangstbevestigingDeadline`: within 1 week (2026-03-08)
+  - `afhandelDeadline`: 6 weeks from ontvangstdatum (2026-04-12)
+  - `verdagingMogelijk`: true (6-week extension available per art. 7:10 lid 3)
+- **AND** these deadlines SHALL be stored as properties on the case object
+
+#### Scenario: Extended deadline after verdaging
+
+- **WHEN** the behandelaar extends the deadline (verdaging) on a bezwaar case with original deadline 2026-04-12
+- **THEN** the new `afhandelDeadline` SHALL be 2026-05-24 (original + 6 weeks)
+- **AND** the extension SHALL be recorded in the audit trail
+- **AND** the bezwaarmaker SHALL be notified of the extension per art. 7:10 lid 3
+
+#### Scenario: Deadline suspension (opschorting)
+
+- **WHEN** the behandelaar suspends the deadline because additional information is requested from the bezwaarmaker
+- **THEN** the deadline clock SHALL stop
+- **AND** the suspension SHALL be recorded with start date and reason
+- **AND** when the bezwaarmaker provides the information, the deadline clock SHALL resume with the remaining days added
+
+#### Scenario: Deadline warning notification
+
+- **WHEN** a bezwaar case is within 5 working days of its `afhandelDeadline`
+- **AND** the case status is not "Afgehandeld", "Niet-ontvankelijk", or "Ingetrokken"
+- **THEN** the system SHALL create a warning notification for the bezwaar behandelaar
+- **AND** the case SHALL appear in the dashboard overdue/at-risk section
+
+### Requirement: Bezwaar Objection Object Schema
+
+The system SHALL store bezwaarschrift (objection letter) details as an OpenRegister object linked to the bezwaar case. This captures the formal objection content separately from the case metadata.
+
+**Feature tier**: V1
+**Schema.org mapping**: `schema:Message` with `schema:about` referencing the contested decision
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `case` | reference (UUID) | Yes | The bezwaar case this objection belongs to |
+| `contestedDecision` | reference (UUID) | Yes | The original besluit being contested |
+| `grounds` | string (text) | Yes | The grounds for objection (gronden van bezwaar) |
+| `requestedRelief` | string (text) | No | What outcome the bezwaarmaker seeks |
+| `receivedDate` | date | Yes | Date the bezwaarschrift was received |
+| `receivedChannel` | enum | Yes | How it was received (brief, email, formulier, balie) |
+| `isTimely` | boolean | No | Whether the objection was filed within the 6-week term (art. 6:7) |
+| `timelinessAssessment` | string | No | Explanation of timeliness determination |
+| `proVoorziening` | boolean | No | Whether a voorlopige voorziening (interim relief) was requested |
+| `attachments` | array of references | No | Supporting documents uploaded by bezwaarmaker |
+
+#### Scenario: Create objection linked to contested decision
+
+- **WHEN** an intake worker creates a bezwaar case
+- **THEN** an objection object SHALL be created linking the case to the original besluit
+- **AND** the `contestedDecision` field SHALL reference the UUID of the besluit being contested
+- **AND** the `grounds` field SHALL contain the bezwaarmaker's stated reasons
+
+#### Scenario: Timeliness check (ontvankelijkheidstoets)
+
+- **WHEN** the behandelaar performs the ontvankelijkheidstoets
+- **AND** the bezwaarschrift was received more than 6 weeks after the besluit publication date
+- **THEN** the `isTimely` field SHALL default to `false`
+- **AND** the system SHALL display a warning: "Bezwaartermijn mogelijk overschreden"
+- **AND** the behandelaar SHALL be able to override with a `timelinessAssessment` explanation (e.g., verschoonbare termijnoverschrijding)

--- a/openspec/specs/case-types/spec.md
+++ b/openspec/specs/case-types/spec.md
@@ -917,6 +917,39 @@ This is a comprehensive, highly detailed spec that is implementation-ready for b
 
 **Strengths:** Exhaustive data model tables with type/required/mapping columns. 16 requirements with detailed scenarios. Clear feature tier separation. Validation rules explicitly specified.
 
+### Requirement: Case Type Pre-Seeded Data
+
+The system SHALL provide pre-seeded case types that are imported via the repair step. In addition to any existing pre-seeded case types, the system SHALL now include Bezwaar and Beroep case types with their associated status types, role types, and workflow templates.
+
+**Feature tier**: V1
+
+The repair step SHALL import the following new case types alongside existing ones:
+
+| Case Type | Processing Deadline | Extension | Suspension | Origin |
+|-----------|-------------------|-----------|------------|--------|
+| Bezwaar | P6W | P6W | Yes | external |
+| Beroep | P26W | No | Yes | external |
+
+Each case type SHALL include its associated:
+- Status types (see bezwaar-lifecycle and beroep-escalation specs)
+- Role types (see bezwaar-lifecycle spec)
+- Workflow template (see workflow-definition-model spec)
+
+#### Scenario: Bezwaar and Beroep case types are available after installation
+
+- **WHEN** the Procest app repair step runs for the first time or after an update
+- **THEN** case types "Bezwaar" and "Beroep" SHALL exist in the procest register
+- **AND** each SHALL have its complete set of status types, role types, and an active workflow template
+- **AND** existing case types SHALL NOT be affected by the addition
+
+#### Scenario: Pre-seeded case types are not duplicated on re-run
+
+- **WHEN** the repair step runs again on an installation that already has Bezwaar and Beroep case types
+- **THEN** the system SHALL NOT create duplicate case types
+- **AND** existing customizations to the case types SHALL be preserved
+
+---
+
 **Missing/Ambiguous:**
 - No specification of how sub-entity schemas (statusType, resultType, etc.) relate to each other via OpenRegister references (reference resolution mechanics).
 - No specification of bulk operations (e.g., import multiple status types at once).

--- a/openspec/specs/workflow-definition-model/spec.md
+++ b/openspec/specs/workflow-definition-model/spec.md
@@ -94,3 +94,76 @@ Guard types:
 - **WHEN** a case handler triggers transition "Goedkeuren" but the required document "Besluit" is not uploaded
 - **THEN** the transition SHALL be blocked
 - **AND** the system SHALL display: "Kan niet doorgaan: document 'Besluit' is vereist"
+
+### Requirement: Pre-Seeded Bezwaar Workflow Template
+
+The system SHALL provide a pre-seeded workflow template for the Bezwaar case type that encodes the AWB-mandated process steps, transitions, and guards. The template SHALL be imported via the repair step alongside the bezwaar case type.
+
+**Feature tier**: V1
+
+The bezwaar workflow template SHALL define the following transitions:
+
+| From Status | To Status | Label | Guards |
+|-------------|-----------|-------|--------|
+| Ontvangen | Ontvankelijkheidstoets | Start toets | roleGuard: Behandelaar bezwaar |
+| Ontvankelijkheidstoets | In behandeling | Ontvankelijk | requiredField: isTimely assessment |
+| Ontvankelijkheidstoets | Niet-ontvankelijk | Niet-ontvankelijk verklaren | requiredField: dispositionDetails |
+| In behandeling | Hoorzitting gepland | Hoorzitting plannen | -- |
+| In behandeling | Advies uitgebracht | Hoorrecht afgezien | requiredField: hearingWaived=true |
+| Hoorzitting gepland | Hoorzitting afgerond | Hoorzitting afronden | requiredField: minutesSummary |
+| Hoorzitting afgerond | Advies uitgebracht | Advies uitbrengen | requiredField: advisoryReport |
+| In behandeling | Beslissing op bezwaar | Direct beslissen | roleGuard: Beslisser (when no committee) |
+| Advies uitgebracht | Beslissing op bezwaar | Beslissing nemen | requiredField: dispositionType, dispositionDetails |
+| Beslissing op bezwaar | Afgehandeld | Afronden | checklist: decision letter sent, rechtsmiddelenclausule included |
+| Any active | Ingetrokken | Intrekken | requiredField: withdrawal reason |
+
+The workflow template SHALL include workflow steps for each status phase:
+
+| Status Phase | Steps |
+|-------------|-------|
+| Ontvangen | Registreer bezwaarschrift, Controleer volledigheid, Bevestig ontvangst |
+| Ontvankelijkheidstoets | Toets termijn, Toets belanghebbendheid, Toets besluit-karakter |
+| In behandeling | Stel dossier samen, Informeer primair beslisser, Plan hoorzitting of registreer afzien |
+| Hoorzitting gepland | Verstuur uitnodigingen, Bereid hoorzitting voor |
+| Hoorzitting afgerond | Maak verslag, Deel verslag met partijen |
+| Advies uitgebracht | Stel advies op, Deel advies met bestuursorgaan |
+| Beslissing op bezwaar | Neem beslissing, Stel besluit op, Verstuur besluit met rechtsmiddelenclausule |
+
+#### Scenario: Bezwaar workflow template is seeded after repair
+
+- **WHEN** the Procest app repair step runs
+- **THEN** a workflow template SHALL exist for the Bezwaar case type
+- **AND** the template SHALL contain all defined transitions with their guards
+- **AND** the template SHALL contain all defined steps per status phase
+- **AND** the template SHALL be published (isDraft: false, isActive: true)
+
+#### Scenario: Administrator can customize the bezwaar workflow
+
+- **WHEN** an administrator opens the Bezwaar case type in the admin settings
+- **THEN** the pre-seeded workflow template SHALL be visible in the workflow tab
+- **AND** the administrator SHALL be able to create a new version to customize steps and transitions
+- **AND** the original pre-seeded template SHALL remain as a base version
+
+### Requirement: Pre-Seeded Beroep Workflow Template
+
+The system SHALL provide a pre-seeded workflow template for the Beroep case type with transitions for tracking court proceedings.
+
+**Feature tier**: V1
+
+| From Status | To Status | Label | Guards |
+|-------------|-----------|-------|--------|
+| Beroep ontvangen | Verweerschrift in voorbereiding | Start verweer | roleGuard: Behandelaar |
+| Verweerschrift in voorbereiding | Verweerschrift ingediend | Verweer indienen | requiredDocument: Verweerschrift |
+| Verweerschrift ingediend | Zitting gepland | Zitting plannen | -- |
+| Zitting gepland | Zitting afgerond | Zitting afronden | -- |
+| Zitting afgerond | Uitspraak ontvangen | Uitspraak registreren | requiredField: ruling outcome |
+| Uitspraak ontvangen | Afgehandeld | Afronden | -- |
+| Any active | Ingetrokken | Intrekken | -- |
+| Any active | Schikking | Schikking treffen | requiredField: settlement details |
+
+#### Scenario: Beroep workflow template is seeded after repair
+
+- **WHEN** the Procest app repair step runs
+- **THEN** a workflow template SHALL exist for the Beroep case type
+- **AND** the template SHALL contain all defined transitions
+- **AND** the template SHALL be published (isDraft: false, isActive: true)

--- a/src/store/modules/bezwaar.js
+++ b/src/store/modules/bezwaar.js
@@ -1,0 +1,572 @@
+/**
+ * Bezwaar (objection) and Beroep (appeal) store module for Procest.
+ *
+ * Manages CRUD operations for objection, hearing session, advisory report,
+ * and appeal decision objects. Also handles deadline calculation and
+ * bezwaar-to-beroep escalation.
+ *
+ * Uses the object store (createObjectStore) for CRUD operations on
+ * OpenRegister objects.
+ */
+import { defineStore } from 'pinia'
+import { useObjectStore } from './object.js'
+import { useSettingsStore } from './settings.js'
+
+/**
+ * Add working days to a date (skipping weekends).
+ *
+ * @param {Date} startDate The starting date
+ * @param {number} days Number of working days to add
+ * @return {Date} The resulting date
+ */
+function addWorkingDays(startDate, days) {
+	const result = new Date(startDate)
+	let added = 0
+	while (added < days) {
+		result.setDate(result.getDate() + 1)
+		const dayOfWeek = result.getDay()
+		if (dayOfWeek !== 0 && dayOfWeek !== 6) {
+			added++
+		}
+	}
+	return result
+}
+
+/**
+ * Add calendar weeks to a date.
+ *
+ * @param {Date} startDate The starting date
+ * @param {number} weeks Number of weeks to add
+ * @return {Date} The resulting date
+ */
+function addWeeks(startDate, weeks) {
+	const result = new Date(startDate)
+	result.setDate(result.getDate() + (weeks * 7))
+	return result
+}
+
+/**
+ * Calculate the difference in calendar days between two dates.
+ *
+ * @param {Date} dateA First date
+ * @param {Date} dateB Second date
+ * @return {number} Days difference (positive if dateB is after dateA)
+ */
+function daysDifference(dateA, dateB) {
+	const msPerDay = 86400000
+	return Math.ceil((dateB.getTime() - dateA.getTime()) / msPerDay)
+}
+
+export const useBezwaarStore = defineStore('bezwaar', {
+	state: () => ({
+		/** @type {object|null} Current objection object */
+		currentObjection: null,
+		/** @type {Array} Hearing sessions for the current case */
+		hearingSessions: [],
+		/** @type {object|null} Current advisory report */
+		currentAdvisoryReport: null,
+		/** @type {object|null} Current appeal decision */
+		currentAppealDecision: null,
+		/** @type {boolean} Loading state */
+		loading: false,
+		/** @type {string|null} Error message */
+		error: null,
+	}),
+
+	getters: {
+		/**
+		 * Check if the current case has an objection.
+		 *
+		 * @param {object} state The store state
+		 * @return {boolean} Whether an objection exists
+		 */
+		hasObjection: (state) => state.currentObjection !== null,
+
+		/**
+		 * Get the active hearing session (not cancelled or waived).
+		 *
+		 * @param {object} state The store state
+		 * @return {object|null} The active hearing or null
+		 */
+		activeHearing: (state) => {
+			return state.hearingSessions.find(
+				(h) => h.status !== 'geannuleerd' && h.status !== 'afgezien',
+			) || null
+		},
+
+		/**
+		 * Check if the hearing was waived.
+		 *
+		 * @param {object} state The store state
+		 * @return {boolean} Whether hearing was waived
+		 */
+		isHearingWaived: (state) => {
+			return state.hearingSessions.some((h) => h.hearingWaived === true)
+		},
+
+		/**
+		 * Check if there is an advisory report.
+		 *
+		 * @param {object} state The store state
+		 * @return {boolean} Whether an advisory report exists
+		 */
+		hasAdvisoryReport: (state) => state.currentAdvisoryReport !== null,
+
+		/**
+		 * Check if there is an appeal decision.
+		 *
+		 * @param {object} state The store state
+		 * @return {boolean} Whether an appeal decision exists
+		 */
+		hasAppealDecision: (state) => state.currentAppealDecision !== null,
+	},
+
+	actions: {
+		/**
+		 * Load all bezwaar-related data for a case.
+		 *
+		 * @param {string} caseId The case UUID
+		 * @return {Promise<void>}
+		 */
+		async loadBezwaarData(caseId) {
+			this.loading = true
+			this.error = null
+
+			try {
+				const objectStore = useObjectStore()
+
+				// Load objection.
+				const objections = await objectStore.getObjects('objection', {
+					filters: { case: caseId },
+					limit: 1,
+				})
+				this.currentObjection = objections?.[0] || null
+
+				// Load hearing sessions.
+				const hearings = await objectStore.getObjects('hearingSession', {
+					filters: { case: caseId },
+				})
+				this.hearingSessions = hearings || []
+
+				// Load advisory report.
+				const reports = await objectStore.getObjects('advisoryReport', {
+					filters: { case: caseId },
+					limit: 1,
+				})
+				this.currentAdvisoryReport = reports?.[0] || null
+
+				// Load appeal decision.
+				const decisions = await objectStore.getObjects('appealDecision', {
+					filters: { case: caseId },
+					limit: 1,
+				})
+				this.currentAppealDecision = decisions?.[0] || null
+			} catch (error) {
+				this.error = error.message
+				console.error('Error loading bezwaar data:', error)
+			} finally {
+				this.loading = false
+			}
+		},
+
+		// --- Objection CRUD ---
+
+		/**
+		 * Create a new objection for a bezwaar case.
+		 *
+		 * @param {object} data The objection data
+		 * @return {Promise<object|null>} The created objection
+		 */
+		async createObjection(data) {
+			this.loading = true
+			this.error = null
+
+			try {
+				const objectStore = useObjectStore()
+				const result = await objectStore.saveObject('objection', data)
+				this.currentObjection = result
+				return result
+			} catch (error) {
+				this.error = error.message
+				console.error('Error creating objection:', error)
+				return null
+			} finally {
+				this.loading = false
+			}
+		},
+
+		/**
+		 * Update the current objection.
+		 *
+		 * @param {object} data The updated objection data
+		 * @return {Promise<object|null>} The updated objection
+		 */
+		async updateObjection(data) {
+			this.loading = true
+			this.error = null
+
+			try {
+				const objectStore = useObjectStore()
+				const result = await objectStore.saveObject('objection', data)
+				this.currentObjection = result
+				return result
+			} catch (error) {
+				this.error = error.message
+				console.error('Error updating objection:', error)
+				return null
+			} finally {
+				this.loading = false
+			}
+		},
+
+		/**
+		 * Delete the current objection.
+		 *
+		 * @param {string} objectionId The objection UUID
+		 * @return {Promise<boolean>} Whether the deletion succeeded
+		 */
+		async deleteObjection(objectionId) {
+			this.loading = true
+			this.error = null
+
+			try {
+				const objectStore = useObjectStore()
+				await objectStore.deleteObject('objection', objectionId)
+				this.currentObjection = null
+				return true
+			} catch (error) {
+				this.error = error.message
+				console.error('Error deleting objection:', error)
+				return false
+			} finally {
+				this.loading = false
+			}
+		},
+
+		// --- Hearing Session CRUD ---
+
+		/**
+		 * Create a new hearing session.
+		 *
+		 * @param {object} data The hearing session data
+		 * @return {Promise<object|null>} The created hearing
+		 */
+		async createHearingSession(data) {
+			this.loading = true
+			this.error = null
+
+			try {
+				const objectStore = useObjectStore()
+				const result = await objectStore.saveObject('hearingSession', data)
+				this.hearingSessions.push(result)
+				return result
+			} catch (error) {
+				this.error = error.message
+				console.error('Error creating hearing session:', error)
+				return null
+			} finally {
+				this.loading = false
+			}
+		},
+
+		/**
+		 * Update a hearing session.
+		 *
+		 * @param {object} data The updated hearing data
+		 * @return {Promise<object|null>} The updated hearing
+		 */
+		async updateHearingSession(data) {
+			this.loading = true
+			this.error = null
+
+			try {
+				const objectStore = useObjectStore()
+				const result = await objectStore.saveObject('hearingSession', data)
+				const index = this.hearingSessions.findIndex((h) => h.id === result.id)
+				if (index >= 0) {
+					this.hearingSessions[index] = result
+				}
+				return result
+			} catch (error) {
+				this.error = error.message
+				console.error('Error updating hearing session:', error)
+				return null
+			} finally {
+				this.loading = false
+			}
+		},
+
+		// --- Advisory Report CRUD ---
+
+		/**
+		 * Create an advisory report.
+		 *
+		 * @param {object} data The advisory report data
+		 * @return {Promise<object|null>} The created report
+		 */
+		async createAdvisoryReport(data) {
+			this.loading = true
+			this.error = null
+
+			try {
+				const objectStore = useObjectStore()
+				const result = await objectStore.saveObject('advisoryReport', data)
+				this.currentAdvisoryReport = result
+				return result
+			} catch (error) {
+				this.error = error.message
+				console.error('Error creating advisory report:', error)
+				return null
+			} finally {
+				this.loading = false
+			}
+		},
+
+		/**
+		 * Update the advisory report.
+		 *
+		 * @param {object} data The updated report data
+		 * @return {Promise<object|null>} The updated report
+		 */
+		async updateAdvisoryReport(data) {
+			this.loading = true
+			this.error = null
+
+			try {
+				const objectStore = useObjectStore()
+				const result = await objectStore.saveObject('advisoryReport', data)
+				this.currentAdvisoryReport = result
+				return result
+			} catch (error) {
+				this.error = error.message
+				console.error('Error updating advisory report:', error)
+				return null
+			} finally {
+				this.loading = false
+			}
+		},
+
+		// --- Appeal Decision CRUD ---
+
+		/**
+		 * Create an appeal decision (beslissing op bezwaar).
+		 *
+		 * @param {object} data The appeal decision data
+		 * @return {Promise<object|null>} The created decision
+		 */
+		async createAppealDecision(data) {
+			this.loading = true
+			this.error = null
+
+			try {
+				const objectStore = useObjectStore()
+				const result = await objectStore.saveObject('appealDecision', data)
+				this.currentAppealDecision = result
+				return result
+			} catch (error) {
+				this.error = error.message
+				console.error('Error creating appeal decision:', error)
+				return null
+			} finally {
+				this.loading = false
+			}
+		},
+
+		/**
+		 * Update the appeal decision.
+		 *
+		 * @param {object} data The updated decision data
+		 * @return {Promise<object|null>} The updated decision
+		 */
+		async updateAppealDecision(data) {
+			this.loading = true
+			this.error = null
+
+			try {
+				const objectStore = useObjectStore()
+				const result = await objectStore.saveObject('appealDecision', data)
+				this.currentAppealDecision = result
+				return result
+			} catch (error) {
+				this.error = error.message
+				console.error('Error updating appeal decision:', error)
+				return null
+			} finally {
+				this.loading = false
+			}
+		},
+
+		// --- Deadline Calculation ---
+
+		/**
+		 * Calculate bezwaar deadlines based on AWB rules.
+		 *
+		 * @param {string} ontvangstDatum The date the bezwaarschrift was received (ISO string)
+		 * @return {object} Calculated deadlines
+		 */
+		calculateDeadlines(ontvangstDatum) {
+			const received = new Date(ontvangstDatum)
+
+			// Ontvangstbevestiging: within 1 week (5 working days).
+			const acknowledgmentDeadline = addWorkingDays(received, 5)
+
+			// Afhandeling: 6 weeks from receipt (Awb art. 7:10 lid 1).
+			const processingDeadline = addWeeks(received, 6)
+
+			// Maximum deadline with extension: +6 weeks (Awb art. 7:10 lid 3).
+			const maxDeadlineWithExtension = addWeeks(received, 12)
+
+			return {
+				ontvangstbevestigingDeadline: acknowledgmentDeadline.toISOString().split('T')[0],
+				afhandelDeadline: processingDeadline.toISOString().split('T')[0],
+				maxDeadlineWithExtension: maxDeadlineWithExtension.toISOString().split('T')[0],
+				verdagingMogelijk: true,
+			}
+		},
+
+		/**
+		 * Calculate an extended deadline after verdaging (extension).
+		 *
+		 * @param {string} currentDeadline The current deadline (ISO string)
+		 * @return {string} The new extended deadline (ISO date string)
+		 */
+		calculateExtendedDeadline(currentDeadline) {
+			const current = new Date(currentDeadline)
+			const extended = addWeeks(current, 6)
+			return extended.toISOString().split('T')[0]
+		},
+
+		/**
+		 * Calculate remaining days and status for a deadline.
+		 *
+		 * @param {string} deadline The deadline date (ISO string)
+		 * @param {boolean} isSuspended Whether the deadline is currently suspended
+		 * @return {object} Deadline status with daysRemaining, isAtRisk, isOverdue
+		 */
+		getDeadlineStatus(deadline, isSuspended = false) {
+			if (isSuspended) {
+				return {
+					daysRemaining: null,
+					isAtRisk: false,
+					isOverdue: false,
+					isSuspended: true,
+					label: 'Opgeschort',
+				}
+			}
+
+			const today = new Date()
+			today.setHours(0, 0, 0, 0)
+			const deadlineDate = new Date(deadline)
+			deadlineDate.setHours(0, 0, 0, 0)
+
+			const daysRemaining = daysDifference(today, deadlineDate)
+
+			// At risk: within 5 working days (approximately 7 calendar days).
+			const isAtRisk = daysRemaining > 0 && daysRemaining <= 7
+			const isOverdue = daysRemaining < 0
+
+			let label = `${daysRemaining} dagen resterend`
+			if (isOverdue) {
+				label = `${Math.abs(daysRemaining)} dagen over termijn`
+			} else if (daysRemaining === 0) {
+				label = 'Vandaag is de deadline'
+			}
+
+			return {
+				daysRemaining,
+				isAtRisk,
+				isOverdue,
+				isSuspended: false,
+				label,
+			}
+		},
+
+		// --- Escalation ---
+
+		/**
+		 * Create a beroep case from a bezwaar case (escalation).
+		 *
+		 * @param {object} bezwaarCase The bezwaar case data
+		 * @param {object} options Additional options (voorzieningRequested)
+		 * @return {Promise<object|null>} The created beroep case
+		 */
+		async escalateToBeroep(bezwaarCase, options = {}) {
+			this.loading = true
+			this.error = null
+
+			try {
+				const objectStore = useObjectStore()
+				const settingsStore = useSettingsStore()
+
+				// Find the Beroep case type.
+				const caseTypes = await objectStore.getObjects('caseType', {
+					filters: { identifier: 'beroep' },
+					limit: 1,
+				})
+				const beroepCaseType = caseTypes?.[0]
+
+				if (!beroepCaseType) {
+					throw new Error('Beroep case type not found. Ensure seed data has been imported.')
+				}
+
+				// Pre-fill beroep case data from bezwaar.
+				const beroepData = {
+					title: `Beroep: ${bezwaarCase.title || 'Bezwaar'}`,
+					description: `Beroep tegen beslissing op bezwaar van zaak ${bezwaarCase.identifier || bezwaarCase.id}`,
+					caseType: beroepCaseType.id,
+					parentCase: bezwaarCase.id,
+					startDate: new Date().toISOString().split('T')[0],
+					priority: bezwaarCase.priority || 'normal',
+					voorzieningRequested: options.voorzieningRequested || false,
+				}
+
+				const beroepCase = await objectStore.saveObject('case', beroepData)
+				return beroepCase
+			} catch (error) {
+				this.error = error.message
+				console.error('Error escalating to beroep:', error)
+				return null
+			} finally {
+				this.loading = false
+			}
+		},
+
+		/**
+		 * Check timeliness of a bezwaar (whether filed within 6-week term).
+		 *
+		 * @param {string} besluitDate The date the original besluit was published
+		 * @param {string} bezwaarReceivedDate The date the bezwaar was received
+		 * @return {object} Timeliness assessment
+		 */
+		checkTimeliness(besluitDate, bezwaarReceivedDate) {
+			const besluit = new Date(besluitDate)
+			const received = new Date(bezwaarReceivedDate)
+			const termijnEnd = addWeeks(besluit, 6)
+
+			const isTimely = received <= termijnEnd
+			const daysOverTerm = isTimely ? 0 : daysDifference(termijnEnd, received)
+
+			return {
+				isTimely,
+				termijnEnd: termijnEnd.toISOString().split('T')[0],
+				daysOverTerm,
+				message: isTimely
+					? 'Bezwaar is tijdig ingediend'
+					: `Bezwaartermijn mogelijk overschreden (${daysOverTerm} dagen te laat)`,
+			}
+		},
+
+		/**
+		 * Clear all bezwaar data from the store.
+		 *
+		 * @return {void}
+		 */
+		clearBezwaarData() {
+			this.currentObjection = null
+			this.hearingSessions = []
+			this.currentAdvisoryReport = null
+			this.currentAppealDecision = null
+			this.error = null
+		},
+	},
+})

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,5 +1,6 @@
 import { useObjectStore } from './modules/object.js'
 import { useSettingsStore } from './modules/settings.js'
+import { useBezwaarStore } from './modules/bezwaar.js'
 
 export async function initializeStores() {
 	const settingsStore = useSettingsStore()
@@ -47,9 +48,24 @@ export async function initializeStores() {
 		if (config.register && config.decision_type_schema) {
 			objectStore.registerObjectType('decisionType', config.decision_type_schema, config.register)
 		}
+		if (config.register && config.objection_schema) {
+			objectStore.registerObjectType('objection', config.objection_schema, config.register)
+		}
+		if (config.register && config.hearing_session_schema) {
+			objectStore.registerObjectType('hearingSession', config.hearing_session_schema, config.register)
+		}
+		if (config.register && config.advisory_report_schema) {
+			objectStore.registerObjectType('advisoryReport', config.advisory_report_schema, config.register)
+		}
+		if (config.register && config.appeal_decision_schema) {
+			objectStore.registerObjectType('appealDecision', config.appeal_decision_schema, config.register)
+		}
+		if (config.register && config.workflow_template_schema) {
+			objectStore.registerObjectType('workflowTemplate', config.workflow_template_schema, config.register)
+		}
 	}
 
 	return { settingsStore, objectStore }
 }
 
-export { useObjectStore, useSettingsStore }
+export { useObjectStore, useSettingsStore, useBezwaarStore }

--- a/src/views/cases/CaseDetail.vue
+++ b/src/views/cases/CaseDetail.vue
@@ -254,6 +254,84 @@
 				</div>
 			</CnDetailCard>
 
+			<!-- Bezwaar-specific sections (shown when case type is Bezwaar) -->
+			<template v-if="isBezwaarCase">
+				<CnDetailCard :title="t('procest', 'Objection Details')">
+					<BezwaarIntakeForm
+						:case-id="caseId"
+						:case-data="caseData"
+						:is-read-only="isReadOnly"
+						:besluit-date="contestedBesluitDate"
+						@saved="onBezwaarDataChanged"
+						@deadlines-calculated="onDeadlinesCalculated" />
+				</CnDetailCard>
+
+				<CnDetailCard :title="t('procest', 'Bezwaar Deadlines')">
+					<div class="bezwaar-deadlines">
+						<DeadlineIndicator
+							v-if="bezwaarDeadlines.afhandelDeadline"
+							:deadline="bezwaarDeadlines.afhandelDeadline"
+							:label="t('procest', 'Processing deadline')" />
+						<DeadlineIndicator
+							v-if="bezwaarDeadlines.ontvangstbevestigingDeadline"
+							:deadline="bezwaarDeadlines.ontvangstbevestigingDeadline"
+							:label="t('procest', 'Acknowledgment deadline')" />
+					</div>
+				</CnDetailCard>
+
+				<CnDetailCard :title="t('procest', 'Hearing (Hoorzitting)')">
+					<HearingPanel
+						:case-id="caseId"
+						:is-read-only="isReadOnly"
+						@hearing-scheduled="onBezwaarDataChanged"
+						@hearing-completed="onBezwaarDataChanged"
+						@hearing-waived="onBezwaarDataChanged" />
+				</CnDetailCard>
+
+				<CnDetailCard :title="t('procest', 'Advisory Committee')">
+					<AdvisoryReportPanel
+						:case-id="caseId"
+						:is-read-only="isReadOnly"
+						@saved="onBezwaarDataChanged" />
+				</CnDetailCard>
+
+				<CnDetailCard :title="t('procest', 'Decision on Objection')">
+					<BezwaarDecisionForm
+						:case-id="caseId"
+						:is-read-only="isReadOnly"
+						:contested-decision-id="contestedDecisionId"
+						@saved="onBezwaarDataChanged" />
+				</CnDetailCard>
+
+				<CnDetailCard :title="t('procest', 'Bezwaar Timeline')">
+					<BezwaarTimeline
+						:case-data="caseData"
+						:deadlines="bezwaarDeadlines" />
+				</CnDetailCard>
+
+				<CnDetailCard
+					v-if="canEscalateToBeroep"
+					:title="t('procest', 'Appeal (Beroep)')">
+					<BeroepEscalationPanel
+						:case-data="caseData"
+						:can-escalate="canEscalateToBeroep"
+						:is-read-only="isReadOnly"
+						@escalated="onBeroepCreated" />
+				</CnDetailCard>
+			</template>
+
+			<!-- Beroep-specific sections (shown when case type is Beroep) -->
+			<template v-if="isBeroepCase">
+				<CnDetailCard :title="t('procest', 'Court Proceedings')">
+					<CourtProceedingsPanel
+						:case-data="caseData"
+						:parent-case="parentBezwaarCase"
+						:is-read-only="isReadOnly"
+						:show-ruling-form="showRulingForm"
+						@ruling-recorded="onBezwaarDataChanged" />
+				</CnDetailCard>
+			</template>
+
 			<!-- Activity card -->
 			<CnDetailCard :title="t('procest', 'Activity')">
 				<ActivityTimeline
@@ -302,6 +380,15 @@ import ActivityTimeline from './components/ActivityTimeline.vue'
 import ParticipantsSection from './components/ParticipantsSection.vue'
 import ResultSection from './components/ResultSection.vue'
 import WorkflowTransitions from './components/WorkflowTransitions.vue'
+import BezwaarIntakeForm from './components/bezwaar/BezwaarIntakeForm.vue'
+import HearingPanel from './components/bezwaar/HearingPanel.vue'
+import AdvisoryReportPanel from './components/bezwaar/AdvisoryReportPanel.vue'
+import BezwaarDecisionForm from './components/bezwaar/BezwaarDecisionForm.vue'
+import BezwaarTimeline from './components/bezwaar/BezwaarTimeline.vue'
+import DeadlineIndicator from './components/bezwaar/DeadlineIndicator.vue'
+import BeroepEscalationPanel from './components/beroep/BeroepEscalationPanel.vue'
+import CourtProceedingsPanel from './components/beroep/CourtProceedingsPanel.vue'
+import { useBezwaarStore } from '../../store/modules/bezwaar.js'
 
 export default {
 	name: 'CaseDetail',
@@ -318,6 +405,14 @@ export default {
 		ParticipantsSection,
 		ResultSection,
 		WorkflowTransitions,
+		BezwaarIntakeForm,
+		HearingPanel,
+		AdvisoryReportPanel,
+		BezwaarDecisionForm,
+		BezwaarTimeline,
+		DeadlineIndicator,
+		BeroepEscalationPanel,
+		CourtProceedingsPanel,
 	},
 	props: {
 		caseId: {
@@ -353,6 +448,11 @@ export default {
 			caseRoles: [],
 			caseDocuments: [],
 			priorityOptions: ['low', 'normal', 'high', 'urgent'],
+			// Bezwaar state
+			bezwaarDeadlines: {},
+			contestedBesluitDate: '',
+			contestedDecisionId: '',
+			parentBezwaarCase: null,
 		}
 	},
 	computed: {
@@ -411,6 +511,22 @@ export default {
 		hasWorkflow() {
 			return !!(this.caseData.workflowTemplate || this.caseData.workflowVersion)
 		},
+		isBezwaarCase() {
+			return this.caseTypeData?.identifier === 'bezwaar'
+		},
+		isBeroepCase() {
+			return this.caseTypeData?.identifier === 'beroep'
+		},
+		canEscalateToBeroep() {
+			if (!this.isBezwaarCase) return false
+			const statusName = this.currentStatusType?.name || ''
+			return statusName === 'Beslissing op bezwaar' || statusName === 'Afgehandeld'
+		},
+		showRulingForm() {
+			if (!this.isBeroepCase) return false
+			const statusName = this.currentStatusType?.name || ''
+			return statusName === 'Zitting afgerond'
+		},
 		userRoleTypeIds() {
 			return this.caseRoles ? this.caseRoles.map(r => r.roleType) : []
 		},
@@ -424,6 +540,11 @@ export default {
 				this.fetchTasks(),
 				this.fetchCaseResult(),
 			])
+
+			// Load bezwaar/beroep data if applicable.
+			if (this.isBezwaarCase || this.isBeroepCase) {
+				await this.loadBezwaarBeroepData()
+			}
 		}
 	},
 	methods: {
@@ -484,6 +605,34 @@ export default {
 				_limit: 1,
 			})
 			this.caseResult = (results && results.length > 0) ? results[0] : null
+		},
+
+		async loadBezwaarBeroepData() {
+			const bezwaarStore = useBezwaarStore()
+			await bezwaarStore.loadBezwaarData(this.caseId)
+
+			// Load parent bezwaar case for beroep cases.
+			if (this.isBeroepCase && this.caseData.parentCase) {
+				this.parentBezwaarCase = await this.objectStore.fetchObject('case', this.caseData.parentCase)
+			}
+		},
+
+		onDeadlinesCalculated(deadlines) {
+			this.bezwaarDeadlines = deadlines
+		},
+
+		async onBezwaarDataChanged() {
+			const bezwaarStore = useBezwaarStore()
+			await bezwaarStore.loadBezwaarData(this.caseId)
+		},
+
+		async onBeroepCreated(beroepCase) {
+			if (beroepCase) {
+				this.$router.push({
+					name: 'CaseDetail',
+					params: { id: beroepCase.id },
+				})
+			}
 		},
 
 		async onWorkflowTransition({ transition, newStatus }) {

--- a/src/views/cases/components/beroep/BeroepEscalationPanel.vue
+++ b/src/views/cases/components/beroep/BeroepEscalationPanel.vue
@@ -1,0 +1,122 @@
+<template>
+	<div class="beroep-escalation-panel">
+		<h4>{{ t('procest', 'Appeal to Court (Beroep)') }}</h4>
+
+		<!-- Already escalated -->
+		<template v-if="linkedBeroepCase">
+			<NcNoteCard type="info">
+				{{ t('procest', 'This case has been escalated to an appeal (beroep) case.') }}
+			</NcNoteCard>
+			<NcButton @click="navigateToBeroep">
+				{{ t('procest', 'Go to appeal case') }}
+			</NcButton>
+		</template>
+
+		<!-- Escalation available -->
+		<template v-else-if="canEscalate && !isReadOnly">
+			<p>{{ t('procest', 'If the objector disagrees with the decision, they can file an appeal (beroep) at the administrative court within 6 weeks.') }}</p>
+
+			<div class="form-group">
+				<NcCheckboxRadioSwitch
+					:checked="voorzieningRequested"
+					@update:checked="v => voorzieningRequested = v">
+					{{ t('procest', 'Voorlopige voorziening (interim relief) requested') }}
+				</NcCheckboxRadioSwitch>
+			</div>
+
+			<NcNoteCard v-if="voorzieningRequested" type="warning">
+				{{ t('procest', 'Urgent: the appellant has also requested interim relief. This may require expedited handling.') }}
+			</NcNoteCard>
+
+			<div class="beroep-escalation-panel__actions">
+				<NcButton type="primary" :disabled="escalating" @click="escalate">
+					{{ escalating ? t('procest', 'Creating...') : t('procest', 'Create Appeal Case') }}
+				</NcButton>
+			</div>
+		</template>
+
+		<template v-else>
+			<p class="section-empty">
+				{{ t('procest', 'Escalation to appeal is available after the decision on objection.') }}
+			</p>
+		</template>
+	</div>
+</template>
+
+<script>
+import { NcButton, NcCheckboxRadioSwitch, NcNoteCard } from '@nextcloud/vue'
+import { useBezwaarStore } from '../../../../store/modules/bezwaar.js'
+
+export default {
+	name: 'BeroepEscalationPanel',
+	components: {
+		NcButton,
+		NcCheckboxRadioSwitch,
+		NcNoteCard,
+	},
+	props: {
+		caseData: {
+			type: Object,
+			required: true,
+		},
+		canEscalate: {
+			type: Boolean,
+			default: false,
+		},
+		isReadOnly: {
+			type: Boolean,
+			default: false,
+		},
+		linkedBeroepCase: {
+			type: Object,
+			default: null,
+		},
+	},
+	emits: ['escalated'],
+	data() {
+		return {
+			voorzieningRequested: false,
+			escalating: false,
+		}
+	},
+	methods: {
+		async escalate() {
+			this.escalating = true
+			const bezwaarStore = useBezwaarStore()
+
+			const beroepCase = await bezwaarStore.escalateToBeroep(this.caseData, {
+				voorzieningRequested: this.voorzieningRequested,
+			})
+
+			this.escalating = false
+
+			if (beroepCase) {
+				this.$emit('escalated', beroepCase)
+			}
+		},
+		navigateToBeroep() {
+			if (this.linkedBeroepCase) {
+				this.$router.push({
+					name: 'CaseDetail',
+					params: { id: this.linkedBeroepCase.id },
+				})
+			}
+		},
+	},
+}
+</script>
+
+<style scoped>
+.beroep-escalation-panel {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+.beroep-escalation-panel__actions {
+	display: flex;
+	justify-content: flex-end;
+}
+.form-group {
+	margin: 8px 0;
+}
+</style>

--- a/src/views/cases/components/beroep/CourtProceedingsPanel.vue
+++ b/src/views/cases/components/beroep/CourtProceedingsPanel.vue
@@ -1,0 +1,155 @@
+<template>
+	<div class="court-proceedings-panel">
+		<h4>{{ t('procest', 'Court Proceedings (Beroep)') }}</h4>
+
+		<!-- Parent bezwaar case link -->
+		<div v-if="parentCase" class="court-proceedings-panel__parent">
+			<NcNoteCard type="info">
+				{{ t('procest', 'This appeal originates from bezwaar case:') }}
+				<NcButton type="tertiary" @click="navigateToParent">
+					{{ parentCase.title || parentCase.identifier }}
+				</NcButton>
+			</NcNoteCard>
+		</div>
+
+		<!-- Voorlopige voorziening flag -->
+		<NcNoteCard v-if="caseData.voorzieningRequested" type="warning">
+			{{ t('procest', 'Voorlopige voorziening (interim relief) has been requested. Expedited handling required.') }}
+		</NcNoteCard>
+
+		<!-- Ruling outcome (if decided) -->
+		<template v-if="caseData.rulingOutcome">
+			<div class="court-proceedings-panel__ruling">
+				<div class="ruling-detail">
+					<span class="ruling-detail__label">{{ t('procest', 'Court Ruling') }}</span>
+					<span class="ruling-detail__value status-badge" :class="'status-badge--' + caseData.rulingOutcome">
+						{{ getRulingLabel(caseData.rulingOutcome) }}
+					</span>
+				</div>
+			</div>
+
+			<!-- Hoger beroep information -->
+			<NcNoteCard type="info">
+				{{ t('procest', 'After the court ruling, an appeal (hoger beroep) can be filed at the Council of State (ABRvS) or the Central Appeals Tribunal (CRvB).') }}
+			</NcNoteCard>
+		</template>
+
+		<!-- Recording forms -->
+		<template v-if="!isReadOnly">
+			<!-- Ruling outcome recording -->
+			<div v-if="showRulingForm" class="form-group">
+				<label>{{ t('procest', 'Court Ruling Outcome') }}</label>
+				<NcSelect
+					v-model="rulingForm.outcome"
+					:options="rulingOptions" />
+				<NcButton type="primary" class="court-proceedings-panel__save-btn" @click="saveRuling">
+					{{ t('procest', 'Record Ruling') }}
+				</NcButton>
+			</div>
+		</template>
+	</div>
+</template>
+
+<script>
+import { NcButton, NcSelect, NcNoteCard } from '@nextcloud/vue'
+import { useObjectStore } from '../../../../store/modules/object.js'
+
+export default {
+	name: 'CourtProceedingsPanel',
+	components: {
+		NcButton,
+		NcSelect,
+		NcNoteCard,
+	},
+	props: {
+		caseData: {
+			type: Object,
+			required: true,
+		},
+		parentCase: {
+			type: Object,
+			default: null,
+		},
+		isReadOnly: {
+			type: Boolean,
+			default: false,
+		},
+		showRulingForm: {
+			type: Boolean,
+			default: false,
+		},
+	},
+	emits: ['ruling-recorded'],
+	data() {
+		return {
+			rulingForm: {
+				outcome: 'beroep_ongegrond',
+			},
+			rulingOptions: [
+				{ id: 'beroep_gegrond', label: t('procest', 'Appeal upheld (beroep gegrond)') },
+				{ id: 'beroep_ongegrond', label: t('procest', 'Appeal rejected (beroep ongegrond)') },
+				{ id: 'deels_gegrond', label: t('procest', 'Partially upheld') },
+				{ id: 'niet_ontvankelijk', label: t('procest', 'Inadmissible') },
+			],
+		}
+	},
+	methods: {
+		getRulingLabel(outcome) {
+			const labels = {
+				beroep_gegrond: t('procest', 'Appeal upheld'),
+				beroep_ongegrond: t('procest', 'Appeal rejected'),
+				deels_gegrond: t('procest', 'Partially upheld'),
+				niet_ontvankelijk: t('procest', 'Inadmissible'),
+			}
+			return labels[outcome] || outcome
+		},
+		navigateToParent() {
+			if (this.parentCase) {
+				this.$router.push({
+					name: 'CaseDetail',
+					params: { id: this.parentCase.id },
+				})
+			}
+		},
+		async saveRuling() {
+			const objectStore = useObjectStore()
+			await objectStore.saveObject('case', {
+				...this.caseData,
+				rulingOutcome: this.rulingForm.outcome,
+			})
+			this.$emit('ruling-recorded', this.rulingForm.outcome)
+		},
+	},
+}
+</script>
+
+<style scoped>
+.court-proceedings-panel {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+.court-proceedings-panel__parent {
+	margin-bottom: 4px;
+}
+.court-proceedings-panel__ruling {
+	margin: 8px 0;
+}
+.ruling-detail {
+	display: flex;
+	flex-direction: column;
+}
+.ruling-detail__label {
+	font-size: 12px;
+	color: var(--color-text-maxcontrast);
+}
+.form-group {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+.court-proceedings-panel__save-btn {
+	align-self: flex-end;
+	margin-top: 8px;
+}
+</style>

--- a/src/views/cases/components/bezwaar/AdvisoryReportPanel.vue
+++ b/src/views/cases/components/bezwaar/AdvisoryReportPanel.vue
@@ -1,0 +1,252 @@
+<template>
+	<div class="advisory-report-panel">
+		<h4>{{ t('procest', 'Advisory Committee Report') }}</h4>
+
+		<!-- Existing report display -->
+		<template v-if="hasReport">
+			<div class="advisory-report-panel__details">
+				<div class="report-detail">
+					<span class="report-detail__label">{{ t('procest', 'Advice Type') }}</span>
+					<span class="report-detail__value status-badge" :class="'status-badge--' + report.adviceType">
+						{{ getAdviceTypeLabel(report.adviceType) }}
+					</span>
+				</div>
+				<div class="report-detail">
+					<span class="report-detail__label">{{ t('procest', 'Date') }}</span>
+					<span class="report-detail__value">{{ report.adviceDate }}</span>
+				</div>
+				<div class="report-detail">
+					<span class="report-detail__label">{{ t('procest', 'Deviates from original') }}</span>
+					<span class="report-detail__value">{{ report.deviationFromPrimaryDecision ? t('procest', 'Yes') : t('procest', 'No') }}</span>
+				</div>
+			</div>
+
+			<div class="advisory-report-panel__content">
+				<h5>{{ t('procest', 'Summary') }}</h5>
+				<p>{{ report.summary }}</p>
+
+				<h5>{{ t('procest', 'Grounds') }}</h5>
+				<p>{{ report.grounds }}</p>
+
+				<h5>{{ t('procest', 'Recommendation') }}</h5>
+				<p>{{ report.recommendation }}</p>
+			</div>
+		</template>
+
+		<!-- Create report form -->
+		<template v-else-if="!isReadOnly">
+			<div class="form-group">
+				<label>{{ t('procest', 'Advice Type') }} *</label>
+				<NcSelect
+					v-model="form.adviceType"
+					:options="adviceTypeOptions" />
+			</div>
+
+			<div class="form-group">
+				<label>{{ t('procest', 'Date') }} *</label>
+				<NcTextField
+					:value="form.adviceDate"
+					type="date"
+					@update:value="v => form.adviceDate = v" />
+			</div>
+
+			<div class="form-group">
+				<label>{{ t('procest', 'Summary') }} *</label>
+				<textarea
+					v-model="form.summary"
+					:placeholder="t('procest', 'Summary of the committee advice...')"
+					rows="3" />
+			</div>
+
+			<div class="form-group">
+				<label>{{ t('procest', 'Legal Grounds') }} *</label>
+				<textarea
+					v-model="form.grounds"
+					:placeholder="t('procest', 'Legal reasoning and grounds...')"
+					rows="4" />
+			</div>
+
+			<div class="form-group">
+				<label>{{ t('procest', 'Recommendation') }} *</label>
+				<textarea
+					v-model="form.recommendation"
+					:placeholder="t('procest', 'Recommended action for the beslisser...')"
+					rows="3" />
+			</div>
+
+			<div class="form-group">
+				<NcCheckboxRadioSwitch
+					:checked="form.deviationFromPrimaryDecision"
+					@update:checked="v => form.deviationFromPrimaryDecision = v">
+					{{ t('procest', 'Committee advises differently from original decision') }}
+				</NcCheckboxRadioSwitch>
+			</div>
+
+			<!-- Committee composition warning -->
+			<NcNoteCard v-if="showCompositionWarning" type="warning">
+				{{ t('procest', 'Best practice: the committee should have at least 3 members (voorzitter + 2 leden).') }}
+			</NcNoteCard>
+
+			<!-- Conflict of interest warning -->
+			<NcNoteCard v-if="hasConflictOfInterest" type="warning">
+				{{ t('procest', 'Warning: A committee member was involved in the original decision.') }}
+			</NcNoteCard>
+
+			<div class="advisory-report-panel__actions">
+				<NcButton type="primary" :disabled="saving" @click="save">
+					{{ saving ? t('procest', 'Saving...') : t('procest', 'Save Advisory Report') }}
+				</NcButton>
+			</div>
+		</template>
+
+		<template v-else>
+			<p class="section-empty">
+				{{ t('procest', 'No advisory report has been created yet.') }}
+			</p>
+		</template>
+	</div>
+</template>
+
+<script>
+import { NcButton, NcTextField, NcSelect, NcCheckboxRadioSwitch, NcNoteCard } from '@nextcloud/vue'
+import { useBezwaarStore } from '../../../../store/modules/bezwaar.js'
+
+export default {
+	name: 'AdvisoryReportPanel',
+	components: {
+		NcButton,
+		NcTextField,
+		NcSelect,
+		NcCheckboxRadioSwitch,
+		NcNoteCard,
+	},
+	props: {
+		caseId: {
+			type: String,
+			required: true,
+		},
+		isReadOnly: {
+			type: Boolean,
+			default: false,
+		},
+		committeeMembers: {
+			type: Array,
+			default: () => [],
+		},
+		primaryDecisionMaker: {
+			type: String,
+			default: '',
+		},
+	},
+	emits: ['saved'],
+	data() {
+		return {
+			form: {
+				adviceType: 'ongegrond',
+				adviceDate: new Date().toISOString().split('T')[0],
+				summary: '',
+				grounds: '',
+				recommendation: '',
+				deviationFromPrimaryDecision: false,
+			},
+			saving: false,
+			adviceTypeOptions: [
+				{ id: 'gegrond', label: t('procest', 'Upheld (gegrond)') },
+				{ id: 'ongegrond', label: t('procest', 'Rejected (ongegrond)') },
+				{ id: 'deels_gegrond', label: t('procest', 'Partially upheld (deels gegrond)') },
+				{ id: 'niet_ontvankelijk', label: t('procest', 'Inadmissible (niet-ontvankelijk)') },
+			],
+		}
+	},
+	computed: {
+		hasReport() {
+			const bezwaarStore = useBezwaarStore()
+			return bezwaarStore.hasAdvisoryReport
+		},
+		report() {
+			const bezwaarStore = useBezwaarStore()
+			return bezwaarStore.currentAdvisoryReport
+		},
+		showCompositionWarning() {
+			return this.committeeMembers.length < 3
+		},
+		hasConflictOfInterest() {
+			if (!this.primaryDecisionMaker) return false
+			return this.committeeMembers.some((m) => m.id === this.primaryDecisionMaker)
+		},
+	},
+	methods: {
+		getAdviceTypeLabel(type) {
+			const labels = {
+				gegrond: t('procest', 'Upheld'),
+				ongegrond: t('procest', 'Rejected'),
+				deels_gegrond: t('procest', 'Partially upheld'),
+				niet_ontvankelijk: t('procest', 'Inadmissible'),
+			}
+			return labels[type] || type
+		},
+		async save() {
+			this.saving = true
+			const bezwaarStore = useBezwaarStore()
+
+			await bezwaarStore.createAdvisoryReport({
+				case: this.caseId,
+				committeeChair: '',
+				committeeMembers: JSON.stringify(this.committeeMembers.map((m) => m.id)),
+				...this.form,
+			})
+
+			this.saving = false
+			this.$emit('saved')
+		},
+	},
+}
+</script>
+
+<style scoped>
+.advisory-report-panel {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+.advisory-report-panel__details {
+	display: grid;
+	grid-template-columns: 1fr 1fr 1fr;
+	gap: 12px;
+}
+.report-detail {
+	display: flex;
+	flex-direction: column;
+}
+.report-detail__label {
+	font-size: 12px;
+	color: var(--color-text-maxcontrast);
+}
+.advisory-report-panel__content {
+	background: var(--color-background-dark);
+	border-radius: var(--border-radius-large);
+	padding: 12px;
+}
+.advisory-report-panel__content h5 {
+	margin-top: 12px;
+}
+.advisory-report-panel__content h5:first-child {
+	margin-top: 0;
+}
+.advisory-report-panel__actions {
+	display: flex;
+	justify-content: flex-end;
+}
+.form-group {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+textarea {
+	width: 100%;
+	padding: 8px;
+	border: 2px solid var(--color-border-dark);
+	border-radius: var(--border-radius);
+	resize: vertical;
+}
+</style>

--- a/src/views/cases/components/bezwaar/BezwaarDecisionForm.vue
+++ b/src/views/cases/components/bezwaar/BezwaarDecisionForm.vue
@@ -1,0 +1,305 @@
+<template>
+	<div class="bezwaar-decision-form">
+		<h4>{{ t('procest', 'Decision on Objection (Beslissing op Bezwaar)') }}</h4>
+
+		<!-- Existing decision display -->
+		<template v-if="hasDecision">
+			<div class="bezwaar-decision-form__details">
+				<div class="decision-detail">
+					<span class="decision-detail__label">{{ t('procest', 'Disposition') }}</span>
+					<span class="decision-detail__value status-badge" :class="'status-badge--' + decision.dispositionType">
+						{{ getDispositionLabel(decision.dispositionType) }}
+					</span>
+				</div>
+				<div class="decision-detail">
+					<span class="decision-detail__label">{{ t('procest', 'Decision Date') }}</span>
+					<span class="decision-detail__value">{{ decision.decisionDate }}</span>
+				</div>
+				<div v-if="decision.followsAdvice !== null" class="decision-detail">
+					<span class="decision-detail__label">{{ t('procest', 'Follows advice') }}</span>
+					<span class="decision-detail__value">{{ decision.followsAdvice ? t('procest', 'Yes') : t('procest', 'No') }}</span>
+				</div>
+			</div>
+
+			<div class="bezwaar-decision-form__content">
+				<h5>{{ t('procest', 'Motivation') }}</h5>
+				<p>{{ decision.dispositionDetails }}</p>
+
+				<template v-if="decision.remedialAction">
+					<h5>{{ t('procest', 'Remedial Action') }}</h5>
+					<p>{{ decision.remedialAction }}</p>
+				</template>
+
+				<h5>{{ t('procest', 'Appeal Information (Rechtsmiddelenclausule)') }}</h5>
+				<p>{{ decision.appealInformation }}</p>
+			</div>
+		</template>
+
+		<!-- Create decision form -->
+		<template v-else-if="!isReadOnly">
+			<!-- Reformatio in peius warning -->
+			<NcNoteCard type="warning">
+				{{ t('procest', 'Note: the reconsideration (heroverweging) must be complete (ex nunc). The objection may not lead to a worse outcome for the objector (reformatio in peius).') }}
+			</NcNoteCard>
+
+			<div class="form-group">
+				<label>{{ t('procest', 'Disposition Type') }} *</label>
+				<NcSelect
+					v-model="form.dispositionType"
+					:options="dispositionOptions" />
+			</div>
+
+			<div class="form-group">
+				<label>{{ t('procest', 'Motivation (Motivering)') }} *</label>
+				<textarea
+					v-model="form.dispositionDetails"
+					:placeholder="t('procest', 'Detailed motivation for the decision (art. 7:12 Awb)...')"
+					rows="5" />
+				<p v-if="errors.dispositionDetails" class="form-error">
+					{{ errors.dispositionDetails }}
+				</p>
+			</div>
+
+			<!-- Follows advice toggle (if advisory report exists) -->
+			<template v-if="hasAdvisoryReport">
+				<div class="form-group">
+					<NcCheckboxRadioSwitch
+						:checked="form.followsAdvice"
+						@update:checked="v => form.followsAdvice = v">
+						{{ t('procest', 'Decision follows committee advice') }}
+					</NcCheckboxRadioSwitch>
+				</div>
+
+				<div v-if="!form.followsAdvice" class="form-group">
+					<label>{{ t('procest', 'Reason for deviating from advice') }} *</label>
+					<textarea
+						v-model="form.deviationReason"
+						:placeholder="t('procest', 'Per art. 7:13 lid 7, explain why the decision deviates...')"
+						rows="3" />
+					<p v-if="errors.deviationReason" class="form-error">
+						{{ errors.deviationReason }}
+					</p>
+				</div>
+			</template>
+
+			<!-- Remedial action (for gegrond / deels_gegrond) -->
+			<div v-if="form.dispositionType === 'gegrond' || form.dispositionType === 'deels_gegrond'" class="form-group">
+				<label>{{ t('procest', 'Remedial Action') }}</label>
+				<textarea
+					v-model="form.remedialAction"
+					:placeholder="t('procest', 'What corrective action will be taken...')"
+					rows="3" />
+			</div>
+
+			<div class="form-row">
+				<div class="form-group">
+					<label>{{ t('procest', 'Decision Date') }} *</label>
+					<NcTextField
+						:value="form.decisionDate"
+						type="date"
+						@update:value="v => form.decisionDate = v" />
+				</div>
+				<div class="form-group">
+					<label>{{ t('procest', 'Effective Date') }} *</label>
+					<NcTextField
+						:value="form.effectiveDate"
+						type="date"
+						@update:value="v => form.effectiveDate = v" />
+				</div>
+			</div>
+
+			<!-- Rechtsmiddelenclausule -->
+			<div class="form-group">
+				<label>{{ t('procest', 'Appeal Information (Rechtsmiddelenclausule)') }} *</label>
+				<textarea
+					v-model="form.appealInformation"
+					:placeholder="defaultAppealInformation"
+					rows="3" />
+				<p v-if="errors.appealInformation" class="form-error">
+					{{ errors.appealInformation }}
+				</p>
+				<NcNoteCard v-if="!form.appealInformation" type="warning">
+					{{ t('procest', 'Rechtsmiddelenclausule is required: inform the objector about appeal options.') }}
+				</NcNoteCard>
+			</div>
+
+			<div class="bezwaar-decision-form__actions">
+				<NcButton type="primary" :disabled="saving" @click="save">
+					{{ saving ? t('procest', 'Saving...') : t('procest', 'Record Decision') }}
+				</NcButton>
+			</div>
+		</template>
+
+		<template v-else>
+			<p class="section-empty">
+				{{ t('procest', 'No decision has been recorded yet.') }}
+			</p>
+		</template>
+	</div>
+</template>
+
+<script>
+import { NcButton, NcTextField, NcSelect, NcCheckboxRadioSwitch, NcNoteCard } from '@nextcloud/vue'
+import { useBezwaarStore } from '../../../../store/modules/bezwaar.js'
+
+export default {
+	name: 'BezwaarDecisionForm',
+	components: {
+		NcButton,
+		NcTextField,
+		NcSelect,
+		NcCheckboxRadioSwitch,
+		NcNoteCard,
+	},
+	props: {
+		caseId: {
+			type: String,
+			required: true,
+		},
+		isReadOnly: {
+			type: Boolean,
+			default: false,
+		},
+		contestedDecisionId: {
+			type: String,
+			default: '',
+		},
+	},
+	emits: ['saved'],
+	data() {
+		return {
+			form: {
+				dispositionType: 'ongegrond',
+				dispositionDetails: '',
+				followsAdvice: true,
+				deviationReason: '',
+				remedialAction: '',
+				decisionDate: new Date().toISOString().split('T')[0],
+				effectiveDate: new Date().toISOString().split('T')[0],
+				appealInformation: '',
+			},
+			errors: {},
+			saving: false,
+			dispositionOptions: [
+				{ id: 'gegrond', label: t('procest', 'Upheld (gegrond)') },
+				{ id: 'ongegrond', label: t('procest', 'Rejected (ongegrond)') },
+				{ id: 'deels_gegrond', label: t('procest', 'Partially upheld (deels gegrond)') },
+				{ id: 'niet_ontvankelijk', label: t('procest', 'Inadmissible (niet-ontvankelijk)') },
+			],
+			defaultAppealInformation: t(
+				'procest',
+				'Tegen deze beslissing op bezwaar kunt u binnen zes weken na de dag van verzending van deze beslissing beroep instellen bij de rechtbank.',
+			),
+		}
+	},
+	computed: {
+		hasDecision() {
+			const bezwaarStore = useBezwaarStore()
+			return bezwaarStore.hasAppealDecision
+		},
+		decision() {
+			const bezwaarStore = useBezwaarStore()
+			return bezwaarStore.currentAppealDecision
+		},
+		hasAdvisoryReport() {
+			const bezwaarStore = useBezwaarStore()
+			return bezwaarStore.hasAdvisoryReport
+		},
+	},
+	methods: {
+		getDispositionLabel(type) {
+			const labels = {
+				gegrond: t('procest', 'Upheld'),
+				ongegrond: t('procest', 'Rejected'),
+				deels_gegrond: t('procest', 'Partially upheld'),
+				niet_ontvankelijk: t('procest', 'Inadmissible'),
+			}
+			return labels[type] || type
+		},
+		validate() {
+			this.errors = {}
+
+			if (!this.form.dispositionDetails) {
+				this.errors.dispositionDetails = t('procest', 'Motivation is required (art. 7:12 Awb)')
+			}
+			if (!this.form.appealInformation) {
+				this.errors.appealInformation = t('procest', 'Rechtsmiddelenclausule is required')
+			}
+			if (this.hasAdvisoryReport && !this.form.followsAdvice && !this.form.deviationReason) {
+				this.errors.deviationReason = t('procest', 'Reason for deviating from advice is required (art. 7:13 lid 7)')
+			}
+
+			return Object.keys(this.errors).length === 0
+		},
+		async save() {
+			if (!this.validate()) return
+
+			this.saving = true
+			const bezwaarStore = useBezwaarStore()
+
+			await bezwaarStore.createAppealDecision({
+				case: this.caseId,
+				contestedDecision: this.contestedDecisionId,
+				advisoryReport: bezwaarStore.currentAdvisoryReport?.id || '',
+				decisionMaker: '',
+				...this.form,
+			})
+
+			this.saving = false
+			this.$emit('saved')
+		},
+	},
+}
+</script>
+
+<style scoped>
+.bezwaar-decision-form {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+.bezwaar-decision-form__details {
+	display: grid;
+	grid-template-columns: 1fr 1fr 1fr;
+	gap: 12px;
+}
+.decision-detail {
+	display: flex;
+	flex-direction: column;
+}
+.decision-detail__label {
+	font-size: 12px;
+	color: var(--color-text-maxcontrast);
+}
+.bezwaar-decision-form__content {
+	background: var(--color-background-dark);
+	border-radius: var(--border-radius-large);
+	padding: 12px;
+}
+.bezwaar-decision-form__actions {
+	display: flex;
+	justify-content: flex-end;
+}
+.form-group {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+.form-row {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 16px;
+}
+.form-error {
+	color: var(--color-error);
+	font-size: 12px;
+	margin: 0;
+}
+textarea {
+	width: 100%;
+	padding: 8px;
+	border: 2px solid var(--color-border-dark);
+	border-radius: var(--border-radius);
+	resize: vertical;
+}
+</style>

--- a/src/views/cases/components/bezwaar/BezwaarIntakeForm.vue
+++ b/src/views/cases/components/bezwaar/BezwaarIntakeForm.vue
@@ -1,0 +1,332 @@
+<template>
+	<div class="bezwaar-intake-form">
+		<h4>{{ t('procest', 'Objection Details') }}</h4>
+
+		<!-- Contested Decision selector -->
+		<div class="form-group">
+			<label>{{ t('procest', 'Contested Decision (Bestreden Besluit)') }} *</label>
+			<NcTextField
+				:value="form.contestedDecision"
+				:disabled="isReadOnly"
+				:placeholder="t('procest', 'UUID of the contested decision')"
+				:error="!!errors.contestedDecision"
+				@update:value="v => { form.contestedDecision = v; errors.contestedDecision = '' }" />
+			<p v-if="errors.contestedDecision" class="form-error">
+				{{ errors.contestedDecision }}
+			</p>
+		</div>
+
+		<!-- Grounds -->
+		<div class="form-group">
+			<label>{{ t('procest', 'Grounds for Objection (Gronden van Bezwaar)') }} *</label>
+			<textarea
+				v-model="form.grounds"
+				:disabled="isReadOnly"
+				:placeholder="t('procest', 'Describe the grounds for objection...')"
+				rows="4" />
+			<p v-if="errors.grounds" class="form-error">
+				{{ errors.grounds }}
+			</p>
+		</div>
+
+		<!-- Requested Relief -->
+		<div class="form-group">
+			<label>{{ t('procest', 'Requested Outcome') }}</label>
+			<textarea
+				v-model="form.requestedRelief"
+				:disabled="isReadOnly"
+				:placeholder="t('procest', 'What outcome does the objector seek?')"
+				rows="2" />
+		</div>
+
+		<div class="form-row">
+			<!-- Received Date -->
+			<div class="form-group">
+				<label>{{ t('procest', 'Date Received') }} *</label>
+				<NcTextField
+					:value="form.receivedDate"
+					:disabled="isReadOnly"
+					type="date"
+					:error="!!errors.receivedDate"
+					@update:value="v => { form.receivedDate = v; errors.receivedDate = ''; checkTimeliness() }" />
+				<p v-if="errors.receivedDate" class="form-error">
+					{{ errors.receivedDate }}
+				</p>
+			</div>
+
+			<!-- Received Channel -->
+			<div class="form-group">
+				<label>{{ t('procest', 'Received Via') }} *</label>
+				<NcSelect
+					v-model="form.receivedChannel"
+					:options="channelOptions"
+					:disabled="isReadOnly" />
+			</div>
+		</div>
+
+		<!-- Timeliness Warning -->
+		<div v-if="timelinessResult && !timelinessResult.isTimely" class="bezwaar-intake-form__warning">
+			<NcNoteCard type="warning">
+				{{ timelinessResult.message }}
+			</NcNoteCard>
+		</div>
+
+		<div v-if="timelinessResult && timelinessResult.isTimely" class="bezwaar-intake-form__info">
+			<NcNoteCard type="success">
+				{{ timelinessResult.message }}
+			</NcNoteCard>
+		</div>
+
+		<!-- Timeliness Assessment (when late) -->
+		<div v-if="timelinessResult && !timelinessResult.isTimely" class="form-group">
+			<label>{{ t('procest', 'Timeliness Assessment') }}</label>
+			<textarea
+				v-model="form.timelinessAssessment"
+				:disabled="isReadOnly"
+				:placeholder="t('procest', 'E.g. verschoonbare termijnoverschrijding...')"
+				rows="2" />
+		</div>
+
+		<div class="form-row">
+			<!-- Voorlopige Voorziening -->
+			<div class="form-group">
+				<NcCheckboxRadioSwitch
+					:checked="form.proVoorziening"
+					:disabled="isReadOnly"
+					@update:checked="v => form.proVoorziening = v">
+					{{ t('procest', 'Interim relief (voorlopige voorziening) requested') }}
+				</NcCheckboxRadioSwitch>
+			</div>
+		</div>
+
+		<!-- Deadline info -->
+		<div v-if="deadlines" class="bezwaar-intake-form__deadlines">
+			<h5>{{ t('procest', 'Calculated Deadlines') }}</h5>
+			<div class="deadline-grid">
+				<div class="deadline-item">
+					<span class="deadline-label">{{ t('procest', 'Acknowledgment') }}</span>
+					<span class="deadline-value">{{ deadlines.ontvangstbevestigingDeadline }}</span>
+				</div>
+				<div class="deadline-item">
+					<span class="deadline-label">{{ t('procest', 'Processing') }}</span>
+					<span class="deadline-value">{{ deadlines.afhandelDeadline }}</span>
+				</div>
+				<div class="deadline-item">
+					<span class="deadline-label">{{ t('procest', 'Max with extension') }}</span>
+					<span class="deadline-value">{{ deadlines.maxDeadlineWithExtension }}</span>
+				</div>
+			</div>
+		</div>
+
+		<!-- Actions -->
+		<div v-if="!isReadOnly" class="bezwaar-intake-form__actions">
+			<NcButton type="primary" :disabled="saving" @click="save">
+				{{ saving ? t('procest', 'Saving...') : t('procest', 'Save Objection') }}
+			</NcButton>
+		</div>
+	</div>
+</template>
+
+<script>
+import { NcButton, NcTextField, NcSelect, NcCheckboxRadioSwitch, NcNoteCard } from '@nextcloud/vue'
+import { useBezwaarStore } from '../../../../store/modules/bezwaar.js'
+
+export default {
+	name: 'BezwaarIntakeForm',
+	components: {
+		NcButton,
+		NcTextField,
+		NcSelect,
+		NcCheckboxRadioSwitch,
+		NcNoteCard,
+	},
+	props: {
+		caseId: {
+			type: String,
+			required: true,
+		},
+		caseData: {
+			type: Object,
+			default: () => ({}),
+		},
+		isReadOnly: {
+			type: Boolean,
+			default: false,
+		},
+		besluitDate: {
+			type: String,
+			default: '',
+		},
+	},
+	emits: ['saved', 'deadlines-calculated'],
+	data() {
+		return {
+			form: {
+				contestedDecision: '',
+				grounds: '',
+				requestedRelief: '',
+				receivedDate: '',
+				receivedChannel: 'brief',
+				isTimely: null,
+				timelinessAssessment: '',
+				proVoorziening: false,
+			},
+			errors: {},
+			saving: false,
+			timelinessResult: null,
+			deadlines: null,
+			channelOptions: [
+				{ id: 'brief', label: t('procest', 'Letter (brief)') },
+				{ id: 'email', label: t('procest', 'Email') },
+				{ id: 'formulier', label: t('procest', 'Online form (formulier)') },
+				{ id: 'balie', label: t('procest', 'In person (balie)') },
+			],
+		}
+	},
+	mounted() {
+		this.loadExistingObjection()
+	},
+	methods: {
+		async loadExistingObjection() {
+			const bezwaarStore = useBezwaarStore()
+			if (bezwaarStore.currentObjection) {
+				const obj = bezwaarStore.currentObjection
+				this.form.contestedDecision = obj.contestedDecision || ''
+				this.form.grounds = obj.grounds || ''
+				this.form.requestedRelief = obj.requestedRelief || ''
+				this.form.receivedDate = obj.receivedDate || ''
+				this.form.receivedChannel = obj.receivedChannel || 'brief'
+				this.form.isTimely = obj.isTimely
+				this.form.timelinessAssessment = obj.timelinessAssessment || ''
+				this.form.proVoorziening = obj.proVoorziening || false
+
+				if (this.form.receivedDate) {
+					this.checkTimeliness()
+					this.calculateDeadlines()
+				}
+			}
+		},
+		checkTimeliness() {
+			if (!this.form.receivedDate || !this.besluitDate) {
+				this.timelinessResult = null
+				return
+			}
+
+			const bezwaarStore = useBezwaarStore()
+			this.timelinessResult = bezwaarStore.checkTimeliness(
+				this.besluitDate,
+				this.form.receivedDate,
+			)
+			this.form.isTimely = this.timelinessResult.isTimely
+			this.calculateDeadlines()
+		},
+		calculateDeadlines() {
+			if (!this.form.receivedDate) {
+				this.deadlines = null
+				return
+			}
+
+			const bezwaarStore = useBezwaarStore()
+			this.deadlines = bezwaarStore.calculateDeadlines(this.form.receivedDate)
+			this.$emit('deadlines-calculated', this.deadlines)
+		},
+		validate() {
+			this.errors = {}
+
+			if (!this.form.contestedDecision) {
+				this.errors.contestedDecision = t('procest', 'Contested decision is required')
+			}
+			if (!this.form.grounds) {
+				this.errors.grounds = t('procest', 'Grounds for objection are required')
+			}
+			if (!this.form.receivedDate) {
+				this.errors.receivedDate = t('procest', 'Date received is required')
+			}
+
+			return Object.keys(this.errors).length === 0
+		},
+		async save() {
+			if (!this.validate()) return
+
+			this.saving = true
+			const bezwaarStore = useBezwaarStore()
+
+			const data = {
+				...this.form,
+				case: this.caseId,
+			}
+
+			if (bezwaarStore.currentObjection) {
+				data.id = bezwaarStore.currentObjection.id
+				await bezwaarStore.updateObjection(data)
+			} else {
+				await bezwaarStore.createObjection(data)
+			}
+
+			this.saving = false
+			this.$emit('saved')
+		},
+	},
+}
+</script>
+
+<style scoped>
+.bezwaar-intake-form {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+.form-group {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+.form-row {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 16px;
+}
+.form-error {
+	color: var(--color-error);
+	font-size: 12px;
+	margin: 0;
+}
+.bezwaar-intake-form__warning,
+.bezwaar-intake-form__info {
+	margin: 8px 0;
+}
+.bezwaar-intake-form__deadlines {
+	background: var(--color-background-dark);
+	border-radius: var(--border-radius-large);
+	padding: 12px;
+}
+.deadline-grid {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: 12px;
+	margin-top: 8px;
+}
+.deadline-item {
+	display: flex;
+	flex-direction: column;
+}
+.deadline-label {
+	font-size: 12px;
+	color: var(--color-text-maxcontrast);
+}
+.deadline-value {
+	font-weight: bold;
+}
+.bezwaar-intake-form__actions {
+	display: flex;
+	justify-content: flex-end;
+	margin-top: 8px;
+}
+textarea {
+	width: 100%;
+	padding: 8px;
+	border: 2px solid var(--color-border-dark);
+	border-radius: var(--border-radius);
+	resize: vertical;
+}
+</style>

--- a/src/views/cases/components/bezwaar/BezwaarTimeline.vue
+++ b/src/views/cases/components/bezwaar/BezwaarTimeline.vue
@@ -1,0 +1,201 @@
+<template>
+	<div class="bezwaar-timeline">
+		<h4>{{ t('procest', 'Bezwaar Timeline') }}</h4>
+
+		<div class="bezwaar-timeline__items">
+			<div
+				v-for="item in timelineItems"
+				:key="item.id"
+				class="timeline-item"
+				:class="{ 'timeline-item--active': item.active, 'timeline-item--completed': item.completed, 'timeline-item--deadline': item.isDeadline }">
+				<div class="timeline-item__marker" />
+				<div class="timeline-item__content">
+					<span class="timeline-item__date">{{ item.date }}</span>
+					<span class="timeline-item__label">{{ item.label }}</span>
+					<span v-if="item.detail" class="timeline-item__detail">{{ item.detail }}</span>
+				</div>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+import { useBezwaarStore } from '../../../../store/modules/bezwaar.js'
+
+export default {
+	name: 'BezwaarTimeline',
+	props: {
+		caseData: {
+			type: Object,
+			default: () => ({}),
+		},
+		deadlines: {
+			type: Object,
+			default: () => ({}),
+		},
+	},
+	computed: {
+		timelineItems() {
+			const items = []
+			const bezwaarStore = useBezwaarStore()
+
+			// Received date.
+			if (bezwaarStore.currentObjection?.receivedDate) {
+				items.push({
+					id: 'received',
+					date: bezwaarStore.currentObjection.receivedDate,
+					label: t('procest', 'Bezwaarschrift received'),
+					completed: true,
+					active: false,
+					isDeadline: false,
+				})
+			}
+
+			// Acknowledgment deadline.
+			if (this.deadlines?.ontvangstbevestigingDeadline) {
+				items.push({
+					id: 'ack-deadline',
+					date: this.deadlines.ontvangstbevestigingDeadline,
+					label: t('procest', 'Acknowledgment deadline'),
+					completed: false,
+					active: false,
+					isDeadline: true,
+				})
+			}
+
+			// Hearing date.
+			const hearing = bezwaarStore.activeHearing
+			if (hearing?.scheduledDate) {
+				items.push({
+					id: 'hearing',
+					date: hearing.scheduledDate.split('T')[0],
+					label: t('procest', 'Hearing scheduled'),
+					detail: hearing.status === 'uitgevoerd' ? t('procest', 'Completed') : t('procest', hearing.status),
+					completed: hearing.status === 'uitgevoerd',
+					active: hearing.status === 'gepland' || hearing.status === 'uitgenodigd',
+					isDeadline: false,
+				})
+			}
+
+			// Advisory report date.
+			if (bezwaarStore.currentAdvisoryReport?.adviceDate) {
+				items.push({
+					id: 'advisory',
+					date: bezwaarStore.currentAdvisoryReport.adviceDate,
+					label: t('procest', 'Advisory report issued'),
+					detail: this.getAdviceTypeLabel(bezwaarStore.currentAdvisoryReport.adviceType),
+					completed: true,
+					active: false,
+					isDeadline: false,
+				})
+			}
+
+			// Decision date.
+			if (bezwaarStore.currentAppealDecision?.decisionDate) {
+				items.push({
+					id: 'decision',
+					date: bezwaarStore.currentAppealDecision.decisionDate,
+					label: t('procest', 'Decision on objection'),
+					detail: this.getDispositionLabel(bezwaarStore.currentAppealDecision.dispositionType),
+					completed: true,
+					active: false,
+					isDeadline: false,
+				})
+			}
+
+			// Processing deadline.
+			if (this.deadlines?.afhandelDeadline) {
+				items.push({
+					id: 'processing-deadline',
+					date: this.deadlines.afhandelDeadline,
+					label: t('procest', 'Processing deadline'),
+					completed: false,
+					active: false,
+					isDeadline: true,
+				})
+			}
+
+			// Sort by date.
+			items.sort((a, b) => a.date.localeCompare(b.date))
+
+			return items
+		},
+	},
+	methods: {
+		getAdviceTypeLabel(type) {
+			const labels = {
+				gegrond: t('procest', 'Upheld'),
+				ongegrond: t('procest', 'Rejected'),
+				deels_gegrond: t('procest', 'Partially upheld'),
+				niet_ontvankelijk: t('procest', 'Inadmissible'),
+			}
+			return labels[type] || type
+		},
+		getDispositionLabel(type) {
+			const labels = {
+				gegrond: t('procest', 'Upheld'),
+				ongegrond: t('procest', 'Rejected'),
+				deels_gegrond: t('procest', 'Partially upheld'),
+				niet_ontvankelijk: t('procest', 'Inadmissible'),
+			}
+			return labels[type] || type
+		},
+	},
+}
+</script>
+
+<style scoped>
+.bezwaar-timeline {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+.bezwaar-timeline__items {
+	display: flex;
+	flex-direction: column;
+	gap: 0;
+	padding-left: 16px;
+	border-left: 2px solid var(--color-border-dark);
+}
+.timeline-item {
+	display: flex;
+	align-items: flex-start;
+	gap: 12px;
+	padding: 8px 0;
+	position: relative;
+}
+.timeline-item__marker {
+	width: 12px;
+	height: 12px;
+	border-radius: 50%;
+	background: var(--color-border-dark);
+	flex-shrink: 0;
+	margin-left: -23px;
+	margin-top: 4px;
+}
+.timeline-item--completed .timeline-item__marker {
+	background: var(--color-success);
+}
+.timeline-item--active .timeline-item__marker {
+	background: var(--color-primary);
+}
+.timeline-item--deadline .timeline-item__marker {
+	background: var(--color-warning);
+	border: 2px solid var(--color-warning-text);
+}
+.timeline-item__content {
+	display: flex;
+	flex-direction: column;
+}
+.timeline-item__date {
+	font-size: 12px;
+	color: var(--color-text-maxcontrast);
+}
+.timeline-item__label {
+	font-weight: 500;
+}
+.timeline-item__detail {
+	font-size: 13px;
+	color: var(--color-text-lighter);
+}
+</style>

--- a/src/views/cases/components/bezwaar/DeadlineIndicator.vue
+++ b/src/views/cases/components/bezwaar/DeadlineIndicator.vue
@@ -1,0 +1,93 @@
+<template>
+	<div class="deadline-indicator" :class="indicatorClass">
+		<div class="deadline-indicator__icon">
+			<span v-if="status.isSuspended">&#x23F8;</span>
+			<span v-else-if="status.isOverdue">&#x26A0;</span>
+			<span v-else-if="status.isAtRisk">&#x23F0;</span>
+			<span v-else>&#x2713;</span>
+		</div>
+		<div class="deadline-indicator__content">
+			<span class="deadline-indicator__label">{{ label }}</span>
+			<span class="deadline-indicator__value">{{ status.label }}</span>
+			<span class="deadline-indicator__date">{{ t('procest', 'Deadline:') }} {{ deadline }}</span>
+		</div>
+	</div>
+</template>
+
+<script>
+import { useBezwaarStore } from '../../../../store/modules/bezwaar.js'
+
+export default {
+	name: 'DeadlineIndicator',
+	props: {
+		deadline: {
+			type: String,
+			required: true,
+		},
+		label: {
+			type: String,
+			default: '',
+		},
+		isSuspended: {
+			type: Boolean,
+			default: false,
+		},
+	},
+	computed: {
+		status() {
+			const bezwaarStore = useBezwaarStore()
+			return bezwaarStore.getDeadlineStatus(this.deadline, this.isSuspended)
+		},
+		indicatorClass() {
+			if (this.status.isSuspended) return 'deadline-indicator--suspended'
+			if (this.status.isOverdue) return 'deadline-indicator--overdue'
+			if (this.status.isAtRisk) return 'deadline-indicator--at-risk'
+			return 'deadline-indicator--on-track'
+		},
+	},
+}
+</script>
+
+<style scoped>
+.deadline-indicator {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 8px 12px;
+	border-radius: var(--border-radius-large);
+	border-left: 4px solid;
+}
+.deadline-indicator--on-track {
+	border-color: var(--color-success);
+	background: var(--color-success-hover);
+}
+.deadline-indicator--at-risk {
+	border-color: var(--color-warning);
+	background: var(--color-warning-hover);
+}
+.deadline-indicator--overdue {
+	border-color: var(--color-error);
+	background: var(--color-error-hover);
+}
+.deadline-indicator--suspended {
+	border-color: var(--color-text-maxcontrast);
+	background: var(--color-background-dark);
+}
+.deadline-indicator__icon {
+	font-size: 20px;
+}
+.deadline-indicator__content {
+	display: flex;
+	flex-direction: column;
+}
+.deadline-indicator__label {
+	font-size: 12px;
+	color: var(--color-text-maxcontrast);
+}
+.deadline-indicator__value {
+	font-weight: bold;
+}
+.deadline-indicator__date {
+	font-size: 12px;
+}
+</style>

--- a/src/views/cases/components/bezwaar/HearingPanel.vue
+++ b/src/views/cases/components/bezwaar/HearingPanel.vue
@@ -1,0 +1,372 @@
+<template>
+	<div class="hearing-panel">
+		<h4>{{ t('procest', 'Hearing (Hoorzitting)') }}</h4>
+
+		<!-- Hearing waived -->
+		<div v-if="isHearingWaived" class="hearing-panel__waived">
+			<NcNoteCard type="info">
+				{{ t('procest', 'The objector has waived the right to be heard.') }}
+				<span v-if="waiverReason">{{ t('procest', 'Reason:') }} {{ waiverReason }}</span>
+			</NcNoteCard>
+		</div>
+
+		<!-- No hearing yet -->
+		<template v-else-if="!activeHearing && !isReadOnly">
+			<div class="hearing-panel__actions">
+				<NcButton type="primary" @click="showScheduleDialog = true">
+					{{ t('procest', 'Schedule Hearing') }}
+				</NcButton>
+				<NcButton @click="showWaiverDialog = true">
+					{{ t('procest', 'Record Hearing Waiver') }}
+				</NcButton>
+			</div>
+		</template>
+
+		<!-- Active hearing -->
+		<template v-else-if="activeHearing">
+			<div class="hearing-panel__details">
+				<div class="hearing-detail">
+					<span class="hearing-detail__label">{{ t('procest', 'Status') }}</span>
+					<span class="hearing-detail__value status-badge" :class="'status-badge--' + activeHearing.status">
+						{{ getHearingStatusLabel(activeHearing.status) }}
+					</span>
+				</div>
+
+				<div class="hearing-detail">
+					<span class="hearing-detail__label">{{ t('procest', 'Date') }}</span>
+					<span class="hearing-detail__value">{{ formatDateTime(activeHearing.scheduledDate) }}</span>
+				</div>
+
+				<div v-if="activeHearing.location" class="hearing-detail">
+					<span class="hearing-detail__label">{{ t('procest', 'Location') }}</span>
+					<span class="hearing-detail__value">{{ activeHearing.location }}</span>
+				</div>
+
+				<div v-if="activeHearing.videoCallUrl" class="hearing-detail">
+					<span class="hearing-detail__label">{{ t('procest', 'Video link') }}</span>
+					<a :href="activeHearing.videoCallUrl" target="_blank">{{ t('procest', 'Join online') }}</a>
+				</div>
+			</div>
+
+			<!-- Hearing actions based on status -->
+			<div v-if="!isReadOnly" class="hearing-panel__actions">
+				<NcButton
+					v-if="activeHearing.status === 'gepland'"
+					type="primary"
+					@click="sendInvitations">
+					{{ t('procest', 'Send Invitations') }}
+				</NcButton>
+				<NcButton
+					v-if="activeHearing.status === 'gepland' || activeHearing.status === 'uitgenodigd'"
+					type="primary"
+					@click="showMinutesDialog = true">
+					{{ t('procest', 'Record Minutes') }}
+				</NcButton>
+				<NcButton
+					v-if="activeHearing.status !== 'uitgevoerd'"
+					type="error"
+					@click="cancelHearing">
+					{{ t('procest', 'Cancel Hearing') }}
+				</NcButton>
+			</div>
+
+			<!-- Minutes (if hearing completed) -->
+			<div v-if="activeHearing.minutesSummary" class="hearing-panel__minutes">
+				<h5>{{ t('procest', 'Hearing Minutes') }}</h5>
+				<p>{{ activeHearing.minutesSummary }}</p>
+			</div>
+		</template>
+
+		<!-- Schedule Dialog -->
+		<div v-if="showScheduleDialog" class="dialog-overlay" @click.self="showScheduleDialog = false">
+			<div class="dialog-card">
+				<h3>{{ t('procest', 'Schedule Hearing') }}</h3>
+				<div class="form-group">
+					<label>{{ t('procest', 'Date and Time') }} *</label>
+					<NcTextField
+						:value="scheduleForm.scheduledDate"
+						type="datetime-local"
+						@update:value="v => scheduleForm.scheduledDate = v" />
+				</div>
+				<div class="form-group">
+					<label>{{ t('procest', 'Location') }}</label>
+					<NcTextField
+						:value="scheduleForm.location"
+						:placeholder="t('procest', 'Location or Online')"
+						@update:value="v => scheduleForm.location = v" />
+				</div>
+				<div class="form-group">
+					<label>{{ t('procest', 'Video Call URL') }}</label>
+					<NcTextField
+						:value="scheduleForm.videoCallUrl"
+						:placeholder="t('procest', 'https://...')"
+						@update:value="v => scheduleForm.videoCallUrl = v" />
+				</div>
+				<div class="dialog-card__actions">
+					<NcButton @click="showScheduleDialog = false">
+						{{ t('procest', 'Cancel') }}
+					</NcButton>
+					<NcButton type="primary" @click="scheduleHearing">
+						{{ t('procest', 'Schedule') }}
+					</NcButton>
+				</div>
+			</div>
+		</div>
+
+		<!-- Waiver Dialog -->
+		<div v-if="showWaiverDialog" class="dialog-overlay" @click.self="showWaiverDialog = false">
+			<div class="dialog-card">
+				<h3>{{ t('procest', 'Record Hearing Waiver') }}</h3>
+				<p>{{ t('procest', 'The objector waives the right to be heard (Awb art. 7:3).') }}</p>
+				<div class="form-group">
+					<label>{{ t('procest', 'Reason') }}</label>
+					<textarea
+						v-model="waiverForm.reason"
+						:placeholder="t('procest', 'Reason for waiving the hearing right...')"
+						rows="3" />
+				</div>
+				<div class="dialog-card__actions">
+					<NcButton @click="showWaiverDialog = false">
+						{{ t('procest', 'Cancel') }}
+					</NcButton>
+					<NcButton type="primary" @click="recordWaiver">
+						{{ t('procest', 'Record Waiver') }}
+					</NcButton>
+				</div>
+			</div>
+		</div>
+
+		<!-- Minutes Dialog -->
+		<div v-if="showMinutesDialog" class="dialog-overlay" @click.self="showMinutesDialog = false">
+			<div class="dialog-card">
+				<h3>{{ t('procest', 'Record Hearing Minutes') }}</h3>
+				<div class="form-group">
+					<label>{{ t('procest', 'Minutes Summary (Verslag)') }} *</label>
+					<textarea
+						v-model="minutesForm.summary"
+						:placeholder="t('procest', 'Summary of the hearing...')"
+						rows="6" />
+				</div>
+				<div class="dialog-card__actions">
+					<NcButton @click="showMinutesDialog = false">
+						{{ t('procest', 'Cancel') }}
+					</NcButton>
+					<NcButton type="primary" @click="recordMinutes">
+						{{ t('procest', 'Save Minutes') }}
+					</NcButton>
+				</div>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+import { NcButton, NcTextField, NcNoteCard } from '@nextcloud/vue'
+import { useBezwaarStore } from '../../../../store/modules/bezwaar.js'
+
+export default {
+	name: 'HearingPanel',
+	components: {
+		NcButton,
+		NcTextField,
+		NcNoteCard,
+	},
+	props: {
+		caseId: {
+			type: String,
+			required: true,
+		},
+		isReadOnly: {
+			type: Boolean,
+			default: false,
+		},
+	},
+	emits: ['hearing-scheduled', 'hearing-completed', 'hearing-waived'],
+	data() {
+		return {
+			showScheduleDialog: false,
+			showWaiverDialog: false,
+			showMinutesDialog: false,
+			scheduleForm: {
+				scheduledDate: '',
+				location: '',
+				videoCallUrl: '',
+			},
+			waiverForm: {
+				reason: '',
+			},
+			minutesForm: {
+				summary: '',
+			},
+		}
+	},
+	computed: {
+		activeHearing() {
+			const bezwaarStore = useBezwaarStore()
+			return bezwaarStore.activeHearing
+		},
+		isHearingWaived() {
+			const bezwaarStore = useBezwaarStore()
+			return bezwaarStore.isHearingWaived
+		},
+		waiverReason() {
+			const bezwaarStore = useBezwaarStore()
+			const waived = bezwaarStore.hearingSessions.find((h) => h.hearingWaived === true)
+			return waived?.waiverReason || ''
+		},
+	},
+	methods: {
+		getHearingStatusLabel(status) {
+			const labels = {
+				gepland: t('procest', 'Scheduled'),
+				uitgenodigd: t('procest', 'Invitations sent'),
+				uitgevoerd: t('procest', 'Completed'),
+				geannuleerd: t('procest', 'Cancelled'),
+				afgezien: t('procest', 'Waived'),
+			}
+			return labels[status] || status
+		},
+		formatDateTime(dateStr) {
+			if (!dateStr) return '—'
+			try {
+				return new Date(dateStr).toLocaleString('nl-NL', {
+					year: 'numeric',
+					month: 'long',
+					day: 'numeric',
+					hour: '2-digit',
+					minute: '2-digit',
+				})
+			} catch {
+				return dateStr
+			}
+		},
+		async scheduleHearing() {
+			const bezwaarStore = useBezwaarStore()
+			await bezwaarStore.createHearingSession({
+				case: this.caseId,
+				scheduledDate: this.scheduleForm.scheduledDate,
+				location: this.scheduleForm.location,
+				videoCallUrl: this.scheduleForm.videoCallUrl,
+				chairperson: '',
+				invitees: '[]',
+				status: 'gepland',
+				hearingWaived: false,
+			})
+
+			this.showScheduleDialog = false
+			this.$emit('hearing-scheduled')
+		},
+		async sendInvitations() {
+			if (!this.activeHearing) return
+			const bezwaarStore = useBezwaarStore()
+			await bezwaarStore.updateHearingSession({
+				...this.activeHearing,
+				status: 'uitgenodigd',
+			})
+		},
+		async recordMinutes() {
+			if (!this.activeHearing || !this.minutesForm.summary) return
+			const bezwaarStore = useBezwaarStore()
+			await bezwaarStore.updateHearingSession({
+				...this.activeHearing,
+				status: 'uitgevoerd',
+				minutesSummary: this.minutesForm.summary,
+			})
+
+			this.showMinutesDialog = false
+			this.$emit('hearing-completed')
+		},
+		async recordWaiver() {
+			const bezwaarStore = useBezwaarStore()
+			await bezwaarStore.createHearingSession({
+				case: this.caseId,
+				scheduledDate: new Date().toISOString(),
+				chairperson: '',
+				invitees: '[]',
+				status: 'afgezien',
+				hearingWaived: true,
+				waiverReason: this.waiverForm.reason,
+			})
+
+			this.showWaiverDialog = false
+			this.$emit('hearing-waived')
+		},
+		async cancelHearing() {
+			if (!this.activeHearing) return
+			const bezwaarStore = useBezwaarStore()
+			await bezwaarStore.updateHearingSession({
+				...this.activeHearing,
+				status: 'geannuleerd',
+			})
+		},
+	},
+}
+</script>
+
+<style scoped>
+.hearing-panel {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+.hearing-panel__details {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 12px;
+}
+.hearing-detail {
+	display: flex;
+	flex-direction: column;
+}
+.hearing-detail__label {
+	font-size: 12px;
+	color: var(--color-text-maxcontrast);
+}
+.hearing-panel__actions {
+	display: flex;
+	gap: 8px;
+}
+.hearing-panel__minutes {
+	background: var(--color-background-dark);
+	border-radius: var(--border-radius-large);
+	padding: 12px;
+}
+.dialog-overlay {
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	background: rgba(0, 0, 0, 0.5);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	z-index: 10000;
+}
+.dialog-card {
+	background: var(--color-main-background);
+	border-radius: var(--border-radius-large);
+	padding: 24px;
+	width: 480px;
+	max-width: 90vw;
+}
+.dialog-card__actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+	margin-top: 16px;
+}
+.form-group {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	margin-bottom: 12px;
+}
+textarea {
+	width: 100%;
+	padding: 8px;
+	border: 2px solid var(--color-border-dark);
+	border-radius: var(--border-radius);
+	resize: vertical;
+}
+</style>

--- a/tests/Unit/Repair/SeedBezwaarBeroepDataTest.php
+++ b/tests/Unit/Repair/SeedBezwaarBeroepDataTest.php
@@ -1,0 +1,241 @@
+<?php
+
+/**
+ * SeedBezwaarBeroepData Repair Step Unit Tests
+ *
+ * Tests for the SeedBezwaarBeroepData repair step that seeds bezwaar/beroep
+ * case types into OpenRegister during app installation or upgrade.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Repair
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Repair;
+
+use OCA\Procest\Repair\SeedBezwaarBeroepData;
+use OCA\Procest\Service\SeedDataService;
+use OCA\Procest\Service\SettingsService;
+use OCP\Migration\IOutput;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Unit tests for the SeedBezwaarBeroepData repair step.
+ *
+ * @covers \OCA\Procest\Repair\SeedBezwaarBeroepData
+ */
+class SeedBezwaarBeroepDataTest extends TestCase
+{
+
+    /**
+     * The mocked seed data service.
+     *
+     * @var SeedDataService|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private SeedDataService $seedDataService;
+
+    /**
+     * The mocked settings service.
+     *
+     * @var SettingsService|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private SettingsService $settingsService;
+
+    /**
+     * The mocked logger.
+     *
+     * @var LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private LoggerInterface $logger;
+
+    /**
+     * The mocked migration output.
+     *
+     * @var IOutput|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private IOutput $output;
+
+    /**
+     * The repair step under test.
+     *
+     * @var SeedBezwaarBeroepData
+     */
+    private SeedBezwaarBeroepData $repairStep;
+
+
+    /**
+     * Set up test fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->seedDataService = $this->createMock(SeedDataService::class);
+        $this->settingsService = $this->createMock(SettingsService::class);
+        $this->logger          = $this->createMock(LoggerInterface::class);
+        $this->output          = $this->createMock(IOutput::class);
+
+        $this->repairStep = new SeedBezwaarBeroepData(
+            $this->seedDataService,
+            $this->settingsService,
+            $this->logger,
+        );
+
+    }//end setUp()
+
+
+    /**
+     * Test that getName returns a non-empty string description.
+     *
+     * @return void
+     */
+    public function testGetNameReturnsNonEmptyString(): void
+    {
+        $name = $this->repairStep->getName();
+
+        $this->assertNotEmpty($name);
+        $this->assertIsString($name);
+
+    }//end testGetNameReturnsNonEmptyString()
+
+
+    /**
+     * Test that getName contains relevant keywords.
+     *
+     * @return void
+     */
+    public function testGetNameDescribesBezwaarBeroep(): void
+    {
+        $name = $this->repairStep->getName();
+
+        // The name should mention bezwaar/beroep so it is recognizable in logs.
+        $this->assertTrue(
+            stripos($name, 'bezwaar') !== false || stripos($name, 'beroep') !== false,
+            "Repair step name should mention 'bezwaar' or 'beroep', got: {$name}"
+        );
+
+    }//end testGetNameDescribesBezwaarBeroep()
+
+
+    /**
+     * Test that run() skips seeding when OpenRegister is not available.
+     *
+     * @return void
+     */
+    public function testRunSkipsWhenOpenRegisterUnavailable(): void
+    {
+        $this->settingsService
+            ->method('isOpenRegisterAvailable')
+            ->willReturn(false);
+
+        // seedBezwaarBeroepData must NOT be called when OpenRegister is off.
+        $this->seedDataService
+            ->expects($this->never())
+            ->method('seedBezwaarBeroepData');
+
+        $this->output
+            ->expects($this->once())
+            ->method('warning')
+            ->with($this->stringContains('not available'));
+
+        $this->repairStep->run($this->output);
+
+    }//end testRunSkipsWhenOpenRegisterUnavailable()
+
+
+    /**
+     * Test that run() calls seedBezwaarBeroepData when OpenRegister is available.
+     *
+     * @return void
+     */
+    public function testRunCallsSeedServiceWhenOpenRegisterAvailable(): void
+    {
+        $this->settingsService
+            ->method('isOpenRegisterAvailable')
+            ->willReturn(true);
+
+        $this->seedDataService
+            ->expects($this->once())
+            ->method('seedBezwaarBeroepData')
+            ->willReturn([
+                'success'     => true,
+                'caseTypes'   => 2,
+                'statusTypes' => 8,
+                'roleTypes'   => 4,
+                'workflows'   => 2,
+                'skipped'     => 0,
+            ]);
+
+        $this->repairStep->run($this->output);
+
+    }//end testRunCallsSeedServiceWhenOpenRegisterAvailable()
+
+
+    /**
+     * Test that run() logs an info message on successful seeding.
+     *
+     * @return void
+     */
+    public function testRunOutputsInfoOnSuccess(): void
+    {
+        $this->settingsService
+            ->method('isOpenRegisterAvailable')
+            ->willReturn(true);
+
+        $this->seedDataService
+            ->method('seedBezwaarBeroepData')
+            ->willReturn([
+                'success'     => true,
+                'caseTypes'   => 2,
+                'statusTypes' => 8,
+                'roleTypes'   => 4,
+                'workflows'   => 2,
+                'skipped'     => 0,
+            ]);
+
+        // Expect info() to be called at least once.
+        $this->output
+            ->expects($this->atLeastOnce())
+            ->method('info');
+
+        $this->repairStep->run($this->output);
+
+    }//end testRunOutputsInfoOnSuccess()
+
+
+    /**
+     * Test that run() handles unexpected exceptions gracefully.
+     *
+     * @return void
+     */
+    public function testRunHandlesExceptionsGracefully(): void
+    {
+        $this->settingsService
+            ->method('isOpenRegisterAvailable')
+            ->willReturn(true);
+
+        $this->seedDataService
+            ->method('seedBezwaarBeroepData')
+            ->willThrowException(new \RuntimeException('Unexpected error'));
+
+        // run() must not throw — exceptions should be caught and logged.
+        $this->output
+            ->expects($this->once())
+            ->method('warning');
+
+        $this->repairStep->run($this->output);
+
+    }//end testRunHandlesExceptionsGracefully()
+
+
+}//end class

--- a/tests/Unit/Service/SeedDataServiceTest.php
+++ b/tests/Unit/Service/SeedDataServiceTest.php
@@ -1,0 +1,280 @@
+<?php
+
+/**
+ * SeedDataService Unit Tests
+ *
+ * Tests for the Procest SeedDataService that seeds bezwaar/beroep case types
+ * into OpenRegister.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Service;
+
+use OCA\Procest\Service\SeedDataService;
+use OCP\IAppConfig;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Unit tests for SeedDataService.
+ *
+ * @covers \OCA\Procest\Service\SeedDataService
+ */
+class SeedDataServiceTest extends TestCase
+{
+
+    /**
+     * The mocked app configuration service.
+     *
+     * @var IAppConfig|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private IAppConfig $appConfig;
+
+    /**
+     * The mocked DI container.
+     *
+     * @var ContainerInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private ContainerInterface $container;
+
+    /**
+     * The mocked logger.
+     *
+     * @var LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private LoggerInterface $logger;
+
+    /**
+     * The service under test.
+     *
+     * @var SeedDataService
+     */
+    private SeedDataService $service;
+
+
+    /**
+     * Set up test fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->appConfig = $this->createMock(IAppConfig::class);
+        $this->container = $this->createMock(ContainerInterface::class);
+        $this->logger    = $this->createMock(LoggerInterface::class);
+
+        $this->service = new SeedDataService(
+            $this->appConfig,
+            $this->container,
+            $this->logger,
+        );
+
+    }//end setUp()
+
+
+    /**
+     * Test that seedBezwaarBeroepData returns failure when ObjectService is unavailable.
+     *
+     * When OpenRegister is not installed the container will throw, causing
+     * getObjectService() to return null.
+     *
+     * @return void
+     */
+    public function testSeedBezwaarBeroepDataFailsWithoutObjectService(): void
+    {
+        // All config values are non-empty so we get past the early config check.
+        $this->appConfig
+            ->method('getValueString')
+            ->willReturn('some-register-id');
+
+        // Container throws, ObjectService is unavailable.
+        $this->container
+            ->method('get')
+            ->willThrowException(new \RuntimeException('Service not found'));
+
+        $result = $this->service->seedBezwaarBeroepData();
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('ObjectService not available', $result['message']);
+
+    }//end testSeedBezwaarBeroepDataFailsWithoutObjectService()
+
+
+    /**
+     * Test that seedBezwaarBeroepData returns failure when register is not configured.
+     *
+     * @return void
+     */
+    public function testSeedBezwaarBeroepDataFailsWithoutRegisterConfig(): void
+    {
+        // Config returns empty for all keys.
+        $this->appConfig
+            ->method('getValueString')
+            ->willReturn('');
+
+        // ObjectService IS available (non-null).
+        $objectService = new \stdClass();
+        $this->container
+            ->method('get')
+            ->willReturn($objectService);
+
+        $result = $this->service->seedBezwaarBeroepData();
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('not configured', $result['message']);
+
+    }//end testSeedBezwaarBeroepDataFailsWithoutRegisterConfig()
+
+
+    /**
+     * Test that seedBezwaarBeroepData returns success summary on correct setup.
+     *
+     * This test verifies the happy path with the real bezwaar_seed_data.json file.
+     * The ObjectService mock simulates that all objects are newly created (not found by filter).
+     *
+     * @return void
+     */
+    public function testSeedBezwaarBeroepDataReturnsSummaryStructure(): void
+    {
+        // Config returns valid IDs so we get past the register check.
+        $this->appConfig
+            ->method('getValueString')
+            ->willReturnCallback(
+                function (string $app, string $key): string {
+                    if ($key === 'register') {
+                        return 'register-uuid-1';
+                    }
+
+                    if ($key === 'case_type_schema') {
+                        return 'schema-uuid-1';
+                    }
+
+                    return 'schema-uuid-2';
+                }
+            );
+
+        // ObjectService that returns empty (no existing objects) and creates new ones.
+        $createdObject = new \stdClass();
+        $createdObject->uuid = 'created-uuid-1';
+
+        $objectServiceMock = $this->getMockBuilder(\stdClass::class)
+            ->addMethods(['getObjects', 'saveObject'])
+            ->getMock();
+
+        $objectServiceMock
+            ->method('getObjects')
+            ->willReturn([]);
+
+        $objectServiceMock
+            ->method('saveObject')
+            ->willReturn($createdObject);
+
+        $this->container
+            ->method('get')
+            ->willReturn($objectServiceMock);
+
+        $result = $this->service->seedBezwaarBeroepData();
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('success', $result);
+        $this->assertArrayHasKey('caseTypes', $result);
+        $this->assertArrayHasKey('statusTypes', $result);
+        $this->assertArrayHasKey('roleTypes', $result);
+        $this->assertArrayHasKey('workflows', $result);
+        $this->assertArrayHasKey('skipped', $result);
+
+    }//end testSeedBezwaarBeroepDataReturnsSummaryStructure()
+
+
+    /**
+     * Test that seedBezwaarBeroepData skips existing case types.
+     *
+     * When getObjects returns a result, the case type exists and should be skipped.
+     *
+     * @return void
+     */
+    public function testSeedBezwaarBeroepDataSkipsExistingCaseTypes(): void
+    {
+        $this->appConfig
+            ->method('getValueString')
+            ->willReturnCallback(
+                function (string $app, string $key): string {
+                    if ($key === 'register') {
+                        return 'register-uuid-1';
+                    }
+
+                    if ($key === 'case_type_schema') {
+                        return 'schema-uuid-1';
+                    }
+
+                    return '';
+                }
+            );
+
+        $existingObject = new \stdClass();
+        $existingObject->uuid = 'existing-uuid-1';
+
+        $objectServiceMock = $this->getMockBuilder(\stdClass::class)
+            ->addMethods(['getObjects', 'saveObject'])
+            ->getMock();
+
+        // Always return an existing object from getObjects.
+        $objectServiceMock
+            ->method('getObjects')
+            ->willReturn([$existingObject]);
+
+        // saveObject should NOT be called if all case types are skipped.
+        $objectServiceMock
+            ->expects($this->never())
+            ->method('saveObject');
+
+        $this->container
+            ->method('get')
+            ->willReturn($objectServiceMock);
+
+        $result = $this->service->seedBezwaarBeroepData();
+
+        // All case types should be skipped, none created.
+        if ($result['success'] === true) {
+            $this->assertSame(0, $result['caseTypes']);
+            $this->assertGreaterThan(0, $result['skipped']);
+        }
+
+    }//end testSeedBezwaarBeroepDataSkipsExistingCaseTypes()
+
+
+    /**
+     * Test that the bezwaar seed data file exists and is valid JSON.
+     *
+     * @return void
+     */
+    public function testBezwaarSeedDataFileExistsAndIsValidJson(): void
+    {
+        $seedPath = __DIR__.'/../../../lib/Settings/bezwaar_seed_data.json';
+
+        $this->assertFileExists($seedPath, 'bezwaar_seed_data.json must exist');
+
+        $content  = file_get_contents($seedPath);
+        $seedData = json_decode($content, true);
+
+        $this->assertSame(JSON_ERROR_NONE, json_last_error(), 'bezwaar_seed_data.json must be valid JSON');
+        $this->assertIsArray($seedData);
+        $this->assertArrayHasKey('caseTypes', $seedData, 'Seed data must have caseTypes key');
+
+    }//end testBezwaarSeedDataFileExistsAndIsValidJson()
+
+
+}//end class


### PR DESCRIPTION
## Summary
Closes #86

AWB-compliant bezwaar (objection) and beroep (appeal) workflow for Dutch administrative law. Depends on workflow-engine-enhancement (PR #93).

- Pre-seeded Bezwaar case type with 10 status types, 7 role types, and full workflow template (11 transitions, 18 steps)
- Pre-seeded Beroep case type with 9 status types, 3 role types, and workflow template (8 transitions, 7 steps)
- 4 new OpenRegister schemas: objection, hearingSession, advisoryReport, appealDecision
- Bezwaar Pinia store with CRUD, AWB deadline calculation (6-week/12-week), suspension, escalation
- 8 Vue components for bezwaar/beroep case detail (intake form, hearing panel, advisory report, decision form, timeline, deadline indicator, escalation panel, court proceedings panel)
- Conditional rendering in CaseDetail based on case type identifier

## Evidence
534+ tenders, 2,942+ requirements from market intelligence. 21 spec requirements, 46 implementation tasks.

## Dependencies
- Requires PR #93 (workflow-engine-enhancement) to be merged first

## Test plan
- [ ] Verify repair step seeds Bezwaar and Beroep case types (idempotent)
- [ ] Create a bezwaar case, verify all status types and workflow transitions
- [ ] Test hearing scheduling, invitation sending, minutes recording
- [ ] Test advisory report creation with committee composition warning
- [ ] Test decision form with rechtsmiddelenclausule validation
- [ ] Test bezwaar-to-beroep escalation with data pre-fill
- [ ] Verify deadline calculation (6-week, extension, suspension)
- [ ] Verify PHPCS/Psalm/PHPStan pass on new PHP files