### PR TITLE
feat(procest-adopt-or-abstractions): apply spec

### DIFF
--- a/openspec/changes/procest-adopt-or-abstractions/builds/build.json
+++ b/openspec/changes/procest-adopt-or-abstractions/builds/build.json
@@ -1,0 +1,6 @@
+{
+  "phase": "apply",
+  "timestamp": "2026-05-11T00:00:00+00:00",
+  "scope": "spec-only",
+  "notes": "Applies the procest-adopt-or-abstractions spec consolidation: retirement notes added to parafering-actions, parafering-audit-trail, parafeerroute-engine; OR capability citations added to case-location, parafering-dashboard, case-dashboard-view; bezwaar-lifecycle deadline now declared via x-openregister-calculations; case-management gains the consolidated lifecycle section, OR capability citations, migration map, ZGW boundary clarification, manifest sketch, and follow-up code change references. No code modified."
+}

--- a/openspec/specs/bezwaar-lifecycle/spec.md
+++ b/openspec/specs/bezwaar-lifecycle/spec.md
@@ -89,6 +89,14 @@ The system SHALL automatically calculate legal deadlines when a bezwaar case is 
 
 **Feature tier**: V1
 
+**Implementation**: Deadlines SHALL be declared via OR's
+`x-openregister-calculations` annotation on the bezwaar case schema,
+not via a procest-specific `BezwaarDeadlineService`. Each AWB article
+maps to a calculation rule with `formula`, `inputs`, and `outputField`
+(per ADR-022, procest-adopt-or-abstractions; cross-reference
+Algemene wet bestuursrecht art. 6:7, 6:8, 7:10, 7:24). See OR's
+computed-fields capability (`RenderObject.php:1418`).
+
 #### Scenario: Standard deadline calculation on case creation
 
 - **WHEN** a bezwaar case is created with `ontvangstdatum` 2026-03-01 (Monday)

--- a/openspec/specs/case-dashboard-view/spec.md
+++ b/openspec/specs/case-dashboard-view/spec.md
@@ -4,6 +4,17 @@ status: implemented
 
 # Case Dashboard View Specification
 
+## OR Capability Citations
+
+This spec consumes the following OpenRegister capabilities (per
+ADR-022, procest-adopt-or-abstractions):
+
+- `aggregations-backend-native` — KPI cards on the case dashboard bind
+  directly to the aggregations endpoint via
+  `x-openregister-aggregations` annotations on the case schema; no
+  custom dashboard service. See
+  `openregister/openspec/changes/aggregations-backend-native/`.
+
 ## Purpose
 
 The Case Dashboard View is the primary working screen for behandelaars. It combines all relevant information for a single case into one integrated view: timeline, documents, status, tasks, contactmomenten, besluiten, and linked objects. While the Case Management spec (`../case-management/spec.md`) defines the data model and individual panels (REQ-CM-06 through REQ-CM-13), this spec defines how those panels are composed into a cohesive working screen with interactions between them.

--- a/openspec/specs/case-location/spec.md
+++ b/openspec/specs/case-location/spec.md
@@ -7,6 +7,15 @@ Enable location display and editing on cases. Cases already have a `geometry` fi
 **Standards**: GeoJSON (RFC 7946), PDOK Locatieserver API v3, BAG (Basisregistratie Adressen en Gebouwen)
 **Feature tier**: V1
 
+## OR Capability Citations
+
+This spec consumes the following OpenRegister capabilities (per
+ADR-022, procest-adopt-or-abstractions):
+
+- `geo-metadata-kaart` — geo metadata is annotation-driven on the case
+  schema, not a custom location service. See
+  `openregister/openspec/changes/geo-metadata-kaart/`.
+
 ## Requirements
 
 ---

--- a/openspec/specs/case-management/spec.md
+++ b/openspec/specs/case-management/spec.md
@@ -11,6 +11,88 @@ Case management is the core capability of Procest. A case represents a coherent 
 **Standards**: CMMN 1.1 (CasePlanModel), Schema.org (`Project`), ZGW (`Zaak`)
 **Feature tier**: MVP (core case CRUD, list, detail, status, deadline), V1 (sub-cases, confidentiality, result types, document checklist, suspension)
 
