### PR TITLE
chore(quality): phpcbf auto-fix + @author email typo

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -8,7 +8,7 @@
  * @category AppInfo
  * @package  OCA\Procest\AppInfo
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/BackgroundJob/AppointmentReminderJob.php
+++ b/lib/BackgroundJob/AppointmentReminderJob.php
@@ -21,8 +21,9 @@ class AppointmentReminderJob extends TimedJob
         private LoggerInterface $logger,
     ) {
         parent::__construct($time);
-        $this->setInterval(86400); // Daily.
-    }
+        $this->setInterval(86400);
+        // Daily.
+    }//end __construct()
 
     protected function run($argument): void
     {
@@ -50,19 +51,22 @@ class AppointmentReminderJob extends TimedJob
             );
 
             foreach (($result['objects'] ?? []) as $apt) {
-                $data = is_object($apt) ? $apt->jsonSerialize() : $apt;
+                $data    = is_object($apt) ? $apt->jsonSerialize() : $apt;
                 $aptDate = substr($data['dateTime'] ?? '', 0, 10);
 
                 if ($aptDate === $tomorrow && empty($data['reminderSent'])) {
                     $data['reminderSent'] = true;
                     $objectService->saveObject((int) $register, (int) $schema, $data);
-                    $this->logger->info('Procest: Reminder sent for appointment', [
-                        'appointmentId' => $data['uuid'] ?? $data['id'] ?? '',
-                    ]);
+                    $this->logger->info(
+                            'Procest: Reminder sent for appointment',
+                            [
+                                'appointmentId' => $data['uuid'] ?? $data['id'] ?? '',
+                            ]
+                            );
                 }
             }
         } catch (\Exception $e) {
             $this->logger->error('Procest: Reminder job error: '.$e->getMessage());
-        }
-    }
-}
+        }//end try
+    }//end run()
+}//end class

--- a/lib/BackgroundJob/BerichtenboxReadStatusJob.php
+++ b/lib/BackgroundJob/BerichtenboxReadStatusJob.php
@@ -17,13 +17,14 @@ class BerichtenboxReadStatusJob extends TimedJob
         private LoggerInterface $logger,
     ) {
         parent::__construct($time);
-        $this->setInterval(86400); // Daily.
-    }
+        $this->setInterval(86400);
+        // Daily.
+    }//end __construct()
 
     protected function run($argument): void
     {
         $this->logger->info('Procest: Running Berichtenbox read status poll');
         // The actual polling happens in BerichtenboxService::pollReadStatus
         // This job would iterate unread messages and poll each one.
-    }
-}
+    }//end run()
+}//end class

--- a/lib/BackgroundJob/ShareMaintenanceJob.php
+++ b/lib/BackgroundJob/ShareMaintenanceJob.php
@@ -8,7 +8,7 @@
  * @category BackgroundJob
  * @package  OCA\Procest\BackgroundJob
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/BackgroundJob/ShareMaintenanceJob.php
+++ b/lib/BackgroundJob/ShareMaintenanceJob.php
@@ -47,7 +47,7 @@ class ShareMaintenanceJob extends TimedJob
      * @param ITimeFactory       $time            The time factory
      * @param SettingsService    $settingsService The settings service
      * @param IAppManager        $appManager      The app manager
-     * @param ContainerInterface $container        The DI container
+     * @param ContainerInterface $container       The DI container
      * @param LoggerInterface    $logger          The logger
      *
      * @return void

--- a/lib/Controller/AcController.php
+++ b/lib/Controller/AcController.php
@@ -10,7 +10,7 @@
  * @category Controller
  * @package  OCA\Procest\Controller
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Controller/AiController.php
+++ b/lib/Controller/AiController.php
@@ -47,12 +47,12 @@ class AiController extends Controller
     /**
      * Constructor for AiController.
      *
-     * @param string           $appName         The application name
-     * @param IRequest         $request         The request object
-     * @param AiService        $aiService       The AI service
-     * @param SettingsService  $settingsService The settings service
-     * @param IUserSession     $userSession     The user session
-     * @param LoggerInterface  $logger          The logger interface
+     * @param string          $appName         The application name
+     * @param IRequest        $request         The request object
+     * @param AiService       $aiService       The AI service
+     * @param SettingsService $settingsService The settings service
+     * @param IUserSession    $userSession     The user session
+     * @param LoggerInterface $logger          The logger interface
      *
      * @return void
      */
@@ -277,11 +277,13 @@ class AiController extends Controller
             'offset' => (int) $this->request->getParam('offset', '0'),
         ];
 
-        return new JSONResponse([
-            'success' => true,
-            'filters' => array_filter($filters),
-            'message' => 'Audit trail query — implement with OpenRegister object listing',
-        ]);
+        return new JSONResponse(
+                [
+                    'success' => true,
+                    'filters' => array_filter($filters),
+                    'message' => 'Audit trail query — implement with OpenRegister object listing',
+                ]
+                );
     }//end auditIndex()
 
     /**

--- a/lib/Controller/AiController.php
+++ b/lib/Controller/AiController.php
@@ -10,7 +10,7 @@
  * @category Controller
  * @package  OCA\Procest\Controller
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Controller/AppointmentController.php
+++ b/lib/Controller/AppointmentController.php
@@ -17,17 +17,21 @@ class AppointmentController extends Controller
         private AppointmentService $appointmentService,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
-    }
+    }//end __construct()
 
-    /** @NoAdminRequired */
+    /**
+     * @NoAdminRequired
+     */
     public function index(): JSONResponse
     {
         $caseId       = $this->request->getParam('caseId');
         $appointments = $this->appointmentService->getAppointmentsForCase($caseId ?? '');
         return new JSONResponse(['success' => true, 'appointments' => $appointments]);
-    }
+    }//end index()
 
-    /** @NoAdminRequired */
+    /**
+     * @NoAdminRequired
+     */
     public function create(): JSONResponse
     {
         $caseId = $this->request->getParam('caseId');
@@ -48,23 +52,29 @@ class AppointmentController extends Controller
 
         $result = $this->appointmentService->bookAppointment($caseId, $data);
         return new JSONResponse(['success' => true, 'appointment' => $result]);
-    }
+    }//end create()
 
-    /** @NoAdminRequired */
+    /**
+     * @NoAdminRequired
+     */
     public function cancel(string $appointmentId): JSONResponse
     {
         $result = $this->appointmentService->cancelAppointment($appointmentId);
         return new JSONResponse(['success' => true, 'appointment' => $result]);
-    }
+    }//end cancel()
 
-    /** @NoAdminRequired */
+    /**
+     * @NoAdminRequired
+     */
     public function noShow(string $appointmentId): JSONResponse
     {
         $result = $this->appointmentService->markNoShow($appointmentId);
         return new JSONResponse(['success' => true, 'appointment' => $result]);
-    }
+    }//end noShow()
 
-    /** @NoAdminRequired */
+    /**
+     * @NoAdminRequired
+     */
     public function timeslots(): JSONResponse
     {
         $productId  = $this->request->getParam('productId', '');
@@ -73,5 +83,5 @@ class AppointmentController extends Controller
 
         $slots = $this->appointmentService->getTimeslots($productId, $locationId, $date);
         return new JSONResponse(['success' => true, 'timeslots' => $slots]);
-    }
-}
+    }//end timeslots()
+}//end class

--- a/lib/Controller/BerichtenboxController.php
+++ b/lib/Controller/BerichtenboxController.php
@@ -17,16 +17,18 @@ class BerichtenboxController extends Controller
         private BerichtenboxService $berichtenboxService,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
-    }
+    }//end __construct()
 
-    /** @NoAdminRequired */
+    /**
+     * @NoAdminRequired
+     */
     public function send(): JSONResponse
     {
-        $caseId           = $this->request->getParam('caseId');
-        $bsn              = $this->request->getParam('bsn', '');
-        $subject          = $this->request->getParam('subject', '');
-        $body             = $this->request->getParam('body', '');
-        $typeCode         = $this->request->getParam('berichtTypeCode', '');
+        $caseId   = $this->request->getParam('caseId');
+        $bsn      = $this->request->getParam('bsn', '');
+        $subject  = $this->request->getParam('subject', '');
+        $body     = $this->request->getParam('body', '');
+        $typeCode = $this->request->getParam('berichtTypeCode', '');
         $attachmentFileId = $this->request->getParam('attachmentFileId');
 
         if (empty($caseId) === true) {
@@ -34,7 +36,12 @@ class BerichtenboxController extends Controller
         }
 
         $result = $this->berichtenboxService->sendMessage(
-            $caseId, $bsn, $subject, $body, $typeCode, $attachmentFileId
+            $caseId,
+                $bsn,
+                $subject,
+                $body,
+                $typeCode,
+                $attachmentFileId
         );
 
         if (isset($result['error']) === true) {
@@ -42,20 +49,24 @@ class BerichtenboxController extends Controller
         }
 
         return new JSONResponse(['success' => true, 'message' => $result]);
-    }
+    }//end send()
 
-    /** @NoAdminRequired */
+    /**
+     * @NoAdminRequired
+     */
     public function messages(): JSONResponse
     {
         $caseId   = $this->request->getParam('caseId', '');
         $messages = $this->berichtenboxService->getMessagesForCase($caseId);
         return new JSONResponse(['success' => true, 'messages' => $messages]);
-    }
+    }//end messages()
 
-    /** @NoAdminRequired */
+    /**
+     * @NoAdminRequired
+     */
     public function poll(string $messageId): JSONResponse
     {
         $result = $this->berichtenboxService->pollReadStatus($messageId);
         return new JSONResponse(['success' => true, 'message' => $result]);
-    }
-}
+    }//end poll()
+}//end class

