### PR TITLE
docs(adr): foundation cleanup — adr-000 non-ADR header reframe

### DIFF
--- a/openspec/architecture/adr-000-data-model.md
+++ b/openspec/architecture/adr-000-data-model.md
@@ -1,5 +1,17 @@
 # Data Model — Procest
 
+> **Note:** despite the `adr-000-` filename, this is **not** an ADR — it's
+> the per-app entity catalogue. The OR-contract paragraphs below are a
+> reminder of the platform's authoritative ADRs (hydra
+> [ADR-001 Data layer](../../../hydra/openspec/architecture/adr-001-data-layer.md)
+> and
+> [ADR-022 Apps consume OR abstractions](../../../hydra/openspec/architecture/adr-022-apps-consume-or-abstractions.md)),
+> not duplicates or override decisions. Any architecture decision
+> specific to procest belongs in a properly-numbered file (`adr-001-…`,
+> `adr-002-…`, …) with a Status / Date / Context / Decision /
+> Consequences shape. Filename rename to `data-model.md` (no `adr-`
+> prefix) is queued — see procest's adoption change.
+
 **App:** Procest — Case management, VTH, forms
 **Platform:** OpenRegister (register/schema/object pattern)
 **Entities:** 39


### PR DESCRIPTION
## Summary

Phase 1 of the OR-abstraction audit (2026-05-03). One doc-only fix.

`adr-000-data-model.md` is the per-app entity catalogue (39 procest entities), not an architecture decision. Added a non-ADR header citing hydra ADR-001 + ADR-022 so the OR-contract reminder isn't mistaken for a duplicate ADR (the anti-pattern hydra ADR-022 was written to prevent). Filename rename to `data-model.md` is queued for the upcoming procest adoption change.

## Test plan

- [x] No code changes
- [x] hydra ADR-022 cross-link resolves