+## Consolidated Lifecycle (procest-adopt-or-abstractions)
+
+Procest case lifecycle is expressed as an OR `x-openregister-lifecycle`
+annotation on the case schema. **This spec is the canonical home;
+previously sibling specs (`parafering-actions`, `parafering-audit-trail`,
+`parafeerroute-engine`) are retired and their requirements live here.**
+
+### OR Capabilities Consumed
+
+Per ADR-022 and the `procest-adopt-or-abstractions` change, this spec
+consumes:
+
+- `object-lifecycle` — six lifecycle states (`concept`,
+  `in_parafering`, `teruggestuurd`, `geparafeerd`, `aangeboden`,
+  `besloten`) with guarded transitions, role-based authorization
+  (ADR-023), and `requires` guards encoding skip-step / ad-hoc-step
+  rules previously in `parafeerroute-engine`.
+- `audit-trail-immutable` — replaces custom parafeeractie versioning
+  from `parafering-audit-trail`; transition events capture `actorType`,
+  `onBehalfOf`, `comment`, transition action, from/to state, timestamp.
+- `notificatie-engine` — three per-transition notifications previously
+  in `ParaferingNotificationService.php` are declared via
+  `x-openregister-notifications` annotations on the case schema.
+- `register-i18n` — state and transition labels, notification subjects
+  and bodies flow through OR's i18n source of truth (ADR-025);
+  Dutch + English minimum per `feedback_i18n-requirement.md`.
+- `aggregations-backend-native` — count-by-status queries for
+  parafering / case dashboards via `x-openregister-aggregations`.
+- `register-resolver-service` (forthcoming) — replaces direct
+  `IAppConfig::getValueString(APP_ID, 'foo_register', '')` lookups
+  with `RegisterResolver::resolve('case')`. See ADR-022.
+
+### Lifecycle States
+
+| Lifecycle state | STATUS_* constant | i18n key |
+|-----------------|-------------------|----------|
+| `concept` | `STATUS_CONCEPT` | `case.status.concept` |
+| `in_parafering` | `STATUS_IN_PARAFERING` | `case.status.in_parafering` |
+| `teruggestuurd` | `STATUS_TERUGGESTUURD` | `case.status.teruggestuurd` |
+| `geparafeerd` | `STATUS_GEPARAFEERD` | `case.status.geparafeerd` |
+| `aangeboden` | `STATUS_AANGEBODEN` | `case.status.aangeboden` |
+| `besloten` | `STATUS_BESLOTEN` | `case.status.besloten` |
+
+### Migration Map (retired specs → consolidated home)
+
+| Retired spec | New home in this spec |
+|--------------|------------------------|
+| `parafering-actions/spec.md` | Lifecycle transitions with `roles` array (advies, parafering, accordering). |
+| `parafering-audit-trail/spec.md` | OR `audit-trail-immutable` capability; delegation captured as audit context. |
+| `parafeerroute-engine/spec.md` | Lifecycle transitions with `requires` guards (skip-step / ad-hoc-step semantics). |
+
+### ZGW Notificaties API boundary preserved
+
+`lib/Service/NotificatieService.php` remains **app-local**. It dispatches
+messages to the VNG ZGW Notificaties API per Dutch government protocol
+and is NOT subsumed by OR's `AnnotationNotificationDispatcher`.
+Lifecycle notifications to NC users flow through schema annotations;
+ZGW protocol notifications flow through `NotificatieService`.
+
+### Manifest (ADR-024)
+
+Procest declares itself **Tier 2** (ramps to 3 once full lifecycle
+adoption code change lands) with
+`dependencies: ["openregister", "openconnector"]`. See follow-up code
+change `procest-implement-or-lifecycle`.
+
+### Follow-up code changes
+
+This spec consolidation is spec-only. The corresponding implementation
+refactor is tracked separately and will:
+
+1. Replace `ParaferingService.php:43-353` guarded transitions with calls
+   to OR's lifecycle engine.
+2. Delete `ParaferingNotificationService.php` (subsumed by
+   `AnnotationNotificationDispatcher`).
+3. Move `ShareMaintenanceJob::REMINDER_DAYS`,
+   `MetricsController::CACHE_TTL_*` to admin-config; move
+   `CaseEmailService::setSubject()` PHP-built copy to schema-declared
+   notification copy.
+4. Fix the `ZgwDocumentService::getUserFolder('admin')` fallback to
+   throw on missing user rather than silently fall back to admin.
+
 ## Data Model
 
 ### Case Entity

--- a/openspec/specs/parafeerroute-engine/spec.md
+++ b/openspec/specs/parafeerroute-engine/spec.md
@@ -1,3 +1,20 @@
+---
+status: retired
+retired_in: procest-adopt-or-abstractions
+canonical_home: case-management/spec.md
+---
+
+> **RETIRED — route modification expressed as `requires` guards on
+> lifecycle transitions.**
+>
+> Skip-step and ad-hoc-step semantics live in the consolidated
+> `x-openregister-lifecycle` annotation on the case schema. Routes
+> become a data attribute on case-types, not a separate engine. See
+> ADR-022 and `case-management/spec.md`.
+>
+> This file is preserved as a historical appendix. Refer to
+> `case-management/spec.md` for canonical route semantics.
+
 ## ADDED Requirements
 
 ### Requirement: Parafeerroute Schema Registration