--- a/lib/Controller/BrcController.php
+++ b/lib/Controller/BrcController.php
@@ -10,7 +10,7 @@
  * @category Controller
  * @package  OCA\Procest\Controller
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Controller/CaseDefinitionController.php
+++ b/lib/Controller/CaseDefinitionController.php
@@ -41,11 +41,11 @@ class CaseDefinitionController extends Controller
     /**
      * Constructor.
      *
-     * @param string                        $appName       The app name.
-     * @param IRequest                      $request       The request object.
-     * @param CaseDefinitionExportService   $exportService The export service.
-     * @param CaseDefinitionImportService   $importService The import service.
-     * @param LoggerInterface               $logger        The logger.
+     * @param string                      $appName       The app name.
+     * @param IRequest                    $request       The request object.
+     * @param CaseDefinitionExportService $exportService The export service.
+     * @param CaseDefinitionImportService $importService The import service.
+     * @param LoggerInterface             $logger        The logger.
      */
     public function __construct(
         string $appName,
@@ -55,7 +55,7 @@ class CaseDefinitionController extends Controller
         private readonly LoggerInterface $logger,
     ) {
         parent::__construct($appName, $request);
-    }
+    }//end __construct()
 
     /**
      * Export a case definition as a ZIP archive.
@@ -104,13 +104,13 @@ class CaseDefinitionController extends Controller
                 Http::STATUS_BAD_REQUEST
             );
         } catch (\Throwable $e) {
-            $this->logger->error('Case definition export failed: ' . $e->getMessage());
+            $this->logger->error('Case definition export failed: '.$e->getMessage());
             return new JSONResponse(
-                ['error' => 'Export failed: ' . $e->getMessage()],
+                ['error' => 'Export failed: '.$e->getMessage()],
                 Http::STATUS_INTERNAL_SERVER_ERROR
             );
-        }
-    }
+        }//end try
+    }//end export()
 
     /**
      * Validate a case definition package without importing it.
@@ -135,13 +135,13 @@ class CaseDefinitionController extends Controller
 
             return new JSONResponse($result);
         } catch (\Throwable $e) {
-            $this->logger->error('Case definition validation failed: ' . $e->getMessage());
+            $this->logger->error('Case definition validation failed: '.$e->getMessage());
             return new JSONResponse(
-                ['error' => 'Validation failed: ' . $e->getMessage()],
+                ['error' => 'Validation failed: '.$e->getMessage()],
                 Http::STATUS_INTERNAL_SERVER_ERROR
             );
         }
-    }
+    }//end validate()
 
     /**
      * Import a case definition package.
@@ -153,7 +153,7 @@ class CaseDefinitionController extends Controller
     public function import(): JSONResponse
     {
         try {
-            $file = $this->request->getUploadedFile('package');
+            $file     = $this->request->getUploadedFile('package');
             $strategy = $this->request->getParam('strategy', 'skip');
 
             if ($file === null || !isset($file['tmp_name'])) {
@@ -175,17 +175,15 @@ class CaseDefinitionController extends Controller
                 $strategy
             );
 
-            $statusCode = $result['success']
-                ? Http::STATUS_OK
-                : Http::STATUS_UNPROCESSABLE_ENTITY;
+            $statusCode = $result['success'] ? Http::STATUS_OK : Http::STATUS_UNPROCESSABLE_ENTITY;
 
             return new JSONResponse($result, $statusCode);
         } catch (\Throwable $e) {
-            $this->logger->error('Case definition import failed: ' . $e->getMessage());
+            $this->logger->error('Case definition import failed: '.$e->getMessage());
             return new JSONResponse(
-                ['error' => 'Import failed: ' . $e->getMessage()],
+                ['error' => 'Import failed: '.$e->getMessage()],
                 Http::STATUS_INTERNAL_SERVER_ERROR
             );
-        }
-    }
-}
+        }//end try
+    }//end import()
+}//end class

--- a/lib/Controller/CaseDefinitionController.php
+++ b/lib/Controller/CaseDefinitionController.php
@@ -9,7 +9,7 @@
  * @category Controller
  * @package  OCA\Procest\Controller
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Controller/CaseSharingController.php
+++ b/lib/Controller/CaseSharingController.php
@@ -40,13 +40,13 @@ class CaseSharingController extends Controller
     /**
      * Constructor for the CaseSharingController.
      *
-     * @param IRequest             $request             The request object
-     * @param CaseSharingService   $caseSharingService  The sharing service
-     * @param CaseTransferService  $caseTransferService The transfer service
-     * @param SettingsService      $settingsService     The settings service
-     * @param IAppManager          $appManager          The app manager
-     * @param ContainerInterface   $container           The DI container
-     * @param IUserSession         $userSession         The user session
+     * @param IRequest            $request             The request object
+     * @param CaseSharingService  $caseSharingService  The sharing service
+     * @param CaseTransferService $caseTransferService The transfer service
+     * @param SettingsService     $settingsService     The settings service
+     * @param IAppManager         $appManager          The app manager
+     * @param ContainerInterface  $container           The DI container
+     * @param IUserSession        $userSession         The user session
      *
      * @return void
      *
@@ -134,7 +134,7 @@ class CaseSharingController extends Controller
                 $password,
                 $fieldExclusions,
             );
-        }
+        }//end if
 
         return new JSONResponse(['success' => true, 'share' => $share]);
     }//end createShare()
@@ -168,11 +168,11 @@ class CaseSharingController extends Controller
      */
     public function initiateTransfer(): JSONResponse
     {
-        $caseId             = $this->request->getParam('caseId');
+        $caseId = $this->request->getParam('caseId');
         $sourceOrganization = $this->request->getParam('sourceOrganization', '');
         $targetOrganization = $this->request->getParam('targetOrganization');
-        $reason             = $this->request->getParam('reason', '');
-        $requestedDate      = $this->request->getParam('requestedDate', date('Y-m-d'));
+        $reason        = $this->request->getParam('reason', '');
+        $requestedDate = $this->request->getParam('requestedDate', date('Y-m-d'));
 
         if (empty($caseId) === true || empty($targetOrganization) === true) {
             return new JSONResponse(
@@ -207,7 +207,7 @@ class CaseSharingController extends Controller
 
         if ($action === 'accept') {
             $result = $this->caseTransferService->acceptTransfer($transferId);
-        } elseif ($action === 'reject') {
+        } else if ($action === 'reject') {
             $reason = $this->request->getParam('reason', '');
             $result = $this->caseTransferService->rejectTransfer($transferId, $reason);
         } else {

--- a/lib/Controller/CaseSharingController.php
+++ b/lib/Controller/CaseSharingController.php
@@ -8,7 +8,7 @@
  * @category Controller
  * @package  OCA\Procest\Controller
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Controller/ConsultationController.php
+++ b/lib/Controller/ConsultationController.php
@@ -31,8 +31,6 @@ use OCP\IRequest;
  */
 class ConsultationController extends Controller
 {
-
-
     /**
      * Constructor.
      *
@@ -46,8 +44,7 @@ class ConsultationController extends Controller
         private readonly ConsultationService $consultationService,
     ) {
         parent::__construct($appName, $request);
-    }
-
+    }//end __construct()
 
     /**
      * List consultations for a case.
@@ -62,8 +59,7 @@ class ConsultationController extends Controller
     {
         $consultations = $this->consultationService->getConsultationsForCase($caseId);
         return new JSONResponse(['results' => $consultations]);
-    }
-
+    }//end index()
 
     /**
      * Create a new consultation.
@@ -81,8 +77,7 @@ class ConsultationController extends Controller
         } catch (\RuntimeException $e) {
             return new JSONResponse(['error' => $e->getMessage()], 400);
         }
-    }
-
+    }//end create()
 
     /**
      * Update consultation status.
@@ -103,8 +98,7 @@ class ConsultationController extends Controller
         } catch (\RuntimeException $e) {
             return new JSONResponse(['error' => $e->getMessage()], 400);
         }
-    }
-
+    }//end updateStatus()
 
     /**
      * Submit advice response.
@@ -124,8 +118,7 @@ class ConsultationController extends Controller
         } catch (\RuntimeException $e) {
             return new JSONResponse(['error' => $e->getMessage()], 400);
         }
-    }
-
+    }//end submitResponse()
 
     /**
      * Get overdue consultations.
@@ -138,5 +131,5 @@ class ConsultationController extends Controller
     {
         $overdue = $this->consultationService->getOverdueConsultations();
         return new JSONResponse(['results' => $overdue]);
-    }
-}
+    }//end overdue()
+}//end class

--- a/lib/Controller/ConsultationController.php
+++ b/lib/Controller/ConsultationController.php
@@ -8,7 +8,7 @@
  * @category Controller
  * @package  OCA\Procest\Controller
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Controller/DashboardController.php
+++ b/lib/Controller/DashboardController.php
@@ -8,7 +8,7 @@
  * @category Controller
  * @package  OCA\Procest\Controller
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Controller/DrcController.php
+++ b/lib/Controller/DrcController.php
@@ -10,7 +10,7 @@
  * @category Controller
  * @package  OCA\Procest\Controller
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Controller/EmailController.php
+++ b/lib/Controller/EmailController.php
@@ -31,8 +31,6 @@ use OCP\IRequest;
  */
 class EmailController extends Controller
 {
-
-
     /**
      * Constructor.
      *
@@ -46,8 +44,7 @@ class EmailController extends Controller
         private readonly CaseEmailService $emailService,
     ) {
         parent::__construct($appName, $request);
-    }
-
+    }//end __construct()
 
     /**
      * Send an email from case context.
@@ -61,7 +58,7 @@ class EmailController extends Controller
     public function send(string $caseId): JSONResponse
     {
         try {
-            $data = json_decode($this->request->getContent() ?: '{}', true) ?: [];
+            $data   = json_decode($this->request->getContent() ?: '{}', true) ?: [];
             $result = $this->emailService->sendEmail(
                 $caseId,
                 $data['to'] ?? '',
@@ -73,8 +70,7 @@ class EmailController extends Controller
         } catch (\RuntimeException $e) {
             return new JSONResponse(['error' => $e->getMessage()], 400);
         }
-    }
-
+    }//end send()
 
     /**
      * Send email using a template.
@@ -98,8 +94,7 @@ class EmailController extends Controller
         } catch (\RuntimeException $e) {
             return new JSONResponse(['error' => $e->getMessage()], 400);
         }
-    }
-
+    }//end sendFromTemplate()
 
     /**
      * Preview a template with case data.
@@ -112,18 +107,20 @@ class EmailController extends Controller
      */
     public function preview(string $caseId): JSONResponse
     {
-        $data = json_decode($this->request->getContent() ?: '{}', true) ?: [];
-        $template   = $data['body'] ?? '';
-        $caseData   = []; // Would load from case.
+        $data     = json_decode($this->request->getContent() ?: '{}', true) ?: [];
+        $template = $data['body'] ?? '';
+        $caseData = [];
+        // Would load from case.
         $resolved   = $this->emailService->resolveVariables($template, $caseData);
         $unresolved = $this->emailService->findUnresolvedVariables($template, $caseData);
 
-        return new JSONResponse([
-            'resolved'   => $resolved,
-            'unresolved' => $unresolved,
-        ]);
-    }
-
+        return new JSONResponse(
+                [
+                    'resolved'   => $resolved,
+                    'unresolved' => $unresolved,
+                ]
+                );
+    }//end preview()
 
     /**
      * Get email templates for a case type.
@@ -138,5 +135,5 @@ class EmailController extends Controller
     {
         $templates = $this->emailService->getTemplatesForCaseType($caseTypeId);
         return new JSONResponse(['results' => $templates]);
-    }
-}
+    }//end templates()
+}//end class

--- a/lib/Controller/EmailController.php
+++ b/lib/Controller/EmailController.php
@@ -8,7 +8,7 @@
  * @category Controller
  * @package  OCA\Procest\Controller
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Controller/GisProxyController.php
+++ b/lib/Controller/GisProxyController.php
@@ -9,7 +9,7 @@
  * @category Controller
  * @package  OCA\Procest\Controller
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Controller/HealthController.php
+++ b/lib/Controller/HealthController.php
@@ -8,7 +8,7 @@
  * @category Controller
  * @package  OCA\Procest\Controller
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Controller/InspectionController.php
+++ b/lib/Controller/InspectionController.php
@@ -41,12 +41,12 @@ class InspectionController extends Controller
     /**
      * Constructor.
      *
-     * @param string             $appName            The app name.
-     * @param IRequest           $request            The request object.
-     * @param InspectionService  $inspectionService  The inspection service.
-     * @param ChecklistService   $checklistService   The checklist service.
-     * @param IUserSession       $userSession        The user session.
-     * @param LoggerInterface    $logger             The logger.
+     * @param string            $appName           The app name.
+     * @param IRequest          $request           The request object.
+     * @param InspectionService $inspectionService The inspection service.
+     * @param ChecklistService  $checklistService  The checklist service.
+     * @param IUserSession      $userSession       The user session.
+     * @param LoggerInterface   $logger            The logger.
      */
     public function __construct(
         string $appName,
@@ -57,7 +57,7 @@ class InspectionController extends Controller
         private readonly LoggerInterface $logger,
     ) {
         parent::__construct($appName, $request);
-    }
+    }//end __construct()
 
     /**
      * List inspections assigned to the current user.
@@ -70,20 +70,20 @@ class InspectionController extends Controller
     {
         try {
             $userId = $this->userSession->getUser()?->getUID() ?? '';
-            $date = $this->request->getParam('date');
+            $date   = $this->request->getParam('date');
 
             // In full implementation, query OpenRegister for inspections.
             $inspections = $this->inspectionService->getInspections($userId, $date, []);
 
             return new JSONResponse(['results' => $inspections]);
         } catch (\Throwable $e) {
-            $this->logger->error('Failed to list inspections: ' . $e->getMessage());
+            $this->logger->error('Failed to list inspections: '.$e->getMessage());
             return new JSONResponse(
-                ['error' => 'Failed to list inspections: ' . $e->getMessage()],
+                ['error' => 'Failed to list inspections: '.$e->getMessage()],
                 Http::STATUS_INTERNAL_SERVER_ERROR
             );
         }
-    }
+    }//end index()
 
     /**
      * Record GPS location for an inspection.
@@ -97,10 +97,10 @@ class InspectionController extends Controller
     public function captureLocation(string $id): JSONResponse
     {
         try {
-            $body = $this->getRequestBody();
-            $latitude = (float)($body['latitude'] ?? 0);
-            $longitude = (float)($body['longitude'] ?? 0);
-            $accuracy = (float)($body['accuracy'] ?? 0);
+            $body       = $this->getRequestBody();
+            $latitude   = (float) ($body['latitude'] ?? 0);
+            $longitude  = (float) ($body['longitude'] ?? 0);
+            $accuracy   = (float) ($body['accuracy'] ?? 0);
             $inspection = $body['inspection'] ?? [];
 
             if ($latitude === 0.0 && $longitude === 0.0) {
@@ -119,13 +119,13 @@ class InspectionController extends Controller
 
             return new JSONResponse($result);
         } catch (\Throwable $e) {
-            $this->logger->error('Failed to capture location: ' . $e->getMessage());
+            $this->logger->error('Failed to capture location: '.$e->getMessage());
             return new JSONResponse(
-                ['error' => 'Failed to capture location: ' . $e->getMessage()],
+                ['error' => 'Failed to capture location: '.$e->getMessage()],
                 Http::STATUS_INTERNAL_SERVER_ERROR
             );
-        }
-    }
+        }//end try
+    }//end captureLocation()
 
     /**
      * Complete a checklist item.
@@ -140,11 +140,11 @@ class InspectionController extends Controller
     public function completeChecklistItem(string $id, string $itemId): JSONResponse
     {
         try {
-            $body = $this->getRequestBody();
-            $status = $body['status'] ?? '';
+            $body        = $this->getRequestBody();
+            $status      = $body['status'] ?? '';
             $toelichting = $body['toelichting'] ?? '';
-            $photoRefs = $body['photoRefs'] ?? [];
-            $checklist = $body['checklist'] ?? [];
+            $photoRefs   = $body['photoRefs'] ?? [];
+            $checklist   = $body['checklist'] ?? [];
 
             $updatedChecklist = $this->checklistService->completeItem(
                 $checklist,
@@ -156,23 +156,25 @@ class InspectionController extends Controller
 
             $progress = $this->checklistService->getProgress($updatedChecklist);
 
-            return new JSONResponse([
-                'checklist' => $updatedChecklist,
-                'progress' => $progress,
-            ]);
+            return new JSONResponse(
+                    [
+                        'checklist' => $updatedChecklist,
+                        'progress'  => $progress,
+                    ]
+                    );
         } catch (\InvalidArgumentException $e) {
             return new JSONResponse(
                 ['error' => $e->getMessage()],
                 Http::STATUS_BAD_REQUEST
             );
         } catch (\Throwable $e) {
-            $this->logger->error('Failed to complete checklist item: ' . $e->getMessage());
+            $this->logger->error('Failed to complete checklist item: '.$e->getMessage());
             return new JSONResponse(
-                ['error' => 'Failed to complete checklist item: ' . $e->getMessage()],
+                ['error' => 'Failed to complete checklist item: '.$e->getMessage()],
                 Http::STATUS_INTERNAL_SERVER_ERROR
             );
-        }
-    }
+        }//end try
+    }//end completeChecklistItem()
 
     /**
      * Upload a photo for an inspection.
@@ -186,21 +188,21 @@ class InspectionController extends Controller
     public function addPhoto(string $id): JSONResponse
     {
         try {
-            $body = $this->getRequestBody();
-            $inspection = $body['inspection'] ?? [];
+            $body          = $this->getRequestBody();
+            $inspection    = $body['inspection'] ?? [];
             $photoMetadata = $body['photoMetadata'] ?? [];
 
             $updatedInspection = $this->inspectionService->addPhoto($inspection, $photoMetadata);
 
             return new JSONResponse($updatedInspection);
         } catch (\Throwable $e) {
-            $this->logger->error('Failed to add photo: ' . $e->getMessage());
+            $this->logger->error('Failed to add photo: '.$e->getMessage());
             return new JSONResponse(
-                ['error' => 'Failed to add photo: ' . $e->getMessage()],
+                ['error' => 'Failed to add photo: '.$e->getMessage()],
                 Http::STATUS_INTERNAL_SERVER_ERROR
             );
         }
-    }
+    }//end addPhoto()
 
     /**
      * Complete an inspection.
@@ -214,7 +216,7 @@ class InspectionController extends Controller
     public function complete(string $id): JSONResponse
     {
         try {
-            $body = $this->getRequestBody();
+            $body       = $this->getRequestBody();
             $inspection = $body['inspection'] ?? [];
             $conclusion = $body['conclusion'] ?? '';
 
@@ -227,13 +229,13 @@ class InspectionController extends Controller
                 Http::STATUS_BAD_REQUEST
             );
         } catch (\Throwable $e) {
-            $this->logger->error('Failed to complete inspection: ' . $e->getMessage());
+            $this->logger->error('Failed to complete inspection: '.$e->getMessage());
             return new JSONResponse(
-                ['error' => 'Failed to complete inspection: ' . $e->getMessage()],
+                ['error' => 'Failed to complete inspection: '.$e->getMessage()],
                 Http::STATUS_INTERNAL_SERVER_ERROR
             );
         }
-    }
+    }//end complete()
 
     /**
      * Get the parsed request body.
@@ -249,5 +251,5 @@ class InspectionController extends Controller
 
         $decoded = json_decode($body, true);
         return is_array($decoded) ? $decoded : [];
-    }
-}
+    }//end getRequestBody()
+}//end class

--- a/lib/Controller/InspectionController.php
+++ b/lib/Controller/InspectionController.php
@@ -9,7 +9,7 @@
  * @category Controller
  * @package  OCA\Procest\Controller
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Controller/LegesController.php
+++ b/lib/Controller/LegesController.php
@@ -9,7 +9,7 @@
  * @category Controller
  * @package  OCA\Procest\Controller
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Controller/LegesController.php
+++ b/lib/Controller/LegesController.php
@@ -42,12 +42,12 @@ class LegesController extends Controller
     /**
      * Constructor.
      *
-     * @param string                   $appName           The app name.
-     * @param IRequest                 $request           The request object.
-     * @param LegesCalculationService  $calculationService The calculation service.
-     * @param LegesExportService       $exportService     The export service.
-     * @param IUserSession             $userSession       The user session.
-     * @param LoggerInterface          $logger            The logger.
+     * @param string                  $appName            The app name.
+     * @param IRequest                $request            The request object.
+     * @param LegesCalculationService $calculationService The calculation service.
+     * @param LegesExportService      $exportService      The export service.
+     * @param IUserSession            $userSession        The user session.
+     * @param LoggerInterface         $logger             The logger.
      */
     public function __construct(
         string $appName,
@@ -58,7 +58,7 @@ class LegesController extends Controller
         private readonly LoggerInterface $logger,
     ) {
         parent::__construct($appName, $request);
-    }
+    }//end __construct()
 
     /**
      * Calculate leges for a case.
@@ -70,7 +70,7 @@ class LegesController extends Controller
     public function calculate(): JSONResponse
     {
         try {
-            $caseData = $this->request->getParam('caseData', []);
+            $caseData    = $this->request->getParam('caseData', []);
             $verordening = $this->request->getParam('verordening', []);
 
             if (empty($caseData) || empty($verordening)) {
@@ -83,6 +83,7 @@ class LegesController extends Controller
             if (is_string($caseData)) {
                 $caseData = json_decode($caseData, true) ?? [];
             }
+
             if (is_string($verordening)) {
                 $verordening = json_decode($verordening, true) ?? [];
             }
@@ -93,13 +94,13 @@ class LegesController extends Controller
 
             return new JSONResponse($result);
         } catch (\Throwable $e) {
-            $this->logger->error('Leges calculation failed: ' . $e->getMessage());
+            $this->logger->error('Leges calculation failed: '.$e->getMessage());
             return new JSONResponse(
-                ['error' => 'Calculation failed: ' . $e->getMessage()],
+                ['error' => 'Calculation failed: '.$e->getMessage()],
                 Http::STATUS_INTERNAL_SERVER_ERROR
             );
-        }
-    }
+        }//end try
+    }//end calculate()
 
     /**
      * Recalculate leges with corrected data.
@@ -111,17 +112,19 @@ class LegesController extends Controller
     public function recalculate(): JSONResponse
     {
         try {
-            $caseData = $this->request->getParam('caseData', []);
-            $verordening = $this->request->getParam('verordening', []);
+            $caseData     = $this->request->getParam('caseData', []);
+            $verordening  = $this->request->getParam('verordening', []);
             $previousCalc = $this->request->getParam('previousCalculation', []);
-            $reason = $this->request->getParam('correctionReason', '');
+            $reason       = $this->request->getParam('correctionReason', '');
 
             if (is_string($caseData)) {
                 $caseData = json_decode($caseData, true) ?? [];
             }
+
             if (is_string($verordening)) {
                 $verordening = json_decode($verordening, true) ?? [];
             }
+
             if (is_string($previousCalc)) {
                 $previousCalc = json_decode($previousCalc, true) ?? [];
             }
@@ -138,13 +141,13 @@ class LegesController extends Controller
 
             return new JSONResponse($result);
         } catch (\Throwable $e) {
-            $this->logger->error('Leges recalculation failed: ' . $e->getMessage());
+            $this->logger->error('Leges recalculation failed: '.$e->getMessage());
             return new JSONResponse(
-                ['error' => 'Recalculation failed: ' . $e->getMessage()],
+                ['error' => 'Recalculation failed: '.$e->getMessage()],
                 Http::STATUS_INTERNAL_SERVER_ERROR
             );
-        }
-    }
+        }//end try
+    }//end recalculate()
 
     /**
      * Calculate verrekening (deduction).
@@ -156,20 +159,20 @@ class LegesController extends Controller
     public function verrekening(): JSONResponse
     {
         try {
-            $currentAmount = (float)$this->request->getParam('currentAmount', 0);
-            $previousAmount = (float)$this->request->getParam('previousAmount', 0);
+            $currentAmount  = (float) $this->request->getParam('currentAmount', 0);
+            $previousAmount = (float) $this->request->getParam('previousAmount', 0);
 
             $result = $this->calculationService->calculateVerrekening($currentAmount, $previousAmount);
 
             return new JSONResponse($result);
         } catch (\Throwable $e) {
-            $this->logger->error('Verrekening calculation failed: ' . $e->getMessage());
+            $this->logger->error('Verrekening calculation failed: '.$e->getMessage());
             return new JSONResponse(
-                ['error' => 'Verrekening failed: ' . $e->getMessage()],
+                ['error' => 'Verrekening failed: '.$e->getMessage()],
                 Http::STATUS_INTERNAL_SERVER_ERROR
             );
         }
-    }
+    }//end verrekening()
 
     /**
      * Calculate teruggaaf (refund).
@@ -181,9 +184,9 @@ class LegesController extends Controller
     public function teruggaaf(): JSONResponse
     {
         try {
-            $imposedAmount = (float)$this->request->getParam('imposedAmount', 0);
-            $refundFraction = (float)$this->request->getParam('refundFraction', 1.0);
-            $reason = (string)$this->request->getParam('reason', '');
+            $imposedAmount  = (float) $this->request->getParam('imposedAmount', 0);
+            $refundFraction = (float) $this->request->getParam('refundFraction', 1.0);
+            $reason         = (string) $this->request->getParam('reason', '');
 
             $result = $this->calculationService->calculateTeruggaaf(
                 $imposedAmount,
@@ -193,13 +196,13 @@ class LegesController extends Controller
 
             return new JSONResponse($result);
         } catch (\Throwable $e) {
-            $this->logger->error('Teruggaaf calculation failed: ' . $e->getMessage());
+            $this->logger->error('Teruggaaf calculation failed: '.$e->getMessage());
             return new JSONResponse(
-                ['error' => 'Teruggaaf failed: ' . $e->getMessage()],
+                ['error' => 'Teruggaaf failed: '.$e->getMessage()],
                 Http::STATUS_INTERNAL_SERVER_ERROR
             );
         }
-    }
+    }//end teruggaaf()
 
     /**
      * Export berekeningen to financial system format.
@@ -212,7 +215,7 @@ class LegesController extends Controller
     {
         try {
             $berekeningen = $this->request->getParam('berekeningen', []);
-            $format = $this->request->getParam('format', LegesExportService::FORMAT_CSV);
+            $format       = $this->request->getParam('format', LegesExportService::FORMAT_CSV);
 
             if (is_string($berekeningen)) {
                 $berekeningen = json_decode($berekeningen, true) ?? [];
@@ -238,11 +241,11 @@ class LegesController extends Controller
                 Http::STATUS_BAD_REQUEST
             );
         } catch (\Throwable $e) {
-            $this->logger->error('Leges export failed: ' . $e->getMessage());
+            $this->logger->error('Leges export failed: '.$e->getMessage());
             return new JSONResponse(
-                ['error' => 'Export failed: ' . $e->getMessage()],
+                ['error' => 'Export failed: '.$e->getMessage()],
                 Http::STATUS_INTERNAL_SERVER_ERROR
             );
-        }
-    }
-}
+        }//end try
+    }//end export()
+}//end class

--- a/lib/Controller/MetricsController.php
+++ b/lib/Controller/MetricsController.php
@@ -109,9 +109,13 @@ class MetricsController extends Controller
         // Cases total by status and case_type.
         $lines[]    = '# HELP procest_cases_total Total cases by status and case_type';
         $lines[]    = '# TYPE procest_cases_total gauge';
-        $caseCounts = $this->getCached('procest_metrics_case_counts', self::CACHE_TTL_DEFAULT, function () {
-            return $this->getCaseCounts();
-        });
+        $caseCounts = $this->getCached(
+                'procest_metrics_case_counts',
+                self::CACHE_TTL_DEFAULT,
+                function () {
+                    return $this->getCaseCounts();
+                }
+                );
         foreach ($caseCounts as $row) {
             $status   = $this->sanitizeLabel(value: $row['status']);
             $caseType = $this->sanitizeLabel(value: $row['case_type']);
@@ -122,29 +126,41 @@ class MetricsController extends Controller
         $lines[] = '';
 
         // Cases overdue total.
-        $overdueCount = $this->getCached('procest_metrics_overdue_cases', self::CACHE_TTL_OVERDUE, function () {
-            return $this->getOverdueCasesCount();
-        });
-        $lines[] = '# HELP procest_cases_overdue_total Cases past their deadline';
-        $lines[] = '# TYPE procest_cases_overdue_total gauge';
-        $lines[] = 'procest_cases_overdue_total '.$overdueCount;
-        $lines[] = '';
+        $overdueCount = $this->getCached(
+                'procest_metrics_overdue_cases',
+                self::CACHE_TTL_OVERDUE,
+                function () {
+                    return $this->getOverdueCasesCount();
+                }
+                );
+        $lines[]      = '# HELP procest_cases_overdue_total Cases past their deadline';
+        $lines[]      = '# TYPE procest_cases_overdue_total gauge';
+        $lines[]      = 'procest_cases_overdue_total '.$overdueCount;
+        $lines[]      = '';
 
         // Cases created today.
-        $createdToday = $this->getCached('procest_metrics_created_today', self::CACHE_TTL_DEFAULT, function () {
-            return $this->getCasesCreatedTodayCount();
-        });
-        $lines[] = '# HELP procest_cases_created_today Cases created today';
-        $lines[] = '# TYPE procest_cases_created_today gauge';
-        $lines[] = 'procest_cases_created_today '.$createdToday;
-        $lines[] = '';
+        $createdToday = $this->getCached(
+                'procest_metrics_created_today',
+                self::CACHE_TTL_DEFAULT,
+                function () {
+                    return $this->getCasesCreatedTodayCount();
+                }
+                );
+        $lines[]      = '# HELP procest_cases_created_today Cases created today';
+        $lines[]      = '# TYPE procest_cases_created_today gauge';
+        $lines[]      = 'procest_cases_created_today '.$createdToday;
+        $lines[]      = '';
 
         // Tasks total by status.
         $lines[]    = '# HELP procest_tasks_total Total tasks by status';
         $lines[]    = '# TYPE procest_tasks_total gauge';
-        $taskCounts = $this->getCached('procest_metrics_task_counts', self::CACHE_TTL_DEFAULT, function () {
-            return $this->getTaskCounts();
-        });
+        $taskCounts = $this->getCached(
+                'procest_metrics_task_counts',
+                self::CACHE_TTL_DEFAULT,
+                function () {
+                    return $this->getTaskCounts();
+                }
+                );
         foreach ($taskCounts as $row) {
             $status  = $this->sanitizeLabel(value: $row['status']);
             $count   = (int) $row['cnt'];
@@ -154,13 +170,17 @@ class MetricsController extends Controller
         $lines[] = '';
 
         // Tasks overdue total.
-        $overdueTasksCount = $this->getCached('procest_metrics_overdue_tasks', self::CACHE_TTL_OVERDUE, function () {
-            return $this->getOverdueTasksCount();
-        });
-        $lines[] = '# HELP procest_tasks_overdue_total Tasks past their deadline';
-        $lines[] = '# TYPE procest_tasks_overdue_total gauge';
-        $lines[] = 'procest_tasks_overdue_total '.$overdueTasksCount;
-        $lines[] = '';
+        $overdueTasksCount = $this->getCached(
+                'procest_metrics_overdue_tasks',
+                self::CACHE_TTL_OVERDUE,
+                function () {
+                    return $this->getOverdueTasksCount();
+                }
+                );
+        $lines[]           = '# HELP procest_tasks_overdue_total Tasks past their deadline';
+        $lines[]           = '# TYPE procest_tasks_overdue_total gauge';
+        $lines[]           = 'procest_tasks_overdue_total '.$overdueTasksCount;
+        $lines[]           = '';
 
         return implode("\n", $lines)."\n";
     }//end collectMetrics()

--- a/lib/Controller/MetricsController.php
+++ b/lib/Controller/MetricsController.php
@@ -8,7 +8,7 @@
  * @category Controller
  * @package  OCA\Procest\Controller
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Controller/MilestoneController.php
+++ b/lib/Controller/MilestoneController.php
@@ -32,8 +32,6 @@ use OCP\IUserSession;
  */
 class MilestoneController extends Controller
 {
-
-
     /**
      * Constructor.
      *
@@ -49,8 +47,7 @@ class MilestoneController extends Controller
         private readonly IUserSession $userSession,
     ) {
         parent::__construct($appName, $request);
-    }
-
+    }//end __construct()
 
     /**
      * Get milestone progress for a case.
@@ -70,8 +67,7 @@ class MilestoneController extends Controller
         } catch (\RuntimeException $e) {
             return new JSONResponse(['error' => $e->getMessage()], 500);
         }
-    }
-
+    }//end progress()
 
     /**
      * Mark a milestone as reached.
@@ -99,8 +95,7 @@ class MilestoneController extends Controller
         } catch (\RuntimeException $e) {
             return new JSONResponse(['error' => $e->getMessage()], 400);
         }
-    }
-
+    }//end mark()
 
     /**
      * Reverse a milestone.
@@ -136,5 +131,5 @@ class MilestoneController extends Controller
         } catch (\RuntimeException $e) {
             return new JSONResponse(['error' => $e->getMessage()], 400);
         }
-    }
-}
+    }//end reverse()
+}//end class

--- a/lib/Controller/MilestoneController.php
+++ b/lib/Controller/MilestoneController.php
@@ -8,7 +8,7 @@
  * @category Controller
  * @package  OCA\Procest\Controller
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Controller/NrcController.php
+++ b/lib/Controller/NrcController.php
@@ -10,7 +10,7 @@
  * @category Controller
  * @package  OCA\Procest\Controller
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Controller/ParaferingController.php
+++ b/lib/Controller/ParaferingController.php
@@ -9,7 +9,7 @@
  * @category Controller
  * @package  OCA\Procest\Controller
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Controller/ParaferingController.php
+++ b/lib/Controller/ParaferingController.php
@@ -40,11 +40,11 @@ class ParaferingController extends Controller
     /**
      * Constructor.
      *
-     * @param string             $appName            The app name.
-     * @param IRequest           $request            The request object.
-     * @param ParaferingService  $paraferingService  The parafering service.
-     * @param IUserSession       $userSession        The user session.
-     * @param LoggerInterface    $logger             The logger.
+     * @param string            $appName           The app name.
+     * @param IRequest          $request           The request object.
+     * @param ParaferingService $paraferingService The parafering service.
+     * @param IUserSession      $userSession       The user session.
+     * @param LoggerInterface   $logger            The logger.
      */
     public function __construct(
         string $appName,
@@ -54,7 +54,7 @@ class ParaferingController extends Controller
         private readonly LoggerInterface $logger,
     ) {
         parent::__construct($appName, $request);
-    }
+    }//end __construct()
 
     /**
      * Create a new voorstel.
@@ -66,7 +66,7 @@ class ParaferingController extends Controller
     public function createVoorstel(): JSONResponse
     {
         try {
-            $data = $this->getRequestBody();
+            $data   = $this->getRequestBody();
             $userId = $this->userSession->getUser()?->getUID() ?? 'system';
 
             if (empty($data['caseId'])) {
@@ -77,17 +77,17 @@ class ParaferingController extends Controller
             }
 
             $data['steller'] = $data['steller'] ?? $userId;
-            $voorstel = $this->paraferingService->createVoorstel($data);
+            $voorstel        = $this->paraferingService->createVoorstel($data);
 
             return new JSONResponse($voorstel, Http::STATUS_CREATED);
         } catch (\Throwable $e) {
-            $this->logger->error('Failed to create voorstel: ' . $e->getMessage());
+            $this->logger->error('Failed to create voorstel: '.$e->getMessage());
             return new JSONResponse(
-                ['error' => 'Failed to create voorstel: ' . $e->getMessage()],
+                ['error' => 'Failed to create voorstel: '.$e->getMessage()],
                 Http::STATUS_INTERNAL_SERVER_ERROR
             );
-        }
-    }
+        }//end try
+    }//end createVoorstel()
 
     /**
      * Start parafering on a voorstel.
@@ -101,9 +101,9 @@ class ParaferingController extends Controller
     public function startParafering(string $id): JSONResponse
     {
         try {
-            $data = $this->getRequestBody();
+            $data     = $this->getRequestBody();
             $voorstel = $data['voorstel'] ?? [];
-            $route = $data['route'] ?? [];
+            $route    = $data['route'] ?? [];
 
             if (empty($voorstel) || empty($route)) {
                 return new JSONResponse(
@@ -121,13 +121,13 @@ class ParaferingController extends Controller
                 Http::STATUS_BAD_REQUEST
             );
         } catch (\Throwable $e) {
-            $this->logger->error('Failed to start parafering: ' . $e->getMessage());
+            $this->logger->error('Failed to start parafering: '.$e->getMessage());
             return new JSONResponse(
-                ['error' => 'Failed to start parafering: ' . $e->getMessage()],
+                ['error' => 'Failed to start parafering: '.$e->getMessage()],
                 Http::STATUS_INTERNAL_SERVER_ERROR
             );
-        }
-    }
+        }//end try
+    }//end startParafering()
 
     /**
      * Execute a parafering action (paraferen).
@@ -141,7 +141,7 @@ class ParaferingController extends Controller
     public function paraferen(string $id): JSONResponse
     {
         return $this->handleAction($id, ParaferingService::ACTION_PARAFEREN);
-    }
+    }//end paraferen()
 
     /**
      * Execute a terugsturen action.
@@ -155,7 +155,7 @@ class ParaferingController extends Controller
     public function terugsturen(string $id): JSONResponse
     {
         return $this->handleAction($id, ParaferingService::ACTION_TERUGSTUREN);
-    }
+    }//end terugsturen()
 
     /**
      * Execute an adviseren action.
@@ -169,7 +169,7 @@ class ParaferingController extends Controller
     public function adviseren(string $id): JSONResponse
     {
         return $this->handleAction($id, ParaferingService::ACTION_ADVISEREN);
-    }
+    }//end adviseren()
 
     /**
      * Get the audit trail for a voorstel.
@@ -183,20 +183,20 @@ class ParaferingController extends Controller
     public function auditTrail(string $id): JSONResponse
     {
         try {
-            $data = $this->getRequestBody();
+            $data     = $this->getRequestBody();
             $voorstel = $data['voorstel'] ?? [];
 
             $trail = $this->paraferingService->getAuditTrail($voorstel);
 
             return new JSONResponse(['auditTrail' => $trail]);
         } catch (\Throwable $e) {
-            $this->logger->error('Failed to get audit trail: ' . $e->getMessage());
+            $this->logger->error('Failed to get audit trail: '.$e->getMessage());
             return new JSONResponse(
-                ['error' => 'Failed to get audit trail: ' . $e->getMessage()],
+                ['error' => 'Failed to get audit trail: '.$e->getMessage()],
                 Http::STATUS_INTERNAL_SERVER_ERROR
             );
         }
-    }
+    }//end auditTrail()
 
     /**
      * Handle a parafering action.
@@ -209,10 +209,10 @@ class ParaferingController extends Controller
     private function handleAction(string $id, string $action): JSONResponse
     {
         try {
-            $data = $this->getRequestBody();
+            $data     = $this->getRequestBody();
             $voorstel = $data['voorstel'] ?? [];
-            $comment = $data['comment'] ?? '';
-            $namens = $data['namens'] ?? null;
+            $comment  = $data['comment'] ?? '';
+            $namens   = $data['namens'] ?? null;
 
             $userId = $this->userSession->getUser()?->getUID() ?? 'system';
 
@@ -231,13 +231,13 @@ class ParaferingController extends Controller
                 Http::STATUS_BAD_REQUEST
             );
         } catch (\Throwable $e) {
-            $this->logger->error("Failed to execute {$action}: " . $e->getMessage());
+            $this->logger->error("Failed to execute {$action}: ".$e->getMessage());
             return new JSONResponse(
-                ['error' => "Failed to execute {$action}: " . $e->getMessage()],
+                ['error' => "Failed to execute {$action}: ".$e->getMessage()],
                 Http::STATUS_INTERNAL_SERVER_ERROR
             );
-        }
-    }
+        }//end try
+    }//end handleAction()
 
     /**
      * Get the parsed request body.
@@ -253,5 +253,5 @@ class ParaferingController extends Controller
 
         $decoded = json_decode($body, true);
         return is_array($decoded) ? $decoded : [];
-    }
-}
+    }//end getRequestBody()
+}//end class

--- a/lib/Controller/PublicAppointmentController.php
+++ b/lib/Controller/PublicAppointmentController.php
@@ -17,7 +17,7 @@ class PublicAppointmentController extends Controller
         private AppointmentService $appointmentService,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
-    }
+    }//end __construct()
 
     /**
      * @PublicPage
@@ -30,17 +30,19 @@ class PublicAppointmentController extends Controller
             return new JSONResponse(['error' => 'Afspraak niet gevonden'], 404);
         }
 
-        return new JSONResponse([
-            'success'     => true,
-            'appointment' => [
-                'dateTime'    => $appointment['dateTime'] ?? null,
-                'duration'    => $appointment['duration'] ?? 30,
-                'status'      => $appointment['status'] ?? 'scheduled',
-                'locationId'  => $appointment['locationId'] ?? null,
-                'productId'   => $appointment['productId'] ?? null,
-            ],
-        ]);
-    }
+        return new JSONResponse(
+                [
+                    'success'     => true,
+                    'appointment' => [
+                        'dateTime'   => $appointment['dateTime'] ?? null,
+                        'duration'   => $appointment['duration'] ?? 30,
+                        'status'     => $appointment['status'] ?? 'scheduled',
+                        'locationId' => $appointment['locationId'] ?? null,
+                        'productId'  => $appointment['productId'] ?? null,
+                    ],
+                ]
+                );
+    }//end view()
 
     /**
      * @PublicPage
@@ -60,5 +62,5 @@ class PublicAppointmentController extends Controller
         $id     = $appointment['uuid'] ?? $appointment['id'] ?? '';
         $result = $this->appointmentService->cancelAppointment($id);
         return new JSONResponse(['success' => true, 'appointment' => $result]);
-    }
-}
+    }//end cancel()
+}//end class

--- a/lib/Controller/PublicShareController.php
+++ b/lib/Controller/PublicShareController.php
@@ -46,7 +46,7 @@ class PublicShareController extends Controller
      * @param CaseSharingService $caseSharingService The sharing service
      * @param SettingsService    $settingsService    The settings service
      * @param IAppManager        $appManager         The app manager
-     * @param ContainerInterface $container           The DI container
+     * @param ContainerInterface $container          The DI container
      * @param LoggerInterface    $logger             The logger
      *
      * @return void
@@ -118,16 +118,18 @@ class PublicShareController extends Controller
             ]
         );
 
-        return new JSONResponse([
-            'success'         => true,
-            'case'            => $filteredData,
-            'permissionLevel' => $shareData['permissionLevel'],
-            'canComment'      => in_array(
+        return new JSONResponse(
+                [
+                    'success'         => true,
+                    'case'            => $filteredData,
+                    'permissionLevel' => $shareData['permissionLevel'],
+                    'canComment'      => in_array(
                 $shareData['permissionLevel'],
                 ['bekijken_reageren', 'bekijken_bijdragen']
             ),
-            'canUpload'       => $shareData['permissionLevel'] === 'bekijken_bijdragen',
-        ]);
+                    'canUpload'       => $shareData['permissionLevel'] === 'bekijken_bijdragen',
+                ]
+                );
     }//end accessShare()
 
     /**
@@ -185,10 +187,12 @@ class PublicShareController extends Controller
             ]
         );
 
-        return new JSONResponse([
-            'success' => true,
-            'message' => 'Reactie toegevoegd',
-        ]);
+        return new JSONResponse(
+                [
+                    'success' => true,
+                    'message' => 'Reactie toegevoegd',
+                ]
+                );
     }//end addComment()
 
     /**
@@ -226,11 +230,11 @@ class PublicShareController extends Controller
 
         // Return only citizen-safe status information.
         $statusData = [
-            'title'               => ($caseData['title'] ?? ''),
-            'identifier'          => ($caseData['identifier'] ?? ''),
-            'currentStatus'       => ($caseData['status'] ?? ''),
-            'plannedEndDate'      => ($caseData['plannedEndDate'] ?? null),
-            'startDate'           => ($caseData['startDate'] ?? null),
+            'title'          => ($caseData['title'] ?? ''),
+            'identifier'     => ($caseData['identifier'] ?? ''),
+            'currentStatus'  => ($caseData['status'] ?? ''),
+            'plannedEndDate' => ($caseData['plannedEndDate'] ?? null),
+            'startDate'      => ($caseData['startDate'] ?? null),
         ];
 
         return new JSONResponse(['success' => true, 'status' => $statusData]);
@@ -270,6 +274,6 @@ class PublicShareController extends Controller
                 ]
             );
             return null;
-        }
+        }//end try
     }//end loadCaseData()
 }//end class

--- a/lib/Controller/PublicShareController.php
+++ b/lib/Controller/PublicShareController.php
@@ -8,7 +8,7 @@
  * @category Controller
  * @package  OCA\Procest\Controller
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -8,7 +8,7 @@
  * @category Controller
  * @package  OCA\Procest\Controller
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Controller/StufController.php
+++ b/lib/Controller/StufController.php
@@ -51,7 +51,7 @@ class StufController extends Controller
      */
     private const DEFAULT_ZENDER = [
         'organisatie' => 'Procest',
-        'applicatie' => 'Procest',
+        'applicatie'  => 'Procest',
     ];
 
     /**
@@ -71,7 +71,7 @@ class StufController extends Controller
         private readonly LoggerInterface $logger,
     ) {
         parent::__construct($appName, $request);
-    }
+    }//end __construct()
 
     /**
      * Handle inbound StUF-ZKN SOAP messages for case operations.
@@ -83,7 +83,7 @@ class StufController extends Controller
     public function zaken(): DataDisplayResponse
     {
         return $this->handleSoapMessage('zaken');
-    }
+    }//end zaken()
 
     /**
      * Handle inbound StUF-BG SOAP messages for person operations.
@@ -95,7 +95,7 @@ class StufController extends Controller
     public function personen(): DataDisplayResponse
     {
         return $this->handleSoapMessage('personen');
-    }
+    }//end personen()
 
     /**
      * Handle an inbound SOAP message.
@@ -117,11 +117,11 @@ class StufController extends Controller
         $dom = new \DOMDocument();
         libxml_use_internal_errors(true);
         $parseResult = $dom->loadXML($rawBody);
-        $errors = libxml_get_errors();
+        $errors      = libxml_get_errors();
         libxml_clear_errors();
 
         if (!$parseResult || !empty($errors)) {
-            $this->logger->warning('Invalid XML received at StUF endpoint: ' . $service);
+            $this->logger->warning('Invalid XML received at StUF endpoint: '.$service);
             $response = $this->messageBuilder->buildSoapFault('Ongeldig XML bericht');
             return $this->soapResponse($response, Http::STATUS_BAD_REQUEST);
         }
@@ -172,7 +172,7 @@ class StufController extends Controller
             'edcLk01' => $this->handleEdcLk01($messageElement),
             default => $this->handleUnknownMessage($messageType),
         };
-    }
+    }//end handleSoapMessage()
 
     /**
      * Handle zakLk01 (case create/update) message.
@@ -196,20 +196,23 @@ class StufController extends Controller
             return $this->soapResponse($response);
         }
 
-        $objectEl = $objectElements->item(0);
+        $objectEl     = $objectElements->item(0);
         $mutatiesoort = $message->getAttribute('mutatiesoort');
 
         // Extract basic fields.
-        $stufFields = $this->extractFields($objectEl, [
-            'identificatie',
-            'omschrijving',
-            'toelichting',
-            'startdatum',
-            'einddatum',
-            'einddatumGepland',
-            'uiterlijkeEinddatumAfdoening',
-            'vertrouwelijkAanduiding',
-        ]);
+        $stufFields = $this->extractFields(
+                $objectEl,
+                [
+                    'identificatie',
+                    'omschrijving',
+                    'toelichting',
+                    'startdatum',
+                    'einddatum',
+                    'einddatumGepland',
+                    'uiterlijkeEinddatumAfdoening',
+                    'vertrouwelijkAanduiding',
+                ]
+                );
 
         // Map to internal properties.
         $internalData = $this->mappingService->mapZknToInternal($stufFields);
@@ -218,13 +221,13 @@ class StufController extends Controller
             'Processed zakLk01 mutatiesoort={mutatiesoort}, identifier={id}',
             [
                 'mutatiesoort' => $mutatiesoort,
-                'id' => $internalData['identifier'] ?? 'none',
+                'id'           => $internalData['identifier'] ?? 'none',
             ]
         );
 
         // Extract referentienummer for cross-reference.
         $stuurgegevens = $message->getElementsByTagName('stuurgegevens');
-        $crossRef = '';
+        $crossRef      = '';
         if ($stuurgegevens->length > 0) {
             $refElements = $stuurgegevens->item(0)->getElementsByTagName('referentienummer');
             if ($refElements->length > 0) {
@@ -241,7 +244,7 @@ class StufController extends Controller
         );
 
         return $this->soapResponse($response);
-    }
+    }//end handleZakLk01()
 
     /**
      * Handle zakLv01 (case query) message.
@@ -254,15 +257,18 @@ class StufController extends Controller
     {
         // Extract query criteria from gelijk element.
         $gelijkElements = $message->getElementsByTagName('gelijk');
-        $criteria = [];
+        $criteria       = [];
 
         if ($gelijkElements->length > 0) {
-            $gelijk = $gelijkElements->item(0);
-            $criteria = $this->extractFields($gelijk, [
-                'identificatie',
-                'omschrijving',
-                'startdatum',
-            ]);
+            $gelijk   = $gelijkElements->item(0);
+            $criteria = $this->extractFields(
+                    $gelijk,
+                    [
+                        'identificatie',
+                        'omschrijving',
+                        'startdatum',
+                    ]
+                    );
         }
 
         $this->logger->info(
@@ -272,8 +278,8 @@ class StufController extends Controller
 
         // In a full implementation, query OpenRegister and build zakLa01 response.
         // For now, return an empty zakLa01 response.
-        $body = '<zkn:zakLa01 xmlns:zkn="' . StufMessageBuilder::NS_ZKN . '" '
-            . 'xmlns:stuf="' . StufMessageBuilder::NS_STUF . '">';
+        $body  = '<zkn:zakLa01 xmlns:zkn="'.StufMessageBuilder::NS_ZKN.'" '
+            .'xmlns:stuf="'.StufMessageBuilder::NS_STUF.'">';
         $body .= $this->messageBuilder->buildStuurgegevens(self::DEFAULT_ZENDER, []);
         $body .= '<zkn:antwoord/>';
         $body .= '</zkn:zakLa01>';
@@ -281,7 +287,7 @@ class StufController extends Controller
         $response = $this->messageBuilder->buildSoapEnvelope($body);
 
         return $this->soapResponse($response);
-    }
+    }//end handleZakLv01()
 
     /**
      * Handle npsLv01 (person query) message.
@@ -294,7 +300,7 @@ class StufController extends Controller
     {
         // Extract BSN from gelijk element.
         $gelijkElements = $message->getElementsByTagName('gelijk');
-        $bsn = '';
+        $bsn            = '';
 
         if ($gelijkElements->length > 0) {
             $bsnElements = $gelijkElements->item(0)->getElementsByTagName('bsn');
@@ -305,13 +311,13 @@ class StufController extends Controller
 
         $this->logger->info(
             'Processed npsLv01 person query for BSN {bsn}',
-            ['bsn' => substr($bsn, 0, 3) . '***']
+            ['bsn' => substr($bsn, 0, 3).'***']
         );
 
         // In a full implementation, query OpenRegister for person data.
         // For now, return an empty npsLa01 response.
-        $body = '<bg:npsLa01 xmlns:bg="' . StufMessageBuilder::NS_BG . '" '
-            . 'xmlns:stuf="' . StufMessageBuilder::NS_STUF . '">';
+        $body  = '<bg:npsLa01 xmlns:bg="'.StufMessageBuilder::NS_BG.'" '
+            .'xmlns:stuf="'.StufMessageBuilder::NS_STUF.'">';
         $body .= $this->messageBuilder->buildStuurgegevens(self::DEFAULT_ZENDER, []);
         $body .= '<bg:antwoord/>';
         $body .= '</bg:npsLa01>';
@@ -319,7 +325,7 @@ class StufController extends Controller
         $response = $this->messageBuilder->buildSoapEnvelope($body);
 
         return $this->soapResponse($response);
-    }
+    }//end handleNpsLv01()
 
     /**
      * Handle edcLk01 (document create/update) message.
@@ -334,7 +340,7 @@ class StufController extends Controller
 
         // Extract referentienummer.
         $stuurgegevens = $message->getElementsByTagName('stuurgegevens');
-        $crossRef = '';
+        $crossRef      = '';
         if ($stuurgegevens->length > 0) {
             $refElements = $stuurgegevens->item(0)->getElementsByTagName('referentienummer');
             if ($refElements->length > 0) {
@@ -349,7 +355,7 @@ class StufController extends Controller
         );
 
         return $this->soapResponse($response);
-    }
+    }//end handleEdcLk01()
 
     /**
      * Handle unknown message type.
@@ -360,18 +366,18 @@ class StufController extends Controller
      */
     private function handleUnknownMessage(string $messageType): DataDisplayResponse
     {
-        $this->logger->warning('Unknown StUF message type: ' . $messageType);
+        $this->logger->warning('Unknown StUF message type: '.$messageType);
 
         $response = $this->messageBuilder->buildFo01(
             'StUF001',
-            'Onbekend berichttype: ' . $messageType,
+            'Onbekend berichttype: '.$messageType,
             'server',
             self::DEFAULT_ZENDER,
             []
         );
 
         return $this->soapResponse($response, Http::STATUS_BAD_REQUEST);
-    }
+    }//end handleUnknownMessage()
 
     /**
      * Extract field values from a DOM element.
@@ -397,7 +403,7 @@ class StufController extends Controller
         }
 
         return $result;
-    }
+    }//end extractFields()
 
     /**
      * Create a SOAP XML response.
@@ -407,10 +413,10 @@ class StufController extends Controller
      *
      * @return DataDisplayResponse
      */
-    private function soapResponse(string $xml, int $statusCode = Http::STATUS_OK): DataDisplayResponse
+    private function soapResponse(string $xml, int $statusCode=Http::STATUS_OK): DataDisplayResponse
     {
         $response = new DataDisplayResponse($xml, $statusCode);
         $response->addHeader('Content-Type', 'text/xml; charset=utf-8');
         return $response;
-    }
-}
+    }//end soapResponse()
+}//end class

