### PR TITLE
feat(case-definition-portability): apply spec

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -41,6 +41,11 @@ return [
         ['name' => 'zgw_mapping#destroy', 'url' => '/api/zgw-mappings/{resourceKey}', 'verb' => 'DELETE'],
         ['name' => 'zgw_mapping#reset', 'url' => '/api/zgw-mappings/{resourceKey}/reset', 'verb' => 'POST'],
 
+        // Case Definition Portability (export/import zaaktype packages).
+        ['name' => 'case_definition#export', 'url' => '/api/case-definitions/export', 'verb' => 'POST'],
+        ['name' => 'case_definition#validate', 'url' => '/api/case-definitions/validate', 'verb' => 'POST'],
+        ['name' => 'case_definition#import', 'url' => '/api/case-definitions/import', 'verb' => 'POST'],
+
         // ── DRC (Documenten) ────────────────────────────────────────────
         // Special endpoints (must precede wildcard routes).
         ['name' => 'drc#download', 'url' => '/api/zgw/documenten/v1/enkelvoudiginformatieobjecten/{uuid}/download', 'verb' => 'GET'],


### PR DESCRIPTION
## Summary

Applies `openspec/changes/case-definition-portability`.

The backend (`CaseDefinitionController`, `CaseDefinitionExportService`, `CaseDefinitionImportService`) was already present on `development` but its routes had not been registered, so the endpoints were unreachable. This PR adds the three missing route entries in `appinfo/routes.php`.

## Endpoints exposed

- `POST /api/case-definitions/export` -- export a configured case type as a ZIP package
- `POST /api/case-definitions/validate` -- dry-run validation of an uploaded package
- `POST /api/case-definitions/import` -- import a ZIP package with conflict detection

## Validation

- `php -l appinfo/routes.php` -- OK
- `php -l` on all three CaseDefinition* PHP files -- OK
- No i18n strings added; strict watchdog (php -l + jq only) respected.

## Flags

- Strict watchdog: NO composer check:strict, NO i18n changes, php -l only.
- Spec proposal mentions an "admin UI"; tasks.md only enumerates backend tasks (all `[x]`). UI work, if desired, belongs to a follow-up change.