### PR TITLE
feat(stuf-support): apply spec

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -147,6 +147,11 @@ return [
         ['name' => 'parafeer_route#update',       'url' => '/api/parafeer-route/{id}',                                 'verb' => 'PUT'],
         ['name' => 'parafeer_route#destroy',      'url' => '/api/parafeer-route/{id}',                                 'verb' => 'DELETE'],
 
+        // ── StUF (Standaard Uitwisselings Formaat) ──────────────────────
+        // Inbound SOAP endpoints accept raw XML POST.
+        ['name' => 'stuf#zaken',    'url' => '/api/stuf/zaken',    'verb' => 'POST'],
+        ['name' => 'stuf#personen', 'url' => '/api/stuf/personen', 'verb' => 'POST'],
+
         // Prometheus metrics endpoint.
         ['name' => 'metrics#index', 'url' => '/api/metrics', 'verb' => 'GET'],
         // Health check endpoint.


### PR DESCRIPTION
## Summary
Applies openspec change `stuf-support` by wiring the StUF SOAP routes that were missing on development.

The three implementation files (`StufFieldMappingService`, `StufMessageBuilder`, `StufController`) were already merged in a prior build commit, but `appinfo/routes.php` had no `stuf#*` entries — inbound `POST /api/stuf/zaken` and `POST /api/stuf/personen` would 404. This PR adds those two routes so the controller is reachable.

## Changes
- `appinfo/routes.php`: register `stuf#zaken` and `stuf#personen` POST routes

## Validation (STRICT watchdog)
- [x] `php -l` clean on `appinfo/routes.php`, `lib/Controller/StufController.php`, `lib/Service/StufFieldMappingService.php`, `lib/Service/StufMessageBuilder.php`
- [ ] `composer check:strict` — skipped per STRICT watchdog
- [ ] i18n — out of scope per STRICT watchdog

## Spec
- `openspec/changes/stuf-support/proposal.md`
- `openspec/changes/stuf-support/specs/stuf-support/spec.md`

## Flags
StUF support is V1 foundation only — outbound message dispatch (event triggers, OpenConnector SOAPService wiring), WSDL generation, and XSD validation are explicitly out of scope per the proposal. mTLS/WS-Security is delegated to OpenConnector.