--- a/lib/Controller/StufController.php
+++ b/lib/Controller/StufController.php
@@ -10,7 +10,7 @@
  * @category Controller
  * @package  OCA\Procest\Controller
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Controller/TemplateController.php
+++ b/lib/Controller/TemplateController.php
@@ -32,8 +32,6 @@ use Psr\Log\LoggerInterface;
  */
 class TemplateController extends Controller
 {
-
-
     /**
      * Constructor.
      *
@@ -49,8 +47,7 @@ class TemplateController extends Controller
         private readonly LoggerInterface $logger,
     ) {
         parent::__construct($appName, $request);
-    }
-
+    }//end __construct()
 
     /**
      * List all available templates.
@@ -63,8 +60,7 @@ class TemplateController extends Controller
     {
         $templates = $this->templateService->listTemplates();
         return new JSONResponse(['results' => $templates]);
-    }
-
+    }//end index()
 
     /**
      * Get a single template by ID.
@@ -83,8 +79,7 @@ class TemplateController extends Controller
         }
 
         return new JSONResponse($template);
-    }
-
+    }//end show()
 
     /**
      * Activate a template (create all objects from it).
@@ -106,5 +101,5 @@ class TemplateController extends Controller
                 400,
             );
         }
-    }
-}
+    }//end activate()
+}//end class

--- a/lib/Controller/TemplateController.php
+++ b/lib/Controller/TemplateController.php
@@ -8,7 +8,7 @@
  * @category Controller
  * @package  OCA\Procest\Controller
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Controller/TenantController.php
+++ b/lib/Controller/TenantController.php
@@ -8,7 +8,7 @@
  * @category Controller
  * @package  OCA\Procest\Controller
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Controller/ZgwMappingController.php
+++ b/lib/Controller/ZgwMappingController.php
@@ -8,7 +8,7 @@
  * @category Controller
  * @package  OCA\Procest\Controller
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Controller/ZrcController.php
+++ b/lib/Controller/ZrcController.php
@@ -13,7 +13,7 @@
  * @category Controller
  * @package  OCA\Procest\Controller
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Controller/ZtcController.php
+++ b/lib/Controller/ZtcController.php
@@ -11,7 +11,7 @@
  * @category Controller
  * @package  OCA\Procest\Controller
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Dashboard/CasesOverviewWidget.php
+++ b/lib/Dashboard/CasesOverviewWidget.php
@@ -8,7 +8,7 @@
  * @category Dashboard
  * @package  OCA\Procest\Dashboard
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Dashboard/DeadlineAlertsWidget.php
+++ b/lib/Dashboard/DeadlineAlertsWidget.php
@@ -9,7 +9,7 @@
  * @category Dashboard
  * @package  OCA\Procest\Dashboard
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Dashboard/MyTasksWidget.php
+++ b/lib/Dashboard/MyTasksWidget.php
@@ -8,7 +8,7 @@
  * @category Dashboard
  * @package  OCA\Procest\Dashboard
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Dashboard/OverdueCasesWidget.php
+++ b/lib/Dashboard/OverdueCasesWidget.php
@@ -8,7 +8,7 @@
  * @category Dashboard
  * @package  OCA\Procest\Dashboard
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Dashboard/StalledCasesWidget.php
+++ b/lib/Dashboard/StalledCasesWidget.php
@@ -9,7 +9,7 @@
  * @category Dashboard
  * @package  OCA\Procest\Dashboard
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Dashboard/StartCaseWidget.php
+++ b/lib/Dashboard/StartCaseWidget.php
@@ -8,7 +8,7 @@
  * @category Dashboard
  * @package  OCA\Procest\Dashboard
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Dashboard/TaskRemindersWidget.php
+++ b/lib/Dashboard/TaskRemindersWidget.php
@@ -9,7 +9,7 @@
  * @category Dashboard
  * @package  OCA\Procest\Dashboard
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Listener/DeepLinkRegistrationListener.php
+++ b/lib/Listener/DeepLinkRegistrationListener.php
@@ -8,7 +8,7 @@
  * @category Listener
  * @package  OCA\Procest\Listener
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Middleware/TenantMiddleware.php
+++ b/lib/Middleware/TenantMiddleware.php
@@ -51,10 +51,10 @@ class TenantMiddleware extends Middleware
     /**
      * Constructor for the TenantMiddleware.
      *
-     * @param TenantService  $tenantService The tenant service
-     * @param IUserSession   $userSession   The user session
-     * @param IRequest       $request       The request object
-     * @param LoggerInterface $logger       The logger
+     * @param TenantService   $tenantService The tenant service
+     * @param IUserSession    $userSession   The user session
+     * @param IRequest        $request       The request object
+     * @param LoggerInterface $logger        The logger
      *
      * @return void
      */
@@ -69,8 +69,8 @@ class TenantMiddleware extends Middleware
     /**
      * Check tenant context before controller execution.
      *
-     * @param \OCP\AppFramework\Controller $controller  The controller
-     * @param string                        $methodName The method name
+     * @param \OCP\AppFramework\Controller $controller The controller
+     * @param string                       $methodName The method name
      *
      * @return void
      *
@@ -117,9 +117,9 @@ class TenantMiddleware extends Middleware
     /**
      * Handle exceptions from controllers.
      *
-     * @param \OCP\AppFramework\Controller $controller  The controller
-     * @param string                        $methodName The method name
-     * @param \Exception                    $exception  The exception
+     * @param \OCP\AppFramework\Controller $controller The controller
+     * @param string                       $methodName The method name
+     * @param \Exception                   $exception  The exception
      *
      * @return JSONResponse The error response
      *

--- a/lib/Middleware/TenantMiddleware.php
+++ b/lib/Middleware/TenantMiddleware.php
@@ -8,7 +8,7 @@
  * @category Middleware
  * @package  OCA\Procest\Middleware
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Middleware/ZgwAuthException.php
+++ b/lib/Middleware/ZgwAuthException.php
@@ -8,7 +8,7 @@
  * @category Middleware
  * @package  OCA\Procest\Middleware
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Middleware/ZgwAuthMiddleware.php
+++ b/lib/Middleware/ZgwAuthMiddleware.php
@@ -8,7 +8,7 @@
  * @category Middleware
  * @package  OCA\Procest\Middleware
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Repair/InitializeSettings.php
+++ b/lib/Repair/InitializeSettings.php
@@ -8,7 +8,7 @@
  * @category Repair
  * @package  OCA\Procest\Repair
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Repair/LoadDefaultZgwMappings.php
+++ b/lib/Repair/LoadDefaultZgwMappings.php
@@ -10,7 +10,7 @@
  * @category Repair
  * @package  OCA\Procest\Repair
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Repair/SeedBezwaarBeroepData.php
+++ b/lib/Repair/SeedBezwaarBeroepData.php
@@ -9,7 +9,7 @@
  * @category Repair
  * @package  OCA\Procest\Repair
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Sections/SettingsSection.php
+++ b/lib/Sections/SettingsSection.php
@@ -8,7 +8,7 @@
  * @category Sections
  * @package  OCA\Procest\Sections
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Service/AiService.php
+++ b/lib/Service/AiService.php
@@ -55,9 +55,9 @@ class AiService
     /**
      * Constructor for AiService.
      *
-     * @param IAppConfig         $appConfig  The app configuration service
-     * @param ContainerInterface $container  The DI container
-     * @param LoggerInterface    $logger     The logger interface
+     * @param IAppConfig         $appConfig The app configuration service
+     * @param ContainerInterface $container The DI container
+     * @param LoggerInterface    $logger    The logger interface
      *
      * @return void
      */
@@ -133,19 +133,21 @@ class AiService
 
             $responseTimeMs = (int) ((microtime(true) - $startTime) * 1000);
 
-            $this->recordAuditEntry([
-                'type'           => 'classification',
-                'action'         => 'suggested',
-                'caseId'         => $caseId,
-                'documentId'     => $documentId,
-                'model'          => $this->getModelIdentifier(),
-                'prompt'         => $prompt,
-                'suggestion'     => $result,
-                'confidence'     => ($result['confidence'] ?? 0.0),
-                'userId'         => $userId,
-                'timestamp'      => date('c'),
-                'responseTimeMs' => $responseTimeMs,
-            ]);
+            $this->recordAuditEntry(
+                    [
+                        'type'           => 'classification',
+                        'action'         => 'suggested',
+                        'caseId'         => $caseId,
+                        'documentId'     => $documentId,
+                        'model'          => $this->getModelIdentifier(),
+                        'prompt'         => $prompt,
+                        'suggestion'     => $result,
+                        'confidence'     => ($result['confidence'] ?? 0.0),
+                        'userId'         => $userId,
+                        'timestamp'      => date('c'),
+                        'responseTimeMs' => $responseTimeMs,
+                    ]
+                    );
 
             return [
                 'success'    => true,
@@ -191,19 +193,21 @@ class AiService
 
             $responseTimeMs = (int) ((microtime(true) - $startTime) * 1000);
 
-            $this->recordAuditEntry([
-                'type'           => 'extraction',
-                'action'         => 'suggested',
-                'caseId'         => $caseId,
-                'documentId'     => ($documentId ?? ''),
-                'model'          => $this->getModelIdentifier(),
-                'prompt'         => $prompt,
-                'suggestion'     => $result,
-                'confidence'     => ($result['averageConfidence'] ?? 0.0),
-                'userId'         => $userId,
-                'timestamp'      => date('c'),
-                'responseTimeMs' => $responseTimeMs,
-            ]);
+            $this->recordAuditEntry(
+                    [
+                        'type'           => 'extraction',
+                        'action'         => 'suggested',
+                        'caseId'         => $caseId,
+                        'documentId'     => ($documentId ?? ''),
+                        'model'          => $this->getModelIdentifier(),
+                        'prompt'         => $prompt,
+                        'suggestion'     => $result,
+                        'confidence'     => ($result['averageConfidence'] ?? 0.0),
+                        'userId'         => $userId,
+                        'timestamp'      => date('c'),
+                        'responseTimeMs' => $responseTimeMs,
+                    ]
+                    );
 
             return [
                 'success' => true,
@@ -248,18 +252,20 @@ class AiService
 
             $responseTimeMs = (int) ((microtime(true) - $startTime) * 1000);
 
-            $this->recordAuditEntry([
-                'type'           => 'qa',
-                'action'         => 'suggested',
-                'caseId'         => $caseId,
-                'model'          => $this->getModelIdentifier(),
-                'prompt'         => $question,
-                'suggestion'     => $result,
-                'confidence'     => ($result['confidence'] ?? 0.0),
-                'userId'         => $userId,
-                'timestamp'      => date('c'),
-                'responseTimeMs' => $responseTimeMs,
-            ]);
+            $this->recordAuditEntry(
+                    [
+                        'type'           => 'qa',
+                        'action'         => 'suggested',
+                        'caseId'         => $caseId,
+                        'model'          => $this->getModelIdentifier(),
+                        'prompt'         => $question,
+                        'suggestion'     => $result,
+                        'confidence'     => ($result['confidence'] ?? 0.0),
+                        'userId'         => $userId,
+                        'timestamp'      => date('c'),
+                        'responseTimeMs' => $responseTimeMs,
+                    ]
+                    );
 
             return [
                 'success' => true,
@@ -307,18 +313,20 @@ class AiService
 
             $responseTimeMs = (int) ((microtime(true) - $startTime) * 1000);
 
-            $this->recordAuditEntry([
-                'type'           => 'summary',
-                'action'         => 'suggested',
-                'caseId'         => $caseId,
-                'documentId'     => ($documentId ?? ''),
-                'model'          => $this->getModelIdentifier(),
-                'prompt'         => $prompt,
-                'suggestion'     => ['summary' => ($result['summary'] ?? '')],
-                'userId'         => $userId,
-                'timestamp'      => date('c'),
-                'responseTimeMs' => $responseTimeMs,
-            ]);
+            $this->recordAuditEntry(
+                    [
+                        'type'           => 'summary',
+                        'action'         => 'suggested',
+                        'caseId'         => $caseId,
+                        'documentId'     => ($documentId ?? ''),
+                        'model'          => $this->getModelIdentifier(),
+                        'prompt'         => $prompt,
+                        'suggestion'     => ['summary' => ($result['summary'] ?? '')],
+                        'userId'         => $userId,
+                        'timestamp'      => date('c'),
+                        'responseTimeMs' => $responseTimeMs,
+                    ]
+                    );
 
             return [
                 'success' => true,
@@ -362,18 +370,20 @@ class AiService
 
             $responseTimeMs = (int) ((microtime(true) - $startTime) * 1000);
 
-            $this->recordAuditEntry([
-                'type'           => 'routing',
-                'action'         => 'suggested',
-                'caseId'         => $caseId,
-                'model'          => $this->getModelIdentifier(),
-                'prompt'         => $prompt,
-                'suggestion'     => $result,
-                'confidence'     => ($result['confidence'] ?? 0.0),
-                'userId'         => $userId,
-                'timestamp'      => date('c'),
-                'responseTimeMs' => $responseTimeMs,
-            ]);
+            $this->recordAuditEntry(
+                    [
+                        'type'           => 'routing',
+                        'action'         => 'suggested',
+                        'caseId'         => $caseId,
+                        'model'          => $this->getModelIdentifier(),
+                        'prompt'         => $prompt,
+                        'suggestion'     => $result,
+                        'confidence'     => ($result['confidence'] ?? 0.0),
+                        'userId'         => $userId,
+                        'timestamp'      => date('c'),
+                        'responseTimeMs' => $responseTimeMs,
+                    ]
+                    );
 
             return [
                 'success'     => true,
@@ -417,17 +427,19 @@ class AiService
 
             $responseTimeMs = (int) ((microtime(true) - $startTime) * 1000);
 
-            $this->recordAuditEntry([
-                'type'           => 'decision_support',
-                'action'         => 'suggested',
-                'caseId'         => $caseId,
-                'model'          => $this->getModelIdentifier(),
-                'prompt'         => $prompt,
-                'suggestion'     => $result,
-                'userId'         => $userId,
-                'timestamp'      => date('c'),
-                'responseTimeMs' => $responseTimeMs,
-            ]);
+            $this->recordAuditEntry(
+                    [
+                        'type'           => 'decision_support',
+                        'action'         => 'suggested',
+                        'caseId'         => $caseId,
+                        'model'          => $this->getModelIdentifier(),
+                        'prompt'         => $prompt,
+                        'suggestion'     => $result,
+                        'userId'         => $userId,
+                        'timestamp'      => date('c'),
+                        'responseTimeMs' => $responseTimeMs,
+                    ]
+                    );
 
             return [
                 'success'     => true,
@@ -469,18 +481,20 @@ class AiService
         ?string $reason,
         string $userId,
     ): array {
-        $this->recordAuditEntry([
-            'type'        => $type,
-            'action'      => $userAction,
-            'caseId'      => $caseId,
-            'model'       => $this->getModelIdentifier(),
-            'suggestion'  => $suggestion,
-            'userAction'  => $userAction,
-            'actualValue' => ($actualValue ?? []),
-            'reason'      => ($reason ?? ''),
-            'userId'      => $userId,
-            'timestamp'   => date('c'),
-        ]);
+        $this->recordAuditEntry(
+                [
+                    'type'        => $type,
+                    'action'      => $userAction,
+                    'caseId'      => $caseId,
+                    'model'       => $this->getModelIdentifier(),
+                    'suggestion'  => $suggestion,
+                    'userAction'  => $userAction,
+                    'actualValue' => ($actualValue ?? []),
+                    'reason'      => ($reason ?? ''),
+                    'userId'      => $userId,
+                    'timestamp'   => date('c'),
+                ]
+                );
 
         return ['success' => true];
     }//end recordUserAction()
@@ -524,19 +538,19 @@ class AiService
     public function getAiSettings(): array
     {
         return [
-            'ai_enabled'                   => $this->appConfig->getValueString(Application::APP_ID, 'ai_enabled', ''),
-            'ai_model_type'                => $this->appConfig->getValueString(Application::APP_ID, 'ai_model_type', 'local'),
-            'ai_model_url'                 => $this->appConfig->getValueString(Application::APP_ID, 'ai_model_url', ''),
-            'ai_model_name'                => $this->appConfig->getValueString(Application::APP_ID, 'ai_model_name', ''),
-            'ai_api_key_set'               => $this->appConfig->getValueString(Application::APP_ID, 'ai_api_key', '') !== '',
-            'ai_feature_classification'    => $this->appConfig->getValueString(Application::APP_ID, 'ai_feature_classification', ''),
-            'ai_feature_extraction'        => $this->appConfig->getValueString(Application::APP_ID, 'ai_feature_extraction', ''),
-            'ai_feature_qa'                => $this->appConfig->getValueString(Application::APP_ID, 'ai_feature_qa', ''),
-            'ai_feature_summary'           => $this->appConfig->getValueString(Application::APP_ID, 'ai_feature_summary', ''),
-            'ai_feature_routing'           => $this->appConfig->getValueString(Application::APP_ID, 'ai_feature_routing', ''),
-            'ai_feature_decision_support'  => $this->appConfig->getValueString(Application::APP_ID, 'ai_feature_decision_support', ''),
-            'ai_dpia_acknowledged'         => $this->appConfig->getValueString(Application::APP_ID, 'ai_dpia_acknowledged', ''),
-            'ai_pii_stripping'             => $this->appConfig->getValueString(Application::APP_ID, 'ai_pii_stripping', '1'),
+            'ai_enabled'                  => $this->appConfig->getValueString(Application::APP_ID, 'ai_enabled', ''),
+            'ai_model_type'               => $this->appConfig->getValueString(Application::APP_ID, 'ai_model_type', 'local'),
+            'ai_model_url'                => $this->appConfig->getValueString(Application::APP_ID, 'ai_model_url', ''),
+            'ai_model_name'               => $this->appConfig->getValueString(Application::APP_ID, 'ai_model_name', ''),
+            'ai_api_key_set'              => $this->appConfig->getValueString(Application::APP_ID, 'ai_api_key', '') !== '',
+            'ai_feature_classification'   => $this->appConfig->getValueString(Application::APP_ID, 'ai_feature_classification', ''),
+            'ai_feature_extraction'       => $this->appConfig->getValueString(Application::APP_ID, 'ai_feature_extraction', ''),
+            'ai_feature_qa'               => $this->appConfig->getValueString(Application::APP_ID, 'ai_feature_qa', ''),
+            'ai_feature_summary'          => $this->appConfig->getValueString(Application::APP_ID, 'ai_feature_summary', ''),
+            'ai_feature_routing'          => $this->appConfig->getValueString(Application::APP_ID, 'ai_feature_routing', ''),
+            'ai_feature_decision_support' => $this->appConfig->getValueString(Application::APP_ID, 'ai_feature_decision_support', ''),
+            'ai_dpia_acknowledged'        => $this->appConfig->getValueString(Application::APP_ID, 'ai_dpia_acknowledged', ''),
+            'ai_pii_stripping'            => $this->appConfig->getValueString(Application::APP_ID, 'ai_pii_stripping', '1'),
         ];
     }//end getAiSettings()
 
@@ -616,12 +630,14 @@ class AiService
         );
 
         // Build the request payload for Ollama-compatible API.
-        $payload = json_encode([
-            'model'   => $modelName,
-            'prompt'  => $prompt,
-            'stream'  => false,
-            'format'  => 'json',
-        ]);
+        $payload = json_encode(
+                [
+                    'model'  => $modelName,
+                    'prompt' => $prompt,
+                    'stream' => false,
+                    'format' => 'json',
+                ]
+                );
 
         $endpoint = rtrim($modelUrl, '/').'/api/generate';
 
@@ -640,10 +656,14 @@ class AiService
                 ''
             );
             if (empty($apiKey) === false) {
-                curl_setopt($ch, CURLOPT_HTTPHEADER, [
-                    'Content-Type: application/json',
-                    'Authorization: Bearer '.$apiKey,
-                ]);
+                curl_setopt(
+                        $ch,
+                        CURLOPT_HTTPHEADER,
+                        [
+                            'Content-Type: application/json',
+                            'Authorization: Bearer '.$apiKey,
+                        ]
+                        );
             }
         }
 
@@ -696,7 +716,7 @@ class AiService
                 'register',
                 ''
             );
-            $schemaId = $this->appConfig->getValueString(
+            $schemaId   = $this->appConfig->getValueString(
                 Application::APP_ID,
                 'ai_audit_entry_schema',
                 ''
@@ -717,7 +737,7 @@ class AiService
                 'Failed to record AI audit entry',
                 ['error' => $e->getMessage()]
             );
-        }
+        }//end try
     }//end recordAuditEntry()
 
     /**

--- a/lib/Service/AiService.php
+++ b/lib/Service/AiService.php
@@ -10,7 +10,7 @@
  * @category Service
  * @package  OCA\Procest\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Service/AppointmentBackend/JccBackend.php
+++ b/lib/Service/AppointmentBackend/JccBackend.php
@@ -21,7 +21,7 @@ class JccBackend implements AppointmentBackendInterface
         private string $apiUrl,
         private string $apiKey,
     ) {
-    }
+    }//end __construct()
 
     public function getTimeslots(string $productId, string $locationId, string $date): array
     {
@@ -44,7 +44,7 @@ class JccBackend implements AppointmentBackendInterface
             $this->logger->error('JCC API error: '.$e->getMessage());
             return [];
         }
-    }
+    }//end getTimeslots()
 
     public function bookAppointment(array $data): array
     {
@@ -63,7 +63,7 @@ class JccBackend implements AppointmentBackendInterface
             $this->logger->error('JCC booking error: '.$e->getMessage());
             return ['error' => $e->getMessage()];
         }
-    }
+    }//end bookAppointment()
 
     public function cancelAppointment(string $externalId): bool
     {
@@ -78,11 +78,11 @@ class JccBackend implements AppointmentBackendInterface
             $this->logger->error('JCC cancel error: '.$e->getMessage());
             return false;
         }
-    }
+    }//end cancelAppointment()
 
     public function rescheduleAppointment(string $externalId, string $newDateTime): array
     {
         $this->cancelAppointment($externalId);
         return $this->bookAppointment(['dateTime' => $newDateTime, 'externalId' => $externalId]);
-    }
-}
+    }//end rescheduleAppointment()
+}//end class

--- a/lib/Service/AppointmentBackend/LocalBackend.php
+++ b/lib/Service/AppointmentBackend/LocalBackend.php
@@ -21,7 +21,7 @@ class LocalBackend implements AppointmentBackendInterface
     public function __construct(
         private LoggerInterface $logger,
     ) {
-    }
+    }//end __construct()
 
     public function getTimeslots(string $productId, string $locationId, string $date): array
     {
@@ -38,21 +38,21 @@ class LocalBackend implements AppointmentBackendInterface
         }
 
         return $slots;
-    }
+    }//end getTimeslots()
 
     public function bookAppointment(array $data): array
     {
         return ['externalId' => 'local-'.bin2hex(random_bytes(8))];
-    }
+    }//end bookAppointment()
 
     public function cancelAppointment(string $externalId): bool
     {
         $this->logger->info('Local backend: appointment cancelled', ['externalId' => $externalId]);
         return true;
-    }
+    }//end cancelAppointment()
 
     public function rescheduleAppointment(string $externalId, string $newDateTime): array
     {
         return ['externalId' => $externalId];
-    }
-}
+    }//end rescheduleAppointment()
+}//end class

--- a/lib/Service/AppointmentBackend/QmaticBackend.php
+++ b/lib/Service/AppointmentBackend/QmaticBackend.php
@@ -18,7 +18,7 @@ class QmaticBackend implements AppointmentBackendInterface
         private string $apiUrl,
         private string $apiKey,
     ) {
-    }
+    }//end __construct()
 
     public function getTimeslots(string $productId, string $locationId, string $date): array
     {
@@ -38,12 +38,13 @@ class QmaticBackend implements AppointmentBackendInterface
                     'available' => true,
                 ];
             }
+
             return $slots;
         } catch (\Exception $e) {
             $this->logger->error('Qmatic API error: '.$e->getMessage());
             return [];
-        }
-    }
+        }//end try
+    }//end getTimeslots()
 
     public function bookAppointment(array $data): array
     {
@@ -62,7 +63,7 @@ class QmaticBackend implements AppointmentBackendInterface
             $this->logger->error('Qmatic booking error: '.$e->getMessage());
             return ['error' => $e->getMessage()];
         }
-    }
+    }//end bookAppointment()
 
     public function cancelAppointment(string $externalId): bool
     {
@@ -77,11 +78,11 @@ class QmaticBackend implements AppointmentBackendInterface
             $this->logger->error('Qmatic cancel error: '.$e->getMessage());
             return false;
         }
-    }
+    }//end cancelAppointment()
 
     public function rescheduleAppointment(string $externalId, string $newDateTime): array
     {
         $this->cancelAppointment($externalId);
         return $this->bookAppointment(['dateTime' => $newDateTime]);
-    }
-}
+    }//end rescheduleAppointment()
+}//end class

--- a/lib/Service/AppointmentService.php
+++ b/lib/Service/AppointmentService.php
@@ -28,7 +28,7 @@ class AppointmentService
         private ContainerInterface $container,
         private LoggerInterface $logger,
     ) {
-    }
+    }//end __construct()
 
     /**
      * Get available timeslots via the configured backend.
@@ -36,7 +36,7 @@ class AppointmentService
     public function getTimeslots(string $productId, string $locationId, string $date): array
     {
         return $this->getBackend()->getTimeslots($productId, $locationId, $date);
-    }
+    }//end getTimeslots()
 
     /**
      * Book an appointment linked to a case.
@@ -55,13 +55,16 @@ class AppointmentService
         $register = $this->settingsService->getConfigValue('register');
         $schema   = $this->settingsService->getConfigValue('appointment_schema');
 
-        $appointmentData = array_merge($data, [
-            'caseId'       => $caseId,
-            'status'       => 'scheduled',
-            'externalId'   => $backendResult['externalId'] ?? null,
-            'cancelToken'  => bin2hex(random_bytes(16)),
-            'reminderSent' => false,
-        ]);
+        $appointmentData = array_merge(
+                $data,
+                [
+                    'caseId'       => $caseId,
+                    'status'       => 'scheduled',
+                    'externalId'   => $backendResult['externalId'] ?? null,
+                    'cancelToken'  => bin2hex(random_bytes(16)),
+                    'reminderSent' => false,
+                ]
+                );
 
         $result = $objectService->saveObject(
             (int) $register,
@@ -69,13 +72,16 @@ class AppointmentService
             $appointmentData,
         );
 
-        $this->logger->info('Procest: Appointment booked', [
-            'caseId'       => $caseId,
-            'appointmentId' => $result->getUuid(),
-        ]);
+        $this->logger->info(
+                'Procest: Appointment booked',
+                [
+                    'caseId'        => $caseId,
+                    'appointmentId' => $result->getUuid(),
+                ]
+                );
 
         return $result->jsonSerialize();
-    }
+    }//end bookAppointment()
 
     /**
      * Cancel an appointment.
@@ -99,10 +105,10 @@ class AppointmentService
         }
 
         $data['status'] = 'cancelled';
-        $result = $objectService->saveObject((int) $register, (int) $schema, $data);
+        $result         = $objectService->saveObject((int) $register, (int) $schema, $data);
 
         return $result->jsonSerialize();
-    }
+    }//end cancelAppointment()
 
     /**
      * Mark an appointment as no-show.
@@ -117,13 +123,13 @@ class AppointmentService
         $register = $this->settingsService->getConfigValue('register');
         $schema   = $this->settingsService->getConfigValue('appointment_schema');
 
-        $appointment = $objectService->getObject((int) $register, (int) $schema, $appointmentId);
-        $data        = $appointment->jsonSerialize();
+        $appointment    = $objectService->getObject((int) $register, (int) $schema, $appointmentId);
+        $data           = $appointment->jsonSerialize();
         $data['status'] = 'no_show';
 
         $result = $objectService->saveObject((int) $register, (int) $schema, $data);
         return $result->jsonSerialize();
-    }
+    }//end markNoShow()
 
     /**
      * Get appointments for a case.
@@ -145,7 +151,7 @@ class AppointmentService
         );
 
         return $result['objects'] ?? [];
-    }
+    }//end getAppointmentsForCase()
 
     /**
      * Validate cancel token and return appointment.
@@ -173,7 +179,7 @@ class AppointmentService
 
         $apt = reset($appointments);
         return is_object($apt) ? $apt->jsonSerialize() : $apt;
-    }
+    }//end getAppointmentByToken()
 
     /**
      * Get the configured appointment backend.
@@ -192,7 +198,7 @@ class AppointmentService
             default:
                 return new LocalBackend($this->logger);
         }
-    }
+    }//end getBackend()
 
     private function getObjectService(): ?\OCA\OpenRegister\Service\ObjectService
     {
@@ -206,5 +212,5 @@ class AppointmentService
             $this->logger->error('Procest: Could not get ObjectService', ['exception' => $e->getMessage()]);
             return null;
         }
-    }
-}
+    }//end getObjectService()
+}//end class

--- a/lib/Service/BerichtenboxAdapter/BerichtenboxAdapterInterface.php
+++ b/lib/Service/BerichtenboxAdapter/BerichtenboxAdapterInterface.php
@@ -25,7 +25,7 @@ interface BerichtenboxAdapterInterface
         string $subject,
         string $body,
         string $typeCode,
-        ?string $attachment = null,
+        ?string $attachment=null,
     ): array;
 
     /**
@@ -36,4 +36,4 @@ interface BerichtenboxAdapterInterface
      * @return array Status with read (bool), readAt (datetime|null)
      */
     public function getReadStatus(string $messageId): array;
