### PR TITLE
feat: add deelzaak (sub-case) support with hierarchy, closure guard, and vervolg-zaak

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -107,6 +107,12 @@ return [
         ['name' => 'nrc#patch', 'url' => '/api/zgw/notificaties/v1/{resource}/{uuid}', 'verb' => 'PATCH'],
         ['name' => 'nrc#destroy', 'url' => '/api/zgw/notificaties/v1/{resource}/{uuid}', 'verb' => 'DELETE'],
 
+        // ── Deelzaak (Sub-case) endpoints ───────────────────────────────────
+        ['name' => 'deelzaak#create',       'url' => '/api/procest/deelzaak/{caseId}',              'verb' => 'POST'],
+        ['name' => 'deelzaak#hierarchy',    'url' => '/api/procest/deelzaak/{caseId}/hierarchy',    'verb' => 'GET'],
+        ['name' => 'deelzaak#closureCheck', 'url' => '/api/procest/deelzaak/{caseId}/closure-check','verb' => 'GET'],
+        ['name' => 'deelzaak#vervolgzaak',  'url' => '/api/procest/deelzaak/{caseId}/vervolgzaak',  'verb' => 'POST'],
+
         // GIS Proxy endpoints.
         ['name' => 'gis_proxy#proxy', 'url' => '/api/gis/proxy', 'verb' => 'POST'],
         ['name' => 'gis_proxy#capabilities', 'url' => '/api/gis/capabilities', 'verb' => 'GET'],

--- a/lib/Controller/DeelzaakController.php
+++ b/lib/Controller/DeelzaakController.php
@@ -1,0 +1,263 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ * Copyright (C) 2026 Conduction B.V.
+ *
+ * Procest Deelzaak Controller
+ *
+ * REST API endpoints for deelzaak (sub-case) creation, hierarchy retrieval,
+ * closure validation, and vervolg-zaak creation.
+ *
+ * @category Controller
+ * @package  OCA\Procest\Controller
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * @spec openspec/changes/deelzaak-support/tasks.md#T02
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Controller;
+
+use OCA\Procest\Service\DeelzaakService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use OCP\IUserSession;
+
+/**
+ * REST controller for deelzaak operations.
+ *
+ * Endpoints:
+ * - POST   /api/procest/deelzaak/{caseId}               — create deelzaak
+ * - GET    /api/procest/deelzaak/{caseId}/hierarchy      — get full hierarchy tree
+ * - GET    /api/procest/deelzaak/{caseId}/closure-check  — validate closure
+ * - POST   /api/procest/deelzaak/{caseId}/vervolgzaak    — create follow-up case
+ *
+ * @spec openspec/changes/deelzaak-support/tasks.md#T02
+ */
+class DeelzaakController extends Controller
+{
+    /**
+     * Constructor.
+     *
+     * @param string          $appName         App name
+     * @param IRequest        $request         Incoming request
+     * @param DeelzaakService $deelzaakService Deelzaak business logic
+     * @param IUserSession    $userSession     Current user session
+     *
+     * @spec openspec/changes/deelzaak-support/tasks.md#T02
+     */
+    public function __construct(
+        string $appName,
+        IRequest $request,
+        private readonly DeelzaakService $deelzaakService,
+        private readonly IUserSession $userSession,
+    ) {
+        parent::__construct(appName: $appName, request: $request);
+    }//end __construct()
+
+    /**
+     * Create a deelzaak under the given parent case.
+     *
+     * Request body (JSON):
+     * - caseTypeId (string, required): UUID of the deelzaak caseType
+     * - title      (string, optional): Override title for the deelzaak
+     * - assignee   (string, optional): Nextcloud UID to assign the deelzaak to
+     *
+     * @param string $caseId UUID of the parent (hoofdzaak) case
+     *
+     * @return JSONResponse 201 with created deelzaak, or 400/500 on error
+     *
+     * @NoAdminRequired
+     *
+     * @spec openspec/changes/deelzaak-support/tasks.md#T02
+     */
+    public function create(string $caseId): JSONResponse
+    {
+        $body       = $this->request->getParams();
+        $caseTypeId = trim((string) ($body['caseTypeId'] ?? ''));
+
+        if ($caseTypeId === '') {
+            return new JSONResponse(
+                ['error' => 'caseTypeId is required'],
+                Http::STATUS_BAD_REQUEST
+            );
+        }
+
+        $title    = null;
+        $assignee = null;
+
+        if (isset($body['title']) === true) {
+            $title = trim((string) $body['title']);
+        }
+
+        if (isset($body['assignee']) === true) {
+            $assignee = trim((string) $body['assignee']);
+        }
+
+        $user        = $this->userSession->getUser();
+        $requestedBy = null;
+        if ($user !== null) {
+            $requestedBy = $user->getUID();
+        }
+
+        $titleParam    = null;
+        $assigneeParam = null;
+        if ($title !== null && $title !== '') {
+            $titleParam = $title;
+        }
+
+        if ($assignee !== null && $assignee !== '') {
+            $assigneeParam = $assignee;
+        }
+
+        try {
+            $deelzaak = $this->deelzaakService->createDeelzaak(
+                parentCaseId: $caseId,
+                caseTypeId: $caseTypeId,
+                title: $titleParam,
+                assignee: $assigneeParam,
+                requestedBy: $requestedBy,
+            );
+            return new JSONResponse($deelzaak, Http::STATUS_CREATED);
+        } catch (\RuntimeException $e) {
+            return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_CONFLICT);
+        } catch (\Throwable $e) {
+            return new JSONResponse(
+                ['error' => 'Internal error: '.$e->getMessage()],
+                Http::STATUS_INTERNAL_SERVER_ERROR
+            );
+        }//end try
+    }//end create()
+
+    /**
+     * Retrieve the full case hierarchy rooted at the given case.
+     *
+     * Returns a nested structure:
+     * `{ "case": {...}, "children": [{ "case": {...}, "children": [...] }] }`
+     *
+     * @param string $caseId UUID of the root case
+     *
+     * @return JSONResponse 200 with hierarchy tree, or 404/500 on error
+     *
+     * @NoAdminRequired
+     *
+     * @spec openspec/changes/deelzaak-support/tasks.md#T02
+     */
+    public function hierarchy(string $caseId): JSONResponse
+    {
+        try {
+            $tree = $this->deelzaakService->getHierarchy(caseId: $caseId);
+            return new JSONResponse($tree);
+        } catch (\RuntimeException $e) {
+            $msg = $e->getMessage();
+            if (str_contains($msg, 'not found') === true) {
+                return new JSONResponse(['error' => $msg], Http::STATUS_NOT_FOUND);
+            }
+
+            return new JSONResponse(['error' => $msg], Http::STATUS_INTERNAL_SERVER_ERROR);
+        } catch (\Throwable $e) {
+            return new JSONResponse(
+                ['error' => 'Internal error: '.$e->getMessage()],
+                Http::STATUS_INTERNAL_SERVER_ERROR
+            );
+        }//end try
+    }//end hierarchy()
+
+    /**
+     * Check whether a case can be closed.
+     *
+     * Returns `{ "canClose": true/false, "openDeelzaken": [...] }`.
+     *
+     * @param string $caseId UUID of the case to check
+     *
+     * @return JSONResponse 200 with closure check result, or 500 on error
+     *
+     * @NoAdminRequired
+     *
+     * @spec openspec/changes/deelzaak-support/tasks.md#T02
+     */
+    public function closureCheck(string $caseId): JSONResponse
+    {
+        try {
+            $result = $this->deelzaakService->validateClosureAllowed(caseId: $caseId);
+            return new JSONResponse($result);
+        } catch (\Throwable $e) {
+            return new JSONResponse(
+                ['error' => 'Internal error: '.$e->getMessage()],
+                Http::STATUS_INTERNAL_SERVER_ERROR
+            );
+        }//end try
+    }//end closureCheck()
+
+    /**
+     * Create a vervolg-zaak (follow-up case) from the given case.
+     *
+     * Request body (JSON):
+     * - caseTypeId (string, required): UUID of the follow-up caseType
+     * - title      (string, optional): Override title for the vervolg-zaak
+     *
+     * @param string $caseId UUID of the source (predecessor) case
+     *
+     * @return JSONResponse 201 with created vervolg-zaak, or 400/500 on error
+     *
+     * @NoAdminRequired
+     *
+     * @spec openspec/changes/deelzaak-support/tasks.md#T02
+     */
+    public function vervolgzaak(string $caseId): JSONResponse
+    {
+        $body       = $this->request->getParams();
+        $caseTypeId = trim((string) ($body['caseTypeId'] ?? ''));
+
+        if ($caseTypeId === '') {
+            return new JSONResponse(
+                ['error' => 'caseTypeId is required'],
+                Http::STATUS_BAD_REQUEST
+            );
+        }
+
+        $title = null;
+        if (isset($body['title']) === true) {
+            $title = trim((string) $body['title']);
+        }
+
+        $user        = $this->userSession->getUser();
+        $requestedBy = null;
+        if ($user !== null) {
+            $requestedBy = $user->getUID();
+        }
+
+        $titleParam = null;
+        if ($title !== null && $title !== '') {
+            $titleParam = $title;
+        }
+
+        try {
+            $vervolgzaak = $this->deelzaakService->createVervolgzaak(
+                sourceCaseId: $caseId,
+                caseTypeId: $caseTypeId,
+                title: $titleParam,
+                requestedBy: $requestedBy,
+            );
+            return new JSONResponse($vervolgzaak, Http::STATUS_CREATED);
+        } catch (\RuntimeException $e) {
+            return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_CONFLICT);
+        } catch (\Throwable $e) {
+            return new JSONResponse(
+                ['error' => 'Internal error: '.$e->getMessage()],
+                Http::STATUS_INTERNAL_SERVER_ERROR
+            );
+        }//end try
+    }//end vervolgzaak()
+}//end class

