### PR TITLE
feat(bw-parafering): apply spec

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -147,6 +147,14 @@ return [
         ['name' => 'parafeer_route#update',       'url' => '/api/parafeer-route/{id}',                                 'verb' => 'PUT'],
         ['name' => 'parafeer_route#destroy',      'url' => '/api/parafeer-route/{id}',                                 'verb' => 'DELETE'],
 
+        // ── B&W Parafering (voorstellen workflow) ───────────────────────
+        ['name' => 'parafering#createVoorstel',   'url' => '/api/parafering/voorstellen',                              'verb' => 'POST'],
+        ['name' => 'parafering#startParafering',  'url' => '/api/parafering/voorstellen/{id}/start',                   'verb' => 'POST'],
+        ['name' => 'parafering#paraferen',        'url' => '/api/parafering/voorstellen/{id}/paraferen',               'verb' => 'POST'],
+        ['name' => 'parafering#terugsturen',     'url' => '/api/parafering/voorstellen/{id}/terugsturen',             'verb' => 'POST'],
+        ['name' => 'parafering#adviseren',        'url' => '/api/parafering/voorstellen/{id}/adviseren',               'verb' => 'POST'],
+        ['name' => 'parafering#auditTrail',       'url' => '/api/parafering/voorstellen/{id}/audit-trail',             'verb' => 'GET'],
+
         // ── StUF (Standaard Uitwisselings Formaat) ──────────────────────
         // Inbound SOAP endpoints accept raw XML POST.
         ['name' => 'stuf#zaken',    'url' => '/api/stuf/zaken',    'verb' => 'POST'],

--- a/openspec/changes/bw-parafering/builds/build.json
+++ b/openspec/changes/bw-parafering/builds/build.json
@@ -1,0 +1,10 @@
+{
+  "phase": "apply",
+  "timestamp": "2026-05-11T00:00:00+00:00",
+  "model": "claude-opus-4-7",
+  "notes": "Most of bw-parafering already merged via #331 (parafering-actions) and #332 (parafeerroute-engine). ParaferingService and ParaferingController already exist in lib/. This apply registers the missing /api/parafering/voorstellen/* routes per spec REQ-BW-03 and design.md endpoints.",
+  "files_changed": [
+    "appinfo/routes.php"
+  ],
+  "flags": []
+}


### PR DESCRIPTION
## Summary

Apply `openspec/changes/bw-parafering` (B&W parafering / Burgemeester en Wethouders signing routes).

Most of the spec was already delivered by the companion PRs:
- #331 — `parafering-actions` (ParafeerActieController/Service)
- #332 — `parafeerroute-engine` (ParafeerRouteController/Service + routes)
- Pre-existing — `ParaferingController` + `ParaferingService` (createVoorstel, paraferen, terugsturen, adviseren, auditTrail) already on `development`

This PR finishes the wiring by registering the missing HTTP routes for `ParaferingController` so the surface matches `design.md`:

- `POST /api/parafering/voorstellen`
- `POST /api/parafering/voorstellen/{id}/start`
- `POST /api/parafering/voorstellen/{id}/paraferen`
- `POST /api/parafering/voorstellen/{id}/terugsturen`
- `POST /api/parafering/voorstellen/{id}/adviseren`
- `GET  /api/parafering/voorstellen/{id}/audit-trail`

## Files

- `appinfo/routes.php` — 6 new routes for ParaferingController
- `openspec/changes/bw-parafering/builds/build.json` — apply record

## Test plan

- [ ] `php -l appinfo/routes.php` passes (verified locally)
- [ ] `php -l lib/Controller/ParaferingController.php` passes (verified locally)
- [ ] Confirm endpoints resolve once deployed