### PR TITLE
feat(advice-management): apply spec

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -173,6 +173,14 @@ return [
         ['name' => 'leges#teruggaaf',   'url' => '/api/leges/teruggaaf',    'verb' => 'POST'],
         ['name' => 'leges#export',      'url' => '/api/leges/export',       'verb' => 'POST'],
 
+        // ── Advice Management (adviesAanvraag) ──────────────────────────
+        ['name' => 'advice#index',   'url' => '/api/advice',             'verb' => 'GET'],
+        ['name' => 'advice#create',  'url' => '/api/advice',             'verb' => 'POST'],
+        ['name' => 'advice#show',    'url' => '/api/advice/{id}',        'verb' => 'GET'],
+        ['name' => 'advice#update',  'url' => '/api/advice/{id}',        'verb' => 'PUT'],
+        ['name' => 'advice#destroy', 'url' => '/api/advice/{id}',        'verb' => 'DELETE'],
+        ['name' => 'advice#remind',  'url' => '/api/advice/{id}/remind', 'verb' => 'POST'],
+
         // Multi-Tenant SaaS — tenant management endpoints (platform admin scoped).
         ['name' => 'tenant#current',   'url' => '/api/tenants/current',                'verb' => 'GET'],
         ['name' => 'tenant#index',     'url' => '/api/tenants',                        'verb' => 'GET'],

--- a/lib/BackgroundJob/AdviceDeadlineJob.php
+++ b/lib/BackgroundJob/AdviceDeadlineJob.php
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * Procest Advice Deadline Job.
+ *
+ * Daily background job that processes advice request deadlines:
+ * sends reminders 3 days before deadline and transitions overdue
+ * advice requests to status `verlopen`.
+ *
+ * @category BackgroundJob
+ * @package  OCA\Procest\BackgroundJob
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\BackgroundJob;
+
+use OCA\Procest\AppInfo\Application;
+use OCA\Procest\Service\AdviceService;
+use OCA\Procest\Service\SettingsService;
+use OCP\App\IAppManager;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\TimedJob;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Daily timed job that processes advice request deadlines and reminders.
+ */
+class AdviceDeadlineJob extends TimedJob
+{
+
+    /**
+     * Constructor.
+     *
+     * @param ITimeFactory    $time            The time factory
+     * @param AdviceService   $adviceService   The advice service
+     * @param SettingsService $settingsService The settings service
+     * @param IAppManager     $appManager      The app manager
+     * @param LoggerInterface $logger          The logger
+     */
+    public function __construct(
+        ITimeFactory $time,
+        private readonly AdviceService $adviceService,
+        private readonly SettingsService $settingsService,
+        private readonly IAppManager $appManager,
+        private readonly LoggerInterface $logger,
+    ) {
+        parent::__construct(time: $time);
+        // Daily.
+        $this->setInterval(seconds: 86400);
+    }//end __construct()
+
+    /**
+     * Run the advice deadline processing.
+     *
+     * @param mixed $argument The job argument
+     *
+     * @return void
+     */
+    protected function run($argument): void
+    {
+        if (in_array('openregister', $this->appManager->getInstalledApps(), true) === false) {
+            return;
+        }
+
+        $reminderDays = (int) ($this->settingsService->getConfigValue('advice_reminder_days', '3'));
+        if ($reminderDays <= 0) {
+            $reminderDays = 3;
+        }
+
+        $today      = new \DateTimeImmutable('today');
+        $reminderOn = $today->modify('+'.$reminderDays.' days')->format('Y-m-d');
+        $todayStr   = $today->format('Y-m-d');
+
+        $this->logger->info(
+            'Procest: running advice deadline job (today='.$todayStr.', reminderOn='.$reminderOn.')',
+            ['app' => Application::APP_ID],
+        );
+
+        $open = $this->adviceService->getOpenAdvice();
+
+        foreach ($open as $advice) {
+            $deadline = (string) ($advice['deadline'] ?? '');
+            if ($deadline === '') {
+                continue;
+            }
+
+            $deadlineDate = substr($deadline, 0, 10);
+            $adviceId     = (string) ($advice['uuid'] ?? ($advice['id'] ?? ''));
+            if ($adviceId === '') {
+                continue;
+            }
+
+            if ($deadlineDate < $todayStr) {
+                $this->adviceService->expireAdvice($adviceId);
+                $this->logger->info(
+                    'Procest: advice request expired',
+                    [
+                        'app'      => Application::APP_ID,
+                        'adviceId' => $adviceId,
+                    ],
+                );
+                continue;
+            }
+
+            if ($deadlineDate === $reminderOn) {
+                $this->adviceService->sendReminder($adviceId);
+                $this->logger->info(
+                    'Procest: advice reminder dispatched',
+                    [
+                        'app'      => Application::APP_ID,
+                        'adviceId' => $adviceId,
+                    ],
+                );
+            }
+        }
+    }//end run()
+}//end class

--- a/lib/Controller/AdviceController.php
+++ b/lib/Controller/AdviceController.php
@@ -1,0 +1,275 @@
+<?php
+
+/**
+ * Procest Advice Controller.
+ *
+ * REST API for managing advice requests (adviesAanvraag) on cases.
+ *
+ * @category Controller
+ * @package  OCA\Procest\Controller
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Controller;
+
+use OCA\Procest\Service\AdviceService;
+use OCA\Procest\Service\SettingsService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Controller for advice request management on cases.
+ */
+class AdviceController extends Controller
+{
+
+    /**
+     * Constructor.
+     *
+     * @param string          $appName         The app name
+     * @param IRequest        $request         The HTTP request
+     * @param AdviceService   $adviceService   The advice service
+     * @param SettingsService $settingsService The settings service
+     * @param LoggerInterface $logger          The logger
+     */
+    public function __construct(
+        string $appName,
+        IRequest $request,
+        private readonly AdviceService $adviceService,
+        private readonly SettingsService $settingsService,
+        private readonly LoggerInterface $logger,
+    ) {
+        parent::__construct(appName: $appName, request: $request);
+    }//end __construct()
+
+    /**
+     * List advice requests for a case.
+     *
+     * @param string $case The case UUID (query param)
+     *
+     * @return JSONResponse List of advice records
+     *
+     * @NoAdminRequired
+     */
+    public function index(string $case = ''): JSONResponse
+    {
+        if ($case === '') {
+            return new JSONResponse(
+                ['error' => 'case parameter is required'],
+                Http::STATUS_BAD_REQUEST,
+            );
+        }
+
+        try {
+            $advice = $this->adviceService->getAdviceForCase($case);
+            return new JSONResponse(['results' => $advice]);
+        } catch (\Throwable $e) {
+            $this->logger->error('Procest: advice index failed: '.$e->getMessage());
+            return new JSONResponse(
+                ['error' => 'Could not list advice requests'],
+                Http::STATUS_INTERNAL_SERVER_ERROR,
+            );
+        }
+    }//end index()
+
+    /**
+     * Create a new advice request.
+     *
+     * @return JSONResponse Created record
+     *
+     * @NoAdminRequired
+     */
+    public function create(): JSONResponse
+    {
+        $data = $this->readJsonBody();
+
+        $caseId = (string) ($data['case'] ?? '');
+
+        try {
+            $advice = $this->adviceService->createAdvice($caseId, $data);
+            return new JSONResponse($advice, Http::STATUS_CREATED);
+        } catch (\RuntimeException $e) {
+            return new JSONResponse(
+                ['error' => $e->getMessage()],
+                Http::STATUS_BAD_REQUEST,
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error('Procest: advice create failed: '.$e->getMessage());
+            return new JSONResponse(
+                ['error' => 'Could not create advice request'],
+                Http::STATUS_INTERNAL_SERVER_ERROR,
+            );
+        }
+    }//end create()
+
+    /**
+     * Show a single advice request.
+     *
+     * @param string $id The advice UUID
+     *
+     * @return JSONResponse Advice record
+     *
+     * @NoAdminRequired
+     */
+    public function show(string $id): JSONResponse
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return new JSONResponse(
+                ['error' => 'OpenRegister is not available'],
+                Http::STATUS_SERVICE_UNAVAILABLE,
+            );
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('advies_aanvraag_schema');
+
+        if (empty($register) === true || empty($schema) === true) {
+            return new JSONResponse(
+                ['error' => 'Advice schema is not configured'],
+                Http::STATUS_SERVICE_UNAVAILABLE,
+            );
+        }
+
+        try {
+            $advice = $objectService->findObject($register, $schema, $id);
+            return new JSONResponse($advice);
+        } catch (\Throwable $e) {
+            $this->logger->error('Procest: advice show failed: '.$e->getMessage());
+            return new JSONResponse(
+                ['error' => 'Could not load advice request'],
+                Http::STATUS_NOT_FOUND,
+            );
+        }
+    }//end show()
+
+    /**
+     * Update / mark received an advice request.
+     *
+     * @param string $id The advice UUID
+     *
+     * @return JSONResponse Updated record
+     *
+     * @NoAdminRequired
+     */
+    public function update(string $id): JSONResponse
+    {
+        $data   = $this->readJsonBody();
+        $fileId = (string) ($data['adviesDocument'] ?? ($data['fileId'] ?? ''));
+
+        try {
+            $advice = $this->adviceService->receiveAdvice($id, $fileId);
+            return new JSONResponse($advice);
+        } catch (\RuntimeException $e) {
+            return new JSONResponse(
+                ['error' => $e->getMessage()],
+                Http::STATUS_BAD_REQUEST,
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error('Procest: advice update failed: '.$e->getMessage());
+            return new JSONResponse(
+                ['error' => 'Could not update advice request'],
+                Http::STATUS_INTERNAL_SERVER_ERROR,
+            );
+        }
+    }//end update()
+
+    /**
+     * Delete an advice request.
+     *
+     * @param string $id The advice UUID
+     *
+     * @return JSONResponse Empty success or error
+     *
+     * @NoAdminRequired
+     */
+    public function destroy(string $id): JSONResponse
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return new JSONResponse(
+                ['error' => 'OpenRegister is not available'],
+                Http::STATUS_SERVICE_UNAVAILABLE,
+            );
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('advies_aanvraag_schema');
+
+        if (empty($register) === true || empty($schema) === true) {
+            return new JSONResponse(
+                ['error' => 'Advice schema is not configured'],
+                Http::STATUS_SERVICE_UNAVAILABLE,
+            );
+        }
+
+        try {
+            $objectService->deleteObject($register, $schema, $id);
+            return new JSONResponse(['status' => 'deleted']);
+        } catch (\Throwable $e) {
+            $this->logger->error('Procest: advice destroy failed: '.$e->getMessage());
+            return new JSONResponse(
+                ['error' => 'Could not delete advice request'],
+                Http::STATUS_INTERNAL_SERVER_ERROR,
+            );
+        }
+    }//end destroy()
+
+    /**
+     * Send a manual reminder to the adviseur.
+     *
+     * @param string $id The advice UUID
+     *
+     * @return JSONResponse Success response
+     *
+     * @NoAdminRequired
+     */
+    public function remind(string $id): JSONResponse
+    {
+        try {
+            $this->adviceService->sendReminder($id);
+            return new JSONResponse(['status' => 'reminded']);
+        } catch (\Throwable $e) {
+            $this->logger->error('Procest: advice remind failed: '.$e->getMessage());
+            return new JSONResponse(
+                ['error' => 'Could not send reminder'],
+                Http::STATUS_INTERNAL_SERVER_ERROR,
+            );
+        }
+    }//end remind()
+
+    /**
+     * Decode a JSON request body safely.
+     *
+     * @return array<string, mixed> Decoded payload or empty array
+     */
+    private function readJsonBody(): array
+    {
+        $content = $this->request->getContent();
+        if ($content === '' || $content === false) {
+            return [];
+        }
+
+        $decoded = json_decode($content, true);
+        if (is_array($decoded) === true) {
+            return $decoded;
+        }
+
+        return [];
+    }//end readJsonBody()
+}//end class

--- a/lib/Service/AdviceService.php
+++ b/lib/Service/AdviceService.php
@@ -1,0 +1,485 @@
+<?php
+
+/**
+ * Procest Advice Service.
+ *
+ * Service for managing advice requests (adviesAanvraag) on cases.
+ * Handles CRUD, status transitions, deadline tracking, and notification
+ * dispatch for internal and external advice.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service;
+
+use OCA\Procest\AppInfo\Application;
+use OCP\IUserSession;
+use OCP\Notification\IManager as INotificationManager;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Service for advice request (adviesAanvraag) management.
+ */
+class AdviceService
+{
+
+    /**
+     * Valid advice statuses.
+     */
+    private const VALID_STATUSES = [
+        'aangevraagd',
+        'ontvangen',
+        'verlopen',
+    ];
+
+    /**
+     * Valid advice types.
+     */
+    private const VALID_TYPES = [
+        'intern',
+        'extern',
+    ];
+
+    /**
+     * Constructor.
+     *
+     * @param SettingsService      $settingsService     The settings service
+     * @param IUserSession         $userSession         The current user session
+     * @param INotificationManager $notificationManager The notification manager
+     * @param LoggerInterface      $logger              The logger
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+        private readonly IUserSession $userSession,
+        private readonly INotificationManager $notificationManager,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Create a new advice request linked to a case.
+     *
+     * @param string               $caseId The case UUID this advice is for
+     * @param array<string, mixed> $data   Advice data (adviseur, type, onderwerp, deadline, questions)
+     *
+     * @return array<string, mixed> Created advice record
+     *
+     * @throws \RuntimeException When OpenRegister unavailable or validation fails
+     */
+    public function createAdvice(string $caseId, array $data): array
+    {
+        if ($caseId === '') {
+            throw new \RuntimeException('Case ID is required');
+        }
+
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            throw new \RuntimeException('OpenRegister is not available');
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('advies_aanvraag_schema');
+
+        if (empty($register) === true || empty($schema) === true) {
+            throw new \RuntimeException('Advice schema is not configured');
+        }
+
+        $adviseur = (string) ($data['adviseur'] ?? '');
+        $type     = (string) ($data['type'] ?? '');
+
+        if ($adviseur === '') {
+            throw new \RuntimeException('adviseur is required');
+        }
+
+        if (in_array($type, self::VALID_TYPES, true) === false) {
+            throw new \RuntimeException('Invalid advice type');
+        }
+
+        $payload = [
+            'case'        => $caseId,
+            'adviseur'    => $adviseur,
+            'type'        => $type,
+            'onderwerp'   => (string) ($data['onderwerp'] ?? ''),
+            'deadline'    => (string) ($data['deadline'] ?? ''),
+            'status'      => 'aangevraagd',
+            'requestedAt' => date('c'),
+            'questions'   => (string) ($data['questions'] ?? ''),
+        ];
+
+        try {
+            $advice = $objectService->saveObject($register, $schema, $payload);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Procest: failed to create advice request: '.$e->getMessage(),
+                ['app' => Application::APP_ID]
+            );
+            throw new \RuntimeException('Could not create advice request');
+        }
+
+        $this->notifyAdviseur($adviseur, $caseId, $payload['onderwerp']);
+
+        return $this->normalizeResult($advice);
+    }//end createAdvice()
+
+    /**
+     * Mark an advice request as received (status -> ontvangen).
+     *
+     * @param string $adviceId The advice UUID
+     * @param string $fileId   Nextcloud file ID of the advice document
+     *
+     * @return array<string, mixed> Updated advice record
+     *
+     * @throws \RuntimeException When OpenRegister unavailable
+     */
+    public function receiveAdvice(string $adviceId, string $fileId): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            throw new \RuntimeException('OpenRegister is not available');
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('advies_aanvraag_schema');
+
+        if (empty($register) === true || empty($schema) === true) {
+            throw new \RuntimeException('Advice schema is not configured');
+        }
+
+        $update = [
+            'status'         => 'ontvangen',
+            'receivedAt'     => date('c'),
+        ];
+
+        if ($fileId !== '') {
+            $update['adviesDocument'] = $fileId;
+        }
+
+        try {
+            $advice = $objectService->saveObject($register, $schema, $update, $adviceId);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Procest: failed to mark advice received: '.$e->getMessage(),
+                ['app' => Application::APP_ID]
+            );
+            throw new \RuntimeException('Could not update advice request');
+        }
+
+        $current = $this->getUserId();
+        if ($current !== '') {
+            $this->sendUserNotification($current, 'advies_ontvangen', $adviceId);
+        }
+
+        return $this->normalizeResult($advice);
+    }//end receiveAdvice()
+
+    /**
+     * Send a reminder notification to the adviseur for an advice request.
+     *
+     * @param string $adviceId The advice UUID
+     *
+     * @return void
+     */
+    public function sendReminder(string $adviceId): void
+    {
+        $advice = $this->loadAdvice($adviceId);
+        if ($advice === null) {
+            return;
+        }
+
+        $adviseur = (string) ($advice['adviseur'] ?? '');
+        if ($adviseur === '') {
+            return;
+        }
+
+        $this->sendUserNotification($adviseur, 'advies_herinnering', $adviceId);
+    }//end sendReminder()
+
+    /**
+     * Get all advice requests for a case.
+     *
+     * @param string $caseId The case UUID
+     *
+     * @return array<int, array<string, mixed>> Advice records for the case
+     */
+    public function getAdviceForCase(string $caseId): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return [];
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('advies_aanvraag_schema');
+
+        if (empty($register) === true || empty($schema) === true) {
+            return [];
+        }
+
+        try {
+            $results = $objectService->findObjects(
+                $register,
+                $schema,
+                ['case' => $caseId],
+                [],
+                200,
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Procest: failed to fetch advice for case: '.$e->getMessage(),
+                ['app' => Application::APP_ID]
+            );
+            return [];
+        }
+
+        if (is_array($results) === true) {
+            return $results;
+        }
+
+        return [];
+    }//end getAdviceForCase()
+
+    /**
+     * Get pending advice (status=aangevraagd) for a case — used as workflow guard.
+     *
+     * @param string $caseId The case UUID
+     *
+     * @return array<int, array<string, mixed>> Pending advice records
+     */
+    public function checkGuard(string $caseId): array
+    {
+        $all     = $this->getAdviceForCase($caseId);
+        $pending = [];
+
+        foreach ($all as $advice) {
+            $status = (string) ($advice['status'] ?? '');
+            if ($status === 'aangevraagd') {
+                $pending[] = $advice;
+            }
+        }
+
+        return $pending;
+    }//end checkGuard()
+
+    /**
+     * Load all open advice requests across the system (for the deadline job).
+     *
+     * @return array<int, array<string, mixed>> Open advice records
+     */
+    public function getOpenAdvice(): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return [];
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('advies_aanvraag_schema');
+
+        if (empty($register) === true || empty($schema) === true) {
+            return [];
+        }
+
+        try {
+            $results = $objectService->findObjects(
+                $register,
+                $schema,
+                ['status' => 'aangevraagd'],
+                [],
+                500,
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Procest: failed to load open advice: '.$e->getMessage(),
+                ['app' => Application::APP_ID]
+            );
+            return [];
+        }
+
+        if (is_array($results) === true) {
+            return $results;
+        }
+
+        return [];
+    }//end getOpenAdvice()
+
+    /**
+     * Mark an advice request as expired (status -> verlopen).
+     *
+     * @param string $adviceId The advice UUID
+     *
+     * @return array<string, mixed> Updated advice record
+     */
+    public function expireAdvice(string $adviceId): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return [];
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('advies_aanvraag_schema');
+
+        if (empty($register) === true || empty($schema) === true) {
+            return [];
+        }
+
+        try {
+            $advice = $objectService->saveObject(
+                $register,
+                $schema,
+                ['status' => 'verlopen'],
+                $adviceId,
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Procest: failed to expire advice: '.$e->getMessage(),
+                ['app' => Application::APP_ID]
+            );
+            return [];
+        }
+
+        return $this->normalizeResult($advice);
+    }//end expireAdvice()
+
+    /**
+     * Load a single advice request by id.
+     *
+     * @param string $adviceId The advice UUID
+     *
+     * @return array<string, mixed>|null Advice data or null
+     */
+    private function loadAdvice(string $adviceId): ?array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return null;
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('advies_aanvraag_schema');
+
+        if (empty($register) === true || empty($schema) === true) {
+            return null;
+        }
+
+        try {
+            $advice = $objectService->findObject($register, $schema, $adviceId);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Procest: failed to load advice: '.$e->getMessage(),
+                ['app' => Application::APP_ID]
+            );
+            return null;
+        }
+
+        return $this->normalizeResult($advice);
+    }//end loadAdvice()
+
+    /**
+     * Convert an object/array result to an associative array.
+     *
+     * @param mixed $result The OpenRegister return value
+     *
+     * @return array<string, mixed> Normalized advice record
+     */
+    private function normalizeResult($result): array
+    {
+        if (is_array($result) === true) {
+            return $result;
+        }
+
+        if (is_object($result) === true && method_exists($result, 'jsonSerialize') === true) {
+            $data = $result->jsonSerialize();
+            if (is_array($data) === true) {
+                return $data;
+            }
+        }
+
+        return [];
+    }//end normalizeResult()
+
+    /**
+     * Resolve the current user id from session (never trust client-supplied user).
+     *
+     * @return string The current user UID or empty string
+     */
+    private function getUserId(): string
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return '';
+        }
+
+        return $user->getUID();
+    }//end getUserId()
+
+    /**
+     * Notify the adviseur (internal) about a new advice request.
+     *
+     * @param string $adviseur Adviseur identifier (UID for internal)
+     * @param string $caseId   The case UUID
+     * @param string $subject  Subject of the advice request
+     *
+     * @return void
+     */
+    private function notifyAdviseur(string $adviseur, string $caseId, string $subject): void
+    {
+        if ($adviseur === '') {
+            return;
+        }
+
+        $this->sendUserNotification($adviseur, 'advies_aangevraagd', $caseId, $subject);
+    }//end notifyAdviseur()
+
+    /**
+     * Send a Nextcloud notification to a user.
+     *
+     * @param string $userId   Recipient user UID
+     * @param string $subject  Notification subject key
+     * @param string $objectId The object UUID (case or advice)
+     * @param string $message  Additional message context
+     *
+     * @return void
+     */
+    private function sendUserNotification(
+        string $userId,
+        string $subject,
+        string $objectId,
+        string $message = '',
+    ): void {
+        try {
+            $notification = $this->notificationManager->createNotification();
+            $notification
+                ->setApp(Application::APP_ID)
+                ->setUser($userId)
+                ->setDateTime(new \DateTime())
+                ->setObject('advies', $objectId)
+                ->setSubject($subject, ['object' => $objectId]);
+
+            if ($message !== '') {
+                $notification->setMessage('plain', ['message' => $message]);
+            }
+
+            $this->notificationManager->notify($notification);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Procest: failed to send advice notification: '.$e->getMessage(),
+                ['app' => Application::APP_ID]
+            );
+        }
+    }//end sendUserNotification()
+}//end class

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -75,6 +75,7 @@ class SettingsService
         'inspectie_rapport_schema',
         'handhavingsactie_schema',
         'advies_aanvraag_schema',