-}
+}//end interface

--- a/lib/Service/BerichtenboxAdapter/MockAdapter.php
+++ b/lib/Service/BerichtenboxAdapter/MockAdapter.php
@@ -16,31 +16,34 @@ class MockAdapter implements BerichtenboxAdapterInterface
     public function __construct(
         private LoggerInterface $logger,
     ) {
-    }
+    }//end __construct()
 
     public function sendMessage(
         string $bsn,
         string $subject,
         string $body,
         string $typeCode,
-        ?string $attachment = null,
+        ?string $attachment=null,
     ): array {
         $messageId = 'mock-'.bin2hex(random_bytes(8));
 
-        $this->logger->info('MockBerichtenbox: Message sent', [
-            'messageId' => $messageId,
-            'bsn'       => substr($bsn, 0, 4).'*****',
-            'subject'   => $subject,
-            'typeCode'  => $typeCode,
-            'hasAttachment' => $attachment !== null,
-        ]);
+        $this->logger->info(
+                'MockBerichtenbox: Message sent',
+                [
+                    'messageId'     => $messageId,
+                    'bsn'           => substr($bsn, 0, 4).'*****',
+                    'subject'       => $subject,
+                    'typeCode'      => $typeCode,
+                    'hasAttachment' => $attachment !== null,
+                ]
+                );
 
         return [
             'messageId' => $messageId,
             'status'    => 'sent',
             'sentAt'    => (new \DateTime())->format('c'),
         ];
-    }
+    }//end sendMessage()
 
     public function getReadStatus(string $messageId): array
     {
@@ -49,5 +52,5 @@ class MockAdapter implements BerichtenboxAdapterInterface
             'read'   => true,
             'readAt' => (new \DateTime('-1 hour'))->format('c'),
         ];
-    }
-}
+    }//end getReadStatus()
+}//end class

--- a/lib/Service/BerichtenboxService.php
+++ b/lib/Service/BerichtenboxService.php
@@ -15,15 +15,15 @@ use Psr\Log\LoggerInterface;
  */
 class BerichtenboxService
 {
-    private const MAX_ATTACHMENT_SIZE = 10485760; // 10 MB
-
+    private const MAX_ATTACHMENT_SIZE = 10485760;
+    // 10 MB
     public function __construct(
         private SettingsService $settingsService,
         private IAppManager $appManager,
         private ContainerInterface $container,
         private LoggerInterface $logger,
     ) {
-    }
+    }//end __construct()
 
     /**
      * Send a message to the Berichtenbox.
@@ -34,7 +34,7 @@ class BerichtenboxService
         string $subject,
         string $body,
         string $typeCode,
-        ?string $attachmentFileId = null,
+        ?string $attachmentFileId=null,
     ): array {
         // Validate inputs.
         $errors = $this->validateMessage($bsn, $subject, $body);
@@ -51,7 +51,8 @@ class BerichtenboxService
         $attachmentContent = null;
         if ($attachmentFileId !== null) {
             // Attachment validation would check file size here.
-            $attachmentContent = ''; // Placeholder -- actual file reading via IRootFolder.
+            $attachmentContent = '';
+            // Placeholder -- actual file reading via IRootFolder.
         }
 
         // Send via adapter.
@@ -80,13 +81,16 @@ class BerichtenboxService
             $messageData,
         );
 
-        $this->logger->info('Procest: Berichtenbox message sent', [
-            'caseId'    => $caseId,
-            'messageId' => $result['messageId'] ?? '',
-        ]);
+        $this->logger->info(
+                'Procest: Berichtenbox message sent',
+                [
+                    'caseId'    => $caseId,
+                    'messageId' => $result['messageId'] ?? '',
+                ]
+                );
 
         return $saved->jsonSerialize();
-    }
+    }//end sendMessage()
 
     /**
      * Get sent messages for a case.
@@ -108,7 +112,7 @@ class BerichtenboxService
         );
 
         return $result['objects'] ?? [];
-    }
+    }//end getMessagesForCase()
 
     /**
      * Poll read status for a message.
@@ -154,7 +158,7 @@ class BerichtenboxService
         }
 
         return $data;
-    }
+    }//end pollReadStatus()
 
     /**
      * Validate a BSN using the 11-proef.
@@ -169,10 +173,11 @@ class BerichtenboxService
         for ($i = 0; $i < 8; $i++) {
             $sum += (int) $bsn[$i] * (9 - $i);
         }
+
         $sum -= (int) $bsn[8];
 
         return ($sum % 11) === 0 && $sum !== 0;
-    }
+    }//end validateBsn()
 
     /**
      * Validate message inputs.
@@ -183,7 +188,7 @@ class BerichtenboxService
 
         if (empty($bsn) === true) {
             $errors[] = 'BSN is verplicht voor berichten via Mijn Overheid';
-        } elseif ($this->validateBsn($bsn) === false) {
+        } else if ($this->validateBsn($bsn) === false) {
             $errors[] = 'Ongeldig BSN-nummer';
         }
 
@@ -201,13 +206,13 @@ class BerichtenboxService
         }
 
         return $errors;
-    }
+    }//end validateMessage()
 
     private function getAdapter(): BerichtenboxAdapterInterface
     {
         // For MVP, always use mock adapter.
         return new MockAdapter($this->logger);
-    }
+    }//end getAdapter()
 
     private function getObjectService(): ?\OCA\OpenRegister\Service\ObjectService
     {
@@ -221,5 +226,5 @@ class BerichtenboxService
             $this->logger->error('Procest: Could not get ObjectService', ['exception' => $e->getMessage()]);
             return null;
         }
-    }
-}
+    }//end getObjectService()
+}//end class

--- a/lib/Service/CaseDefinitionExportService.php
+++ b/lib/Service/CaseDefinitionExportService.php
@@ -9,7 +9,7 @@
  * @category Service
  * @package  OCA\Procest\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Service/CaseDefinitionExportService.php
+++ b/lib/Service/CaseDefinitionExportService.php
@@ -65,7 +65,7 @@ class CaseDefinitionExportService
         private readonly IAppConfig $appConfig,
         private readonly LoggerInterface $logger,
     ) {
-    }
+    }//end __construct()
 
     /**
      * Export a case definition as a ZIP archive.
@@ -81,7 +81,7 @@ class CaseDefinitionExportService
      */
     public function exportCaseDefinition(
         string $caseTypeId,
-        array $components = [],
+        array $components=[],
     ): array {
         if (empty($components)) {
             $components = self::COMPONENTS;
@@ -91,7 +91,7 @@ class CaseDefinitionExportService
         $invalidComponents = array_diff($components, self::COMPONENTS);
         if (!empty($invalidComponents)) {
             throw new \InvalidArgumentException(
-                'Invalid export components: ' . implode(', ', $invalidComponents)
+                'Invalid export components: '.implode(', ', $invalidComponents)
             );
         }
 
@@ -112,10 +112,10 @@ class CaseDefinitionExportService
             throw new \RuntimeException('Failed to create temporary file for export');
         }
 
-        $zip = new \ZipArchive();
+        $zip    = new \ZipArchive();
         $result = $zip->open($tempPath, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
         if ($result !== true) {
-            throw new \RuntimeException('Failed to create ZIP archive: error code ' . $result);
+            throw new \RuntimeException('Failed to create ZIP archive: error code '.$result);
         }
 
         // Add manifest.
@@ -125,17 +125,17 @@ class CaseDefinitionExportService
         foreach ($components as $component) {
             $data = $this->exportComponent($caseTypeId, $component);
             if ($data !== null) {
-                $filename = $component === 'workflows' ? 'workflows/' : $component . '.json';
+                $filename = $component === 'workflows' ? 'workflows/' : $component.'.json';
                 if ($component === 'workflows' && is_array($data)) {
                     foreach ($data as $workflowName => $workflowData) {
                         $zip->addFromString(
-                            'workflows/' . $workflowName . '.json',
+                            'workflows/'.$workflowName.'.json',
                             json_encode($workflowData, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)
                         );
                     }
                 } else {
                     $zip->addFromString(
-                        $component . '.json',
+                        $component.'.json',
                         json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)
                     );
                 }
@@ -144,14 +144,14 @@ class CaseDefinitionExportService
 
         $zip->close();
 
-        $slug = $manifest['caseType']['slug'] ?? 'unknown';
+        $slug    = $manifest['caseType']['slug'] ?? 'unknown';
         $version = $manifest['version'] ?? '1.0';
 
         return [
-            'path' => $tempPath,
+            'path'     => $tempPath,
             'filename' => "case-definition-{$slug}-v{$version}.zip",
         ];
-    }
+    }//end exportCaseDefinition()
 
     /**
      * Build the manifest for a case definition export.
@@ -165,7 +165,7 @@ class CaseDefinitionExportService
     {
         $previousVersion = $this->appConfig->getValueString(
             Application::APP_ID,
-            'export_version_' . $caseTypeId,
+            'export_version_'.$caseTypeId,
             '0.0'
         );
 
@@ -174,35 +174,35 @@ class CaseDefinitionExportService
         // Store the new version.
         $this->appConfig->setValueString(
             Application::APP_ID,
-            'export_version_' . $caseTypeId,
+            'export_version_'.$caseTypeId,
             $newVersion
         );
 
         $excludedComponents = array_values(array_diff(self::COMPONENTS, $components));
 
         return [
-            'version' => $newVersion,
-            'previousVersion' => $previousVersion !== '0.0' ? $previousVersion : null,
-            'exportDate' => (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM),
-            'sourceEnvironment' => $this->appConfig->getValueString(
+            'version'            => $newVersion,
+            'previousVersion'    => $previousVersion !== '0.0' ? $previousVersion : null,
+            'exportDate'         => (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM),
+            'sourceEnvironment'  => $this->appConfig->getValueString(
                 Application::APP_ID,
                 'environment_name',
                 'unknown'
             ),
-            'generator' => 'procest/' . $this->appConfig->getValueString(
+            'generator'          => 'procest/'.$this->appConfig->getValueString(
                 'procest',
                 'installed_version',
                 'unknown'
             ),
-            'caseType' => [
-                'id' => $caseTypeId,
+            'caseType'           => [
+                'id'   => $caseTypeId,
                 'slug' => $caseTypeId,
             ],
-            'components' => $components,
+            'components'         => $components,
             'excludedComponents' => $excludedComponents,
-            'dependencies' => [],
+            'dependencies'       => [],
         ];
-    }
+    }//end buildManifest()
 
     /**
      * Export a single component.
@@ -219,8 +219,8 @@ class CaseDefinitionExportService
         // demonstrate the expected format.
         return match ($component) {
             'schema' => [
-                'caseTypeId' => $caseTypeId,
-                'fields' => [],
+                'caseTypeId'  => $caseTypeId,
+                'fields'      => [],
                 'validations' => [],
             ],
             'statuses' => [
@@ -233,16 +233,16 @@ class CaseDefinitionExportService
             ],
             'documents' => [
                 'documentTypes' => [],
-                'templates' => [],
+                'templates'     => [],
             ],
             'metadata' => [
-                'resultTypes' => [],
+                'resultTypes'   => [],
                 'decisionTypes' => [],
             ],
             'workflows' => [],
             default => null,
-        };
-    }
+        };//end match
+    }//end exportComponent()
 
     /**
      * Increment a version string (e.g., "1.0" -> "1.1").
@@ -254,9 +254,9 @@ class CaseDefinitionExportService
     private function incrementVersion(string $version): string
     {
         $parts = explode('.', $version);
-        $major = (int)($parts[0] ?? 1);
-        $minor = (int)($parts[1] ?? 0);
+        $major = (int) ($parts[0] ?? 1);
+        $minor = (int) ($parts[1] ?? 0);
 
         return sprintf(self::VERSION_FORMAT, $major, $minor + 1);
-    }
-}
+    }//end incrementVersion()
+}//end class

--- a/lib/Service/CaseDefinitionImportService.php
+++ b/lib/Service/CaseDefinitionImportService.php
@@ -9,7 +9,7 @@
  * @category Service
  * @package  OCA\Procest\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Service/CaseDefinitionImportService.php
+++ b/lib/Service/CaseDefinitionImportService.php
@@ -66,7 +66,7 @@ class CaseDefinitionImportService
         private readonly IAppConfig $appConfig,
         private readonly LoggerInterface $logger,
     ) {
-    }
+    }//end __construct()
 
     /**
      * Validate a case definition package without importing it.
@@ -80,26 +80,26 @@ class CaseDefinitionImportService
     public function validatePackage(string $zipPath): array
     {
         $result = [
-            'valid' => true,
-            'errors' => [],
-            'warnings' => [],
-            'manifest' => null,
+            'valid'     => true,
+            'errors'    => [],
+            'warnings'  => [],
+            'manifest'  => null,
             'conflicts' => [],
         ];
 
         // Open the ZIP.
-        $zip = new \ZipArchive();
+        $zip        = new \ZipArchive();
         $openResult = $zip->open($zipPath, \ZipArchive::RDONLY);
         if ($openResult !== true) {
-            $result['valid'] = false;
-            $result['errors'][] = 'Failed to open ZIP archive: error code ' . $openResult;
+            $result['valid']    = false;
+            $result['errors'][] = 'Failed to open ZIP archive: error code '.$openResult;
             return $result;
         }
 
         // Check required files.
         foreach (self::REQUIRED_FILES as $requiredFile) {
             if ($zip->locateName($requiredFile) === false) {
-                $result['valid'] = false;
+                $result['valid']    = false;
                 $result['errors'][] = "Missing required file: {$requiredFile}";
             }
         }
@@ -112,7 +112,7 @@ class CaseDefinitionImportService
         // Parse manifest.
         $manifestJson = $zip->getFromName('manifest.json');
         if ($manifestJson === false) {
-            $result['valid'] = false;
+            $result['valid']    = false;
             $result['errors'][] = 'Failed to read manifest.json';
             $zip->close();
             return $result;
@@ -120,8 +120,8 @@ class CaseDefinitionImportService
 
         $manifest = json_decode($manifestJson, true);
         if ($manifest === null) {
-            $result['valid'] = false;
-            $result['errors'][] = 'Invalid JSON in manifest.json: ' . json_last_error_msg();
+            $result['valid']    = false;
+            $result['errors'][] = 'Invalid JSON in manifest.json: '.json_last_error_msg();
             $zip->close();
             return $result;
         }
@@ -132,7 +132,7 @@ class CaseDefinitionImportService
         $requiredManifestFields = ['version', 'exportDate', 'caseType', 'components'];
         foreach ($requiredManifestFields as $field) {
             if (!isset($manifest[$field])) {
-                $result['valid'] = false;
+                $result['valid']    = false;
                 $result['errors'][] = "Missing required manifest field: {$field}";
             }
         }
@@ -150,30 +150,32 @@ class CaseDefinitionImportService
                         break;
                     }
                 }
+
                 if (!$hasWorkflows) {
                     $result['warnings'][] = 'Component "workflows" declared but no workflow files found';
                 }
             } else {
-                $componentFile = $component . '.json';
+                $componentFile = $component.'.json';
                 if ($zip->locateName($componentFile) === false) {
-                    $result['valid'] = false;
+                    $result['valid']    = false;
                     $result['errors'][] = "Component '{$component}' declared in manifest but file '{$componentFile}' not found";
                 }
-            }
-        }
+            }//end if
+        }//end foreach
 
         // Validate component JSON.
         foreach ($components as $component) {
             if ($component === 'workflows') {
                 continue;
             }
-            $componentFile = $component . '.json';
-            $content = $zip->getFromName($componentFile);
+
+            $componentFile = $component.'.json';
+            $content       = $zip->getFromName($componentFile);
             if ($content !== false) {
                 $decoded = json_decode($content, true);
                 if ($decoded === null && json_last_error() !== JSON_ERROR_NONE) {
-                    $result['valid'] = false;
-                    $result['errors'][] = "Invalid JSON in {$componentFile}: " . json_last_error_msg();
+                    $result['valid']    = false;
+                    $result['errors'][] = "Invalid JSON in {$componentFile}: ".json_last_error_msg();
                 }
             }
         }
@@ -192,20 +194,20 @@ class CaseDefinitionImportService
         $this->logger->info(
             'Validated case definition package: {valid}, errors: {errorCount}, warnings: {warningCount}',
             [
-                'valid' => $result['valid'] ? 'true' : 'false',
-                'errorCount' => count($result['errors']),
+                'valid'        => $result['valid'] ? 'true' : 'false',
+                'errorCount'   => count($result['errors']),
                 'warningCount' => count($result['warnings']),
             ]
         );
 
         return $result;
-    }
+    }//end validatePackage()
 
     /**
      * Import a case definition package.
      *
-     * @param string $zipPath   Path to the uploaded ZIP file.
-     * @param string $strategy  Conflict resolution strategy: 'skip', 'overwrite', or 'merge'.
+     * @param string $zipPath  Path to the uploaded ZIP file.
+     * @param string $strategy Conflict resolution strategy: 'skip', 'overwrite', or 'merge'.
      *
      * @return array{success: bool, message: string, components: array<string, array{status: string, message: string}>}
      *
@@ -215,21 +217,21 @@ class CaseDefinitionImportService
      */
     public function importCaseDefinition(
         string $zipPath,
-        string $strategy = 'skip',
+        string $strategy='skip',
     ): array {
         // First validate.
         $validation = $this->validatePackage($zipPath);
         if (!$validation['valid']) {
             return [
-                'success' => false,
-                'message' => 'Package validation failed: ' . implode('; ', $validation['errors']),
+                'success'    => false,
+                'message'    => 'Package validation failed: '.implode('; ', $validation['errors']),
                 'components' => [],
             ];
         }
 
-        $manifest = $validation['manifest'];
+        $manifest   = $validation['manifest'];
         $components = $manifest['components'] ?? [];
-        $results = [];
+        $results    = [];
 
         $zip = new \ZipArchive();
         $zip->open($zipPath, \ZipArchive::RDONLY);
@@ -239,14 +241,14 @@ class CaseDefinitionImportService
                 $results[$component] = $this->importComponent($zip, $component, $strategy);
             } catch (\Throwable $e) {
                 $results[$component] = [
-                    'status' => 'error',
+                    'status'  => 'error',
                     'message' => $e->getMessage(),
                 ];
                 $this->logger->error(
                     'Failed to import component {component}: {error}',
                     [
                         'component' => $component,
-                        'error' => $e->getMessage(),
+                        'error'     => $e->getMessage(),
                     ]
                 );
             }
@@ -260,16 +262,16 @@ class CaseDefinitionImportService
             'Case definition import completed: {success}, components: {count}',
             [
                 'success' => $allSuccess ? 'true' : 'false',
-                'count' => count($results),
+                'count'   => count($results),
             ]
         );
 
         return [
-            'success' => $allSuccess,
-            'message' => $allSuccess ? 'Import completed successfully' : 'Import completed with errors',
+            'success'    => $allSuccess,
+            'message'    => $allSuccess ? 'Import completed successfully' : 'Import completed with errors',
             'components' => $results,
         ];
