### PR TITLE
feat(legesberekening): apply spec

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -166,6 +166,13 @@ return [
         ['name' => 'inspection#addPhoto',             'url' => '/api/inspections/{id}/photos',                       'verb' => 'POST'],
         ['name' => 'inspection#complete',             'url' => '/api/inspections/{id}/complete',                     'verb' => 'POST'],
 
+        // ── Legesberekening (municipal fee calculation) ─────────────────
+        ['name' => 'leges#calculate',   'url' => '/api/leges/calculate',    'verb' => 'POST'],
+        ['name' => 'leges#recalculate', 'url' => '/api/leges/recalculate',  'verb' => 'POST'],
+        ['name' => 'leges#verrekening', 'url' => '/api/leges/verrekening',  'verb' => 'POST'],
+        ['name' => 'leges#teruggaaf',   'url' => '/api/leges/teruggaaf',    'verb' => 'POST'],
+        ['name' => 'leges#export',      'url' => '/api/leges/export',       'verb' => 'POST'],
+
         // SPA catch-all — serves the Vue app for any frontend route (history mode).
         ['name' => 'dashboard#page', 'url' => '/{path}', 'verb' => 'GET', 'requirements' => ['path' => '.+'], 'defaults' => ['path' => '']],
     ],


### PR DESCRIPTION
## Summary
- Applies openspec change `legesberekening` per `openspec/changes/legesberekening/tasks.md`.
- Registers leges API routes wiring the existing `LegesController` (calculate / recalculate / verrekening / teruggaaf / export) into `appinfo/routes.php`.
- LegesCalculationService and LegesExportService were already merged on development; routes were the missing piece blocking the API surface.

## Scope
- Task 1 (LegesCalculationService): already on development — no-op.
- Task 2 (LegesExportService): already on development — no-op.
- Task 3 (LegesController + routes): controller already present; routes added here.

## Deferred / out of scope (V2)
- Verordening admin UI, case-dashboard Leges panel, OpenRegister schemas for legesverordening/artikel/berekening, 4-ogen workflow, Excel import — all marked V2 in spec or out of scope for V1.

## Validation
- `php -l appinfo/routes.php` — OK
- `php -l lib/Controller/LegesController.php` — OK
- `php -l lib/Service/Leges{Calculation,Export}Service.php` — OK
- `jq` on `composer.json` / `package.json` — valid
- Skipped per strict watchdog: i18n, `composer check:strict`

## Test plan
- [ ] POST /api/leges/calculate with sample staffel verordening returns EUR 4,750 for bouwkosten 180,000
- [ ] POST /api/leges/export with definitieve berekeningen returns CSV/XML download