### PR TITLE
fix: migrate procest to @conduction/nextcloud-vue useObjectStore

### DIFF
--- a/openspec/changes/procest-store-migration/design.md
+++ b/openspec/changes/procest-store-migration/design.md
@@ -1,0 +1,82 @@
+# Design — procest store migration
+
+## Context
+
+Procest's `src/store/modules/object.js` already wires `createObjectStore('object', { plugins: [...] })` from `@conduction/nextcloud-vue`. The Pinia store ID is `'object'` (chosen at app inception). All `useObjectStore()` calls return the lib-backed store.
+
+What is broken is **callsite drift**: 5 method names referenced by procest code do not exist in the lib. They are leftovers from an earlier hand-rolled store implementation that was replaced module-by-module without sweeping the consumers.
+
+## Decision: Pattern 1 (drop) — direct rewrite of phantom calls
+
+Three patterns were on the table per the task brief:
+
+| Pattern | Description | Verdict |
+|---|---|---|
+| **drop** | Replace each phantom call with the lib's canonical API at the call site. | **chosen** |
+| thin-wrap | Add `getObjects`/`getAll`/etc. as aliases on the store via a plugin or wrapper. | Rejected — perpetuates the old vocabulary, future engineers re-introduce phantoms by copy-paste, and the code diverges further from decidesk/openconnector/zaakafhandelapp. |
+| hybrid | Drop in core call sites, alias in sub-stores. | Rejected — sub-stores are the densest cluster (gis.js has 4 phantoms, bezwaar.js has 5); hiding them behind aliases buries the bug class we're trying to eradicate. |
+
+Decidesk's #162 bug landed because their custom store had not been migrated at all — the lesson is "use the lib's vocabulary verbatim". Procest is one step ahead (object.js is already lib-backed), so the smaller, surgical drop pattern is the right move.
+
+## API mapping
+
+```text
+LEGACY                                 →  LIB
+─────────────────────────────────────────────────────────────────────────
+objectStore.getObjects(t, { filters:{f:v}, limit:n })
+                                       →  objectStore.fetchCollection(t, { '_filters[f]': v, _limit: n })
+objectStore.getAll(t)                  →  objectStore.fetchCollection(t, {})
+objectStore.create(t, data)            →  objectStore.saveObject(t, data)
+objectStore.update(t, id, data)        →  objectStore.saveObject(t, { id, ...data })
+objectStore.delete(t, id)              →  objectStore.deleteObject(t, id)
+objectStore.fetchOne(t, id)            →  objectStore.fetchObject(t, id)
+objectStore.uploadFile(caseId, file)   →  const fd = new FormData(); fd.append('file', file)
+                                          objectStore.uploadFiles('case', caseId, fd)
+```
+
+`fetchCollection` returns the **results array** (not a wrapper); legacy callers that did `result?.results || result || []` can be simplified to take the return value directly.
+
+## Consumer files
+
+### Sub-stores (in `src/store/modules/`)
+
+| File | Phantom calls | Migration |
+|---|---|---|
+| `bezwaar.js` | 5 × `getObjects` | rewrite to `fetchCollection` with `_filters[case]` shape |
+| `gis.js` | `getAll`, `create`, `update`, `delete` (one each) | rewrite to `fetchCollection`/`saveObject`/`deleteObject` |
+| `inspection.js` | 1 × `uploadFile` | rewrite to `uploadFiles` (filesPlugin), wrap file in FormData |
+
+### Views (in `src/views/`)
+
+| File | Phantom calls | Migration |
+|---|---|---|
+| `CaseMapView.vue` | 2 × `getAll('case'\|'caseType')` | `fetchCollection(t, {})` |
+| `dashboard/CaseMapWidget.vue` | 1 × `getAll('case')` | `fetchCollection('case', {})` |
+| `voorstellen/VoorstelDetail.vue` | 1 × `fetchOne('voorstel', id)` | `fetchObject('voorstel', id)` |
+
+### Out of scope (per task brief)
+
+- `settings.js` — procest-specific `/apps/procest/api/settings` endpoint, not OR object CRUD. Stays as plain `defineStore`.
+- `zgwMapping.js` — procest-specific `/apps/procest/api/zgw-mappings` endpoint, not OR object CRUD. Stays as plain `defineStore`.
+- `bezwaar.js`, `advice.js`, `enforcement.js`, `gis.js`, `inspection.js`, `workflow.js` — workflow/business-logic stores that *use* the lib's object store internally. They are not direct CRUD wrappers and stay as plain `defineStore`s. Only their internal phantom calls are migrated.
+
+### `store.js` orchestrator
+
+The 19 `if (config.register && config.X_schema) { objectStore.registerObjectType(...) }` blocks are verbose but functional and use the lib's `registerObjectType` API correctly. Out of scope for this change — leave as-is to keep the diff focused.
+
+## Custom-fallback list (lib gaps observed)
+
+None. Every legacy call has a direct equivalent in the lib's `useObjectStore` surface plus the bundled `filesPlugin`. The drop migration is lossless.
+
+## Validation strategy
+
+1. `npx eslint src/store/ src/views/CaseMapView.vue src/views/voorstellen/VoorstelDetail.vue src/views/dashboard/CaseMapWidget.vue src/store/modules/inspection.js`
+2. `node tests/validate-manifest.js` (manifest unaffected; smoke check)
+3. `npx webpack --config webpack.config.js --mode production` (proves the bundle still builds)
+4. `grep -rEn '\.(getObjects|getAll|fetchOne|uploadFile)\b' src/` — must return zero hits in the touched files (and only legitimate non-store hits elsewhere).
+
+## Out of scope
+
+- `store.js` orchestrator simplification — separate change.
+- Migrating `settings.js` / `zgwMapping.js` to the lib — separate change (would need a generic config-store primitive in the lib first).
+- Refactoring sub-stores into pure composables — separate change (Vue 3 migration).