+        'advice_reminder_days',
         'tenant_schema',
         'lhsMatrix',
     ];

--- a/lib/Settings/procest_register.json
+++ b/lib/Settings/procest_register.json
@@ -3386,6 +3386,82 @@
         "description": "Melding is afgehandeld",
         "archivalAction": "vernietigen",
         "archivalPeriod": "P1Y"
+      },
+      {
+        "@self": {
+          "register": "procest",
+          "schema": "adviesAanvraag",
+          "slug": "advies-welstand-2026-0042"
+        },
+        "case": "zaak-omgevingsvergunning-0042",
+        "adviseur": "welstandscommissie",
+        "type": "intern",
+        "onderwerp": "Welstandstoets gevelwijziging Keizersgracht 123",
+        "deadline": "2026-04-30",
+        "status": "aangevraagd",
+        "requestedAt": "2026-04-16T09:00:00+02:00",
+        "questions": "Voldoet de voorgestelde gevelwijziging aan het welstandsbeleid voor de historische binnenstad?"
+      },
+      {
+        "@self": {
+          "register": "procest",
+          "schema": "adviesAanvraag",
+          "slug": "advies-veiligheidsregio-2026-0038"
+        },
+        "case": "zaak-evenementenvergunning-0038",
+        "adviseur": "Veiligheidsregio Amsterdam-Amstelland",
+        "type": "extern",
+        "onderwerp": "Veiligheidsadvies evenement Museumplein 500+ bezoekers",
+        "deadline": "2026-04-25",
+        "status": "aangevraagd",
+        "requestedAt": "2026-04-10T14:30:00+02:00",
+        "questions": "Is de nooduitgang-capaciteit voldoende voor 500 bezoekers? Zijn er aanvullende EHBO-posten vereist?"
+      },
+      {
+        "@self": {
+          "register": "procest",
+          "schema": "adviesAanvraag",
+          "slug": "advies-rud-2026-0031"
+        },
+        "case": "zaak-milieumelding-0031",
+        "adviseur": "Regionale Uitvoeringsdienst Noord-Holland",
+        "type": "extern",
+        "onderwerp": "Milieukundig advies lozing grondwater bouwproject",
+        "deadline": "2026-03-28",
+        "status": "verlopen",
+        "requestedAt": "2026-03-07T10:00:00+01:00",
+        "questions": "Is lozing van het opgepompte grondwater toelaatbaar gezien de nabijgelegen watergang?"
+      },
+      {
+        "@self": {
+          "register": "procest",
+          "schema": "adviesAanvraag",
+          "slug": "advies-juridisch-2026-0055"
+        },
+        "case": "zaak-bezwaar-0055",
+        "adviseur": "juridische-dienst",
+        "type": "intern",
+        "onderwerp": "Juridische toets ontvankelijkheid bezwaarschrift",
+        "deadline": "2026-05-02",
+        "status": "ontvangen",
+        "requestedAt": "2026-04-11T08:45:00+02:00",
+        "receivedAt": "2026-04-15T16:20:00+02:00",
+        "questions": "Is het bezwaar tijdig ingediend en is de bezwaarmaker ontvankelijk?"
+      },
+      {
+        "@self": {
+          "register": "procest",
+          "schema": "adviesAanvraag",
+          "slug": "advies-brandweer-2026-0047"
+        },
+        "case": "zaak-bouwvergunning-0047",
+        "adviseur": "Brandweer Amsterdam-Amstelland",
+        "type": "extern",
+        "onderwerp": "Brandveiligheidsadvies transformatie kantoorpand naar woningen",
+        "deadline": "2026-05-14",
+        "status": "aangevraagd",
+        "requestedAt": "2026-04-14T11:00:00+02:00",
+        "questions": "Voldoet het vluchtrouteplan aan de eisen uit het Bouwbesluit 2012, art. 2.113 e.v.?"
       }
     ]
   }