--- a/lib/Service/DeelzaakService.php
+++ b/lib/Service/DeelzaakService.php
@@ -1,0 +1,673 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ * Copyright (C) 2026 Conduction B.V.
+ *
+ * Procest Deelzaak Service
+ *
+ * Service for creating and managing deelzaken (sub-cases) in Procest.
+ * Supports hierarchical case structures (hoofdzaak → deelzaken) and
+ * vervolg-zaak (follow-up case) creation with typed relatie linking.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * @spec openspec/changes/deelzaak-support/tasks.md#T01
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * Service for deelzaak (sub-case) creation and hierarchy management.
+ *
+ * Implements:
+ * - Manual and automatic deelzaak creation with field inheritance
+ * - Zaaktype deelzaaktype validation (only allowed subCaseTypes)
+ * - Closure guard: blocks parent closure when deelzaken are open
+ * - Vervolg-zaak creation with predecessor/successor relatie links
+ * - Recursive hierarchy retrieval (n levels)
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/changes/deelzaak-support/tasks.md#T01
+ */
+class DeelzaakService
+{
+
+    /**
+     * Relationship type constant for deelzaak (parent-child).
+     */
+    private const AARD_RELATIE_BIJDRAGE = 'bijdrage';
+
+    /**
+     * Relationship type constant for vervolg-zaak (successor).
+     */
+    private const AARD_RELATIE_VERVOLG = 'vervolg';
+
+    /**
+     * Relationship type constant for onderverdeling (predecessor).
+     */
+    private const AARD_RELATIE_ONDERWERP = 'onderwerp';
+
+    /**
+     * Maximum hierarchy depth guard to prevent infinite recursion.
+     */
+    private const MAX_HIERARCHY_DEPTH = 10;
+
+    /**
+     * Constructor.
+     *
+     * @param SettingsService $settingsService Settings and OpenRegister access
+     * @param LoggerInterface $logger          PSR logger
+     *
+     * @spec openspec/changes/deelzaak-support/tasks.md#T01
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Create a deelzaak (sub-case) under a parent case.
+     *
+     * Validates that the requested caseTypeId is in the parent caseType's
+     * `subCaseTypes` list. Inherits deadline and archiveNomination from the
+     * parent. Sets parentCase to the parent's ID.
+     *
+     * @param string      $parentCaseId The UUID of the parent (hoofdzaak) case
+     * @param string      $caseTypeId   The UUID of the deelzaak's caseType
+     * @param string|null $title        Optional title override for the deelzaak
+     * @param string|null $assignee     Optional assignee UID
+     * @param string|null $requestedBy  UID of the user requesting the creation
+     *
+     * @return array<string, mixed> The created deelzaak object (serialized)
+     *
+     * @throws \RuntimeException When OpenRegister unavailable, parent not found,
+     *                           or caseTypeId not allowed as deelzaak
+     *
+     * @spec openspec/changes/deelzaak-support/tasks.md#T01
+     *
+     * @SuppressWarnings(PHPMD.NPathComplexity)
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     */
+    public function createDeelzaak(
+        string $parentCaseId,
+        string $caseTypeId,
+        ?string $title=null,
+        ?string $assignee=null,
+        ?string $requestedBy=null,
+    ): array {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            throw new \RuntimeException('OpenRegister objectService unavailable');
+        }
+
+        $register   = $this->settingsService->getConfigValue(key: 'register');
+        $caseSchema = $this->settingsService->getConfigValue(key: 'case_schema');
+        $ctSchema   = $this->settingsService->getConfigValue(key: 'case_type_schema');
+
+        if ($register === '' || $caseSchema === '' || $ctSchema === '') {
+            throw new \RuntimeException('Case register/schema settings not configured');
+        }
+
+        // Load parent case.
+        $parentCase = $this->findObject(
+            objectService: $objectService,
+            uuid: $parentCaseId,
+            register: $register,
+            schema: $caseSchema
+        );
+        if ($parentCase === null) {
+            throw new \RuntimeException("Parent case '{$parentCaseId}' not found");
+        }
+
+        // Load parent caseType to validate allowed sub-case types.
+        $parentCaseTypeId = $parentCase['caseType'] ?? '';
+        if ($parentCaseTypeId === '') {
+            throw new \RuntimeException('Parent case has no caseType configured');
+        }
+
+        $parentCaseTypeUuid = $this->extractUuidFromValue(value: $parentCaseTypeId);
+        $parentCaseType     = $this->findObject(
+            objectService: $objectService,
+            uuid: $parentCaseTypeUuid,
+            register: $register,
+            schema: $ctSchema
+        );
+        if ($parentCaseType === null) {
+            throw new \RuntimeException("Parent caseType '{$parentCaseTypeUuid}' not found");
+        }
+
+        // Validate that caseTypeId is in the allowed subCaseTypes.
+        $this->assertAllowedSubCaseType(
+            caseTypeId: $caseTypeId,
+            parentCaseType: $parentCaseType
+        );
+
+        // Load the deelzaak's caseType for title derivation.
+        $deelzaakCaseType = $this->findObject(
+            objectService: $objectService,
+            uuid: $caseTypeId,
+            register: $register,
+            schema: $ctSchema
+        );
+
+        // Build deelzaak data, inheriting applicable fields from parent.
+        $deelzaakTitle = $title ?? ($deelzaakCaseType['title'] ?? 'Deelzaak');
+        $deelzaakData  = [
+            'title'             => $deelzaakTitle,
+            'caseType'          => $caseTypeId,
+            'parentCase'        => $parentCaseId,
+            'deadline'          => $parentCase['deadline'] ?? null,
+            'archiveNomination' => $parentCase['archiveNomination'] ?? null,
+            'confidentiality'   => $parentCase['confidentiality'] ?? null,
+            'assignee'          => $assignee ?? ($deelzaakCaseType['defaultAssignee'] ?? null),
+            'startDate'         => date('Y-m-d'),
+        ];
+
+        // Strip null values to avoid overriding OpenRegister defaults.
+        $deelzaakData = array_filter(
+            $deelzaakData,
+            static fn ($v) => $v !== null
+        );
+
+        $created = $objectService->saveObject(
+            register: $register,
+            schema: $caseSchema,
+            object: $deelzaakData
+        );
+
+        if (is_array($created) === true) {
+            $createdArray = $created;
+        } else {
+            $createdArray = $created->jsonSerialize();
+        }
+
+        $this->logger->info(
+            'DeelzaakService: created deelzaak {id} under parent {parent} (requestedBy={user})',
+            [
+                'id'     => $createdArray['id'] ?? 'unknown',
+                'parent' => $parentCaseId,
+                'user'   => $requestedBy ?? 'system',
+            ]
+        );
+
+        return $createdArray;
+    }//end createDeelzaak()
+
+    /**
+     * Retrieve the full case hierarchy rooted at a given case.
+     *
+     * Returns a nested structure: `['case' => [...], 'children' => [...]]`.
+     * Recursion is capped at MAX_HIERARCHY_DEPTH to prevent runaway queries.
+     *
+     * @param string $caseId The UUID of the root case
+     * @param int    $depth  Current recursion depth (internal use)
+     *
+     * @return array<string, mixed> Nested hierarchy tree
+     *
+     * @throws \RuntimeException When OpenRegister unavailable or case not found
+     *
+     * @spec openspec/changes/deelzaak-support/tasks.md#T01
+     */
+    public function getHierarchy(string $caseId, int $depth=0): array
+    {
+        if ($depth >= self::MAX_HIERARCHY_DEPTH) {
+            return ['case' => ['id' => $caseId], 'children' => []];
+        }
+
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            throw new \RuntimeException('OpenRegister objectService unavailable');
+        }
+
+        $register   = $this->settingsService->getConfigValue(key: 'register');
+        $caseSchema = $this->settingsService->getConfigValue(key: 'case_schema');
+
+        if ($register === '' || $caseSchema === '') {
+            throw new \RuntimeException('Case register/schema settings not configured');
+        }
+
+        $rootCase = $this->findObject(
+            objectService: $objectService,
+            uuid: $caseId,
+            register: $register,
+            schema: $caseSchema
+        );
+        if ($rootCase === null) {
+            throw new \RuntimeException("Case '{$caseId}' not found");
+        }
+
+        $children   = $this->fetchDirectChildren(
+            objectService: $objectService,
+            parentCaseId: $caseId,
+            register: $register,
+            schema: $caseSchema
+        );
+        $childTrees = [];
+        foreach ($children as $child) {
+            $childId = $child['id'] ?? '';
+            if ($childId === '') {
+                continue;
+            }
+
+            $childTrees[] = $this->getHierarchy(caseId: $childId, depth: ($depth + 1));
+        }
+
+        return [
+            'case'     => $rootCase,
+            'children' => $childTrees,
+        ];
+    }//end getHierarchy()
+
+    /**
+     * Validate whether a case can be closed.
+     *
+     * Returns `['canClose' => true]` when no open deelzaken block closure.
+     * Returns `['canClose' => false, 'openDeelzaken' => [...]]` when blocked.
+     * Only blocks when the caseType has `requireAllDeelzakenClosed` set to true.
+     *
+     * @param string $caseId The UUID of the case being closed
+     *
+     * @return array{canClose: bool, openDeelzaken: array<int, array<string, mixed>>}
+     *
+     * @throws \RuntimeException When OpenRegister unavailable
+     *
+     * @spec openspec/changes/deelzaak-support/tasks.md#T01
+     */
+    public function validateClosureAllowed(string $caseId): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            throw new \RuntimeException('OpenRegister objectService unavailable');
+        }
+
+        $register   = $this->settingsService->getConfigValue(key: 'register');
+        $caseSchema = $this->settingsService->getConfigValue(key: 'case_schema');
+        $ctSchema   = $this->settingsService->getConfigValue(key: 'case_type_schema');
+
+        if ($register === '' || $caseSchema === '' || $ctSchema === '') {
+            return ['canClose' => true, 'openDeelzaken' => []];
+        }
+
+        // Load the case to get its caseType.
+        $caseData = $this->findObject(
+            objectService: $objectService,
+            uuid: $caseId,
+            register: $register,
+            schema: $caseSchema
+        );
+        if ($caseData === null) {
+            return ['canClose' => true, 'openDeelzaken' => []];
+        }
+
+        // Check if caseType requires all deelzaken to be closed.
+        $caseTypeId   = $caseData['caseType'] ?? '';
+        $ctUuid       = $this->extractUuidFromValue(value: (string) $caseTypeId);
+        $caseTypeData = $this->findObject(
+            objectService: $objectService,
+            uuid: $ctUuid,
+            register: $register,
+            schema: $ctSchema
+        );
+
+        $requireAll = $caseTypeData['requireAllDeelzakenClosed'] ?? false;
+        if ($requireAll === false || $requireAll === 'false' || $requireAll === 0) {
+            return ['canClose' => true, 'openDeelzaken' => []];
+        }
+
+        // Find all direct deelzaken that are not yet closed (endDate is null/empty).
+        $children  = $this->fetchDirectChildren(
+            objectService: $objectService,
+            parentCaseId: $caseId,
+            register: $register,
+            schema: $caseSchema
+        );
+        $openCases = [];
+        foreach ($children as $child) {
+            $endDate = $child['endDate'] ?? null;
+            if ($endDate === null || $endDate === '') {
+                $openCases[] = [
+                    'id'     => $child['id'] ?? '',
+                    'title'  => $child['title'] ?? '',
+                    'status' => $child['status'] ?? '',
+                ];
+            }
+        }
+
+        if (empty($openCases) === true) {
+            return ['canClose' => true, 'openDeelzaken' => []];
+        }
+
+        return [
+            'canClose'      => false,
+            'openDeelzaken' => $openCases,
+        ];
+    }//end validateClosureAllowed()
+
+    /**
+     * Create a vervolg-zaak (follow-up case) from an existing case.
+     *
+     * Creates a new case of the given caseType and links it back to the
+     * original case via `relatedCases` with `aardRelatie=vervolg`. The
+     * original case's `relatedCases` is updated with the successor's URL.
+     *
+     * @param string      $sourceCaseId The UUID of the source case (predecessor)
+     * @param string      $caseTypeId   The UUID of the follow-up caseType
+     * @param string|null $title        Optional title override
+     * @param string|null $requestedBy  UID of the user requesting creation
+     *
+     * @return array<string, mixed> The created vervolg-zaak object (serialized)
+     *
+     * @throws \RuntimeException When OpenRegister unavailable or source not found
+     *
+     * @spec openspec/changes/deelzaak-support/tasks.md#T01
+     */
+    public function createVervolgzaak(
+        string $sourceCaseId,
+        string $caseTypeId,
+        ?string $title=null,
+        ?string $requestedBy=null,
+    ): array {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            throw new \RuntimeException('OpenRegister objectService unavailable');
+        }
+
+        $register   = $this->settingsService->getConfigValue(key: 'register');
+        $caseSchema = $this->settingsService->getConfigValue(key: 'case_schema');
+        $ctSchema   = $this->settingsService->getConfigValue(key: 'case_type_schema');
+
+        if ($register === '' || $caseSchema === '') {
+            throw new \RuntimeException('Case register/schema settings not configured');
+        }
+
+        // Load source case.
+        $sourceCase = $this->findObject(
+            objectService: $objectService,
+            uuid: $sourceCaseId,
+            register: $register,
+            schema: $caseSchema
+        );
+        if ($sourceCase === null) {
+            throw new \RuntimeException("Source case '{$sourceCaseId}' not found");
+        }
+
+        // Load caseType for title derivation.
+        $vervolgCaseType = null;
+        if ($ctSchema !== '') {
+            $vervolgCaseType = $this->findObject(
+                objectService: $objectService,
+                uuid: $caseTypeId,
+                register: $register,
+                schema: $ctSchema
+            );
+        }
+
+        $vervolgTitle = $title ?? ($vervolgCaseType['title'] ?? 'Vervolg-zaak');
+
+        // Build the predecessor relatie entry referencing the source case.
+        $sourceUri           = $sourceCase['uri'] ?? $sourceCase['@self']['uri'] ?? null;
+        $predecessorRelaties = [
+            [
+                'url'         => $sourceUri ?? $sourceCaseId,
+                'aardRelatie' => self::AARD_RELATIE_ONDERWERP,
+            ],
+        ];
+        $predecessorRelatieJson = json_encode($predecessorRelaties);
+
+        $vervolgData = [
+            'title'        => $vervolgTitle,
+            'caseType'     => $caseTypeId,
+            'relatedCases' => $predecessorRelatieJson,
+            'startDate'    => date('Y-m-d'),
+        ];
+
+        // Inherit assignee from caseType default.
+        if ($vervolgCaseType !== null && isset($vervolgCaseType['defaultAssignee']) === true) {
+            $vervolgData['assignee'] = $vervolgCaseType['defaultAssignee'];
+        }
+
+        $created = $objectService->saveObject(
+            register: $register,
+            schema: $caseSchema,
+            object: $vervolgData
+        );
+
+        if (is_array($created) === true) {
+            $createdArray = $created;
+        } else {
+            $createdArray = $created->jsonSerialize();
+        }
+
+        // Update the source case's relatedCases to include the successor.
+        $this->addSuccessorRelatie(
+            objectService: $objectService,
+            sourceCaseId: $sourceCaseId,
+            sourceCase: $sourceCase,
+            successorUri: ($createdArray['uri'] ?? $createdArray['@self']['uri'] ?? $createdArray['id'] ?? ''),
+            register: $register,
+            schema: $caseSchema
+        );
+
+        $this->logger->info(
+            'DeelzaakService: created vervolgzaak {id} from source {source} (requestedBy={user})',
+            [
+                'id'     => $createdArray['id'] ?? 'unknown',
+                'source' => $sourceCaseId,
+                'user'   => $requestedBy ?? 'system',
+            ]
+        );
+
+        return $createdArray;
+    }//end createVervolgzaak()
+
+    /**
+     * Assert that a caseTypeId is in the parent caseType's subCaseTypes list.
+     *
+     * @param string               $caseTypeId     The deelzaak caseType UUID to check
+     * @param array<string, mixed> $parentCaseType The parent caseType data
+     *
+     * @return void
+     *
+     * @throws \RuntimeException When caseTypeId is not allowed
+     *
+     * @spec openspec/changes/deelzaak-support/tasks.md#T01
+     */
+    private function assertAllowedSubCaseType(string $caseTypeId, array $parentCaseType): void
+    {
+        $subCaseTypes = $parentCaseType['subCaseTypes'] ?? [];
+        if (is_string($subCaseTypes) === true) {
+            $subCaseTypes = json_decode($subCaseTypes, true) ?? [];
+        }
+
+        if (is_array($subCaseTypes) === false || empty($subCaseTypes) === true) {
+            // No restrictions configured — all types allowed.
+            return;
+        }
+
+        // Normalize allowed UUIDs (strip URLs to bare UUID).
+        $allowedUuids = array_map(
+            fn ($v) => $this->extractUuidFromValue(value: (string) $v),
+            $subCaseTypes
+        );
+
+        $requestedUuid = $this->extractUuidFromValue(value: $caseTypeId);
+
+        if (in_array($requestedUuid, $allowedUuids, true) === false) {
+            throw new \RuntimeException(
+                "CaseType '{$caseTypeId}' is not configured as an allowed deelzaaktype"
+            );
+        }
+    }//end assertAllowedSubCaseType()
+
+    /**
+     * Fetch direct children of a case (first level only).
+     *
+     * @param object $objectService OpenRegister objectService
+     * @param string $parentCaseId  The parent case UUID
+     * @param string $register      Register ID
+     * @param string $schema        Case schema ID
+     *
+     * @return array<int, array<string, mixed>> Array of child case objects
+     *
+     * @spec openspec/changes/deelzaak-support/tasks.md#T01
+     */
+    private function fetchDirectChildren(
+        object $objectService,
+        string $parentCaseId,
+        string $register,
+        string $schema
+    ): array {
+        try {
+            $query  = $objectService->buildSearchQuery(
+                requestParams: [
+                    '_filters[parentCase]' => $parentCaseId,
+                    '_limit'               => 500,
+                ],
+                register: $register,
+                schema: $schema
+            );
+            $result = $objectService->searchObjectsPaginated(query: $query);
+
+            $children = [];
+            foreach (($result['results'] ?? []) as $obj) {
+                if (is_array($obj) === true) {
+                    $children[] = $obj;
+                } else {
+                    $children[] = $obj->jsonSerialize();
+                }
+            }
+
+            return $children;
+        } catch (\Throwable $e) {
+            $this->logger->warning(
+                'DeelzaakService: failed to fetch children for {id}: {msg}',
+                ['id' => $parentCaseId, 'msg' => $e->getMessage()]
+            );
+            return [];
+        }//end try
+    }//end fetchDirectChildren()
+
+    /**
+     * Update the source case's relatedCases to add a successor relatie entry.
+     *
+     * @param object               $objectService OpenRegister objectService
+     * @param string               $sourceCaseId  The source case UUID
+     * @param array<string, mixed> $sourceCase    The source case data
+     * @param string               $successorUri  The successor URI/URL
+     * @param string               $register      Register ID
+     * @param string               $schema        Case schema ID
+     *
+     * @return void
+     *
+     * @spec openspec/changes/deelzaak-support/tasks.md#T01
+     */
+    private function addSuccessorRelatie(
+        object $objectService,
+        string $sourceCaseId,
+        array $sourceCase,
+        string $successorUri,
+        string $register,
+        string $schema
+    ): void {
+        if ($successorUri === '') {
+            return;
+        }
+
+        // Decode existing relatedCases.
+        $existing = $sourceCase['relatedCases'] ?? null;
+        if (is_string($existing) === true && $existing !== '') {
+            $relaties = json_decode($existing, true) ?? [];
+        } else if (is_array($existing) === true) {
+            $relaties = $existing;
+        } else {
+            $relaties = [];
+        }
+
+        $relaties[] = [
+            'url'         => $successorUri,
+            'aardRelatie' => self::AARD_RELATIE_VERVOLG,
+        ];
+
+        try {
+            $objectService->saveObject(
+                register: $register,
+                schema: $schema,
+                object: ['id' => $sourceCaseId, 'relatedCases' => json_encode($relaties)]
+            );
+        } catch (\Throwable $e) {
+            $this->logger->warning(
+                'DeelzaakService: failed to update relatedCases on source {id}: {msg}',
+                ['id' => $sourceCaseId, 'msg' => $e->getMessage()]
+            );
+        }
+    }//end addSuccessorRelatie()
+
+    /**
+     * Find an OpenRegister object by UUID.
+     *
+     * @param object $objectService The OpenRegister objectService
+     * @param string $uuid          The UUID to look up
+     * @param string $register      Register ID
+     * @param string $schema        Schema ID
+     *
+     * @return array<string, mixed>|null The object data, or null when not found
+     *
+     * @spec openspec/changes/deelzaak-support/tasks.md#T01
+     */
+    private function findObject(
+        object $objectService,
+        string $uuid,
+        string $register,
+        string $schema
+    ): ?array {
+        if ($uuid === '' || $register === '' || $schema === '') {
+            return null;
+        }
+
+        try {
+            $obj = $objectService->find(id: $uuid, register: $register, schema: $schema);
+            if (is_array($obj) === true) {
+                return $obj;
+            }
+
+            return $obj->jsonSerialize();
+        } catch (\Throwable $e) {
+            return null;
+        }
+    }//end findObject()
+
+    /**
+     * Extract a bare UUID from a value that may be a URL, UUID, or UUID string.
+     *
+     * @param string $value The value to extract a UUID from
+     *
+     * @return string The extracted UUID, or the original string when no UUID found
+     *
+     * @spec openspec/changes/deelzaak-support/tasks.md#T01
+     */
+    private function extractUuidFromValue(string $value): string
+    {
+        $pattern = '/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i';
+        if (preg_match($pattern, $value, $matches) === 1) {
+            return $matches[0];
+        }
+
+        return $value;
+    }//end extractUuidFromValue()
+}//end class

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -308,6 +308,30 @@ class SettingsService
     }//end setConfigValue()
 
     /**
+     * Get the OpenRegister ObjectService, or null when unavailable.
+     *
+     * @return object|null The ObjectService, or null when OpenRegister is not installed
+     *
+     * @spec openspec/changes/deelzaak-support/tasks.md#T01
+     */
+    public function getObjectService(): ?object
+    {
+        if ($this->isOpenRegisterAvailable() === false) {
+            return null;
+        }
+
+        try {
+            return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+        } catch (\Exception $e) {
+            $this->logger->warning(
+                'SettingsService: Could not get ObjectService',
+                ['exception' => $e->getMessage()]
+            );
+            return null;
+        }
+    }//end getObjectService()
+
+    /**
      * Auto-configure schema and register IDs from the import result.
      *
      * Extracts schema entities from the ConfigurationService import result,

--- a/openspec/changes/deelzaak-support/design.md
+++ b/openspec/changes/deelzaak-support/design.md
@@ -1,0 +1,56 @@
+# Design: deelzaak-support
+
+**Status:** pr-created
+**Issue:** #136
+**Change:** deelzaak-support
+
+## Summary
+
+Add sub-case (deelzaak) creation and linking to Procest, enabling hierarchical case structures
+where a main case (hoofdzaak) can spawn child cases that follow their own workflows while
+remaining linked to the parent. Includes vervolg-zaak (follow-up case) support and generic
+zaak-relatie management.
+
+## Architecture
+
+All logic is built on top of the existing OpenRegister `case` data model which already has
+`parentCase` and `relatedCases` fields, and `caseType` which already has `subCaseTypes`.
+
+### New PHP Classes
+
+| File | Purpose |
+|------|---------|
+| `lib/Service/DeelzaakService.php` | Core service: create deelzaken, inherit fields, validate allowed types, closure guard |
+| `lib/Controller/DeelzaakController.php` | REST endpoints for deelzaak operations |
+| `tests/Unit/Service/DeelzaakServiceTest.php` | PHPUnit tests |
+
+### New Vue Components
+
+| File | Purpose |
+|------|---------|
+| `src/views/cases/components/DeelzaakHierarchyTree.vue` | Recursive tree view of hoofdzaak → deelzaken with status badges |
+| `src/views/cases/components/CreateDeelzaakDialog.vue` | Dialog to manually create a deelzaak from an allowed type |
+| `src/views/settings/tabs/DeelzaakTypenTab.vue` | CaseTypeDetail tab for configuring allowed deelzaaktypen |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `appinfo/routes.php` | Add deelzaak REST routes |
+| `src/views/cases/CaseDetail.vue` | Replace SubCasesSection with DeelzaakHierarchyTree; wire CreateDeelzaakDialog |
+| `src/views/settings/CaseTypeDetail.vue` | Add DeelzaakTypenTab |
+| `lib/AppInfo/Application.php` | Register DeelzaakController |
+
+## Data Flow
+
+1. User opens a case → `DeelzaakHierarchyTree` fetches child cases by `parentCase` filter
+2. Handler clicks "Create Sub-case" → `CreateDeelzaakDialog` opens, showing only allowed `subCaseTypes`
+3. On submit → `POST /api/deelzaak/{caseId}` → `DeelzaakService::createDeelzaak()` creates child, inherits deadline/archief, links `parentCase`
+4. On case status change (workflow engine) → `DeelzaakService::createVervolgzaak()` called when trigger status reached
+5. On case closure → `DeelzaakService::validateClosureAllowed()` blocks if open deelzaken remain
+
+## Decisions
+
+- Nesting is tracked via the existing `parentCase` field on `case` (supports n levels, no depth limit in data model; ADR-000 already defines this)
+- The ZRC nesting guard in `ZgwZrcRulesService::validateHoofdzaakNesting()` applies to ZGW API calls only; UI allows multi-level via the Procest API
+- Vervolg-zaak relationships use a `zaakRelatie` object with `aardRelatie=vervolg` (predecessor/successor)

--- a/openspec/changes/deelzaak-support/specs/deelzaak-support/spec.md
+++ b/openspec/changes/deelzaak-support/specs/deelzaak-support/spec.md
@@ -1,0 +1,95 @@
+# Spec: deelzaak-support
+
+## Acceptance Criteria
+
+### AC-1: Zaaktype deelzaaktype configuration
+GIVEN a zaaktype configuration,
+WHEN an administrator defines allowed deelzaak types via the `subCaseTypes` field,
+THEN only those zaaktypen are selectable when a handler creates a deelzaak from a parent case.
+
+### AC-2: Deelzaak inherits parent fields
+GIVEN a parent case,
+WHEN a handler creates a deelzaak (manually or automatically),
+THEN the deelzaak inherits `deadline` (from `processingDeadline` on the caseType) and
+`archiveNomination` from the parent, and `parentCase` is set to the parent's ID.
+
+### AC-3: Automatic deelzaak on trigger status
+GIVEN a zaaktype with a workflow transition action `createSubCase`,
+WHEN the parent case reaches the configured trigger status,
+THEN the deelzaak is created automatically by `DeelzaakService::createDeelzaak()`.
+
+### AC-4: 3-level hierarchy tree
+GIVEN a parent case with deelzaken that themselves have deelzaken (3+ levels),
+WHEN a user views the case detail page,
+THEN the `DeelzaakHierarchyTree` component renders all levels recursively
+with a status badge per case.
+
+### AC-5: Closure guard
+GIVEN a parent case configured to require deelzaken completion (`requireAllDeelzakenClosed`),
+WHEN the handler attempts to close (set endDate on) the parent case,
+THEN `DeelzaakService::validateClosureAllowed()` returns `false` with a list of open deelzaken,
+and the UI shows a blocking error listing each open sub-case.
+
+### AC-6: Vervolg-zaak creation
+GIVEN a case reaching a trigger status with `aardRelatie=vervolg` configured,
+WHEN `DeelzaakService::createVervolgzaak()` is called,
+THEN a new follow-up case is created, the original case gets `relatedCases` updated with
+the successor URL, and the new case has `relatedCases` updated with the predecessor URL.
+
+## API Contracts
+
+### POST /api/procest/deelzaak/{caseId}
+Creates a deelzaak from the given parent case.
+
+Request body:
+```json
+{
+  "caseTypeId": "<uuid>",
+  "title": "optional override",
+  "assignee": "optional"
+}
+```
+
+Response: `201 Created` with the created case object, or `409 Conflict` with error detail.
+
+### GET /api/procest/deelzaak/{caseId}/hierarchy
+Returns the full case hierarchy tree rooted at `caseId`.
+
+Response:
+```json
+{
+  "case": { ...caseFields },
+  "children": [
+    {
+      "case": { ...caseFields },
+      "children": [ ... ]
+    }
+  ]
+}
+```
+
+### GET /api/procest/deelzaak/{caseId}/closure-check
+Returns whether the case can be closed.
+
+Response:
+```json
+{
+  "canClose": false,
+  "openDeelzaken": [
+    { "id": "<uuid>", "title": "...", "status": "..." }
+  ]
+}
+```
+
+### POST /api/procest/deelzaak/{caseId}/vervolgzaak
+Creates a vervolg-zaak from the given case.
+
+Request body:
+```json
+{
+  "caseTypeId": "<uuid>",
+  "title": "optional"
+}
+```
+
+Response: `201 Created` with the created vervolg-zaak object.

--- a/openspec/changes/deelzaak-support/tasks.md
+++ b/openspec/changes/deelzaak-support/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: deelzaak-support
+
+## Implementation Tasks
+
+- [x] **T01**: Create `DeelzaakService` with `createDeelzaak()`, `getHierarchy()`, `validateClosureAllowed()`, and `createVervolgzaak()` methods
+- [x] **T02**: Create `DeelzaakController` with REST endpoints for create, hierarchy, and closure-check
+- [x] **T03**: Register `DeelzaakController` routes in `appinfo/routes.php`
+- [x] **T04**: Create `DeelzaakHierarchyTree.vue` — recursive tree component showing case hierarchy with status badges (min 3 levels)
+- [x] **T05**: Create `CreateDeelzaakDialog.vue` — modal dialog for manual deelzaak creation with type selector restricted to `subCaseTypes`
+- [x] **T06**: Create `DeelzaakTypenTab.vue` — settings tab for configuring `subCaseTypes` on a caseType
+- [x] **T07**: Wire `DeelzaakHierarchyTree` and `CreateDeelzaakDialog` into `CaseDetail.vue`
+- [x] **T08**: Add `DeelzaakTypenTab` to `CaseTypeDetail.vue`
+
+## Verification Tasks
+
+- [x] **V01**: Deelzaak inherits `deadline` and `archiveNomination` from parent when created
+- [x] **V02**: Only `subCaseTypes` configured on the caseType are shown in the create dialog
+- [x] **V03**: Hierarchy tree shows at least 3 levels of nesting with correct status badges
+- [x] **V04**: Closure guard blocks parent case closure when deelzaken are still open
+- [x] **V05**: `createVervolgzaak()` creates a new case with `aardRelatie=vervolg` linking back to the original
+- [x] **V06**: PHPUnit tests cover createDeelzaak, validateClosureAllowed, and createVervolgzaak (min 3 methods each)

--- a/src/views/cases/CaseDetail.vue
+++ b/src/views/cases/CaseDetail.vue
@@ -209,20 +209,37 @@
 					@handler-changed="onHandlerChanged" />
 			</CnDetailCard>
 
-			<!-- Sub-cases card -->
+			<!-- Sub-cases hierarchy card (deelzaak-support) -->
 			<CnDetailCard
-				v-if="hasSubCaseTypes"
+				v-if="deelzaakHierarchy"
 				:title="subCasesSectionTitle">
-				<SubCasesSection
-					:case-id="caseId"
-					:parent-case="caseData.parentCase || null"
-					:end-date="caseData.endDate || null"
-					:sub-case-types="subCaseTypesArray"
-					@create-sub-case="showSubCaseDialog = true"
-					@sub-cases-loaded="onSubCasesLoaded" />
+				<template v-if="!deelzaakHierarchyLoading" #actions>
+					<NcButton
+						v-if="!caseData.endDate && subCaseTypesArray && subCaseTypesArray.length > 0"
+						type="secondary"
+						@click="showCreateDeelzaakDialog = true">
+						{{ t('procest', 'Create sub-case') }}
+					</NcButton>
+				</template>
+				<NcLoadingIcon v-if="deelzaakHierarchyLoading" />
+				<DeelzaakHierarchyTree
+					v-else-if="deelzaakHierarchy"
+					:node="deelzaakHierarchy"
+					:status-type-map="statusTypeMap"
+					:current-case-id="caseId"
+					@navigate="id => $router.push({ name: 'CaseDetail', params: { id } })" />
 			</CnDetailCard>
 
-			<!-- Sub-case creation dialog -->
+			<!-- Sub-case creation dialog (deelzaak-support) -->
+			<CreateDeelzaakDialog
+				v-if="showCreateDeelzaakDialog"
+				:open="showCreateDeelzaakDialog"
+				:case-id="caseId"
+				:allowed-case-types="allowedDeelzaakCaseTypes"
+				@update:open="showCreateDeelzaakDialog = $event"
+				@created="onDeelzaakCreated" />
+
+			<!-- Legacy sub-case creation dialog (kept for backward compatibility) -->
 			<CaseCreateDialog
 				v-if="showSubCaseDialog"
 				:parent-case="caseId"
@@ -431,6 +448,8 @@
 <script>
 import { NcButton, NcLoadingIcon, NcTextField, NcSelect } from '@nextcloud/vue'
 import { CnDetailPage, CnDetailCard } from '@conduction/nextcloud-vue'
+import axios from '@nextcloud/axios'
+import { generateUrl } from '@nextcloud/router'
 import { useObjectStore } from '../../store/modules/object.js'
 import { getStatusLabel as getTaskStatusLabel } from '../../utils/taskLifecycle.js'
 import { isOverdue, isDueToday, getOverdueText, formatDueDate, sortTasks, getPriorityLevels } from '../../utils/taskHelpers.js'
@@ -443,6 +462,8 @@ import ParticipantsSection from './components/ParticipantsSection.vue'
 import ResultSection from './components/ResultSection.vue'
 import SubCasesSection from './components/SubCasesSection.vue'
 import CaseCreateDialog from './CaseCreateDialog.vue'
+import DeelzaakHierarchyTree from './components/DeelzaakHierarchyTree.vue'
+import CreateDeelzaakDialog from './components/CreateDeelzaakDialog.vue'
 import InspectionPanel from './components/InspectionPanel.vue'
 import EnforcementPanel from './components/EnforcementPanel.vue'
 import AdvicePanel from './components/AdvicePanel.vue'
@@ -476,6 +497,8 @@ export default {
 		ResultSection,
 		SubCasesSection,
 		CaseCreateDialog,
+		DeelzaakHierarchyTree,
+		CreateDeelzaakDialog,
 		InspectionPanel,
 		EnforcementPanel,
 		AdvicePanel,
@@ -527,8 +550,14 @@ export default {
 			priorityOptions: ['low', 'normal', 'high', 'urgent'],
 			// Sub-case state
 			showSubCaseDialog: false,
+			showCreateDeelzaakDialog: false,
 			parentCaseData: null,
 			subCases: [],
+			// Deelzaak hierarchy state (deelzaak-support)
+			deelzaakHierarchy: null,
+			deelzaakHierarchyLoading: false,
+			statusTypeMap: {},
+			allowedDeelzaakCaseTypes: [],
 			// Bezwaar state
 			bezwaarDeadlines: {},
 			contestedBesluitDate: '',
@@ -673,6 +702,13 @@ export default {
 				this.fetchTasks(),
 				this.fetchCaseResult(),
 				this.fetchParentCase(),
+			])
+
+			// Load deelzaak hierarchy and status type map (deelzaak-support).
+			await Promise.all([
+				this.loadDeelzaakHierarchy(),
+				this.loadStatusTypeMap(),
+				this.loadAllowedDeelzaakCaseTypes(),
 			])
 
 			// Load bezwaar/beroep data if applicable.
@@ -955,6 +991,81 @@ export default {
 		onSubCaseCreated(caseId) {
 			this.showSubCaseDialog = false
 			this.$router.push({ name: 'CaseDetail', params: { id: caseId } })
+		},
+
+		// --- Deelzaak hierarchy (deelzaak-support) ---
+
+		/**
+		 * Load the full deelzaak hierarchy rooted at this case.
+		 *
+		 * @spec openspec/changes/deelzaak-support/tasks.md#T07
+		 */
+		async loadDeelzaakHierarchy() {
+			if (!this.caseId) return
+			this.deelzaakHierarchyLoading = true
+			try {
+				const url = generateUrl(`/apps/procest/api/procest/deelzaak/${this.caseId}/hierarchy`)
+				const response = await axios.get(url)
+				this.deelzaakHierarchy = response.data
+				// Keep subCases in sync for legacy delete guard.
+				this.subCases = response.data?.children?.map(c => c.case) || []
+			} catch {
+				this.deelzaakHierarchy = null
+			} finally {
+				this.deelzaakHierarchyLoading = false
+			}
+		},
+
+		/**
+		 * Build a statusType UUID→object map for status badge display.
+		 *
+		 * @spec openspec/changes/deelzaak-support/tasks.md#T07
+		 */
+		async loadStatusTypeMap() {
+			try {
+				const types = await this.objectStore.fetchCollection('statusType', { _limit: 500 })
+				const map = {}
+				for (const st of (types || [])) {
+					map[st.id] = st
+				}
+				this.statusTypeMap = map
+			} catch {
+				// Non-blocking; badges will just show '—'.
+			}
+		},
+
+		/**
+		 * Load the full caseType objects for the allowed deelzaaktypen.
+		 *
+		 * @spec openspec/changes/deelzaak-support/tasks.md#T07
+		 */
+		async loadAllowedDeelzaakCaseTypes() {
+			const ids = this.subCaseTypesArray
+			if (!ids || ids.length === 0) {
+				this.allowedDeelzaakCaseTypes = []
+				return
+			}
+			try {
+				const all = await this.objectStore.fetchCollection('caseType', { _limit: 500 })
+				this.allowedDeelzaakCaseTypes = (all || []).filter(ct => ids.includes(ct.id))
+			} catch {
+				this.allowedDeelzaakCaseTypes = []
+			}
+		},
+
+		/**
+		 * Handle a newly-created deelzaak: refresh hierarchy and navigate to child.
+		 *
+		 * @param {object} deelzaak The newly created deelzaak object
+		 *
+		 * @spec openspec/changes/deelzaak-support/tasks.md#T07
+		 */
+		async onDeelzaakCreated(deelzaak) {
+			this.showCreateDeelzaakDialog = false
+			await this.loadDeelzaakHierarchy()
+			if (deelzaak?.id) {
+				this.$router.push({ name: 'CaseDetail', params: { id: deelzaak.id } })
+			}
 		},
 
 		// --- Delete ---

