### PR TITLE
feat(mijn-overheid-integration): apply spec

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -173,6 +173,11 @@ return [
         ['name' => 'leges#teruggaaf',   'url' => '/api/leges/teruggaaf',    'verb' => 'POST'],
         ['name' => 'leges#export',      'url' => '/api/leges/export',       'verb' => 'POST'],
 
+        // ── Mijn Overheid Berichtenbox ──────────────────────────────────
+        ['name' => 'berichtenbox#messages', 'url' => '/api/berichtenbox/messages', 'verb' => 'GET'],
+        ['name' => 'berichtenbox#send',     'url' => '/api/berichtenbox/send',     'verb' => 'POST'],
+        ['name' => 'berichtenbox#poll',     'url' => '/api/berichtenbox/poll/{messageId}', 'verb' => 'POST'],
+
         // SPA catch-all — serves the Vue app for any frontend route (history mode).
         ['name' => 'dashboard#page', 'url' => '/{path}', 'verb' => 'GET', 'requirements' => ['path' => '.+'], 'defaults' => ['path' => '']],
     ],

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -75,6 +75,13 @@ class SettingsService
         'inspectie_rapport_schema',
         'handhavingsactie_schema',
         'advies_aanvraag_schema',
+        'berichtenbox_message_schema',
+        'berichtenbox_type_code_schema',
+        'berichtenbox_enabled',
+        'berichtenbox_api_url',
+        'berichtenbox_oin',
+        'berichtenbox_certificate_path',
+        'berichtenbox_default_type_code',
         'lhsMatrix',
     ];
 
@@ -122,6 +129,8 @@ class SettingsService
         'voorstel'                     => 'voorstel_schema',
         'parafeerroute'                => 'parafeerroute_schema',
         'parafeeractie'                => 'parafeeractie_schema',
+        'berichtenboxMessage'          => 'berichtenbox_message_schema',
+        'berichtenboxTypeCode'         => 'berichtenbox_type_code_schema',
     ];
 
     private const OPENREGISTER_APP_ID = 'openregister';

--- a/lib/Settings/procest_register.json
+++ b/lib/Settings/procest_register.json
@@ -2293,7 +2293,7 @@
             "minimum": 0,
             "maximum": 1,
             "description": "Layer opacity from 0.0 (transparent) to 1.0 (opaque)",
-            "default": 1.0
+            "default": 1
           },
           "minZoom": {
             "type": "integer",
@@ -2672,6 +2672,131 @@
             "description": "Whether follow-up action is required"
           }
         }