--- a/src/services/adviceApi.js
+++ b/src/services/adviceApi.js
@@ -1,0 +1,101 @@
+/**
+ * Advice API service for Procest.
+ *
+ * Wraps the /api/advice endpoints for advice request (adviesAanvraag)
+ * management on cases. Uses @nextcloud/axios so CSRF tokens are attached
+ * automatically.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ */
+import axios from '@nextcloud/axios'
+import { generateUrl } from '@nextcloud/router'
+
+const APP_BASE = 'apps/procest/api/advice'
+
+/**
+ * Build the base URL for an advice endpoint.
+ *
+ * @param {string} path Optional sub-path (id or id/action)
+ * @return {string} Fully qualified Nextcloud URL
+ */
+function url(path = '') {
+	const suffix = path ? `/${path}` : ''
+	return generateUrl(`/${APP_BASE}${suffix}`)
+}
+
+/**
+ * Get advice requests for a case.
+ *
+ * @param {string} caseId Case UUID
+ * @return {Promise<Array>} List of advice records
+ */
+export async function getAdviceForCase(caseId) {
+	const response = await axios.get(url(), { params: { case: caseId } })
+	return response.data?.results || []
+}
+
+/**
+ * Create a new advice request.
+ *
+ * @param {object} data Advice payload (case, adviseur, type, ...)
+ * @return {Promise<object>} Created record
+ */
+export async function createAdvice(data) {
+	const response = await axios.post(url(), data)
+	return response.data
+}
+
+/**
+ * Get a single advice request.
+ *
+ * @param {string} id Advice UUID
+ * @return {Promise<object>} Advice record
+ */
+export async function getAdvice(id) {
+	const response = await axios.get(url(id))
+	return response.data
+}
+
+/**
+ * Update / mark received an advice request.
+ *
+ * @param {string} id   Advice UUID
+ * @param {object} data Update payload (adviesDocument, etc.)
+ * @return {Promise<object>} Updated record
+ */
+export async function updateAdvice(id, data) {
+	const response = await axios.put(url(id), data)
+	return response.data
+}
+
+/**
+ * Delete an advice request.
+ *
+ * @param {string} id Advice UUID
+ * @return {Promise<object>} Server confirmation
+ */
+export async function deleteAdvice(id) {
+	const response = await axios.delete(url(id))
+	return response.data
+}
+
+/**
+ * Send a manual reminder to the adviseur.
+ *
+ * @param {string} id Advice UUID
+ * @return {Promise<object>} Server confirmation
+ */
+export async function sendReminder(id) {
+	const response = await axios.post(url(`${id}/remind`))
+	return response.data
+}
+
+export default {
+	getAdviceForCase,
+	createAdvice,
+	getAdvice,
+	updateAdvice,
+	deleteAdvice,
+	sendReminder,
+}