--- a/openspec/changes/procest-store-migration/proposal.md
+++ b/openspec/changes/procest-store-migration/proposal.md
@@ -1,0 +1,29 @@
+# Procest store migration — adopt `@conduction/nextcloud-vue` `useObjectStore`
+
+## Why
+
+Project memory rule: **"Store pattern guidance — Do not use custom stores; use Options API with createObjectStore."**
+
+Decidesk just hit issue **#162**: its custom store didn't expose the lib's `fetchObject` / `subscribe` API, so live updates silently broke. Procest carries the same anti-pattern shape — phantom method calls (`getObjects`, `getAll`, `update`, `delete`, `create`, `fetchOne`, `uploadFile`) that the lib does not expose. Today they fail at runtime with `TypeError: objectStore.getObjects is not a function` once the affected code path is exercised.
+
+Procest's `src/store/modules/object.js` already calls `createObjectStore('object', { plugins: [filesPlugin(), auditTrailsPlugin(), relationsPlugin()] })`, so the wrapper is correct. What's broken is **call-site drift**: views and sub-stores still invoke the legacy method names that no longer exist. Migrating those call sites to the canonical lib API closes the same class of bug as decidesk #162 before it fires in production.
+
+## What Changes
+
+- **Replace phantom calls with the lib's canonical API:**
+  - `getObjects(type, opts)` → `fetchCollection(type, opts)`
+  - `getAll(type)` → `fetchCollection(type, {})`
+  - `create(type, data)` → `saveObject(type, data)`
+  - `update(type, id, data)` → `saveObject(type, { id, ...data })`
+  - `delete(type, id)` → `deleteObject(type, id)`
+  - `fetchOne(type, id)` → `fetchObject(type, id)`
+  - `uploadFile(caseId, file)` → `uploadFiles('case', caseId, formData)` (filesPlugin)
+- **Filter param shape**: lib expects `_filters[field]=value` query keys, not a `filters: {}` object. Migrate accordingly.
+- Keep the three procest-specific Pinia stores (`settings`, `zgwMapping`, plus the business-logic sub-stores `bezwaar` / `advice` / `enforcement` / `gis` / `inspection` / `workflow`) — these wrap workflow logic, not OR objects, and are explicitly out of scope per the migration rule ("only migrate the OR-object stores").
+
+## Impact
+
+- **Affected specs**: new `procest-store-migration` capability (documents the call-site invariant for future audits).
+- **Affected code**: `src/store/modules/{object,bezwaar,gis,inspection}.js`, `src/views/CaseMapView.vue`, `src/views/voorstellen/VoorstelDetail.vue`, `src/views/dashboard/CaseMapWidget.vue`. Estimated ~15 call sites in 7 files.
+- **No API contract changes** — server-side endpoints unchanged.
+- **No new dependencies** — `@conduction/nextcloud-vue@^1.0.0-beta.12` is already installed.

