### PR TITLE
perf: split shared Vue/@nextcloud/vue chunks (~47 MB -> ~24 MB widget JS)

### DIFF
--- a/lib/Dashboard/CasesOverviewWidget.php
+++ b/lib/Dashboard/CasesOverviewWidget.php
@@ -117,6 +117,9 @@ class CasesOverviewWidget implements IWidget
      */
     public function load(): void
     {
+        // Shared vendor chunks emitted by webpack splitChunks (see webpack.config.js).
+        Util::addScript(Application::APP_ID, Application::APP_ID.'-shared-vendor');
+        Util::addScript(Application::APP_ID, Application::APP_ID.'-shared-nc-vue');
         Util::addScript(Application::APP_ID, Application::APP_ID.'-casesOverviewWidget');
         Util::addStyle(Application::APP_ID, 'dashboardWidgets');
 

--- a/lib/Dashboard/DeadlineAlertsWidget.php
+++ b/lib/Dashboard/DeadlineAlertsWidget.php
@@ -118,6 +118,9 @@ class DeadlineAlertsWidget implements IWidget
      */
     public function load(): void
     {
+        // Shared vendor chunks emitted by webpack splitChunks (see webpack.config.js).
+        Util::addScript(Application::APP_ID, Application::APP_ID.'-shared-vendor');
+        Util::addScript(Application::APP_ID, Application::APP_ID.'-shared-nc-vue');
         Util::addScript(Application::APP_ID, Application::APP_ID.'-deadlineAlertsWidget');
         Util::addStyle(Application::APP_ID, 'dashboardWidgets');
 

--- a/lib/Dashboard/MyTasksWidget.php
+++ b/lib/Dashboard/MyTasksWidget.php
@@ -117,6 +117,9 @@ class MyTasksWidget implements IWidget
      */
     public function load(): void
     {
+        // Shared vendor chunks emitted by webpack splitChunks (see webpack.config.js).
+        Util::addScript(Application::APP_ID, Application::APP_ID.'-shared-vendor');
+        Util::addScript(Application::APP_ID, Application::APP_ID.'-shared-nc-vue');
         Util::addScript(Application::APP_ID, Application::APP_ID.'-myTasksWidget');
         Util::addStyle(Application::APP_ID, 'dashboardWidgets');
 

--- a/lib/Dashboard/OverdueCasesWidget.php
+++ b/lib/Dashboard/OverdueCasesWidget.php
@@ -117,6 +117,9 @@ class OverdueCasesWidget implements IWidget
      */
     public function load(): void
     {
+        // Shared vendor chunks emitted by webpack splitChunks (see webpack.config.js).
+        Util::addScript(Application::APP_ID, Application::APP_ID.'-shared-vendor');
+        Util::addScript(Application::APP_ID, Application::APP_ID.'-shared-nc-vue');
         Util::addScript(Application::APP_ID, Application::APP_ID.'-overdueCasesWidget');
         Util::addStyle(Application::APP_ID, 'dashboardWidgets');
 

--- a/lib/Dashboard/StalledCasesWidget.php
+++ b/lib/Dashboard/StalledCasesWidget.php
@@ -118,6 +118,9 @@ class StalledCasesWidget implements IWidget
      */
     public function load(): void
     {
+        // Shared vendor chunks emitted by webpack splitChunks (see webpack.config.js).
+        Util::addScript(Application::APP_ID, Application::APP_ID.'-shared-vendor');
+        Util::addScript(Application::APP_ID, Application::APP_ID.'-shared-nc-vue');
         Util::addScript(Application::APP_ID, Application::APP_ID.'-stalledCasesWidget');
         Util::addStyle(Application::APP_ID, 'dashboardWidgets');
 

--- a/lib/Dashboard/StartCaseWidget.php
+++ b/lib/Dashboard/StartCaseWidget.php
@@ -112,6 +112,9 @@ class StartCaseWidget implements IWidget
      */
     public function load(): void
     {
+        // Shared vendor chunks emitted by webpack splitChunks (see webpack.config.js).
+        Util::addScript(Application::APP_ID, Application::APP_ID.'-shared-vendor');
+        Util::addScript(Application::APP_ID, Application::APP_ID.'-shared-nc-vue');
         Util::addScript(Application::APP_ID, Application::APP_ID.'-startCaseWidget');
         Util::addStyle(Application::APP_ID, 'dashboardWidgets');
     }//end load()

--- a/lib/Dashboard/TaskRemindersWidget.php
+++ b/lib/Dashboard/TaskRemindersWidget.php
@@ -118,6 +118,9 @@ class TaskRemindersWidget implements IWidget
      */
     public function load(): void
     {
+        // Shared vendor chunks emitted by webpack splitChunks (see webpack.config.js).
+        Util::addScript(Application::APP_ID, Application::APP_ID.'-shared-vendor');
+        Util::addScript(Application::APP_ID, Application::APP_ID.'-shared-nc-vue');
         Util::addScript(Application::APP_ID, Application::APP_ID.'-taskRemindersWidget');
         Util::addStyle(Application::APP_ID, 'dashboardWidgets');
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -101,4 +101,41 @@ webpackConfig.plugins = [
 // preventing the nextcloud-vue submodule's nested deps (Vue 3) from leaking in.
 webpackConfig.resolve.alias['@nextcloud/dialogs'] = path.resolve(__dirname, 'node_modules/@nextcloud/dialogs')
 
+// Share Vue + @nextcloud/vue + pinia + icons + @conduction/nextcloud-vue
+// across every entry-point so each widget bundle no longer inlines its own
+// ~5 MB framework copy. Stable filenames (no contenthash in the JS name)
+// mean each widget's `Util::addScript` PHP call can reference the chunk
+// directly without a manifest. The vendor chunk is loaded once and cached
+// across every widget/page in the app.
+webpackConfig.optimization = {
+	...(webpackConfig.optimization || {}),
+	splitChunks: {
+		...(webpackConfig.optimization?.splitChunks || {}),
+		chunks: 'all',
+		cacheGroups: {
+			default: false,
+			defaultVendors: false,
+			ncVue: {
+				name: appId + '-shared-nc-vue',
+				// Matches both node_modules entries AND the monorepo-dev alias
+				// `../nextcloud-vue/src/...` which webpack resolves outside
+				// node_modules when @conduction/nextcloud-vue is aliased to it.
+				test: /[\\/]node_modules[\\/](@nextcloud[\\/]vue|@conduction[\\/]nextcloud-vue)[\\/]|[\\/]nextcloud-vue[\\/]src[\\/]/,
+				priority: 30,
+				reuseExistingChunk: true,
+				enforce: true,
+				filename: appId + '-shared-nc-vue.js',
+			},
+			vendor: {
+				name: appId + '-shared-vendor',
+				test: /[\\/]node_modules[\\/](vue|pinia|vue-material-design-icons|@vueuse|core-js)[\\/]/,
+				priority: 20,
+				reuseExistingChunk: true,
+				enforce: true,
+				filename: appId + '-shared-vendor.js',
+			},
+		},
+	},
+}
+
 module.exports = webpackConfig


### PR DESCRIPTION
Mirror of the same fix that just landed on pipelinq. Each procest widget was inlining its own framework copy; now extracted into shared chunks loaded once.

## Bundle sizes after `npm run build`

| Bundle | Before | After |
|---|---:|---:|
| `procest-main.js` | ~9 MB | **4.73 MB** |
| `procest-settings.js` | ~6 MB | **3.35 MB** |
| `procest-<each>Widget.js` | ~6.7 MB | **3.00 MB** |
| `procest-shared-nc-vue.js` | — | **2.79 MB** (loaded once) |
| `procest-shared-vendor.js` | — | **0.33 MB** (loaded once) |

Total widget JS on `/apps/mydash/`: **~47 MB → ~24 MB** cold cache; per-widget delta only on warm cache.

## Validation

- Built locally with `NODE_OPTIONS=--max-old-space-size=8192 npm run build` ✓
- Reloaded `/apps/mydash/` and confirmed shared chunks load before per-widget bundles ✓
- Console: same 11 baseline errors (pre-existing procest store-registration errors), no new errors

## Test plan
- [ ] CI build passes
- [ ] Open `/apps/mydash/`, confirm procest widgets render (cases overview, my tasks, etc.)