--- a/src/views/cases/components/CreateDeelzaakDialog.vue
+++ b/src/views/cases/components/CreateDeelzaakDialog.vue
@@ -1,0 +1,221 @@
+<template>
+	<NcDialog
+		:name="t('procest', 'Create Sub-case')"
+		:open="open"
+		@update:open="$emit('update:open', $event)"
+		@close="$emit('update:open', false)">
+		<template #default>
+			<div class="create-deelzaak-dialog">
+				<!-- Case type selector — limited to configured subCaseTypes -->
+				<div class="create-deelzaak-dialog__field">
+					<label for="deelzaak-type-select">
+						{{ t('procest', 'Sub-case type') }} *
+					</label>
+					<NcSelect
+						id="deelzaak-type-select"
+						v-model="selectedCaseType"
+						:options="allowedCaseTypeOptions"
+						:placeholder="t('procest', 'Select a sub-case type')"
+						label="label"
+						track-by="value" />
+					<p v-if="allowedCaseTypeOptions.length === 0" class="create-deelzaak-dialog__hint">
+						{{ t('procest', 'No sub-case types configured for this case type') }}
+					</p>
+				</div>
+
+				<!-- Optional title override -->
+				<div class="create-deelzaak-dialog__field">
+					<label for="deelzaak-title">
+						{{ t('procest', 'Title (optional)') }}
+					</label>
+					<NcInputField
+						id="deelzaak-title"
+						v-model="title"
+						:placeholder="t('procest', 'Leave empty to use case type name')" />
+				</div>
+
+				<!-- Optional assignee -->
+				<div class="create-deelzaak-dialog__field">
+					<label for="deelzaak-assignee">
+						{{ t('procest', 'Assignee (optional)') }}
+					</label>
+					<NcInputField
+						id="deelzaak-assignee"
+						v-model="assignee"
+						:placeholder="t('procest', 'Nextcloud username')" />
+				</div>
+
+				<!-- Error display -->
+				<div v-if="errorMessage" class="create-deelzaak-dialog__error">
+					{{ errorMessage }}
+				</div>
+			</div>
+		</template>
+
+		<template #actions>
+			<NcButton @click="$emit('update:open', false)">
+				{{ t('procest', 'Cancel') }}
+			</NcButton>
+			<NcButton
+				type="primary"
+				:disabled="!selectedCaseType || saving"
+				@click="handleCreate">
+				<template v-if="saving">
+					{{ t('procest', 'Creating…') }}
+				</template>
+				<template v-else>
+					{{ t('procest', 'Create sub-case') }}
+				</template>
+			</NcButton>
+		</template>
+	</NcDialog>
+</template>
+
+<script>
+import { NcButton, NcDialog, NcInputField, NcSelect } from '@nextcloud/vue'
+import axios from '@nextcloud/axios'
+import { generateUrl } from '@nextcloud/router'
+
+/**
+ * Dialog for manually creating a deelzaak under a parent case.
+ *
+ * Only offers the caseTypes configured in parentCaseType.subCaseTypes.
+ * Emits 'created' with the new deelzaak object on success.
+ *
+ * @spec openspec/changes/deelzaak-support/tasks.md#T05
+ */
+export default {
+	name: 'CreateDeelzaakDialog',
+
+	components: {
+		NcButton,
+		NcDialog,
+		NcInputField,
+		NcSelect,
+	},
+
+	props: {
+		/** Whether the dialog is open. */
+		open: {
+			type: Boolean,
+			required: true,
+		},
+		/** UUID of the parent case. */
+		caseId: {
+			type: String,
+			required: true,
+		},
+		/** Allowed subCaseTypes (array of caseType objects from the parent caseType). */
+		allowedCaseTypes: {
+			type: Array,
+			default: () => [],
+		},
+	},
+
+	emits: ['update:open', 'created'],
+
+	data() {
+		return {
+			selectedCaseType: null,
+			title: '',
+			assignee: '',
+			saving: false,
+			errorMessage: '',
+		}
+	},
+
+	computed: {
+		/**
+		 * Build NcSelect option list from the allowed caseTypes.
+		 *
+		 * @spec openspec/changes/deelzaak-support/tasks.md#T05
+		 */
+		allowedCaseTypeOptions() {
+			return (this.allowedCaseTypes || []).map(ct => ({
+				value: ct.id,
+				label: ct.title || ct.id,
+			}))
+		},
+	},
+
+	methods: {
+		/**
+		 * Submit the deelzaak creation request.
+		 *
+		 * @spec openspec/changes/deelzaak-support/tasks.md#T05
+		 */
+		async handleCreate() {
+			if (!this.selectedCaseType) return
+
+			this.saving = true
+			this.errorMessage = ''
+
+			try {
+				const url = generateUrl(`/apps/procest/api/procest/deelzaak/${this.caseId}`)
+				const payload = {
+					caseTypeId: this.selectedCaseType.value,
+					title: this.title.trim() || undefined,
+					assignee: this.assignee.trim() || undefined,
+				}
+
+				const response = await axios.post(url, payload)
+
+				this.$emit('created', response.data)
+				this.$emit('update:open', false)
+				this.resetForm()
+			} catch (err) {
+				this.errorMessage = err?.response?.data?.error
+					|| t('procest', 'Failed to create sub-case')
+			} finally {
+				this.saving = false
+			}
+		},
+
+		/**
+		 * Reset form fields to initial state.
+		 *
+		 * @spec openspec/changes/deelzaak-support/tasks.md#T05
+		 */
+		resetForm() {
+			this.selectedCaseType = null
+			this.title = ''
+			this.assignee = ''
+			this.errorMessage = ''
+		},
+	},
+}
+</script>
+
+<style scoped>
+.create-deelzaak-dialog {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+	padding: 8px 0;
+}
+
+.create-deelzaak-dialog__field {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.create-deelzaak-dialog__field label {
+	font-weight: 500;
+	font-size: 13px;
+}
+
+.create-deelzaak-dialog__hint {
+	color: var(--color-text-maxcontrast);
+	font-size: 12px;
+	margin: 0;
+}
+
+.create-deelzaak-dialog__error {
+	color: var(--color-error);
+	font-size: 13px;
+	padding: 8px;
+	background: var(--color-error-bg, #ffeaea);
+	border-radius: var(--border-radius);
+}
+</style>

--- a/src/views/cases/components/DeelzaakHierarchyTree.vue
+++ b/src/views/cases/components/DeelzaakHierarchyTree.vue
@@ -1,0 +1,184 @@
+<template>
+	<div class="deelzaak-hierarchy-tree">
+		<!-- Root case node -->
+		<div class="hierarchy-node hierarchy-node--root">
+			<span class="hierarchy-node__icon">📁</span>
+			<span class="hierarchy-node__title">{{ node.case.title || '—' }}</span>
+			<span class="status-badge" :class="getStatusClass(node.case)">
+				{{ getStatusName(node.case) }}
+			</span>
+			<span v-if="isCurrentCase" class="hierarchy-node__badge-current">
+				{{ t('procest', 'This case') }}
+			</span>
+		</div>
+
+		<!-- Children -->
+		<div v-if="node.children && node.children.length > 0" class="hierarchy-children">
+			<div
+				v-for="child in node.children"
+				:key="child.case.id"
+				class="hierarchy-child-wrapper">
+				<div class="hierarchy-connector" />
+				<!-- Recurse for each child — supports arbitrary depth (min 3 levels per spec) -->
+				<DeelzaakHierarchyTree
+					:node="child"
+					:status-type-map="statusTypeMap"
+					:current-case-id="currentCaseId"
+					@navigate="$emit('navigate', $event)" />
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+/**
+ * Recursive hierarchy tree component for deelzaken (sub-cases).
+ *
+ * Renders a hoofdzaak with all its deelzaken at arbitrary depth,
+ * each with a coloured status badge. Clicking a non-current node
+ * emits 'navigate' with the case ID.
+ *
+ * @spec openspec/changes/deelzaak-support/tasks.md#T04
+ */
+export default {
+	name: 'DeelzaakHierarchyTree',
+
+	props: {
+		/**
+		 * Hierarchy node: { case: {...}, children: [...] }
+		 */
+		node: {
+			type: Object,
+			required: true,
+		},
+		/**
+		 * Map of statusType UUID → statusType object for badge labels.
+		 */
+		statusTypeMap: {
+			type: Object,
+			default: () => ({}),
+		},
+		/**
+		 * UUID of the case currently being viewed (highlighted differently).
+		 */
+		currentCaseId: {
+			type: String,
+			default: null,
+		},
+	},
+
+	emits: ['navigate'],
+
+	computed: {
+		isCurrentCase() {
+			return this.node.case.id === this.currentCaseId
+		},
+	},
+
+	methods: {
+		/**
+		 * Return the status display name for a case.
+		 *
+		 * @param {object} caseObj The case object
+		 * @returns {string}
+		 *
+		 * @spec openspec/changes/deelzaak-support/tasks.md#T04
+		 */
+		getStatusName(caseObj) {
+			if (!caseObj.status) return '—'
+			return this.statusTypeMap[caseObj.status]?.name || '—'
+		},
+
+		/**
+		 * Return CSS modifier class for the status badge.
+		 *
+		 * @param {object} caseObj The case object
+		 * @returns {string}
+		 *
+		 * @spec openspec/changes/deelzaak-support/tasks.md#T04
+		 */
+		getStatusClass(caseObj) {
+			if (caseObj.endDate) return 'status-badge--closed'
+			const st = caseObj.status ? this.statusTypeMap[caseObj.status] : null
+			if (st?.isFinal === true || st?.isFinal === 'true') return 'status-badge--final'
+			return 'status-badge--active'
+		},
+	},
+}
+</script>
+
+<style scoped>
+.deelzaak-hierarchy-tree {
+	font-size: 14px;
+}
+
+.hierarchy-node {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 6px 8px;
+	border-radius: var(--border-radius);
+	cursor: pointer;
+	transition: background-color 0.15s ease;
+}
+
+.hierarchy-node:hover {
+	background: var(--color-background-hover);
+}
+
+.hierarchy-node--root {
+	font-weight: 600;
+}
+
+.hierarchy-node__title {
+	flex: 1;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.hierarchy-node__badge-current {
+	font-size: 11px;
+	padding: 1px 6px;
+	border-radius: var(--border-radius-pill);
+	background: var(--color-primary);
+	color: var(--color-primary-text);
+}
+
+.hierarchy-children {
+	padding-left: 20px;
+	border-left: 2px solid var(--color-border);
+	margin-left: 12px;
+}
+
+.hierarchy-child-wrapper {
+	position: relative;
+}
+
+.hierarchy-connector {
+	position: absolute;
+	left: -20px;
+	top: 50%;
+	width: 18px;
+	height: 2px;
+	background: var(--color-border);
+}
+
+.status-badge {
+	font-size: 11px;
+	padding: 2px 8px;
+	border-radius: var(--border-radius-pill);
+	white-space: nowrap;
+}
+
+.status-badge--active {
+	background: var(--color-primary-light);
+	color: var(--color-primary-text);
+}
+
+.status-badge--final,
+.status-badge--closed {
+	background: var(--color-success);
+	color: #fff;
+}
+</style>

--- a/src/views/settings/CaseTypeDetail.vue
+++ b/src/views/settings/CaseTypeDetail.vue
@@ -89,6 +89,11 @@
 				<WorkflowTab
 					v-else-if="activeTab === 'workflow'"
 					:case-type-id="caseTypeId" />
+				<DeelzaakTypenTab
+					v-else-if="activeTab === 'deelzaaktypen'"
+					:is-create="isCreate"
+					:case-type="currentCaseType"
+					@save="onDeelzaakTypenSave" />
 			</div>
 		</template>
 	</div>
@@ -100,6 +105,7 @@ import ArrowLeftIcon from 'vue-material-design-icons/ArrowLeft.vue'
 import GeneralTab from './tabs/GeneralTab.vue'
 import StatusesTab from './tabs/StatusesTab.vue'
 import WorkflowTab from './tabs/WorkflowTab.vue'
+import DeelzaakTypenTab from './tabs/DeelzaakTypenTab.vue'
 import { useObjectStore } from '../../store/modules/object.js'
 import { validateCaseType, validateForPublish } from '../../utils/caseTypeValidation.js'
 
@@ -138,6 +144,7 @@ export default {
 		GeneralTab,
 		StatusesTab,
 		WorkflowTab,
+		DeelzaakTypenTab,
 	},
 	props: {
 		caseTypeId: {
@@ -171,7 +178,11 @@ export default {
 				{ id: 'general', label: t('procest', 'General') },
 				{ id: 'statuses', label: t('procest', 'Statuses') },
 				{ id: 'workflow', label: t('procest', 'Workflow') },
+				{ id: 'deelzaaktypen', label: t('procest', 'Sub-case types') },
 			]
+		},
+		currentCaseType() {
+			return { ...this.form, id: this.caseTypeId }
 		},
 	},
 	async mounted() {
@@ -208,6 +219,35 @@ export default {
 				const errors = { ...this.validationErrors }
 				delete errors[field]
 				this.validationErrors = errors
+			}
+		},
+
+		/**
+		 * Handle save from DeelzaakTypenTab: patch subCaseTypes and closure flag.
+		 *
+		 * @param {object} payload { subCaseTypes, requireAllDeelzakenClosed }
+		 *
+		 * @spec openspec/changes/deelzaak-support/tasks.md#T08
+		 */
+		async onDeelzaakTypenSave(payload) {
+			this.saveError = ''
+			this.saveSuccess = false
+			this.saving = true
+			const update = {
+				...this.form,
+				id: this.caseTypeId,
+				subCaseTypes: payload.subCaseTypes,
+				requireAllDeelzakenClosed: payload.requireAllDeelzakenClosed,
+			}
+			const result = await this.objectStore.saveObject('caseType', update)
+			this.saving = false
+			if (result) {
+				this.form = { ...EMPTY_FORM, ...result }
+				this.saveSuccess = true
+				setTimeout(() => { this.saveSuccess = false }, 3000)
+			} else {
+				this.saveError = this.objectStore.getError('caseType')
+					|| t('procest', 'Failed to save sub-case type configuration')
 			}
 		},
 

--- a/src/views/settings/tabs/DeelzaakTypenTab.vue
+++ b/src/views/settings/tabs/DeelzaakTypenTab.vue
@@ -1,0 +1,313 @@
+<template>
+	<div class="deelzaaktypen-tab">
+		<div v-if="isCreate" class="deelzaaktypen-tab__notice">
+			<p>{{ t('procest', 'Save the case type first before configuring sub-case types.') }}</p>
+		</div>
+
+		<template v-else>
+			<p class="deelzaaktypen-tab__intro">
+				{{ t('procest', 'Configure which case types can be created as a sub-case (deelzaak) under cases of this type. Leave empty to allow any type.') }}
+			</p>
+
+			<NcLoadingIcon v-if="loading" />
+
+			<template v-else>
+				<!-- List of currently configured sub-case types -->
+				<div v-if="configuredTypes.length > 0" class="deelzaaktypen-tab__list">
+					<div
+						v-for="ct in configuredTypes"
+						:key="ct.id"
+						class="deelzaaktype-row">
+						<span class="deelzaaktype-row__name">{{ ct.title || ct.id }}</span>
+						<NcButton
+							type="tertiary"
+							:aria-label="t('procest', 'Remove')"
+							@click="removeType(ct.id)">
+							<template #icon>
+								<CloseIcon :size="20" />
+							</template>
+						</NcButton>
+					</div>
+				</div>
+
+				<div v-else class="deelzaaktypen-tab__empty">
+					{{ t('procest', 'No sub-case types configured — any case type is allowed.') }}
+				</div>
+
+				<!-- Add a new sub-case type -->
+				<div class="deelzaaktypen-tab__add">
+					<NcSelect
+						v-model="selectedToAdd"
+						:options="availableOptions"
+						:placeholder="t('procest', 'Add a sub-case type…')"
+						label="label"
+						track-by="value" />
+					<NcButton
+						type="secondary"
+						:disabled="!selectedToAdd"
+						@click="addSelectedType">
+						{{ t('procest', 'Add') }}
+					</NcButton>
+				</div>
+
+				<!-- Closure guard option -->
+				<div class="deelzaaktypen-tab__option">
+					<NcCheckboxRadioSwitch
+						:checked="requireAllClosed"
+						@update:checked="toggleRequireAllClosed">
+						{{ t('procest', 'Require all sub-cases to be closed before this case can be closed') }}
+					</NcCheckboxRadioSwitch>
+				</div>
+
+				<!-- Save -->
+				<div class="deelzaaktypen-tab__actions">
+					<NcButton
+						type="primary"
+						:disabled="saving"
+						@click="saveConfiguration">
+						{{ saving ? t('procest', 'Saving…') : t('procest', 'Save') }}
+					</NcButton>
+				</div>
+			</template>
+		</template>
+	</div>
+</template>
+
+<script>
+import { NcButton, NcCheckboxRadioSwitch, NcLoadingIcon, NcSelect } from '@nextcloud/vue'
+import CloseIcon from 'vue-material-design-icons/Close.vue'
+import { useObjectStore } from '../../../store/modules/object.js'
+
+/**
+ * Settings tab for configuring which caseTypes can be created as a
+ * deelzaak (sub-case) under a given caseType. Also controls the
+ * closure guard (`requireAllDeelzakenClosed`).
+ *
+ * @spec openspec/changes/deelzaak-support/tasks.md#T06
+ */
+export default {
+	name: 'DeelzaakTypenTab',
+
+	components: {
+		NcButton,
+		NcCheckboxRadioSwitch,
+		NcLoadingIcon,
+		NcSelect,
+		CloseIcon,
+	},
+
+	props: {
+		/** Whether this is a new (unsaved) caseType. */
+		isCreate: {
+			type: Boolean,
+			default: false,
+		},
+		/** The current caseType data object. */
+		caseType: {
+			type: Object,
+			default: () => ({}),
+		},
+	},
+
+	emits: ['save'],
+
+	data() {
+		return {
+			loading: true,
+			saving: false,
+			allCaseTypes: [],
+			configuredIds: [],
+			requireAllClosed: false,
+			selectedToAdd: null,
+		}
+	},
+
+	computed: {
+		objectStore() {
+			return useObjectStore()
+		},
+
+		/**
+		 * Full caseType objects for the currently configured IDs.
+		 *
+		 * @spec openspec/changes/deelzaak-support/tasks.md#T06
+		 */
+		configuredTypes() {
+			return this.allCaseTypes.filter(ct => this.configuredIds.includes(ct.id))
+		},
+
+		/**
+		 * Options for the add-selector: all types NOT already configured,
+		 * and excluding the current caseType itself (no self-nesting).
+		 *
+		 * @spec openspec/changes/deelzaak-support/tasks.md#T06
+		 */
+		availableOptions() {
+			const currentId = this.caseType?.id ?? null
+			return this.allCaseTypes
+				.filter(ct => ct.id !== currentId && !this.configuredIds.includes(ct.id))
+				.map(ct => ({ value: ct.id, label: ct.title || ct.id }))
+		},
+	},
+
+	watch: {
+		caseType: {
+			immediate: true,
+			handler(val) {
+				if (val && !this.isCreate) {
+					this.initFromCaseType(val)
+				}
+			},
+		},
+	},
+
+	async mounted() {
+		if (!this.isCreate) {
+			await this.loadAllCaseTypes()
+		}
+		this.loading = false
+	},
+
+	methods: {
+		/**
+		 * Load all available case types for the selector.
+		 *
+		 * @spec openspec/changes/deelzaak-support/tasks.md#T06
+		 */
+		async loadAllCaseTypes() {
+			try {
+				const types = await this.objectStore.fetchCollection('caseType', { _limit: 500 })
+				this.allCaseTypes = types || []
+			} catch (err) {
+				console.error('DeelzaakTypenTab: failed to load case types', err)
+			}
+		},
+
+		/**
+		 * Initialise local state from a caseType object.
+		 *
+		 * @param {object} caseType The caseType to read from
+		 *
+		 * @spec openspec/changes/deelzaak-support/tasks.md#T06
+		 */
+		initFromCaseType(caseType) {
+			const raw = caseType.subCaseTypes ?? []
+			this.configuredIds = Array.isArray(raw) ? [...raw] : []
+			this.requireAllClosed = caseType.requireAllDeelzakenClosed === true
+				|| caseType.requireAllDeelzakenClosed === 'true'
+		},
+
+		/**
+		 * Add the currently-selected case type to the configured list.
+		 *
+		 * @spec openspec/changes/deelzaak-support/tasks.md#T06
+		 */
+		addSelectedType() {
+			if (!this.selectedToAdd) return
+			const id = this.selectedToAdd.value
+			if (!this.configuredIds.includes(id)) {
+				this.configuredIds.push(id)
+			}
+			this.selectedToAdd = null
+		},
+
+		/**
+		 * Remove a case type from the configured list.
+		 *
+		 * @param {string} id The case type UUID to remove
+		 *
+		 * @spec openspec/changes/deelzaak-support/tasks.md#T06
+		 */
+		removeType(id) {
+			this.configuredIds = this.configuredIds.filter(i => i !== id)
+		},
+
+		/**
+		 * Toggle the requireAllDeelzakenClosed flag.
+		 *
+		 * @param {boolean} value New value
+		 *
+		 * @spec openspec/changes/deelzaak-support/tasks.md#T06
+		 */
+		toggleRequireAllClosed(value) {
+			this.requireAllClosed = value
+		},
+
+		/**
+		 * Persist changes via parent emit (CaseTypeDetail handles the save call).
+		 *
+		 * @spec openspec/changes/deelzaak-support/tasks.md#T06
+		 */
+		async saveConfiguration() {
+			this.saving = true
+			try {
+				this.$emit('save', {
+					subCaseTypes: [...this.configuredIds],
+					requireAllDeelzakenClosed: this.requireAllClosed,
+				})
+			} finally {
+				this.saving = false
+			}
+		},
+	},
+}
+</script>
+
+<style scoped>
+.deelzaaktypen-tab {
+	padding: 16px 0;
+}
+
+.deelzaaktypen-tab__notice,
+.deelzaaktypen-tab__intro {
+	color: var(--color-text-maxcontrast);
+	font-size: 13px;
+	margin-bottom: 16px;
+}
+
+.deelzaaktypen-tab__list {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	margin-bottom: 16px;
+}
+
+.deelzaaktype-row {
+	display: flex;
+	align-items: center;
+	padding: 6px 10px;
+	background: var(--color-background-dark);
+	border-radius: var(--border-radius);
+	gap: 8px;
+}
+
+.deelzaaktype-row__name {
+	flex: 1;
+}
+
+.deelzaaktypen-tab__empty {
+	color: var(--color-text-maxcontrast);
+	font-style: italic;
+	margin-bottom: 16px;
+}
+
+.deelzaaktypen-tab__add {
+	display: flex;
+	gap: 8px;
+	align-items: flex-end;
+	margin-bottom: 16px;
+}
+
+.deelzaaktypen-tab__add .vs__dropdown-toggle {
+	min-width: 260px;
+}
+
+.deelzaaktypen-tab__option {
+	margin-bottom: 16px;
+}
+
+.deelzaaktypen-tab__actions {
+	display: flex;
+	justify-content: flex-end;
+}
+</style>

--- a/tests/Unit/Service/DeelzaakServiceTest.php
+++ b/tests/Unit/Service/DeelzaakServiceTest.php
@@ -1,0 +1,623 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ * Copyright (C) 2026 Conduction B.V.
+ *
+ * Procest DeelzaakService Unit Tests
+ *
+ * Tests for deelzaak (sub-case) creation, hierarchy retrieval,
+ * closure guard, and vervolg-zaak creation.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * @spec openspec/changes/deelzaak-support/tasks.md#T01
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Service;
+
+use OCA\Procest\Service\DeelzaakService;
+use OCA\Procest\Service\SettingsService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Unit tests for DeelzaakService.
+ *
+ * @covers \OCA\Procest\Service\DeelzaakService
+ *
+ * @spec openspec/changes/deelzaak-support/tasks.md#T01
+ */
+class DeelzaakServiceTest extends TestCase
+{
+
+    /**
+     * Mock PSR logger.
+     *
+     * @var LoggerInterface&MockObject
+     */
+    private LoggerInterface $logger;
+
+    /**
+     * Mock settings service.
+     *
+     * @var SettingsService&MockObject
+     */
+    private SettingsService $settingsService;
+
+    /**
+     * The service under test.
+     *
+     * @var DeelzaakService
+     */
+    private DeelzaakService $service;
+
+    /**
+     * Set up the test environment before each test.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->logger          = $this->createMock(LoggerInterface::class);
+        $this->settingsService = $this->createMock(SettingsService::class);
+
+        $this->service = new DeelzaakService(
+            settingsService: $this->settingsService,
+            logger: $this->logger
+        );
+    }//end setUp()
+
+    // -------------------------------------------------------------------------
+    // createDeelzaak() tests
+    // -------------------------------------------------------------------------
+
+    /**
+     * CreateDeelzaak throws RuntimeException when objectService unavailable.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/deelzaak-support/tasks.md#V01
+     */
+    public function testCreateDeelzaakThrowsWhenNoObjectService(): void
+    {
+        $this->settingsService
+            ->method('getObjectService')
+            ->willReturn(null);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/objectService unavailable/');
+
+        $this->service->createDeelzaak(
+            parentCaseId: 'parent-uuid',
+            caseTypeId: 'type-uuid'
+        );
+    }//end testCreateDeelzaakThrowsWhenNoObjectService()
+
+    /**
+     * CreateDeelzaak throws RuntimeException when parent case not found.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/deelzaak-support/tasks.md#V01
+     */
+    public function testCreateDeelzaakThrowsWhenParentNotFound(): void
+    {
+        $objectService = $this->createMockObjectService();
+        $objectService->method('find')->willThrowException(new \Exception('not found'));
+
+        $this->settingsService->method('getObjectService')->willReturn($objectService);
+        $this->settingsService->method('getConfigValue')->willReturnCallback(
+            static function (string $key): string {
+                return match ($key) {
+                    'register'         => 'reg1',
+                    'case_schema'      => 'cs1',
+                    'case_type_schema' => 'cts1',
+                    default            => '',
+                };
+            }
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/Parent case.*not found/');
+
+        $this->service->createDeelzaak(
+            parentCaseId: '00000000-0000-0000-0000-000000000001',
+            caseTypeId: '00000000-0000-0000-0000-000000000002'
+        );
+    }//end testCreateDeelzaakThrowsWhenParentNotFound()
+
+    /**
+     * CreateDeelzaak throws RuntimeException when caseTypeId is not in subCaseTypes.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/deelzaak-support/tasks.md#V02
+     */
+    public function testCreateDeelzaakThrowsWhenTypeNotAllowed(): void
+    {
+        $parentCaseUuid     = '00000000-0000-0000-0000-000000000001';
+        $parentCaseTypeUuid = '00000000-0000-0000-0000-000000000002';
+        $allowedTypeUuid    = '00000000-0000-0000-0000-000000000003';
+        $disallowedTypeUuid = '00000000-0000-0000-0000-000000000099';
+
+        $parentCase = [
+            'id'       => $parentCaseUuid,
+            'title'    => 'Parent case',
+            'caseType' => $parentCaseTypeUuid,
+        ];
+
+        $parentCaseType = [
+            'id'           => $parentCaseTypeUuid,
+            'title'        => 'Parent Type',
+            'subCaseTypes' => [$allowedTypeUuid],
+        ];
+
+        $objectService = $this->createMockObjectService();
+        $objectService->method('find')->willReturnCallback(
+            static function (string $id) use ($parentCaseUuid, $parentCase, $parentCaseTypeUuid, $parentCaseType): array {
+                return match ($id) {
+                    $parentCaseUuid     => $parentCase,
+                    $parentCaseTypeUuid => $parentCaseType,
+                    default             => throw new \Exception("not found: {$id}"),
+                };
+            }
+        );
+
+        $this->settingsService->method('getObjectService')->willReturn($objectService);
+        $this->settingsService->method('getConfigValue')->willReturnCallback(
+            static function (string $key): string {
+                return match ($key) {
+                    'register'         => 'reg1',
+                    'case_schema'      => 'cs1',
+                    'case_type_schema' => 'cts1',
+                    default            => '',
+                };
+            }
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/not configured as an allowed deelzaaktype/');
+
+        $this->service->createDeelzaak(
+            parentCaseId: $parentCaseUuid,
+            caseTypeId: $disallowedTypeUuid
+        );
+    }//end testCreateDeelzaakThrowsWhenTypeNotAllowed()
+
+    /**
+     * CreateDeelzaak inherits deadline and archiveNomination from parent.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/deelzaak-support/tasks.md#V01
+     */
+    public function testCreateDeelzaakInheritsParentFields(): void
+    {
+        $parentCaseUuid     = '00000000-0000-0000-0000-000000000001';
+        $parentCaseTypeUuid = '00000000-0000-0000-0000-000000000002';
+        $deelzaakTypeUuid   = '00000000-0000-0000-0000-000000000003';
+
+        $parentCase = [
+            'id'                => $parentCaseUuid,
+            'title'             => 'Parent case',
+            'caseType'          => $parentCaseTypeUuid,
+            'deadline'          => '2026-12-31',
+            'archiveNomination' => 'vernietigen',
+            'confidentiality'   => 'intern',
+        ];
+
+        $parentCaseType = [
+            'id'           => $parentCaseTypeUuid,
+            'title'        => 'Parent Type',
+            'subCaseTypes' => [],
+        ];
+
+        $deelzaakType = [
+            'id'    => $deelzaakTypeUuid,
+            'title' => 'Advies Deelzaak',
+        ];
+
+        $capturedObject = [];
+
+        $objectService = $this->createMockObjectService();
+        $objectService->method('find')->willReturnCallback(
+            static function (string $id) use ($parentCaseUuid, $parentCase, $parentCaseTypeUuid, $parentCaseType, $deelzaakTypeUuid, $deelzaakType): array {
+                return match ($id) {
+                    $parentCaseUuid     => $parentCase,
+                    $parentCaseTypeUuid => $parentCaseType,
+                    $deelzaakTypeUuid   => $deelzaakType,
+                    default             => throw new \Exception("not found: {$id}"),
+                };
+            }
+        );
+        $objectService->method('saveObject')->willReturnCallback(
+            static function (string $register, string $schema, array $object) use (&$capturedObject): array {
+                $capturedObject = $object;
+                return array_merge(['id' => '00000000-0000-0000-0000-000000000099'], $object);
+            }
+        );
+
+        $this->settingsService->method('getObjectService')->willReturn($objectService);
+        $this->settingsService->method('getConfigValue')->willReturnCallback(
+            static function (string $key): string {
+                return match ($key) {
+                    'register'         => 'reg1',
+                    'case_schema'      => 'cs1',
+                    'case_type_schema' => 'cts1',
+                    default            => '',
+                };
+            }
+        );
+
+        // subCaseTypes empty = all types allowed.
+        $result = $this->service->createDeelzaak(
+            parentCaseId: $parentCaseUuid,
+            caseTypeId: $deelzaakTypeUuid
+        );
+
+        self::assertArrayHasKey('id', $result);
+        self::assertSame('2026-12-31', $capturedObject['deadline']);
+        self::assertSame('vernietigen', $capturedObject['archiveNomination']);
+        self::assertSame($parentCaseUuid, $capturedObject['parentCase']);
+    }//end testCreateDeelzaakInheritsParentFields()
+
+    // -------------------------------------------------------------------------
+    // validateClosureAllowed() tests
+    // -------------------------------------------------------------------------
+
+    /**
+     * ValidateClosureAllowed throws when objectService unavailable.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/deelzaak-support/tasks.md#V04
+     */
+    public function testValidateClosureAllowedThrowsWhenNoService(): void
+    {
+        $this->settingsService->method('getObjectService')->willReturn(null);
+
+        $this->expectException(\RuntimeException::class);
+
+        $this->service->validateClosureAllowed(caseId: 'some-id');
+    }//end testValidateClosureAllowedThrowsWhenNoService()
+
+    /**
+     * ValidateClosureAllowed returns canClose=true when caseType does NOT require deelzaken closed.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/deelzaak-support/tasks.md#V04
+     */
+    public function testValidateClosureAllowedWhenNotRequired(): void
+    {
+        $caseUuid     = '00000000-0000-0000-0000-000000000001';
+        $caseTypeUuid = '00000000-0000-0000-0000-000000000002';
+
+        $caseData = [
+            'id'       => $caseUuid,
+            'caseType' => $caseTypeUuid,
+        ];
+
+        $caseTypeData = [
+            'id'                        => $caseTypeUuid,
+            'requireAllDeelzakenClosed' => false,
+        ];
+
+        $objectService = $this->createMockObjectService();
+        $objectService->method('find')->willReturnCallback(
+            static function (string $id) use ($caseUuid, $caseData, $caseTypeUuid, $caseTypeData): array {
+                return match ($id) {
+                    $caseUuid     => $caseData,
+                    $caseTypeUuid => $caseTypeData,
+                    default       => throw new \Exception("not found: {$id}"),
+                };
+            }
+        );
+
+        $this->settingsService->method('getObjectService')->willReturn($objectService);
+        $this->settingsService->method('getConfigValue')->willReturnCallback(
+            static function (string $key): string {
+                return match ($key) {
+                    'register'         => 'reg1',
+                    'case_schema'      => 'cs1',
+                    'case_type_schema' => 'cts1',
+                    default            => '',
+                };
+            }
+        );
+
+        $result = $this->service->validateClosureAllowed(caseId: $caseUuid);
+
+        self::assertTrue($result['canClose']);
+        self::assertEmpty($result['openDeelzaken']);
+    }//end testValidateClosureAllowedWhenNotRequired()
+
+    /**
+     * ValidateClosureAllowed returns canClose=false when open deelzaken exist.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/deelzaak-support/tasks.md#V04
+     */
+    public function testValidateClosureBlockedWhenOpenDeelzakenExist(): void
+    {
+        $caseUuid     = '00000000-0000-0000-0000-000000000001';
+        $caseTypeUuid = '00000000-0000-0000-0000-000000000002';
+        $childUuid    = '00000000-0000-0000-0000-000000000003';
+
+        $caseData = [
+            'id'       => $caseUuid,
+            'caseType' => $caseTypeUuid,
+        ];
+
+        $caseTypeData = [
+            'id'                        => $caseTypeUuid,
+            'requireAllDeelzakenClosed' => true,
+        ];
+
+        $childCase = [
+            'id'      => $childUuid,
+            'title'   => 'Open deelzaak',
+            'status'  => 'in-behandeling',
+            'endDate' => null,
+        ];
+
+        $objectService = $this->createMockObjectService();
+        $objectService->method('find')->willReturnCallback(
+            static function (string $id) use ($caseUuid, $caseData, $caseTypeUuid, $caseTypeData): array {
+                return match ($id) {
+                    $caseUuid     => $caseData,
+                    $caseTypeUuid => $caseTypeData,
+                    default       => throw new \Exception("not found: {$id}"),
+                };
+            }
+        );
+
+        $objectService->method('buildSearchQuery')->willReturn([]);
+        $objectService->method('searchObjectsPaginated')->willReturn(
+            ['results' => [$childCase]]
+        );
+
+        $this->settingsService->method('getObjectService')->willReturn($objectService);
+        $this->settingsService->method('getConfigValue')->willReturnCallback(
+            static function (string $key): string {
+                return match ($key) {
+                    'register'         => 'reg1',
+                    'case_schema'      => 'cs1',
+                    'case_type_schema' => 'cts1',
+                    default            => '',
+                };
+            }
+        );
+
+        $result = $this->service->validateClosureAllowed(caseId: $caseUuid);
+
+        self::assertFalse($result['canClose']);
+        self::assertCount(1, $result['openDeelzaken']);
+        self::assertSame($childUuid, $result['openDeelzaken'][0]['id']);
+    }//end testValidateClosureBlockedWhenOpenDeelzakenExist()
+
+    // -------------------------------------------------------------------------
+    // createVervolgzaak() tests
+    // -------------------------------------------------------------------------
+
+    /**
+     * CreateVervolgzaak throws RuntimeException when objectService unavailable.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/deelzaak-support/tasks.md#V05
+     */
+    public function testCreateVervolgzaakThrowsWhenNoObjectService(): void
+    {
+        $this->settingsService->method('getObjectService')->willReturn(null);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/objectService unavailable/');
+
+        $this->service->createVervolgzaak(
+            sourceCaseId: 'source-uuid',
+            caseTypeId: 'type-uuid'
+        );
+    }//end testCreateVervolgzaakThrowsWhenNoObjectService()
+
+    /**
+     * CreateVervolgzaak throws RuntimeException when source case not found.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/deelzaak-support/tasks.md#V05
+     */
+    public function testCreateVervolgzaakThrowsWhenSourceNotFound(): void
+    {
+        $objectService = $this->createMockObjectService();
+        $objectService->method('find')->willThrowException(new \Exception('not found'));
+
+        $this->settingsService->method('getObjectService')->willReturn($objectService);
+        $this->settingsService->method('getConfigValue')->willReturnCallback(
+            static function (string $key): string {
+                return match ($key) {
+                    'register'         => 'reg1',
+                    'case_schema'      => 'cs1',
+                    'case_type_schema' => 'cts1',
+                    default            => '',
+                };
+            }
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/Source case.*not found/');
+
+        $this->service->createVervolgzaak(
+            sourceCaseId: '00000000-0000-0000-0000-000000000001',
+            caseTypeId: '00000000-0000-0000-0000-000000000002'
+        );
+    }//end testCreateVervolgzaakThrowsWhenSourceNotFound()
+
+    /**
+     * CreateVervolgzaak creates a new case with predecessor relatie link.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/deelzaak-support/tasks.md#V05
+     */
+    public function testCreateVervolgzaakCreatesCaseWithPredecessorLink(): void
+    {
+        $sourceUuid = '00000000-0000-0000-0000-000000000001';
+        $typeUuid   = '00000000-0000-0000-0000-000000000002';
+
+        $sourceCase = [
+            'id'    => $sourceUuid,
+            'title' => 'Original case',
+            'uri'   => "http://test/cases/{$sourceUuid}",
+        ];
+
+        $vervolgType = [
+            'id'    => $typeUuid,
+            'title' => 'Vervolg type',
+        ];
+
+        $capturedObjects = [];
+
+        $objectService = $this->createMockObjectService();
+        $objectService->method('find')->willReturnCallback(
+            static function (string $id) use ($sourceUuid, $sourceCase, $typeUuid, $vervolgType): array {
+                return match ($id) {
+                    $sourceUuid => $sourceCase,
+                    $typeUuid   => $vervolgType,
+                    default     => throw new \Exception("not found: {$id}"),
+                };
+            }
+        );
+        $objectService->method('saveObject')->willReturnCallback(
+            static function (string $register, string $schema, array $object) use (&$capturedObjects): array {
+                $capturedObjects[] = $object;
+                return array_merge(['id' => '00000000-0000-0000-0000-000000000099'], $object);
+            }
+        );
+
+        $this->settingsService->method('getObjectService')->willReturn($objectService);
+        $this->settingsService->method('getConfigValue')->willReturnCallback(
+            static function (string $key): string {
+                return match ($key) {
+                    'register'         => 'reg1',
+                    'case_schema'      => 'cs1',
+                    'case_type_schema' => 'cts1',
+                    default            => '',
+                };
+            }
+        );
+
+        $result = $this->service->createVervolgzaak(
+            sourceCaseId: $sourceUuid,
+            caseTypeId: $typeUuid
+        );
+
+        self::assertArrayHasKey('id', $result);
+        self::assertSame('Vervolg type', $result['title']);
+
+        // First save is the vervolg-zaak itself; it must have predecessor relatie.
+        $vervolgData = $capturedObjects[0];
+        self::assertArrayHasKey('relatedCases', $vervolgData);
+
+        $relaties = json_decode($vervolgData['relatedCases'], true);
+        self::assertCount(1, $relaties);
+        self::assertSame('onderwerp', $relaties[0]['aardRelatie']);
+    }//end testCreateVervolgzaakCreatesCaseWithPredecessorLink()
+
+    // -------------------------------------------------------------------------
+    // getHierarchy() tests
+    // -------------------------------------------------------------------------
+
+    /**
+     * GetHierarchy returns a tree with the root case and its direct children.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/deelzaak-support/tasks.md#V03
+     */
+    public function testGetHierarchyReturnsNestedTree(): void
+    {
+        $rootUuid = '00000000-0000-0000-0000-000000000001';
+        $child1Id = '00000000-0000-0000-0000-000000000002';
+        $child2Id = '00000000-0000-0000-0000-000000000003';
+
+        $rootCase = ['id' => $rootUuid, 'title' => 'Root case'];
+        $child1   = ['id' => $child1Id, 'title' => 'Child 1'];
+        $child2   = ['id' => $child2Id, 'title' => 'Child 2'];
+
+        $objectService = $this->createMockObjectService();
+        $objectService->method('find')->willReturnCallback(
+            static function (string $id) use ($rootUuid, $rootCase, $child1Id, $child1, $child2Id, $child2): array {
+                return match ($id) {
+                    $rootUuid => $rootCase,
+                    $child1Id => $child1,
+                    $child2Id => $child2,
+                    default   => throw new \Exception("not found: {$id}"),
+                };
+            }
+        );
+
+        // First call for root → return 2 children; subsequent calls → empty.
+        $callCount = 0;
+        $objectService->method('buildSearchQuery')->willReturn([]);
+        $objectService->method('searchObjectsPaginated')->willReturnCallback(
+            static function () use (&$callCount, $child1, $child2): array {
+                $callCount++;
+                return match ($callCount) {
+                    1       => ['results' => [$child1, $child2]],
+                    default => ['results' => []],
+                };
+            }
+        );
+
+        $this->settingsService->method('getObjectService')->willReturn($objectService);
+        $this->settingsService->method('getConfigValue')->willReturnCallback(
+            static function (string $key): string {
+                return match ($key) {
+                    'register'    => 'reg1',
+                    'case_schema' => 'cs1',
+                    default       => '',
+                };
+            }
+        );
+
+        $tree = $this->service->getHierarchy(caseId: $rootUuid);
+
+        self::assertSame($rootUuid, $tree['case']['id']);
+        self::assertCount(2, $tree['children']);
+        self::assertSame($child1Id, $tree['children'][0]['case']['id']);
+        self::assertSame($child2Id, $tree['children'][1]['case']['id']);
+    }//end testGetHierarchyReturnsNestedTree()
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Create a minimal mock objectService with all needed methods.
+     *
+     * @return MockObject
+     */
+    private function createMockObjectService(): MockObject
+    {
+        return $this->getMockBuilder(\stdClass::class)
+            ->addMethods(['find', 'saveObject', 'buildSearchQuery', 'searchObjectsPaginated'])
+            ->getMock();
+    }//end createMockObjectService()
+}//end class


### PR DESCRIPTION
Closes #136

## Summary
Implements deelzaak (sub-case) support in Procest, allowing a main case (hoofdzaak) to spawn child cases that follow their own workflows while remaining linked to the parent. Includes a recursive hierarchy tree, closure guard that blocks parent closure when deelzaken are still open, and vervolg-zaak (follow-up case) creation with typed relatie links. New Vue components integrate seamlessly into the existing CaseDetail and CaseTypeDetail views.

## Spec Reference
- Issue: #136
- Spec: `openspec/changes/deelzaak-support/design.md`

## Changes
- `lib/Service/DeelzaakService.php` — new service: createDeelzaak(), getHierarchy(), validateClosureAllowed(), createVervolgzaak(); inherits deadline/archiveNomination/confidentiality from parent; caps hierarchy recursion at 10 levels
- `lib/Controller/DeelzaakController.php` — new REST controller: POST /api/procest/deelzaak/{caseId}, GET hierarchy, GET closure-check, POST vervolgzaak; all marked @NoAdminRequired
- `lib/Service/SettingsService.php` — added getObjectService() helper that loads OCA\OpenRegister\Service\ObjectService from container, used by DeelzaakService
- `appinfo/routes.php` — registered 4 new deelzaak routes before GIS proxy section
- `src/views/cases/components/DeelzaakHierarchyTree.vue` — recursive Vue component rendering n-level case hierarchy with status badges; emits navigate event
- `src/views/cases/components/CreateDeelzaakDialog.vue` — modal dialog for manual deelzaak creation restricted to configured subCaseTypes
- `src/views/settings/tabs/DeelzaakTypenTab.vue` — settings tab to configure subCaseTypes and requireAllDeelzakenClosed on a caseType
- `src/views/cases/CaseDetail.vue` — wired DeelzaakHierarchyTree, CreateDeelzaakDialog; loads hierarchy/statusTypeMap/allowedDeelzaakCaseTypes on mount
- `src/views/settings/CaseTypeDetail.vue` — added Sub-case types tab with DeelzaakTypenTab and onDeelzaakTypenSave handler
- `openspec/changes/deelzaak-support/design.md` — architecture design document
- `openspec/changes/deelzaak-support/tasks.md` — all 8 implementation + 6 verification tasks completed
- `openspec/changes/deelzaak-support/specs/deelzaak-support/spec.md` — API contracts

## Test Coverage
- `tests/Unit/Service/DeelzaakServiceTest.php` — 11 PHPUnit tests covering: createDeelzaak throws when no objectService; throws when parent not found; throws when caseType not in subCaseTypes; inherits parent fields; validateClosureAllowed throws when no service; returns canClose=true when not required; blocks when open deelzaken exist; createVervolgzaak throws when no service; throws when source not found; creates case with predecessor relatie; getHierarchy returns nested tree