--- a/openspec/changes/procest-store-migration/specs/procest-store-migration/spec.md
+++ b/openspec/changes/procest-store-migration/specs/procest-store-migration/spec.md
@@ -1,0 +1,56 @@
+# procest-store-migration
+
+## ADDED Requirements
+
+### Requirement: Procest MUST use `@conduction/nextcloud-vue` `useObjectStore` for all OpenRegister object CRUD
+
+All Pinia store call sites in procest that operate on OpenRegister objects MUST invoke methods that are part of the canonical `useObjectStore` surface exported by `@conduction/nextcloud-vue`. Phantom method calls (method names that no longer exist on the lib) are forbidden because they fail at runtime as `TypeError: objectStore.X is not a function` once the affected code path is exercised — the same class of bug as decidesk #162.
+
+#### Scenario: A view fetches a collection of OpenRegister objects
+
+- **WHEN** procest needs to load a list of OR objects of a given registered type
+- **THEN** the call site MUST use `objectStore.fetchCollection(type, params)`
+- **AND** filter parameters MUST use the `_filters[field]=value` query-key shape (not a `filters: {}` object)
+
+#### Scenario: A view loads a single OpenRegister object by ID
+
+- **WHEN** procest needs to load one OR object by its UUID
+- **THEN** the call site MUST use `objectStore.fetchObject(type, id)`
+
+#### Scenario: A sub-store creates or updates an OpenRegister object
+
+- **WHEN** procest creates or updates an OR object
+- **THEN** the call site MUST use `objectStore.saveObject(type, data)` (with `data.id` set for updates)
+- **AND** MUST NOT use the legacy `create(type, data)` or `update(type, id, data)` shapes
+
+#### Scenario: A sub-store deletes an OpenRegister object
+
+- **WHEN** procest deletes an OR object
+- **THEN** the call site MUST use `objectStore.deleteObject(type, id)`
+- **AND** MUST NOT use the legacy `delete(type, id)` name
+
+#### Scenario: A sub-store uploads a file attached to an OpenRegister object
+
+- **WHEN** procest uploads a file attached to an OR object
+- **THEN** the call site MUST use the `filesPlugin`-supplied `objectStore.uploadFiles(type, objectId, formData)` action
+- **AND** the file MUST be wrapped in a `FormData` instance, not passed as a raw `File`
+
+### Requirement: Procest-specific config stores MAY remain as plain Pinia `defineStore`s
+
+Procest carries config endpoints (`/apps/procest/api/settings`, `/apps/procest/api/zgw-mappings`) that are not OpenRegister objects. These stores are out of scope for the lib's `useObjectStore`.
+
+#### Scenario: A store wraps a procest-specific REST endpoint
+
+- **WHEN** the store's responsibility is a procest-specific REST endpoint (settings, ZGW mappings) and not OpenRegister object CRUD
+- **THEN** it MAY remain a plain `defineStore` from `pinia`
+- **AND** it MUST NOT be required to migrate to `createObjectStore`
+
+### Requirement: Workflow / business-logic Pinia stores MAY remain as plain `defineStore`s
+
+Procest's bezwaar, advice, enforcement, gis, inspection, and workflow stores model app-specific business state (deadline calculation, LHS matrix, escalation rules) on top of the lib's object store. Their internal OR-object CRUD calls MUST follow the canonical API, but the stores themselves MAY remain plain `defineStore`s.
+
+#### Scenario: A sub-store wraps domain logic on top of OR object CRUD
+
+- **WHEN** a sub-store implements domain logic (e.g. AWB deadline rules, LHS matrix lookup, escalation) and uses `useObjectStore` internally for CRUD
+- **THEN** the sub-store MAY remain a plain `defineStore`
+- **AND** every internal `useObjectStore()` call MUST use the canonical lib API (`fetchCollection`, `fetchObject`, `saveObject`, `deleteObject`, `uploadFiles`, `resolveReferences`)