-    }
+    }//end importCaseDefinition()
 
     /**
      * Import a single component from the ZIP archive.
@@ -289,10 +291,10 @@ class CaseDefinitionImportService
             return $this->importWorkflows($zip, $strategy);
         }
 
-        $content = $zip->getFromName($component . '.json');
+        $content = $zip->getFromName($component.'.json');
         if ($content === false) {
             return [
-                'status' => 'skipped',
+                'status'  => 'skipped',
                 'message' => "Component file {$component}.json not found in archive",
             ];
         }
@@ -300,7 +302,7 @@ class CaseDefinitionImportService
         $data = json_decode($content, true);
         if ($data === null) {
             return [
-                'status' => 'error',
+                'status'  => 'error',
                 'message' => "Invalid JSON in {$component}.json",
             ];
         }
@@ -311,15 +313,15 @@ class CaseDefinitionImportService
             'Imported component {component} with strategy {strategy}',
             [
                 'component' => $component,
-                'strategy' => $strategy,
+                'strategy'  => $strategy,
             ]
         );
 
         return [
-            'status' => 'success',
+            'status'  => 'success',
             'message' => "Component '{$component}' imported successfully",
         ];
-    }
+    }//end importComponent()
 
     /**
      * Import workflow files from the ZIP archive.
@@ -345,8 +347,8 @@ class CaseDefinitionImportService
         }
 
         return [
-            'status' => 'success',
+            'status'  => 'success',
             'message' => "Imported {$workflowCount} workflow(s)",
         ];
-    }
-}
+    }//end importWorkflows()
+}//end class

--- a/lib/Service/CaseEmailService.php
+++ b/lib/Service/CaseEmailService.php
@@ -10,7 +10,7 @@
  * @category Service
  * @package  OCA\Procest\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Service/CaseEmailService.php
+++ b/lib/Service/CaseEmailService.php
@@ -39,7 +39,6 @@ class CaseEmailService
      */
     private const CASE_NUMBER_PATTERN = '/\[ZAAK-(\d{4}-\d{4,})\]/';
 
-
     /**
      * Constructor.
      *
@@ -54,17 +53,16 @@ class CaseEmailService
         private readonly IConfig $config,
         private readonly LoggerInterface $logger,
     ) {
-    }
-
+    }//end __construct()
 
     /**
      * Send an email from case context.
      *
-     * @param string               $caseId     The case UUID
-     * @param string               $to         Recipient email address
-     * @param string               $subject    Email subject
-     * @param string               $body       Email body (HTML or plain text)
-     * @param array<string>        $attachments File paths to attach
+     * @param string        $caseId      The case UUID
+     * @param string        $to          Recipient email address
+     * @param string        $subject     Email subject
+     * @param string        $body        Email body (HTML or plain text)
+     * @param array<string> $attachments File paths to attach
      *
      * @return array<string, mixed> Send result with message ID
      *
@@ -75,14 +73,14 @@ class CaseEmailService
         string $to,
         string $subject,
         string $body,
-        array $attachments = [],
+        array $attachments=[],
     ): array {
         $fromAddress = $this->config->getAppValue(
             Application::APP_ID,
             'email_from_address',
             'noreply@example.nl',
         );
-        $fromName = $this->config->getAppValue(
+        $fromName    = $this->config->getAppValue(
             Application::APP_ID,
             'email_from_name',
             'Procest',
@@ -106,17 +104,17 @@ class CaseEmailService
             $this->mailer->send($message);
         } catch (\Exception $e) {
             $this->logger->error(
-                'Failed to send email for case ' . $caseId . ': ' . $e->getMessage(),
+                'Failed to send email for case '.$caseId.': '.$e->getMessage(),
                 ['app' => Application::APP_ID],
             );
-            throw new \RuntimeException('Email sending failed: ' . $e->getMessage());
+            throw new \RuntimeException('Email sending failed: '.$e->getMessage());
         }
 
         // Record the sent email as a case document.
         $messageId = $this->recordSentEmail($caseId, $to, $subject, $body);
 
         $this->logger->info(
-            'Email sent for case ' . $caseId . ' to ' . $to,
+            'Email sent for case '.$caseId.' to '.$to,
             ['app' => Application::APP_ID],
         );
 
@@ -126,8 +124,7 @@ class CaseEmailService
             'subject'   => $subject,
             'sentAt'    => date('Y-m-d\TH:i:s'),
         ];
-    }
-
+    }//end sendEmail()
 
     /**
      * Send an email using a template.
@@ -158,8 +155,7 @@ class CaseEmailService
         $body    = $this->resolveVariables($template['body'] ?? '', $caseData);
 
         return $this->sendEmail($caseId, $to, $subject, $body);
-    }
-
+    }//end sendFromTemplate()
 
     /**
      * Resolve template variables in a string.
@@ -180,12 +176,13 @@ class CaseEmailService
                 if (isset($data[$key]) === true && is_scalar($data[$key]) === true) {
                     return (string) $data[$key];
                 }
-                return $matches[0]; // Leave unresolved variables as-is.
+
+                return $matches[0];
+                // Leave unresolved variables as-is.
             },
             $template,
         ) ?? $template;
-    }
-
+    }//end resolveVariables()
 
     /**
      * Find unresolved variables in a template string.
@@ -207,8 +204,7 @@ class CaseEmailService
         }
 
         return array_unique($unresolved);
-    }
-
+    }//end findUnresolvedVariables()
 
     /**
      * Extract case number from email subject.
@@ -224,16 +220,15 @@ class CaseEmailService
         }
 
         return null;
-    }
-
+    }//end extractCaseNumber()
 
     /**
      * Process an inbound email and link it to a case.
      *
-     * @param string $from    Sender email address
-     * @param string $to      Recipient email address
-     * @param string $subject Email subject
-     * @param string $body    Email body
+     * @param string $from      Sender email address
+     * @param string $to        Recipient email address
+     * @param string $subject   Email subject
+     * @param string $body      Email body
      * @param string $inReplyTo In-Reply-To header (for threading)
      *
      * @return array<string, mixed> Processing result
@@ -243,7 +238,7 @@ class CaseEmailService
         string $to,
         string $subject,
         string $body,
-        string $inReplyTo = '',
+        string $inReplyTo='',
     ): array {
         $caseNumber = $this->extractCaseNumber($subject);
 
@@ -260,7 +255,7 @@ class CaseEmailService
                 );
 
                 $this->logger->info(
-                    'Inbound email auto-linked to case ' . $caseId,
+                    'Inbound email auto-linked to case '.$caseId,
                     ['app' => Application::APP_ID],
                 );
 
@@ -270,19 +265,18 @@ class CaseEmailService
                     'messageId' => $messageId,
                     'method'    => 'auto',
                 ];
-            }
-        }
+            }//end if
+        }//end if
 
         // Could not auto-link; add to unlinked queue.
         return [
-            'linked'       => false,
-            'caseNumber'   => $caseNumber,
-            'from'         => $from,
-            'subject'      => $subject,
-            'method'       => 'unlinked',
+            'linked'     => false,
+            'caseNumber' => $caseNumber,
+            'from'       => $from,
+            'subject'    => $subject,
+            'method'     => 'unlinked',
         ];
-    }
-
+    }//end processInbound()
 
     /**
      * Get email templates for a case type.
@@ -314,8 +308,7 @@ class CaseEmailService
         );
 
         return is_array($results) ? $results : [];
-    }
-
+    }//end getTemplatesForCaseType()
 
     /**
      * Load an email template.
@@ -340,8 +333,7 @@ class CaseEmailService
 
         $result = $objectService->getObject($register, $schema, $templateId);
         return is_array($result) ? $result : null;
-    }
-
+    }//end loadTemplate()
 
     /**
      * Load case data for template variable resolution.
@@ -367,15 +359,14 @@ class CaseEmailService
 
         // Flatten for variable resolution.
         return [
-            'zaakNummer'   => $caseObj['identifier'] ?? '',
-            'titel'        => $caseObj['title'] ?? '',
-            'startdatum'   => $caseObj['startDate'] ?? '',
-            'deadline'     => $caseObj['deadline'] ?? '',
-            'status'       => $caseObj['status'] ?? '',
-            'behandelaar'  => $caseObj['assignee'] ?? '',
+            'zaakNummer'  => $caseObj['identifier'] ?? '',
+            'titel'       => $caseObj['title'] ?? '',
+            'startdatum'  => $caseObj['startDate'] ?? '',
+            'deadline'    => $caseObj['deadline'] ?? '',
+            'status'      => $caseObj['status'] ?? '',
+            'behandelaar' => $caseObj['assignee'] ?? '',
         ];
-    }
-
+    }//end loadCaseData()
 
     /**
      * Record a sent email as a case document.
@@ -394,7 +385,7 @@ class CaseEmailService
         string $body,
     ): string {
         // Store as activity on the case.
-        $messageId = 'msg-' . uniqid();
+        $messageId = 'msg-'.uniqid();
 
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
@@ -405,21 +396,24 @@ class CaseEmailService
         $schema   = $this->settingsService->getConfigValue('email_message_schema');
 
         if (empty($register) === false && empty($schema) === false) {
-            $objectService->saveObject($register, $schema, [
-                'case'      => $caseId,
-                'direction' => 'outbound',
-                'from'      => $this->config->getAppValue(Application::APP_ID, 'email_from_address', ''),
-                'to'        => $to,
-                'subject'   => $subject,
-                'body'      => $body,
-                'messageId' => $messageId,
-                'sentAt'    => date('Y-m-d\TH:i:s'),
-            ]);
+            $objectService->saveObject(
+                    $register,
+                    $schema,
+                    [
+                        'case'      => $caseId,
+                        'direction' => 'outbound',
+                        'from'      => $this->config->getAppValue(Application::APP_ID, 'email_from_address', ''),
+                        'to'        => $to,
+                        'subject'   => $subject,
+                        'body'      => $body,
+                        'messageId' => $messageId,
+                        'sentAt'    => date('Y-m-d\TH:i:s'),
+                    ]
+                    );
         }
 
         return $messageId;
-    }
-
+    }//end recordSentEmail()
 
     /**
      * Record a received email.
@@ -439,7 +433,7 @@ class CaseEmailService
         string $body,
         string $inReplyTo,
     ): string {
-        $messageId = 'msg-' . uniqid();
+        $messageId = 'msg-'.uniqid();
 
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
@@ -450,22 +444,25 @@ class CaseEmailService
         $schema   = $this->settingsService->getConfigValue('email_message_schema');
 
         if (empty($register) === false && empty($schema) === false) {
-            $objectService->saveObject($register, $schema, [
-                'case'       => $caseId,
-                'direction'  => 'inbound',
-                'from'       => $from,
-                'to'         => '',
-                'subject'    => $subject,
-                'body'       => $body,
-                'messageId'  => $messageId,
-                'inReplyTo'  => $inReplyTo,
-                'receivedAt' => date('Y-m-d\TH:i:s'),
-            ]);
+            $objectService->saveObject(
+                    $register,
+                    $schema,
+                    [
+                        'case'       => $caseId,
+                        'direction'  => 'inbound',
+                        'from'       => $from,
+                        'to'         => '',
+                        'subject'    => $subject,
+                        'body'       => $body,
+                        'messageId'  => $messageId,
+                        'inReplyTo'  => $inReplyTo,
+                        'receivedAt' => date('Y-m-d\TH:i:s'),
+                    ]
+                    );
         }
 
         return $messageId;
-    }
-
+    }//end recordReceivedEmail()
 
     /**
      * Find a case by its identifier.
@@ -497,5 +494,5 @@ class CaseEmailService
         }
 
         return null;
-    }
-}
+    }//end findCaseByIdentifier()
+}//end class

--- a/lib/Service/CaseSharingService.php
+++ b/lib/Service/CaseSharingService.php
@@ -60,8 +60,8 @@ class CaseSharingService
      *
      * @param SettingsService    $settingsService The settings service
      * @param IAppManager        $appManager      The app manager
-     * @param ContainerInterface $container        The DI container
-     * @param LoggerInterface    $logger           The logger
+     * @param ContainerInterface $container       The DI container
+     * @param LoggerInterface    $logger          The logger
      *
      * @return void
      */
@@ -246,7 +246,7 @@ class CaseSharingService
     /**
      * Revoke a share by marking it with revocation timestamp.
      *
-     * @param string $shareId  The UUID of the share to revoke
+     * @param string $shareId   The UUID of the share to revoke
      * @param string $revokedBy The user ID of the revoker
      *
      * @return array The updated share data
@@ -267,7 +267,7 @@ class CaseSharingService
             $shareId,
         );
 
-        $shareData              = $share->jsonSerialize();
+        $shareData = $share->jsonSerialize();
         $shareData['revokedAt'] = (new \DateTime())->format('c');
         $shareData['revokedBy'] = $revokedBy;
 
@@ -441,9 +441,9 @@ class CaseSharingService
         $shareData['failedAttempts'] = (int) ($shareData['failedAttempts'] ?? 0) + 1;
 
         if ($shareData['failedAttempts'] >= self::MAX_FAILED_ATTEMPTS) {
-            $lockUntil                 = new \DateTime();
+            $lockUntil = new \DateTime();
             $lockUntil->modify('+'.self::LOCKOUT_MINUTES.' minutes');
-            $shareData['lockedUntil']  = $lockUntil->format('c');
+            $shareData['lockedUntil']    = $lockUntil->format('c');
             $shareData['failedAttempts'] = 0;
 
             $this->logger->warning(

--- a/lib/Service/CaseSharingService.php
+++ b/lib/Service/CaseSharingService.php
@@ -8,7 +8,7 @@
  * @category Service
  * @package  OCA\Procest\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Service/CaseTransferService.php
+++ b/lib/Service/CaseTransferService.php
@@ -8,7 +8,7 @@
  * @category Service
  * @package  OCA\Procest\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Service/CaseTransferService.php
+++ b/lib/Service/CaseTransferService.php
@@ -38,8 +38,8 @@ class CaseTransferService
      *
      * @param SettingsService    $settingsService The settings service
      * @param IAppManager        $appManager      The app manager
-     * @param ContainerInterface $container        The DI container
-     * @param LoggerInterface    $logger           The logger
+     * @param ContainerInterface $container       The DI container
+     * @param LoggerInterface    $logger          The logger
      *
      * @return void
      */
@@ -155,7 +155,7 @@ class CaseTransferService
     /**
      * Reject a pending case transfer request.
      *
-     * @param string $transferId     The UUID of the transfer request
+     * @param string $transferId      The UUID of the transfer request
      * @param string $rejectionReason The reason for rejection
      *
      * @return array The updated transfer data

--- a/lib/Service/ChecklistService.php
+++ b/lib/Service/ChecklistService.php
@@ -9,7 +9,7 @@
  * @category Service
  * @package  OCA\Procest\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Service/ChecklistService.php
+++ b/lib/Service/ChecklistService.php
@@ -68,7 +68,7 @@ class ChecklistService
     public function __construct(
         private readonly LoggerInterface $logger,
     ) {
-    }
+    }//end __construct()
 
     /**
      * Complete a checklist item with a conformity status.
@@ -89,16 +89,16 @@ class ChecklistService
         array $checklist,
         string $itemId,
         string $status,
-        string $toelichting = '',
-        array $photoRefs = [],
+        string $toelichting='',
+        array $photoRefs=[],
     ): array {
         if (!in_array($status, self::VALID_STATUSES, true)) {
             throw new \InvalidArgumentException(
-                'Invalid conformity status: ' . $status . '. Valid: ' . implode(', ', self::VALID_STATUSES)
+                'Invalid conformity status: '.$status.'. Valid: '.implode(', ', self::VALID_STATUSES)
             );
         }
 
-        $items = $checklist['items'] ?? [];
+        $items     = $checklist['items'] ?? [];
         $itemFound = false;
 
         foreach ($items as $index => $item) {
@@ -107,13 +107,13 @@ class ChecklistService
                 $requiresPhoto = $item['fotoVerplichtBijNietConform'] ?? false;
                 if ($status === self::STATUS_NIET_CONFORM && $requiresPhoto && empty($photoRefs)) {
                     throw new \InvalidArgumentException(
-                        'Foto verplicht bij niet-conform voor item: ' . ($item['description'] ?? $itemId)
+                        'Foto verplicht bij niet-conform voor item: '.($item['description'] ?? $itemId)
                     );
                 }
 
-                $items[$index]['status'] = $status;
+                $items[$index]['status']      = $status;
                 $items[$index]['toelichting'] = $toelichting;
-                $items[$index]['photoRefs'] = $photoRefs;
+                $items[$index]['photoRefs']   = $photoRefs;
                 $items[$index]['completedAt'] = (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM);
                 $itemFound = true;
                 break;
@@ -121,7 +121,7 @@ class ChecklistService
         }
 
         if (!$itemFound) {
-            throw new \InvalidArgumentException('Checklist item not found: ' . $itemId);
+            throw new \InvalidArgumentException('Checklist item not found: '.$itemId);
         }
 
         $checklist['items'] = $items;
@@ -132,7 +132,7 @@ class ChecklistService
         );
 
         return $checklist;
-    }
+    }//end completeItem()
 
     /**
      * Get the completion progress of a checklist.
@@ -145,8 +145,8 @@ class ChecklistService
      */
     public function getProgress(array $checklist): array
     {
-        $items = $checklist['items'] ?? [];
-        $total = count($items);
+        $items     = $checklist['items'] ?? [];
+        $total     = count($items);
         $completed = 0;
 
         foreach ($items as $item) {
@@ -156,11 +156,11 @@ class ChecklistService
         }
 
         return [
-            'completed' => $completed,
-            'total' => $total,
+            'completed'  => $completed,
+            'total'      => $total,
             'percentage' => $total > 0 ? round(($completed / $total) * 100, 1) : 0.0,
         ];
-    }
+    }//end getProgress()
 
     /**
      * Validate that all checklist items are completed.
@@ -173,7 +173,7 @@ class ChecklistService
      */
     public function validateCompletion(array $checklist): array
     {
-        $items = $checklist['items'] ?? [];
+        $items        = $checklist['items'] ?? [];
         $missingItems = [];
 
         foreach ($items as $item) {
@@ -183,10 +183,10 @@ class ChecklistService
         }
 
         return [
-            'valid' => empty($missingItems),
+            'valid'        => empty($missingItems),
             'missingItems' => $missingItems,
         ];
-    }
+    }//end validateCompletion()
 
     /**
      * Get a summary of conformity results.
@@ -199,11 +199,11 @@ class ChecklistService
      */
     public function getConformitySummary(array $checklist): array
     {
-        $items = $checklist['items'] ?? [];
+        $items   = $checklist['items'] ?? [];
         $summary = [
-            'conform' => 0,
-            'nietConform' => 0,
-            'nvt' => 0,
+            'conform'      => 0,
+            'nietConform'  => 0,
+            'nvt'          => 0,
             'notCompleted' => 0,
         ];
 
@@ -218,5 +218,5 @@ class ChecklistService
         }
 
         return $summary;
-    }
-}
+    }//end getConformitySummary()
+}//end class

--- a/lib/Service/ConsultationService.php
+++ b/lib/Service/ConsultationService.php
@@ -52,7 +52,6 @@ class ConsultationService
         'niet_van_toepassing',
     ];
 
-
     /**
      * Constructor.
      *
@@ -63,8 +62,7 @@ class ConsultationService
         private readonly SettingsService $settingsService,
         private readonly LoggerInterface $logger,
     ) {
-    }
-
+    }//end __construct()
 
     /**
      * Create a consultation linked to a parent case.
@@ -105,8 +103,8 @@ class ConsultationService
         $consultation = $objectService->saveObject($register, $schema, $data);
 
         $this->logger->info(
-            'Consultation created: ' . $consultation->getUuid()
-            . ' for case ' . $data['parentZaak'],
+            'Consultation created: '.$consultation->getUuid()
+            .' for case '.$data['parentZaak'],
             ['app' => Application::APP_ID],
         );
 
@@ -114,8 +112,7 @@ class ConsultationService
             'id'     => $consultation->getUuid(),
             'status' => 'open',
         ];
-    }
-
+    }//end createConsultation()
 
     /**
      * Get all consultations for a case.
@@ -147,8 +144,7 @@ class ConsultationService
         );
 
         return is_array($results) ? $results : [];
-    }
-
+    }//end getConsultationsForCase()
 
     /**
      * Update consultation status.
@@ -163,7 +159,7 @@ class ConsultationService
     public function updateStatus(string $consultationId, string $newStatus): array
     {
         if (in_array($newStatus, self::VALID_STATUSES, true) === false) {
-            throw new \RuntimeException('Invalid status: ' . $newStatus);
+            throw new \RuntimeException('Invalid status: '.$newStatus);
         }
 
         $objectService = $this->settingsService->getObjectService();
@@ -182,7 +178,7 @@ class ConsultationService
         $result = $objectService->saveObject($register, $schema, $updateData, $consultationId);
 
         $this->logger->info(
-            'Consultation ' . $consultationId . ' status updated to ' . $newStatus,
+            'Consultation '.$consultationId.' status updated to '.$newStatus,
             ['app' => Application::APP_ID],
         );
 
@@ -190,8 +186,7 @@ class ConsultationService
             'id'     => $consultationId,
             'status' => $newStatus,
         ];
-    }
-
+    }//end updateStatus()
 
     /**
      * Submit advice response to a consultation.
@@ -207,7 +202,7 @@ class ConsultationService
     {
         $advies = $response['advies'] ?? '';
         if (in_array($advies, self::VALID_RESPONSES, true) === false) {
-            throw new \RuntimeException('Invalid advice type: ' . $advies);
+            throw new \RuntimeException('Invalid advice type: '.$advies);
         }
 
         $objectService = $this->settingsService->getObjectService();
@@ -219,19 +214,17 @@ class ConsultationService
         $schema   = $this->settingsService->getConfigValue('consultation_schema');
 
         $updateData = [
-            'advies'       => $advies,
-            'toelichting'  => $response['toelichting'] ?? '',
-            'voorwaarden'  => isset($response['voorwaarden'])
-                ? json_encode($response['voorwaarden'])
-                : null,
-            'adviesDatum'  => date('Y-m-d'),
-            'status'       => 'advies_uitgebracht',
+            'advies'      => $advies,
+            'toelichting' => $response['toelichting'] ?? '',
+            'voorwaarden' => isset($response['voorwaarden']) ? json_encode($response['voorwaarden']) : null,
+            'adviesDatum' => date('Y-m-d'),
+            'status'      => 'advies_uitgebracht',
         ];
 
         $result = $objectService->saveObject($register, $schema, $updateData, $consultationId);
 
         $this->logger->info(
-            'Consultation ' . $consultationId . ' advice submitted: ' . $advies,
+            'Consultation '.$consultationId.' advice submitted: '.$advies,
             ['app' => Application::APP_ID],
         );
 
@@ -240,8 +233,7 @@ class ConsultationService
             'advies' => $advies,
             'status' => 'advies_uitgebracht',
         ];
-    }
-
+    }//end submitResponse()
 
     /**
      * Get overdue consultations.
@@ -294,5 +286,5 @@ class ConsultationService
         }
 
         return $overdue;
-    }
-}
+    }//end getOverdueConsultations()
+}//end class

--- a/lib/Service/ConsultationService.php
+++ b/lib/Service/ConsultationService.php
@@ -10,7 +10,7 @@
  * @category Service
  * @package  OCA\Procest\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Service/DsoIntakeService.php
+++ b/lib/Service/DsoIntakeService.php
@@ -9,7 +9,7 @@
  * @category Service
  * @package  OCA\Procest\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Service/DsoIntakeService.php
+++ b/lib/Service/DsoIntakeService.php
@@ -39,10 +39,9 @@ class DsoIntakeService
      * Deadline durations per procedure type (ISO 8601).
      */
     private const DEADLINE_DURATIONS = [
-        'regulier'    => 'P56D',
-        'uitgebreid'  => 'P182D',
+        'regulier'   => 'P56D',
+        'uitgebreid' => 'P182D',
     ];
