### PR TITLE
feat(appointment-scheduling): apply spec

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -206,6 +206,18 @@ return [
         ['name' => 'tenant#provision', 'url' => '/api/tenants/{tenantId}/provision',   'verb' => 'POST'],
         ['name' => 'tenant#usage',     'url' => '/api/tenants/{tenantId}/usage',       'verb' => 'GET'],
 
+        // ── Appointment Scheduling (afsprakenbeheer) ────────────────────
+        // Specific endpoints (must precede wildcard {appointmentId} routes).
+        ['name' => 'appointment#timeslots', 'url' => '/api/appointments/timeslots',                'verb' => 'GET'],
+        ['name' => 'appointment#noShow',    'url' => '/api/appointments/{appointmentId}/no-show',  'verb' => 'POST'],
+        // CRUD.
+        ['name' => 'appointment#index',     'url' => '/api/appointments',                          'verb' => 'GET'],
+        ['name' => 'appointment#create',    'url' => '/api/appointments',                          'verb' => 'POST'],
+        ['name' => 'appointment#cancel',    'url' => '/api/appointments/{appointmentId}',          'verb' => 'DELETE'],
+        // Public (citizen self-service via token).
+        ['name' => 'public_appointment#view',   'url' => '/api/public/appointment/{token}',         'verb' => 'GET'],
+        ['name' => 'public_appointment#cancel', 'url' => '/api/public/appointment/{token}/cancel',  'verb' => 'POST'],
+
         // SPA catch-all — serves the Vue app for any frontend route (history mode).
         ['name' => 'dashboard#page', 'url' => '/{path}', 'verb' => 'GET', 'requirements' => ['path' => '.+'], 'defaults' => ['path' => '']],
     ],

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -76,6 +76,13 @@ class SettingsService
         'handhavingsactie_schema',
         'advies_aanvraag_schema',
         'tenant_schema',
+        'appointment_schema',
+        'appointment_product_schema',
+        'appointment_location_schema',
+        'appointment_backend',
+        'appointment_backend_url',
+        'appointment_backend_api_key',
+        'appointment_reminder_days',
         'lhsMatrix',
         // AI-Assisted Processing settings.
         'ai_audit_entry_schema',
@@ -140,6 +147,9 @@ class SettingsService
         'parafeeractie'                => 'parafeeractie_schema',
         'tenant'                       => 'tenant_schema',
         'aiAuditEntry'                 => 'ai_audit_entry_schema',
+        'appointment'                  => 'appointment_schema',
+        'appointmentProduct'           => 'appointment_product_schema',
+        'appointmentLocation'          => 'appointment_location_schema',
     ];
 
     private const OPENREGISTER_APP_ID = 'openregister';


### PR DESCRIPTION
## Summary

Wires the appointment-scheduling MVP that was scaffolded on the branch but never connected to the runtime.

- Schemas `appointment`, `appointmentProduct`, `appointmentLocation` added to `lib/Settings/procest_register.json` and included in the `procest` register.
- 7 new config keys (`appointment_schema`, `appointment_product_schema`, `appointment_location_schema`, `appointment_backend`, `appointment_backend_url`, `appointment_backend_api_key`, `appointment_reminder_days`) plus 3 slug-to-key mappings registered in `SettingsService` so `AppointmentService::getConfigValue('appointment_schema')` resolves.
- Routes for `AppointmentController` (`index`, `create`, `cancel`, `noShow`, `timeslots`) and `PublicAppointmentController` (`view`, `cancel`) registered ahead of the SPA catch-all, matching `design.md`.

All other artifacts (services, backends, controllers, background job, Vue components, API service, settings tab, public page) were already on `development` from the original feature/appointment-scheduling merge (#70) — this PR completes the wiring.

Per strict watchdog: no composer check:strict, no i18n, php -l + jq validation only.

## Spec

`openspec/changes/appointment-scheduling/`

## Test plan

- [ ] php -l clean on touched files (verified locally)
- [ ] jq parses procest_register.json and lists 3 new schemas (verified locally)
- [ ] Manual: open Settings — appointment-related app-config keys persist
- [ ] Manual: GET /api/appointments?caseId=... returns 200 once schemas are seeded