### PR TITLE
feat(mobiel-inspectie): apply spec

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -154,6 +154,13 @@ return [
         // Dashboard KPI aggregation endpoint.
         ['name' => 'kpi#index', 'url' => '/api/dashboard/kpis', 'verb' => 'GET'],
 
+        // ── Mobile Inspection (PWA) ─────────────────────────────────────
+        ['name' => 'inspection#index',                'url' => '/api/inspections',                                   'verb' => 'GET'],
+        ['name' => 'inspection#captureLocation',      'url' => '/api/inspections/{id}/location',                     'verb' => 'POST'],
+        ['name' => 'inspection#completeChecklistItem','url' => '/api/inspections/{id}/checklist/{itemId}',           'verb' => 'POST'],
+        ['name' => 'inspection#addPhoto',             'url' => '/api/inspections/{id}/photos',                       'verb' => 'POST'],
+        ['name' => 'inspection#complete',             'url' => '/api/inspections/{id}/complete',                     'verb' => 'POST'],
+
         // SPA catch-all — serves the Vue app for any frontend route (history mode).
         ['name' => 'dashboard#page', 'url' => '/{path}', 'verb' => 'GET', 'requirements' => ['path' => '.+'], 'defaults' => ['path' => '']],
     ],


### PR DESCRIPTION
## Summary
Applies openspec change `mobiel-inspectie` (mobile inspection PWA for VTH field inspectors).

The controller (`InspectionController`), services (`InspectionService`, `ChecklistService`), and PWA manifest (`img/manifest.json`) were already implemented per `openspec/changes/mobiel-inspectie/tasks.md`. The only missing piece was route registration, which is added here.

## Routes added
- `GET  /api/inspections` -- list assigned inspections
- `POST /api/inspections/{id}/location` -- record GPS coordinates
- `POST /api/inspections/{id}/checklist/{itemId}` -- complete checklist item
- `POST /api/inspections/{id}/photos` -- upload photo metadata
- `POST /api/inspections/{id}/complete` -- finalize inspection

## Validation
- `php -l` clean on `appinfo/routes.php`, `InspectionController`, `InspectionService`, `ChecklistService`
- `jq empty img/manifest.json` clean

## Test plan
- [ ] Inspector lists today's inspections via `/api/inspections`
- [ ] GPS capture warns when >500m from planned address
- [ ] Niet-conform checklist item blocks save without photo
- [ ] PWA manifest enables Add to Home Screen on mobile

Refs `openspec/changes/mobiel-inspectie/`