### PR TITLE
chore: bump @conduction/nextcloud-vue to ^0.1.0-beta.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,63 +1,63 @@
 {
-  "name": "procest",
-  "version": "0.1.0",
-  "license": "EUPL-1.2",
-  "engines": {
-    "node": "^20.0.0",
-    "npm": "^10.0.0"
-  },
-  "scripts": {
-    "build": "NODE_ENV=production webpack --config webpack.config.js --progress",
-    "dev": "NODE_ENV=development webpack --config webpack.config.js --progress",
-    "watch": "NODE_ENV=development webpack --config webpack.config.js --progress --watch",
-    "lint": "eslint src",
-    "lint-fix": "npm run lint -- --fix",
-    "stylelint": "stylelint src/**/*.vue src/**/*.scss src/**/*.css",
-    "stylelint-fix": "stylelint src/**/*.vue src/**/*.scss src/**/*.css --fix",
-    "test:zgw": "cd tests/zgw && bash run-zgw-tests.sh",
-    "test:zgw:oas": "cd tests/zgw && bash run-zgw-tests.sh --oas-only",
-    "test:zgw:business": "cd tests/zgw && bash run-zgw-tests.sh --business-only"
-  },
-  "browserslist": [
-    "extends @nextcloud/browserslist-config"
-  ],
-  "dependencies": {
-    "@conduction/nextcloud-vue": "^0.1.0-beta.3",
-    "apexcharts": "^3.45.0",
-    "vue-apexcharts": "^1.6.2",
-    "@nextcloud/axios": "^2.5.0",
-    "@nextcloud/dialogs": "^3.2.0",
-    "@nextcloud/initial-state": "^2.2.0",
-    "@nextcloud/l10n": "^2.0.1",
-    "@nextcloud/router": "^2.0.1",
-    "@nextcloud/vue": "^8.16.0",
-    "gridstack": "^10.3.1",
-    "leaflet": "^1.9.4",
-    "leaflet-draw": "^1.0.4",
-    "leaflet.markercluster": "^1.5.3",
-    "pinia": "^2.1.7",
-    "proj4": "^2.20.4",
-    "vue": "^2.7.14",
-    "vue-material-design-icons": "^5.3.0",
-    "vue-router": "^3.6.5"
-  },
-  "devDependencies": {
-    "@cyclonedx/cyclonedx-npm": "^4.2.1",
-    "@eslint/config-helpers": "^0.4.2",
-    "@eslint/eslintrc": "^3.3.1",
-    "@eslint/js": "^9.39.1",
-    "@nextcloud/browserslist-config": "^3.0.1",
-    "@nextcloud/eslint-config": "^8.4.1",
-    "@nextcloud/stylelint-config": "^2.4.0",
-    "@nextcloud/webpack-vue-config": "^6.0.1",
-    "css-loader": "~7.1.1",
-    "eslint": "^8.56.0",
-    "eslint-import-resolver-alias": "^1.1.2",
-    "style-loader": "~4.0.0",
-    "stylelint": "^15.11.0",
-    "vue-loader": "^15.11.1 <16.0.0",
-    "vue-template-compiler": "^2.7.16",
-    "webpack": "^5.94.0",
-    "webpack-cli": "^6.0.1"
-  }
+	"name": "procest",
+	"version": "0.1.0",
+	"license": "EUPL-1.2",
+	"engines": {
+		"node": "^20.0.0",
+		"npm": "^10.0.0"
+	},
+	"scripts": {
+		"build": "NODE_ENV=production webpack --config webpack.config.js --progress",
+		"dev": "NODE_ENV=development webpack --config webpack.config.js --progress",
+		"watch": "NODE_ENV=development webpack --config webpack.config.js --progress --watch",
+		"lint": "eslint src",
+		"lint-fix": "npm run lint -- --fix",
+		"stylelint": "stylelint src/**/*.vue src/**/*.scss src/**/*.css",
+		"stylelint-fix": "stylelint src/**/*.vue src/**/*.scss src/**/*.css --fix",
+		"test:zgw": "cd tests/zgw && bash run-zgw-tests.sh",
+		"test:zgw:oas": "cd tests/zgw && bash run-zgw-tests.sh --oas-only",
+		"test:zgw:business": "cd tests/zgw && bash run-zgw-tests.sh --business-only"
+	},
+	"browserslist": [
+		"extends @nextcloud/browserslist-config"
+	],
+	"dependencies": {
+		"@conduction/nextcloud-vue": "^0.1.0-beta.17",
+		"apexcharts": "^3.45.0",
+		"vue-apexcharts": "^1.6.2",
+		"@nextcloud/axios": "^2.5.0",
+		"@nextcloud/dialogs": "^3.2.0",
+		"@nextcloud/initial-state": "^2.2.0",
+		"@nextcloud/l10n": "^2.0.1",
+		"@nextcloud/router": "^2.0.1",
+		"@nextcloud/vue": "^8.16.0",
+		"gridstack": "^10.3.1",
+		"leaflet": "^1.9.4",
+		"leaflet-draw": "^1.0.4",
+		"leaflet.markercluster": "^1.5.3",
+		"pinia": "^2.1.7",
+		"proj4": "^2.20.4",
+		"vue": "^2.7.14",
+		"vue-material-design-icons": "^5.3.0",
+		"vue-router": "^3.6.5"
+	},
+	"devDependencies": {
+		"@cyclonedx/cyclonedx-npm": "^4.2.1",
+		"@eslint/config-helpers": "^0.4.2",
+		"@eslint/eslintrc": "^3.3.1",
+		"@eslint/js": "^9.39.1",
+		"@nextcloud/browserslist-config": "^3.0.1",
+		"@nextcloud/eslint-config": "^8.4.1",
+		"@nextcloud/stylelint-config": "^2.4.0",
+		"@nextcloud/webpack-vue-config": "^6.0.1",
+		"css-loader": "~7.1.1",
+		"eslint": "^8.56.0",
+		"eslint-import-resolver-alias": "^1.1.2",
+		"style-loader": "~4.0.0",
+		"stylelint": "^15.11.0",
+		"vue-loader": "^15.11.1 <16.0.0",
+		"vue-template-compiler": "^2.7.16",
+		"webpack": "^5.94.0",
+		"webpack-cli": "^6.0.1"
+	}
 }


### PR DESCRIPTION
## Summary

Aligns `@conduction/nextcloud-vue` with the fleet-leading version (`^0.1.0-beta.17`).

Single-line bump in `package.json`.

## Audit reference

2026-05-03 OR-abstraction audit, stream 3 (repo hygiene).

## Merge mode

Pre-production app — auto-merged on creation.