### PR TITLE
feat(admin-settings): apply spec

### DIFF
--- a/src/views/settings/CaseTypeDetail.vue
+++ b/src/views/settings/CaseTypeDetail.vue
@@ -86,6 +86,18 @@
 					v-else-if="activeTab === 'statuses'"
 					:case-type-id="caseTypeId"
 					:is-create="isCreate" />
+				<ResultsTab
+					v-else-if="activeTab === 'results'"
+					:case-type-id="caseTypeId"
+					:is-create="isCreate" />
+				<RolesTab
+					v-else-if="activeTab === 'roles'"
+					:case-type-id="caseTypeId"
+					:is-create="isCreate" />
+				<PropertiesTab
+					v-else-if="activeTab === 'properties'"
+					:case-type-id="caseTypeId"
+					:is-create="isCreate" />
 				<WorkflowTab
 					v-else-if="activeTab === 'workflow'"
 					:case-type-id="caseTypeId" />
@@ -100,6 +112,9 @@ import ArrowLeftIcon from 'vue-material-design-icons/ArrowLeft.vue'
 import GeneralTab from './tabs/GeneralTab.vue'
 import StatusesTab from './tabs/StatusesTab.vue'
 import WorkflowTab from './tabs/WorkflowTab.vue'
+import ResultsTab from './tabs/ResultsTab.vue'
+import RolesTab from './tabs/RolesTab.vue'
+import PropertiesTab from './tabs/PropertiesTab.vue'
 import { useObjectStore } from '../../store/modules/object.js'
 import { validateCaseType, validateForPublish } from '../../utils/caseTypeValidation.js'
 
@@ -138,6 +153,9 @@ export default {
 		GeneralTab,
 		StatusesTab,
 		WorkflowTab,
+		ResultsTab,
+		RolesTab,
+		PropertiesTab,
 	},
 	props: {
 		caseTypeId: {
@@ -170,6 +188,9 @@ export default {
 			return [
 				{ id: 'general', label: t('procest', 'General') },
 				{ id: 'statuses', label: t('procest', 'Statuses') },
+				{ id: 'results', label: t('procest', 'Results') },
+				{ id: 'roles', label: t('procest', 'Roles') },
+				{ id: 'properties', label: t('procest', 'Properties') },
 				{ id: 'workflow', label: t('procest', 'Workflow') },
 			]
 		},


### PR DESCRIPTION
## Summary

Apply OpenSpec change `admin-settings` — integrate Results, Roles, Properties tabs into `CaseTypeDetail.vue`.

- Tab components (T01-T03 `ResultsTab.vue`, `RolesTab.vue`, `PropertiesTab.vue`) already exist on development from prior commit `b01f60c`.
- This PR applies T04 (CaseTypeDetail integration) and V05 (tab order: General, Statuses, Results, Roles, Properties, Workflow).
- Spec: `openspec/changes/admin-settings/specs/admin-settings/spec.md` (REQ-ADMIN-004, REQ-ADMIN-009, REQ-ADMIN-010, REQ-ADMIN-011).

## i18n keys deferred (per watchdog rules)

The integration introduces three new tab labels (`procest` domain) that need translations in `l10n/en.json` + `l10n/nl.json`:

- `Results` -> nl: `Resultaten`
- `Roles` -> nl: `Rollen`
- `Properties` -> nl: `Eigenschappen`

These will be added in a follow-up i18n sweep.

## Validation

- Vue file structure check (`template` + `script` parse) — passed
- 9 references (3 each in template, import, components) confirmed via grep
- `composer check:strict` skipped per watchdog rules (no PHP changes anyway)

## Test plan

- [ ] Verify CaseTypeDetail shows 6 tabs (General, Statuses, Results, Roles, Properties, Workflow)
- [ ] Click each new tab — content renders without errors
- [ ] Add/edit/delete a Result type, Role type, Property definition
- [ ] Confirm tab labels show English by default and Dutch when locale switched (after i18n follow-up)