--- a/openspec/specs/parafering-actions/spec.md
+++ b/openspec/specs/parafering-actions/spec.md
@@ -1,3 +1,20 @@
+---
+status: retired
+retired_in: procest-adopt-or-abstractions
+canonical_home: case-management/spec.md
+---
+
+> **RETIRED — see `case-management/spec.md`.**
+>
+> Action-specific guards and audit recording moved to the consolidated
+> `x-openregister-lifecycle` annotation on the case schema. Per-transition
+> role-based authorization (advies, parafering, accordering) lives in the
+> annotation's `transitions[].roles` array. Audit recording flows through
+> OR's `audit-trail-immutable` capability. See ADR-022, ADR-023.
+>
+> This file is preserved as a historical appendix. Refer to
+> `case-management/spec.md` for the canonical lifecycle annotation.
+
 ## ADDED Requirements
 
 ### Requirement: Parafeeractie Schema Registration

--- a/openspec/specs/parafering-audit-trail/spec.md
+++ b/openspec/specs/parafering-audit-trail/spec.md
@@ -1,3 +1,19 @@
+---
+status: retired
+retired_in: procest-adopt-or-abstractions
+canonical_home: case-management/spec.md
+---
+
+> **RETIRED — consume OR `audit-trail-immutable`.**
+>
+> Delegation tracking (`actorType`, `onBehalfOf`) is recorded as audit
+> context on lifecycle transitions in the consolidated case-management
+> annotation. Immutability is provided by OR's `audit-trail-immutable`
+> capability, not a procest-specific custom service. See ADR-022.
+>
+> This file is preserved as a historical appendix. Refer to
+> `case-management/spec.md` for canonical audit semantics.
+
 ## ADDED Requirements
 
 ### Requirement: Immutable Parafering Audit Trail

--- a/openspec/specs/parafering-dashboard/spec.md
+++ b/openspec/specs/parafering-dashboard/spec.md
@@ -1,3 +1,13 @@
+## OR Capability Citations
+
+This spec consumes the following OpenRegister capabilities (per
+ADR-022, procest-adopt-or-abstractions):
+
+- `aggregations-backend-native` — count-by-status queries for the
+  parafering dashboard are expressed as `x-openregister-aggregations`
+  annotations on the case schema, not a custom dashboard service. See
+  `openregister/openspec/changes/aggregations-backend-native/`.
+
 ## ADDED Requirements
 
 ### Requirement: Secretariaat Parafering Overview


### PR DESCRIPTION
## Summary

Spec-only consolidation per the `procest-adopt-or-abstractions` change (proposal landed in PR #311). All edits are markdown only; no code is modified. The corresponding implementation refactor is deferred to a follow-up opsx change (`procest-implement-or-lifecycle`).

### Retirements (3 specs, closing notes added)

- `parafering-actions/spec.md` — folded into `case-management` as transitions with role-based authorization.
- `parafering-audit-trail/spec.md` — consume OR `audit-trail-immutable`; delegation captured as audit context.
- `parafeerroute-engine/spec.md` — skip-step / ad-hoc-step expressed as transition `requires` guards.

### OR-feature citations added

- `case-location/spec.md` cites `geo-metadata-kaart`.
- `parafering-dashboard/spec.md` cites `aggregations-backend-native`.
- `case-dashboard-view/spec.md` cites `aggregations-backend-native`.

### Calculations annotation

- `bezwaar-lifecycle/spec.md` — AWB 6:7, 6:8, 7:10, 7:24 deadlines declared via `x-openregister-calculations`.

### Consolidated lifecycle home

- `case-management/spec.md` — adds an OR-capabilities section, six-state lifecycle table, migration map, ZGW Notificaties API boundary, tier-2 manifest sketch, and follow-up code change references.

## Watchdog flags (deferred per task rules)

- i18n: keys cited but not added to translation files (rule 1).
- `composer check:strict` not run (rule 2) — no PHP touched.
- Annotation JSON examples remain in `openspec/changes/procest-adopt-or-abstractions/design.md` and `specs/procest-adopt-or-abstractions/spec.md`; not duplicated inline.
- Follow-up code change `procest-implement-or-lifecycle` will: refactor `ParaferingService` onto OR's lifecycle engine, delete `ParaferingNotificationService`, move `REMINDER_DAYS` and `CACHE_TTL_*` to admin config, fix the `ZgwDocumentService::getUserFolder('admin')` security smell, and emit the manifest.

## Test plan

- [ ] Confirm retirement notes resolve correctly.
- [ ] Confirm case-management cites OR capabilities + ADR-022/024/025.
- [ ] Confirm bezwaar-lifecycle deadline section points to `x-openregister-calculations`.
- [ ] Validate no code files modified.

Refs: ADR-022, ADR-024, ADR-025.