### PR TITLE
chore(openspec): generate workflow-definition-model spec

### DIFF
--- a/openspec/changes/workflow-definition-model/design.md
+++ b/openspec/changes/workflow-definition-model/design.md
@@ -1,0 +1,128 @@
+# Design: workflow-definition-model
+
+## Architecture Overview
+
+A `workflowTemplate` (aliased `WorkflowDefinition` in code and docs) is a single OpenRegister object that aggregates the lifecycle of one `caseType`: ordered steps, allowed transitions, guards, allowed roles, and automatic actions. It lives behind a thin `WorkflowDefinitionService` that enforces the draft → published → deprecated lifecycle and version pinning. `status-transition-engine` and `role-based-step-routing` are *consumers only* — they never mutate definitions.
+
+```
+AdminSettings.vue
+└── WorkflowDefinitionsTab.vue (list per caseType: version, status badge, isActive)
+    └── WorkflowDefinitionDialog.vue (form: title, description, steps[], transitions[])
+        ├── WorkflowStepsEditor.vue (ordered steps, assigneeRole, checklist)
+        └── WorkflowTransitionsEditor.vue (from/to status, label, guards, allowedRoles)
+
+CaseTypeDialog.vue
+└── workflowDefinition reference field (picker of published definitions)
+
+Backend
+├── WorkflowDefinitionService.php (CRUD + lifecycle: publish, deprecate, clone)
+├── WorkflowDefinitionController.php (REST: /api/workflow-definition/*)
+└── Migration/BackfillWorkflowDefinitions.php (repair step)
+```
+
+## Entity Model
+
+`workflowTemplate` (already in `procest_register.json`):
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `title` | string | Human-readable name |
+| `description` | string | Purpose and usage notes |
+| `caseType` | uuid ref | Owning case type |
+| `version` | integer | Monotonically increasing per `caseType` |
+| `isActive` | boolean | Convenience flag; one active version per caseType |
+| `isDraft` | boolean | If true: editable; if false: published and immutable |
+| `lifecycleStatus` | enum | `draft` \| `published` \| `deprecated` (new — replaces the boolean pair semantically) |
+| `steps` | json string | Array of `WorkflowStep` (id, title, status, order, assigneeRole, isRequired, checklist, automaticActions) |
+| `transitions` | json string | Array of `StatusTransition` (id, fromStatus, toStatus, label, guards, allowedRoles, automaticActions) |
+| `nodePositions` | json string | x/y map for the future visual editor |
+| `parentWorkflow` | uuid ref | Inheritance (Enterprise) |
+
+`caseType.workflowDefinition` (new): UUID reference to the active `workflowTemplate`. New cases pin to whichever version was `published` and `isActive` at the moment of case creation.
+
+`case.workflowVersion` (already in ADR-000 as `workflowVersion`): the integer version this case is locked to. Determines which definition `status-transition-engine` loads when displaying transition buttons.
+
+## Lifecycle
+
+```
+            publish()                  deprecate()
+   draft  ─────────────►   published  ────────────►   deprecated
+     ▲                          │
+     │       clone()            │
+     └──────────────────────────┘
+```
+
+- **draft** — editable; cannot back new cases; can be `publish()`ed.
+- **published** — immutable; can back new cases; only one published+`isActive` version per caseType at a time; can be `deprecate()`d or `clone()`d to a new draft.
+- **deprecated** — immutable; cannot back new cases; existing cases continue to use it (frozen).
+
+Publishing a new version automatically deprecates the previous active version for the same `caseType`. Cloning a published version produces a new draft with `version = previous + 1`.
+
+## Storage Decision
+
+`workflowTemplate` is stored as a single OpenRegister object with two large JSON-encoded string fields (`steps`, `transitions`). This matches the existing schema in `procest_register.json`. We considered exploding steps and transitions into separate entities (`workflowStep`, `workflowTransition`), but this would: (a) require joins on every read in a hot path; (b) duplicate the immutability discipline across three tables; (c) make publish-time snapshotting harder. The single-object approach keeps the published version trivially immutable — the whole record is locked.
+
+## Editor UI (Low-Fidelity)
+
+```
+┌─ Settings › Workflows ────────────────────────────────┐
+│  Case type:  [Omgevingsvergunning ▼]                  │
+│                                                       │
+│  ┌─ Versions ───────────────────────────────────────┐ │
+│  │ v3 ● Published (active)    [Clone] [Deprecate]   │ │
+│  │ v2 ○ Deprecated                                   │ │
+│  │ v1 ○ Deprecated                                   │ │
+│  └──────────────────────────────────────────────────┘ │
+│                                                       │
+│  [+ New draft from v3]   [+ Empty draft]              │
+└───────────────────────────────────────────────────────┘
+
+┌─ Edit draft v4 ────────────────────────────────────────┐
+│  Title: [Omgevingsvergunning — strenger toezicht    ]  │
+│                                                        │
+│  Steps                                  [+ Add step]   │
+│  ┌────────────────────────────────────────────────────┐│
+│  │ 1. Intake-controle    status: Ontvangen  role: …  ││
+│  │ 2. Inhoudelijke beoor status: In behand  role: …  ││
+│  └────────────────────────────────────────────────────┘│
+│                                                        │
+│  Transitions                          [+ Add transition│
+│  ┌────────────────────────────────────────────────────┐│
+│  │ Ontvangen → In behandeling  label: "Start"  guards:││
+│  │                                  [edit] [remove]   ││
+│  └────────────────────────────────────────────────────┘│
+│                                                        │
+│  [Save draft]   [Publish…]                             │
+└────────────────────────────────────────────────────────┘
+```
+
+Form-based only in V1. The visual editor (`visual-workflow-editor` spec) is V2 and consumes the same model.
+
+## Integration with Other Specs
+
+- `status-transition-engine` calls `WorkflowDefinitionService::getActiveDefinitionFor($caseType)` (or `getDefinition($id)` when a case is pinned) and reads `transitions[]` + `guards[]` to compute available transitions for the current user.
+- `role-based-step-routing` reads `steps[].assigneeRole` and `transitions[].allowedRoles` from the same object to filter visibility.
+- `visual-workflow-editor` (V2) reads/writes the same `workflowTemplate` object plus `nodePositions` for layout.
+- `workflow-import-export` (V2) serialises and deserialises `workflowTemplate` JSON.
+
+## Consumer API (Read-Only)
+
+| Method | Purpose |
+|--------|---------|
+| `getActiveDefinitionFor(string $caseTypeId): ?array` | Latest published+active definition for a caseType |
+| `getDefinition(string $id): array` | Specific definition by UUID (used when a case is pinned) |
+| `getDefinitionForCase(string $caseId): array` | Resolves through `case.workflowVersion` to the exact pinned version |
+| `listVersions(string $caseTypeId): array` | All versions of a definition for the admin UI |
+
+## Migration Plan
+
+The repair step `BackfillWorkflowDefinitions` runs once per app upgrade and for every existing `caseType` that has no `workflowDefinition` reference:
+
+1. Read all `statusType` records for the caseType ordered by `order`.
+2. Synthesise a `steps` array (one step per non-final status, no assigneeRole).
+3. Synthesise a `transitions` array linking each status to the next in order, with no guards.
+4. Create a `workflowTemplate` with `version: 1`, `lifecycleStatus: published`, `isActive: true`.
+5. Set `caseType.workflowDefinition` to the new template UUID.
+6. For each existing open case, set `case.workflowVersion = 1`.
+
+The repair step is idempotent (skips caseTypes that already have `workflowDefinition` set).