-
 
     /**
      * Constructor.
@@ -54,8 +53,7 @@ class DsoIntakeService
         private readonly SettingsService $settingsService,
         private readonly LoggerInterface $logger,
     ) {
-    }
-
+    }//end __construct()
 
     /**
      * Process a DSO vergunningaanvraag and create a case.
@@ -94,18 +92,17 @@ class DsoIntakeService
             },
             $activiteiten,
         );
-        $activityStr = implode(', ', array_filter($activityNames));
+        $activityStr   = implode(', ', array_filter($activityNames));
 
         // Determine processing deadline.
-        $deadline = self::DEADLINE_DURATIONS[$procedureType]
-            ?? self::DEADLINE_DURATIONS['regulier'];
+        $deadline = self::DEADLINE_DURATIONS[$procedureType] ?? self::DEADLINE_DURATIONS['regulier'];
 
         // Create the case.
         $caseSchema = $this->settingsService->getConfigValue('case_schema');
         $caseData   = [
-            'title'       => 'Omgevingsvergunning' . ($activityStr !== '' ? ': ' . $activityStr : ''),
+            'title'       => 'Omgevingsvergunning'.($activityStr !== '' ? ': '.$activityStr : ''),
             'description' => 'Vergunningaanvraag ontvangen via DSO/Omgevingsloket'
-                . ($dsoZaaknummer !== '' ? ' (DSO: ' . $dsoZaaknummer . ')' : ''),
+                .($dsoZaaknummer !== '' ? ' (DSO: '.$dsoZaaknummer.')' : ''),
             'startDate'   => date('Y-m-d'),
             'priority'    => 'normal',
         ];
@@ -129,15 +126,19 @@ class DsoIntakeService
                 continue;
             }
 
-            $objectService->saveObject($register, $propertySchema, [
-                'case'  => $caseId,
-                'name'  => $name,
-                'value' => $value,
-            ]);
+            $objectService->saveObject(
+                    $register,
+                    $propertySchema,
+                    [
+                        'case'  => $caseId,
+                        'name'  => $name,
+                        'value' => $value,
+                    ]
+                    );
         }
 
         $this->logger->info(
-            'DSO intake processed: case ' . $caseId . ' (DSO: ' . $dsoZaaknummer . ')',
+            'DSO intake processed: case '.$caseId.' (DSO: '.$dsoZaaknummer.')',
             ['app' => Application::APP_ID],
         );
 
@@ -148,8 +149,7 @@ class DsoIntakeService
             'procedureType' => $procedureType,
             'deadline'      => $deadline,
         ];
-    }
-
+    }//end processAanvraag()
 
     /**
      * Get the processing deadline duration for a procedure type.
@@ -160,7 +160,6 @@ class DsoIntakeService
      */
     public function getDeadlineDuration(string $procedureType): string
     {
-        return self::DEADLINE_DURATIONS[$procedureType]
-            ?? self::DEADLINE_DURATIONS['regulier'];
-    }
-}
+        return self::DEADLINE_DURATIONS[$procedureType] ?? self::DEADLINE_DURATIONS['regulier'];
+    }//end getDeadlineDuration()
+}//end class

--- a/lib/Service/GisProxyService.php
+++ b/lib/Service/GisProxyService.php
@@ -9,7 +9,7 @@
  * @category Service
  * @package  OCA\Procest\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Service/InspectionService.php
+++ b/lib/Service/InspectionService.php
@@ -9,7 +9,7 @@
  * @category Service
  * @package  OCA\Procest\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Service/InspectionService.php
+++ b/lib/Service/InspectionService.php
@@ -69,13 +69,13 @@ class InspectionService
         private readonly SettingsService $settingsService,
         private readonly LoggerInterface $logger,
     ) {
-    }
+    }//end __construct()
 
     /**
      * Get inspections assigned to an inspector, optionally filtered by date.
      *
-     * @param string      $inspectorId The inspector's user ID.
-     * @param string|null $date        Optional date filter (Y-m-d format).
+     * @param string                           $inspectorId    The inspector's user ID.
+     * @param string|null                      $date           Optional date filter (Y-m-d format).
      * @param array<int, array<string, mixed>> $allInspections All inspection data (from OpenRegister).
      *
      * @return array<int, array<string, mixed>> Filtered and sorted inspections.
@@ -87,26 +87,34 @@ class InspectionService
         ?string $date,
         array $allInspections,
     ): array {
-        $filtered = array_filter($allInspections, function (array $inspection) use ($inspectorId, $date): bool {
-            if (($inspection['inspectorId'] ?? '') !== $inspectorId) {
-                return false;
-            }
-            if ($date !== null) {
-                $inspectionDate = substr($inspection['plannedDateTime'] ?? '', 0, 10);
-                if ($inspectionDate !== $date) {
-                    return false;
+        $filtered = array_filter(
+                $allInspections,
+                function (array $inspection) use ($inspectorId, $date): bool {
+                    if (($inspection['inspectorId'] ?? '') !== $inspectorId) {
+                        return false;
+                    }
+
+                    if ($date !== null) {
+                        $inspectionDate = substr($inspection['plannedDateTime'] ?? '', 0, 10);
+                        if ($inspectionDate !== $date) {
+                            return false;
+                        }
+                    }
+
+                    return true;
                 }
-            }
-            return true;
-        });
+                );
 
         // Sort by planned time.
-        usort($filtered, function (array $a, array $b): int {
-            return ($a['plannedDateTime'] ?? '') <=> ($b['plannedDateTime'] ?? '');
-        });
+        usort(
+                $filtered,
+                function (array $a, array $b): int {
+                    return ($a['plannedDateTime'] ?? '') <=> ($b['plannedDateTime'] ?? '');
+                }
+                );
 
         return array_values($filtered);
-    }
+    }//end getInspections()
 
     /**
      * Capture GPS location for an inspection and validate against planned location.
@@ -131,18 +139,18 @@ class InspectionService
         float $accuracy,
     ): array {
         $inspection['capturedLocation'] = [
-            'latitude' => $latitude,
-            'longitude' => $longitude,
-            'accuracy' => $accuracy,
+            'latitude'   => $latitude,
+            'longitude'  => $longitude,
+            'accuracy'   => $accuracy,
             'capturedAt' => (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM),
         ];
 
-        $warning = null;
+        $warning  = null;
         $distance = 0.0;
 
         // Check distance from planned location.
-        $plannedLat = (float)($inspection['plannedLatitude'] ?? 0.0);
-        $plannedLon = (float)($inspection['plannedLongitude'] ?? 0.0);
+        $plannedLat = (float) ($inspection['plannedLatitude'] ?? 0.0);
+        $plannedLon = (float) ($inspection['plannedLongitude'] ?? 0.0);
 
         if ($plannedLat !== 0.0 && $plannedLon !== 0.0) {
             $distance = $this->calculateDistance($latitude, $longitude, $plannedLat, $plannedLon);
@@ -155,7 +163,7 @@ class InspectionService
                 $this->logger->warning(
                     'Location mismatch for inspection {id}: {distance}m from planned',
                     [
-                        'id' => $inspection['id'] ?? 'unknown',
+                        'id'       => $inspection['id'] ?? 'unknown',
                         'distance' => round($distance),
                     ]
                 );
@@ -168,16 +176,16 @@ class InspectionService
 
         return [
             'inspection' => $inspection,
-            'warning' => $warning,
-            'distance' => round($distance, 1),
+            'warning'    => $warning,
+            'distance'   => round($distance, 1),
         ];
-    }
+    }//end captureLocation()
 
     /**
      * Record photo metadata for an inspection.
      *
-     * @param array<string, mixed> $inspection     The inspection data.
-     * @param array<string, mixed> $photoMetadata  Photo info (fileRef, latitude, longitude, checklistItemId).
+     * @param array<string, mixed> $inspection    The inspection data.
+     * @param array<string, mixed> $photoMetadata Photo info (fileRef, latitude, longitude, checklistItemId).
      *
      * @return array<string, mixed> The updated inspection with photo added.
      *
@@ -186,19 +194,19 @@ class InspectionService
     public function addPhoto(array $inspection, array $photoMetadata): array
     {
         $photo = [
-            'id' => $photoMetadata['id'] ?? uniqid('photo_', true),
-            'fileRef' => $photoMetadata['fileRef'] ?? '',
-            'latitude' => $photoMetadata['latitude'] ?? null,
-            'longitude' => $photoMetadata['longitude'] ?? null,
+            'id'              => $photoMetadata['id'] ?? uniqid('photo_', true),
+            'fileRef'         => $photoMetadata['fileRef'] ?? '',
+            'latitude'        => $photoMetadata['latitude'] ?? null,
+            'longitude'       => $photoMetadata['longitude'] ?? null,
             'checklistItemId' => $photoMetadata['checklistItemId'] ?? null,
-            'capturedAt' => (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM),
+            'capturedAt'      => (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM),
         ];
 
-        $inspection['photos'] = $inspection['photos'] ?? [];
+        $inspection['photos']   = $inspection['photos'] ?? [];
         $inspection['photos'][] = $photo;
 
         return $inspection;
-    }
+    }//end addPhoto()
 
     /**
      * Complete an inspection.
@@ -212,22 +220,22 @@ class InspectionService
      *
      * @psalm-suppress PossiblyUnusedMethod
      */
-    public function completeInspection(array $inspection, string $conclusion = ''): array
+    public function completeInspection(array $inspection, string $conclusion=''): array
     {
         $checklist = $inspection['checklist'] ?? [];
-        $items = $checklist['items'] ?? [];
+        $items     = $checklist['items'] ?? [];
 
         // Check if all items are completed.
         foreach ($items as $item) {
             if (empty($item['status'])) {
                 throw new \InvalidArgumentException(
-                    'Not all checklist items are completed. Item: ' . ($item['description'] ?? 'unknown')
+                    'Not all checklist items are completed. Item: '.($item['description'] ?? 'unknown')
                 );
             }
         }
 
-        $inspection['status'] = self::STATUS_COMPLETED;
-        $inspection['conclusion'] = $conclusion;
+        $inspection['status']      = self::STATUS_COMPLETED;
+        $inspection['conclusion']  = $conclusion;
         $inspection['completedAt'] = (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM);
 
         $this->logger->info(
@@ -236,7 +244,7 @@ class InspectionService
         );
 
         return $inspection;
-    }
+    }//end completeInspection()
 
     /**
      * Calculate distance between two GPS coordinates using Haversine formula.
@@ -253,12 +261,10 @@ class InspectionService
         $dLat = deg2rad($lat2 - $lat1);
         $dLon = deg2rad($lon2 - $lon1);
 
-        $a = sin($dLat / 2) * sin($dLat / 2)
-            + cos(deg2rad($lat1)) * cos(deg2rad($lat2))
-            * sin($dLon / 2) * sin($dLon / 2);
+        $a = sin($dLat / 2) * sin($dLat / 2) + cos(deg2rad($lat1)) * cos(deg2rad($lat2)) * sin($dLon / 2) * sin($dLon / 2);
 
         $c = 2 * atan2(sqrt($a), sqrt(1 - $a));
 
         return self::EARTH_RADIUS * $c;
-    }
-}
+    }//end calculateDistance()
+}//end class

--- a/lib/Service/LegesCalculationService.php
+++ b/lib/Service/LegesCalculationService.php
@@ -73,14 +73,14 @@ class LegesCalculationService
     public function __construct(
         private readonly LoggerInterface $logger,
     ) {
-    }
+    }//end __construct()
 
     /**
      * Calculate leges for a case based on applicable verordening.
      *
-     * @param array<string, mixed> $caseData      The case data (bouwkosten, activiteiten, etc.).
-     * @param array<string, mixed> $verordening   The applicable verordening with artikelen.
-     * @param string               $calculatedBy  User ID of the person triggering the calculation.
+     * @param array<string, mixed> $caseData     The case data (bouwkosten, activiteiten, etc.).
+     * @param array<string, mixed> $verordening  The applicable verordening with artikelen.
+     * @param string               $calculatedBy User ID of the person triggering the calculation.
      *
      * @return array{
      *     total: float,
@@ -105,33 +105,33 @@ class LegesCalculationService
 
         $artikelen = $verordening['artikelen'] ?? [];
         $breakdown = [];
-        $total = 0.0;
+        $total     = 0.0;
 
         foreach ($artikelen as $artikel) {
             $result = $this->calculateArtikel($artikel, $caseData);
             if ($result !== null) {
                 $breakdown[] = $result;
-                $total += $result['amount'];
+                $total      += $result['amount'];
             }
         }
 
         // Apply global maximum if configured.
         $globalMax = $verordening['globalMaximum'] ?? null;
-        if ($globalMax !== null && $total > (float)$globalMax) {
-            $total = (float)$globalMax;
+        if ($globalMax !== null && $total > (float) $globalMax) {
+            $total = (float) $globalMax;
         }
 
         $total = round($total, self::PRECISION);
 
         return [
-            'total' => $total,
-            'breakdown' => $breakdown,
-            'verordening' => $verordening['name'] ?? '',
+            'total'        => $total,
+            'breakdown'    => $breakdown,
+            'verordening'  => $verordening['name'] ?? '',
             'calculatedBy' => $calculatedBy,
             'calculatedAt' => (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM),
-            'version' => 1,
+            'version'      => 1,
         ];
-    }
+    }//end calculate()
 
     /**
      * Recalculate leges with corrected case data, preserving history.
@@ -153,18 +153,18 @@ class LegesCalculationService
         string $calculatedBy,
         string $correctionReason,
     ): array {
-        $newCalc = $this->calculate($caseData, $verordening, $calculatedBy);
+        $newCalc            = $this->calculate($caseData, $verordening, $calculatedBy);
         $newCalc['version'] = ($previousCalc['version'] ?? 0) + 1;
-        $newCalc['previousVersion'] = $previousCalc['version'] ?? 0;
+        $newCalc['previousVersion']  = $previousCalc['version'] ?? 0;
         $newCalc['correctionReason'] = $correctionReason;
-        $newCalc['previousTotal'] = $previousCalc['total'] ?? 0.0;
-        $newCalc['difference'] = round(
+        $newCalc['previousTotal']    = $previousCalc['total'] ?? 0.0;
+        $newCalc['difference']       = round(
             $newCalc['total'] - ($previousCalc['total'] ?? 0.0),
             self::PRECISION
         );
 
         return $newCalc;
-    }
+    }//end recalculate()
 
     /**
      * Calculate verrekening (deduction of previously imposed fees).
@@ -181,12 +181,12 @@ class LegesCalculationService
         $netAmount = round($currentAmount - $previousAmount, self::PRECISION);
 
         return [
-            'netAmount' => $netAmount,
-            'deduction' => $previousAmount,
-            'currentAmount' => $currentAmount,
+            'netAmount'      => $netAmount,
+            'deduction'      => $previousAmount,
+            'currentAmount'  => $currentAmount,
             'previousAmount' => $previousAmount,
         ];
-    }
+    }//end calculateVerrekening()
 
     /**
      * Calculate teruggaaf (refund).
@@ -201,18 +201,18 @@ class LegesCalculationService
      */
     public function calculateTeruggaaf(
         float $imposedAmount,
-        float $refundFraction = 1.0,
-        string $reason = '',
+        float $refundFraction=1.0,
+        string $reason='',
     ): array {
         $refundAmount = round(-1 * $imposedAmount * $refundFraction, self::PRECISION);
 
         return [
-            'refundAmount' => $refundAmount,
+            'refundAmount'   => $refundAmount,
             'originalAmount' => $imposedAmount,
-            'fraction' => $refundFraction,
-            'reason' => $reason,
+            'fraction'       => $refundFraction,
+            'reason'         => $reason,
         ];
-    }
+    }//end calculateTeruggaaf()
 
     /**
      * Calculate a single artikel.
@@ -224,13 +224,13 @@ class LegesCalculationService
      */
     private function calculateArtikel(array $artikel, array $caseData): ?array
     {
-        $type = $artikel['type'] ?? '';
-        $artikelNr = $artikel['nummer'] ?? '';
+        $type        = $artikel['type'] ?? '';
+        $artikelNr   = $artikel['nummer'] ?? '';
         $description = $artikel['omschrijving'] ?? '';
 
         // Determine the grondslag (base amount) from case data.
         $grondslagField = $artikel['grondslagField'] ?? 'bouwkosten';
-        $grondslag = (float)($caseData[$grondslagField] ?? 0.0);
+        $grondslag      = (float) ($caseData[$grondslagField] ?? 0.0);
 
         $amount = match ($type) {
             self::TYPE_VAST => $this->calculateVast($artikel),
@@ -246,13 +246,13 @@ class LegesCalculationService
         }
 
         return [
-            'artikel' => $artikelNr,
+            'artikel'     => $artikelNr,
             'description' => $description,
-            'grondslag' => $grondslag,
-            'amount' => round($amount, self::PRECISION),
-            'type' => $type,
+            'grondslag'   => $grondslag,
+            'amount'      => round($amount, self::PRECISION),
+            'type'        => $type,
         ];
-    }
+    }//end calculateArtikel()
 
     /**
      * Calculate a fixed amount (vast bedrag).
@@ -263,8 +263,8 @@ class LegesCalculationService
      */
     private function calculateVast(array $artikel): float
     {
-        return (float)($artikel['bedrag'] ?? 0.0);
-    }
+        return (float) ($artikel['bedrag'] ?? 0.0);
+    }//end calculateVast()
 
     /**
      * Calculate a percentage of the grondslag.
@@ -276,9 +276,9 @@ class LegesCalculationService
      */
     private function calculatePercentage(float $grondslag, array $artikel): float
     {
-        $percentage = (float)($artikel['percentage'] ?? 0.0);
+        $percentage = (float) ($artikel['percentage'] ?? 0.0);
         return $grondslag * ($percentage / 100.0);
-    }
+    }//end calculatePercentage()
 
     /**
      * Calculate using tiered brackets (staffel).
@@ -294,12 +294,12 @@ class LegesCalculationService
     private function calculateStaffel(float $grondslag, array $artikel): float
     {
         $brackets = $artikel['brackets'] ?? [];
-        $total = 0.0;
+        $total    = 0.0;
 
         foreach ($brackets as $bracket) {
-            $from = (float)($bracket['from'] ?? 0.0);
-            $to = (float)($bracket['to'] ?? PHP_FLOAT_MAX);
-            $percentage = (float)($bracket['percentage'] ?? 0.0);
+            $from       = (float) ($bracket['from'] ?? 0.0);
+            $to         = (float) ($bracket['to'] ?? PHP_FLOAT_MAX);
+            $percentage = (float) ($bracket['percentage'] ?? 0.0);
 
             if ($grondslag <= $from) {
                 break;
@@ -312,7 +312,7 @@ class LegesCalculationService
         }
 
         return $total;
-    }
+    }//end calculateStaffel()
 
     /**
      * Calculate with a maximum cap.
@@ -324,7 +324,7 @@ class LegesCalculationService
      */
     private function calculateMaximum(float $grondslag, array $artikel): float
     {
-        $maximum = (float)($artikel['maximum'] ?? PHP_FLOAT_MAX);
+        $maximum = (float) ($artikel['maximum'] ?? PHP_FLOAT_MAX);
         $subType = $artikel['subType'] ?? self::TYPE_PERCENTAGE;
 
         $calculated = match ($subType) {
@@ -334,7 +334,7 @@ class LegesCalculationService
         };
 
         return min($calculated, $maximum);
-    }
+    }//end calculateMaximum()
 
     /**
      * Calculate a combination of multiple sub-calculations.
@@ -351,7 +351,7 @@ class LegesCalculationService
         array $caseData,
     ): float {
         $subArtikelen = $artikel['subArtikelen'] ?? [];
-        $total = 0.0;
+        $total        = 0.0;
 
         foreach ($subArtikelen as $subArtikel) {
             $result = $this->calculateArtikel($subArtikel, $caseData);
@@ -361,5 +361,5 @@ class LegesCalculationService
         }
 
         return $total;
-    }
-}
+    }//end calculateCombinatie()
+}//end class

--- a/lib/Service/LegesCalculationService.php
+++ b/lib/Service/LegesCalculationService.php
@@ -10,7 +10,7 @@
  * @category Service
  * @package  OCA\Procest\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Service/LegesExportService.php
+++ b/lib/Service/LegesExportService.php
@@ -9,7 +9,7 @@
  * @category Service
  * @package  OCA\Procest\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Service/LegesExportService.php
+++ b/lib/Service/LegesExportService.php
@@ -85,7 +85,7 @@ class LegesExportService
     public function __construct(
         private readonly LoggerInterface $logger,
     ) {
-    }
+    }//end __construct()
 
     /**
      * Export berekeningen to the specified format.
@@ -99,11 +99,11 @@ class LegesExportService
      *
      * @psalm-suppress PossiblyUnusedMethod
      */
-    public function export(array $berekeningen, string $format = self::FORMAT_CSV): array
+    public function export(array $berekeningen, string $format=self::FORMAT_CSV): array
     {
         if (!in_array($format, self::SUPPORTED_FORMATS, true)) {
             throw new \InvalidArgumentException(
-                'Unsupported export format: ' . $format . '. Supported: ' . implode(', ', self::SUPPORTED_FORMATS)
+                'Unsupported export format: '.$format.'. Supported: '.implode(', ', self::SUPPORTED_FORMATS)
             );
         }
 
@@ -117,7 +117,7 @@ class LegesExportService
             self::FORMAT_ASCII => $this->exportASCII($berekeningen),
             self::FORMAT_XML => $this->exportXML($berekeningen),
         };
-    }
+    }//end export()
 
     /**
      * Export berekeningen as CSV.
@@ -153,11 +153,11 @@ class LegesExportService
         $date = (new \DateTimeImmutable())->format('Y-m-d');
 
         return [
-            'content' => $content !== false ? $content : '',
-            'filename' => "leges-export-{$date}.csv",
+            'content'     => $content !== false ? $content : '',
+            'filename'    => "leges-export-{$date}.csv",
             'contentType' => 'text/csv; charset=utf-8',
         ];
-    }
+    }//end exportCSV()
 
     /**
      * Export berekeningen as ASCII flat file.
@@ -180,22 +180,22 @@ class LegesExportService
         foreach ($berekeningen as $berekening) {
             $rows = $this->flattenBerekening($berekening);
             foreach ($rows as $row) {
-                $lines[] = 'D|' . implode('|', $row);
+                $lines[] = 'D|'.implode('|', $row);
             }
         }
 
         // Footer line.
-        $total = array_sum(array_column($berekeningen, 'total'));
+        $total   = array_sum(array_column($berekeningen, 'total'));
         $lines[] = sprintf('F|%d|%.2f', count($berekeningen), $total);
 
         $date = (new \DateTimeImmutable())->format('Y-m-d');
 
         return [
-            'content' => implode("\r\n", $lines),
-            'filename' => "leges-export-{$date}.txt",
+            'content'     => implode("\r\n", $lines),
+            'filename'    => "leges-export-{$date}.txt",
             'contentType' => 'text/plain; charset=utf-8',
         ];
-    }
+    }//end exportASCII()
 
     /**
      * Export berekeningen as XML (StUF-FIN compatible structure).
@@ -211,23 +211,23 @@ class LegesExportService
 
         $root = $dom->createElement('legesExport');
         $root->setAttribute('exportDatum', (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM));
-        $root->setAttribute('aantalRecords', (string)count($berekeningen));
+        $root->setAttribute('aantalRecords', (string) count($berekeningen));
         $dom->appendChild($root);
 
         foreach ($berekeningen as $berekening) {
             $berekeningEl = $dom->createElement('berekening');
-            $berekeningEl->setAttribute('zaaknummer', (string)($berekening['zaaknummer'] ?? ''));
+            $berekeningEl->setAttribute('zaaknummer', (string) ($berekening['zaaknummer'] ?? ''));
 
-            $this->addXmlElement($dom, $berekeningEl, 'bsnKvk', (string)($berekening['bsnKvk'] ?? ''));
-            $this->addXmlElement($dom, $berekeningEl, 'naam', (string)($berekening['naam'] ?? ''));
+            $this->addXmlElement($dom, $berekeningEl, 'bsnKvk', (string) ($berekening['bsnKvk'] ?? ''));
+            $this->addXmlElement($dom, $berekeningEl, 'naam', (string) ($berekening['naam'] ?? ''));
             $this->addXmlElement($dom, $berekeningEl, 'totaalBedrag', number_format($berekening['total'] ?? 0.0, 2, '.', ''));
-            $this->addXmlElement($dom, $berekeningEl, 'datumBeschikking', (string)($berekening['datumBeschikking'] ?? ''));
+            $this->addXmlElement($dom, $berekeningEl, 'datumBeschikking', (string) ($berekening['datumBeschikking'] ?? ''));
 
             $breakdown = $berekening['breakdown'] ?? [];
             foreach ($breakdown as $regel) {
                 $regelEl = $dom->createElement('regel');
-                $this->addXmlElement($dom, $regelEl, 'artikelnummer', (string)($regel['artikel'] ?? ''));
-                $this->addXmlElement($dom, $regelEl, 'omschrijving', (string)($regel['description'] ?? ''));
+                $this->addXmlElement($dom, $regelEl, 'artikelnummer', (string) ($regel['artikel'] ?? ''));
+                $this->addXmlElement($dom, $regelEl, 'omschrijving', (string) ($regel['description'] ?? ''));
                 $this->addXmlElement($dom, $regelEl, 'bedrag', number_format($regel['amount'] ?? 0.0, 2, '.', ''));
                 $berekeningEl->appendChild($regelEl);
             }
@@ -236,14 +236,14 @@ class LegesExportService
         }
 
         $content = $dom->saveXML();
-        $date = (new \DateTimeImmutable())->format('Y-m-d');
+        $date    = (new \DateTimeImmutable())->format('Y-m-d');
 
         return [
-            'content' => $content !== false ? $content : '',
-            'filename' => "leges-export-{$date}.xml",
+            'content'     => $content !== false ? $content : '',
+            'filename'    => "leges-export-{$date}.xml",
             'contentType' => 'application/xml; charset=utf-8',
         ];
-    }
+    }//end exportXML()
 
     /**
      * Flatten a berekening into export rows (one row per artikel in breakdown).
@@ -254,45 +254,45 @@ class LegesExportService
      */
     private function flattenBerekening(array $berekening): array
     {
-        $rows = [];
+        $rows      = [];
         $breakdown = $berekening['breakdown'] ?? [];
 
         if (empty($breakdown)) {
             $rows[] = [
-                (string)($berekening['zaaknummer'] ?? ''),
-                (string)($berekening['bsnKvk'] ?? ''),
-                (string)($berekening['naam'] ?? ''),
-                (string)($berekening['adres'] ?? ''),
+                (string) ($berekening['zaaknummer'] ?? ''),
+                (string) ($berekening['bsnKvk'] ?? ''),
+                (string) ($berekening['naam'] ?? ''),
+                (string) ($berekening['adres'] ?? ''),
                 '',
                 'Totaal',
                 number_format($berekening['total'] ?? 0.0, 2, '.', ''),
-                (string)($berekening['datumBeschikking'] ?? ''),
+                (string) ($berekening['datumBeschikking'] ?? ''),
             ];
         } else {
             foreach ($breakdown as $regel) {
                 $rows[] = [
-                    (string)($berekening['zaaknummer'] ?? ''),
-                    (string)($berekening['bsnKvk'] ?? ''),
-                    (string)($berekening['naam'] ?? ''),
-                    (string)($berekening['adres'] ?? ''),
-                    (string)($regel['artikel'] ?? ''),
-                    (string)($regel['description'] ?? ''),
+                    (string) ($berekening['zaaknummer'] ?? ''),
+                    (string) ($berekening['bsnKvk'] ?? ''),
+                    (string) ($berekening['naam'] ?? ''),
+                    (string) ($berekening['adres'] ?? ''),
+                    (string) ($regel['artikel'] ?? ''),
+                    (string) ($regel['description'] ?? ''),
                     number_format($regel['amount'] ?? 0.0, 2, '.', ''),
-                    (string)($berekening['datumBeschikking'] ?? ''),
+                    (string) ($berekening['datumBeschikking'] ?? ''),
                 ];
             }
-        }
+        }//end if
 
         return $rows;
