### PR TITLE
chore: add SPDX headers to lib/ (51/89, partial)

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -12,6 +12,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/BackgroundJob/ShareMaintenanceJob.php
+++ b/lib/BackgroundJob/ShareMaintenanceJob.php
@@ -12,6 +12,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Controller/AcController.php
+++ b/lib/Controller/AcController.php
@@ -14,6 +14,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Controller/AiController.php
+++ b/lib/Controller/AiController.php
@@ -14,6 +14,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Controller/BrcController.php
+++ b/lib/Controller/BrcController.php
@@ -14,6 +14,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Controller/CaseDefinitionController.php
+++ b/lib/Controller/CaseDefinitionController.php
@@ -13,6 +13,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Controller/CaseSharingController.php
+++ b/lib/Controller/CaseSharingController.php
@@ -12,6 +12,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Controller/ConsultationController.php
+++ b/lib/Controller/ConsultationController.php
@@ -12,6 +12,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Controller/DashboardController.php
+++ b/lib/Controller/DashboardController.php
@@ -12,6 +12,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Controller/DrcController.php
+++ b/lib/Controller/DrcController.php
@@ -14,6 +14,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Controller/EmailController.php
+++ b/lib/Controller/EmailController.php
@@ -12,6 +12,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Controller/GisProxyController.php
+++ b/lib/Controller/GisProxyController.php
@@ -13,6 +13,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Controller/HealthController.php
+++ b/lib/Controller/HealthController.php
@@ -12,6 +12,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Controller/InspectionController.php
+++ b/lib/Controller/InspectionController.php
@@ -13,6 +13,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Controller/LegesController.php
+++ b/lib/Controller/LegesController.php
@@ -13,6 +13,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Controller/MetricsController.php
+++ b/lib/Controller/MetricsController.php
@@ -12,6 +12,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Controller/MilestoneController.php
+++ b/lib/Controller/MilestoneController.php
@@ -12,6 +12,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Controller/NrcController.php
+++ b/lib/Controller/NrcController.php
@@ -14,6 +14,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Controller/ParaferingController.php
+++ b/lib/Controller/ParaferingController.php
@@ -13,6 +13,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Controller/PublicShareController.php
+++ b/lib/Controller/PublicShareController.php
@@ -12,6 +12,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -12,6 +12,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Controller/StufController.php
+++ b/lib/Controller/StufController.php
@@ -14,6 +14,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Controller/TemplateController.php
+++ b/lib/Controller/TemplateController.php
@@ -12,6 +12,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Controller/TenantController.php
+++ b/lib/Controller/TenantController.php
@@ -12,6 +12,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Controller/ZgwMappingController.php
+++ b/lib/Controller/ZgwMappingController.php
@@ -12,6 +12,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Controller/ZrcController.php
+++ b/lib/Controller/ZrcController.php
@@ -17,6 +17,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Controller/ZtcController.php
+++ b/lib/Controller/ZtcController.php
@@ -15,6 +15,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Dashboard/CasesOverviewWidget.php
+++ b/lib/Dashboard/CasesOverviewWidget.php
@@ -12,6 +12,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Dashboard/DeadlineAlertsWidget.php
+++ b/lib/Dashboard/DeadlineAlertsWidget.php
@@ -13,6 +13,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Dashboard/MyTasksWidget.php
+++ b/lib/Dashboard/MyTasksWidget.php
@@ -12,6 +12,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Dashboard/OverdueCasesWidget.php
+++ b/lib/Dashboard/OverdueCasesWidget.php
@@ -12,6 +12,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Dashboard/StalledCasesWidget.php
+++ b/lib/Dashboard/StalledCasesWidget.php
@@ -13,6 +13,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Dashboard/StartCaseWidget.php
+++ b/lib/Dashboard/StartCaseWidget.php
@@ -12,6 +12,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Dashboard/TaskRemindersWidget.php
+++ b/lib/Dashboard/TaskRemindersWidget.php
@@ -13,6 +13,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Listener/DeepLinkRegistrationListener.php
+++ b/lib/Listener/DeepLinkRegistrationListener.php
@@ -12,6 +12,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Middleware/TenantMiddleware.php
+++ b/lib/Middleware/TenantMiddleware.php
@@ -12,6 +12,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Middleware/ZgwAuthException.php
+++ b/lib/Middleware/ZgwAuthException.php
@@ -12,6 +12,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Middleware/ZgwAuthMiddleware.php
+++ b/lib/Middleware/ZgwAuthMiddleware.php
@@ -12,6 +12,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Repair/InitializeSettings.php
+++ b/lib/Repair/InitializeSettings.php
@@ -12,6 +12,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Repair/LoadDefaultZgwMappings.php
+++ b/lib/Repair/LoadDefaultZgwMappings.php
@@ -14,6 +14,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Repair/SeedBezwaarBeroepData.php
+++ b/lib/Repair/SeedBezwaarBeroepData.php
@@ -13,6 +13,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Sections/SettingsSection.php
+++ b/lib/Sections/SettingsSection.php
@@ -12,6 +12,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Service/AiService.php
+++ b/lib/Service/AiService.php
@@ -14,6 +14,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Service/CaseDefinitionExportService.php
+++ b/lib/Service/CaseDefinitionExportService.php
@@ -13,6 +13,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Service/CaseDefinitionImportService.php
+++ b/lib/Service/CaseDefinitionImportService.php
@@ -13,6 +13,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Service/CaseEmailService.php
+++ b/lib/Service/CaseEmailService.php
@@ -14,6 +14,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Service/CaseSharingService.php
+++ b/lib/Service/CaseSharingService.php
@@ -12,6 +12,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Service/CaseTransferService.php
+++ b/lib/Service/CaseTransferService.php
@@ -12,6 +12,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Service/ChecklistService.php
+++ b/lib/Service/ChecklistService.php
@@ -13,6 +13,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Service/ConsultationService.php
+++ b/lib/Service/ConsultationService.php
@@ -14,6 +14,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -12,6 +12,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
  * @version GIT: <git-id>
  *
  * @link https://procest.nl


### PR DESCRIPTION
## Summary

Adds `SPDX-License-Identifier: EUPL-1.2` + `SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>` lines INSIDE the main file docblock for **51 PHP files** in `lib/`. Per project memory `feedback_spdx-in-docblock.md`: SPDX must live INSIDE the docblock, not as line comments.

This is a **partial** rollout — the remaining 38 files (mostly `Service/Zgw*`, `Service/Appointment*`, `Service/Berichtenbox*`, plus a few BackgroundJob entries) hit the automation usage cap and are queued for a follow-up PR.

## Test plan

- [x] All 51 modified files contain both SPDX lines inside their main docblock
- [x] No code changes — only docblock additions (153 insertions, 0 deletions)
- [x] No non-PHP files touched

## Audit reference

2026-05-03 OR-abstraction audit, stream 3 (repo hygiene) — procest at 0/89; this PR brings it to 51/89.

## Auto-merge

procest is pre-production per `feedback_pr-merge-authority.md` — markdown- and docblock-only PR auto-merged on creation.