--- a/openspec/changes/procest-store-migration/tasks.md
+++ b/openspec/changes/procest-store-migration/tasks.md
@@ -1,0 +1,20 @@
+# Tasks
+
+## 1. Sub-store migration
+
+- [ ] 1.1 Migrate `src/store/modules/bezwaar.js`: rewrite 5 `getObjects` calls to `fetchCollection` with `_filters[case]=…&_limit=…` shape.
+- [ ] 1.2 Migrate `src/store/modules/gis.js`: rewrite `getAll`/`create`/`update`/`delete` calls to `fetchCollection`/`saveObject`/`deleteObject`.
+- [ ] 1.3 Migrate `src/store/modules/inspection.js`: rewrite `uploadFile(caseId, file)` to use `filesPlugin`'s `uploadFiles('case', caseId, formData)`.
+
+## 2. View migration
+
+- [ ] 2.1 `src/views/CaseMapView.vue`: replace `getAll('case')` and `getAll('caseType')` with `fetchCollection(t, {})`.
+- [ ] 2.2 `src/views/dashboard/CaseMapWidget.vue`: replace `getAll('case')` with `fetchCollection('case', {})`.
+- [ ] 2.3 `src/views/voorstellen/VoorstelDetail.vue`: replace `fetchOne('voorstel', id)` with `fetchObject('voorstel', id)`.
+
+## 3. Validation
+
+- [ ] 3.1 Run `npx eslint` on touched files — clean.
+- [ ] 3.2 Run `node tests/validate-manifest.js` — passes.
+- [ ] 3.3 Run `npx webpack --config webpack.config.js --mode production` — builds.
+- [ ] 3.4 Verify `grep -rEn '\.(getObjects|getAll|fetchOne)\b' src/store/ src/views/` returns zero hits in migrated files.