--- a/openspec/changes/workflow-definition-model/proposal.md
+++ b/openspec/changes/workflow-definition-model/proposal.md
@@ -1,0 +1,46 @@
+# Proposal: Workflow Definition Model
+
+## Summary
+
+Procest needs a declarative workflow-definition format so that case workflows can be configured by tenant administrators instead of hard-coded by developers. Today, the lifecycle of a case is implicit in the `statusType` ordering plus a handful of ad-hoc transition rules scattered between the case controller and frontend buttons. This change introduces a single `workflowTemplate` entity (already drafted in ADR-000 and `lib/Settings/procest_register.json`, but not yet exposed via service, controller, or admin UI) that aggregates the steps, transitions, guards, and automatic actions for a given `caseType`. It establishes the canonical contract that `status-transition-engine` and `role-based-step-routing` consume.
+
+## Problem
+
+The `workflowTemplate` schema lives in `procest_register.json` and the `workflow-definition-model/spec.md` exists in `openspec/specs/`, but no CRUD service or UI exposes it. Case transitions remain implicit and untestable. Tenants cannot pin a case type to a specific workflow version, so any edit to the lifecycle silently mutates in-flight cases. There is no published / deprecated lifecycle, no immutability guarantee, and no migration path from the existing implicit configuration.
+
+## Affected Projects
+
+- [ ] Project: `procest` — Expose the existing `workflowTemplate` schema via `WorkflowDefinitionService` + `WorkflowDefinitionController`, add the draft → published → deprecated lifecycle, add a `caseType.workflowDefinition` pin, build a Vue admin component, and migrate legacy implicit workflows into seeded `workflowTemplate` objects.
+
+## Scope
+
+### In Scope (V1)
+
+- **Declarative WorkflowDefinition entity** (REQ-WDM-1..3): exposing the existing `workflowTemplate` schema with steps, transitions, guards, allowedRoles, and automaticActions as a first-class CRUD object.
+- **Draft → Published → Deprecated lifecycle** (REQ-WDM-4..6): published versions are immutable; deprecated versions cannot back new cases but continue to back existing ones.
+- **Versioning and caseType pinning** (REQ-WDM-7): `caseType.workflowDefinition` + `case.workflowVersion`; new cases bind to the latest *published* version of the pinned definition.
+- **Admin UI surface** (REQ-WDM-8): a settings tab listing definitions per caseType with create / publish / deprecate / clone actions.
+- **Backfill migration** (REQ-WDM-9): a repair step that promotes the current implicit lifecycle of every existing caseType into a seeded `workflowTemplate` published as version 1.
+- **Consumer contract** (REQ-WDM-10): a stable read-only API (`getActiveDefinitionFor(caseType)`, `getDefinition(id)`) that `status-transition-engine` and `role-based-step-routing` consume — no other path is supported.
+
+### Out of Scope
+
+- **Guard evaluation engine** — owned by `status-transition-engine` (already specced).
+- **Role/step visibility filtering** — owned by `role-based-step-routing` (already specced).
+- **Visual drag-and-drop editor** — V2 (`visual-workflow-editor` spec already exists; this change ships only a form-based admin UI).
+- **Workflow import / export** — owned by `workflow-import-export` (already specced).
+- **Cross-tenant template marketplace** — Enterprise / out of scope.
+
+## Approach
+
+1. Wrap the existing `workflowTemplate` register schema with a `WorkflowDefinitionService` (CRUD + lifecycle handlers) and a `WorkflowDefinitionController` (REST endpoints under `/api/workflow-definition`).
+2. Add `caseType.workflowDefinition` (UUID reference) and `case.workflowVersion` (int) — both already partly drafted in ADR-000.
+3. Build `WorkflowDefinitionsTab.vue` + `WorkflowDefinitionDialog.vue` for the admin settings page.
+4. Add a repair step that backfills one published `workflowTemplate` per existing caseType from the implicit ordering of its `statusType` records.
+
+## Cross-Project Dependencies
+
+- **OpenRegister**: object storage, audit trail, relations.
+- **`status-transition-engine` (procest)**: consumes the published transitions array.
+- **`role-based-step-routing` (procest)**: consumes the `allowedRoles` on transitions and `assigneeRole` on steps.
+- **`case-types` (procest)**: needs the new `workflowDefinition` reference field.

