### PR TITLE
feat(zaak-intake-flow): apply spec

### DIFF
--- a/lib/Settings/procest_register.json
+++ b/lib/Settings/procest_register.json
@@ -164,6 +164,11 @@
               "type": "string"
             },
             "description": "References to decision types (besluittypen) linked to this case type"
+          },
+          "defaultAssignee": {
+            "type": "string",
+            "description": "Nextcloud user UID or group ID for automatic assignment of cases of this type (REQ-INTAKE-03a)",
+            "title": "Default assignee"
           }
         }
       },
@@ -594,6 +599,23 @@
             "type": "string",
             "description": "Nextcloud user ID of the primary handler",
             "title": "Assignee",
+            "facetable": true
+          },
+          "intakeChannel": {
+            "type": "string",
+            "enum": [
+              "manual",
+              "balie",
+              "telefoon",
+              "email",
+              "post",
+              "website",
+              "overig",
+              "zgw-api"
+            ],
+            "default": "manual",
+            "description": "The channel through which this case was intaken (REQ-INTAKE-08b, REQ-INTAKE-11a)",
+            "title": "Intake channel",
             "facetable": true
           },
           "priority": {

--- a/src/views/cases/CaseCreateDialog.vue
+++ b/src/views/cases/CaseCreateDialog.vue
@@ -71,6 +71,23 @@
 						:placeholder="t('procest', 'Optional description...')"
 						rows="3" />
 				</div>
+
+				<!-- Intake channel (REQ-INTAKE-11a/b) -->
+				<div class="form-group">
+					<label>{{ t('procest', 'Intake channel') }}</label>
+					<NcSelect
+						v-model="selectedIntakeChannel"
+						:options="intakeChannelOptions"
+						label="label"
+						track-by="value"
+						:placeholder="t('procest', 'Select intake channel...')"
+						:clearable="false" />
+				</div>
+
+				<!-- Auto-assign preview (REQ-INTAKE-03a) -->
+				<div v-if="selectedCaseType && selectedCaseType.defaultAssignee" class="case-create-dialog__assignee-hint">
+					{{ t('procest', 'Will be auto-assigned to: {assignee}', { assignee: selectedCaseType.defaultAssignee }) }}
+				</div>
 			</div>
 
 			<div class="case-create-dialog__footer">
@@ -129,6 +146,7 @@ export default {
 			errors: {},
 			saving: false,
 			loadingTypes: false,
+			selectedIntakeChannel: { value: 'manual', label: 'Manual' },
 		}
 	},
 	computed: {
@@ -137,6 +155,19 @@ export default {
 		},
 		isSubCaseMode() {
 			return !!this.parentCase
+		},
+		intakeChannelOptions() {
+			// REQ-INTAKE-11a: channel options (Balie, Telefoon, E-mail, Post, Website, Overig)
+			// Default is "manual" per REQ-INTAKE-11b.
+			return [
+				{ value: 'manual', label: t('procest', 'Manual') },
+				{ value: 'balie', label: t('procest', 'Counter (Balie)') },
+				{ value: 'telefoon', label: t('procest', 'Phone') },
+				{ value: 'email', label: t('procest', 'E-mail') },
+				{ value: 'post', label: t('procest', 'Mail (Post)') },
+				{ value: 'website', label: t('procest', 'Website') },
+				{ value: 'overig', label: t('procest', 'Other') },
+			]
 		},
 		dialogTitle() {
 			return this.isSubCaseMode
@@ -227,6 +258,13 @@ export default {
 				? t('procest', 'Sub-case created with type \'{type}\'', { type: this.selectedCaseType.title })
 				: t('procest', 'Case created with type \'{type}\'', { type: this.selectedCaseType.title })
 
+			// REQ-INTAKE-03a: auto-assign handler from caseType.defaultAssignee
+			// REQ-INTAKE-03c: cases with no default assignee remain unassigned (null).
+			const autoAssignee = this.selectedCaseType.defaultAssignee || null
+
+			// REQ-INTAKE-11a/b: store selected intake channel (defaults to 'manual').
+			const intakeChannel = this.selectedIntakeChannel?.value || 'manual'
+
 			const caseData = {
 				title: this.form.title.trim(),
 				description: this.form.description.trim(),
@@ -236,7 +274,8 @@ export default {
 				startDate,
 				deadline: deadline ? deadline.toISOString().split('T')[0] + 'T17:00:00Z' : null,
 				confidentiality: this.selectedCaseType.confidentiality || 'public',
-				assignee: null,
+				assignee: autoAssignee,
+				intakeChannel,
 				priority: 'normal',
 				endDate: null,
 				result: null,
@@ -635,6 +674,15 @@ export default {
 .preview-label {
 	color: var(--color-text-maxcontrast);
 	font-size: 13px;
+}
+
+.case-create-dialog__assignee-hint {
+	background: var(--color-primary-element-light);
+	border-radius: var(--border-radius);
+	padding: 8px 12px;
+	margin-bottom: 16px;
+	font-size: 13px;
+	color: var(--color-main-text);
 }
 
 .case-create-dialog__footer {


### PR DESCRIPTION
## Summary

Applies the `zaak-intake-flow` openspec change for procest. Closes intake gaps flagged by 61% of tenders requiring intake capabilities.

- **Schema** (`lib/Settings/procest_register.json`):
  - `caseType.defaultAssignee` (string) — Nextcloud user UID / group ID for auto-assignment
  - `case.intakeChannel` (enum) — `manual` | `balie` | `telefoon` | `email` | `post` | `website` | `overig` | `zgw-api`, default `manual`, facetable
- **Frontend** (`src/views/cases/CaseCreateDialog.vue`):
  - Intake channel dropdown (7 options, default `manual`) — REQ-INTAKE-11a/b
  - Auto-assign handler from `selectedCaseType.defaultAssignee` on submit; null when not configured — REQ-INTAKE-03a/c
- **Backend** (`lib/Service/ZgwZrcRulesService.php`):
  - Pre-existing: API intake already sets `intakeChannel='zgw-api'` and applies `defaultAssignee` (TASK-5/6 verified, no change needed)
- **CaseDetail**: intake channel surfaces automatically via the manifest schema-driven `data` widget — no template change required.

## Deferred / flagged

- **REQ-INTAKE-03d** (Nextcloud notification on assignment): `NotificatieService` is the ZGW pub/sub channel, not a user-targeted notification mechanism, and is not injected into the rules service. Wiring requires container changes and a design decision (NotificatieService vs `OCP\Notification\IManager`). Out of MVP scope; track in follow-up.
- **i18n**: Deferred per watchdog rules.
- **Pre-existing**: `CaseCreateDialog.vue` contains two duplicate `<template>`/`<script>` SFC blocks from a prior merge. Only the first block is parsed by Vue; this change edits only the canonical first block. Cleanup of the dead trailing block is out of scope here.

## Spec refs

REQ-INTAKE-03a, REQ-INTAKE-03c, REQ-INTAKE-08b, REQ-INTAKE-08d, REQ-INTAKE-11a, REQ-INTAKE-11b

## Test plan

- [ ] Open New Case dialog; verify intake channel dropdown shows 7 options with `Manual` selected by default.
- [ ] Configure a `defaultAssignee` on a caseType; create a case of that type; verify the new case has `assignee` set.
- [ ] Create a case via ZGW API (`POST /zaken/v1/zaken`); verify the resulting case object has `intakeChannel='zgw-api'`.
- [ ] On the CaseDetail page, confirm `intakeChannel` renders in the overview tab `data` widget.

## Validation performed

- `php -l lib/Service/ZgwZrcRulesService.php` — clean
- `jq empty lib/Settings/procest_register.json` — passes
- `jq empty src/manifest.json` — passes
- `composer check:strict` — skipped per watchdog rules