### PR TITLE
fix(my-work): un-block grouped Overdue/Today/Upcoming sections

### DIFF
--- a/src/views/MyWork.vue
+++ b/src/views/MyWork.vue
@@ -58,7 +58,7 @@
 		<ParafeerInbox v-if="!loading" />
 
 		<!-- Grouped sections -->
-		<template v-else-if="!loading">
+		<template v-if="!loading">
 			<!-- Overdue -->
 			<div v-if="filteredGroups.overdue.length > 0" class="my-work__section my-work__section--overdue">
 				<h3 class="my-work__section-header my-work__section-header--overdue">


### PR DESCRIPTION
Behaviour change — needs smoke-test. src/views/MyWork.vue had a dead v-else-if branch that prevented Overdue/Today/Upcoming sections from rendering. Git history (commit 5847d05) shows those sections were the original intent. Companion to fix/323-mechanical-eslint-fixes (cosmetic-only PR). Smoke-test: load /apps/procest's My Work view; confirm grouped sections render alongside ParafeerInbox.