--- a/openspec/changes/workflow-definition-model/specs/workflow-definition-model/spec.md
+++ b/openspec/changes/workflow-definition-model/specs/workflow-definition-model/spec.md
@@ -1,0 +1,282 @@
+---
+status: draft
+---
+# workflow-definition-model Specification
+
+## Purpose
+
+Establish the declarative workflow-definition contract for Procest. A `workflowTemplate` aggregates the steps, transitions, guards, allowed roles, and automatic actions for a single `caseType` and is the single source of truth that `status-transition-engine`, `role-based-step-routing`, `visual-workflow-editor`, and `workflow-import-export` all consume. This change formalises the entity already present in `procest_register.json`, adds a draft → published → deprecated lifecycle with immutability after publish, introduces version pinning on `caseType`, and ships an admin UI for tenant administrators.
+
+## Context
+
+The `workflowTemplate` schema is in `lib/Settings/procest_register.json` and the legacy `openspec/specs/workflow-definition-model/spec.md` already describes the data shape and a seeded bezwaar/beroep workflow. What is missing is the surface that turns the schema into a usable, governed configuration object: CRUD service, lifecycle, REST endpoints, admin UI, and migration of legacy implicit lifecycles. Today, case lifecycles are implicit in `statusType` ordering and scattered button logic, which makes them impossible to test, version, or hand to a tenant admin.
+
+## Requirements
+
+---
+
+### REQ-WDM-1: Declarative Workflow Definition Entity
+
+The system SHALL expose a declarative `workflowTemplate` (aliased `WorkflowDefinition`) entity that aggregates the entire lifecycle of one `caseType`: ordered `steps[]`, allowed `transitions[]`, embedded guards, `allowedRoles`, and `automaticActions`. The entity SHALL be stored as a single OpenRegister object.
+
+**Feature tier**: V1
+
+#### REQ-WDM-1-001: Definition stores steps and transitions in one object
+
+- **GIVEN** an administrator has created a workflow definition for caseType "Omgevingsvergunning"
+- **WHEN** the definition is saved
+- **THEN** a single `workflowTemplate` object SHALL exist in OpenRegister
+- **AND** the object SHALL carry `steps` (JSON-encoded array) and `transitions` (JSON-encoded array)
+- **AND** every `transitions[].fromStatus` and `transitions[].toStatus` SHALL reference a `statusType` UUID that belongs to the linked `caseType`
+- **AND** every `steps[].status` SHALL reference a `statusType` UUID that belongs to the linked `caseType`
+
+#### REQ-WDM-1-002: Definition is the single source of lifecycle truth
+
+- **GIVEN** a case bound to a published workflow definition
+- **WHEN** `status-transition-engine` or `role-based-step-routing` computes available actions for the current user
+- **THEN** these consumers SHALL read transitions and roles ONLY from the bound workflow definition
+- **AND** no other source (hard-coded button list, scattered controller logic) SHALL contribute additional transitions or steps
+
+---
+
+### REQ-WDM-2: CRUD Service
+
+The system SHALL provide a `WorkflowDefinitionService` exposing create, read, update, delete, and lifecycle operations for `workflowTemplate` objects. All mutations SHALL derive the actor from `IUserSession`; no caller-supplied identity SHALL be accepted.
+
+**Feature tier**: V1
+
+#### REQ-WDM-2-001: Create a new draft
+
+- **GIVEN** an administrator submits a request to create a workflow definition for caseType X
+- **WHEN** `WorkflowDefinitionService::createDraft($caseTypeId, $data)` is invoked
+- **THEN** a `workflowTemplate` SHALL be persisted with `lifecycleStatus: draft`, `isDraft: true`, `isActive: false`, and `version` set to (max existing version for caseType X) + 1
+- **AND** if no prior version exists, `version` SHALL equal 1
+
+#### REQ-WDM-2-002: Update a draft
+
+- **GIVEN** a workflow definition with `lifecycleStatus: draft`
+- **WHEN** `updateDraft($id, $data)` is invoked with new steps/transitions
+- **THEN** the object SHALL be updated in OpenRegister
+- **AND** referential integrity SHALL be revalidated (every status reference belongs to the linked caseType)
+
+#### REQ-WDM-2-003: Delete restricted to drafts
+
+- **GIVEN** an administrator attempts to delete a workflow definition
+- **WHEN** the definition has `lifecycleStatus` other than `draft`
+- **THEN** the operation SHALL be rejected with a static error message
+- **AND** no object SHALL be deleted
+
+---
+
+### REQ-WDM-3: REST API
+
+The system SHALL expose authenticated REST endpoints under `/api/workflow-definition` for definition CRUD and lifecycle operations. Endpoints SHALL never return raw exception messages.
+
+**Feature tier**: V1
+
+#### REQ-WDM-3-001: Endpoint contract
+
+- **WHEN** the controller is registered
+- **THEN** the following endpoints SHALL respond on the listed verbs:
+  - `GET /api/workflow-definition` (list, supports `caseType` and `lifecycleStatus` filters)
+  - `POST /api/workflow-definition` (create draft — admin only)
+  - `GET /api/workflow-definition/{id}` (read one)
+  - `PUT /api/workflow-definition/{id}` (update draft — admin only)
+  - `DELETE /api/workflow-definition/{id}` (delete draft — admin only)
+  - `POST /api/workflow-definition/{id}/publish` (publish — admin only)
+  - `POST /api/workflow-definition/{id}/deprecate` (deprecate — admin only)
+  - `POST /api/workflow-definition/{id}/clone` (clone into new draft)
+
+#### REQ-WDM-3-002: No raw exception leakage
+
+- **WHEN** any controller method handles a `\Throwable`
+- **THEN** the response SHALL contain a static, human-readable error message
+- **AND** the actual exception SHALL be logged via `$this->logger->error()` with the full message and trace
+
+---
+
+### REQ-WDM-4: Draft → Published → Deprecated Lifecycle
+
+The system SHALL implement a strict three-state lifecycle for every workflow definition: `draft`, `published`, `deprecated`. Transitions between states SHALL be one-directional except for `clone` which forks a new draft.
+
+**Feature tier**: V1
+
+#### REQ-WDM-4-001: Allowed lifecycle transitions
+
+- **GIVEN** a workflow definition in some `lifecycleStatus`
+- **WHEN** a lifecycle operation is invoked
+- **THEN** only the following transitions SHALL be permitted:
+  - `draft` → `published` via `publish()`
+  - `published` → `deprecated` via `deprecate()`
+  - `published` → new `draft` (separate object) via `clone()`
+  - `deprecated` → new `draft` (separate object) via `clone()`
+- **AND** any other transition SHALL be rejected with a static error
+
+#### REQ-WDM-4-002: Published versions are immutable
+
+- **GIVEN** a workflow definition with `lifecycleStatus: published` or `lifecycleStatus: deprecated`
+- **WHEN** any caller attempts `updateDraft($id, ...)` or `delete($id)`
+- **THEN** the operation SHALL be rejected with a static error
+- **AND** the persisted object SHALL be unchanged
+
+---
+
+### REQ-WDM-5: Publish Operation
+
+Publishing a draft SHALL be a single atomic operation that promotes the draft, deprecates any previously active version of the same `caseType`, and re-points the `caseType.workflowDefinition` reference to the newly active version.
+
+**Feature tier**: V1
+
+#### REQ-WDM-5-001: Publish atomically promotes and deprecates
+
+- **GIVEN** caseType X has workflow definition v2 with `lifecycleStatus: published, isActive: true`
+- **AND** a new draft v3 exists for caseType X
+- **WHEN** `publish(v3)` is invoked
+- **THEN** v3 SHALL become `published`, `isActive: true`
+- **AND** v2 SHALL become `deprecated`, `isActive: false`
+- **AND** `caseType.workflowDefinition` SHALL point at v3
+- **AND** if any step in the operation fails, the system SHALL not leave both v2 and v3 active
+
+#### REQ-WDM-5-002: Publish validates referential integrity
+
+- **GIVEN** a draft definition whose `transitions[]` contains a `statusType` UUID that does not belong to the linked `caseType`
+- **WHEN** `publish($id)` is invoked
+- **THEN** publication SHALL be rejected
+- **AND** the user SHALL see a static error: "Workflow bevat statussen die niet bij dit zaaktype horen"
+
+---
+
+### REQ-WDM-6: Deprecate Operation
+
+The system SHALL allow deprecating a published definition. Deprecated definitions SHALL not back new cases but SHALL continue to back existing in-flight cases.
+
+**Feature tier**: V1
+
+#### REQ-WDM-6-001: Deprecate marks inactive but preserves existing cases
+
+- **GIVEN** workflow definition v2 is `published, isActive: true` for caseType X
+- **AND** five open cases of caseType X are bound to v2 via `case.workflowVersion = 2`
+- **WHEN** `deprecate(v2)` is invoked AND no other published version exists for caseType X
+- **THEN** the deprecation SHALL be rejected with a static error referencing the open cases
+- **AND** no field SHALL change on v2
+
+#### REQ-WDM-6-002: Deprecation succeeds when another published version exists
+
+- **GIVEN** workflow definition v2 (`published, isActive: true`) and v3 (`published, isActive: false`) both exist for caseType X
+- **WHEN** `publish(v3)` is invoked
+- **THEN** v2 SHALL become `deprecated, isActive: false` automatically per REQ-WDM-5-001
+- **AND** open cases pinned to v2 SHALL continue to load v2 via `case.workflowVersion = 2`
+
+---
+
+### REQ-WDM-7: Versioning and Case Pinning
+
+The system SHALL pin each case to a specific workflow version at the moment the case is created. New cases SHALL bind to the currently active published version; subsequent definition edits SHALL NOT affect in-flight cases.
+
+**Feature tier**: V1
+
+#### REQ-WDM-7-001: Case binds to active version on creation
+
+- **GIVEN** caseType X has workflow definition v3 with `lifecycleStatus: published, isActive: true`
+- **WHEN** a new case of caseType X is created
+- **THEN** `case.workflowTemplate` SHALL be set to v3's UUID
+- **AND** `case.workflowVersion` SHALL be set to `3`
+
+#### REQ-WDM-7-002: Existing cases keep their pinned version after a new publish
+
+- **GIVEN** a case pinned to v3 (`case.workflowVersion = 3`)
+- **AND** the administrator subsequently publishes v4
+- **WHEN** `status-transition-engine` or `role-based-step-routing` loads the workflow for that case
+- **THEN** `getDefinitionForCase($caseId)` SHALL return v3, not v4
+- **AND** the transition buttons and step visibility SHALL reflect v3's configuration
+
+#### REQ-WDM-7-003: CaseType.workflowDefinition pin overrides "latest published"
+
+- **GIVEN** caseType X has `workflowDefinition` set to a specific version v2 (a hand-pinned override)
+- **WHEN** a new case of caseType X is created
+- **THEN** the case SHALL be pinned to v2 regardless of which version is currently `isActive`
+
+---
+
+### REQ-WDM-8: Admin UI
+
+The system SHALL provide an admin settings tab where tenant administrators can list workflow definitions per `caseType`, create drafts, edit drafts, publish, deprecate, and clone versions. All confirmations SHALL use `CnDialog` (never `window.confirm`).
+
+**Feature tier**: V1
+
+#### REQ-WDM-8-001: Admin tab lists versions per caseType
+
+- **GIVEN** the administrator opens "Settings → Workflows"
+- **AND** selects caseType "Omgevingsvergunning" from the top selector
+- **THEN** a table SHALL list every workflow definition version for that caseType
+- **AND** each row SHALL show: version number, `lifecycleStatus` badge, `isActive` indicator, `updatedAt`, action buttons
+
+#### REQ-WDM-8-002: Actions available per lifecycleStatus
+
+- **GIVEN** the rendered version table
+- **THEN** rows in `draft` SHALL expose: Edit, Publish, Delete
+- **AND** rows in `published` SHALL expose: Deprecate, Clone
+- **AND** rows in `deprecated` SHALL expose: Clone
+
+#### REQ-WDM-8-003: Edit dialog supports steps and transitions
+
+- **GIVEN** the administrator clicks "Edit" on a draft
+- **THEN** a dialog SHALL open with: title, description, an ordered steps editor, and a transitions editor
+- **AND** every reference to a `statusType` in either editor SHALL be picked from a dropdown scoped to the linked caseType's statusTypes
+- **AND** saving SHALL call `PUT /api/workflow-definition/{id}` in try/catch with user-facing error feedback
+
+---
+
+### REQ-WDM-9: Backfill Migration
+
+The system SHALL provide a one-time idempotent migration that creates one `workflowTemplate` per existing `caseType` from the implicit ordering of its `statusType` records and pins existing open cases to that synthesised definition.
+
+**Feature tier**: V1
+
+#### REQ-WDM-9-001: Backfill synthesises one definition per caseType
+
+- **GIVEN** a tenant upgrade where caseType X has no `workflowDefinition` set
+- **AND** caseType X has six `statusType` records ordered by `order`
+- **WHEN** the repair step `BackfillWorkflowDefinitions` runs
+- **THEN** a `workflowTemplate` SHALL be created for caseType X with `version: 1`, `lifecycleStatus: published`, `isActive: true`
+- **AND** `steps[]` SHALL contain one step per non-final statusType in the original order
+- **AND** `transitions[]` SHALL contain a transition from each statusType to the next in the ordering with `guards: []` and `allowedRoles: []`
+- **AND** `caseType.workflowDefinition` SHALL be set to the new template UUID
+
+#### REQ-WDM-9-002: Backfill pins existing open cases
+
+- **GIVEN** caseType X has eight open cases without `workflowVersion` set when the migration runs
+- **THEN** every open case SHALL receive `case.workflowTemplate` = the synthesised template UUID
+- **AND** every open case SHALL receive `case.workflowVersion = 1`
+
+#### REQ-WDM-9-003: Backfill is idempotent
+
+- **GIVEN** the repair step has already run for caseType X
+- **WHEN** the same repair step runs again (e.g. next app upgrade)
+- **THEN** caseType X SHALL be skipped — no new workflow definition SHALL be created
+- **AND** the existing `workflowDefinition` reference SHALL be preserved
+
+---
+
+### REQ-WDM-10: Stable Consumer Contract
+
+The system SHALL expose a stable read-only API consumed by `status-transition-engine` and `role-based-step-routing`. Consumers SHALL never reach into OpenRegister directly to read workflow data.
+
+**Feature tier**: V1
+
+#### REQ-WDM-10-001: Read API surface
+
+- **WHEN** a consumer needs workflow data
+- **THEN** it SHALL use exclusively one of:
+  - `WorkflowDefinitionService::getActiveDefinitionFor(string $caseTypeId): ?array`
+  - `WorkflowDefinitionService::getDefinition(string $id): array`
+  - `WorkflowDefinitionService::getDefinitionForCase(string $caseId): array`
+  - `WorkflowDefinitionService::listVersions(string $caseTypeId): array`
+- **AND** no consumer SHALL invoke `ObjectService::findObject(...)` on the `workflowTemplate` schema directly
+
+#### REQ-WDM-10-002: getDefinitionForCase resolves pinned version
+
+- **GIVEN** a case with `case.workflowTemplate = T` and `case.workflowVersion = 2`
+- **WHEN** `getDefinitionForCase($caseId)` is invoked
+- **THEN** the method SHALL return the `workflowTemplate` UUID T's `version: 2` object
+- **AND** the returned object SHALL include the resolved `lifecycleStatus` so consumers can warn when a case is on a deprecated version