+      },
+      "berichtenboxMessage": {
+        "slug": "berichtenboxMessage",
+        "icon": "EmailSendOutline",
+        "version": "1.0.0",
+        "x-schema-org-type": "schema:Message",
+        "title": "Berichtenbox Message",
+        "description": "A message sent to a citizen via Mijn Overheid Berichtenbox, linked to a case for audit trail",
+        "type": "object",
+        "required": [
+          "caseId",
+          "bsn",
+          "subject",
+          "body"
+        ],
+        "properties": {
+          "caseId": {
+            "type": "string",
+            "format": "uuid",
+            "$ref": "case",
+            "description": "Reference to the parent case",
+            "title": "Case",
+            "facetable": true
+          },
+          "bsn": {
+            "type": "string",
+            "maxLength": 9,
+            "description": "Burgerservicenummer (BSN) of the recipient citizen"
+          },
+          "subject": {
+            "type": "string",
+            "maxLength": 100,
+            "description": "Message subject (max 100 chars per Mijn Overheid spec)"
+          },
+          "body": {
+            "type": "string",
+            "maxLength": 10000,
+            "description": "Plain text message body (max 10,000 chars per Mijn Overheid spec)"
+          },
+          "berichtTypeCode": {
+            "type": "string",
+            "maxLength": 64,
+            "description": "Bericht type code for routing and categorization in Mijn Overheid",
+            "title": "Bericht Type",
+            "facetable": true
+          },
+          "attachmentFileId": {
+            "type": "string",
+            "description": "Nextcloud file ID of the optional PDF attachment"
+          },
+          "externalMessageId": {
+            "type": "string",
+            "description": "Berichtenbox API reference ID returned on send"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "draft",
+              "sent",
+              "delivered",
+              "read",
+              "unread_flagged",
+              "failed"
+            ],
+            "default": "draft",
+            "description": "Current message status",
+            "title": "Status",
+            "facetable": true
+          },
+          "sentAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp the message was sent to Berichtenbox"
+          },
+          "readAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp the citizen read the message"
+          },
+          "readPolledAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp of the last read-status poll"
+          },
+          "errorMessage": {
+            "type": "string",
+            "description": "Error details when the send fails"
+          }
+        }
+      },
+      "berichtenboxTypeCode": {
+        "slug": "berichtenboxTypeCode",
+        "icon": "TagOutline",
+        "version": "1.0.0",
+        "x-schema-org-type": "schema:DefinedTerm",
+        "title": "Berichtenbox Type Code",
+        "description": "A configurable bericht type code for Mijn Overheid Berichtenbox messages, optionally bound to a zaaktype as default",
+        "type": "object",
+        "required": [
+          "code",
+          "label"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "maxLength": 64,
+            "description": "The bericht type code as registered with Mijn Overheid"
+          },
+          "label": {
+            "type": "string",
+            "maxLength": 255,
+            "description": "Human-readable Dutch description of the bericht type"
+          },
+          "caseType": {
+            "type": "string",
+            "format": "uuid",
+            "$ref": "caseType",
+            "description": "Optional zaaktype this code applies to"
+          },
+          "isDefault": {
+            "type": "boolean",
+            "default": false,
+            "description": "When true, this code is the default for the bound zaaktype"
+          }
+        }
       }
     },
     "registers": {
@@ -2737,10 +2862,34 @@
         "isDefault": true,
         "description": "Standaard accorderingslijn voor collegeadviezen over omgevingsvergunningen",
         "steps": [
-          {"order": 1, "type": "advies",      "actor": "juridische-dienst",   "actorType": "group", "mandatory": false},
-          {"order": 2, "type": "parafering",  "actor": "teamleider-vth",      "actorType": "role",  "mandatory": true},
-          {"order": 3, "type": "parafering",  "actor": "afdelingshoofd-vth",  "actorType": "role",  "mandatory": true},
-          {"order": 4, "type": "accordering", "actor": "portefeuillehouder",  "actorType": "role",  "mandatory": true}
+          {
+            "order": 1,
+            "type": "advies",
+            "actor": "juridische-dienst",
+            "actorType": "group",
+            "mandatory": false
+          },
+          {
+            "order": 2,
+            "type": "parafering",
+            "actor": "teamleider-vth",
+            "actorType": "role",
+            "mandatory": true
+          },
+          {
+            "order": 3,
+            "type": "parafering",
+            "actor": "afdelingshoofd-vth",
+            "actorType": "role",
+            "mandatory": true
+          },
+          {
+            "order": 4,
+            "type": "accordering",
+            "actor": "portefeuillehouder",
+            "actorType": "role",
+            "mandatory": true
+          }
         ]
       },
       {
@@ -2754,11 +2903,41 @@
         "isDefault": false,
         "description": "Uitgebreide route voor bestemmingsplanwijzigingen met planologisch en juridisch advies",
         "steps": [
-          {"order": 1, "type": "advies",      "actor": "planologisch-adviseur",          "actorType": "role",  "mandatory": true},
-          {"order": 2, "type": "advies",      "actor": "juridische-dienst",              "actorType": "group", "mandatory": true},
-          {"order": 3, "type": "parafering",  "actor": "teamleider-ro",                  "actorType": "role",  "mandatory": true},
-          {"order": 4, "type": "parafering",  "actor": "afdelingshoofd-ro",              "actorType": "role",  "mandatory": true},
-          {"order": 5, "type": "accordering", "actor": "wethouder-ruimtelijke-ordening", "actorType": "role",  "mandatory": true}
+          {
+            "order": 1,
+            "type": "advies",
+            "actor": "planologisch-adviseur",
+            "actorType": "role",
+            "mandatory": true
+          },
+          {
+            "order": 2,
+            "type": "advies",
+            "actor": "juridische-dienst",
+            "actorType": "group",
+            "mandatory": true
+          },
+          {
+            "order": 3,
+            "type": "parafering",
+            "actor": "teamleider-ro",
+            "actorType": "role",
+            "mandatory": true
+          },
+          {
+            "order": 4,
+            "type": "parafering",
+            "actor": "afdelingshoofd-ro",
+            "actorType": "role",
+            "mandatory": true
+          },
+          {
+            "order": 5,
+            "type": "accordering",
+            "actor": "wethouder-ruimtelijke-ordening",
+            "actorType": "role",
+            "mandatory": true
+          }
         ]
       },
       {
@@ -2772,8 +2951,20 @@
         "isDefault": true,
         "description": "Standaard directieteam-advies: behandelaar parafering gevolgd door afdelingshoofd accordering",
         "steps": [
-          {"order": 1, "type": "parafering",  "actor": "behandelaar",    "actorType": "role", "mandatory": true},
-          {"order": 2, "type": "accordering", "actor": "afdelingshoofd", "actorType": "role", "mandatory": true}
+          {
+            "order": 1,
+            "type": "parafering",
+            "actor": "behandelaar",
+            "actorType": "role",
+            "mandatory": true
+          },
+          {
+            "order": 2,
+            "type": "accordering",
+            "actor": "afdelingshoofd",
+            "actorType": "role",
+            "mandatory": true
+          }
         ]
       },
       {
@@ -2787,12 +2978,48 @@
         "isDefault": true,
         "description": "Volledige route voor raadsvoorstellen: financieel, juridisch, management, gemeentesecretaris en burgemeester",
         "steps": [
-          {"order": 1, "type": "advies",      "actor": "financieel-adviseur",  "actorType": "role",  "mandatory": true},
-          {"order": 2, "type": "advies",      "actor": "juridische-dienst",    "actorType": "group", "mandatory": true},
-          {"order": 3, "type": "parafering",  "actor": "teamleider",           "actorType": "role",  "mandatory": true},
-          {"order": 4, "type": "parafering",  "actor": "afdelingshoofd",       "actorType": "role",  "mandatory": true},
-          {"order": 5, "type": "accordering", "actor": "gemeentesecretaris",   "actorType": "role",  "mandatory": true},
-          {"order": 6, "type": "accordering", "actor": "burgemeester",         "actorType": "role",  "mandatory": true}
+          {
+            "order": 1,
+            "type": "advies",
+            "actor": "financieel-adviseur",
+            "actorType": "role",
+            "mandatory": true
+          },
+          {
+            "order": 2,
+            "type": "advies",
+            "actor": "juridische-dienst",
+            "actorType": "group",
+            "mandatory": true
+          },
+          {
+            "order": 3,
+            "type": "parafering",
+            "actor": "teamleider",
+            "actorType": "role",
+            "mandatory": true
+          },
+          {
+            "order": 4,
+            "type": "parafering",
+            "actor": "afdelingshoofd",
+            "actorType": "role",
+            "mandatory": true
+          },
+          {
+            "order": 5,
+            "type": "accordering",
+            "actor": "gemeentesecretaris",
+            "actorType": "role",
+            "mandatory": true
+          },
+          {
+            "order": 6,
+            "type": "accordering",
+            "actor": "burgemeester",
+            "actorType": "role",
+            "mandatory": true
+          }
         ]
       },
       {

--- a/openspec/changes/mijn-overheid-integration/builds/build.json
+++ b/openspec/changes/mijn-overheid-integration/builds/build.json
@@ -1,0 +1,52 @@
+{
+  "phase": "apply",
+  "timestamp": "2026-05-11T00:00:00+00:00",
+  "status": "applied",
+  "summary": "Wired up the existing Berichtenbox backend (Service, Controller, MockAdapter, ReadStatusJob) and frontend (BerichtenboxTab, BerichtenboxComposeDialog, BerichtenboxSettingsTab, berichtenboxApi.js) by adding the missing register schemas, SettingsService config keys, and HTTP routes. MVP per proposal.md.",
+  "tasks_complete": [
+    "T01",
+    "T02",
+    "T03",
+    "T04",
+    "T05",
+    "T06",
+    "T07",
+    "T08",
+    "T09",
+    "T10",
+    "T11"
+  ],
+  "changed_files": [
+    "lib/Settings/procest_register.json",
+    "lib/Service/SettingsService.php",
+    "appinfo/routes.php"
+  ],
+  "pre_existing_files": [
+    "lib/Service/BerichtenboxService.php",
+    "lib/Service/BerichtenboxAdapter/BerichtenboxAdapterInterface.php",
+    "lib/Service/BerichtenboxAdapter/MockAdapter.php",
+    "lib/Controller/BerichtenboxController.php",
+    "lib/BackgroundJob/BerichtenboxReadStatusJob.php",
+    "src/services/berichtenboxApi.js",
+    "src/views/cases/components/BerichtenboxTab.vue",
+    "src/views/cases/components/BerichtenboxComposeDialog.vue",
+    "src/views/settings/tabs/BerichtenboxSettingsTab.vue"
+  ],
+  "validation": {
+    "php_lint": "pass",
+    "jq": "pass",
+    "composer_check_strict": "deferred per watchdog",
+    "i18n": "deferred per watchdog"
+  },
+  "deferred": [
+    "REQ-5 case status push to Mijn Overheid Zaakstatus API (out of MVP scope)",
+    "REQ-6 DigiD-authenticated citizen portal (out of MVP scope, lives in municipality portal)",
+    "REQ-7.3 PKIoverheid certificate expiration monitoring (out of MVP scope)",
+    "REQ-7.4 stuuromgeving test mode toggle (out of MVP scope)",
+    "REQ-7.5 OpenConnector adapter (only MockAdapter shipped; real adapter is post-MVP)",
+    "REQ-8 multi-channel sending and postal fallback (out of MVP scope)",
+    "REQ-10 deceased / minor / KVK handling (out of MVP scope)",
+    "GET /api/berichtenbox/types endpoint and controller method (no consumer yet; BerichtenboxSettingsTab manages codes via OpenRegister directly)"
+  ],
+  "notes": "Bulk of the implementation already existed on development; this apply commit closes the loop by registering schemas + config keys + routes so the controller is reachable and the service can resolve the schema IDs. MockAdapter remains the default per design.md — real Berichtenbox API integration is a follow-up change."
+}


### PR DESCRIPTION
## Summary

Apply the `mijn-overheid-integration` openspec change. The Berichtenbox backend (`BerichtenboxService`, `BerichtenboxController`, `MockAdapter`, `BerichtenboxReadStatusJob`) and frontend (`BerichtenboxTab.vue`, `BerichtenboxComposeDialog.vue`, `BerichtenboxSettingsTab.vue`, `berichtenboxApi.js`) already lived on `development` from the earlier feature branch. This PR closes the loop so the controller is reachable and the service can resolve its schema IDs:

- Add `berichtenboxMessage` + `berichtenboxTypeCode` schemas to `lib/Settings/procest_register.json`.
- Add `berichtenbox_message_schema`, `berichtenbox_type_code_schema`, `berichtenbox_enabled`, `berichtenbox_api_url`, `berichtenbox_oin`, `berichtenbox_certificate_path`, `berichtenbox_default_type_code` config keys and slug mappings in `SettingsService`.
- Register `GET /api/berichtenbox/messages`, `POST /api/berichtenbox/send`, `POST /api/berichtenbox/poll/{messageId}` in `appinfo/routes.php`.
- Record apply state in `openspec/changes/mijn-overheid-integration/builds/build.json`.

MVP per `proposal.md`: mock adapter only; real Berichtenbox API, status push to Zaakstatus API, DigiD citizen portal, certificate monitoring, multi-channel fallback and deceased/minor handling are explicitly deferred (see `build.json` deferred list).

## Validation

- `php -l` on all touched + adjacent PHP files: pass
- `jq empty` on `procest_register.json` and `build.json`: pass
- `composer check:strict` and i18n: deferred per STRICT watchdog (15-min budget)

## Test plan

- [ ] `docker exec nextcloud php occ app:enable procest` and load `procest_register.json` -- verify `berichtenboxMessage` + `berichtenboxTypeCode` schemas appear
- [ ] Configure `berichtenbox_message_schema` via admin settings, then `POST /api/berichtenbox/send` with a valid BSN and verify a record lands in OpenRegister
- [ ] Open `BerichtenboxTab` in case detail; confirm composer dialog opens, validates BSN/subject/body
- [ ] Trigger `BerichtenboxReadStatusJob` and verify mock read status propagates back to the record