### PR TITLE
Harmonize .gitignore with shared template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,19 +1,53 @@
-/node_modules/
-/js/
+# IDE
+/.idea/
+/*.iml
+*.Identifier
+
+# Dependencies
 /vendor/
+/vendor-bin/*/vendor/
+/node_modules/
+
+# Build artifacts
+/js/
+
+# Documentation
+/docs/node_modules/
+/docs/build/
+/docs/.docusaurus/
 /docusaurus/node_modules/
 /docusaurus/build/
 /docusaurus/.docusaurus/
-docs/.docusaurus/
-docs/node_modules/
 
-# Test/build artifacts
+# Testing & Quality
+/.php-cs-fixer.cache
+/tests/.phpunit.cache
+/.phpunit.cache/
 .phpunit.cache
 .phpunit.cache/
 .phpunit.result.cache
+/coverage/
 coverage/
+/coverage-frontend/
+/phpmetrics/
 phpmetrics/
+/quality-reports/
+/phpqa/
 
 # Playwright output (paths align with the shared quality.yml artifact uploads)
 /test-results/
 /playwright-report/
+
+# Nextcloud
+/custom_apps/
+/config/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Claude Code
+.claude/worktrees/
+
+# Repo-specific
+tests/e2e/.auth/


### PR DESCRIPTION
## Summary
- Harmonizes `.gitignore` with the shared Conduction template
- Adds IDE, dependency, documentation, Nextcloud, OS, Claude Code, and repo-specific (e2e auth) patterns

Closes #119