### PR TITLE
chore: drop App.vue OR-availability guard (use CnAppRoot default)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.0",
 			"license": "EUPL-1.2",
 			"dependencies": {
-				"@conduction/nextcloud-vue": "^1.0.0-beta.12",
+				"@conduction/nextcloud-vue": "^1.0.0-beta.29",
 				"@nextcloud/axios": "~2.5.2",
 				"@nextcloud/dialogs": "^3.2.0",
 				"@nextcloud/initial-state": "^2.2.0",
@@ -307,9 +307,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "1.0.0-beta.13",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.13.tgz",
-			"integrity": "sha512-vhWXjNo8nP294otJkLyE5sh/tjAP6RFnbse1pureYY7aIt4lIgVDd8VCFjndnUoanF9S6TY5q410JmUz4Zm7lA==",
+			"version": "1.0.0-beta.29",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.29.tgz",
+			"integrity": "sha512-gFnC9I9z2v76HutB7klBvZ52k7ep7VvCsYlM0iyK4R8yIOIb7bKTBV4OBMG51Epfg5hkVoKwayDxUnju+lUerg==",
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.0.0",
@@ -330,7 +330,9 @@
 				"apexcharts": "^4.7.0",
 				"codemirror": "^6.0.0",
 				"gridstack": "^10.3.1",
+				"leaflet": "^1.9.0",
 				"lodash": "^4.17.21",
+				"marked": "^15.0.0",
 				"style-mod": "^4.0.0",
 				"vue-apexcharts": "^1.7.0",
 				"vue-codemirror6": "^1.4.3",
@@ -6495,6 +6497,18 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/marked": {
+			"version": "15.0.12",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+			"integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
 		"node_modules/material-colors": {
 			"version": "1.2.6",
 			"resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
@@ -11405,9 +11419,9 @@
 			}
 		},
 		"@conduction/nextcloud-vue": {
-			"version": "1.0.0-beta.13",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.13.tgz",
-			"integrity": "sha512-vhWXjNo8nP294otJkLyE5sh/tjAP6RFnbse1pureYY7aIt4lIgVDd8VCFjndnUoanF9S6TY5q410JmUz4Zm7lA==",
+			"version": "1.0.0-beta.29",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.29.tgz",
+			"integrity": "sha512-gFnC9I9z2v76HutB7klBvZ52k7ep7VvCsYlM0iyK4R8yIOIb7bKTBV4OBMG51Epfg5hkVoKwayDxUnju+lUerg==",
 			"requires": {
 				"@codemirror/autocomplete": "^6.0.0",
 				"@codemirror/commands": "^6.0.0",
@@ -11427,7 +11441,9 @@
 				"apexcharts": "^4.7.0",
 				"codemirror": "^6.0.0",
 				"gridstack": "^10.3.1",
+				"leaflet": "^1.9.0",
 				"lodash": "^4.17.21",
+				"marked": "^15.0.0",
 				"style-mod": "^4.0.0",
 				"vue-apexcharts": "^1.7.0",
 				"vue-codemirror6": "^1.4.3",
@@ -15763,6 +15779,11 @@
 			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
 			"integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
 			"dev": true
+		},
+		"marked": {
+			"version": "15.0.12",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+			"integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="
 		},
 		"material-colors": {
 			"version": "1.2.6",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"extends @nextcloud/browserslist-config"
 	],
 	"dependencies": {
-		"@conduction/nextcloud-vue": "^1.0.0-beta.12",
+		"@conduction/nextcloud-vue": "^1.0.0-beta.29",
 		"apexcharts": "^3.45.0",
 		"vue-apexcharts": "^1.6.2",
 		"@nextcloud/axios": "~2.5.2",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,59 +1,23 @@
 <!-- SPDX-License-Identifier: EUPL-1.2 -->
 <template>
-	<NcContent app-name="procest">
-		<template v-if="storesReady && !hasOpenRegisters">
-			<NcAppContent class="open-register-missing">
-				<NcEmptyContent
-					:name="t('procest', 'OpenRegister is required')"
-					:description="t('procest', 'Procest needs the OpenRegister app to store and manage data. Please install OpenRegister from the app store to get started.')">
-					<template #icon>
-						<img
-							:src="appIcon"
-							alt=""
-							width="64"
-							height="64">
-					</template>
-					<template #action>
-						<NcButton
-							v-if="isAdmin"
-							type="primary"
-							:href="appStoreUrl">
-							{{ t('procest', 'Install OpenRegister') }}
-						</NcButton>
-					</template>
-				</NcEmptyContent>
-			</NcAppContent>
-		</template>
-		<template v-else-if="storesReady && hasOpenRegisters">
-			<CnAppRoot
-				:manifest="manifest"
-				:custom-components="customComponents"
-				:page-types="pageTypes" />
-		</template>
-		<NcAppContent v-else>
-			<div style="display: flex; justify-content: center; align-items: center; height: 100%;">
-				<NcLoadingIcon :size="64" />
-			</div>
-		</NcAppContent>
-	</NcContent>
+	<CnAppRoot
+		:manifest="manifest"
+		:custom-components="customComponents"
+		:page-types="pageTypes"
+		app-id="procest"
+		:translate="translateForApp"
+		:permissions="permissions" />
 </template>
 
 <script>
 import Vue from 'vue'
-import { NcButton, NcContent, NcAppContent, NcEmptyContent, NcLoadingIcon } from '@nextcloud/vue'
+import { translate as ncT } from '@nextcloud/l10n'
 import { CnAppRoot } from '@conduction/nextcloud-vue'
-import { generateUrl, imagePath } from '@nextcloud/router'
 import { initializeStores } from './store/store.js'
-import { useSettingsStore } from './store/modules/settings.js'
 
 export default {
 	name: 'App',
 	components: {
-		NcButton,
-		NcContent,
-		NcAppContent,
-		NcEmptyContent,
-		NcLoadingIcon,
 		CnAppRoot,
 	},
 
@@ -87,7 +51,6 @@ export default {
 
 	data() {
 		return {
-			storesReady: false,
 			objectSidebarState: Vue.observable({
 				active: false,
 				open: true,
@@ -102,25 +65,32 @@ export default {
 			}),
 		}
 	},
+
 	computed: {
-		hasOpenRegisters() {
-			const settingsStore = useSettingsStore()
-			return settingsStore.hasOpenRegisters
-		},
-		isAdmin() {
-			const settingsStore = useSettingsStore()
-			return settingsStore.getIsAdmin
-		},
-		appIcon() {
-			return imagePath('procest', 'app-dark.svg')
-		},
-		appStoreUrl() {
-			return generateUrl('/settings/apps/integration/openregister')
+		permissions() {
+			return window.OC?.currentUser?.permissions ?? []
 		},
 	},
+
 	async created() {
+		// Pinia stores still need to come up so legacy custom components
+		// keep working through the manifest transition. CnAppRoot itself
+		// doesn't depend on them.
 		await initializeStores()
-		this.storesReady = true
+	},
+
+	methods: {
+		/**
+		 * Translate function passed down to CnAppRoot / CnAppNav /
+		 * CnPageRenderer. Closes over the Nextcloud `translate` import so
+		 * the lib never has to know our app id.
+		 *
+		 * @param {string} key Translation key.
+		 * @return {string} Translated string (or the key on miss).
+		 */
+		translateForApp(key) {
+			return ncT('procest', key)
+		},
 	},
 }
 </script>


### PR DESCRIPTION
## Summary

@conduction/nextcloud-vue beta now ships the OpenRegister-availability guard built into `CnAppRoot` itself — it reads `manifest.dependencies` and routes the shell into a `dependency-missing` phase rendered by `CnDependencyMissing` when any dependency is uninstalled or disabled. Procest's manifest already declares `"dependencies": ["openregister"]`, so the host-level guard in `App.vue` is redundant.

This brings procest to pure manifest parity with decidesk / pipelinq / softwarecatalog.

Refs: openspec change `cnapproot-app-availability-guard`, lib PR ConductionNL/nextcloud-vue#191.

## Lib version bump

`@conduction/nextcloud-vue`: `^1.0.0-beta.12` → `^1.0.0-beta.29`

(Caret on a `1.0.0-beta.X` pre-release does **not** slide forward across pre-release versions in npm semver, so an explicit bump was required to pick up the guard implementation.)

## Removed (only the guard)

- `<template v-if="storesReady && !hasOpenRegisters">` empty-state branch (NcEmptyContent + "Install OpenRegister" NcButton CTA)
- `<template v-else-if="storesReady && hasOpenRegisters">` wrapper
- `<NcAppContent v-else>` loading-spinner branch
- `storesReady` data flag (no longer needed; CnAppRoot handles its own dependency-resolution phase)
- `hasOpenRegisters`, `isAdmin`, `appIcon`, `appStoreUrl` computed properties (only fed the empty-state CTA)
- `useSettingsStore`, `generateUrl`, `imagePath` imports
- `NcButton`, `NcContent`, `NcAppContent`, `NcEmptyContent`, `NcLoadingIcon` imports (no longer mounted)

## Kept (other App.vue responsibilities)

- `provide()` channel for `objectSidebarState` (+ legacy `sidebarState` alias) — index pages rely on this for sidebar hoisting
- `objectSidebarState` reactive data (`Vue.observable`)
- `await initializeStores()` in `created()` — Pinia stores still feed legacy custom components through the manifest transition

## Added (lib API alignment, mirrors decidesk)

- `app-id="procest"` prop on CnAppRoot (now required by the lib)
- `translate` prop wired through `ncT('procest', key)` so CnAppRoot / CnAppNav / CnPageRenderer get app-scoped translations
- `permissions` prop sourced from `window.OC.currentUser.permissions`

## Asset cleanup

None. `img/app-dark.svg` (the empty-state icon source) is still used by seven dashboard widgets, and `img/app-store.svg` is referenced by `appinfo/info.xml` as a screenshot. No images were exclusive to the guard.

## No opt-out passed

Procest does **not** pass `:requires-apps="[]"` (because it wants the default behaviour); CnAppRoot reads `manifest.dependencies` automatically.

## Gates

- `npm install --legacy-peer-deps` — OK; lockfile updated to beta.29
- `npm run build` — OK (webpack 5 compiled, all imports resolve; 9 pre-existing asset-size warnings unrelated to this change)
- `npm run lint` — pre-existing tooling breakage on `development` baseline (missing transitive peer deps `eslint-plugin-import` / `eslint-plugin-n` from `@nextcloud/eslint-config`); not introduced by this PR. Build verifies App.vue imports resolve correctly.

## Test plan

- [ ] Manual smoke: with OpenRegister enabled, procest shell mounts as before (manifest-driven dashboard, menu, routes)
- [ ] Manual smoke: with OpenRegister **disabled** via `occ app:disable openregister`, procest renders `CnDependencyMissing` empty-state from the lib (replacing the deleted host-level branch)
- [ ] Manual smoke: index pages still hoist their sidebars via `objectSidebarState` provide channel (Cases / Tasks / Voorstellen list pages)
- [ ] CI checks pass on the PR
