### PR TITLE
feat(ai-assisted-processing): apply spec

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -30,6 +30,19 @@ return [
         ['name' => 'settings#create', 'url' => '/api/settings', 'verb' => 'POST'],
         ['name' => 'settings#load',  'url' => '/api/settings/load', 'verb' => 'POST'],
 
+        // AI-Assisted Processing (specific endpoints precede wildcard routes).
+        ['name' => 'ai#classify',        'url' => '/api/ai/classify',        'verb' => 'POST'],
+        ['name' => 'ai#extract',         'url' => '/api/ai/extract',         'verb' => 'POST'],
+        ['name' => 'ai#ask',             'url' => '/api/ai/ask',             'verb' => 'POST'],
+        ['name' => 'ai#summarize',       'url' => '/api/ai/summarize',       'verb' => 'POST'],
+        ['name' => 'ai#suggestRouting',  'url' => '/api/ai/suggest-routing', 'verb' => 'POST'],
+        ['name' => 'ai#suggestNext',     'url' => '/api/ai/suggest-next',    'verb' => 'POST'],
+        ['name' => 'ai#recordAction',    'url' => '/api/ai/record-action',   'verb' => 'POST'],
+        ['name' => 'ai#auditIndex',      'url' => '/api/ai/audit',           'verb' => 'GET'],
+        ['name' => 'ai#getSettings',     'url' => '/api/ai/settings',        'verb' => 'GET'],
+        ['name' => 'ai#updateSettings',  'url' => '/api/ai/settings',        'verb' => 'POST'],
+        ['name' => 'ai#healthCheck',     'url' => '/api/ai/health',          'verb' => 'POST'],
+
         // Parafering Actions (must precede any wildcard routes).
         ['name' => 'parafeer_actie#create', 'url' => '/api/parafeer-actie', 'verb' => 'POST'],
         ['name' => 'parafeer_actie#index',  'url' => '/api/parafeer-actie', 'verb' => 'GET'],

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -77,6 +77,21 @@ class SettingsService
         'advies_aanvraag_schema',
         'tenant_schema',
         'lhsMatrix',
+        // AI-Assisted Processing settings.
+        'ai_audit_entry_schema',
+        'ai_enabled',
+        'ai_model_type',
+        'ai_model_url',
+        'ai_model_name',
+        'ai_api_key',
+        'ai_feature_classification',
+        'ai_feature_extraction',
+        'ai_feature_qa',
+        'ai_feature_summary',
+        'ai_feature_routing',
+        'ai_feature_decision_support',
+        'ai_dpia_acknowledged',
+        'ai_pii_stripping',
     ];
 
     /**
@@ -124,6 +139,7 @@ class SettingsService
         'parafeerroute'                => 'parafeerroute_schema',
         'parafeeractie'                => 'parafeeractie_schema',
         'tenant'                       => 'tenant_schema',
+        'aiAuditEntry'                 => 'ai_audit_entry_schema',
     ];
 
     private const OPENREGISTER_APP_ID = 'openregister';

--- a/lib/Settings/procest_register.json
+++ b/lib/Settings/procest_register.json
@@ -2740,6 +2740,104 @@
             "description": "Whether tenant is active"
           }
         }
+      },
+      "aiAuditEntry": {
+        "slug": "aiAuditEntry",
+        "icon": "RobotOutline",
+        "version": "1.0.0",
+        "x-schema-org-type": "schema:DigitalDocument",
+        "title": "AI Audit Entry",
+        "description": "Immutable audit log entry for AI-assisted processing interactions",
+        "type": "object",
+        "required": [
+          "type",
+          "action",
+          "userId",
+          "timestamp"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "classification",
+              "extraction",
+              "qa",
+              "summary",
+              "routing",
+              "decision_support"
+            ],
+            "description": "AI feature type that produced the entry",
+            "title": "Type",
+            "facetable": true
+          },
+          "action": {
+            "type": "string",
+            "enum": [
+              "suggestion",
+              "accepted",
+              "rejected",
+              "modified"
+            ],
+            "description": "Outcome of the AI suggestion",
+            "title": "Action",
+            "facetable": true
+          },
+          "caseId": {
+            "type": "string",
+            "description": "Reference to the case (zaak) the AI was invoked on"
+          },
+          "documentId": {
+            "type": "string",
+            "description": "Reference to the document (informatieobject) if applicable"
+          },
+          "model": {
+            "type": "string",
+            "description": "Identifier of the AI model used (e.g. qwen3.5:9b)"
+          },
+          "prompt": {
+            "type": "string",
+            "description": "Prompt sent to the AI model (PII-stripped if enabled)"
+          },
+          "suggestion": {
+            "type": "object",
+            "description": "Structured AI suggestion payload"
+          },
+          "confidence": {
+            "type": "number",
+            "description": "AI confidence score between 0.0 and 1.0"
+          },
+          "userAction": {
+            "type": "string",
+            "enum": [
+              "accepted",
+              "rejected",
+              "modified",
+              "ignored"
+            ],
+            "description": "Action taken by the human user on the suggestion"
+          },
+          "actualValue": {
+            "type": "object",
+            "description": "Final value applied by the user (if modified)"
+          },
+          "reason": {
+            "type": "string",
+            "description": "User-provided reason (e.g. for rejection)"
+          },
+          "userId": {
+            "type": "string",
+            "description": "Nextcloud user UID who triggered the AI call"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the AI call was made"
+          },
+          "responseTimeMs": {
+            "type": "integer",
+            "description": "AI response time in milliseconds"
+          }
+        }
       }
     },
     "registers": {

--- a/src/views/settings/AdminRoot.vue
+++ b/src/views/settings/AdminRoot.vue
@@ -58,6 +58,13 @@
 			<ZgwMappingSettings v-if="storesReady" />
 		</CnSettingsSection>
 
+		<CnSettingsSection
+			:name="t('procest', 'AI-Assisted Processing')"
+			:description="t('procest', 'Configure AI features for document classification, data extraction, Q&A, summarization, routing and decision support')"
+			:loading="!storesReady">
+			<AiSettingsTab v-if="storesReady" />
+		</CnSettingsSection>
+
 		<!-- Re-import Status -->
 		<div v-if="message" class="actions-section">
 			<NcNoteCard :type="messageType">
@@ -76,6 +83,7 @@ import CaseTypeAdmin from './CaseTypeAdmin.vue'
 import ParafeerRoutesTab from './components/ParafeerRoutesTab.vue'
 import ZgwMappingSettings from './ZgwMappingSettings.vue'
 import MapLayerSettings from './MapLayerSettings.vue'
+import AiSettingsTab from './tabs/AiSettingsTab.vue'
 import { initializeStores } from '../../store/store.js'
 
 export default {
@@ -92,6 +100,7 @@ export default {
 		ParafeerRoutesTab,
 		ZgwMappingSettings,
 		MapLayerSettings,
+		AiSettingsTab,
 	},
 	data() {
 		return {


### PR DESCRIPTION
## Summary

Applies the `ai-assisted-processing` openspec change in procest, finalizing the wiring around the AI components/services that were already scaffolded in the codebase.

- Add 11 AI routes under `/api/ai/*` (classify, extract, ask, summarize, suggest-routing, suggest-next, record-action, audit, settings GET, settings POST, health) matching the existing `AiController` method names
- Register 14 AI config keys in `SettingsService::CONFIG_KEYS` (`ai_enabled`, model type/url/name/key, 6 feature toggles, dpia/pii) and add `aiAuditEntry` slug-to-config mapping
- Add `aiAuditEntry` schema to `lib/Settings/procest_register.json` with required type/action/userId/timestamp plus caseId, documentId, model, prompt, suggestion, confidence, userAction, actualValue, reason, responseTimeMs fields
- Mount `AiSettingsTab` in `AdminRoot.vue` so the existing settings component is reachable

`AiController`, `AiService`, `aiApi.js` and all `Ai*` Vue components were already in the repo; this PR closes the gap so they are actually reachable and configurable.

Case-detail-side integration (AI buttons in case header / document list, AI panel in sidebar) is deferred: a `CaseDetail.vue` shell does not yet exist; the AI components remain ready for that future wiring.

## Test plan

- [ ] `php -l` clean for `appinfo/routes.php`, `lib/Service/SettingsService.php`, `lib/Controller/AiController.php`, `lib/Service/AiService.php`
- [ ] `jq empty lib/Settings/procest_register.json` clean
- [ ] After `Re-import configuration` runs, `aiAuditEntry` is registered in OpenRegister and `ai_audit_entry_schema` app-config key is set
- [ ] `GET /apps/procest/api/ai/settings` returns 200 with default flags
- [ ] AI Settings section is visible in admin and persists toggles via `POST /api/ai/settings`