### PR TITLE
fix(#323): clear 7 ESLint source errors

### DIFF
--- a/src/store/modules/bezwaar.js
+++ b/src/store/modules/bezwaar.js
@@ -10,7 +10,6 @@
  */
 import { defineStore } from 'pinia'
 import { useObjectStore } from './object.js'
-import { useSettingsStore } from './settings.js'
 
 /**
  * Add working days to a date (skipping weekends).
@@ -496,7 +495,6 @@ export const useBezwaarStore = defineStore('bezwaar', {
 
 			try {
 				const objectStore = useObjectStore()
-				const settingsStore = useSettingsStore()
 
 				// Find the Beroep case type.
 				const caseTypes = await objectStore.fetchCollection('caseType', {

--- a/src/views/MyWork.vue
+++ b/src/views/MyWork.vue
@@ -58,7 +58,7 @@
 		<ParafeerInbox v-if="!loading" />
 
 		<!-- Grouped sections -->
-		<template v-else-if="!loading">
+		<template v-if="!loading">
 			<!-- Overdue -->
 			<div v-if="filteredGroups.overdue.length > 0" class="my-work__section my-work__section--overdue">
 				<h3 class="my-work__section-header my-work__section-header--overdue">

--- a/src/views/cases/components/CaseTransferDialog.vue
+++ b/src/views/cases/components/CaseTransferDialog.vue
@@ -34,19 +34,19 @@
 					v-model="form.requestedDate"
 					type="date" />
 			</div>
-
-			<template #actions>
-				<NcButton @click="$emit('update:open', false)">
-					{{ t('procest', 'Cancel') }}
-				</NcButton>
-				<NcButton
-					type="primary"
-					:disabled="!isValid || saving"
-					@click="submitTransfer">
-					{{ saving ? t('procest', 'Submitting...') : t('procest', 'Submit transfer request') }}
-				</NcButton>
-			</template>
 		</div>
+
+		<template #actions>
+			<NcButton @click="$emit('update:open', false)">
+				{{ t('procest', 'Cancel') }}
+			</NcButton>
+			<NcButton
+				type="primary"
+				:disabled="!isValid || saving"
+				@click="submitTransfer">
+				{{ saving ? t('procest', 'Submitting...') : t('procest', 'Submit transfer request') }}
+			</NcButton>
+		</template>
 	</NcDialog>
 </template>
 

--- a/src/views/cases/components/CreateShareDialog.vue
+++ b/src/views/cases/components/CreateShareDialog.vue
@@ -88,19 +88,19 @@
 					</NcButton>
 				</div>
 			</div>
-
-			<template #actions>
-				<NcButton @click="$emit('update:open', false)">
-					{{ t('procest', 'Cancel') }}
-				</NcButton>
-				<NcButton
-					type="primary"
-					:disabled="saving"
-					@click="createShare">
-					{{ saving ? t('procest', 'Creating...') : t('procest', 'Create share') }}
-				</NcButton>
-			</template>
 		</div>
+
+		<template #actions>
+			<NcButton @click="$emit('update:open', false)">
+				{{ t('procest', 'Cancel') }}
+			</NcButton>
+			<NcButton
+				type="primary"
+				:disabled="saving"
+				@click="createShare">
+				{{ saving ? t('procest', 'Creating...') : t('procest', 'Create share') }}
+			</NcButton>
+		</template>
 	</NcDialog>
 </template>
 

--- a/src/views/cases/components/EmailComposer.vue
+++ b/src/views/cases/components/EmailComposer.vue
@@ -46,7 +46,7 @@
 			<div v-if="unresolvedVars.length > 0" class="email-composer__warning">
 				{{ t('procest', 'Unresolved variables:') }}
 				<span v-for="v in unresolvedVars" :key="v" class="email-composer__unresolved">
-					{{ '{{' + v + '}}' }}
+					{{ formatVariable(v) }}
 				</span>
 			</div>
 
@@ -56,7 +56,7 @@
 					<summary>{{ t('procest', 'Available variables') }}</summary>
 					<div class="email-composer__variable-list">
 						<code v-for="v in availableVariables" :key="v" @click="insertVariable(v)">
-							{{ '{{' + v + '}}' }}
+							{{ formatVariable(v) }}
 						</code>
 					</div>
 				</details>
@@ -163,6 +163,9 @@ export default {
 		},
 	},
 	methods: {
+		formatVariable(varName) {
+			return '{{' + varName + '}}'
+		},
 		onTemplateSelected(template) {
 			if (!template) return
 			this.form.subject = template.subjectPattern || ''

--- a/src/views/settings/components/DurationPicker.vue
+++ b/src/views/settings/components/DurationPicker.vue
@@ -28,7 +28,7 @@
 
 <script>
 import { NcTextField } from '@nextcloud/vue'
-import { parseDuration, formatDuration, isValidDuration } from '../../../utils/durationHelpers.js'
+import { parseDuration, isValidDuration } from '../../../utils/durationHelpers.js'
 
 export default {
 	name: 'DurationPicker',


### PR DESCRIPTION
## Summary

Closes #323. The baseline-fix PR (#324) un-blocked ESLint on `procest`, which surfaced 7 real source-level errors (parsing errors, v-slot scoping, unused vars, duplicate `v-else-if`). This PR fixes all of them with the smallest possible change per rule.

Lint result: **7 errors -> 0 errors**. Warnings are deliberately left untouched (separate cleanup).

## Error -> fix mapping

| File:line | Rule | Fix |
|---|---|---|
| `src/store/modules/bezwaar.js:499` | `no-unused-vars` | Remove unused `settingsStore` + its `useSettingsStore` import (no other references). |
| `src/views/MyWork.vue:61` | `vue/no-dupe-v-else-if` | Change `v-else-if="!loading"` to `v-if="!loading"` so the grouped-sections template renders alongside `ParafeerInbox`. The `v-else-if` was a copy-paste leftover from commit `5847d05` (when `<ParafeerInbox v-if="!loading" />` was inserted into the chain) and the branch could never execute. |
| `src/views/cases/components/CaseTransferDialog.vue:38` | `vue/valid-v-slot` | Move `<template #actions>` out of the inner wrapper `<div class=\"case-transfer-dialog\">` so it is a direct child of `NcDialog` (which is what owns the `actions` slot). |
| `src/views/cases/components/CreateShareDialog.vue:92` | `vue/valid-v-slot` | Same as above - move `<template #actions>` out of the inner wrapper `<div>` so it is a direct child of `NcDialog`. |
| `src/views/cases/components/EmailComposer.vue:49` | `vue/no-parsing-error` | The literal `'{{' + v + '}}'` inside `{{ }}` confused Vue's template parser. Replaced with a `formatVariable(v)` method that returns the same string. |
| `src/views/cases/components/EmailComposer.vue:59` | `vue/no-parsing-error` | Same as above - second occurrence in the available-variables list. |
| `src/views/settings/components/DurationPicker.vue:31` | `no-unused-vars` | Remove unused `formatDuration` from the named import (kept `parseDuration`, `isValidDuration`). |

## Files touched

- `src/store/modules/bezwaar.js`
- `src/views/MyWork.vue`
- `src/views/cases/components/CaseTransferDialog.vue`
- `src/views/cases/components/CreateShareDialog.vue`
- `src/views/cases/components/EmailComposer.vue`
- `src/views/settings/components/DurationPicker.vue`

## Test plan

- [x] `npm ci` - clean install OK
- [x] `npm run lint` - 7 errors -> 0 errors (13 warnings unchanged, out of scope)
- [x] `npm run build` - succeeds (webpack compiled with 9 warnings, same as before)
- [ ] Manual smoke test of MyWork view to confirm grouped sections render now (see note below)

## Note on `MyWork.vue` (small behaviour fix)

The `vue/no-dupe-v-else-if` fix on `MyWork.vue` is technically a behaviour change - but it fixes a bug, not introduces one. The `v-else-if="!loading"` was a dead branch (impossible to satisfy), meaning the grouped sections (Overdue / Today / Upcoming, lines 62-onwards) **never rendered** under any conditions. With `v-if="!loading"` they now render whenever the loading state is false, which is clearly the intent based on git history (commit `5847d05` introduced the bug when adding `<ParafeerInbox>`).

Worth a quick smoke-test before merge to confirm the My Work view now shows its grouped sections. If reviewers prefer to revert just this one hunk and file a follow-up issue, the other 6 fixes are pure no-ops.