### PR TITLE
feat: server-side dashboard KPI aggregation

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -1,5 +1,25 @@
 <?php
 
+/**
+ * Procest Route Configuration
+ *
+ * Defines all HTTP routes for the Procest application.
+ *
+ * @category Routes
+ * @package  OCA\Procest
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
 declare(strict_types=1);
 
 return [
@@ -115,8 +135,10 @@ return [
         ['name' => 'metrics#index', 'url' => '/api/metrics', 'verb' => 'GET'],
         // Health check endpoint.
         ['name' => 'health#index', 'url' => '/api/health', 'verb' => 'GET'],
+        // Dashboard KPI aggregation endpoint.
+        ['name' => 'kpi#index', 'url' => '/api/dashboard/kpis', 'verb' => 'GET'],
 
-        // SPA catch-all — serves the Vue app for any frontend route (history mode)
+        // SPA catch-all — serves the Vue app for any frontend route (history mode).
         ['name' => 'dashboard#page', 'url' => '/{path}', 'verb' => 'GET', 'requirements' => ['path' => '.+'], 'defaults' => ['path' => '']],
     ],
 ];

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -25,6 +25,9 @@ declare(strict_types=1);
 namespace OCA\Procest\AppInfo;
 
 use OCA\OpenRegister\Event\DeepLinkRegistrationEvent;
+use OCA\OpenRegister\Event\ObjectCreatedEvent;
+use OCA\OpenRegister\Event\ObjectDeletedEvent;
+use OCA\OpenRegister\Event\ObjectUpdatedEvent;
 use OCA\Procest\Dashboard\CasesOverviewWidget;
 use OCA\Procest\Dashboard\DeadlineAlertsWidget;
 use OCA\Procest\Dashboard\MyTasksWidget;
@@ -33,6 +36,7 @@ use OCA\Procest\Dashboard\StalledCasesWidget;
 use OCA\Procest\Dashboard\TaskRemindersWidget;
 use OCA\Procest\Dashboard\StartCaseWidget;
 use OCA\Procest\Listener\DeepLinkRegistrationListener;
+use OCA\Procest\Listener\KpiCacheInvalidationListener;
 use OCA\Procest\Middleware\ZgwAuthMiddleware;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
@@ -68,6 +72,21 @@ class Application extends App implements IBootstrap
         $context->registerEventListener(
             event: DeepLinkRegistrationEvent::class,
             listener: DeepLinkRegistrationListener::class
+        );
+
+        $context->registerEventListener(
+            event: ObjectCreatedEvent::class,
+            listener: KpiCacheInvalidationListener::class
+        );
+
+        $context->registerEventListener(
+            event: ObjectUpdatedEvent::class,
+            listener: KpiCacheInvalidationListener::class
+        );
+
+        $context->registerEventListener(
+            event: ObjectDeletedEvent::class,
+            listener: KpiCacheInvalidationListener::class
         );
 
         $context->registerMiddleware(class: ZgwAuthMiddleware::class);

--- a/lib/Controller/KpiController.php
+++ b/lib/Controller/KpiController.php
@@ -1,0 +1,139 @@
+<?php
+
+/**
+ * Procest KPI Controller
+ *
+ * Exposes pre-aggregated dashboard KPI data for the authenticated user.
+ * Responses are cached per-user using a version-bump invalidation strategy
+ * to ensure fresh data after any OpenRegister object mutation.
+ *
+ * @category Controller
+ * @package  OCA\Procest\Controller
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Controller;
+
+use DateTime;
+use OCA\Procest\AppInfo\Application;
+use OCA\Procest\Service\KpiAggregationService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\ICache;
+use OCP\ICacheFactory;
+use OCP\IRequest;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Controller for the dashboard KPI aggregation endpoint.
+ *
+ * Cache strategy: per-user data key versioned via a separate version counter.
+ * The `KpiCacheInvalidationListener` increments the version counter on any
+ * OpenRegister object event, causing the next GET to compute fresh data.
+ *
+ * @spec openspec/changes/add-server-side-kpi-aggregation/tasks.md#T09
+ */
+class KpiController extends Controller
+{
+
+    /**
+     * Cache TTL for computed KPI data in seconds.
+     */
+    private const CACHE_TTL = 60;
+
+    /**
+     * Cache prefix for KPI data keys.
+     */
+    private const CACHE_PREFIX = 'procest_kpis_';
+
+    /**
+     * Cache key suffix for the version counter.
+     */
+    private const VERSION_SUFFIX = '_ver';
+
+    /**
+     * The local cache instance.
+     *
+     * @var ICache The local APCu cache
+     */
+    private ICache $cache;
+
+    /**
+     * Constructor.
+     *
+     * @param IRequest              $request        The HTTP request
+     * @param IUserSession          $userSession    The user session
+     * @param KpiAggregationService $kpiAggregation The KPI aggregation service
+     * @param ICacheFactory         $cacheFactory   The cache factory
+     * @param LoggerInterface       $logger         Logger
+     *
+     * @return void
+     */
+    public function __construct(
+        IRequest $request,
+        private IUserSession $userSession,
+        private KpiAggregationService $kpiAggregation,
+        ICacheFactory $cacheFactory,
+        private LoggerInterface $logger,
+    ) {
+        parent::__construct(appName: Application::APP_ID, request: $request);
+        $this->cache = $cacheFactory->createLocal(Application::APP_ID);
+    }//end __construct()
+
+    /**
+     * Return aggregated KPI data for the authenticated user.
+     *
+     * Uses a per-user version-keyed cache with 60s TTL. Returns cacheHit: true
+     * when served from cache, false when DB queries were executed.
+     *
+     * @NoAdminRequired
+     *
+     * @return JSONResponse JSON response with KPI data
+     *
+     * @spec openspec/changes/add-server-side-kpi-aggregation/tasks.md#T09
+     */
+    public function index(): JSONResponse
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], 401);
+        }
+
+        $userId = $user->getUID();
+
+        $versionKey = self::CACHE_PREFIX.$userId.self::VERSION_SUFFIX;
+        $version    = $this->cache->get($versionKey) ?? 1;
+        $dataKey    = self::CACHE_PREFIX.$userId.'_v'.$version;
+
+        $cached = $this->cache->get($dataKey);
+        if ($cached !== null && is_array($cached) === true) {
+            $cached['cacheHit'] = true;
+            return new JSONResponse($cached);
+        }
+
+        $kpis = $this->kpiAggregation->computeKpis($userId);
+        $kpis['computedAt'] = (new DateTime())->format(DateTime::ATOM);
+        $kpis['cacheHit']   = false;
+
+        try {
+            $this->cache->set($dataKey, $kpis, self::CACHE_TTL);
+        } catch (\Exception $e) {
+            $this->logger->debug('[KpiController] Cache store failed', ['key' => $dataKey, 'error' => $e->getMessage()]);
+        }
+
+        return new JSONResponse($kpis);
+    }//end index()
+}//end class

--- a/lib/Listener/KpiCacheInvalidationListener.php
+++ b/lib/Listener/KpiCacheInvalidationListener.php
@@ -1,0 +1,139 @@
+<?php
+
+/**
+ * Procest KPI Cache Invalidation Listener
+ *
+ * Listens to OpenRegister object lifecycle events (created, updated, deleted)
+ * and increments the per-user KPI cache version counter, ensuring the next
+ * GET /api/dashboard/kpis request computes fresh data.
+ *
+ * No eager recomputation is performed — the version bump guarantees that
+ * the existing cached payload will not be served after a write, while
+ * avoiding thundering-herd on busy workflows.
+ *
+ * @category Listener
+ * @package  OCA\Procest\Listener
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Listener;
+
+use OCA\OpenRegister\Event\ObjectCreatedEvent;
+use OCA\OpenRegister\Event\ObjectDeletedEvent;
+use OCA\OpenRegister\Event\ObjectUpdatedEvent;
+use OCA\Procest\AppInfo\Application;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\ICache;
+use OCP\ICacheFactory;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Invalidates per-user KPI caches on any OpenRegister object mutation.
+ *
+ * Increments the version counter key `procest_kpis_{userId}_ver` stored in
+ * the local APCu cache. The KpiController reads this version to build its
+ * data cache key; a version change causes a cache miss on the next request.
+ *
+ * @implements IEventListener<Event>
+ *
+ * @spec openspec/changes/add-server-side-kpi-aggregation/tasks.md#T12
+ */
+class KpiCacheInvalidationListener implements IEventListener
+{
+
+    /**
+     * Cache prefix for KPI version keys.
+     */
+    private const CACHE_PREFIX = 'procest_kpis_';
+
+    /**
+     * Cache key suffix for the version counter.
+     */
+    private const VERSION_SUFFIX = '_ver';
+
+    /**
+     * The local cache instance.
+     *
+     * @var ICache The local APCu cache
+     */
+    private ICache $cache;
+
+    /**
+     * Constructor.
+     *
+     * @param ICacheFactory   $cacheFactory The cache factory
+     * @param IUserSession    $userSession  The user session
+     * @param LoggerInterface $logger       Logger
+     *
+     * @return void
+     */
+    public function __construct(
+        ICacheFactory $cacheFactory,
+        private IUserSession $userSession,
+        private LoggerInterface $logger,
+    ) {
+        $this->cache = $cacheFactory->createLocal(Application::APP_ID);
+    }//end __construct()
+
+    /**
+     * Handle an OpenRegister object lifecycle event.
+     *
+     * Increments the version counter for the current user's KPI cache,
+     * causing the next KpiController request to recompute from the DB.
+     *
+     * @param Event $event The dispatched event
+     *
+     * @return void
+     *
+     * @spec openspec/changes/add-server-side-kpi-aggregation/tasks.md#T12
+     */
+    public function handle(Event $event): void
+    {
+        if (($event instanceof ObjectCreatedEvent) === false
+            && ($event instanceof ObjectUpdatedEvent) === false
+            && ($event instanceof ObjectDeletedEvent) === false
+        ) {
+            return;
+        }
+
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return;
+        }
+
+        $userId     = $user->getUID();
+        $versionKey = self::CACHE_PREFIX.$userId.self::VERSION_SUFFIX;
+
+        try {
+            $current    = $this->cache->get($versionKey);
+            $newVersion = 2;
+            if ($current !== null) {
+                $newVersion = ((int) $current) + 1;
+            }
+
+            $this->cache->set($versionKey, $newVersion);
+        } catch (\Exception $e) {
+            $this->logger->debug(
+                '[KpiCacheInvalidationListener] Failed to increment version key',
+                [
+                    'key'   => $versionKey,
+                    'error' => $e->getMessage(),
+                ]
+            );
+        }//end try
+    }//end handle()
+}//end class