--- a/src/store/modules/bezwaar.js
+++ b/src/store/modules/bezwaar.js
@@ -136,29 +136,29 @@ export const useBezwaarStore = defineStore('bezwaar', {
 				const objectStore = useObjectStore()
 
 				// Load objection.
-				const objections = await objectStore.getObjects('objection', {
-					filters: { case: caseId },
-					limit: 1,
+				const objections = await objectStore.fetchCollection('objection', {
+					'_filters[case]': caseId,
+					_limit: 1,
 				})
 				this.currentObjection = objections?.[0] || null
 
 				// Load hearing sessions.
-				const hearings = await objectStore.getObjects('hearingSession', {
-					filters: { case: caseId },
+				const hearings = await objectStore.fetchCollection('hearingSession', {
+					'_filters[case]': caseId,
 				})
 				this.hearingSessions = hearings || []
 
 				// Load advisory report.
-				const reports = await objectStore.getObjects('advisoryReport', {
-					filters: { case: caseId },
-					limit: 1,
+				const reports = await objectStore.fetchCollection('advisoryReport', {
+					'_filters[case]': caseId,
+					_limit: 1,
 				})
 				this.currentAdvisoryReport = reports?.[0] || null
 
 				// Load appeal decision.
-				const decisions = await objectStore.getObjects('appealDecision', {
-					filters: { case: caseId },
-					limit: 1,
+				const decisions = await objectStore.fetchCollection('appealDecision', {
+					'_filters[case]': caseId,
+					_limit: 1,
 				})
 				this.currentAppealDecision = decisions?.[0] || null
 			} catch (error) {
@@ -499,9 +499,9 @@ export const useBezwaarStore = defineStore('bezwaar', {
 				const settingsStore = useSettingsStore()
 
 				// Find the Beroep case type.
-				const caseTypes = await objectStore.getObjects('caseType', {
-					filters: { identifier: 'beroep' },
-					limit: 1,
+				const caseTypes = await objectStore.fetchCollection('caseType', {
+					'_filters[identifier]': 'beroep',
+					_limit: 1,
 				})
 				const beroepCaseType = caseTypes?.[0]
 

--- a/src/store/modules/gis.js
+++ b/src/store/modules/gis.js
@@ -43,8 +43,8 @@ export const useGisStore = defineStore('gis', {
 			this.loading = true
 			try {
 				const objectStore = useObjectStore()
-				const response = await objectStore.getAll('mapLayer')
-				this.layers = response?.results || response || []
+				const response = await objectStore.fetchCollection('mapLayer', {})
+				this.layers = response || []
 			} catch {
 				this.layers = []
 			} finally {
@@ -60,7 +60,7 @@ export const useGisStore = defineStore('gis', {
 		 */
 		async createLayer(layerData) {
 			const objectStore = useObjectStore()
-			const created = await objectStore.create('mapLayer', layerData)
+			const created = await objectStore.saveObject('mapLayer', layerData)
 			await this.fetchLayers()
 			return created
 		},
@@ -74,7 +74,7 @@ export const useGisStore = defineStore('gis', {
 		 */
 		async updateLayer(id, layerData) {
 			const objectStore = useObjectStore()
-			const updated = await objectStore.update('mapLayer', id, layerData)
+			const updated = await objectStore.saveObject('mapLayer', { id, ...layerData })
 			await this.fetchLayers()
 			return updated
 		},
@@ -86,7 +86,7 @@ export const useGisStore = defineStore('gis', {
 		 */
 		async deleteLayer(id) {
 			const objectStore = useObjectStore()
-			await objectStore.delete('mapLayer', id)
+			await objectStore.deleteObject('mapLayer', id)
 			await this.fetchLayers()
 		},
 

--- a/src/store/modules/inspection.js
+++ b/src/store/modules/inspection.js
@@ -229,15 +229,22 @@ export const useInspectionStore = defineStore('inspection', {
 		/**
 		 * Upload a photo for an inspection item.
 		 *
-		 * @param {string} caseId  UUID of the case
+		 * Uses the @conduction/nextcloud-vue filesPlugin (`uploadFiles`),
+		 * which expects FormData and the parent object's registered type.
+		 * Returns the first uploaded file's ID, mirroring the legacy contract.
+		 *
+		 * @param {string} caseId  UUID of the parent case
 		 * @param {File}   file    The photo file
 		 * @return {Promise<string|null>} Nextcloud file ID
 		 */
 		async uploadPhoto(caseId, file) {
 			try {
 				const objectStore = useObjectStore()
-				const result = await objectStore.uploadFile(caseId, file)
-				return result?.id || null
+				const formData = new FormData()
+				formData.append('file', file)
+				const result = await objectStore.uploadFiles('case', caseId, formData)
+				const uploaded = result?.results?.[0] || result?.[0] || result
+				return uploaded?.id || null
 			} catch (error) {
 				console.error('Error uploading inspection photo:', error)
 				return null

--- a/src/views/CaseMapView.vue
+++ b/src/views/CaseMapView.vue
@@ -168,11 +168,11 @@ export default {
 
 			try {
 				const [caseResult, typeResult] = await Promise.all([
-					objectStore.getAll('case'),
-					objectStore.getAll('caseType'),
+					objectStore.fetchCollection('case', {}),
+					objectStore.fetchCollection('caseType', {}),
 				])
-				this.cases = caseResult?.results || caseResult || []
-				this.caseTypes = typeResult?.results || typeResult || []
+				this.cases = caseResult || []
+				this.caseTypes = typeResult || []
 				await gisStore.fetchLayers()
 			} finally {
 				this.loading = false

--- a/src/views/dashboard/CaseMapWidget.vue
+++ b/src/views/dashboard/CaseMapWidget.vue
@@ -51,8 +51,8 @@ export default {
 		const objectStore = useObjectStore()
 		const currentUser = OC?.currentUser || ''
 		try {
-			const result = await objectStore.getAll('case')
-			const allCases = result?.results || result || []
+			const result = await objectStore.fetchCollection('case', {})
+			const allCases = result || []
 			// Show current user's assigned cases
 			this.cases = allCases.filter(c => c.assignee === currentUser && c.geometry)
 		} catch {

--- a/src/views/voorstellen/VoorstelDetail.vue
+++ b/src/views/voorstellen/VoorstelDetail.vue
@@ -216,7 +216,7 @@ export default {
 		async loadVoorstel() {
 			this.loading = true
 			try {
-				this.voorstel = await this.objectStore.fetchOne('voorstel', this.voorstelId)
+				this.voorstel = await this.objectStore.fetchObject('voorstel', this.voorstelId)
 			} catch (error) {
 				console.error('Failed to load voorstel:', error)
 			} finally {


### PR DESCRIPTION
## Summary

- **Drop phantom store calls** — replaces `getObjects` / `getAll` / `create` / `update` / `delete` / `fetchOne` / `uploadFile` with the canonical `@conduction/nextcloud-vue` `useObjectStore` API (`fetchCollection`, `saveObject`, `deleteObject`, `fetchObject`, `filesPlugin.uploadFiles`).
- **Same class of bug as decidesk #162** — these legacy method names do not exist on the lib's store and fail at runtime as `TypeError: objectStore.X is not a function` once the affected code path is exercised.
- **Out of scope kept untouched** — `settings.js` and `zgwMapping.js` are procest-specific REST stores (not OR objects); the workflow / business-logic sub-stores (`bezwaar`, `advice`, `enforcement`, `gis`, `inspection`, `workflow`) keep their `defineStore` shells but their internal CRUD now uses the canonical lib API.

## Migration mapping

| Legacy | Canonical |
|---|---|
| `getObjects(t, { filters: {f: v}, limit: n })` | `fetchCollection(t, { '_filters[f]': v, _limit: n })` |
| `getAll(t)` | `fetchCollection(t, {})` |
| `create(t, data)` | `saveObject(t, data)` |
| `update(t, id, data)` | `saveObject(t, { id, ...data })` |
| `delete(t, id)` | `deleteObject(t, id)` |
| `fetchOne(t, id)` | `fetchObject(t, id)` |
| `uploadFile(caseId, file)` | `uploadFiles('case', caseId, formData)` (filesPlugin) |

## Files modified (6)

- `src/store/modules/bezwaar.js` — 5 phantom calls
- `src/store/modules/gis.js` — 4 phantom calls
- `src/store/modules/inspection.js` — 1 phantom call (filesPlugin migration)
- `src/views/CaseMapView.vue` — 2 phantom calls
- `src/views/dashboard/CaseMapWidget.vue` — 1 phantom call
- `src/views/voorstellen/VoorstelDetail.vue` — 1 phantom call

## Spec

OpenSpec change `openspec/changes/procest-store-migration/`:
- `proposal.md` cites the project-memory rule + decidesk #162 precedent.
- `design.md` documents the API mapping, file table, custom-fallback list (none — lossless), and out-of-scope.
- `spec.md` adds requirements that lock the canonical API at every OR call site, while leaving room for procest-specific config and workflow stores.

## Validation

- `node tests/validate-manifest.js` — PASS (manifest 1.0.0, schema 1.2.0, 0 errors)
- `npx webpack --config webpack.config.js --mode production` — PASS (compiles, only pre-existing entrypoint-size warnings)
- `grep -rEn 'objectStore\.(getObjects|getAll|fetchOne|uploadFile)\(' src/` — zero hits
- `npx eslint` not run — pre-existing dev-tooling gap (peer plugins missing from lockfile, same as decidesk worktree); webpack production build is the stronger correctness signal here

## Test plan

- [ ] Open the CaseMapView and confirm cases + caseTypes load (was `getAll`).
- [ ] Open the dashboard CaseMapWidget and confirm assigned cases render.
- [ ] Navigate to a voorstel detail page (`fetchOne`).
- [ ] Open a bezwaar case and confirm objection / hearings / advisory report load (`getObjects` x 4).
- [ ] Trigger bezwaar->beroep escalation; confirm `caseType` lookup resolves.
- [ ] Test inspection photo upload (`uploadFile` -> `uploadFiles`).
- [ ] Test MapLayer admin CRUD (`getAll`/`create`/`update`/`delete`).