### PR TITLE
feat(zaaktype-configuratie): apply spec (no-op — already implemented)

### DIFF
--- a/openspec/changes/zaaktype-configuratie/builds/build.json
+++ b/openspec/changes/zaaktype-configuratie/builds/build.json
@@ -1,0 +1,34 @@
+{
+  "phase": "apply",
+  "timestamp": "2026-05-11T00:00:00+00:00",
+  "status": "no-op",
+  "reason": "All 4 V1 tasks (DurationPicker.vue, GeneralTab integration, active case count warning, publish validation with Dutch error messages) already implemented on development. Spec marked status: implemented. No code changes required.",
+  "verified_files": [
+    "src/views/settings/components/DurationPicker.vue",
+    "src/views/settings/tabs/GeneralTab.vue",
+    "src/views/settings/CaseTypeDetail.vue",
+    "src/utils/caseTypeValidation.js"
+  ],
+  "tasks_complete": [
+    "TASK-ZC-01",
+    "TASK-ZC-02",
+    "TASK-ZC-03",
+    "TASK-ZC-04"
+  ],
+  "validation": {
+    "php_lint": "pass",
+    "jq": "pass",
+    "composer_check_strict": "deferred per watchdog",
+    "i18n": "deferred per watchdog"
+  },
+  "deferred": [
+    "REQ-ZTC-03 document type admin UI (V1 future)",
+    "REQ-ZTC-04 property definition admin UI (V1 future)",
+    "REQ-ZTC-05 role type admin UI (V1 future)",
+    "REQ-ZTC-06 result type admin UI (V1 future)",
+    "REQ-ZTC-07 parafeerroute admin UI (V2)",
+    "REQ-ZTC-08 import/export (V2)",
+    "REQ-ZTC-09 version management (V2)",
+    "REQ-ZTC-10 test mode (V2)"
+  ]
+}


### PR DESCRIPTION
## Summary

Records the apply phase for the `zaaktype-configuratie` openspec change as a **no-op**. All four V1 tasks defined in `tasks.md` are already implemented on `development` via earlier commits (notably `5497d07 feat: Implement zaaktype-configuratie spec — duration picker, active case warnings`).

- TASK-ZC-01: `src/views/settings/components/DurationPicker.vue` exists
- TASK-ZC-02: `src/views/settings/tabs/GeneralTab.vue` integrates `DurationPicker` for `processingDeadline`, `serviceTarget`, `extensionPeriod`
- TASK-ZC-03: `src/views/settings/CaseTypeDetail.vue` shows the active case count warning
- TASK-ZC-04: `src/utils/caseTypeValidation.js` exposes `validateForPublish()` with Dutch error messages

Spec is marked `status: implemented`. This PR adds the missing `builds/build.json` apply marker so the change is tracked in the openspec pipeline.

## Validation

- `php -l` clean across `lib/`
- `jq -e .` valid for `procest_register.json` and the new `build.json`
- Composer `check:strict` gates and i18n: deferred per fleet-wide pattern

## Deferred (future changes)

V1 admin UIs still missing for document types, property definitions, role types, result types. All V2 features (parafeerroute UI, import/export, versioning, test mode) tracked in the spec's "Not yet implemented" section.

## Test plan

- [ ] DurationPicker renders presets and emits ISO 8601 duration
- [ ] Active case count warning appears on edit
- [ ] Publish validation shows Dutch error messages