-    }
+    }//end flattenBerekening()
 
     /**
      * Add a text element to an XML parent.
      *
-     * @param \DOMDocument $dom     The DOM document.
-     * @param \DOMElement  $parent  The parent element.
-     * @param string       $name    The element name.
-     * @param string       $value   The text value.
+     * @param \DOMDocument $dom    The DOM document.
+     * @param \DOMElement  $parent The parent element.
+     * @param string       $name   The element name.
+     * @param string       $value  The text value.
      *
      * @return void
      */
@@ -301,5 +301,5 @@ class LegesExportService
         $element = $dom->createElement($name);
         $element->appendChild($dom->createTextNode($value));
         $parent->appendChild($element);
-    }
-}
+    }//end addXmlElement()
+}//end class

--- a/lib/Service/MilestoneService.php
+++ b/lib/Service/MilestoneService.php
@@ -9,7 +9,7 @@
  * @category Service
  * @package  OCA\Procest\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Service/MilestoneService.php
+++ b/lib/Service/MilestoneService.php
@@ -30,8 +30,6 @@ use Psr\Log\LoggerInterface;
  */
 class MilestoneService
 {
-
-
     /**
      * Constructor.
      *
@@ -42,8 +40,7 @@ class MilestoneService
         private readonly SettingsService $settingsService,
         private readonly LoggerInterface $logger,
     ) {
-    }
-
+    }//end __construct()
 
     /**
      * Get milestone definitions for a case type.
@@ -77,8 +74,7 @@ class MilestoneService
         );
 
         return is_array($results) ? $results : [];
-    }
-
+    }//end getMilestones()
 
     /**
      * Get milestone progress for a specific case.
@@ -93,14 +89,14 @@ class MilestoneService
         $definitions = $this->getMilestones($caseTypeId);
         if (count($definitions) === 0) {
             return [
-                'milestones'  => [],
-                'reached'     => 0,
-                'total'       => 0,
-                'percentage'  => 0,
+                'milestones' => [],
+                'reached'    => 0,
+                'total'      => 0,
+                'percentage' => 0,
             ];
         }
 
-        $records = $this->getMilestoneRecords($caseId);
+        $records   = $this->getMilestoneRecords($caseId);
         $recordMap = [];
         foreach ($records as $record) {
             $recordMap[$record['milestoneDefinition'] ?? ''] = $record;
@@ -109,8 +105,8 @@ class MilestoneService
         $milestones = [];
         $reached    = 0;
         foreach ($definitions as $def) {
-            $defId  = $def['id'] ?? $def['uuid'] ?? '';
-            $record = $recordMap[$defId] ?? null;
+            $defId     = $def['id'] ?? $def['uuid'] ?? '';
+            $record    = $recordMap[$defId] ?? null;
             $isReached = $record !== null;
 
             if ($isReached === true) {
@@ -136,8 +132,7 @@ class MilestoneService
             'total'      => $total,
             'percentage' => $total > 0 ? (int) round(($reached / $total) * 100) : 0,
         ];
-    }
-
+    }//end getCaseProgress()
 
     /**
      * Mark a milestone as reached for a case.
@@ -155,7 +150,7 @@ class MilestoneService
         string $caseId,
         string $milestoneDefinitionId,
         string $userId,
-        string $trigger = 'manual',
+        string $trigger='manual',
     ): array {
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
@@ -180,7 +175,7 @@ class MilestoneService
         $record = $objectService->saveObject($register, $schema, $recordData);
 
         $this->logger->info(
-            'Milestone marked: ' . $milestoneDefinitionId . ' on case ' . $caseId,
+            'Milestone marked: '.$milestoneDefinitionId.' on case '.$caseId,
             ['app' => Application::APP_ID],
         );
 
@@ -189,8 +184,7 @@ class MilestoneService
             'reachedAt' => $recordData['reachedAt'],
             'reachedBy' => $userId,
         ];
-    }
-
+    }//end markMilestone()
 
     /**
      * Reverse a milestone (with reason for audit trail).
@@ -240,14 +234,13 @@ class MilestoneService
         }
 
         $this->logger->info(
-            'Milestone reversed: ' . $milestoneDefinitionId . ' on case ' . $caseId
-            . ' by ' . $userId . ' reason: ' . $reason,
+            'Milestone reversed: '.$milestoneDefinitionId.' on case '.$caseId
+            .' by '.$userId.' reason: '.$reason,
             ['app' => Application::APP_ID],
         );
 
         return true;
-    }
-
+    }//end reverseMilestone()
 
     /**
      * Calculate average duration between milestones for a case type.
@@ -261,7 +254,7 @@ class MilestoneService
         // Placeholder: in production, this would aggregate milestone records
         // across all cases of this type and calculate averages.
         $this->logger->debug(
-            'Duration analytics requested for case type: ' . $caseTypeId,
+            'Duration analytics requested for case type: '.$caseTypeId,
             ['app' => Application::APP_ID],
         );
 
@@ -270,8 +263,7 @@ class MilestoneService
             'phases'     => [],
             'message'    => 'Duration analytics requires sufficient historical data',
         ];
-    }
-
+    }//end getDurationAnalytics()
 
     /**
      * Get milestone records for a case.
@@ -303,5 +295,5 @@ class MilestoneService
         );
 
         return is_array($results) ? $results : [];
-    }
-}
+    }//end getMilestoneRecords()
+}//end class

--- a/lib/Service/NotificatieService.php
+++ b/lib/Service/NotificatieService.php
@@ -9,7 +9,7 @@
  * @category Service
  * @package  OCA\Procest\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Service/ParaferingNotificationService.php
+++ b/lib/Service/ParaferingNotificationService.php
@@ -8,7 +8,7 @@
  * @category Service
  * @package  OCA\Procest\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Service/ParaferingService.php
+++ b/lib/Service/ParaferingService.php
@@ -105,7 +105,7 @@ class ParaferingService
     public function __construct(
         private readonly LoggerInterface $logger,
     ) {
-    }
+    }//end __construct()
 
     /**
      * Create a new voorstel linked to a case.
@@ -119,18 +119,18 @@ class ParaferingService
     public function createVoorstel(array $voorstelData): array
     {
         $voorstel = [
-            'id' => $voorstelData['id'] ?? $this->generateId(),
-            'caseId' => $voorstelData['caseId'] ?? '',
-            'type' => $voorstelData['type'] ?? 'collegeadvies',
-            'onderwerp' => $voorstelData['onderwerp'] ?? '',
-            'steller' => $voorstelData['steller'] ?? '',
-            'afdeling' => $voorstelData['afdeling'] ?? '',
+            'id'                 => $voorstelData['id'] ?? $this->generateId(),
+            'caseId'             => $voorstelData['caseId'] ?? '',
+            'type'               => $voorstelData['type'] ?? 'collegeadvies',
+            'onderwerp'          => $voorstelData['onderwerp'] ?? '',
+            'steller'            => $voorstelData['steller'] ?? '',
+            'afdeling'           => $voorstelData['afdeling'] ?? '',
             'portefeuillehouder' => $voorstelData['portefeuillehouder'] ?? '',
-            'status' => self::STATUS_CONCEPT,
-            'currentStep' => 0,
-            'parafeerRoute' => [],
-            'auditTrail' => [],
-            'createdAt' => (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM),
+            'status'             => self::STATUS_CONCEPT,
+            'currentStep'        => 0,
+            'parafeerRoute'      => [],
+            'auditTrail'         => [],
+            'createdAt'          => (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM),
         ];
 
         $this->logger->info(
@@ -139,13 +139,13 @@ class ParaferingService
         );
 
         return $voorstel;
-    }
+    }//end createVoorstel()
 
     /**
      * Start the parafering process on a voorstel.
      *
-     * @param array<string, mixed>                         $voorstel The voorstel.
-     * @param array<int, array<string, mixed>> $route     The parafeerroute (ordered steps).
+     * @param array<string, mixed>             $voorstel The voorstel.
+     * @param array<int, array<string, mixed>> $route    The parafeerroute (ordered steps).
      *
      * @return array<string, mixed> The updated voorstel with parafering started.
      *
@@ -167,17 +167,17 @@ class ParaferingService
             throw new \InvalidArgumentException('Parafeerroute cannot be empty');
         }
 
-        $voorstel['status'] = self::STATUS_IN_PARAFERING;
-        $voorstel['currentStep'] = 0;
+        $voorstel['status']        = self::STATUS_IN_PARAFERING;
+        $voorstel['currentStep']   = 0;
         $voorstel['parafeerRoute'] = $route;
 
         // Record in audit trail.
         $voorstel['auditTrail'][] = [
-            'action' => 'started',
-            'actor' => $voorstel['steller'],
+            'action'    => 'started',
+            'actor'     => $voorstel['steller'],
             'timestamp' => (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM),
-            'comment' => 'Parafering gestart',
-            'step' => 0,
+            'comment'   => 'Parafering gestart',
+            'step'      => 0,
         ];
 
         $this->logger->info(
@@ -186,7 +186,7 @@ class ParaferingService
         );
 
         return $voorstel;
-    }
+    }//end startParafering()
 
     /**
      * Execute a parafering action on a voorstel.
@@ -207,8 +207,8 @@ class ParaferingService
         array $voorstel,
         string $action,
         string $actor,
-        string $comment = '',
-        ?string $namens = null,
+        string $comment='',
+        ?string $namens=null,
     ): array {
         if ($voorstel['status'] !== self::STATUS_IN_PARAFERING) {
             throw new \InvalidArgumentException('Voorstel is not in parafering status');
@@ -217,7 +217,7 @@ class ParaferingService
         $validActions = [self::ACTION_PARAFEREN, self::ACTION_TERUGSTUREN, self::ACTION_ADVISEREN];
         if (!in_array($action, $validActions, true)) {
             throw new \InvalidArgumentException(
-                'Invalid action: ' . $action . '. Valid: ' . implode(', ', $validActions)
+                'Invalid action: '.$action.'. Valid: '.implode(', ', $validActions)
             );
         }
 
@@ -225,16 +225,16 @@ class ParaferingService
 
         // Record the action in audit trail.
         $auditEntry = [
-            'action' => $action,
-            'actor' => $actor,
+            'action'    => $action,
+            'actor'     => $actor,
             'timestamp' => (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM),
-            'comment' => $comment,
-            'step' => $currentStep,
+            'comment'   => $comment,
+            'step'      => $currentStep,
         ];
 
         if ($namens !== null) {
-            $auditEntry['namens'] = $namens;
-            $auditEntry['comment'] = "Geparafeerd door {$actor} namens {$namens} (mandaat). " . $comment;
+            $auditEntry['namens']  = $namens;
+            $auditEntry['comment'] = "Geparafeerd door {$actor} namens {$namens} (mandaat). ".$comment;
         }
 
         $voorstel['auditTrail'][] = $auditEntry;
@@ -246,13 +246,13 @@ class ParaferingService
                 'Voorstel {id} returned by {actor}: {comment}',
                 ['id' => $voorstel['id'], 'actor' => $actor, 'comment' => $comment]
             );
-        } elseif ($action === self::ACTION_ADVISEREN) {
+        } else if ($action === self::ACTION_ADVISEREN) {
             // Advisory is non-blocking: advance to next step.
             $voorstel = $this->advanceStep($voorstel);
-        } elseif ($action === self::ACTION_PARAFEREN) {
+        } else if ($action === self::ACTION_PARAFEREN) {
             // Check if this completes a parallel step.
-            $route = $voorstel['parafeerRoute'] ?? [];
-            $step = $route[$currentStep] ?? [];
+            $route      = $voorstel['parafeerRoute'] ?? [];
+            $step       = $route[$currentStep] ?? [];
             $isParallel = $step['parallel'] ?? false;
 
             if ($isParallel) {
@@ -260,10 +260,10 @@ class ParaferingService
             } else {
                 $voorstel = $this->advanceStep($voorstel);
             }
-        }
+        }//end if
 
         return $voorstel;
-    }
+    }//end executeAction()
 
     /**
      * Get the full audit trail for a voorstel.
@@ -277,7 +277,7 @@ class ParaferingService
     public function getAuditTrail(array $voorstel): array
     {
         return $voorstel['auditTrail'] ?? [];
-    }
+    }//end getAuditTrail()
 
     /**
      * Get the current step information for a voorstel.
@@ -294,11 +294,11 @@ class ParaferingService
             return null;
         }
 
-        $route = $voorstel['parafeerRoute'] ?? [];
+        $route       = $voorstel['parafeerRoute'] ?? [];
         $currentStep = $voorstel['currentStep'] ?? 0;
 
         return $route[$currentStep] ?? null;
-    }
+    }//end getCurrentStep()
 
     /**
      * Override (modify) the parafeerroute for a specific voorstel.
@@ -321,11 +321,11 @@ class ParaferingService
         $voorstel['parafeerRoute'] = $newRoute;
 
         $voorstel['auditTrail'][] = [
-            'action' => 'route_overridden',
-            'actor' => $actor,
+            'action'    => 'route_overridden',
+            'actor'     => $actor,
             'timestamp' => (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM),
-            'comment' => "Parafeerroute aangepast door {$actor}, reden: {$reason}",
-            'step' => $voorstel['currentStep'] ?? 0,
+            'comment'   => "Parafeerroute aangepast door {$actor}, reden: {$reason}",
+            'step'      => $voorstel['currentStep'] ?? 0,
         ];
 
         $this->logger->info(
@@ -334,7 +334,7 @@ class ParaferingService
         );
 
         return $voorstel;
-    }
+    }//end overrideRoute()
 
     /**
      * Advance to the next step in the parafeerroute.
@@ -345,18 +345,18 @@ class ParaferingService
      */
     private function advanceStep(array $voorstel): array
     {
-        $route = $voorstel['parafeerRoute'] ?? [];
+        $route    = $voorstel['parafeerRoute'] ?? [];
         $nextStep = ($voorstel['currentStep'] ?? 0) + 1;
 
         if ($nextStep >= count($route)) {
             // All steps completed.
-            $voorstel['status'] = self::STATUS_GEPARAFEERD;
+            $voorstel['status']       = self::STATUS_GEPARAFEERD;
             $voorstel['auditTrail'][] = [
-                'action' => 'completed',
-                'actor' => 'system',
+                'action'    => 'completed',
+                'actor'     => 'system',
                 'timestamp' => (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM),
-                'comment' => 'Alle paraferingstappen voltooid',
-                'step' => $nextStep,
+                'comment'   => 'Alle paraferingstappen voltooid',
+                'step'      => $nextStep,
             ];
             $this->logger->info('Voorstel {id} parafering completed', ['id' => $voorstel['id']]);
         } else {
@@ -364,25 +364,25 @@ class ParaferingService
         }
 
         return $voorstel;
-    }
+    }//end advanceStep()
 
     /**
      * Handle a parallel parafering step (completes when ALL actors have parafered).
      *
-     * @param array<string, mixed> $voorstel    The voorstel.
-     * @param string               $actor       The actor who just parafered.
-     * @param int                  $stepIndex   The step index.
+     * @param array<string, mixed> $voorstel  The voorstel.
+     * @param string               $actor     The actor who just parafered.
+     * @param int                  $stepIndex The step index.
      *
      * @return array<string, mixed> The updated voorstel.
      */
     private function handleParallelStep(array $voorstel, string $actor, int $stepIndex): array
     {
-        $route = $voorstel['parafeerRoute'] ?? [];
-        $step = $route[$stepIndex] ?? [];
+        $route          = $voorstel['parafeerRoute'] ?? [];
+        $step           = $route[$stepIndex] ?? [];
         $requiredActors = $step['actors'] ?? [];
 
         // Check which actors have already parafered for this step.
-        $auditTrail = $voorstel['auditTrail'] ?? [];
+        $auditTrail      = $voorstel['auditTrail'] ?? [];
         $paraferedActors = [];
         foreach ($auditTrail as $entry) {
             if (($entry['step'] ?? -1) === $stepIndex
@@ -407,7 +407,7 @@ class ParaferingService
         }
 
         return $voorstel;
-    }
+    }//end handleParallelStep()
 
     /**
      * Generate a unique ID.
@@ -427,5 +427,5 @@ class ParaferingService
             mt_rand(0, 0xffff),
             mt_rand(0, 0xffff)
         );
-    }
-}
+    }//end generateId()
+}//end class

--- a/lib/Service/ParaferingService.php
+++ b/lib/Service/ParaferingService.php
@@ -10,7 +10,7 @@
  * @category Service
  * @package  OCA\Procest\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Service/SeedDataService.php
+++ b/lib/Service/SeedDataService.php
@@ -9,7 +9,7 @@
  * @category Service
  * @package  OCA\Procest\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -8,7 +8,7 @@
  * @category Service
  * @package  OCA\Procest\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Service/StufFieldMappingService.php
+++ b/lib/Service/StufFieldMappingService.php
@@ -52,15 +52,15 @@ class StufFieldMappingService
      * @var array<string, array{property: string, transform: string|null}>
      */
     private const DEFAULT_ZKN_MAPPINGS = [
-        'identificatie' => ['property' => 'identifier', 'transform' => null],
-        'omschrijving' => ['property' => 'title', 'transform' => null],
-        'toelichting' => ['property' => 'description', 'transform' => null],
-        'startdatum' => ['property' => 'startDate', 'transform' => 'stufDateToIso'],
-        'einddatum' => ['property' => 'endDate', 'transform' => 'stufDateToIso'],
-        'einddatumGepland' => ['property' => 'plannedEndDate', 'transform' => 'stufDateToIso'],
+        'identificatie'                => ['property' => 'identifier', 'transform' => null],
+        'omschrijving'                 => ['property' => 'title', 'transform' => null],
+        'toelichting'                  => ['property' => 'description', 'transform' => null],
+        'startdatum'                   => ['property' => 'startDate', 'transform' => 'stufDateToIso'],
+        'einddatum'                    => ['property' => 'endDate', 'transform' => 'stufDateToIso'],
+        'einddatumGepland'             => ['property' => 'plannedEndDate', 'transform' => 'stufDateToIso'],
         'uiterlijkeEinddatumAfdoening' => ['property' => 'deadline', 'transform' => 'stufDateToIso'],
-        'registratiedatum' => ['property' => 'registrationDate', 'transform' => 'stufDateToIso'],
-        'vertrouwelijkAanduiding' => ['property' => 'confidentiality', 'transform' => 'confidentialityToInternal'],
+        'registratiedatum'             => ['property' => 'registrationDate', 'transform' => 'stufDateToIso'],
+        'vertrouwelijkAanduiding'      => ['property' => 'confidentiality', 'transform' => 'confidentialityToInternal'],
     ];
 
     /**
@@ -69,11 +69,11 @@ class StufFieldMappingService
      * @var array<string, array{property: string, transform: string|null}>
      */
     private const DEFAULT_BG_MAPPINGS = [
-        'inp.bsn' => ['property' => 'bsn', 'transform' => null],
-        'geslachtsnaam' => ['property' => 'lastName', 'transform' => null],
+        'inp.bsn'                  => ['property' => 'bsn', 'transform' => null],
+        'geslachtsnaam'            => ['property' => 'lastName', 'transform' => null],
         'voorvoegselGeslachtsnaam' => ['property' => 'namePrefix', 'transform' => null],
-        'voornamen' => ['property' => 'firstName', 'transform' => null],
-        'geboortedatum' => ['property' => 'dateOfBirth', 'transform' => 'stufDateToIso'],
+        'voornamen'                => ['property' => 'firstName', 'transform' => null],
+        'geboortedatum'            => ['property' => 'dateOfBirth', 'transform' => 'stufDateToIso'],
     ];
 
     /**
@@ -82,14 +82,14 @@ class StufFieldMappingService
      * @var array<string, string>
      */
     private const CONFIDENTIALITY_MAP = [
-        'OPENBAAR' => 'public',
-        'BEPERKT OPENBAAR' => 'restricted',
-        'INTERN' => 'internal',
+        'OPENBAAR'          => 'public',
+        'BEPERKT OPENBAAR'  => 'restricted',
+        'INTERN'            => 'internal',
         'ZAAKVERTROUWELIJK' => 'case_sensitive',
-        'VERTROUWELIJK' => 'confidential',
-        'CONFIDENTIEEL' => 'highly_confidential',
-        'GEHEIM' => 'secret',
-        'ZEER GEHEIM' => 'top_secret',
+        'VERTROUWELIJK'     => 'confidential',
+        'CONFIDENTIEEL'     => 'highly_confidential',
+        'GEHEIM'            => 'secret',
+        'ZEER GEHEIM'       => 'top_secret',
     ];
 
     /**
@@ -107,7 +107,7 @@ class StufFieldMappingService
     public function __construct(
         private readonly LoggerInterface $logger,
     ) {
-    }
+    }//end __construct()
 
     /**
      * Map StUF-ZKN fields to OpenRegister case properties.
@@ -126,7 +126,7 @@ class StufFieldMappingService
         );
 
         return $this->applyMappings($stufData, $mappings, 'toInternal');
-    }
+    }//end mapZknToInternal()
 
     /**
      * Map OpenRegister case properties to StUF-ZKN fields.
@@ -145,7 +145,7 @@ class StufFieldMappingService
         );
 
         return $this->applyReverseMappings($internalData, $mappings);
-    }
+    }//end mapInternalToZkn()
 
     /**
      * Map StUF-BG fields to OpenRegister person properties.
@@ -164,7 +164,7 @@ class StufFieldMappingService
         );
 
         return $this->applyMappings($stufData, $mappings, 'toInternal');
-    }
+    }//end mapBgToInternal()
 
     /**
      * Map OpenRegister person properties to StUF-BG fields.
@@ -183,7 +183,7 @@ class StufFieldMappingService
         );
 
         return $this->applyReverseMappings($internalData, $mappings);
-    }
+    }//end mapInternalToBg()
 
     /**
      * Convert a StUF date (YYYYMMDD) to ISO 8601 (YYYY-MM-DD).
@@ -212,7 +212,7 @@ class StufFieldMappingService
 
         $this->logger->warning('Invalid StUF date format: {date}', ['date' => $stufDate]);
         return null;
-    }
+    }//end stufDateToIso()
 
     /**
      * Convert an ISO 8601 date to StUF date format (YYYYMMDD).
@@ -227,7 +227,7 @@ class StufFieldMappingService
     {
         $dt = new \DateTimeImmutable($isoDate);
         return $dt->format(self::STUF_DATE_FORMAT);
-    }
+    }//end isoToStufDate()
 
     /**
      * Convert an ISO 8601 datetime to StUF datetime format (YYYYMMDDHHmmss).
@@ -242,7 +242,7 @@ class StufFieldMappingService
     {
         $dt = new \DateTimeImmutable($isoDateTime);
         return $dt->format(self::STUF_DATETIME_FORMAT);
-    }
+    }//end isoToStufDateTime()
 
     /**
      * Convert a StUF confidentiality value to internal value.
@@ -256,7 +256,7 @@ class StufFieldMappingService
     public function confidentialityToInternal(string $stufValue): string
     {
         return self::CONFIDENTIALITY_MAP[strtoupper($stufValue)] ?? $stufValue;
-    }
+    }//end confidentialityToInternal()
 
     /**
      * Convert an internal confidentiality value to StUF value.
@@ -271,12 +271,12 @@ class StufFieldMappingService
     {
         $flipped = array_flip(self::CONFIDENTIALITY_MAP);
         return $flipped[$internalValue] ?? strtoupper($internalValue);
-    }
+    }//end confidentialityToStuf()
 
     /**
      * Add custom field mappings.
      *
-     * @param string                                                          $type     The mapping type ('zkn' or 'bg').
+     * @param string                                                         $type     The mapping type ('zkn' or 'bg').
      * @param array<string, array{property: string, transform: string|null}> $mappings The custom mappings.
      *
      * @return void
@@ -289,7 +289,7 @@ class StufFieldMappingService
             $this->customMappings[$type] ?? [],
             $mappings
         );
-    }
+    }//end addCustomMappings()
 
     /**
      * Get all default mappings for a type.
@@ -307,14 +307,14 @@ class StufFieldMappingService
             'bg' => self::DEFAULT_BG_MAPPINGS,
             default => [],
         };
-    }
+    }//end getDefaultMappings()
 
     /**
      * Apply mappings to convert StUF data to internal format.
      *
-     * @param array<string, string>                                           $data      The source data.
+     * @param array<string, string>                                          $data      The source data.
      * @param array<string, array{property: string, transform: string|null}> $mappings  The field mappings.
-     * @param string                                                          $direction The direction ('toInternal').
+     * @param string                                                         $direction The direction ('toInternal').
      *
      * @return array<string, mixed> The mapped data.
      */
@@ -327,8 +327,8 @@ class StufFieldMappingService
                 continue;
             }
 
-            $mapping = $mappings[$stufField];
-            $property = $mapping['property'];
+            $mapping   = $mappings[$stufField];
+            $property  = $mapping['property'];
             $transform = $mapping['transform'];
 
             if ($transform !== null && method_exists($this, $transform)) {
@@ -339,12 +339,12 @@ class StufFieldMappingService
         }
 
         return $result;