--- a/openspec/changes/workflow-definition-model/tasks.md
+++ b/openspec/changes/workflow-definition-model/tasks.md
@@ -1,0 +1,104 @@
+# Tasks: workflow-definition-model
+
+## Deduplication Check
+
+- [ ] **D01**: Confirm the existing `workflowTemplate` schema in `lib/Settings/procest_register.json` (lines ~1836–1899) and the existing `workflow_template_schema` config key in `lib/Service/SettingsService.php` (lines ~65, ~118). Confirm no `WorkflowDefinitionService` or `WorkflowDefinitionController` already exists under `lib/Service/` or `lib/Controller/`. Confirm `case.workflowTemplate` and `case.workflowVersion` are already present on the case schema per ADR-000.
+
+---
+
+## Schema & Configuration
+
+- [ ] **T01**: Extend the `workflowTemplate` schema in `lib/Settings/procest_register.json` with a new `lifecycleStatus` enum property (`draft`, `published`, `deprecated`, default `draft`). Keep `isDraft` and `isActive` for backwards compatibility but document that `lifecycleStatus` is authoritative going forward. Bump the schema `version` field.
+
+- [ ] **T02**: Add config key `workflow_definition_schema` (alias of `workflow_template_schema`) to `lib/Service/SettingsService.php` so consumer specs can refer to a stable name independent of the legacy schema slug. Load in `initializeStores()`.
+
+- [ ] **T03**: Add `workflowDefinition` (UUID reference to `workflowTemplate`) to the `caseType` schema in `lib/Settings/procest_register.json`. Document that this is the pinned active definition; absence means "fall through to latest published".
+
+---
+
+## Backend: Service
+
+- [ ] **T04**: Create `lib/Service/WorkflowDefinitionService.php`. Methods (all using `ObjectService` 3-arg API):
+  - `createDraft(string $caseTypeId, array $data): array` — creates a new `workflowTemplate` with `lifecycleStatus: draft`, `version` = max-existing-version-for-caseType + 1.
+  - `updateDraft(string $id, array $data): array` — rejects with error if `lifecycleStatus != draft`.
+  - `publish(string $id): array` — atomically: sets target to `published`+`isActive: true`; deprecates any previously active version for the same caseType; updates `caseType.workflowDefinition` to point at the newly active version. Wraps in a try/catch; on failure logs and returns a static error.
+  - `deprecate(string $id): array` — sets `lifecycleStatus: deprecated`, `isActive: false`. Refuses to deprecate the last published version of a caseType that has open cases (raises a static error). Logs the failure if any.
+  - `clone(string $id): array` — produces a new draft from a published or deprecated version with `version` incremented.
+  - `getActiveDefinitionFor(string $caseTypeId): ?array` — read-only consumer entrypoint.
+  - `getDefinition(string $id): array` — read by UUID.
+  - `getDefinitionForCase(string $caseId): array` — resolves via `case.workflowTemplate` + `case.workflowVersion`.
+  - `listVersions(string $caseTypeId): array` — admin UI listing.
+  All mutations derive user identity from `IUserSession`. Never return `$e->getMessage()` to callers; log with `$this->logger->error()` and return a static error.
+
+- [ ] **T05**: Add publish/deprecate lifecycle invariants enforced in `WorkflowDefinitionService`:
+  - Cannot edit a `published` or `deprecated` object.
+  - Cannot publish a `draft` whose `transitions[]` references a `statusType` that does not belong to the linked `caseType` — validate referential integrity before flipping the status.
+  - On `publish()`, the previously active version for the same caseType is moved to `deprecated`+`isActive: false` in the same logical operation.
+
+---
+
+## Backend: Controller
+
+- [ ] **T06**: Create `lib/Controller/WorkflowDefinitionController.php` exposing:
+  - `GET    /api/workflow-definition` — list (filter by `caseType`, `lifecycleStatus`)
+  - `POST   /api/workflow-definition` — create draft (admin only via `IGroupManager`)
+  - `GET    /api/workflow-definition/{id}` — read one
+  - `PUT    /api/workflow-definition/{id}` — update draft (admin only; rejects non-draft)
+  - `DELETE /api/workflow-definition/{id}` — delete (admin only; only `draft` versions deletable)
+  - `POST   /api/workflow-definition/{id}/publish` — publish (admin only)
+  - `POST   /api/workflow-definition/{id}/deprecate` — deprecate (admin only)
+  - `POST   /api/workflow-definition/{id}/clone` — clone into new draft
+  Never return raw exception messages — use static error strings, log internals.
+
+---
+
+## Routes
+
+- [ ] **T07**: Register the eight endpoints from T06 in `appinfo/routes.php`. Use the kebab-case URL form `/api/workflow-definition[/...]` and PHP controller name `workflow_definition`.
+
+---
+
+## Frontend: Store + API
+
+- [ ] **T08**: Register `workflow-definition` entity type in `src/store/store.js` via `createObjectStore('workflow-definition')` with `relationsPlugin`. Register ONCE. Add `src/services/workflowDefinitionApi.js` with all CRUD + lifecycle calls (`listVersions`, `createDraft`, `updateDraft`, `publish`, `deprecate`, `clone`, `getActiveFor`). Use `@nextcloud/axios` exclusively.
+
+---
+
+## Frontend: Admin UI
+
+- [ ] **T09**: Create `src/views/settings/components/WorkflowDefinitionsTab.vue`:
+  - Imports only from `@conduction/nextcloud-vue`.
+  - Top-level caseType selector; below: table of versions for the selected caseType with columns: version, lifecycleStatus badge (`CnStatusBadge`), updatedAt, actions.
+  - Actions: `Edit` (only for draft), `Publish` (only for draft), `Deprecate` (only for published), `Clone` (for published/deprecated). All confirmed via `CnDialog` (never `window.confirm`).
+  - Empty state via `CnEmptyState`.
+  - All strings via `this.t(appName, '...')`; SPDX header on line 1.
+
+- [ ] **T10**: Create `src/views/settings/components/WorkflowDefinitionDialog.vue` for create/edit of a draft:
+  - Fields: `title`, `description`, `caseType` (read-only after create).
+  - Embeds `WorkflowStepsEditor` (ordered steps; per step: title, status reference, order, assigneeRole, isRequired, checklist) and `WorkflowTransitionsEditor` (per transition: fromStatus, toStatus, label, guards, allowedRoles).
+  - On save calls `workflowDefinitionApi.createDraft` or `updateDraft` in try/catch with user-facing toast/dialog on error.
+  - SPDX header; strings via `this.t(appName, '...')`.
+
+---
+
+## CaseType Integration
+
+- [ ] **T11**: Add `workflowDefinition` reference field to the caseType admin dialog (`src/views/settings/components/CaseTypeDialog.vue` or equivalent). Picker lists only `published` definitions for that caseType. Setting it pins the caseType to a specific definition; unset means "use the latest published".
+
+---
+
+## Migration
+
+- [ ] **T12**: Implement repair step `lib/Migration/BackfillWorkflowDefinitions.php` as described in `design.md` (synthesise one published `workflowTemplate` per existing caseType from its `statusType` order, set `caseType.workflowDefinition`, set `case.workflowVersion = 1` for open cases). Idempotent: skips caseTypes that already have `workflowDefinition` set.
+
+---
+
+## Pre-commit Verification
+
+- [ ] **V01**: `grep -rL 'SPDX-License-Identifier' lib/Service/WorkflowDefinitionService.php lib/Controller/WorkflowDefinitionController.php src/views/settings/components/WorkflowDefinitionsTab.vue src/views/settings/components/WorkflowDefinitionDialog.vue src/services/workflowDefinitionApi.js` → zero results.
+
+- [ ] **V02**: `grep -rn 'findObject\|saveObject\|findObjects\|deleteObject' lib/Service/WorkflowDefinitionService.php` → every call uses the 3-positional-arg API.
+
+- [ ] **V03**: `grep -rn 'getMessage()' lib/Controller/WorkflowDefinitionController.php` → zero results. No raw exception messages in responses.
+
+- [ ] **V04**: Manual QA — Creating a draft, editing it, publishing it, then attempting to edit it: edit MUST be rejected after publish. Cloning the published version creates a draft with `version+1`. Publishing the clone deprecates the previous active version. `caseType.workflowDefinition` updates to point at the newly active version.