--- a/src/views/cases/components/AdviesAanvraagDialog.vue
+++ b/src/views/cases/components/AdviesAanvraagDialog.vue
@@ -1,0 +1,186 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- SPDX-FileCopyrightText: 2026 Conduction B.V. -->
+<template>
+	<NcDialog
+		:name="t(appName, 'Advies aanvragen')"
+		size="normal"
+		@closing="$emit('close')">
+		<div class="advies-dialog">
+			<div class="advies-dialog__row">
+				<label>{{ t(appName, 'Type advies') }}</label>
+				<div class="advies-dialog__type-toggle">
+					<NcButton
+						:type="form.type === 'intern' ? 'primary' : 'secondary'"
+						@click="form.type = 'intern'">
+						{{ t(appName, 'Intern') }}
+					</NcButton>
+					<NcButton
+						:type="form.type === 'extern' ? 'primary' : 'secondary'"
+						@click="form.type = 'extern'">
+						{{ t(appName, 'Extern') }}
+					</NcButton>
+				</div>
+			</div>
+
+			<NcTextField
+				v-model="form.adviseur"
+				:label="form.type === 'intern' ? t(appName, 'Adviseur (gebruiker)') : t(appName, 'Adviseur (organisatie)')"
+				:placeholder="form.type === 'intern' ? 'gebruikersnaam' : 'Naam organisatie'" />
+
+			<NcTextField
+				v-model="form.onderwerp"
+				:label="t(appName, 'Onderwerp')" />
+
+			<NcTextField
+				v-model="form.deadline"
+				type="date"
+				:label="t(appName, 'Deadline')" />
+
+			<label class="advies-dialog__textarea-label">
+				{{ t(appName, 'Specifieke vragen') }}
+				<textarea
+					v-model="form.questions"
+					class="advies-dialog__textarea"
+					rows="4"
+					:placeholder="t(appName, 'Optioneel — beschrijf welke vragen je beantwoord wilt zien.')" />
+			</label>
+
+			<p v-if="errorMessage" class="advies-dialog__error">
+				{{ errorMessage }}
+			</p>
+		</div>
+
+		<template #actions>
+			<NcButton type="tertiary" @click="$emit('close')">
+				{{ t(appName, 'Annuleren') }}
+			</NcButton>
+			<NcButton
+				type="primary"
+				:disabled="!canSubmit || submitting"
+				@click="submit">
+				{{ t(appName, 'Aanvragen') }}
+			</NcButton>
+		</template>
+	</NcDialog>
+</template>
+
+<script>
+import { NcButton, NcDialog, NcTextField } from '@nextcloud/vue'
+import { createAdvice } from '../../../services/adviceApi.js'
+
+const APP_NAME = 'procest'
+
+/**
+ * Build a default deadline date 14 days from today (ISO YYYY-MM-DD).
+ *
+ * @return {string} ISO date string
+ */
+function defaultDeadline() {
+	const date = new Date()
+	date.setDate(date.getDate() + 14)
+	return date.toISOString().substring(0, 10)
+}
+
+export default {
+	name: 'AdviesAanvraagDialog',
+	components: {
+		NcButton,
+		NcDialog,
+		NcTextField,
+	},
+	props: {
+		caseId: {
+			type: String,
+			required: true,
+		},
+	},
+	emits: ['close', 'created'],
+	data() {
+		return {
+			appName: APP_NAME,
+			submitting: false,
+			errorMessage: '',
+			form: {
+				type: 'intern',
+				adviseur: '',
+				onderwerp: '',
+				deadline: defaultDeadline(),
+				questions: '',
+			},
+		}
+	},
+	computed: {
+		canSubmit() {
+			return this.form.adviseur.trim() !== '' && this.form.deadline !== ''
+		},
+	},
+	methods: {
+		async submit() {
+			if (!this.canSubmit) {
+				return
+			}
+			this.submitting = true
+			this.errorMessage = ''
+			try {
+				const payload = {
+					case: this.caseId,
+					type: this.form.type,
+					adviseur: this.form.adviseur.trim(),
+					onderwerp: this.form.onderwerp.trim(),
+					deadline: this.form.deadline,
+					questions: this.form.questions.trim(),
+				}
+				await createAdvice(payload)
+				this.$emit('created')
+			} catch (error) {
+				console.error('Procest: failed to create advice', error)
+				this.errorMessage = this.t(this.appName, 'Aanmaken van advies is mislukt. Probeer het opnieuw.')
+			} finally {
+				this.submitting = false
+			}
+		},
+	},
+}
+</script>
+
+<style scoped>
+.advies-dialog {
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+	padding: 0.5rem 0;
+}
+
+.advies-dialog__row {
+	display: flex;
+	flex-direction: column;
+	gap: 0.25rem;
+}
+
+.advies-dialog__type-toggle {
+	display: flex;
+	gap: 0.5rem;
+}
+
+.advies-dialog__textarea-label {
+	display: flex;
+	flex-direction: column;
+	gap: 0.25rem;
+	font-weight: 500;
+}
+
+.advies-dialog__textarea {
+	width: 100%;
+	border: 1px solid var(--color-border, #d0d0d0);
+	border-radius: var(--border-radius, 4px);
+	padding: 0.5rem;
+	font-family: inherit;
+	background: var(--color-main-background, #fff);
+	color: var(--color-main-text, #000);
+}
+
+.advies-dialog__error {
+	color: var(--color-error, #d94343);
+	margin: 0;
+}
+</style>

--- a/src/views/cases/components/AdviesPanel.vue
+++ b/src/views/cases/components/AdviesPanel.vue
@@ -1,0 +1,273 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- SPDX-FileCopyrightText: 2026 Conduction B.V. -->
+<template>
+	<div class="advies-panel">
+		<div class="advies-panel__header">
+			<h3 class="advies-panel__title">
+				{{ t(appName, 'Adviezen') }}
+			</h3>
+			<NcButton type="primary" @click="openCreateDialog">
+				{{ t(appName, 'Advies aanvragen') }}
+			</NcButton>
+		</div>
+
+		<NcLoadingIcon v-if="loading" :size="32" />
+
+		<CnEmptyState
+			v-else-if="advies.length === 0"
+			:name="t(appName, 'Geen adviezen aangevraagd')"
+			:description="t(appName, 'Vraag advies aan bij interne of externe partijen om hier te tonen.')" />
+
+		<ul v-else class="advies-panel__list">
+			<li
+				v-for="item in advies"
+				:key="item.id || item.uuid"
+				class="advies-panel__item"
+				:class="{ 'advies-panel__item--overdue': isOverdue(item) }">
+				<div class="advies-panel__row">
+					<div class="advies-panel__meta">
+						<strong>{{ item.adviseur }}</strong>
+						<CnStatusBadge :status="typeLabel(item.type)" :type="typeBadgeType(item.type)" />
+						<CnStatusBadge :status="statusLabel(item.status)" :type="statusBadgeType(item.status)" />
+					</div>
+					<div class="advies-panel__deadline">
+						<template v-if="isOverdue(item)">
+							{{ t(appName, '{days} dagen te laat', { days: daysOverdue(item) }) }}
+						</template>
+						<template v-else-if="item.deadline">
+							{{ t(appName, 'Deadline: {date}', { date: formatDate(item.deadline) }) }}
+						</template>
+					</div>
+				</div>
+				<p v-if="item.onderwerp" class="advies-panel__subject">
+					{{ item.onderwerp }}
+				</p>
+				<div class="advies-panel__actions">
+					<NcButton
+						v-if="item.status === 'aangevraagd'"
+						type="secondary"
+						@click="onRemind(item)">
+						{{ t(appName, 'Herinnering sturen') }}
+					</NcButton>
+					<NcButton
+						v-if="item.status === 'aangevraagd' && item.adviesDocument"
+						type="secondary"
+						@click="onMarkReceived(item)">
+						{{ t(appName, 'Markeer als ontvangen') }}
+					</NcButton>
+					<NcButton
+						v-if="item.status === 'ontvangen' && item.adviesDocument"
+						type="tertiary"
+						@click="onViewDocument(item)">
+						{{ t(appName, 'Bekijk advies') }}
+					</NcButton>
+				</div>
+			</li>
+		</ul>
+
+		<AdviesAanvraagDialog
+			v-if="showDialog"
+			:case-id="caseId"
+			@close="showDialog = false"
+			@created="onCreated" />
+	</div>
+</template>
+
+<script>
+import { NcButton, NcLoadingIcon } from '@nextcloud/vue'
+import { CnEmptyState, CnStatusBadge } from '@conduction/nextcloud-vue'
+import {
+	getAdviceForCase,
+	sendReminder,
+	updateAdvice,
+} from '../../../services/adviceApi.js'
+import AdviesAanvraagDialog from './AdviesAanvraagDialog.vue'
+
+const APP_NAME = 'procest'
+
+export default {
+	name: 'AdviesPanel',
+	components: {
+		NcButton,
+		NcLoadingIcon,
+		CnEmptyState,
+		CnStatusBadge,
+		AdviesAanvraagDialog,
+	},
+	props: {
+		caseId: {
+			type: String,
+			required: true,
+		},
+	},
+	data() {
+		return {
+			appName: APP_NAME,
+			advies: [],
+			loading: false,
+			showDialog: false,
+		}
+	},
+	watch: {
+		caseId: {
+			immediate: true,
+			handler(value) {
+				if (value) {
+					this.fetchAdvies()
+				}
+			},
+		},
+	},
+	methods: {
+		async fetchAdvies() {
+			this.loading = true
+			try {
+				this.advies = await getAdviceForCase(this.caseId)
+			} catch (error) {
+				console.error('Procest: failed to load advice', error)
+				this.advies = []
+			} finally {
+				this.loading = false
+			}
+		},
+		openCreateDialog() {
+			this.showDialog = true
+		},
+		onCreated() {
+			this.showDialog = false
+			this.fetchAdvies()
+		},
+		async onRemind(item) {
+			try {
+				await sendReminder(item.id || item.uuid)
+			} catch (error) {
+				console.error('Procest: failed to send reminder', error)
+			}
+		},
+		async onMarkReceived(item) {
+			try {
+				await updateAdvice(item.id || item.uuid, {
+					adviesDocument: item.adviesDocument || '',
+				})
+				await this.fetchAdvies()
+			} catch (error) {
+				console.error('Procest: failed to mark received', error)
+			}
+		},
+		onViewDocument(item) {
+			if (item.adviesDocument) {
+				window.open(`/index.php/f/${item.adviesDocument}`, '_blank')
+			}
+		},
+		typeLabel(type) {
+			return type === 'intern'
+				? this.t(this.appName, 'Intern')
+				: this.t(this.appName, 'Extern')
+		},
+		typeBadgeType(type) {
+			return type === 'intern' ? 'neutral' : 'info'
+		},
+		statusLabel(status) {
+			const labels = {
+				aangevraagd: this.t(this.appName, 'Aangevraagd'),
+				ontvangen: this.t(this.appName, 'Ontvangen'),
+				verlopen: this.t(this.appName, 'Verlopen'),
+			}
+			return labels[status] || status
+		},
+		statusBadgeType(status) {
+			const types = {
+				aangevraagd: 'info',
+				ontvangen: 'success',
+				verlopen: 'error',
+			}
+			return types[status] || 'neutral'
+		},
+		isOverdue(item) {
+			if (item.status !== 'aangevraagd' || !item.deadline) {
+				return false
+			}
+			return new Date(item.deadline) < new Date()
+		},
+		daysOverdue(item) {
+			if (!item.deadline) {
+				return 0
+			}
+			const diff = Date.now() - new Date(item.deadline).getTime()
+			return Math.max(0, Math.floor(diff / (1000 * 60 * 60 * 24)))
+		},
+		formatDate(value) {
+			if (!value) {
+				return ''
+			}
+			try {
+				return new Date(value).toLocaleDateString('nl-NL')
+			} catch (error) {
+				return value
+			}
+		},
+	},
+}
+</script>
+
+<style scoped>
+.advies-panel {
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+	padding: 1rem;
+}
+
+.advies-panel__header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+}
+
+.advies-panel__list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+}
+
+.advies-panel__item {
+	border: 1px solid var(--color-border, #d0d0d0);
+	border-radius: var(--border-radius-large, 8px);
+	padding: 0.75rem 1rem;
+	background: var(--color-main-background, #fff);
+}
+
+.advies-panel__item--overdue {
+	border-color: var(--color-error, #d94343);
+	background: var(--color-error-hover, #fdecec);
+}
+
+.advies-panel__row {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.5rem;
+	flex-wrap: wrap;
+}
+
+.advies-panel__meta {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	flex-wrap: wrap;
+}
+
+.advies-panel__subject {
+	margin: 0.25rem 0 0.5rem 0;
+	color: var(--color-text-maxcontrast, #555);
+}
+
+.advies-panel__actions {
+	display: flex;
+	gap: 0.5rem;
+	flex-wrap: wrap;
+}
+</style>


### PR DESCRIPTION
## Summary

Applies the `advice-management` openspec change to procest.

- Backend: `AdviceService`, `AdviceController`, `AdviceDeadlineJob` daily cron
- REST routes under `/api/advice` (GET / POST / PUT / DELETE / POST remind)
- Frontend: `src/services/adviceApi.js`, `AdviesPanel.vue`, `AdviesAanvraagDialog.vue`
- 5 Dutch seed `adviesAanvraag` objects in `procest_register.json`
- New `advice_reminder_days` config key in `SettingsService`

Spec: `openspec/changes/advice-management/`

## Test plan

- [ ] `php -l` clean on AdviceService / AdviceController / AdviceDeadlineJob (verified locally)
- [ ] `jq .` clean on `lib/Settings/procest_register.json` (verified locally)
- [ ] Re-import register: 5 advice seed objects appear and slug-based re-import is idempotent
- [ ] Manual: open a case detail, `AdviesPanel` renders empty state -> request advice via dialog -> appears in list
- [ ] Manual: `occ background-job:execute` for `OCA\Procest\BackgroundJob\AdviceDeadlineJob` expires overdue advice and sends reminders 3 days out