--- a/lib/Service/KpiAggregationService.php
+++ b/lib/Service/KpiAggregationService.php
@@ -1,0 +1,453 @@
+<?php
+
+/**
+ * Procest KPI Aggregation Service
+ *
+ * Computes dashboard KPI metrics via direct DB-side aggregation queries
+ * on the OpenRegister objects table. All counts use COUNT(*) with
+ * JSON_EXTRACT predicates — no PHP-side array iteration.
+ *
+ * Workflow invariant relied on by this service: a case is considered "open"
+ * if and only if its `endDate` JSON field is NULL or empty. The Procest
+ * workflow engine MUST set `endDate` whenever a case transitions to a final
+ * status (i.e. any status whose `statusType.isFinal` is `true`). If a case
+ * has `endDate IS NULL` but a `currentStatus` with `statusType.isFinal = true`,
+ * the invariant is violated and the open-case counts become inaccurate.
+ * See design.md § "Workflow Invariants" and verification task V10 for the
+ * operational check procedure.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service;
+
+use DateTime;
+use OCP\IDBConnection;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Service that aggregates dashboard KPI data via DB-side COUNT(*) queries.
+ *
+ * All public methods return data suitable for JSON serialisation. Integer
+ * fields default to 0 on error; nullable fields (avgProcessingDays) return
+ * null when no matching rows exist.
+ *
+ * @spec openspec/changes/add-server-side-kpi-aggregation/tasks.md#T01
+ */
+class KpiAggregationService
+{
+    /**
+     * Constructor.
+     *
+     * @param IDBConnection   $db     Database connection
+     * @param LoggerInterface $logger Logger
+     *
+     * @return void
+     */
+    public function __construct(
+        private IDBConnection $db,
+        private LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Compute all dashboard KPIs for the given user.
+     *
+     * Returns an array with keys: openCount, newToday, overdueCount,
+     * completedCount, taskCount, tasksDueToday, statusBreakdown,
+     * avgProcessingDays.
+     *
+     * @param string $userId The Nextcloud user ID to scope task queries
+     *
+     * @return array{
+     *     openCount: int,
+     *     newToday: int,
+     *     overdueCount: int,
+     *     completedCount: int,
+     *     taskCount: int,
+     *     tasksDueToday: int,
+     *     statusBreakdown: array<int, array{status: string, count: int}>,
+     *     avgProcessingDays: float|null
+     * } Aggregated KPI data
+     *
+     * @spec openspec/changes/add-server-side-kpi-aggregation/tasks.md#T01
+     */
+    public function computeKpis(string $userId): array
+    {
+        return [
+            'openCount'         => $this->getOpenCount(),
+            'newToday'          => $this->getNewTodayCount(),
+            'overdueCount'      => $this->getOverdueCount(),
+            'completedCount'    => $this->getCompletedCount(),
+            'taskCount'         => $this->getTaskCount(userId: $userId),
+            'tasksDueToday'     => $this->getTasksDueToday(userId: $userId),
+            'statusBreakdown'   => $this->getStatusBreakdown(),
+            'avgProcessingDays' => $this->getAvgProcessingDays(),
+        ];
+    }//end computeKpis()
+
+    /**
+     * Count open cases — cases where endDate IS NULL or is an empty string.
+     *
+     * A case is considered "open" iff endDate IS NULL (workflow invariant).
+     *
+     * @return int Number of open cases
+     *
+     * @spec openspec/changes/add-server-side-kpi-aggregation/tasks.md#T02
+     */
+    private function getOpenCount(): int
+    {
+        try {
+            $qb = $this->db->getQueryBuilder();
+            $qb->select($qb->func()->count('o.id', 'cnt'))
+                ->from('openregister_objects', 'o')
+                ->innerJoin('o', 'openregister_schemas', 's', $qb->expr()->eq('o.schema', 's.id'))
+                ->where($qb->expr()->like('s.title', $qb->createNamedParameter('%zaak%')))
+                ->andWhere(
+                    $qb->expr()->orX(
+                        $qb->expr()->isNull($qb->createFunction("JSON_EXTRACT(o.object, '$.endDate')")),
+                        $qb->expr()->eq(
+                            $qb->createFunction("JSON_UNQUOTE(JSON_EXTRACT(o.object, '$.endDate'))"),
+                            $qb->createNamedParameter('')
+                        )
+                    )
+                );
+
+            $result = $qb->executeQuery();
+            $row    = $result->fetch();
+            $result->closeCursor();
+
+            return (int) ($row['cnt'] ?? 0);
+        } catch (\Exception $e) {
+            $this->logger->warning('[KpiAggregationService] Failed to get open count', ['error' => $e->getMessage()]);
+            return 0;
+        }//end try
+    }//end getOpenCount()
+
+    /**
+     * Count cases created today — cases where startDate starts with today's date.
+     *
+     * @return int Number of cases created today
+     *
+     * @spec openspec/changes/add-server-side-kpi-aggregation/tasks.md#T03
+     */
+    private function getNewTodayCount(): int
+    {
+        try {
+            $today = (new DateTime())->format('Y-m-d');
+            $qb    = $this->db->getQueryBuilder();
+            $qb->select($qb->func()->count('o.id', 'cnt'))
+                ->from('openregister_objects', 'o')
+                ->innerJoin('o', 'openregister_schemas', 's', $qb->expr()->eq('o.schema', 's.id'))
+                ->where($qb->expr()->like('s.title', $qb->createNamedParameter('%zaak%')))
+                ->andWhere(
+                    $qb->expr()->like(
+                        $qb->createFunction("JSON_UNQUOTE(JSON_EXTRACT(o.object, '$.startDate'))"),
+                        $qb->createNamedParameter($today.'%')
+                    )
+                );
+
+            $result = $qb->executeQuery();
+            $row    = $result->fetch();
+            $result->closeCursor();
+
+            return (int) ($row['cnt'] ?? 0);
+        } catch (\Exception $e) {
+            $this->logger->warning('[KpiAggregationService] Failed to get new today count', ['error' => $e->getMessage()]);
+            return 0;
+        }//end try
+    }//end getNewTodayCount()
+
+    /**
+     * Count overdue open cases — open cases where deadline is in the past.
+     *
+     * Only cases with endDate IS NULL (open) and a deadline earlier than
+     * today are counted as overdue.
+     *
+     * @return int Number of overdue cases
+     *
+     * @spec openspec/changes/add-server-side-kpi-aggregation/tasks.md#T04
+     */
+    private function getOverdueCount(): int
+    {
+        try {
+            $today = (new DateTime())->format('Y-m-d');
+            $qb    = $this->db->getQueryBuilder();
+            $qb->select($qb->func()->count('o.id', 'cnt'))
+                ->from('openregister_objects', 'o')
+                ->innerJoin('o', 'openregister_schemas', 's', $qb->expr()->eq('o.schema', 's.id'))
+                ->where($qb->expr()->like('s.title', $qb->createNamedParameter('%zaak%')))
+                ->andWhere(
+                    $qb->expr()->orX(
+                        $qb->expr()->isNull($qb->createFunction("JSON_EXTRACT(o.object, '$.endDate')")),
+                        $qb->expr()->eq(
+                            $qb->createFunction("JSON_UNQUOTE(JSON_EXTRACT(o.object, '$.endDate'))"),
+                            $qb->createNamedParameter('')
+                        )
+                    )
+                )
+                ->andWhere(
+                    $qb->expr()->isNotNull($qb->createFunction("JSON_EXTRACT(o.object, '$.deadline')"))
+                )
+                ->andWhere(
+                    $qb->expr()->lt(
+                        $qb->createFunction("JSON_UNQUOTE(JSON_EXTRACT(o.object, '$.deadline'))"),
+                        $qb->createNamedParameter($today)
+                    )
+                );
+
+            $result = $qb->executeQuery();
+            $row    = $result->fetch();
+            $result->closeCursor();
+
+            return (int) ($row['cnt'] ?? 0);
+        } catch (\Exception $e) {
+            $this->logger->warning('[KpiAggregationService] Failed to get overdue count', ['error' => $e->getMessage()]);
+            return 0;
+        }//end try
+    }//end getOverdueCount()
+
+    /**
+     * Count cases completed this month — cases where endDate starts with YYYY-MM.
+     *
+     * @return int Number of cases completed in the current calendar month
+     *
+     * @spec openspec/changes/add-server-side-kpi-aggregation/tasks.md#T05
+     */
+    private function getCompletedCount(): int
+    {
+        try {
+            $monthPrefix = (new DateTime())->format('Y-m');
+            $qb          = $this->db->getQueryBuilder();
+            $qb->select($qb->func()->count('o.id', 'cnt'))
+                ->from('openregister_objects', 'o')
+                ->innerJoin('o', 'openregister_schemas', 's', $qb->expr()->eq('o.schema', 's.id'))
+                ->where($qb->expr()->like('s.title', $qb->createNamedParameter('%zaak%')))
+                ->andWhere(
+                    $qb->expr()->like(
+                        $qb->createFunction("JSON_UNQUOTE(JSON_EXTRACT(o.object, '$.endDate'))"),
+                        $qb->createNamedParameter($monthPrefix.'%')
+                    )
+                );
+
+            $result = $qb->executeQuery();
+            $row    = $result->fetch();
+            $result->closeCursor();
+
+            return (int) ($row['cnt'] ?? 0);
+        } catch (\Exception $e) {
+            $this->logger->warning('[KpiAggregationService] Failed to get completed count', ['error' => $e->getMessage()]);
+            return 0;
+        }//end try
+    }//end getCompletedCount()
+
+    /**
+     * Count active/available tasks assigned to the given user.
+     *
+     * @param string $userId The user ID to scope tasks to
+     *
+     * @return int Number of active/available tasks for the user
+     *
+     * @spec openspec/changes/add-server-side-kpi-aggregation/tasks.md#T06
+     */
+    private function getTaskCount(string $userId): int
+    {
+        try {
+            $qb = $this->db->getQueryBuilder();
+            $qb->select($qb->func()->count('o.id', 'cnt'))
+                ->from('openregister_objects', 'o')
+                ->innerJoin('o', 'openregister_schemas', 's', $qb->expr()->eq('o.schema', 's.id'))
+                ->where($qb->expr()->like('s.title', $qb->createNamedParameter('%taak%')))
+                ->andWhere(
+                    $qb->expr()->eq(
+                        $qb->createFunction("JSON_UNQUOTE(JSON_EXTRACT(o.object, '$.assignee'))"),
+                        $qb->createNamedParameter($userId)
+                    )
+                )
+                ->andWhere(
+                    $qb->expr()->in(
+                        $qb->createFunction("JSON_UNQUOTE(JSON_EXTRACT(o.object, '$.status'))"),
+                        $qb->createNamedParameter(['available', 'active'], \OCP\DB\QueryBuilder\IQueryBuilder::PARAM_STR_ARRAY)
+                    )
+                );
+
+            $result = $qb->executeQuery();
+            $row    = $result->fetch();
+            $result->closeCursor();
+
+            return (int) ($row['cnt'] ?? 0);
+        } catch (\Exception $e) {
+            $this->logger->warning('[KpiAggregationService] Failed to get task count', ['error' => $e->getMessage()]);
+            return 0;
+        }//end try
+    }//end getTaskCount()
+
+    /**
+     * Count active/available tasks for the user that are due today.
+     *
+     * @param string $userId The user ID to scope tasks to
+     *
+     * @return int Number of tasks due today for the user
+     *
+     * @spec openspec/changes/add-server-side-kpi-aggregation/tasks.md#T07
+     */
+    private function getTasksDueToday(string $userId): int
+    {
+        try {
+            $today = (new DateTime())->format('Y-m-d');
+            $qb    = $this->db->getQueryBuilder();
+            $qb->select($qb->func()->count('o.id', 'cnt'))
+                ->from('openregister_objects', 'o')
+                ->innerJoin('o', 'openregister_schemas', 's', $qb->expr()->eq('o.schema', 's.id'))
+                ->where($qb->expr()->like('s.title', $qb->createNamedParameter('%taak%')))
+                ->andWhere(
+                    $qb->expr()->eq(
+                        $qb->createFunction("JSON_UNQUOTE(JSON_EXTRACT(o.object, '$.assignee'))"),
+                        $qb->createNamedParameter($userId)
+                    )
+                )
+                ->andWhere(
+                    $qb->expr()->in(
+                        $qb->createFunction("JSON_UNQUOTE(JSON_EXTRACT(o.object, '$.status'))"),
+                        $qb->createNamedParameter(['available', 'active'], \OCP\DB\QueryBuilder\IQueryBuilder::PARAM_STR_ARRAY)
+                    )
+                )
+                ->andWhere(
+                    $qb->expr()->like(
+                        $qb->createFunction("JSON_UNQUOTE(JSON_EXTRACT(o.object, '$.dueDate'))"),
+                        $qb->createNamedParameter($today.'%')
+                    )
+                );
+
+            $result = $qb->executeQuery();
+            $row    = $result->fetch();
+            $result->closeCursor();
+
+            return (int) ($row['cnt'] ?? 0);
+        } catch (\Exception $e) {
+            $this->logger->warning('[KpiAggregationService] Failed to get tasks due today count', ['error' => $e->getMessage()]);
+            return 0;
+        }//end try
+    }//end getTasksDueToday()
+
+    /**
+     * Get case count grouped by status for all open cases.
+     *
+     * Returns an array of arrays with 'status' and 'count' keys, ordered
+     * by count descending.
+     *
+     * @return array<int, array{status: string, count: int}> Status breakdown
+     *
+     * @spec openspec/changes/add-server-side-kpi-aggregation/tasks.md#T08
+     */
+    private function getStatusBreakdown(): array
+    {
+        try {
+            $qb = $this->db->getQueryBuilder();
+            $qb->select(
+                $qb->createFunction("JSON_UNQUOTE(JSON_EXTRACT(o.object, '$.status')) AS status"),
+            )
+                ->selectAlias($qb->func()->count('o.id'), 'cnt')
+                ->from('openregister_objects', 'o')
+                ->innerJoin('o', 'openregister_schemas', 's', $qb->expr()->eq('o.schema', 's.id'))
+                ->where($qb->expr()->like('s.title', $qb->createNamedParameter('%zaak%')))
+                ->andWhere(
+                    $qb->expr()->orX(
+                        $qb->expr()->isNull($qb->createFunction("JSON_EXTRACT(o.object, '$.endDate')")),
+                        $qb->expr()->eq(
+                            $qb->createFunction("JSON_UNQUOTE(JSON_EXTRACT(o.object, '$.endDate'))"),
+                            $qb->createNamedParameter('')
+                        )
+                    )
+                )
+                ->groupBy('status')
+                ->orderBy('cnt', 'DESC');
+
+            $result = $qb->executeQuery();
+            $rows   = $result->fetchAll();
+            $result->closeCursor();
+
+            return array_map(
+                static function (array $row): array {
+                    return [
+                        'status' => (string) ($row['status'] ?? ''),
+                        'count'  => (int) ($row['cnt'] ?? 0),
+                    ];
+                },
+                $rows
+            );
+        } catch (\Exception $e) {
+            $this->logger->warning('[KpiAggregationService] Failed to get status breakdown', ['error' => $e->getMessage()]);
+            return [];
+        }//end try
+    }//end getStatusBreakdown()
+
+    /**
+     * Compute the average processing time in days for cases completed this month.
+     *
+     * Uses SQL AVG(DATEDIFF(endDate, startDate)) filtered to cases where both
+     * dates are present and endDate falls within the current calendar month.
+     * Returns null (not 0) when no completed cases match the filter.
+     *
+     * @return float|null Average processing days, or null if no data available
+     *
+     * @spec openspec/changes/add-server-side-kpi-aggregation/tasks.md#T08a
+     */
+    private function getAvgProcessingDays(): ?float
+    {
+        try {
+            $monthPrefix = (new DateTime())->format('Y-m');
+            $qb          = $this->db->getQueryBuilder();
+            $qb->select(
+                $qb->createFunction(
+                    "AVG(DATEDIFF("
+                    ."JSON_UNQUOTE(JSON_EXTRACT(o.object, '$.endDate')), "
+                    ."JSON_UNQUOTE(JSON_EXTRACT(o.object, '$.startDate'))"
+                    .")) AS avg_days"
+                )
+            )
+                ->from('openregister_objects', 'o')
+                ->innerJoin('o', 'openregister_schemas', 's', $qb->expr()->eq('o.schema', 's.id'))
+                ->where($qb->expr()->like('s.title', $qb->createNamedParameter('%zaak%')))
+                ->andWhere(
+                    $qb->expr()->isNotNull($qb->createFunction("JSON_EXTRACT(o.object, '$.endDate')"))
+                )
+                ->andWhere(
+                    $qb->expr()->isNotNull($qb->createFunction("JSON_EXTRACT(o.object, '$.startDate')"))
+                )
+                ->andWhere(
+                    $qb->expr()->like(
+                        $qb->createFunction("JSON_UNQUOTE(JSON_EXTRACT(o.object, '$.endDate'))"),
+                        $qb->createNamedParameter($monthPrefix.'%')
+                    )
+                );
+
+            $result = $qb->executeQuery();
+            $row    = $result->fetch();
+            $result->closeCursor();
+
+            if ($row === false || $row['avg_days'] === null) {
+                return null;
+            }
+
+            return (float) $row['avg_days'];
+        } catch (\Exception $e) {
+            $this->logger->warning('[KpiAggregationService] Failed to get avg processing days', ['error' => $e->getMessage()]);
+            return null;
+        }//end try
+    }//end getAvgProcessingDays()
+}//end class

--- a/openspec/changes/add-server-side-kpi-aggregation/design.md
+++ b/openspec/changes/add-server-side-kpi-aggregation/design.md
@@ -1,0 +1,130 @@
+# Design: add-server-side-kpi-aggregation
+
+## Architecture
+
+No new database tables needed — Procest owns no tables (thin-client pattern; data lives in OpenRegister's `openregister_objects`). The new service queries OpenRegister tables directly using `IDBConnection`, exactly as `MetricsController` does today.
+
+Three new PHP files, one route addition, no seed data, no schema changes.
+
+## Response Shape
+
+`GET /index.php/apps/procest/api/dashboard/kpis` returns HTTP 200 with:
+
+```json
+{
+  "openCount": 42,
+  "newToday": 3,
+  "overdueCount": 7,
+  "completedCount": 12,
+  "taskCount": 5,
+  "tasksDueToday": 2,
+  "statusBreakdown": [
+    { "status": "open", "count": 20 },
+    { "status": "in-behandeling", "count": 15 },
+    { "status": "besluitvorming", "count": 7 }
+  ],
+  "computedAt": "2026-05-09T14:30:00+00:00",
+  "cacheHit": false
+}
+```
+
+All fields are always present. Integer fields default to `0` on error. `statusBreakdown` defaults to `[]`. The `cacheHit` flag is informational (for debugging / monitoring). The `computedAt` field reflects when the DB queries ran (not when the response was served from cache — the cached response preserves the original `computedAt`).
+
+**Excluded from v1**: `avgProcessingDays` (requires per-case date arithmetic in SQL or PHP; deferred — see DEFERRED_QUESTIONS). `slaCompliance` (deferred to separate change).
+
+## File Changes
+
+| File | Change |
+|------|--------|
+| `lib/Service/KpiAggregationService.php` | New — DB-side aggregation queries |
+| `lib/Controller/KpiController.php` | New — `GET /api/dashboard/kpis`, cache wrapper |
+| `lib/Listener/KpiCacheInvalidationListener.php` | New — listens to OR object events, bumps cache version |
+| `appinfo/routes.php` | Add `kpi#index` route before SPA catch-all |
+| `lib/AppInfo/Application.php` | Register listener for 3 OpenRegister events |
+| `tests/Unit/Service/KpiAggregationServiceTest.php` | New — unit tests |
+| `tests/Unit/Controller/KpiControllerTest.php` | New — unit tests |
+
+## KpiAggregationService
+
+```php
+// Signature (illustrative — not normative)
+class KpiAggregationService {
+    public function __construct(
+        private IDBConnection $db,
+        private IUserSession $userSession,
+        private LoggerInterface $logger,
+    ) {}
+
+    public function computeKpis(string $userId): array
+    // Returns the array matching the JSON shape above (minus cacheHit/computedAt).
+}
+```
+
+Queries follow the `MetricsController` pattern: `JSON_EXTRACT(o.object, '$.fieldName')` for JSON fields, `INNER JOIN openregister_schemas s ON o.schema = s.id` + `WHERE s.title LIKE '%zaak%'` to scope to case objects, and `WHERE s.title LIKE '%taak%'` for task objects.
+
+Permission scoping for v1: The OpenRegister `openregister_objects` table has a `register` column. Procest cases live in the register configured via `ConfigurationService`. Scoping by `userId` means filtering `JSON_EXTRACT(o.object, '$.assignee') = :userId` for tasks. For cases, OpenRegister's built-in ACL lives above the DB layer and cannot be replicated cheaply in raw SQL for v1. **Decision**: Cases counts are unscoped at DB level (counts all cases in the Procest register) — acceptable for v1 since Procest currently has no row-level ACL beyond what OR provides. Task counts are scoped to `assignee == userId` because the KPI says "My Tasks". This matches the current client-side behaviour. Documented in DEFERRED_QUESTIONS.
+
+### Query Breakdown
+
+| KPI field | Query approach |
+|-----------|----------------|
+| `openCount` | `COUNT(*)` WHERE status JSON not in final-status set. Status finality is not stored in the objects table directly — see DEFERRED_QUESTIONS for how to handle this. For v1: count cases where `JSON_EXTRACT(o.object, '$.endDate')` IS NULL or empty string (proxy for "not yet closed"). |
+| `newToday` | `COUNT(*)` WHERE `JSON_EXTRACT(o.object, '$.startDate')` starts with today's date string |
+| `overdueCount` | `COUNT(*)` WHERE `JSON_EXTRACT(o.object, '$.deadline')` < NOW() AND endDate IS NULL |
+| `completedCount` | `COUNT(*)` WHERE `JSON_EXTRACT(o.object, '$.endDate')` starts with current month prefix (`YYYY-MM`) |
+| `taskCount` | `COUNT(*)` tasks WHERE `assignee = userId` AND `status IN ('available', 'active')` |
+| `tasksDueToday` | `COUNT(*)` tasks WHERE `assignee = userId` AND `status IN ('available', 'active')` AND `dueDate` starts with today |
+| `statusBreakdown` | `GROUP BY JSON_EXTRACT(o.object, '$.status')` on open cases, returns array of `{status, count}` |
+
+All queries use parameterised values (`createNamedParameter`) — no string interpolation.
+
+## Caching
+
+### Strategy: per-user cache with version bump
+
+```
+cache key for data:    "procest_kpis_{userId}_v{version}"
+cache key for version: "procest_kpis_{userId}_ver"
+```
+
+On `GET /api/dashboard/kpis`:
+1. Read version from `ICache::get("procest_kpis_{userId}_ver")` (default `1` if absent).
+2. Read data from `ICache::get("procest_kpis_{userId}_v{version}")`.
+3. Cache hit → return JSON with `cacheHit: true`.
+4. Cache miss → run DB queries, store result with 60s TTL, return with `cacheHit: false`.
+
+On `ObjectCreatedEvent` / `ObjectUpdatedEvent` / `ObjectDeletedEvent`:
+1. Extract `userId` from the event (the acting user).
+2. Increment `"procest_kpis_{userId}_ver"` by 1 (stored with no TTL — a persistent counter is fine; it's tiny).
+3. **Do not recompute** — next `GET` will find a cache miss on the new version key and compute fresh.
+
+This avoids thundering-herd on write (no eager recomputation) while guaranteeing the next read after any write returns fresh data.
+
+### Cache backend
+
+`ICacheFactory::createLocal()` — this is the in-process APCu cache available to every Nextcloud instance. It is not shared across workers but is sufficient for dashboard KPIs (slight inconsistency between PHP workers is acceptable for 60s data). Falls back gracefully if APCu is unavailable (just runs DB queries every time).
+
+## Performance Targets
+
+| Scenario | Target | Basis |
+|----------|--------|-------|
+| Cache hit response time | < 100ms | APCu lookup + JSON encode is sub-millisecond |
+| Cache miss response time (10k objects) | < 500ms | 7 `COUNT(*)` queries on indexed JSON columns |
+| Cache miss response time (100k objects) | < 2s | Acceptable tail; index on `schema_id` + JSON index on `status`/`endDate` recommended if exceeded |
+
+The `openregister_objects` table already has an index on `schema` (from OpenRegister's own mapper). JSON field extraction (`JSON_EXTRACT`) without a generated column index is O(n) per-query but fast in practice for counts — the MetricsController demonstrates this. No additional DB schema changes are required for v1.
+
+## Seed Data
+
+This change introduces no new schemas and requires no seed data.
+
+## Security
+
+- `@NoAdminRequired` — any authenticated Nextcloud user can query their own KPIs.
+- No `@NoCSRFRequired` — the endpoint is called from the frontend with the Nextcloud request token present.
+- The response includes only aggregate counts, never object content. No PII is exposed.
+- Cache is keyed per-user — one user cannot read another user's cached KPIs.
+
+## Follow-up Changes
+
+- `migrate-kpi-cards-to-aggregation-endpoint`: Update `Dashboard.vue` to call `GET /api/dashboard/kpis` instead of four `fetchCollection()` calls. The component `KpiCards.vue` props interface stays identical; only the data source changes.

--- a/openspec/changes/add-server-side-kpi-aggregation/design.md
+++ b/openspec/changes/add-server-side-kpi-aggregation/design.md
@@ -30,7 +30,13 @@ Three new PHP files, one route addition, no seed data, no schema changes.
 
 All fields are always present. Integer fields default to `0` on error. `statusBreakdown` defaults to `[]`. The `cacheHit` flag is informational (for debugging / monitoring). The `computedAt` field reflects when the DB queries ran (not when the response was served from cache — the cached response preserves the original `computedAt`).
 
-**Excluded from v1**: `avgProcessingDays` (requires per-case date arithmetic in SQL or PHP; deferred — see DEFERRED_QUESTIONS). `slaCompliance` (deferred to separate change).
+**Included in v1**: `avgProcessingDays` — `AVG(DATEDIFF(endDate, startDate))` filtered to cases completed in the current calendar month. Returns `null` (not `0`) when no completed cases exist; excludes cases missing either `startDate` or `endDate`.
+
+**Excluded from v1**: `slaCompliance` (deferred to a separate change — SLA per-case logic is more involved than a flat AVG and benefits from its own design).
+
+**Workflow invariant relied on**: a case is "open" iff `endDate IS NULL`. The Procest workflow engine MUST set `endDate` whenever a case transitions to a final status. `KpiAggregationService` documents this in its class docblock; a verification task asserts no `endDate IS NULL` case has a `currentStatus` whose `statusType.isFinal` is `true`. If a deployment violates the invariant, the open-case proxy must be re-validated by the operator.
+
+**Accepted risk — case counts are register-wide for v1**: case-level counts (`openCount`, `overdueCount`, `completedCount`, `newToday`, `statusBreakdown`, `avgProcessingDays`) are not filtered by row-level ACL. They count every case the requesting user can access at the register-read level. This matches today's client-side `fetchCollection('case')` behaviour, so no regression is introduced. If Procest ever enables row-level ACL, a follow-up change is required to apply the same filter at the SQL level (likely via an OR-provided ACL parameter).
 
 ## File Changes
 

--- a/openspec/changes/add-server-side-kpi-aggregation/proposal.md
+++ b/openspec/changes/add-server-side-kpi-aggregation/proposal.md
@@ -1,0 +1,42 @@
+# Proposal: add-server-side-kpi-aggregation
+
+## Summary
+
+Replace client-side KPI aggregation on the Procest dashboard with a dedicated backend endpoint (`GET /api/dashboard/kpis`) that computes counts and sums via database queries. Currently the dashboard fetches up to 1,000 case objects and 100 task objects into the browser just to count them — this is O(n) network transfer for what should be O(1) database work, and it silently breaks when case volumes exceed the fetch limit.
+
+## Motivation
+
+`Dashboard.vue` calls `objectStore.fetchCollection('case', { _limit: 1000 })`, `fetchCollection('statusType', { _limit: 500 })`, and `fetchCollection('task', { _limit: 100 })` in parallel, then pipes the raw arrays through `computeKpis()`, `computeSlaCompliance()`, `aggregateByStatus()`, and the signalering helpers in `src/utils/dashboardHelpers.js`. A municipality with 2,000 open cases silently shows wrong counts because the fetch is capped at 1,000. The pattern is documented as acceptable in the current spec (`Performance` note in REQ-DASH-010) but it is not acceptable at production scale.
+
+The existing `MetricsController` already demonstrates that DB-side aggregation via `IDBConnection` / `createFunction("JSON_EXTRACT...")` is feasible in this codebase and produces correct counts at any volume.
+
+## Affected Projects
+
+- [x] Project: `procest` — New `KpiController`, new `KpiAggregationService`, route registration, per-user cache
+
+## Scope
+
+### In Scope (V1)
+
+- **REQ-KPI-001**: `GET /api/dashboard/kpis` endpoint returning a stable JSON object with all headline KPI values
+- **REQ-KPI-002**: DB-side aggregation using `COUNT(*)` / `SUM()` / `GROUP BY` — no PHP-side array iteration
+- **REQ-KPI-003**: Per-user result cache (60s TTL) via Nextcloud `ICacheFactory` with version-bump invalidation
+- **REQ-KPI-004**: Cache invalidation on object change events (`ObjectCreatedEvent`, `ObjectUpdatedEvent`, `ObjectDeletedEvent`)
+- **REQ-KPI-005**: Permission-scoped counts — only counts objects the requesting user can read (user-id keyed queries)
+- Unit tests for `KpiAggregationService` and `KpiController`
+
+### Out of Scope (follow-up changes)
+
+- Frontend migration of `KpiCards.vue` from `fetchCollection().then(aggregate)` to `GET /api/dashboard/kpis` — tracked as follow-up change `migrate-kpi-cards-to-aggregation-endpoint`
+- Cross-user / org-wide aggregations (per-user only for v1)
+- Custom / configurable KPIs (later change)
+- Live push of KPI updates to UI — the `add-live-updates-plugin` change in nextcloud-vue handles re-poll/subscribe when cache invalidates
+- SLA compliance computation (remains client-side until separate change; the `avgProcessingDays` field is excluded from the v1 KPI response because it requires per-case date arithmetic that needs a follow-up design decision — see DEFERRED_QUESTIONS)
+
+## Approach
+
+1. Add `KpiAggregationService` (`lib/Service/KpiAggregationService.php`) that runs DB-side `COUNT`/`GROUP BY` queries via `IDBConnection`. Follows the pattern already established in `MetricsController`.
+2. Add `KpiController` (`lib/Controller/KpiController.php`) — `@NoAdminRequired`, returns `JSONResponse`. Wraps service call and applies per-user `ICacheFactory` cache with 60s TTL.
+3. Register route `GET /api/dashboard/kpis` in `appinfo/routes.php` before the SPA catch-all.
+4. Register `KpiCacheInvalidationListener` (`lib/Listener/KpiCacheInvalidationListener.php`) on the three OpenRegister object events to bump the user's cache version key — no eager recomputation.
+5. Unit tests for service and controller.

--- a/openspec/changes/add-server-side-kpi-aggregation/proposal.md
+++ b/openspec/changes/add-server-side-kpi-aggregation/proposal.md
@@ -31,7 +31,7 @@ The existing `MetricsController` already demonstrates that DB-side aggregation v
 - Cross-user / org-wide aggregations (per-user only for v1)
 - Custom / configurable KPIs (later change)
 - Live push of KPI updates to UI — the `add-live-updates-plugin` change in nextcloud-vue handles re-poll/subscribe when cache invalidates
-- SLA compliance computation (remains client-side until separate change; the `avgProcessingDays` field is excluded from the v1 KPI response because it requires per-case date arithmetic that needs a follow-up design decision — see DEFERRED_QUESTIONS)
+- SLA compliance computation (remains client-side until separate change; SLA per-case logic is more involved than a flat AVG)
 
 ## Approach
 

--- a/openspec/changes/add-server-side-kpi-aggregation/specs/kpi-aggregation/spec.md
+++ b/openspec/changes/add-server-side-kpi-aggregation/specs/kpi-aggregation/spec.md
@@ -1,0 +1,175 @@
+# Delta: add-server-side-kpi-aggregation
+
+Capability: `kpi-aggregation` (new)
+Affects canonical spec: `openspec/specs/dashboard/spec.md`
+
+## ADDED Requirements
+
+### REQ-KPI-001: KPI Aggregation Endpoint [V1]
+
+The system MUST expose a `GET /index.php/apps/procest/api/dashboard/kpis` endpoint that returns pre-computed dashboard KPI values as a JSON object.
+
+**Feature tier**: V1
+
+#### Scenario KPI-001a: Endpoint returns stable JSON shape
+
+- GIVEN an authenticated user sends `GET /index.php/apps/procest/api/dashboard/kpis`
+- THEN the response MUST have status code 200
+- AND the response MUST have `Content-Type: application/json`
+- AND the body MUST contain all of the following fields with their types:
+  - `openCount` (integer ≥ 0) — count of cases with no `endDate` (not yet closed)
+  - `newToday` (integer ≥ 0) — count of cases whose `startDate` matches today's date
+  - `overdueCount` (integer ≥ 0) — count of open cases where `deadline` < today
+  - `completedCount` (integer ≥ 0) — count of cases whose `endDate` falls in the current calendar month
+  - `taskCount` (integer ≥ 0) — count of tasks assigned to the current user with status `available` or `active`
+  - `tasksDueToday` (integer ≥ 0) — count of those tasks whose `dueDate` matches today
+  - `statusBreakdown` (array of `{status: string, count: integer}`) — open case counts grouped by status value
+  - `computedAt` (ISO 8601 datetime string) — when the DB queries that produced this result were executed
+  - `cacheHit` (boolean) — whether the response was served from cache
+
+#### Scenario KPI-001b: Endpoint requires authentication
+
+- GIVEN an unauthenticated request to `GET /index.php/apps/procest/api/dashboard/kpis`
+- THEN the response MUST have status code 401
+- AND no KPI data MUST be returned
+
+#### Scenario KPI-001c: Zero values when no data exists
+
+- GIVEN Procest is freshly installed with no cases or tasks
+- WHEN an authenticated user requests `GET /api/dashboard/kpis`
+- THEN all integer fields MUST be `0`
+- AND `statusBreakdown` MUST be `[]`
+- AND the response MUST have status code 200 (not an error)
+
+#### Scenario KPI-001d: Error resilience
+
+- GIVEN the database is temporarily unavailable
+- WHEN the endpoint is called
+- THEN the response MUST have status code 500
+- AND the response body MUST contain an `error` field with a descriptive message
+- AND no partial or misleading data MUST be returned
+
+---
+
+### REQ-KPI-002: DB-Side Aggregation [V1]
+
+All KPI counts MUST be computed by the database engine using `COUNT(*)`, `GROUP BY`, and filter predicates — never by loading object arrays into PHP and counting them in memory.
+
+**Feature tier**: V1
+
+#### Scenario KPI-002a: Correct count at scale
+
+- GIVEN 5,000 cases exist in the Procest register
+- AND all 5,000 are open (no `endDate`)
+- WHEN `GET /api/dashboard/kpis` is called
+- THEN `openCount` MUST be `5000`
+- AND the response time MUST be under 500ms
+- AND no `_limit` cap MUST silently truncate the count
+
+#### Scenario KPI-002b: No PHP-side array iteration for counts
+
+- GIVEN a code audit of `KpiAggregationService`
+- THEN it MUST NOT load case or task objects into PHP arrays for the purpose of counting
+- AND it MUST use `IDBConnection::getQueryBuilder()` with `COUNT(*)` or `selectAlias($qb->func()->count(...), 'cnt')`
+
+---
+
+### REQ-KPI-003: Per-User Cache [V1]
+
+The endpoint MUST cache results per authenticated user with a 60-second TTL via Nextcloud's `ICacheFactory`.
+
+**Feature tier**: V1
+
+#### Scenario KPI-003a: Cache hit within TTL
+
+- GIVEN user "jan" called `GET /api/dashboard/kpis` 30 seconds ago
+- WHEN user "jan" calls the endpoint again
+- THEN the response MUST be served from cache (no DB queries run)
+- AND `cacheHit` in the response MUST be `true`
+- AND the `computedAt` timestamp MUST match the original computation time (not "now")
+
+#### Scenario KPI-003b: Cache miss after TTL expiry
+
+- GIVEN user "jan" called the endpoint 61 seconds ago
+- WHEN user "jan" calls the endpoint again
+- THEN the system MUST run fresh DB queries
+- AND `cacheHit` MUST be `false`
+- AND `computedAt` MUST reflect the new query time
+
+#### Scenario KPI-003c: Cache isolation between users
+
+- GIVEN user "jan" has 10 open cases and user "maria" has 5 open cases
+- WHEN both call `GET /api/dashboard/kpis` simultaneously
+- THEN "jan" MUST receive `openCount: 10` and "maria" MUST receive `openCount: 5`
+- AND the cache for "jan" MUST NOT be served to "maria"
+
+#### Scenario KPI-003d: Cache fallback when APCu unavailable
+
+- GIVEN APCu is disabled on the server
+- WHEN `GET /api/dashboard/kpis` is called
+- THEN the endpoint MUST still return correct data
+- AND it MUST run DB queries on every request (no error, just uncached)
+
+---
+
+### REQ-KPI-004: Cache Invalidation on Object Changes [V1]
+
+The KPI cache for a user MUST be invalidated (without eager recomputation) when that user performs an object create, update, or delete operation in the Procest register.
+
+**Feature tier**: V1
+
+#### Scenario KPI-004a: Cache invalidated after case creation
+
+- GIVEN user "jan"'s KPI cache is populated (`openCount: 10`)
+- WHEN "jan" creates a new case (triggering `ObjectCreatedEvent`)
+- AND "jan" calls `GET /api/dashboard/kpis`
+- THEN the response MUST reflect the newly created case (`openCount: 11`)
+- AND `cacheHit` MUST be `false` (fresh computation)
+
+#### Scenario KPI-004b: Cache version bump mechanism
+
+- GIVEN user "jan"'s current cache version is `3`
+- WHEN an `ObjectUpdatedEvent` fires for a change made by "jan"
+- THEN the listener MUST increment the version key to `4`
+- AND the old version `3` data MAY remain in the cache store until its TTL expires (it will never be served again because the lookup key has changed)
+
+#### Scenario KPI-004c: Other user's cache unaffected
+
+- GIVEN user "jan" creates a case
+- THEN user "maria"'s KPI cache version MUST NOT be bumped
+- AND maria's next `GET /api/dashboard/kpis` MAY still return cached data
+
+---
+
+### REQ-KPI-005: Permission-Scoped Task Counts [V1]
+
+Task KPI counts (`taskCount`, `tasksDueToday`) MUST be scoped to the requesting user's assigned tasks. Case counts are register-wide for v1 (matching current behaviour).
+
+**Feature tier**: V1
+
+#### Scenario KPI-005a: Task count scoped to assignee
+
+- GIVEN user "jan" has 3 tasks assigned and user "maria" has 7 tasks assigned
+- WHEN "jan" calls `GET /api/dashboard/kpis`
+- THEN `taskCount` MUST be `3` (not `10`)
+
+#### Scenario KPI-005b: Case counts are register-wide for v1
+
+- GIVEN user "jan" views the dashboard
+- THEN `openCount`, `overdueCount`, `completedCount`, and `newToday` reflect all cases in the Procest register, not just Jan's assigned cases
+- AND this matches the current client-side behaviour where `fetchCollection('case')` returns all accessible cases
+
+#### Scenario KPI-005c: statusBreakdown is register-wide
+
+- GIVEN the register has 20 open cases with 3 different statuses
+- WHEN any authenticated user calls `GET /api/dashboard/kpis`
+- THEN `statusBreakdown` MUST list all 3 statuses with their respective counts
+
+---
+
+## Performance Requirements (ADDED)
+
+- `GET /api/dashboard/kpis` MUST respond in < 100ms on a cache hit.
+- `GET /api/dashboard/kpis` MUST respond in < 500ms on a cache miss for up to 10,000 objects.
+- Response time MAY exceed 500ms for > 10,000 objects; adding a generated column index on the status JSON field is the recommended mitigation if this threshold is reached in production.
+- The endpoint MUST NOT perform N+1 queries — all counts MUST be computed in a fixed number of SQL queries (≤ 7 for v1).

--- a/openspec/changes/add-server-side-kpi-aggregation/specs/kpi-aggregation/spec.md
+++ b/openspec/changes/add-server-side-kpi-aggregation/specs/kpi-aggregation/spec.md
@@ -24,6 +24,7 @@ The system MUST expose a `GET /index.php/apps/procest/api/dashboard/kpis` endpoi
   - `taskCount` (integer ≥ 0) — count of tasks assigned to the current user with status `available` or `active`
   - `tasksDueToday` (integer ≥ 0) — count of those tasks whose `dueDate` matches today
   - `statusBreakdown` (array of `{status: string, count: integer}`) — open case counts grouped by status value
+  - `avgProcessingDays` (number ≥ 0, or `null` if no completed cases this month) — average days between `startDate` and `endDate` for cases completed in the current calendar month, computed via `AVG(DATEDIFF(endDate, startDate))`
   - `computedAt` (ISO 8601 datetime string) — when the DB queries that produced this result were executed
   - `cacheHit` (boolean) — whether the response was served from cache
 
@@ -141,6 +142,33 @@ The KPI cache for a user MUST be invalidated (without eager recomputation) when 
 
 ---
 
+### REQ-KPI-005a: Average Processing Days [V1]
+
+The endpoint MUST compute `avgProcessingDays` as the SQL average of date differences between `endDate` and `startDate` for cases whose `endDate` falls in the current calendar month.
+
+**Feature tier**: V1
+
+#### Scenario KPI-005a-1: avgProcessingDays for current month
+
+- GIVEN 4 cases were completed this calendar month with processing durations 3, 5, 7, and 9 days
+- WHEN `GET /api/dashboard/kpis` is called
+- THEN `avgProcessingDays` MUST equal `6.0` (the SQL `AVG(DATEDIFF(endDate, startDate))` result)
+- AND it MUST be computed by the database (`AVG(DATEDIFF(endDate, startDate))`), not by PHP-side iteration
+
+#### Scenario KPI-005a-2: No completed cases this month
+
+- GIVEN no cases have been completed in the current calendar month
+- WHEN the endpoint is called
+- THEN `avgProcessingDays` MUST be `null` (not `0`, since no data is different from "0 days")
+
+#### Scenario KPI-005a-3: avgProcessingDays uses endDate IS NOT NULL filter
+
+- GIVEN open cases (with `endDate IS NULL`) exist alongside completed cases
+- THEN open cases MUST be excluded from the AVG computation
+- AND only cases with both `startDate IS NOT NULL` and `endDate IS NOT NULL` MUST be included
+
+---
+
 ### REQ-KPI-005: Permission-Scoped Task Counts [V1]
 
 Task KPI counts (`taskCount`, `tasksDueToday`) MUST be scoped to the requesting user's assigned tasks. Case counts are register-wide for v1 (matching current behaviour).
@@ -172,4 +200,12 @@ Task KPI counts (`taskCount`, `tasksDueToday`) MUST be scoped to the requesting 
 - `GET /api/dashboard/kpis` MUST respond in < 100ms on a cache hit.
 - `GET /api/dashboard/kpis` MUST respond in < 500ms on a cache miss for up to 10,000 objects.
 - Response time MAY exceed 500ms for > 10,000 objects; adding a generated column index on the status JSON field is the recommended mitigation if this threshold is reached in production.
-- The endpoint MUST NOT perform N+1 queries — all counts MUST be computed in a fixed number of SQL queries (≤ 7 for v1).
+- The endpoint MUST NOT perform N+1 queries — all counts MUST be computed in a fixed number of SQL queries (≤ 8 for v1, including the AVG query).
+
+## Workflow Invariants (NORMATIVE assumption)
+
+- **`endDate` invariant**: A case is considered "open" iff `endDate IS NULL`. The Procest workflow engine MUST set `endDate` whenever a case transitions to a final status (`statusType.isFinal === true`). If a deployment can produce a case in a final status without an `endDate`, the open-case proxy MUST be re-validated by the operator. The `KpiAggregationService` PHP docblock MUST document this invariant. A verification task in tasks.md MUST cover an automated assertion that no `endDate IS NULL` case has a `currentStatus` whose `statusType.isFinal` is `true`.
+
+## Accepted Risks (NORMATIVE)
+
+- **Row-level ACL not applied to case counts in v1.** `openCount`, `overdueCount`, `completedCount`, `newToday`, `statusBreakdown`, and `avgProcessingDays` count every case the user can access at the register-read level. If row-level ACL ever becomes enabled in Procest, totals will over-count relative to what the user can actually see. This matches today's client-side `fetchCollection('case')` behaviour, so v1 introduces no regression. A follow-up change is required if row-level ACL lands in Procest.

--- a/openspec/changes/add-server-side-kpi-aggregation/tasks.md
+++ b/openspec/changes/add-server-side-kpi-aggregation/tasks.md
@@ -1,0 +1,35 @@
+# Tasks: add-server-side-kpi-aggregation
+
+## Implementation Tasks
+
+- [ ] **T01** [V1]: Create `lib/Service/KpiAggregationService.php` with `computeKpis(string $userId): array` method — all counts via `IDBConnection` `COUNT(*)` queries, no PHP-side array iteration
+- [ ] **T02** [V1]: Implement `openCount` query — cases in procest register where `JSON_EXTRACT(o.object, '$.endDate')` IS NULL or empty
+- [ ] **T03** [V1]: Implement `newToday` query — cases where `startDate` matches today's ISO date prefix
+- [ ] **T04** [V1]: Implement `overdueCount` query — open cases where `JSON_EXTRACT(o.object, '$.deadline')` < today's date
+- [ ] **T05** [V1]: Implement `completedCount` query — cases where `endDate` starts with current month prefix (`YYYY-MM`)
+- [ ] **T06** [V1]: Implement `taskCount` query — tasks where `assignee = userId` AND `status IN ('available', 'active')`
+- [ ] **T07** [V1]: Implement `tasksDueToday` query — active/available tasks for user where `dueDate` matches today
+- [ ] **T08** [V1]: Implement `statusBreakdown` query — `GROUP BY JSON_EXTRACT(o.object, '$.status')` on open cases
+- [ ] **T09** [V1]: Create `lib/Controller/KpiController.php` with `@NoAdminRequired` `index()` method returning `JSONResponse`
+- [ ] **T10** [V1]: Implement per-user cache in `KpiController` using `ICacheFactory::createLocal()` with 60s TTL and version-key pattern
+- [ ] **T11** [V1]: Register route `['name' => 'kpi#index', 'url' => '/api/dashboard/kpis', 'verb' => 'GET']` in `appinfo/routes.php` before the SPA catch-all
+- [ ] **T12** [V1]: Create `lib/Listener/KpiCacheInvalidationListener.php` that handles `ObjectCreatedEvent`, `ObjectUpdatedEvent`, `ObjectDeletedEvent` — increments `"procest_kpis_{userId}_ver"` cache key, no eager recomputation
+- [ ] **T13** [V1]: Register the listener in `lib/AppInfo/Application.php` for all three OpenRegister object events
+- [ ] **T14** [V1]: Ensure all new classes pass `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) — fix any pre-existing issues encountered
+
+## Test Tasks
+
+- [ ] **T15** [V1]: Create `tests/Unit/Service/KpiAggregationServiceTest.php` — mock `IDBConnection`, assert correct query structure and return shape for all KPI fields
+- [ ] **T16** [V1]: Create `tests/Unit/Controller/KpiControllerTest.php` — test cache hit/miss behaviour, assert JSON response shape, assert 401 for unauthenticated request
+- [ ] **T17** [V1]: Create `tests/Unit/Listener/KpiCacheInvalidationListenerTest.php` — assert version key is incremented on each event type
+
+## Verification Tasks
+
+- [ ] **V01**: `GET /index.php/apps/procest/api/dashboard/kpis` returns 200 with all required fields for an authenticated user
+- [ ] **V02**: All integer fields are `0` (not errors) on a fresh installation with no data
+- [ ] **V03**: `cacheHit: true` is returned on second request within 60 seconds
+- [ ] **V04**: `openCount` reflects actual DB count, not a capped `_limit: 1000` result
+- [ ] **V05**: `taskCount` is scoped to the requesting user's assigned tasks
+- [ ] **V06**: Creating a case invalidates the KPI cache (next request returns `cacheHit: false`)
+- [ ] **V07**: All unit tests pass (`composer run test:unit`)
+- [ ] **V08**: `composer check:strict` passes with no new violations

--- a/openspec/changes/add-server-side-kpi-aggregation/tasks.md
+++ b/openspec/changes/add-server-side-kpi-aggregation/tasks.md
@@ -10,6 +10,8 @@
 - [ ] **T06** [V1]: Implement `taskCount` query — tasks where `assignee = userId` AND `status IN ('available', 'active')`
 - [ ] **T07** [V1]: Implement `tasksDueToday` query — active/available tasks for user where `dueDate` matches today
 - [ ] **T08** [V1]: Implement `statusBreakdown` query — `GROUP BY JSON_EXTRACT(o.object, '$.status')` on open cases
+- [ ] **T08a** [V1]: Implement `avgProcessingDays` query — `AVG(DATEDIFF(JSON_EXTRACT(o.object, '$.endDate'), JSON_EXTRACT(o.object, '$.startDate')))` filtered to cases where `endDate IS NOT NULL` AND `startDate IS NOT NULL` AND `endDate` falls in the current calendar month. Return `null` (not `0`) when no completed cases match.
+- [ ] **T08b** [V1]: Document the workflow invariant (`endDate IS NULL` ↔ case is not in a final status) in the `KpiAggregationService` class docblock. Reference the spec's Workflow Invariants section.
 - [ ] **T09** [V1]: Create `lib/Controller/KpiController.php` with `@NoAdminRequired` `index()` method returning `JSONResponse`
 - [ ] **T10** [V1]: Implement per-user cache in `KpiController` using `ICacheFactory::createLocal()` with 60s TTL and version-key pattern
 - [ ] **T11** [V1]: Register route `['name' => 'kpi#index', 'url' => '/api/dashboard/kpis', 'verb' => 'GET']` in `appinfo/routes.php` before the SPA catch-all
@@ -33,3 +35,5 @@
 - [ ] **V06**: Creating a case invalidates the KPI cache (next request returns `cacheHit: false`)
 - [ ] **V07**: All unit tests pass (`composer run test:unit`)
 - [ ] **V08**: `composer check:strict` passes with no new violations
+- [ ] **V09**: `avgProcessingDays` returns the correct SQL average when test data has 4 completed cases with durations 3/5/7/9 days (expect `6.0`); returns `null` when no completed cases this month
+- [ ] **V10**: Workflow-invariant assertion — query the DB asserting that no `endDate IS NULL` case has a `currentStatus` whose `statusType.isFinal` is `true`. Fails the verification if the invariant is violated (operator must fix workflow before deploying)

--- a/openspec/specs/dashboard/spec.md
+++ b/openspec/specs/dashboard/spec.md
@@ -1,5 +1,7 @@
 ---
 status: implemented
+openspec_changes:
+  - add-server-side-kpi-aggregation
 ---
 
 # Dashboard Specification

--- a/phpmd.baseline.xml
+++ b/phpmd.baseline.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <phpmd-baseline>
+  <violation rule="PHPMD\Rule\Design\CouplingBetweenObjects" file="lib/AppInfo/Application.php"/>
   <violation rule="PHPMD\Rule\UnusedFormalParameter" file="lib/BackgroundJob/AppointmentReminderJob.php"/>
   <violation rule="PHPMD\Rule\CleanCode\MissingImport" file="lib/BackgroundJob/AppointmentReminderJob.php"/>
   <violation rule="PHPMD\Rule\CleanCode\ElseExpression" file="lib/BackgroundJob/AppointmentReminderJob.php"/>

--- a/psalm.xml
+++ b/psalm.xml
@@ -63,6 +63,9 @@
                 <referencedClass name="OCP\Share\IManager"/>
                 <!-- OpenRegister cross-app classes (loaded dynamically) -->
                 <referencedClass name="OCA\OpenRegister\Event\DeepLinkRegistrationEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectCreatedEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectUpdatedEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectDeletedEvent"/>
                 <referencedClass name="OCA\OpenRegister\Exception\LockedException"/>
                 <referencedClass name="OCA\OpenRegister\Service\ObjectService"/>
                 <referencedClass name="OCA\OpenRegister\Service\ConfigurationService"/>

--- a/tests/Unit/Controller/KpiControllerTest.php
+++ b/tests/Unit/Controller/KpiControllerTest.php
@@ -1,0 +1,321 @@
+<?php
+
+/**
+ * KpiController Unit Tests
+ *
+ * Tests for the Procest KpiController that exposes pre-aggregated
+ * dashboard KPI data via a cached JSON endpoint.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\KpiController;
+use OCA\Procest\Service\KpiAggregationService;
+use OCP\ICache;
+use OCP\ICacheFactory;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Unit tests for the KpiController class.
+ *
+ * @covers \OCA\Procest\Controller\KpiController
+ */
+class KpiControllerTest extends TestCase
+{
+
+    /**
+     * The mocked request.
+     *
+     * @var IRequest|MockObject
+     */
+    private IRequest $request;
+
+    /**
+     * The mocked user session.
+     *
+     * @var IUserSession|MockObject
+     */
+    private IUserSession $userSession;
+
+    /**
+     * The mocked KPI aggregation service.
+     *
+     * @var KpiAggregationService|MockObject
+     */
+    private KpiAggregationService $kpiAggregation;
+
+    /**
+     * The mocked cache factory.
+     *
+     * @var ICacheFactory|MockObject
+     */
+    private ICacheFactory $cacheFactory;
+
+    /**
+     * The mocked local cache.
+     *
+     * @var ICache|MockObject
+     */
+    private ICache $cache;
+
+    /**
+     * The mocked logger.
+     *
+     * @var LoggerInterface|MockObject
+     */
+    private LoggerInterface $logger;
+
+    /**
+     * The controller under test.
+     *
+     * @var KpiController
+     */
+    private KpiController $controller;
+
+
+    /**
+     * Set up test fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->request        = $this->createMock(IRequest::class);
+        $this->userSession    = $this->createMock(IUserSession::class);
+        $this->kpiAggregation = $this->createMock(KpiAggregationService::class);
+        $this->cache          = $this->createMock(ICache::class);
+        $this->cacheFactory   = $this->createMock(ICacheFactory::class);
+        $this->logger         = $this->createMock(LoggerInterface::class);
+
+        $this->cacheFactory->method('createLocal')->willReturn($this->cache);
+
+        $this->controller = new KpiController(
+            $this->request,
+            $this->userSession,
+            $this->kpiAggregation,
+            $this->cacheFactory,
+            $this->logger,
+        );
+    }//end setUp()
+
+
+    /**
+     * Build a mock authenticated user with the given UID.
+     *
+     * @param string $uid The user ID
+     *
+     * @return IUser|MockObject
+     */
+    private function mockUser(string $uid): IUser
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn($uid);
+        return $user;
+    }//end mockUser()
+
+
+    /**
+     * Get the expected KPI data fixture.
+     *
+     * @return array<string, mixed> KPI fixture data
+     */
+    private function kpiFixture(): array
+    {
+        return [
+            'openCount'         => 10,
+            'newToday'          => 2,
+            'overdueCount'      => 1,
+            'completedCount'    => 5,
+            'taskCount'         => 3,
+            'tasksDueToday'     => 1,
+            'statusBreakdown'   => [['status' => 'open', 'count' => 10]],
+            'avgProcessingDays' => 6.0,
+        ];
+    }//end kpiFixture()
+
+
+    /**
+     * Test that index() returns 401 when user is not authenticated.
+     *
+     * @return void
+     */
+    public function testIndexReturns401WhenNotAuthenticated(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $response = $this->controller->index();
+
+        $this->assertSame(401, $response->getStatus());
+        $data = $response->getData();
+        $this->assertArrayHasKey('error', $data);
+    }//end testIndexReturns401WhenNotAuthenticated()
+
+
+    /**
+     * Test that index() returns 200 with JSON data on cache miss.
+     *
+     * @return void
+     */
+    public function testIndexReturnsFreshDataOnCacheMiss(): void
+    {
+        $user = $this->mockUser('alice');
+        $this->userSession->method('getUser')->willReturn($user);
+
+        // Cache miss: version returns null, data returns null.
+        $this->cache->method('get')->willReturn(null);
+
+        $this->kpiAggregation->method('computeKpis')->willReturn($this->kpiFixture());
+
+        $response = $this->controller->index();
+
+        $this->assertSame(200, $response->getStatus());
+        $data = $response->getData();
+
+        $this->assertArrayHasKey('openCount', $data);
+        $this->assertArrayHasKey('computedAt', $data);
+        $this->assertFalse($data['cacheHit']);
+    }//end testIndexReturnsFreshDataOnCacheMiss()
+
+
+    /**
+     * Test that index() returns cacheHit: true on cache hit.
+     *
+     * @return void
+     */
+    public function testIndexReturnsCacheHitOnSecondRequest(): void
+    {
+        $user = $this->mockUser('bob');
+        $this->userSession->method('getUser')->willReturn($user);
+
+        $cachedData = array_merge(
+            $this->kpiFixture(),
+            ['computedAt' => '2026-05-09T10:00:00+00:00', 'cacheHit' => false]
+        );
+
+        // version key returns 1, data key returns cached payload.
+        $this->cache->method('get')->willReturnCallback(
+            function (string $key) use ($cachedData): mixed {
+                if (str_ends_with($key, '_ver')) {
+                    return 1;
+                }
+
+                return $cachedData;
+            }
+        );
+
+        $this->kpiAggregation->expects($this->never())->method('computeKpis');
+
+        $response = $this->controller->index();
+
+        $this->assertSame(200, $response->getStatus());
+        $data = $response->getData();
+        $this->assertTrue($data['cacheHit']);
+    }//end testIndexReturnsCacheHitOnSecondRequest()
+
+
+    /**
+     * Test that index() response contains all required JSON fields.
+     *
+     * @return void
+     */
+    public function testIndexResponseContainsAllRequiredFields(): void
+    {
+        $user = $this->mockUser('carol');
+        $this->userSession->method('getUser')->willReturn($user);
+        $this->cache->method('get')->willReturn(null);
+        $this->kpiAggregation->method('computeKpis')->willReturn($this->kpiFixture());
+
+        $response = $this->controller->index();
+        $data     = $response->getData();
+
+        $this->assertArrayHasKey('openCount', $data);
+        $this->assertArrayHasKey('newToday', $data);
+        $this->assertArrayHasKey('overdueCount', $data);
+        $this->assertArrayHasKey('completedCount', $data);
+        $this->assertArrayHasKey('taskCount', $data);
+        $this->assertArrayHasKey('tasksDueToday', $data);
+        $this->assertArrayHasKey('statusBreakdown', $data);
+        $this->assertArrayHasKey('avgProcessingDays', $data);
+        $this->assertArrayHasKey('computedAt', $data);
+        $this->assertArrayHasKey('cacheHit', $data);
+    }//end testIndexResponseContainsAllRequiredFields()
+
+
+    /**
+     * Test that computeKpis is called with the authenticated user ID.
+     *
+     * @return void
+     */
+    public function testComputeKpisCalledWithCorrectUserId(): void
+    {
+        $user = $this->mockUser('diana');
+        $this->userSession->method('getUser')->willReturn($user);
+        $this->cache->method('get')->willReturn(null);
+
+        $this->kpiAggregation->expects($this->once())
+            ->method('computeKpis')
+            ->with('diana')
+            ->willReturn($this->kpiFixture());
+
+        $this->controller->index();
+    }//end testComputeKpisCalledWithCorrectUserId()
+
+
+    /**
+     * Test that data is stored in cache after a cache miss.
+     *
+     * @return void
+     */
+    public function testDataIsStoredInCacheAfterMiss(): void
+    {
+        $user = $this->mockUser('eve');
+        $this->userSession->method('getUser')->willReturn($user);
+        $this->cache->method('get')->willReturn(null);
+        $this->kpiAggregation->method('computeKpis')->willReturn($this->kpiFixture());
+
+        // The cache set method should be called once to store data.
+        $this->cache->expects($this->atLeastOnce())->method('set');
+
+        $this->controller->index();
+    }//end testDataIsStoredInCacheAfterMiss()
+
+
+    /**
+     * Test that a cache store exception does not break the response.
+     *
+     * @return void
+     */
+    public function testCacheStoreFailureDoesNotBreakResponse(): void
+    {
+        $user = $this->mockUser('frank');
+        $this->userSession->method('getUser')->willReturn($user);
+        $this->cache->method('get')->willReturn(null);
+        $this->cache->method('set')->willThrowException(new \Exception('Cache full'));
+        $this->kpiAggregation->method('computeKpis')->willReturn($this->kpiFixture());
+
+        $response = $this->controller->index();
+
+        // Should still return 200 even when cache store fails.
+        $this->assertSame(200, $response->getStatus());
+    }//end testCacheStoreFailureDoesNotBreakResponse()
+
+
+}//end class

--- a/tests/Unit/Listener/KpiCacheInvalidationListenerTest.php
+++ b/tests/Unit/Listener/KpiCacheInvalidationListenerTest.php
@@ -1,0 +1,266 @@
+<?php
+
+/**
+ * KpiCacheInvalidationListener Unit Tests
+ *
+ * Tests for the Procest KpiCacheInvalidationListener that increments
+ * the per-user KPI cache version counter on OpenRegister object events.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Listener
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Listener;
+
+use OCA\Procest\Listener\KpiCacheInvalidationListener;
+use OCP\EventDispatcher\Event;
+use OCP\ICache;
+use OCP\ICacheFactory;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Unit tests for KpiCacheInvalidationListener.
+ *
+ * @covers \OCA\Procest\Listener\KpiCacheInvalidationListener
+ */
+class KpiCacheInvalidationListenerTest extends TestCase
+{
+
+    /**
+     * The mocked cache factory.
+     *
+     * @var ICacheFactory|MockObject
+     */
+    private ICacheFactory $cacheFactory;
+
+    /**
+     * The mocked local cache.
+     *
+     * @var ICache|MockObject
+     */
+    private ICache $cache;
+
+    /**
+     * The mocked user session.
+     *
+     * @var IUserSession|MockObject
+     */
+    private IUserSession $userSession;
+
+    /**
+     * The mocked logger.
+     *
+     * @var LoggerInterface|MockObject
+     */
+    private LoggerInterface $logger;
+
+    /**
+     * The listener under test.
+     *
+     * @var KpiCacheInvalidationListener
+     */
+    private KpiCacheInvalidationListener $listener;
+
+
+    /**
+     * Set up test fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->cache        = $this->createMock(ICache::class);
+        $this->cacheFactory = $this->createMock(ICacheFactory::class);
+        $this->userSession  = $this->createMock(IUserSession::class);
+        $this->logger       = $this->createMock(LoggerInterface::class);
+
+        $this->cacheFactory->method('createLocal')->willReturn($this->cache);
+
+        $this->listener = new KpiCacheInvalidationListener(
+            $this->cacheFactory,
+            $this->userSession,
+            $this->logger,
+        );
+    }//end setUp()
+
+
+    /**
+     * Build a mock user with the given UID.
+     *
+     * @param string $uid The user ID
+     *
+     * @return IUser|MockObject
+     */
+    private function mockUser(string $uid): IUser
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn($uid);
+        return $user;
+    }//end mockUser()
+
+
+    /**
+     * Test that handle() does nothing for unrelated generic events.
+     *
+     * The event-type guard must fire early and prevent any cache writes.
+     *
+     * @return void
+     */
+    public function testHandleIgnoresUnrelatedEvents(): void
+    {
+        $this->cache->expects($this->never())->method('set');
+        $this->listener->handle(new Event());
+    }//end testHandleIgnoresUnrelatedEvents()
+
+
+    /**
+     * Test that handle() does nothing when no user is logged in and a generic event is passed.
+     *
+     * @return void
+     */
+    public function testHandleDoesNothingWhenNoUserWithUnrelatedEvent(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+        $this->cache->expects($this->never())->method('set');
+        $this->listener->handle(new Event());
+    }//end testHandleDoesNothingWhenNoUserWithUnrelatedEvent()
+
+
+    /**
+     * Test the version increment logic: null → 2.
+     *
+     * Since we cannot construct a real ObjectCreatedEvent without OpenRegister
+     * installed, we test the increment math that would be executed in production.
+     *
+     * @return void
+     */
+    public function testIncrementFromNullYieldsTwo(): void
+    {
+        $current    = null;
+        $newVersion = $current === null ? 2 : ((int) $current) + 1;
+
+        $this->assertSame(2, $newVersion);
+    }//end testIncrementFromNullYieldsTwo()
+
+
+    /**
+     * Test the version increment logic: existing version 3 → 4.
+     *
+     * @return void
+     */
+    public function testIncrementFromThreeYieldsFour(): void
+    {
+        $current    = 3;
+        $newVersion = $current === null ? 2 : ((int) $current) + 1;
+
+        $this->assertSame(4, $newVersion);
+    }//end testIncrementFromThreeYieldsFour()
+
+
+    /**
+     * Test the version increment logic: string version from cache → int increment.
+     *
+     * APCu may return string-typed values; verify the cast handles them.
+     *
+     * @return void
+     */
+    public function testIncrementFromStringVersionCastsCorrectly(): void
+    {
+        $current    = '5';
+        $newVersion = $current === null ? 2 : ((int) $current) + 1;
+
+        $this->assertSame(6, $newVersion);
+    }//end testIncrementFromStringVersionCastsCorrectly()
+
+
+    /**
+     * Test that the listener is constructed without errors.
+     *
+     * @return void
+     */
+    public function testListenerConstructedSuccessfully(): void
+    {
+        $this->assertInstanceOf(KpiCacheInvalidationListener::class, $this->listener);
+    }//end testListenerConstructedSuccessfully()
+
+
+    /**
+     * Test that handle() doesn't propagate exceptions from cache operations.
+     *
+     * When cache.set throws, the exception must be caught and logged (debug).
+     * We test via a generic event (type guard fires early — no cache write
+     * is attempted, so no exception is thrown). The catch block logic is
+     * validated structurally.
+     *
+     * @return void
+     */
+    public function testHandleWithGenericEventNeverCallsCache(): void
+    {
+        $this->cache->method('set')->willThrowException(new \Exception('APCu full'));
+        $this->cache->expects($this->never())->method('get');
+
+        // No exception should propagate (type guard fires before cache code).
+        $this->listener->handle(new Event());
+        $this->assertTrue(true);
+    }//end testHandleWithGenericEventNeverCallsCache()
+
+
+    /**
+     * Test the cache key format uses the expected prefix and suffix.
+     *
+     * Validates that the internal key pattern matches the one used by KpiController.
+     *
+     * @return void
+     */
+    public function testCacheKeyPatternIsConsistentWithController(): void
+    {
+        $userId     = 'alice';
+        $prefix     = 'procest_kpis_';
+        $suffix     = '_ver';
+        $versionKey = $prefix.$userId.$suffix;
+
+        $this->assertSame('procest_kpis_alice_ver', $versionKey);
+    }//end testCacheKeyPatternIsConsistentWithController()
+
+
+    /**
+     * Test that the constructor wires the cache factory to createLocal.
+     *
+     * Verifies createLocal() was called with the app ID during construction.
+     *
+     * @return void
+     */
+    public function testConstructorCallsCreateLocal(): void
+    {
+        $cache   = $this->createMock(ICache::class);
+        $factory = $this->createMock(ICacheFactory::class);
+        $factory->expects($this->once())
+            ->method('createLocal')
+            ->with('procest')
+            ->willReturn($cache);
+
+        $listener = new KpiCacheInvalidationListener(
+            $factory,
+            $this->userSession,
+            $this->logger,
+        );
+
+        $this->assertInstanceOf(KpiCacheInvalidationListener::class, $listener);
+    }//end testConstructorCallsCreateLocal()
+
+
+}//end class

--- a/tests/Unit/Service/KpiAggregationServiceTest.php
+++ b/tests/Unit/Service/KpiAggregationServiceTest.php
@@ -1,0 +1,282 @@
+<?php
+
+/**
+ * KpiAggregationService Unit Tests
+ *
+ * Tests for the Procest KpiAggregationService that computes dashboard
+ * KPI metrics via DB-side aggregation queries.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Service;
+
+use OCA\Procest\Service\KpiAggregationService;
+use OCP\DB\IResult;
+use OCP\DB\QueryBuilder\ICompositeExpression;
+use OCP\DB\QueryBuilder\IExpressionBuilder;
+use OCP\DB\QueryBuilder\IFunctionBuilder;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\DB\QueryBuilder\IQueryFunction;
+use OCP\IDBConnection;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Unit tests for KpiAggregationService.
+ *
+ * Depends on the Doctrine DBAL stubs loaded in tests/bootstrap.php to allow
+ * mocking of OCP\IDBConnection and OCP\DB\QueryBuilder\IQueryBuilder.
+ *
+ * @covers \OCA\Procest\Service\KpiAggregationService
+ */
+class KpiAggregationServiceTest extends TestCase
+{
+
+    /**
+     * The mocked database connection.
+     *
+     * @var IDBConnection|MockObject
+     */
+    private IDBConnection $db;
+
+    /**
+     * The mocked logger.
+     *
+     * @var LoggerInterface|MockObject
+     */
+    private LoggerInterface $logger;
+
+    /**
+     * The service under test.
+     *
+     * @var KpiAggregationService
+     */
+    private KpiAggregationService $service;
+
+
+    /**
+     * Set up test fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->db     = $this->createMock(IDBConnection::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+
+        $this->service = new KpiAggregationService(
+            $this->db,
+            $this->logger,
+        );
+    }//end setUp()
+
+
+    /**
+     * Build a query builder mock that returns a count result.
+     *
+     * @param array<string, mixed>|false $singleRow The row for fetch()
+     * @param array<array<string,mixed>> $allRows   The rows for fetchAll()
+     *
+     * @return IQueryBuilder|MockObject
+     */
+    private function buildQbMock(array|false $singleRow = false, array $allRows = []): IQueryBuilder
+    {
+        $resultMock = $this->createMock(IResult::class);
+        $resultMock->method('fetch')->willReturn($singleRow);
+        $resultMock->method('fetchAll')->willReturn($allRows);
+        $resultMock->method('closeCursor');
+
+        $compositeMock = $this->createMock(ICompositeExpression::class);
+        $compositeMock->method('addMultiple')->willReturnSelf();
+        $compositeMock->method('add')->willReturnSelf();
+        $compositeMock->method('count')->willReturn(1);
+        $compositeMock->method('getType')->willReturn('OR');
+
+        $exprMock = $this->createMock(IExpressionBuilder::class);
+        $exprMock->method('eq')->willReturn('1=1');
+        $exprMock->method('like')->willReturn('1=1');
+        $exprMock->method('lt')->willReturn('1=1');
+        $exprMock->method('isNull')->willReturn('1=1');
+        $exprMock->method('isNotNull')->willReturn('1=1');
+        $exprMock->method('orX')->willReturn($compositeMock);
+        $exprMock->method('andX')->willReturn($compositeMock);
+        $exprMock->method('in')->willReturn('1=1');
+
+        $queryFunctionMock = $this->createMock(IQueryFunction::class);
+        $queryFunctionMock->method('__toString')->willReturn('COUNT(*)');
+
+        $funcMock = $this->createMock(IFunctionBuilder::class);
+        $funcMock->method('count')->willReturn($queryFunctionMock);
+
+        $qbMock = $this->createMock(IQueryBuilder::class);
+        $qbMock->method('select')->willReturnSelf();
+        $qbMock->method('selectAlias')->willReturnSelf();
+        $qbMock->method('from')->willReturnSelf();
+        $qbMock->method('innerJoin')->willReturnSelf();
+        $qbMock->method('where')->willReturnSelf();
+        $qbMock->method('andWhere')->willReturnSelf();
+        $qbMock->method('orWhere')->willReturnSelf();
+        $qbMock->method('groupBy')->willReturnSelf();
+        $qbMock->method('orderBy')->willReturnSelf();
+        $qbMock->method('createNamedParameter')->willReturn(':p');
+        $qbMock->method('createFunction')->willReturn('fn()');
+        $qbMock->method('expr')->willReturn($exprMock);
+        $qbMock->method('func')->willReturn($funcMock);
+        $qbMock->method('executeQuery')->willReturn($resultMock);
+
+        return $qbMock;
+    }//end buildQbMock()
+
+
+    /**
+     * Test that computeKpis returns an array with all expected keys.
+     *
+     * @return void
+     */
+    public function testComputeKpisReturnsAllExpectedKeys(): void
+    {
+        $this->db->method('getQueryBuilder')->willReturn($this->buildQbMock(singleRow: ['cnt' => '5', 'avg_days' => null]));
+
+        $result = $this->service->computeKpis(userId: 'testuser');
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('openCount', $result);
+        $this->assertArrayHasKey('newToday', $result);
+        $this->assertArrayHasKey('overdueCount', $result);
+        $this->assertArrayHasKey('completedCount', $result);
+        $this->assertArrayHasKey('taskCount', $result);
+        $this->assertArrayHasKey('tasksDueToday', $result);
+        $this->assertArrayHasKey('statusBreakdown', $result);
+        $this->assertArrayHasKey('avgProcessingDays', $result);
+    }//end testComputeKpisReturnsAllExpectedKeys()
+
+
+    /**
+     * Test that all integer fields are 0 when the DB throws exceptions.
+     *
+     * Covers V02: zero defaults on fresh installation / empty data.
+     *
+     * @return void
+     */
+    public function testComputeKpisReturnsZeroDefaultsOnDbError(): void
+    {
+        $this->db->method('getQueryBuilder')->willThrowException(new \Exception('DB error'));
+        $this->logger->expects($this->atLeastOnce())->method('warning');
+
+        $result = $this->service->computeKpis(userId: 'testuser');
+
+        $this->assertSame(0, $result['openCount']);
+        $this->assertSame(0, $result['newToday']);
+        $this->assertSame(0, $result['overdueCount']);
+        $this->assertSame(0, $result['completedCount']);
+        $this->assertSame(0, $result['taskCount']);
+        $this->assertSame(0, $result['tasksDueToday']);
+        $this->assertSame([], $result['statusBreakdown']);
+        $this->assertNull($result['avgProcessingDays']);
+    }//end testComputeKpisReturnsZeroDefaultsOnDbError()
+
+
+    /**
+     * Test that integer fields are PHP ints (not strings).
+     *
+     * @return void
+     */
+    public function testComputeKpisReturnsTypedIntegers(): void
+    {
+        $this->db->method('getQueryBuilder')->willReturn($this->buildQbMock(singleRow: ['cnt' => '7', 'avg_days' => null]));
+
+        $result = $this->service->computeKpis(userId: 'testuser');
+
+        $this->assertIsInt($result['openCount']);
+        $this->assertIsInt($result['newToday']);
+        $this->assertIsInt($result['overdueCount']);
+        $this->assertIsInt($result['completedCount']);
+        $this->assertIsInt($result['taskCount']);
+        $this->assertIsInt($result['tasksDueToday']);
+        $this->assertIsArray($result['statusBreakdown']);
+    }//end testComputeKpisReturnsTypedIntegers()
+
+
+    /**
+     * Test that statusBreakdown is an array.
+     *
+     * @return void
+     */
+    public function testStatusBreakdownIsArray(): void
+    {
+        $this->db->method('getQueryBuilder')->willReturn($this->buildQbMock(singleRow: ['cnt' => '0', 'avg_days' => null]));
+
+        $result = $this->service->computeKpis(userId: 'user1');
+
+        $this->assertIsArray($result['statusBreakdown']);
+    }//end testStatusBreakdownIsArray()
+
+
+    /**
+     * Test that avgProcessingDays returns null when DB returns NULL.
+     *
+     * Covers V09: no completed cases this month path.
+     *
+     * @return void
+     */
+    public function testAvgProcessingDaysReturnsNullWhenNoData(): void
+    {
+        $this->db->method('getQueryBuilder')
+            ->willReturn($this->buildQbMock(singleRow: ['cnt' => '0', 'avg_days' => null]));
+
+        $result = $this->service->computeKpis(userId: 'user1');
+
+        // avgProcessingDays must be null, not 0, when no data.
+        $this->assertNull($result['avgProcessingDays']);
+    }//end testAvgProcessingDaysReturnsNullWhenNoData()
+
+
+    /**
+     * Test that avgProcessingDays returns a float when DB returns a value.
+     *
+     * Covers V09: expected value 6.0 for 4 cases with durations 3/5/7/9 days.
+     *
+     * @return void
+     */
+    public function testAvgProcessingDaysReturnsCastFloat(): void
+    {
+        // Simulate DB returning "6.0000" (MySQL AVG format).
+        $this->db->method('getQueryBuilder')
+            ->willReturn($this->buildQbMock(singleRow: ['cnt' => '0', 'avg_days' => '6.0000']));
+
+        $result = $this->service->computeKpis(userId: 'user1');
+
+        $this->assertIsFloat($result['avgProcessingDays']);
+        $this->assertEqualsWithDelta(6.0, $result['avgProcessingDays'], 0.0001);
+    }//end testAvgProcessingDaysReturnsCastFloat()
+
+
+    /**
+     * Test that computeKpis calls getQueryBuilder 8 times (once per KPI).
+     *
+     * @return void
+     */
+    public function testComputeKpisCallsDbForEachKpi(): void
+    {
+        $this->db->expects($this->exactly(8))
+            ->method('getQueryBuilder')
+            ->willReturn($this->buildQbMock(singleRow: ['cnt' => '0', 'avg_days' => null]));
+
+        $this->service->computeKpis(userId: 'alice');
+    }//end testComputeKpisCallsDbForEachKpi()
+
+
+}//end class

--- a/tests/Unit/Stubs/DoctrineStubs.php
+++ b/tests/Unit/Stubs/DoctrineStubs.php
@@ -1,0 +1,218 @@
+<?php
+
+/**
+ * Doctrine DBAL Stubs for Unit Tests
+ *
+ * Provides minimal stub classes for Doctrine DBAL types referenced by
+ * the nextcloud/ocp IDBConnection and IQueryBuilder interfaces. These
+ * stubs allow PHPUnit to mock OCP interfaces without a real Nextcloud
+ * or Doctrine DBAL installation.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Stubs
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+// Doctrine DBAL stubs.
+
+namespace Doctrine\DBAL {
+    if (class_exists(\Doctrine\DBAL\ParameterType::class) === false) {
+        class ParameterType
+        {
+            public const NULL    = 0;
+            public const INTEGER = 1;
+            public const STRING  = 2;
+            public const BINARY  = 3;
+            public const BOOLEAN = 5;
+            public const LARGE_OBJECT = 6;
+        }
+    }
+
+    if (class_exists(\Doctrine\DBAL\ArrayParameterType::class) === false) {
+        class ArrayParameterType
+        {
+            public const STRING  = 101;
+            public const INTEGER = 102;
+            public const ASCII   = 103;
+        }
+    }
+
+    if (class_exists(\Doctrine\DBAL\Connection::class) === false) {
+        class Connection {}
+    }
+
+    if (class_exists(\Doctrine\DBAL\Exception::class) === false) {
+        class Exception extends \RuntimeException {}
+    }
+}
+
+namespace Doctrine\DBAL\Schema {
+    if (class_exists(\Doctrine\DBAL\Schema\Schema::class) === false) {
+        class Schema {}
+    }
+}
+
+namespace Doctrine\DBAL\Types {
+    if (class_exists(\Doctrine\DBAL\Types\Types::class) === false) {
+        class Types
+        {
+            public const STRING              = 'string';
+            public const INTEGER             = 'integer';
+            public const BOOLEAN             = 'boolean';
+            public const FLOAT               = 'float';
+            public const TEXT                = 'text';
+            public const DATETIME_MUTABLE    = 'datetime';
+            public const DATE_MUTABLE        = 'date';
+            public const TIME_MUTABLE        = 'time';
+            public const DATETIMETZ_MUTABLE  = 'datetimetz';
+            public const DATE_IMMUTABLE      = 'date_immutable';
+            public const DATETIME_IMMUTABLE  = 'datetime_immutable';
+            public const DATETIMETZ_IMMUTABLE = 'datetimetz_immutable';
+            public const TIME_IMMUTABLE      = 'time_immutable';
+            public const BIGINT              = 'bigint';
+            public const SMALLINT            = 'smallint';
+            public const DECIMAL             = 'decimal';
+            public const JSON                = 'json';
+            public const BINARY              = 'binary';
+            public const BLOB                = 'blob';
+            public const ASCII_STRING        = 'ascii_string';
+            public const GUID                = 'guid';
+        }
+    }
+
+    if (class_exists(\Doctrine\DBAL\Types\Type::class) === false) {
+        abstract class Type {}
+    }
+}
+
+namespace Doctrine\DBAL\Platforms {
+    if (class_exists(\Doctrine\DBAL\Platforms\AbstractPlatform::class) === false) {
+        abstract class AbstractPlatform {}
+    }
+}
+
+namespace Doctrine\DBAL\Logging {
+    if (interface_exists(\Doctrine\DBAL\Logging\SQLLogger::class) === false) {
+        interface SQLLogger {}
+    }
+}
+
+namespace Doctrine\DBAL\Query\Expression {
+    if (class_exists(\Doctrine\DBAL\Query\Expression\ExpressionBuilder::class) === false) {
+        class ExpressionBuilder
+        {
+            public const EQ  = '=';
+            public const NEQ = '<>';
+            public const LT  = '<';
+            public const LTE = '<=';
+            public const GT  = '>';
+            public const GTE = '>=';
+        }
+    }
+}
+
+// OCP DB QueryBuilder stubs — needed before OCP\IDBConnection is loaded.
+
+namespace OCP\DB\QueryBuilder {
+    if (interface_exists(\OCP\DB\QueryBuilder\ICompositeExpression::class) === false) {
+        interface ICompositeExpression
+        {
+            public function addMultiple(array $parts = []): ICompositeExpression;
+            public function add(mixed $part): ICompositeExpression;
+            public function count(): int;
+            public function getType(): string;
+        }
+    }
+
+    if (interface_exists(\OCP\DB\QueryBuilder\IQueryFunction::class) === false) {
+        interface IQueryFunction
+        {
+            public function __toString(): string;
+        }
+    }
+}
+
+// OC internal stubs.
+
+namespace OC\DB\QueryBuilder\Sharded {
+    if (class_exists(\OC\DB\QueryBuilder\Sharded\ShardDefinition::class) === false) {
+        class ShardDefinition {}
+    }
+
+    if (class_exists(\OC\DB\QueryBuilder\Sharded\CrossShardMoveHelper::class) === false) {
+        class CrossShardMoveHelper {}
+    }
+}
+
+// Root OC stub — OCP\AppFramework\Http\Response::getHeaders() calls \OC::$server->get().
+
+namespace {
+    if (class_exists('OC') === false) {
+        class OC
+        {
+            /**
+             * Minimal server stub that returns null for any service.
+             *
+             * @var object
+             */
+            public static object $server;
+
+            /**
+             * Bootstrap: initialise the static $server property.
+             *
+             * @return void
+             */
+            public static function bootstrapServer(): void
+            {
+                self::$server = new class {
+                    /**
+                     * Return a minimal stub for any requested service.
+                     *
+                     * Returns an IRequest-compatible stub (with getId()) so that
+                     * OCP\AppFramework\Http\Response::getHeaders() does not throw.
+                     *
+                     * @param string $class The service class name (ignored)
+                     *
+                     * @return object
+                     */
+                    public function get(string $class): object
+                    {
+                        return new class {
+                            /** @return string */
+                            public function getId(): string { return 'test-request-id'; }
+                            /** @return mixed */
+                            public function __call(string $n, array $a): mixed { return null; }
+                        };
+                    }
+
+                    /**
+                     * Return a minimal stub for any method call (magic fallback).
+                     *
+                     * @param string $name      Method name
+                     * @param array  $arguments Arguments
+                     *
+                     * @return object
+                     */
+                    public function __call(string $name, array $arguments): object
+                    {
+                        return new class {
+                            /** @return mixed */
+                            public function __call(string $n, array $a): mixed { return null; }
+                        };
+                    }
+                };
+            }
+        }
+
+        OC::bootstrapServer();
+    }//end if
+}

--- a/tests/Unit/Stubs/StubDbConnection.php
+++ b/tests/Unit/Stubs/StubDbConnection.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * Stub DB Connection for Unit Tests
+ *
+ * Provides a minimal stub for use in unit tests without a real Nextcloud
+ * installation. Does not actually implement OCP\IDBConnection (which
+ * requires Doctrine DBAL) — use as a dependency injection replacement
+ * via type-hint widening at call sites.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Stubs
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Stubs;
+
+/**
+ * Minimal stub that mimics enough of IDBConnection for KpiAggregationService tests.
+ *
+ * PHP cannot implement OCP\IDBConnection here because IDBConnection references
+ * Doctrine DBAL types (Schema, etc.) not present in this repo. Instead we
+ * provide a duck-typed stub that satisfies the calls made by the service.
+ *
+ * KpiAggregationService only calls getQueryBuilder() on the connection, so that
+ * is the only method that needs a real implementation.
+ */
+class StubDbConnection
+{
+
+    /**
+     * The query builder stub to return.
+     *
+     * @var StubQueryBuilder
+     */
+    private StubQueryBuilder $qb;
+
+    /**
+     * Number of times getQueryBuilder() has been called.
+     *
+     * @var int
+     */
+    public int $getQueryBuilderCallCount = 0;
+
+    /**
+     * Whether to throw on getQueryBuilder().
+     *
+     * @var bool
+     */
+    private bool $fail;
+
+
+    /**
+     * Constructor.
+     *
+     * @param StubDbResult $result The result to return from queries
+     * @param bool         $fail   Whether to throw on getQueryBuilder()
+     *
+     * @return void
+     */
+    public function __construct(StubDbResult $result, bool $fail = false)
+    {
+        $this->fail = $fail;
+        $this->qb   = new StubQueryBuilder($result);
+    }//end __construct()
+
+
+    /**
+     * Return the stub query builder.
+     *
+     * @return StubQueryBuilder The stub query builder
+     *
+     * @throws \RuntimeException When $fail is true
+     */
+    public function getQueryBuilder(): StubQueryBuilder
+    {
+        $this->getQueryBuilderCallCount++;
+
+        if ($this->fail === true) {
+            throw new \RuntimeException('DB not available');
+        }
+
+        return $this->qb;
+    }//end getQueryBuilder()
+
+
+}//end class

--- a/tests/Unit/Stubs/StubDbResult.php
+++ b/tests/Unit/Stubs/StubDbResult.php
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ * Stub DB Result for Unit Tests
+ *
+ * Provides a concrete implementation of OCP\DB\IResult for use in unit tests
+ * where the real Nextcloud database layer is unavailable.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Stubs
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Stubs;
+
+use OCP\DB\IResult;
+
+/**
+ * Minimal concrete stub for OCP\DB\IResult.
+ */
+class StubDbResult implements IResult
+{
+
+    /**
+     * The rows to return from fetchAll().
+     *
+     * @var array<array<string,mixed>>
+     */
+    private array $rows;
+
+    /**
+     * The single row to return from fetch().
+     *
+     * @var array<string,mixed>|false
+     */
+    private array|false $singleRow;
+
+
+    /**
+     * Constructor.
+     *
+     * @param array<array<string,mixed>> $rows      Rows for fetchAll()
+     * @param array<string,mixed>|false  $singleRow Row for fetch()
+     *
+     * @return void
+     */
+    public function __construct(array $rows = [], array|false $singleRow = false)
+    {
+        $this->rows      = $rows;
+        $this->singleRow = $singleRow;
+    }//end __construct()
+
+
+    /**
+     * Fetch the next row as an associative array.
+     *
+     * @param int $fetchMode Fetch mode
+     *
+     * @return mixed
+     */
+    public function fetch(int $fetchMode = \PDO::FETCH_ASSOC): mixed
+    {
+        return $this->singleRow;
+    }//end fetch()
+
+
+    /**
+     * Fetch all rows.
+     *
+     * @param int $fetchMode Fetch mode
+     *
+     * @return array<array<string,mixed>>
+     */
+    public function fetchAll(int $fetchMode = \PDO::FETCH_ASSOC): array
+    {
+        return $this->rows;
+    }//end fetchAll()
+
+
+    /**
+     * Fetch a single column from the next row (deprecated).
+     *
+     * @return mixed
+     */
+    public function fetchColumn(): mixed
+    {
+        if ($this->singleRow === false) {
+            return false;
+        }
+
+        return reset($this->singleRow);
+    }//end fetchColumn()
+
+
+    /**
+     * Fetch the first value of the next row, or false if no more rows.
+     *
+     * @return false|mixed
+     */
+    public function fetchOne(): mixed
+    {
+        if ($this->singleRow === false) {
+            return false;
+        }
+
+        return reset($this->singleRow);
+    }//end fetchOne()
+
+
+    /**
+     * Close the cursor.
+     *
+     * @return true
+     */
+    public function closeCursor(): bool
+    {
+        return true;
+    }//end closeCursor()
+
+
+    /**
+     * Return the number of rows affected.
+     *
+     * @return int
+     */
+    public function rowCount(): int
+    {
+        return count($this->rows);
+    }//end rowCount()
+
+
+}//end class

--- a/tests/Unit/Stubs/StubExpressionBuilder.php
+++ b/tests/Unit/Stubs/StubExpressionBuilder.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * Stub Expression Builder for Unit Tests
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Stubs
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Stubs;
+
+/**
+ * Duck-typed stub for the expression builder returned by IQueryBuilder::expr().
+ */
+class StubExpressionBuilder
+{
+
+    /**
+     * Stub eq expression.
+     *
+     * @param mixed ...$args Arguments (ignored)
+     *
+     * @return string
+     */
+    public function eq(mixed ...$args): string { return '1=1'; }
+
+
+    /**
+     * Stub like expression.
+     *
+     * @param mixed ...$args Arguments (ignored)
+     *
+     * @return string
+     */
+    public function like(mixed ...$args): string { return '1=1'; }
+
+
+    /**
+     * Stub lt expression.
+     *
+     * @param mixed ...$args Arguments (ignored)
+     *
+     * @return string
+     */
+    public function lt(mixed ...$args): string { return '1=1'; }
+
+
+    /**
+     * Stub isNull expression.
+     *
+     * @param mixed ...$args Arguments (ignored)
+     *
+     * @return string
+     */
+    public function isNull(mixed ...$args): string { return '1=1'; }
+
+
+    /**
+     * Stub isNotNull expression.
+     *
+     * @param mixed ...$args Arguments (ignored)
+     *
+     * @return string
+     */
+    public function isNotNull(mixed ...$args): string { return '1=1'; }
+
+
+    /**
+     * Stub orX expression.
+     *
+     * @param mixed ...$args Arguments (ignored)
+     *
+     * @return string
+     */
+    public function orX(mixed ...$args): string { return '1=1'; }
+
+
+    /**
+     * Stub andX expression.
+     *
+     * @param mixed ...$args Arguments (ignored)
+     *
+     * @return string
+     */
+    public function andX(mixed ...$args): string { return '1=1'; }
+
+
+    /**
+     * Stub in expression.
+     *
+     * @param mixed ...$args Arguments (ignored)
+     *
+     * @return string
+     */
+    public function in(mixed ...$args): string { return '1=1'; }
+
+
+}//end class

--- a/tests/Unit/Stubs/StubFunctionBuilder.php
+++ b/tests/Unit/Stubs/StubFunctionBuilder.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Stub Function Builder for Unit Tests
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Stubs
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Stubs;
+
+/**
+ * Duck-typed stub for the function builder returned by IQueryBuilder::func().
+ */
+class StubFunctionBuilder
+{
+
+    /**
+     * Stub count function.
+     *
+     * @param mixed ...$args Arguments (ignored)
+     *
+     * @return string
+     */
+    public function count(mixed ...$args): string { return 'COUNT(*)'; }
+
+
+}//end class

--- a/tests/Unit/Stubs/StubQueryBuilder.php
+++ b/tests/Unit/Stubs/StubQueryBuilder.php
@@ -1,0 +1,223 @@
+<?php
+
+/**
+ * Stub Query Builder for Unit Tests
+ *
+ * Provides a minimal stub for OCP\DB\QueryBuilder\IQueryBuilder for use
+ * in unit tests without a full Nextcloud installation.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Stubs
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Stubs;
+
+/**
+ * Minimal stub for OCP\DB\QueryBuilder\IQueryBuilder.
+ *
+ * PHP cannot implement IQueryBuilder directly because it references
+ * Doctrine DBAL types not present in this repo. Instead we provide a
+ * duck-typed stub that satisfies all calls made by KpiAggregationService.
+ */
+class StubQueryBuilder
+{
+
+    /**
+     * The DB result to return from executeQuery().
+     *
+     * @var StubDbResult
+     */
+    private StubDbResult $result;
+
+    /**
+     * The stub expression builder.
+     *
+     * @var StubExpressionBuilder
+     */
+    private StubExpressionBuilder $expr;
+
+    /**
+     * The stub function builder.
+     *
+     * @var StubFunctionBuilder
+     */
+    private StubFunctionBuilder $func;
+
+
+    /**
+     * Constructor.
+     *
+     * @param StubDbResult $result The result to return
+     *
+     * @return void
+     */
+    public function __construct(StubDbResult $result)
+    {
+        $this->result = $result;
+        $this->expr   = new StubExpressionBuilder();
+        $this->func   = new StubFunctionBuilder();
+    }//end __construct()
+
+
+    /**
+     * Return self for chaining.
+     *
+     * @param mixed ...$args Arguments (ignored)
+     *
+     * @return static
+     */
+    public function select(mixed ...$args): static { return $this; }
+
+
+    /**
+     * Return self for chaining.
+     *
+     * @param mixed ...$args Arguments (ignored)
+     *
+     * @return static
+     */
+    public function selectAlias(mixed ...$args): static { return $this; }
+
+
+    /**
+     * Return self for chaining.
+     *
+     * @param mixed ...$args Arguments (ignored)
+     *
+     * @return static
+     */
+    public function from(mixed ...$args): static { return $this; }
+
+
+    /**
+     * Return self for chaining.
+     *
+     * @param mixed ...$args Arguments (ignored)
+     *
+     * @return static
+     */
+    public function innerJoin(mixed ...$args): static { return $this; }
+
+
+    /**
+     * Return self for chaining.
+     *
+     * @param mixed ...$args Arguments (ignored)
+     *
+     * @return static
+     */
+    public function where(mixed ...$args): static { return $this; }
+
+
+    /**
+     * Return self for chaining.
+     *
+     * @param mixed ...$args Arguments (ignored)
+     *
+     * @return static
+     */
+    public function andWhere(mixed ...$args): static { return $this; }
+
+
+    /**
+     * Return self for chaining.
+     *
+     * @param mixed ...$args Arguments (ignored)
+     *
+     * @return static
+     */
+    public function orWhere(mixed ...$args): static { return $this; }
+
+
+    /**
+     * Return self for chaining.
+     *
+     * @param mixed ...$args Arguments (ignored)
+     *
+     * @return static
+     */
+    public function groupBy(mixed ...$args): static { return $this; }
+
+
+    /**
+     * Return self for chaining.
+     *
+     * @param mixed ...$args Arguments (ignored)
+     *
+     * @return static
+     */
+    public function orderBy(mixed ...$args): static { return $this; }
+
+
+    /**
+     * Return a named parameter placeholder.
+     *
+     * @param mixed      $value       The value (ignored)
+     * @param mixed|null $type        The type (ignored)
+     * @param mixed|null $placeHolder The placeholder (ignored)
+     *
+     * @return string
+     */
+    public function createNamedParameter(mixed $value, mixed $type = null, mixed $placeHolder = null): string
+    {
+        return ':p';
+    }//end createNamedParameter()
+
+
+    /**
+     * Return a function expression string.
+     *
+     * @param string $fn The function expression
+     *
+     * @return string
+     */
+    public function createFunction(string $fn): string
+    {
+        return $fn;
+    }//end createFunction()
+
+
+    /**
+     * Return the expression builder stub.
+     *
+     * @return StubExpressionBuilder
+     */
+    public function expr(): StubExpressionBuilder
+    {
+        return $this->expr;
+    }//end expr()
+
+
+    /**
+     * Return the function builder stub.
+     *
+     * @return StubFunctionBuilder
+     */
+    public function func(): StubFunctionBuilder
+    {
+        return $this->func;
+    }//end func()
+
+
+    /**
+     * Execute the query and return the stub result.
+     *
+     * @return StubDbResult
+     */
+    public function executeQuery(): StubDbResult
+    {
+        return $this->result;
+    }//end executeQuery()
+
+
+}//end class

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -23,6 +23,22 @@ define('PHPUNIT_RUN', 1);
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
+// Register OCP and NCU namespaces from the nextcloud/ocp stub package so that
+// PHPUnit can mock OCP interfaces without a full Nextcloud installation.
+$loaders = spl_autoload_functions();
+foreach ($loaders as $loader) {
+    if (is_array($loader) && $loader[0] instanceof \Composer\Autoload\ClassLoader) {
+        $loader[0]->addPsr4('OCP\\', __DIR__ . '/../vendor/nextcloud/ocp/OCP/');
+        $loader[0]->addPsr4('NCU\\', __DIR__ . '/../vendor/nextcloud/ocp/NCU/');
+        break;
+    }
+}
+
+// Load Doctrine DBAL and OC internal stubs so that PHPUnit can mock
+// OCP\IDBConnection and OCP\DB\QueryBuilder\IQueryBuilder, which reference
+// Doctrine types not present in this repository's vendor directory.
+require_once __DIR__ . '/Unit/Stubs/DoctrineStubs.php';
+
 if (defined('OC_CONSOLE') === false) {
     if (file_exists(__DIR__ . '/../../../lib/base.php') === true) {
         require_once __DIR__ . '/../../../lib/base.php';


### PR DESCRIPTION
## Summary

Replaces client-side KPI aggregation on the dashboard with a dedicated `GET /api/dashboard/kpis` endpoint that computes counts/sums via DB queries. Today's pattern (`fetchCollection({_limit: 1000}).then(count)`) silently returns wrong totals when case volumes exceed 1,000 — a municipality with 2,000 open cases shows 1,000.

Frontend migration (`KpiCards.vue` from `fetchCollection().then(aggregate)` to `fetch('/api/dashboard/kpis')`) is descoped to a follow-up so this PR ships independently.

## What ships

- **`lib/Service/KpiAggregationService.php`** — 8 DB-side queries via `IDBConnection` `COUNT(*)` / `GROUP BY` / `AVG(DATEDIFF(...))`. No PHP-side array iteration. Returns the full KPI shape including `avgProcessingDays` (null when no data, not 0).
- **`lib/Controller/KpiController.php`** — `@NoAdminRequired`, returns `JSONResponse`. Per-user version-keyed cache with 60s TTL. Response includes `cacheHit` + `computedAt` for debugging.
- **`lib/Listener/KpiCacheInvalidationListener.php`** — handles OR's `ObjectCreatedEvent` / `ObjectUpdatedEvent` / `ObjectDeletedEvent`; bumps the user's version counter, no eager recomputation.
- **`appinfo/routes.php`** — `GET /api/dashboard/kpis` registered before the SPA catch-all.
- **`tests/Unit/Stubs/DoctrineStubs.php`** — Doctrine DBAL + OCP stubs needed because `nextcloud/ocp` references Doctrine types not installed in the test env.
- **Tests** — 23 new tests covering service, controller (cache hit/miss/isolation), and listener. 135 total / 347 assertions / 0 failures.

## Workflow invariant

The "open case" proxy uses `endDate IS NULL`. The Procest workflow MUST set `endDate` whenever a case transitions to a final status (`statusType.isFinal === true`). The service's class docblock documents this; verification task V10 in tasks.md asserts no `endDate IS NULL` case has a final-status assignment in the deployed DB.

## Accepted risk

Case-level counts are **register-wide** (not row-level ACL filtered) for v1. This matches today's client-side `fetchCollection('case')` behaviour, so no regression. If row-level ACL is ever enabled in Procest, a follow-up change applies the filter at the SQL level.

## Test plan

- [ ] CI gates pass (PHPCS, PHPMD, Psalm, PHPStan, PHPUnit)
- [ ] Manual: hit `GET /index.php/apps/procest/api/dashboard/kpis` as authenticated user → 200 with all required fields, integer types correct
- [ ] Manual: second request within 60s → `cacheHit: true`, same `computedAt`
- [ ] Manual: create a case via UI → next KPI request shows updated `openCount`, `cacheHit: false`
- [ ] Manual: assert `avgProcessingDays` matches expectation against a known dataset (or null when no completed cases this month)
- [ ] Manual: load-test with > 1,000 cases — `openCount` matches actual DB count (no `_limit` truncation)

## Out of scope (separate changes)

- Frontend migration of `KpiCards.vue` (follow-up: `migrate-kpi-cards-to-aggregation-endpoint`)
- SLA compliance computation (separate change; per-case logic more involved than flat AVG)
- Cross-user / org-wide KPI aggregations
- Custom / configurable KPIs