### PR DESCRIPTION
## Summary

GENERATE-phase only: this PR ships the OpenSpec **change artifacts** for `workflow-definition-model`. No application code is touched. Implementation lands in a follow-up PR that applies these tasks.

The declarative workflow-definition is the foundation of the procest workflow engine. It promotes the today-implicit case lifecycle (StatusType ordering + scattered button logic) into a single configurable `workflowTemplate` object that tenant admins own.

Files:
- `openspec/changes/workflow-definition-model/proposal.md`
- `openspec/changes/workflow-definition-model/design.md`
- `openspec/changes/workflow-definition-model/tasks.md` (D01, T01–T12, V01–V04)
- `openspec/changes/workflow-definition-model/specs/workflow-definition-model/spec.md` (REQ-WDM-1..10)

## Key decisions

- **Entity** — extend the existing `workflowTemplate` schema in `lib/Settings/procest_register.json`; add `lifecycleStatus` enum (`draft`, `published`, `deprecated`).
- **Storage** — single OpenRegister object with `steps[]` and `transitions[]` as JSON-encoded fields. Considered exploding into separate `workflowStep`/`workflowTransition` entities but rejected: published versions must be trivially immutable and `getDefinitionForCase` is a hot path.
- **Lifecycle** — draft is editable; published is immutable and can back new cases; deprecated continues to back open cases but cannot back new ones. Publishing a new version atomically deprecates the previous active version and re-points `caseType.workflowDefinition`.
- **Pinning** — `case.workflowVersion` locks a case to a specific version on creation; future edits never mutate in-flight cases.
- **Consumer contract** — `WorkflowDefinitionService` is the only read path; `status-transition-engine` and `role-based-step-routing` MUST NOT touch `ObjectService` directly for workflow data.

## Dependencies

Consumed by:

- `status-transition-engine` (already specced) — reads `transitions[]` + `guards[]`.
- `role-based-step-routing` (already specced) — reads `steps[].assigneeRole` and `transitions[].allowedRoles`.
- `visual-workflow-editor` (V2) — read/write same object plus `nodePositions`.
- `workflow-import-export` (V2) — serialises the same object.

Depends on:

- `caseType` schema (procest, existing) — needs the new `workflowDefinition` UUID reference.

## Out of scope

- Guard evaluation engine, role/step visibility filtering, visual editor, import/export, cross-tenant marketplace.

## Test plan

- [ ] OpenSpec lint passes locally (`openspec validate workflow-definition-model`).
- [ ] Review proposal/design/tasks/spec for internal consistency.
- [ ] Confirm the 10 requirements are testable Given/When/Then scenarios.
- [ ] Confirm no application code is touched in this PR.