### PR TITLE
chore(openspec): Chain task-management spec + add integration registry stubs

### DIFF
--- a/openspec/changes/integration-maps/README.md
+++ b/openspec/changes/integration-maps/README.md
@@ -1,0 +1,7 @@
+# integration-maps (cross-repo stub)
+
+Authoritative spec: [ConductionNL/openregister → openspec/changes/integration-maps](https://github.com/ConductionNL/openregister/tree/development/openspec/changes/integration-maps).
+
+Tracking issue: https://github.com/ConductionNL/openregister/issues/1316
+
+Stub exists so Hydra's sibling-based dependency check can resolve cross-repo `depends_on`.

--- a/openspec/changes/integration-maps/hydra.json
+++ b/openspec/changes/integration-maps/hydra.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 2,
+  "spec_slug": "integration-maps",
+  "app": "openregister",
+  "repo": "https://github.com/ConductionNL/openregister",
+  "issue": "https://github.com/ConductionNL/openregister/issues/1316",
+  "depends_on": [],
+  "cross_repo_stub": true,
+  "note": "Cross-repo dependency stub. Authoritative spec lives in ConductionNL/openregister. Do NOT edit here.",
+  "pipeline": {},
+  "cycles": []
+}

--- a/openspec/changes/pluggable-integration-registry/README.md
+++ b/openspec/changes/pluggable-integration-registry/README.md
@@ -1,0 +1,7 @@
+# pluggable-integration-registry (cross-repo stub)
+
+Authoritative spec: [ConductionNL/openregister → openspec/changes/pluggable-integration-registry](https://github.com/ConductionNL/openregister/tree/development/openspec/changes/pluggable-integration-registry).
+
+Tracking issue: https://github.com/ConductionNL/openregister/issues/1307
+
+Stub exists so Hydra's sibling-based dependency check can resolve cross-repo `depends_on`.

--- a/openspec/changes/pluggable-integration-registry/hydra.json
+++ b/openspec/changes/pluggable-integration-registry/hydra.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 2,
+  "spec_slug": "pluggable-integration-registry",
+  "app": "openregister",
+  "repo": "https://github.com/ConductionNL/openregister",
+  "issue": "https://github.com/ConductionNL/openregister/issues/1307",
+  "depends_on": [],
+  "cross_repo_stub": true,
+  "note": "Cross-repo dependency stub. Authoritative spec lives in ConductionNL/openregister. Do NOT edit here.",
+  "pipeline": {},
+  "cycles": []
+}

--- a/openspec/changes/task-management/hydra.json
+++ b/openspec/changes/task-management/hydra.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 2,
+  "spec_slug": "task-management",
+  "app": "procest",
+  "repo": "https://github.com/ConductionNL/procest",
+  "depends_on": [
+    "pluggable-integration-registry"
+  ],
+  "issue": "",
+  "pipeline": {},
+  "cycles": []
+}


### PR DESCRIPTION
## Summary

Chains procest specs to the OpenRegister integration registry. Same cross-repo stub pattern as decidesk ([#133](https://github.com/ConductionNL/decidesk/pull/133)) and pipelinq ([#310](https://github.com/ConductionNL/pipelinq/pull/310)).

## Chained spec
- `task-management` → `pluggable-integration-registry` (umbrella satisfies the tasks built-in provider dep)

## Cross-repo stubs added (2)
- `integration-maps` → ConductionNL/openregister#1316
- `pluggable-integration-registry` → ConductionNL/openregister#1307

## Future drafts
Specter DB has `case-location`, `case-map-overview`, `map-component`, and `parafering-audit-trail` as drafts for this repo — not yet in the repo. When they're pushed, the stubs are already here to resolve their upstream deps.

## Stub pattern
Each stub is a directory with only `hydra.json` + short README. Stub's `hydra.json.issue` points at the upstream openregister tracking issue. Hydra's sibling dep check reads the stub, polls the upstream issue state, and resolves the cross-repo dep through the existing mechanism.

## Test plan
- [ ] Stub pattern acceptable
- [ ] `task-management` hydra.json preserves existing local deps