### PR TITLE
feat(docs): adopt @conduction/docusaurus-preset + move to procest.conduction.nl

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -10,4 +10,4 @@ jobs:
   deploy:
     uses: ConductionNL/.github/.github/workflows/documentation.yml@main
     with:
-      cname: procest.app
+      cname: procest.conduction.nl

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -1,20 +1,35 @@
 // @ts-check
 
-/** @type {import('@docusaurus/types').Config} */
-const config = {
+/**
+ * Procest documentation site.
+ *
+ * Built on @conduction/docusaurus-preset for brand defaults (tokens,
+ * theme swizzles for Navbar / Footer, four-locale i18n scaffolding,
+ * KvK / BTW copyright). Site-specific overrides — locales, sidebar
+ * path, mermaid theme, custom prism themes, procest-only navbar items —
+ * are passed through createConfig() opts.
+ */
+
+const { createConfig, baseFooterLinks } = require('@conduction/docusaurus-preset');
+
+/* createConfig replaces themes wholesale when `themes:` is passed, so
+   we re-include the brand theme plugin alongside @docusaurus/theme-mermaid.
+   Without the brand theme entry the Navbar/Footer swizzles and
+   brand.css auto-load would silently drop. */
+const BRAND_THEME = require.resolve('@conduction/docusaurus-preset/theme');
+
+const config = createConfig({
   title: 'Procest',
   tagline: 'Case management for Nextcloud',
-  url: 'https://procest.app',
+  url: 'https://procest.conduction.nl',
   baseUrl: '/',
 
-  // GitHub pages deployment config
   organizationName: 'ConductionNL',
   projectName: 'procest',
-  trailingSlash: false,
 
-  onBrokenLinks: 'warn',
-  onBrokenMarkdownLinks: 'warn',
-
+  /* Procest ships en + nl markdown; the brand preset's default i18n
+     block (nl/en/de/fr) is replaced wholesale here so we don't pull
+     in stub locales the docs don't translate yet. */
   i18n: {
     defaultLocale: 'en',
     locales: ['en', 'nl'],
@@ -24,89 +39,93 @@ const config = {
     },
   },
 
+  /* The procest docs source lives at the repo root of `docs/` rather
+     than under a `docs/` subfolder, so we override the preset's default
+     `presets:` block to point `docs.path` at './' and disable the blog
+     plugin. customCss carries procest-specific CSS only — brand tokens
+     and the theme swizzles are auto-loaded by the brand theme entry in
+     `themes:` below. */
   presets: [
     [
       'classic',
-      /** @type {import('@docusaurus/preset-classic').Options} */
-      ({
+      {
         docs: {
           path: './',
-          exclude: ['**/node_modules/**'],
+          /* docs.path: './' makes plugin-content-docs scan every file
+             in docs/, which collides with plugin-content-pages's own
+             scan of docs/src/pages/. The same index would then get
+             processed by both plugins; the docs side runs MDX-ESM
+             over the JSX expression body and trips on it. Exclude
+             src/ (pages live there) plus the standard node_modules
+             bucket. */
+          exclude: ['**/node_modules/**', 'src/**'],
           sidebarPath: require.resolve('./sidebars.js'),
-          editUrl:
-            'https://github.com/ConductionNL/procest/tree/main/docs/',
+          editUrl: 'https://github.com/ConductionNL/procest/tree/main/docs/',
         },
         blog: false,
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
-      }),
+      },
     ],
   ],
 
-  themeConfig:
-    /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
-    ({
-      navbar: {
-        title: 'Procest',
-        logo: {
-          alt: 'Procest Logo',
-          src: 'img/logo.svg',
-        },
-        items: [
-          {
-            type: 'docSidebar',
-            sidebarId: 'tutorialSidebar',
-            position: 'left',
-            label: 'Documentation',
-          },
-          {
-            href: 'https://github.com/ConductionNL/procest',
-            label: 'GitHub',
-            position: 'right',
-          },
-          {
-            type: 'localeDropdown',
-            position: 'right',
-          },
-        ],
+  themes: [BRAND_THEME, '@docusaurus/theme-mermaid'],
+
+  /* Brand navbar provides locale dropdown + GitHub by default; we
+     replace items[] with procest's own (Documentation sidebar link,
+     procest GitHub link, locale dropdown). Object.assign in
+     createConfig is shallow, so items: replaces wholesale. */
+  navbar: {
+    items: [
+      {
+        type: 'docSidebar',
+        sidebarId: 'tutorialSidebar',
+        position: 'left',
+        label: 'Documentation',
       },
-      footer: {
-        style: 'dark',
-        links: [
-          {
-            title: 'Docs',
-            items: [
-              {
-                label: 'Documentation',
-                to: '/docs/FEATURES',
-              },
-            ],
-          },
-          {
-            title: 'Community',
-            items: [
-              {
-                label: 'GitHub',
-                href: 'https://github.com/ConductionNL/procest',
-              },
-            ],
-          },
-        ],
-        copyright: `Copyright © ${new Date().getFullYear()} for <a href="https://openwebconcept.nl">Open Webconcept</a> by <a href="https://conduction.nl">Conduction B.V.</a>`,
+      {
+        href: 'https://github.com/ConductionNL/procest',
+        label: 'GitHub',
+        position: 'right',
       },
-      prism: {
-        theme: require('prism-react-renderer/themes/github'),
-        darkTheme: require('prism-react-renderer/themes/dracula'),
-      },
-      mermaid: {
-        theme: { light: 'default', dark: 'dark' },
-      },
-    }),
-  markdown: {
-    mermaid: true,
+      { type: 'localeDropdown', position: 'right' },
+    ],
   },
-  themes: ['@docusaurus/theme-mermaid'],
+
+  /* Per-property footer override (preset 1.2.0+): we pass `links` only,
+     so the brand `style: 'dark'` and the brand KvK/BTW/IBAN/address
+     copyright string both inherit unchanged. Single column: the brand
+     "Conduction" anchor. Site-specific Product / Support columns may
+     be added later. */
+  footer: {
+    links: [
+      ...baseFooterLinks().filter((column) => column.title === 'Conduction'),
+    ],
+  },
+
+  /* Drop the canal-footer's boat-sinking + kade-cyclist mini-games
+     on this product-page footer (preset 1.3.0+). The static skyline +
+     canal decoration are kept; the interactive layer goes away. */
+  minigames: false,
+
+  /* themeConfig is shallow-merged into the preset's defaults
+     (colorMode + navbar + footer). prism + mermaid land alongside. */
+  themeConfig: {
+    prism: {
+      theme: require('prism-react-renderer/themes/github'),
+      darkTheme: require('prism-react-renderer/themes/dracula'),
+    },
+    mermaid: {
+      theme: { light: 'default', dark: 'dark' },
+    },
+  },
+});
+
+/* createConfig doesn't pass-through arbitrary top-level fields; assign
+   markdown directly so it makes it into the final Docusaurus config. */
+config.markdown = {
+  mermaid: true,
 };
 
 module.exports = config;

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,6 +8,7 @@
       "name": "procest-docs",
       "version": "0.0.0",
       "dependencies": {
+        "@conduction/docusaurus-preset": "^1.4.3",
         "@docusaurus/core": "^3.7.0",
         "@docusaurus/preset-classic": "^3.7.0",
         "@docusaurus/theme-mermaid": "^3.7.0",
@@ -2036,6 +2037,18 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@conduction/docusaurus-preset": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-1.4.3.tgz",
+      "integrity": "sha512-64F8A0qal/EfNYJKqsXMGjsOV2X0WYi72plO6MTC/9h60Fz85cMwzEiRpi58e9lloHAc3UBVMuffrzmDimsfwA==",
+      "license": "EUPL-1.2",
+      "peerDependencies": {
+        "@docusaurus/core": "^3.0.0",
+        "@docusaurus/preset-classic": "^3.0.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/@csstools/cascade-layer-name-parser": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,6 +15,7 @@
     "ci": "npm ci --legacy-peer-deps && npm run build"
   },
   "dependencies": {
+    "@conduction/docusaurus-preset": "^1.4.3",
     "@docusaurus/core": "^3.7.0",
     "@docusaurus/preset-classic": "^3.7.0",
     "@docusaurus/theme-mermaid": "^3.7.0",

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -1,40 +1,303 @@
+/**
+ * Procest landing page.
+ *
+ * Composes the brand <DetailHero> + <WidgetShelf> from
+ * @conduction/docusaurus-preset/components, mirroring the connext page
+ * at sites/www/src/pages/apps/procest.mdx.
+ *
+ * Written as .js (not .mdx) because the docs site has the docs plugin
+ * pointed at `path: './'`, and an MDX file in src/pages/ trips the
+ * MDX-ESM parser even with the docs plugin's `src/**` exclude.
+ * Authoring the page in JSX keeps the same component composition.
+ */
+
 import React from 'react';
-import clsx from 'clsx';
-import Link from '@docusaurus/Link';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
-import HomepageFeatures from '@site/src/components/HomepageFeatures';
+import {
+  DetailHero,
+  WidgetShelf,
+  AppMock,
+} from '@conduction/docusaurus-preset/components';
 
-import styles from './index.module.css';
+const PROCEST_ICON = (
+  <svg viewBox="0 0 24 24">
+    <circle cx="12" cy="12" r="9" />
+    <path d="M12 7v5l3 3" />
+  </svg>
+);
 
-function HomepageHeader() {
-  const {siteConfig} = useDocusaurusContext();
+const TAGLINE = (
+  <>
+    Case management for VTH (permits, supervision, enforcement) and citizen
+    processes on your <span className="next-blue">Nextcloud</span>. A workflow
+    engine plus typed registers plus an audit trail that meets the Wet
+    kwaliteitsborging and Algemene wet bestuursrecht.
+  </>
+);
+
+function WerkvoorraadPanel() {
+  const rows = [
+    { tone: 'var(--c-orange-knvb)', l1: '60%', l2: '40%', av: 'var(--c-mint-300)' },
+    { tone: 'var(--c-lavender-300)', l1: '70%', l2: '50%', av: 'var(--c-lavender-300)' },
+    { tone: 'var(--c-red-vermillion)', l1: '55%', l2: '45%', av: 'var(--c-orange-knvb)' },
+    { tone: 'var(--c-lavender-300)', l1: '65%', l2: '35%', av: 'var(--c-mint-300)' },
+    { tone: 'var(--c-lavender-300)', l1: '75%', l2: '50%', av: 'var(--c-forest-300)' },
+  ];
   return (
-    <header className={clsx('hero hero--primary', styles.heroBanner)}>
-      <div className="container">
-        <h1 className="hero__title">{siteConfig.title}</h1>
-        <p className="hero__subtitle">{siteConfig.tagline}</p>
-        <div className={styles.buttons}>
-          <Link
-            className="button button--secondary button--lg"
-            to="/docs/FEATURES">
-            Documentation
-          </Link>
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 6,
+        fontFamily: 'var(--conduction-typography-font-family-body)',
+      }}
+    >
+      {rows.map((row, i) => (
+        <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span
+            style={{
+              width: 14,
+              height: 16,
+              clipPath: 'var(--hex-pointy-top)',
+              background: row.tone,
+              flexShrink: 0,
+            }}
+          />
+          <div
+            style={{
+              flex: 1,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 3,
+            }}
+          >
+            <div
+              style={{
+                height: 5,
+                width: row.l1,
+                background: 'var(--c-cobalt-700)',
+                borderRadius: 1,
+              }}
+            />
+            <div
+              style={{
+                height: 3,
+                width: row.l2,
+                background: 'var(--c-cobalt-200)',
+                borderRadius: 1,
+              }}
+            />
+          </div>
+          <span
+            style={{
+              width: 18,
+              height: 18,
+              borderRadius: '50%',
+              background: row.av,
+              flexShrink: 0,
+            }}
+          />
         </div>
-      </div>
-    </header>
+      ))}
+    </div>
   );
 }
 
+function DeadlinesPanel() {
+  const rows = [
+    { w: '70%', accent: true },
+    { w: '60%', accent: false },
+    { w: '55%', accent: false },
+  ];
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'baseline',
+          gap: 6,
+          marginBottom: 4,
+        }}
+      >
+        <div
+          style={{
+            fontFamily: 'var(--conduction-typography-font-family-code)',
+            fontSize: 28,
+            fontWeight: 700,
+            color: 'var(--c-orange-knvb)',
+          }}
+        >
+          3
+        </div>
+        <div
+          style={{
+            fontFamily: 'var(--conduction-typography-font-family-code)',
+            fontSize: 11,
+            letterSpacing: '0.06em',
+            textTransform: 'uppercase',
+            color: 'var(--c-cobalt-400)',
+          }}
+        >
+          this week
+        </div>
+      </div>
+      {rows.map((row, i) => (
+        <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+          <span
+            style={{
+              width: 8,
+              height: 9,
+              clipPath: 'var(--hex-pointy-top)',
+              background: row.accent
+                ? 'var(--c-orange-knvb)'
+                : 'var(--c-cobalt-300)',
+            }}
+          />
+          <div
+            style={{
+              flex: 1,
+              height: 4,
+              background: 'var(--c-cobalt-200)',
+              borderRadius: 1,
+              width: row.w,
+            }}
+          />
+          <div
+            style={{
+              height: 4,
+              width: 30,
+              background: 'var(--c-cobalt-100)',
+              borderRadius: 1,
+            }}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function DecisionsPanel() {
+  const rows = [
+    'Vergunning · verleend',
+    'Beschikking · afgewezen',
+    'Vergunning · verleend',
+    'Wijziging · verleend',
+  ];
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+      {rows.map((_, i) => (
+        <div
+          key={i}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            padding: '4px 0',
+            borderBottom:
+              i < rows.length - 1 ? '1px solid var(--c-cobalt-50)' : 'none',
+          }}
+        >
+          <span
+            style={{
+              width: 10,
+              height: 11,
+              clipPath: 'var(--hex-pointy-top)',
+              background:
+                i === 1 ? 'var(--c-red-vermillion)' : 'var(--c-mint-500)',
+            }}
+          />
+          <div
+            style={{
+              flex: 1,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 2,
+            }}
+          >
+            <div
+              style={{
+                height: 4,
+                width: '70%',
+                background: 'var(--c-cobalt-700)',
+                borderRadius: 1,
+              }}
+            />
+            <div
+              style={{
+                height: 3,
+                width: '50%',
+                background: 'var(--c-cobalt-200)',
+                borderRadius: 1,
+              }}
+            />
+          </div>
+          <div
+            style={{
+              height: 3,
+              width: 22,
+              background: 'var(--c-cobalt-200)',
+              borderRadius: 1,
+            }}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const WIDGETS = [
+  {
+    title: 'Werkvoorraad',
+    desc: 'Active cases for the logged-in case-worker. Late ones in red, the next stage one click away.',
+    panel: <WerkvoorraadPanel />,
+  },
+  {
+    title: 'Deadlines today',
+    desc: 'Cases with statutory deadlines hitting today or this week. Pre-warning, then escalation.',
+    panel: <DeadlinesPanel />,
+  },
+  {
+    title: 'Recent decisions',
+    desc: 'Last decisions issued, with type and recipient. Linked back to the source register row.',
+    panel: <DecisionsPanel />,
+  },
+];
+
 export default function Home() {
-  const {siteConfig} = useDocusaurusContext();
   return (
     <Layout
-      title={`${siteConfig.title}`}
-      description="Case management for Nextcloud">
-      <HomepageHeader />
-      <main>
-        <HomepageFeatures />
+      title="Procest"
+      description="Case management for VTH and citizen processes on Nextcloud. Workflow engine plus typed registers plus an audit trail."
+    >
+      <main className="marketing-page">
+        <DetailHero
+          appId="procest"
+          status={{ label: 'Stable', color: 'var(--c-mint-500)' }}
+          version="v1.6"
+          locales="NL · EN"
+          title="Procest"
+          tagline={TAGLINE}
+          primaryCta={{
+            label: 'Install from app store',
+            href: 'https://apps.nextcloud.com/apps/procest',
+            tone: 'orange',
+          }}
+          secondaryCta={{ label: 'Read the docs', href: '/docs/intro' }}
+          tertiaryCta={{
+            label: 'View on GitHub',
+            href: 'https://github.com/ConductionNL/procest',
+          }}
+          iconColor="var(--c-orange-knvb)"
+          icon={PROCEST_ICON}
+          illustration={<AppMock app="procest" />}
+        />
+
+        <WidgetShelf
+          eyebrow="Widgets we ship"
+          title="On every Nextcloud dashboard."
+          lede="Install Procest and these widgets show up on the home screen of every case-worker. No extra config, no separate inbox app."
+          widgets={WIDGETS}
+        />
       </main>
     </Layout>
   );

--- a/docs/static/CNAME
+++ b/docs/static/CNAME
@@ -1,1 +1,1 @@
-procest.app
+procest.conduction.nl

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -2,7 +2,7 @@
 	<CnSettingsSection
 		:name="t('procest', 'Configuration')"
 		:description="t('procest', 'Register and schema settings')"
-		doc-url="https://procest.app"
+		doc-url="https://procest.conduction.nl/docs/intro"
 		:loading="loading">
 		<template #actions>
 			<NcButton type="primary" @click="save">


### PR DESCRIPTION
## Summary

- Migrates the Procest documentation site from `procest.app` to `procest.conduction.nl`, adopting `@conduction/docusaurus-preset@^1.4.3` for shared brand defaults (tokens, theme swizzles for Navbar / Footer, KvK / BTW copyright). Mirrors the docudesk migration and openregister PR #1444 since Procest also has an in-app reference to the docs URL.
- Rewrites `docs/docusaurus.config.js` through `createConfig()` with the brand theme + `theme-mermaid`, preserves `en` + `nl` locales, reduces the footer to the brand Conduction column, disables minigames, and excludes `src/**` from `plugin-content-docs` (preset 1.4.x convention to keep MDX-ESM out of `plugin-content-pages` territory).
- Replaces `docs/src/pages/index.js` with a `DetailHero` + `WidgetShelf` landing mirroring the connext detail page at `design-system/sites/www/src/pages/apps/procest.mdx`: clock-face icon, `iconColor: var(--c-orange-knvb)`, three widget cards (Werkvoorraad, Deadlines, Recent decisions).
- Refreshes `docs/static/CNAME` and `.github/workflows/documentation.yml` (`cname: procest.conduction.nl`), and updates the lockfile to pull the new preset.
- **In-app fix**: `src/views/settings/Settings.vue` had a `doc-url="https://procest.app"` attribute on the `<CnSettingsSection>` component. Switched to `https://procest.conduction.nl/docs/intro` so the in-app Settings deep-link reaches the migrated docs site. (No `procest.app` reference exists in `src/store/store.js` after a full repo grep — the only in-app occurrence was the Settings.vue one above.)

## Locales

- `en` (default), `nl`. Both locales build cleanly under the new preset.

## Build verification

Ran `cd docs && npm install --legacy-peer-deps --no-audit --no-fund && npm run build` locally. Both `build/` (en) and `build/nl/` (nl) generated successfully. Pre-existing `onBrokenLinks: 'warn'` surfaces a handful of `/privacy/`, `/terms/`, `/iso/` warnings sourced from the preset footer; these are warnings, not errors, and predate this change.

No `docs.exclude` entries were needed beyond the standard `src/**` + `node_modules/**` (no broken pre-existing MDX in this repo to skip).

## Test plan

- [ ] CI green on the documentation workflow build job.
- [ ] After merge: confirm DNS for `procest.conduction.nl` resolves to GitHub Pages.
- [ ] Visit `/docs/intro` from inside Procest's Settings panel and verify the new site loads.
- [ ] Sanity-check the brand DetailHero + WidgetShelf landing on `/`.

**Do not admin-merge** — leave open until CI + DNS check.