-    }
+    }//end applyMappings()
 
     /**
      * Apply reverse mappings to convert internal data to StUF format.
      *
-     * @param array<string, mixed>                                            $data     The internal data.
+     * @param array<string, mixed>                                           $data     The internal data.
      * @param array<string, array{property: string, transform: string|null}> $mappings The field mappings.
      *
      * @return array<string, string> The StUF data.
@@ -367,21 +367,21 @@ class StufFieldMappingService
                 continue;
             }
 
-            $info = $reverseLookup[$property];
+            $info      = $reverseLookup[$property];
             $stufField = $info['stufField'];
 
             // Apply reverse transform.
             if ($value !== null && $info['transform'] !== null) {
                 $value = match ($info['transform']) {
-                    'stufDateToIso' => $this->isoToStufDate((string)$value),
-                    'confidentialityToInternal' => $this->confidentialityToStuf((string)$value),
-                    default => (string)$value,
+                    'stufDateToIso' => $this->isoToStufDate((string) $value),
+                    'confidentialityToInternal' => $this->confidentialityToStuf((string) $value),
+                    default => (string) $value,
                 };
             }
 
-            $result[$stufField] = (string)($value ?? '');
+            $result[$stufField] = (string) ($value ?? '');
         }
 
         return $result;
-    }
-}
+    }//end applyReverseMappings()
+}//end class

--- a/lib/Service/StufFieldMappingService.php
+++ b/lib/Service/StufFieldMappingService.php
@@ -10,7 +10,7 @@
  * @category Service
  * @package  OCA\Procest\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Service/StufMessageBuilder.php
+++ b/lib/Service/StufMessageBuilder.php
@@ -65,9 +65,9 @@ class StufMessageBuilder
      * @var array<string, string>
      */
     public const NO_VALUE_TYPES = [
-        'geenWaarde' => 'geenWaarde',
-        'waardeOnbekend' => 'waardeOnbekend',
-        'nietOndersteund' => 'nietOndersteund',
+        'geenWaarde'          => 'geenWaarde',
+        'waardeOnbekend'      => 'waardeOnbekend',
+        'nietOndersteund'     => 'nietOndersteund',
         'vastgesteldOnbekend' => 'vastgesteldOnbekend',
     ];
 
@@ -79,7 +79,7 @@ class StufMessageBuilder
     public function __construct(
         private readonly LoggerInterface $logger,
     ) {
-    }
+    }//end __construct()
 
     /**
      * Build a complete SOAP envelope wrapping a StUF message body.
@@ -116,13 +116,13 @@ class StufMessageBuilder
         }
 
         return $dom->saveXML() ?: '';
-    }
+    }//end buildSoapEnvelope()
 
     /**
      * Build stuurgegevens XML element.
      *
-     * @param array<string, string> $zender    Sender info (organisatie, applicatie).
-     * @param array<string, string> $ontvanger Receiver info (organisatie, applicatie).
+     * @param array<string, string> $zender           Sender info (organisatie, applicatie).
+     * @param array<string, string> $ontvanger        Receiver info (organisatie, applicatie).
      * @param string|null           $referentienummer Reference number (auto-generated if null).
      *
      * @return string The stuurgegevens XML fragment.
@@ -132,27 +132,27 @@ class StufMessageBuilder
     public function buildStuurgegevens(
         array $zender,
         array $ontvanger,
-        ?string $referentienummer = null,
+        ?string $referentienummer=null,
     ): string {
-        $refNr = $referentienummer ?? $this->generateUuid();
+        $refNr    = $referentienummer ?? $this->generateUuid();
         $tijdstip = (new \DateTimeImmutable())->format('YmdHis');
 
-        $xml = '<stuf:stuurgegevens>';
+        $xml  = '<stuf:stuurgegevens>';
         $xml .= '<stuf:berichtcode>Lk01</stuf:berichtcode>';
         $xml .= '<stuf:zender>';
-        $xml .= '<stuf:organisatie>' . htmlspecialchars($zender['organisatie'] ?? '') . '</stuf:organisatie>';
-        $xml .= '<stuf:applicatie>' . htmlspecialchars($zender['applicatie'] ?? '') . '</stuf:applicatie>';
+        $xml .= '<stuf:organisatie>'.htmlspecialchars($zender['organisatie'] ?? '').'</stuf:organisatie>';
+        $xml .= '<stuf:applicatie>'.htmlspecialchars($zender['applicatie'] ?? '').'</stuf:applicatie>';
         $xml .= '</stuf:zender>';
         $xml .= '<stuf:ontvanger>';
-        $xml .= '<stuf:organisatie>' . htmlspecialchars($ontvanger['organisatie'] ?? '') . '</stuf:organisatie>';
-        $xml .= '<stuf:applicatie>' . htmlspecialchars($ontvanger['applicatie'] ?? '') . '</stuf:applicatie>';
+        $xml .= '<stuf:organisatie>'.htmlspecialchars($ontvanger['organisatie'] ?? '').'</stuf:organisatie>';
+        $xml .= '<stuf:applicatie>'.htmlspecialchars($ontvanger['applicatie'] ?? '').'</stuf:applicatie>';
         $xml .= '</stuf:ontvanger>';
-        $xml .= '<stuf:referentienummer>' . htmlspecialchars($refNr) . '</stuf:referentienummer>';
-        $xml .= '<stuf:tijdstipBericht>' . $tijdstip . '</stuf:tijdstipBericht>';
+        $xml .= '<stuf:referentienummer>'.htmlspecialchars($refNr).'</stuf:referentienummer>';
+        $xml .= '<stuf:tijdstipBericht>'.$tijdstip.'</stuf:tijdstipBericht>';
         $xml .= '</stuf:stuurgegevens>';
 
         return $xml;
-    }
+    }//end buildStuurgegevens()
 
     /**
      * Build a StUF Bv01 (bevestigingsbericht) response.
@@ -172,25 +172,25 @@ class StufMessageBuilder
     ): string {
         $tijdstip = (new \DateTimeImmutable())->format('YmdHis');
 
-        $body = '<stuf:Bv01Bericht xmlns:stuf="' . self::NS_STUF . '">';
+        $body  = '<stuf:Bv01Bericht xmlns:stuf="'.self::NS_STUF.'">';
         $body .= '<stuf:stuurgegevens>';
         $body .= '<stuf:berichtcode>Bv01</stuf:berichtcode>';
         $body .= '<stuf:zender>';
-        $body .= '<stuf:organisatie>' . htmlspecialchars($zender['organisatie'] ?? '') . '</stuf:organisatie>';
-        $body .= '<stuf:applicatie>' . htmlspecialchars($zender['applicatie'] ?? '') . '</stuf:applicatie>';
+        $body .= '<stuf:organisatie>'.htmlspecialchars($zender['organisatie'] ?? '').'</stuf:organisatie>';
+        $body .= '<stuf:applicatie>'.htmlspecialchars($zender['applicatie'] ?? '').'</stuf:applicatie>';
         $body .= '</stuf:zender>';
         $body .= '<stuf:ontvanger>';
-        $body .= '<stuf:organisatie>' . htmlspecialchars($ontvanger['organisatie'] ?? '') . '</stuf:organisatie>';
-        $body .= '<stuf:applicatie>' . htmlspecialchars($ontvanger['applicatie'] ?? '') . '</stuf:applicatie>';
+        $body .= '<stuf:organisatie>'.htmlspecialchars($ontvanger['organisatie'] ?? '').'</stuf:organisatie>';
+        $body .= '<stuf:applicatie>'.htmlspecialchars($ontvanger['applicatie'] ?? '').'</stuf:applicatie>';
         $body .= '</stuf:ontvanger>';
-        $body .= '<stuf:referentienummer>' . htmlspecialchars($this->generateUuid()) . '</stuf:referentienummer>';
-        $body .= '<stuf:tijdstipBericht>' . $tijdstip . '</stuf:tijdstipBericht>';
-        $body .= '<stuf:crossRefnummer>' . htmlspecialchars($crossRef) . '</stuf:crossRefnummer>';
+        $body .= '<stuf:referentienummer>'.htmlspecialchars($this->generateUuid()).'</stuf:referentienummer>';
+        $body .= '<stuf:tijdstipBericht>'.$tijdstip.'</stuf:tijdstipBericht>';
+        $body .= '<stuf:crossRefnummer>'.htmlspecialchars($crossRef).'</stuf:crossRefnummer>';
         $body .= '</stuf:stuurgegevens>';
         $body .= '</stuf:Bv01Bericht>';
 
         return $this->buildSoapEnvelope($body);
-    }
+    }//end buildBv01()
 
     /**
      * Build a StUF Fo01 (foutbericht) fault response.
@@ -214,29 +214,29 @@ class StufMessageBuilder
     ): string {
         $tijdstip = (new \DateTimeImmutable())->format('YmdHis');
 
-        $body = '<stuf:Fo01Bericht xmlns:stuf="' . self::NS_STUF . '">';
+        $body  = '<stuf:Fo01Bericht xmlns:stuf="'.self::NS_STUF.'">';
         $body .= '<stuf:stuurgegevens>';
         $body .= '<stuf:berichtcode>Fo01</stuf:berichtcode>';
         $body .= '<stuf:zender>';
-        $body .= '<stuf:organisatie>' . htmlspecialchars($zender['organisatie'] ?? '') . '</stuf:organisatie>';
-        $body .= '<stuf:applicatie>' . htmlspecialchars($zender['applicatie'] ?? '') . '</stuf:applicatie>';
+        $body .= '<stuf:organisatie>'.htmlspecialchars($zender['organisatie'] ?? '').'</stuf:organisatie>';
+        $body .= '<stuf:applicatie>'.htmlspecialchars($zender['applicatie'] ?? '').'</stuf:applicatie>';
         $body .= '</stuf:zender>';
         $body .= '<stuf:ontvanger>';
-        $body .= '<stuf:organisatie>' . htmlspecialchars($ontvanger['organisatie'] ?? '') . '</stuf:organisatie>';
-        $body .= '<stuf:applicatie>' . htmlspecialchars($ontvanger['applicatie'] ?? '') . '</stuf:applicatie>';
+        $body .= '<stuf:organisatie>'.htmlspecialchars($ontvanger['organisatie'] ?? '').'</stuf:organisatie>';
+        $body .= '<stuf:applicatie>'.htmlspecialchars($ontvanger['applicatie'] ?? '').'</stuf:applicatie>';
         $body .= '</stuf:ontvanger>';
-        $body .= '<stuf:referentienummer>' . htmlspecialchars($this->generateUuid()) . '</stuf:referentienummer>';
-        $body .= '<stuf:tijdstipBericht>' . $tijdstip . '</stuf:tijdstipBericht>';
+        $body .= '<stuf:referentienummer>'.htmlspecialchars($this->generateUuid()).'</stuf:referentienummer>';
+        $body .= '<stuf:tijdstipBericht>'.$tijdstip.'</stuf:tijdstipBericht>';
         $body .= '</stuf:stuurgegevens>';
         $body .= '<stuf:body>';
-        $body .= '<stuf:code>' . htmlspecialchars($foutcode) . '</stuf:code>';
-        $body .= '<stuf:plek>' . htmlspecialchars($plek) . '</stuf:plek>';
-        $body .= '<stuf:omschrijving>' . htmlspecialchars($foutbeschrijving) . '</stuf:omschrijving>';
+        $body .= '<stuf:code>'.htmlspecialchars($foutcode).'</stuf:code>';
+        $body .= '<stuf:plek>'.htmlspecialchars($plek).'</stuf:plek>';
+        $body .= '<stuf:omschrijving>'.htmlspecialchars($foutbeschrijving).'</stuf:omschrijving>';
         $body .= '</stuf:body>';
         $body .= '</stuf:Fo01Bericht>';
 
         return $this->buildSoapEnvelope($body);
-    }
+    }//end buildFo01()
 
     /**
      * Build a SOAP Fault response for invalid XML.
@@ -269,7 +269,7 @@ class StufMessageBuilder
         $fault->appendChild($faultstringEl);
 
         return $dom->saveXML() ?: '';
-    }
+    }//end buildSoapFault()
 
     /**
      * Generate a UUID.
@@ -289,5 +289,5 @@ class StufMessageBuilder
             mt_rand(0, 0xffff),
             mt_rand(0, 0xffff)
         );
-    }
-}
+    }//end generateUuid()
+}//end class

--- a/lib/Service/StufMessageBuilder.php
+++ b/lib/Service/StufMessageBuilder.php
@@ -9,7 +9,7 @@
  * @category Service
  * @package  OCA\Procest\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Service/TemplateLibraryService.php
+++ b/lib/Service/TemplateLibraryService.php
@@ -35,8 +35,7 @@ class TemplateLibraryService
     /**
      * Path to the templates directory.
      */
-    private const TEMPLATES_DIR = __DIR__ . '/../Settings/templates';
-
+    private const TEMPLATES_DIR = __DIR__.'/../Settings/templates';
 
     /**
      * Constructor.
@@ -48,8 +47,7 @@ class TemplateLibraryService
         private readonly SettingsService $settingsService,
         private readonly LoggerInterface $logger,
     ) {
-    }
-
+    }//end __construct()
 
     /**
      * List all available zaaktype templates.
@@ -67,7 +65,7 @@ class TemplateLibraryService
             return $templates;
         }
 
-        $files = glob($dir . '/*.json');
+        $files = glob($dir.'/*.json');
         if ($files === false) {
             return $templates;
         }
@@ -81,7 +79,7 @@ class TemplateLibraryService
             $data = json_decode($content, true);
             if (json_last_error() !== JSON_ERROR_NONE || is_array($data) === false) {
                 $this->logger->warning(
-                    'Invalid template file: ' . basename($file),
+                    'Invalid template file: '.basename($file),
                     ['app' => Application::APP_ID]
                 );
                 continue;
@@ -95,11 +93,10 @@ class TemplateLibraryService
                 'version'     => $data['version'] ?? '1.0.0',
                 'file'        => basename($file),
             ];
-        }
+        }//end foreach
 
         return $templates;
-    }
-
+    }//end listTemplates()
 
     /**
      * Load a template by its ID.
@@ -116,7 +113,7 @@ class TemplateLibraryService
             return null;
         }
 
-        $files = glob($dir . '/*.json');
+        $files = glob($dir.'/*.json');
         if ($files === false) {
             return null;
         }
@@ -139,8 +136,7 @@ class TemplateLibraryService
         }
 
         return null;
-    }
-
+    }//end loadTemplate()
 
     /**
      * Activate a template by creating OpenRegister objects for the case type and related entities.
@@ -163,7 +159,7 @@ class TemplateLibraryService
     {
         $template = $this->loadTemplate($templateId);
         if ($template === null) {
-            throw new \RuntimeException('Template not found: ' . $templateId);
+            throw new \RuntimeException('Template not found: '.$templateId);
         }
 
         $objectService = $this->settingsService->getObjectService();
@@ -187,21 +183,21 @@ class TemplateLibraryService
         ];
 
         // Create the case type.
-        $caseTypeSchema = $this->settingsService->getConfigValue('case_type_schema');
-        $caseTypeData   = $template['caseType'] ?? [];
-        $caseType       = $objectService->saveObject(
+        $caseTypeSchema     = $this->settingsService->getConfigValue('case_type_schema');
+        $caseTypeData       = $template['caseType'] ?? [];
+        $caseType           = $objectService->saveObject(
             $register,
             $caseTypeSchema,
             $caseTypeData,
         );
-        $caseTypeId     = $caseType->getUuid();
+        $caseTypeId         = $caseType->getUuid();
         $result['caseType'] = $caseTypeId;
 
         // Create status types.
         $statusTypeSchema = $this->settingsService->getConfigValue('status_type_schema');
         foreach (($template['statusTypes'] ?? []) as $statusData) {
             $statusData['caseType'] = $caseTypeId;
-            $status                 = $objectService->saveObject(
+            $status = $objectService->saveObject(
                 $register,
                 $statusTypeSchema,
                 $statusData,
@@ -213,7 +209,7 @@ class TemplateLibraryService
         $propertySchema = $this->settingsService->getConfigValue('property_definition_schema');
         foreach (($template['propertyDefinitions'] ?? []) as $propData) {
             $propData['caseType'] = $caseTypeId;
-            $prop                 = $objectService->saveObject(
+            $prop = $objectService->saveObject(
                 $register,
                 $propertySchema,
                 $propData,
@@ -225,7 +221,7 @@ class TemplateLibraryService
         $docTypeSchema = $this->settingsService->getConfigValue('document_type_schema');
         foreach (($template['documentTypes'] ?? []) as $docData) {
             $docData['caseType'] = $caseTypeId;
-            $doc                 = $objectService->saveObject(
+            $doc = $objectService->saveObject(
                 $register,
                 $docTypeSchema,
                 $docData,
@@ -237,7 +233,7 @@ class TemplateLibraryService
         $decisionTypeSchema = $this->settingsService->getConfigValue('decision_type_schema');
         foreach (($template['decisionTypes'] ?? []) as $decData) {
             $decData['caseType'] = $caseTypeId;
-            $dec                 = $objectService->saveObject(
+            $dec = $objectService->saveObject(
                 $register,
                 $decisionTypeSchema,
                 $decData,
@@ -249,7 +245,7 @@ class TemplateLibraryService
         $roleTypeSchema = $this->settingsService->getConfigValue('role_type_schema');
         foreach (($template['roleTypes'] ?? []) as $roleData) {
             $roleData['caseType'] = $caseTypeId;
-            $role                 = $objectService->saveObject(
+            $role = $objectService->saveObject(
                 $register,
                 $roleTypeSchema,
                 $roleData,
@@ -258,10 +254,10 @@ class TemplateLibraryService
         }
 
         $this->logger->info(
-            'Template activated: ' . $templateId . ' -> caseType ' . $caseTypeId,
+            'Template activated: '.$templateId.' -> caseType '.$caseTypeId,
             ['app' => Application::APP_ID]
         );
 
         return $result;
-    }
-}
+    }//end activateTemplate()
+}//end class

--- a/lib/Service/TemplateLibraryService.php
+++ b/lib/Service/TemplateLibraryService.php
@@ -10,7 +10,7 @@
  * @category Service
  * @package  OCA\Procest\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Service/TenantService.php
+++ b/lib/Service/TenantService.php
@@ -8,7 +8,7 @@
  * @category Service
  * @package  OCA\Procest\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Service/TenantService.php
+++ b/lib/Service/TenantService.php
@@ -48,8 +48,8 @@ class TenantService
      * @param IAppManager        $appManager      The app manager
      * @param IGroupManager      $groupManager    The Nextcloud group manager
      * @param IUserManager       $userManager     The Nextcloud user manager
-     * @param ContainerInterface $container        The DI container
-     * @param LoggerInterface    $logger           The logger
+     * @param ContainerInterface $container       The DI container
+     * @param LoggerInterface    $logger          The logger
      *
      * @return void
      */
@@ -205,10 +205,12 @@ class TenantService
         // Create a dedicated register for this tenant.
         try {
             $registerService = $this->container->get('OCA\OpenRegister\Service\RegisterService');
-            $newRegister     = $registerService->createFromArray([
-                'title'       => 'Procest - '.$tenantData['name'],
-                'description' => 'Case management register for '.$tenantData['name'],
-            ]);
+            $newRegister     = $registerService->createFromArray(
+                    [
+                        'title'       => 'Procest - '.$tenantData['name'],
+                        'description' => 'Case management register for '.$tenantData['name'],
+                    ]
+                    );
 
             $tenantData['registerId'] = (string) $newRegister->getId();
         } catch (\Exception $e) {

--- a/lib/Service/ZgwBrcRulesService.php
+++ b/lib/Service/ZgwBrcRulesService.php
@@ -8,7 +8,7 @@
  * @category Service
  * @package  OCA\Procest\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Service/ZgwBusinessRulesService.php
+++ b/lib/Service/ZgwBusinessRulesService.php
@@ -15,7 +15,7 @@
  * @category Service
  * @package  OCA\Procest\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Service/ZgwDocumentService.php
+++ b/lib/Service/ZgwDocumentService.php
@@ -9,7 +9,7 @@
  * @category Service
  * @package  OCA\Procest\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Service/ZgwDrcRulesService.php
+++ b/lib/Service/ZgwDrcRulesService.php
@@ -8,7 +8,7 @@
  * @category Service
  * @package  OCA\Procest\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Service/ZgwMappingService.php
+++ b/lib/Service/ZgwMappingService.php
@@ -10,7 +10,7 @@
  * @category Service
  * @package  OCA\Procest\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Service/ZgwPaginationHelper.php
+++ b/lib/Service/ZgwPaginationHelper.php
@@ -8,7 +8,7 @@
  * @category Service
  * @package  OCA\Procest\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Service/ZgwRulesBase.php
+++ b/lib/Service/ZgwRulesBase.php
@@ -10,7 +10,7 @@
  * @category Service
  * @package  OCA\Procest\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Service/ZgwService.php
+++ b/lib/Service/ZgwService.php
@@ -10,7 +10,7 @@
  * @category Service
  * @package  OCA\Procest\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Service/ZgwZrcRulesService.php
+++ b/lib/Service/ZgwZrcRulesService.php
@@ -145,7 +145,7 @@ class ZgwZrcRulesService extends ZgwRulesBase
                             register: $register,
                             schema: $schema
                         );
-                        $ztData = is_array($zaaktype) === true ? $zaaktype : $zaaktype->jsonSerialize();
+                        $ztData   = is_array($zaaktype) === true ? $zaaktype : $zaaktype->jsonSerialize();
                         if (empty($ztData['defaultAssignee']) === false) {
                             $body['assignee'] = $ztData['defaultAssignee'];
                         }
@@ -154,7 +154,7 @@ class ZgwZrcRulesService extends ZgwRulesBase
                     }
                 }
             }
-        }
+        }//end if
 
         return $this->validateZaakFields(result: $this->isValid(body: $body), existingObject: null, isPatch: false);
     }//end rulesZakenCreate()

--- a/lib/Service/ZgwZrcRulesService.php
+++ b/lib/Service/ZgwZrcRulesService.php
@@ -8,7 +8,7 @@
  * @category Service
  * @package  OCA\Procest\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Service/ZgwZtcRulesService.php
+++ b/lib/Service/ZgwZtcRulesService.php
@@ -8,7 +8,7 @@
  * @category Service
  * @package  OCA\Procest\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -8,7 +8,7 @@
  * @category Settings
  * @package  OCA\Procest\Settings
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/tests/Unit/Controller/GisProxyControllerTest.php
+++ b/tests/Unit/Controller/GisProxyControllerTest.php
@@ -9,7 +9,7 @@
  * @category Tests
  * @package  OCA\Procest\Tests\Unit\Controller
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/tests/Unit/Controller/HealthControllerTest.php
+++ b/tests/Unit/Controller/HealthControllerTest.php
@@ -8,7 +8,7 @@
  * @category Tests
  * @package  OCA\Procest\Tests\Unit\Controller
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/tests/Unit/Controller/MetricsControllerTest.php
+++ b/tests/Unit/Controller/MetricsControllerTest.php
@@ -8,7 +8,7 @@
  * @category Tests
  * @package  OCA\Procest\Tests\Unit\Controller
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/tests/Unit/Dashboard/SignaleringWidgetsTest.php
+++ b/tests/Unit/Dashboard/SignaleringWidgetsTest.php
@@ -8,7 +8,7 @@
  * @category Tests
  * @package  OCA\Procest\Tests\Unit\Dashboard
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/tests/Unit/Middleware/ZgwAuthMiddlewareTest.php
+++ b/tests/Unit/Middleware/ZgwAuthMiddlewareTest.php
@@ -8,7 +8,7 @@
  * @category Tests
  * @package  OCA\Procest\Tests\Unit\Middleware
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/tests/Unit/Repair/SeedBezwaarBeroepDataTest.php
+++ b/tests/Unit/Repair/SeedBezwaarBeroepDataTest.php
@@ -9,7 +9,7 @@
  * @category Tests
  * @package  OCA\Procest\Tests\Unit\Repair
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/tests/Unit/Service/GisProxyServiceTest.php
+++ b/tests/Unit/Service/GisProxyServiceTest.php
@@ -9,7 +9,7 @@
  * @category Tests
  * @package  OCA\Procest\Tests\Unit\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/tests/Unit/Service/ParaferingNotificationServiceTest.php
+++ b/tests/Unit/Service/ParaferingNotificationServiceTest.php
@@ -9,7 +9,7 @@
  * @category Tests
  * @package  OCA\Procest\Tests\Unit\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/tests/Unit/Service/SeedDataServiceTest.php
+++ b/tests/Unit/Service/SeedDataServiceTest.php
@@ -9,7 +9,7 @@
  * @category Tests
  * @package  OCA\Procest\Tests\Unit\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/tests/Unit/Service/SettingsServiceTest.php
+++ b/tests/Unit/Service/SettingsServiceTest.php
@@ -8,7 +8,7 @@
  * @category Tests
  * @package  OCA\Procest\Tests\Unit\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/tests/Unit/Service/VthSettingsServiceTest.php
+++ b/tests/Unit/Service/VthSettingsServiceTest.php
@@ -10,7 +10,7 @@
  * @category Tests
  * @package  OCA\Procest\Tests\Unit\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/tests/Unit/Service/ZgwMappingServiceTest.php
+++ b/tests/Unit/Service/ZgwMappingServiceTest.php
@@ -8,7 +8,7 @@
  * @category Tests
  * @package  OCA\Procest\Tests\Unit\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/tests/Unit/Service/ZgwPaginationHelperTest.php
+++ b/tests/Unit/Service/ZgwPaginationHelperTest.php
@@ -8,7 +8,7 @@
  * @category Tests
  * @package  OCA\Procest\Tests\Unit\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/tests/Unit/Service/ZgwZrcRulesServiceTest.php
+++ b/tests/Unit/Service/ZgwZrcRulesServiceTest.php
@@ -8,7 +8,7 @@
  * @category Tests
  * @package  OCA\Procest\Tests\Unit\Service
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/tests/Unit/Settings/VthSchemaTest.php
+++ b/tests/Unit/Settings/VthSchemaTest.php
@@ -10,7 +10,7 @@
  * @category Tests
  * @package  OCA\Procest\Tests\Unit\Settings
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/tests/Unit/Settings/WorkflowEngineSchemaTest.php
+++ b/tests/Unit/Settings/WorkflowEngineSchemaTest.php
@@ -9,7 +9,7 @@
  * @category Tests
  * @package  OCA\Procest\Tests\Unit\Settings
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,7 +8,7 @@
  * @category Tests
  * @package  OCA\Procest\Tests
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *


### PR DESCRIPTION
## Summary

Two commits:

1. **phpcbf auto-fixes** — 1147 phpcs violations resolved across 46 lib/ files. Remaining 393 errors require human judgment (named-parameter rewrites, `!` → `=== FALSE`, implicit truthy, inline-if → ternary, etc.)
2. **Email typo sweep** — `dev@conductio.nl` → `info@conduction.nl` across 93 docblock `@author` tags. Same literal replacement as decidesk#123, pipelinq forthcoming.

Before: 1540 phpcs errors. After: 393. (75% reduction.)

## Why

Template fix lives in ConductionNL/nextcloud-app-template#19 — this PR propagates it to procest plus knocks out the auto-fixable phpcs backlog that accumulated on development.

## Test plan

- [ ] `composer check:strict` passes
- [ ] `./vendor/bin/phpcs` reports only the 393 manual-fix violations
- [ ] No references to `dev@conductio.nl` remain in the repo