### PR TITLE
chore(openspec): generate status-transition-engine spec

### DIFF
--- a/openspec/changes/status-transition-engine/design.md
+++ b/openspec/changes/status-transition-engine/design.md
@@ -1,0 +1,137 @@
+# Design: status-transition-engine
+
+## Architecture Overview
+
+The status-transition engine is a runtime component that turns the static rules carried by `workflowTemplate` (see `workflow-definition-model` spec) into deterministic case state changes. It is the **single write path** for `case.status` across Procest: the REST API, the case detail UI, and the bezwaar / parafering / VTH workflow specs all funnel transitions through `StatusTransitionService::execute()`.
+
+```
+CaseDetail.vue
+└── AvailableTransitionsPanel.vue (renders the transitions list from API; disables buttons whose guards fail; tooltips)
+    └── TransitionConfirmDialog.vue (label, target status, side-effect summary, confirm/cancel)
+
+REST: /api/case/{id}/available-transitions, /api/case/{id}/transition, /api/case/{id}/transition-history
+└── StatusTransitionController
+    └── StatusTransitionService (engine)
+        ├── WorkflowTemplateLoader (loads & caches active template per caseType)
+        ├── GuardRegistry
+        │   ├── ChecklistGuard
+        │   ├── RequiredFieldGuard
+        │   ├── RequiredDocumentGuard
+        │   └── RoleGuard
+        ├── SideEffectDispatcher
+        │   ├── SendEmailHandler          → NotificatieService
+        │   ├── CreateTaskHandler         → TasksController
+        │   ├── CreateSubCaseHandler      → ZgwService
+        │   ├── WebhookHandler            → HTTP client
+        │   ├── SetFieldHandler           → ObjectService
+        │   └── NotifyHandler             → NotificatieService
+        └── TransitionLogger              → statusRecord + case.auditTrail
+```
+
+## File Map
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `lib/Service/StatusTransitionService.php` | Engine core: `getAvailableTransitions`, `evaluateGuards`, `execute`, `replay`. Deterministic, no controller deps. |
+| `lib/Service/WorkflowTemplateLoader.php` | Loads active `workflowTemplate` per `caseType`; decodes `transitions[]`, `steps[]`; in-memory cache per request. |
+| `lib/Service/Transitions/GuardRegistry.php` | Strategy-pattern registry mapping guard `type` → `GuardEvaluatorInterface` implementations. |
+| `lib/Service/Transitions/GuardEvaluatorInterface.php` | Interface: `evaluate(array $guardConfig, array $case): GuardResult`. |
+| `lib/Service/Transitions/ChecklistGuard.php` | Evaluates `task.checklist` completion against required items. |
+| `lib/Service/Transitions/RequiredFieldGuard.php` | Evaluates `case.{field}` non-empty against guard's required field list. |
+| `lib/Service/Transitions/RequiredDocumentGuard.php` | Evaluates `case` document attachments against required document types. |
+| `lib/Service/Transitions/RoleGuard.php` | Evaluates current user's role on the case against `allowedRoles[]`. |
+| `lib/Service/Transitions/SideEffectDispatcher.php` | Dispatches `automaticActions[]` post-transition; per-action try/catch; collects results. |
+| `lib/Service/Transitions/ActionHandlerInterface.php` | Interface: `handle(array $actionConfig, array $case, array $transitionContext): ActionResult`. |
+| `lib/Service/Transitions/SendEmailHandler.php` | `sendEmail` action handler → `NotificatieService`. |
+| `lib/Service/Transitions/CreateTaskHandler.php` | `createTask` action handler → existing tasks service. |
+| `lib/Service/Transitions/WebhookHandler.php` | `webhook` action handler — outbound HTTP POST with case payload. |
+| `lib/Service/Transitions/SetFieldHandler.php` | `setField` action handler — writes named field on the case. |
+| `lib/Service/Transitions/NotifyHandler.php` | `notify` action handler → in-app Nextcloud notification. |
+| `lib/Service/Transitions/CreateSubCaseHandler.php` | `createSubCase` action handler → `ZgwService` deelzaak create. |
+| `lib/Controller/StatusTransitionController.php` | REST: list available transitions, execute, replay history. |
+| `src/views/cases/components/AvailableTransitionsPanel.vue` | Lists guard-evaluated transitions on case detail. |
+| `src/views/cases/components/TransitionConfirmDialog.vue` | Confirm transition, show side-effects summary. |
+| `src/services/statusTransitionApi.js` | Frontend API client. |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `lib/Settings/procest_register.json` | Add optional fields to `statusRecord`: `transitionLabel` (string), `evaluatedGuards` (array — guard result snapshots), `dispatchedActions` (array — per-action result snapshots), `fromStatus` (string, format uuid), `noWorkflowTemplate` (boolean). |
+| `lib/Service/ZgwZrcRulesService.php` | Slim down `rulesStatussenCreate` to ZGW-spec validation only; delegate the actual transition to `StatusTransitionService::execute`. Move zrc-007 logic into a registered side-effect handler. |
+| `lib/Controller/ZrcController.php` | Replace `handleEindstatusEffect()` inline logic with `StatusTransitionService::execute()` call. |
+| `lib/Service/SettingsService.php` | Add `status_record_schema` config key (already may exist as `statusRecord` slug — verify). |
+| `appinfo/routes.php` | Add status-transition routes (see below). |
+| `src/views/cases/CaseDetail.vue` | Embed `AvailableTransitionsPanel`. |
+
+## API Surface
+
+```
+GET  /api/case/{caseId}/available-transitions
+     → { transitions: [{id, label, toStatus, guardsPassed: bool, failedGuards: [...]}], current: {statusId, statusName} }
+
+POST /api/case/{caseId}/transition
+     body: { transitionId: <uuid>, comment?: <string> }
+     → { status: 'ok', statusRecord: {...}, dispatchedActions: [...] }
+     → 409 if guards fail; 403 if role not allowed; 404 if no such transition
+
+GET  /api/case/{caseId}/transition-history
+     → { history: [{ statusRecord }, ...], replayable: true }
+```
+
+## Atomicity & Failure Model
+
+1. `execute()` first re-evaluates all guards (defence in depth — UI may be stale).
+2. `case.status` update + `statusRecord` write happen within one OpenRegister save flow. If either fails, the transition aborts with no partial state.
+3. After successful status write, side-effects dispatch **sequentially in declaration order**. Each handler returns `ActionResult { ok: bool, error?: string }`.
+4. Failed side-effects are logged to `statusRecord.dispatchedActions[].error` with full context and surfaced via notification to the case owner — they do NOT roll back the status change (per existing `status-transition-engine/spec.md` REQ-Transition Execution scenario).
+5. Replay reads the `statusRecord` chain in chronological order and reconstructs the state-progression view; it does NOT re-fire side-effects.
+
+## Guard Evaluation Model
+
+Each guard config is a `{type, ...config}` object:
+
+| Guard Type | Config Shape | Pass Condition |
+|------------|--------------|----------------|
+| `checklist` | `{taskId, requiredItems: [...]}` | All required checklist items on linked task are `checked: true` |
+| `requiredField` | `{field: 'resultaat'}` | `case[field]` is non-empty (not null, not `""`, not `[]`) |
+| `requiredDocument` | `{documentType: 'Besluit'}` | At least one document linked to the case has matching type |
+| `roleGuard` | `{allowedRoles: ['Afdelingshoofd']}` | Current user has at least one matching role on this case |
+
+Guards combine **conjunctively** — all must pass. Result includes a per-guard pass/fail breakdown so the UI can render specific error messages (e.g. "1 checklistitem niet afgevinkt: 'Besluit opgesteld'").
+
+## Storage of Transition History
+
+The engine writes one `statusRecord` per executed transition. Required fields on `statusRecord` (from ADR-000) plus engine additions:
+
+- `case` (existing)
+- `statusType` → toStatus (existing)
+- `description` → free-form comment (existing)
+- `transitionLabel` (NEW) — copied from workflowTemplate transition `label`
+- `fromStatus` (NEW, optional) — UUID of the prior `statusType`; absent on first set
+- `evaluatedGuards` (NEW) — JSON-encoded `[{type, passed, details}]`
+- `dispatchedActions` (NEW) — JSON-encoded `[{type, ok, error?}]`
+- `noWorkflowTemplate` (NEW, optional) — `true` for admin free-form transitions on caseTypes lacking an active workflow
+
+Replay = `findObjects(register, statusRecordSchema, { case: $caseId, orderBy: createdAt asc })`. Cases also keep their `auditTrail` (OpenRegister built-in) for the same events, with the `statusRecord.uuid` as cross-reference.
+
+## Integration with bezwaar-lifecycle and parafeerroute-engine
+
+These specs **consume** the engine rather than reimplementing transition logic:
+
+- `bezwaar-lifecycle` registers a `createSubCase` side-effect when the primary bezwaar status transitions to `In behandeling` (creates the advisory case linked to the parent).
+- `parafeerroute-engine` registers a `notify` side-effect on `voorstel.status` transitions to dispatch step-activation notifications. (Note: voorstel status is currently a string lifecycle, not a `statusType` — engine SHALL emit hook events both for `case.status` *and* a configurable list of typed entities so parafering can plug in. V2 may unify these.)
+
+Both specs subscribe through DI service tagging (`'procest.transition_side_effect_handler'`); the engine has no compile-time knowledge of either downstream consumer.
+
+## Backfill Strategy
+
+`ZgwZrcRulesService` shrinks to **pure ZGW Zaken API validation**:
+
+- `zrc-016` (statustype belongs to zaaktype) — stays as request-shape validation.
+- `zrc-007` (eindstatus afsluiten — set `einddatum`, snapshot resultaat) — moves to `SetFieldHandler` actions registered on the bezwaar/standard workflow templates.
+- `zrc-022` (archiefstatus transition rules) — registered as `RequiredFieldGuard` on the `Afgehandeld → Gearchiveerd` transition for archived case types.
+
+The legacy methods stay (now just validation) so the ZGW API contract is preserved; behaviour changes only by gaining audit-log entries.

--- a/openspec/changes/status-transition-engine/hydra.json
+++ b/openspec/changes/status-transition-engine/hydra.json
@@ -1,0 +1,8 @@
+{
+  "spec_slug": "status-transition-engine",
+  "title": "Status Transition Engine",
+  "app": "procest",
+  "repo": "https://github.com/ConductionNL/procest",
+  "depends_on": ["workflow-definition-model"],
+  "issue": null
+}

--- a/openspec/changes/status-transition-engine/proposal.md
+++ b/openspec/changes/status-transition-engine/proposal.md
@@ -1,0 +1,56 @@
+# Proposal: Status Transition Engine
+
+## Summary
+
+Implement a generic status-transition engine in Procest that drives every case through its statuses based on the `workflowTemplate` (defined by the sibling spec `workflow-definition-model`). The engine evaluates guards, enforces role-based authorisation, executes transitions atomically, dispatches side-effects (automatic actions), and writes a replayable audit log. It becomes the single write path for `case.status` — replacing scattered logic in `ZgwZrcRulesService` and `ZrcController`.
+
+## Problem
+
+Today status transitions live in ad-hoc PHP services. `ZgwZrcRulesService::rulesStatussenCreate` only checks the ZGW `statustype` reference; nothing enforces which status can move to which, who is allowed to make the move, or what side-effects should fire. The `workflowTemplate` schema already carries rich transition rules (guards, allowedRoles, automaticActions) but no runtime consumes them. We need a generic engine that turns workflow-definition data into deterministic runtime behaviour, surfaced uniformly to UI, REST, and the future visual workflow editor.
+
+## Affected Projects
+
+- [ ] Project: `procest` — Add `StatusTransitionService` (engine), `StatusTransitionController`, guard registry, side-effect dispatcher, transition-history fields on `statusRecord`; backfill `ZgwZrcRulesService` legacy rules into the engine; surface available transitions on case detail.
+
+## Scope
+
+### In Scope (V1)
+
+- **Transition Rule Consumer** (REQ-STE-1): Parse `workflowTemplate.transitions` into runtime rules indexed by `caseType` + `fromStatus`.
+- **Guard Registry & Evaluation** (REQ-STE-2): Pluggable `checklist`, `requiredField`, `requiredDocument`, `roleGuard` evaluators; conjunctive evaluation.
+- **Available Transitions** (REQ-STE-3): Compute the set allowed for the current user; expose via `GET /api/case/{id}/available-transitions`.
+- **Atomic Execution** (REQ-STE-4): Single write path that updates `case.status`, writes a `statusRecord`, and survives partial side-effect failures.
+- **Side-Effect Dispatcher** (REQ-STE-5): Map `automaticActions` (`sendEmail`, `createTask`, `createSubCase`, `webhook`, `setField`, `notify`) to existing services; failed actions logged, not rolled back.
+- **Audit Log & Replay** (REQ-STE-6): Every transition writes a `statusRecord` with `fromStatus`, `toStatus`, `transitionLabel`, `evaluatedGuards`, `dispatchedActions`; replay via `GET /api/case/{id}/transition-history`.
+- **REST Controller** (REQ-STE-7): Endpoints for listing, executing, replaying.
+- **Backfill** (REQ-STE-8): Migrate zrc-007 (eindstatus afsluiten), zrc-022 (archiefstatus) into engine-evaluated actions/guards; preserve ZGW API contract.
+- **Integration Hooks** (REQ-STE-9): `bezwaar-lifecycle` and `parafeerroute-engine` register side-effect handlers via DI tagging.
+- **No-Workflow Fallback** (REQ-STE-10): Admin free-form transitions on caseTypes without a workflow, flagged on the `statusRecord`.
+
+### Out of Scope
+
+- Visual workflow editor canvas (spec `visual-workflow-editor`).
+- Parallel/branching transitions (CMMN gateways) — V2.
+- Time-based / scheduled transitions — V2.
+- Workflow versioning migrations for in-flight cases — separate change.
+
+## Approach
+
+1. Reuse existing entities (`case`, `statusType`, `statusRecord`, `workflowTemplate`); add optional fields to `statusRecord` (`transitionLabel`, `fromStatus`, `evaluatedGuards`, `dispatchedActions`, `noWorkflowTemplate`).
+2. `StatusTransitionService.php` is the deterministic core — methods `getAvailableTransitions`, `execute`, `executeFreeForm`, `replay`.
+3. Guards via `GuardEvaluatorInterface` strategy pattern; side-effects via `ActionHandlerInterface`; both registered through DI so downstream specs plug in without touching the engine.
+4. Slim `ZgwZrcRulesService` down to ZGW spec validation; route the actual mutation through the engine.
+5. Frontend: `AvailableTransitionsPanel` + `TransitionConfirmDialog` embedded in `CaseDetail.vue`.
+
+## Cross-Project Dependencies
+
+- **`workflow-definition-model`** (procest, in flight): Provides the `transitions[]`, `automaticActions[]`, `allowedRoles[]` schema the engine consumes.
+- **OpenRegister**: `statusRecord`, `case`, `workflowTemplate`, `statusType` storage; built-in `auditTrail` and `relations`.
+- **`NotificatieService`** (platform): backs `sendEmail` and `notify` action handlers.
+- **`TasksController`** (procest): backs `createTask`.
+- **`bezwaar-lifecycle` / `parafeerroute-engine`**: consume the engine — register side-effect handlers via DI tagging.
+
+## Constraints
+
+- Depends on `workflow-definition-model` (transitions JSON shape must be in place before the engine can consume it).
+- Backfill of `ZgwZrcRulesService` MUST preserve the ZGW Zaken API contract; only behaviour change is the added audit-log entry.

--- a/openspec/changes/status-transition-engine/specs/status-transition-engine/spec.md
+++ b/openspec/changes/status-transition-engine/specs/status-transition-engine/spec.md
@@ -1,0 +1,276 @@
+---
+status: draft
+---
+# status-transition-engine Specification
+
+## Purpose
+
+Implement the runtime engine that drives every Procest case through its statuses based on the workflow-definition data model. The engine reads `workflowTemplate.transitions[]`, evaluates guards, enforces role-based authorisation, executes transitions atomically, dispatches configured side-effects (automatic actions), and writes a replayable audit log. It is the single write path for `case.status` across the application: the REST API, the case detail UI, and the bezwaar / parafering / VTH workflow specs all funnel transitions through `StatusTransitionService::execute()`.
+
+## Context
+
+The `workflow-definition-model` spec defined the data shape of workflow templates: ordered steps, transitions with `fromStatus`/`toStatus`/`label`/`guards`/`automaticActions`/`allowedRoles`. Today no Procest service consumes those transitions at runtime — status changes happen through scattered hand-coded paths in `ZgwZrcRulesService` and `ZrcController`, with no guard enforcement, no automatic actions, and inconsistent `statusRecord` writes. This change closes that gap by introducing a single engine that turns workflow-definition data into deterministic runtime behaviour, surfaced uniformly to UI, REST, and the future visual workflow editor.
+
+## Requirements
+
+---
+
+### REQ-STE-1: Transition Rule Consumption
+
+The system SHALL load the active `workflowTemplate` for a case's `caseType` and parse its `transitions[]` JSON into runtime-usable rule objects, indexed by `fromStatus`. Only the workflow template with `isActive: true` for the given `caseType` SHALL be consulted; draft and inactive templates SHALL be ignored at runtime.
+
+**Feature tier**: V1
+
+#### REQ-STE-1-001: Load active workflow template
+
+- **GIVEN** a `caseType` with two `workflowTemplate` objects: `version 1, isActive: false` and `version 2, isActive: true, isDraft: false`
+- **WHEN** the engine is asked for available transitions on a case of that type
+- **THEN** the engine SHALL load `version 2` only
+- **AND** the engine SHALL decode `transitions` and `steps` from JSON
+- **AND** `version 1`'s transitions SHALL NOT be considered
+
+#### REQ-STE-1-002: No active template falls through to free-form
+
+- **GIVEN** a `caseType` with no `workflowTemplate` where `isActive: true`
+- **WHEN** the engine is asked for available transitions
+- **THEN** the engine SHALL return an empty list of guided transitions
+- **AND** admins SHALL retain the ability to set any non-final `statusType` of that case type via the free-form endpoint
+
+---
+
+### REQ-STE-2: Guard Registry and Evaluation
+
+The system SHALL evaluate every guard declared on a transition before allowing the transition to proceed. Guard types `checklist`, `requiredField`, `requiredDocument`, and `roleGuard` SHALL be supported in V1. Guards combine conjunctively: ALL guards must pass for the transition to be available. Guard evaluation SHALL be deterministic and side-effect-free.
+
+**Feature tier**: V1
+
+#### REQ-STE-2-001: All guards pass
+
+- **GIVEN** a transition with one `requiredField` guard on `resultaat` and one `roleGuard` allowing `Behandelaar`
+- **AND** the case has `resultaat: "Toegekend"`
+- **AND** the current user has role `Behandelaar` on the case
+- **WHEN** the engine evaluates guards
+- **THEN** the transition SHALL be reported as `guardsPassed: true`
+- **AND** `failedGuards` SHALL be empty
+
+#### REQ-STE-2-002: Single guard fails — transition unavailable
+
+- **GIVEN** a transition with a `checklist` guard requiring 5 items completed
+- **AND** the case has only 4 of 5 items checked
+- **WHEN** the engine evaluates guards
+- **THEN** the transition SHALL be reported as `guardsPassed: false`
+- **AND** `failedGuards` SHALL contain one entry: `{type: 'checklist', failureMessage: "1 checklistitem niet afgevinkt: 'Besluit opgesteld'"}`
+
+#### REQ-STE-2-003: Role guard hides transition
+
+- **GIVEN** a transition restricted to role `Afdelingshoofd`
+- **AND** the current user has role `Behandelaar`
+- **WHEN** the engine computes available transitions for this user
+- **THEN** the transition SHALL NOT appear in the returned list
+- **AND** the failure SHALL be recorded with `details.silent: true` so the UI does not render a disabled button for it
+
+#### REQ-STE-2-004: Required document guard
+
+- **GIVEN** a transition with a `requiredDocument` guard for type `Besluit`
+- **AND** the case has no document of type `Besluit` attached
+- **WHEN** the engine evaluates guards
+- **THEN** the transition SHALL be reported `guardsPassed: false`
+- **AND** the failure message SHALL be "Vereist document ontbreekt: Besluit"
+
+---
+
+### REQ-STE-3: Available Transitions Computation
+
+The system SHALL compute, for any given case and user, the set of transitions whose `fromStatus` matches the case's current `status`, whose `roleGuard` admits the user, and whose remaining guards (besides RoleGuard) are evaluated and reported with pass/fail breakdown.
+
+**Feature tier**: V1
+
+#### REQ-STE-3-001: List available transitions on case detail
+
+- **GIVEN** a case in status `In behandeling` for a caseType whose active workflow defines two transitions from `In behandeling`: `Goedkeuren` (RoleGuard: `Afdelingshoofd`) and `Terugsturen` (no role guard)
+- **WHEN** a user with role `Behandelaar` opens the case detail
+- **THEN** the API SHALL return `transitions: [{id: <terugsturenId>, label: "Terugsturen", toStatus: <uuid>, guardsPassed: true, failedGuards: []}]`
+- **AND** `Goedkeuren` SHALL NOT appear in the response
+
+#### REQ-STE-3-002: Final status — no transitions
+
+- **GIVEN** a case in a status with `isFinal: true`
+- **WHEN** any user requests available transitions
+- **THEN** the API SHALL return `transitions: []`
+- **AND** the UI SHALL indicate "Zaak is afgehandeld"
+
+---
+
+### REQ-STE-4: Atomic Transition Execution
+
+The system SHALL execute status transitions atomically: case status update, `statusRecord` creation, and `case.auditTrail` append happen as a single logical operation. Guard re-evaluation SHALL occur server-side as defence in depth; UI guard checks SHALL NOT be trusted.
+
+**Feature tier**: V1
+
+#### REQ-STE-4-001: Successful transition writes a statusRecord
+
+- **GIVEN** a case in status `In behandeling`
+- **WHEN** the case handler executes transition `Afronden` to `Afgehandeld` via `POST /api/case/{id}/transition`
+- **THEN** `case.status` SHALL be updated to the `Afgehandeld` `statusType` UUID
+- **AND** a `statusRecord` SHALL be created with `case`, `statusType` (toStatus), `fromStatus`, `transitionLabel: "Afronden"`, `description` (optional comment), `evaluatedGuards`, `dispatchedActions`, and OpenRegister-managed `createdAt` + `owner`
+- **AND** `case.updatedAt` SHALL be refreshed
+- **AND** the response SHALL be `200` with `{status: 'ok', statusRecord, dispatchedActions}`
+
+#### REQ-STE-4-002: Server-side guard re-evaluation blocks stale UI
+
+- **GIVEN** the UI shows a transition as available (cached)
+- **AND** server-side a guard has since failed (e.g. a required document was removed)
+- **WHEN** the user clicks the transition button and the request reaches the engine
+- **THEN** the engine SHALL re-evaluate all guards
+- **AND** the engine SHALL reject the request with HTTP 409 and a static failure message
+- **AND** `case.status` SHALL NOT change
+- **AND** NO `statusRecord` SHALL be created
+
+---
+
+### REQ-STE-5: Side-Effect Dispatching
+
+The system SHALL dispatch all `automaticActions[]` configured on a successful transition. Action types `sendEmail`, `createTask`, `createSubCase`, `webhook`, `setField`, and `notify` SHALL be supported in V1. Actions SHALL fire **sequentially in declaration order**. Failure of any individual action SHALL be logged with full context but SHALL NOT roll back the status change.
+
+**Feature tier**: V1
+
+#### REQ-STE-5-001: Transition triggers automatic actions
+
+- **GIVEN** transition `Goedkeuren` is configured with two actions: `sendEmail` then `createTask`
+- **WHEN** the transition is successfully executed
+- **THEN** the engine SHALL invoke `SendEmailHandler` first, then `CreateTaskHandler`
+- **AND** both handlers SHALL receive the full transition context (`fromStatus`, `toStatus`, `transitionLabel`, `userId`, `statusRecordUuid`)
+- **AND** the resulting `statusRecord.dispatchedActions` SHALL be `[{type: 'sendEmail', ok: true}, {type: 'createTask', ok: true}]`
+
+#### REQ-STE-5-002: Failed action does not roll back
+
+- **GIVEN** transition `Afronden` has a `webhook` action and a `setField` action
+- **WHEN** the webhook target returns HTTP 500
+- **THEN** the case status SHALL still be updated to the target status
+- **AND** the `setField` action SHALL still be invoked (subsequent action)
+- **AND** `statusRecord.dispatchedActions` SHALL include `{type: 'webhook', ok: false, error: <static>}` and `{type: 'setField', ok: true}`
+- **AND** the error SHALL be logged via `$this->logger->error()` with full context
+- **AND** the case owner SHALL receive an in-app notification: "Een automatische actie op zaak <identifier> is mislukt"
+
+#### REQ-STE-5-003: Unknown action type is logged but does not abort
+
+- **GIVEN** a transition includes an action with `type: "publishToLinkedIn"` for which no handler is registered
+- **WHEN** the engine dispatches actions
+- **THEN** the dispatcher SHALL record `{type: 'publishToLinkedIn', ok: false, error: 'unknown_action_type'}` in `statusRecord.dispatchedActions`
+- **AND** subsequent actions in the list SHALL continue to dispatch
+- **AND** a warning SHALL be logged with the unknown type
+
+---
+
+### REQ-STE-6: Transition Audit Log and Replay
+
+The system SHALL persist every transition as a `statusRecord` linked to the case. The full chronological history of a case's transitions SHALL be replayable via a single API call. Replay SHALL NOT re-fire side-effects.
+
+**Feature tier**: V1
+
+#### REQ-STE-6-001: Replay chronological history
+
+- **GIVEN** a case has been through three transitions: `Ontvangen → In behandeling → Afgehandeld`
+- **WHEN** a user requests `GET /api/case/{id}/transition-history`
+- **THEN** the API SHALL return `history: [{statusRecord1}, {statusRecord2}, {statusRecord3}]` in `createdAt asc` order
+- **AND** each record SHALL include `fromStatus`, `statusType` (= toStatus), `transitionLabel`, `userId` (owner), `createdAt`, `evaluatedGuards`, `dispatchedActions`
+- **AND** the response SHALL include `replayable: true`
+- **AND** NO side-effect handlers SHALL be invoked during replay
+
+---
+
+### REQ-STE-7: REST Controller Surface
+
+The system SHALL expose REST endpoints for available-transition queries, transition execution, admin free-form transitions, and history replay. ALL error responses SHALL use static failure messages. The controller SHALL NEVER return `$e->getMessage()` in a response body.
+
+**Feature tier**: V1
+
+#### REQ-STE-7-001: Endpoint table
+
+- **GIVEN** the engine routes are registered
+- **WHEN** the routes are inspected
+- **THEN** the following endpoints SHALL exist:
+  - `GET  /api/case/{caseId}/available-transitions`
+  - `POST /api/case/{caseId}/transition` (body `{transitionId, comment?}`)
+  - `POST /api/case/{caseId}/transition-freeform` (admin only; body `{toStatusId, comment?}`)
+  - `GET  /api/case/{caseId}/transition-history`
+
+#### REQ-STE-7-002: Authorisation enforcement
+
+- **GIVEN** a user without the procest admin group
+- **WHEN** the user calls `POST /api/case/{caseId}/transition-freeform`
+- **THEN** the controller SHALL return HTTP 403 with a static message
+- **AND** the user identity SHALL be derived from `IUserSession`, NEVER from the request body
+
+---
+
+### REQ-STE-8: Backfill of Legacy Status Logic
+
+The system SHALL retire status mutation paths in `ZgwZrcRulesService` and `ZrcController`, delegating instead to the engine. Legacy ZGW API contracts SHALL be preserved: `POST /zaken/v1/statussen` continues to validate `zrc-016` (statustype belongs to zaaktype) and writes a status, but the write SHALL now flow through `StatusTransitionService::execute` (or `executeFreeForm`) so that a `statusRecord` is always emitted.
+
+**Feature tier**: V1
+
+#### REQ-STE-8-001: Eindstatus side-effects migrate to action handlers
+
+- **GIVEN** a workflow template's eindstatus transition is configured with `setField` actions for `einddatum: now()` and `result: <snapshot>` (replacing the inline `handleEindstatusEffect` logic)
+- **WHEN** the transition fires
+- **THEN** the engine SHALL set both fields via `SetFieldHandler`
+- **AND** the legacy `ZrcController::handleEindstatusEffect` method SHALL be removed
+- **AND** existing ZGW Newman regression tests SHALL pass unchanged
+
+#### REQ-STE-8-002: ZGW statussen POST emits a statusRecord
+
+- **GIVEN** a client posts `POST /zaken/v1/statussen` with valid body
+- **WHEN** the request passes `rulesStatussenCreate` validation
+- **THEN** the engine SHALL be invoked (via `execute` if the target status maps to a known transition, otherwise `executeFreeForm`)
+- **AND** a `statusRecord` SHALL be persisted with `noWorkflowTemplate: true` if no active template existed
+- **AND** the API response SHALL remain ZGW-spec-compliant
+
+---
+
+### REQ-STE-9: Integration Hooks for Downstream Specs
+
+The system SHALL allow downstream specs (`bezwaar-lifecycle`, `parafeerroute-engine`) to plug into transition execution by registering side-effect handlers through DI service tagging, without modifying engine source. The dispatcher SHALL be entity-aware: in addition to `case.status` transitions, it SHALL accept transitions on the configured set of typed entities (V1 includes `case`; the extension point reserves the typed-entity dispatch path for parafering's `voorstel.status` flow).
+
+**Feature tier**: V1
+
+#### REQ-STE-9-001: bezwaar-lifecycle registers createSubCase handler
+
+- **GIVEN** the bezwaar workflow template's `Ontvankelijk → In behandeling` transition lists a `createSubCase` action
+- **WHEN** the transition fires
+- **THEN** the engine SHALL invoke the `CreateSubCaseHandler` registered by the `bezwaar-lifecycle` integration
+- **AND** an advisory deelzaak SHALL be created linked to the primary bezwaar case via `hoofdzaak`
+
+#### REQ-STE-9-002: parafeerroute-engine uses the same dispatcher
+
+- **GIVEN** a `voorstel.status` change to `in_parafering` configured to emit a `notify` action
+- **WHEN** parafeerroute-engine triggers the typed-entity transition path
+- **THEN** the engine SHALL invoke `NotifyHandler` via the same dispatcher used for case transitions
+- **AND** the resulting notification SHALL share the same log/error semantics as case-side-effects
+
+---
+
+### REQ-STE-10: No-Workflow Fallback for Free-Form Transitions
+
+The system SHALL allow procest admins to transition cases whose `caseType` lacks an active workflow template to any non-final `statusType` of that caseType, with full audit logging. Free-form transitions SHALL bypass guard evaluation and side-effect dispatching but SHALL still write a `statusRecord` flagged `noWorkflowTemplate: true`.
+
+**Feature tier**: V1
+
+#### REQ-STE-10-001: Admin free-form transition
+
+- **GIVEN** a case of a caseType with no `workflowTemplate` where `isActive: true`
+- **AND** the current user is in the procest admin group
+- **WHEN** the user calls `POST /api/case/{caseId}/transition-freeform` with `{toStatusId, comment}`
+- **THEN** the engine SHALL validate that `toStatusId` is a `statusType` of the case's `caseType`
+- **AND** the engine SHALL reject targets where `isFinal: true` UNLESS the caller is in the procest admin group (admins MAY close cases free-form)
+- **AND** the engine SHALL update `case.status` to `toStatusId`
+- **AND** a `statusRecord` SHALL be written with `noWorkflowTemplate: true`, `evaluatedGuards: []`, `dispatchedActions: []`
+- **AND** no side-effects SHALL fire
+
+#### REQ-STE-10-002: Non-admin cannot free-form
+
+- **GIVEN** a case of a caseType with no active workflow template
+- **AND** the current user is NOT in the procest admin group
+- **WHEN** the user calls `POST /api/case/{caseId}/transition-freeform`
+- **THEN** the engine SHALL return HTTP 403 with a static message
+- **AND** `case.status` SHALL NOT change

--- a/openspec/changes/status-transition-engine/tasks.md
+++ b/openspec/changes/status-transition-engine/tasks.md
@@ -1,0 +1,116 @@
+# Tasks: status-transition-engine
+
+## Deduplication Check
+
+- [ ] **D01**: Search `lib/Service/` and `lib/Controller/` for any existing transition engine / status orchestration. Inventory the status-mutation call-sites in `ZgwZrcRulesService::rulesStatussenCreate`, `ZrcController::handleEindstatusEffect`, and any direct `case.status` writes through `ObjectService`. Verify `WorkflowTemplateLoader` does not already exist (workflow-definition-model spec may have created a stub). Confirm `statusRecord` schema slug and whether config key `status_record_schema` is registered in `SettingsService`. Document findings here (expected: `workflowTemplate` schema exists post `workflow-definition-model` apply; `statusRecord` schema exists; no transition engine exists yet; multiple call-sites mutate `case.status` directly).
+
+---
+
+## Schema & Configuration
+
+- [ ] **T01**: Extend `statusRecord` schema in `lib/Settings/procest_register.json`. Add optional fields: `transitionLabel` (string), `fromStatus` (string, format uuid), `evaluatedGuards` (array — each item `{type: string, passed: boolean, details: object}`), `dispatchedActions` (array — each item `{type: string, ok: boolean, error: string}`), `noWorkflowTemplate` (boolean, default false). Required fields remain `case` and `statusType`. Bump schema `version` to `1.1.0`.
+
+- [ ] **T02**: Add config keys to `lib/Service/SettingsService.php`: `status_record_schema` (slug of `statusRecord` schema), `workflow_template_schema` (slug of `workflowTemplate` schema, may already exist from workflow-definition-model). Load both in `initializeStores()`.
+
+---
+
+## Backend: Engine Core
+
+- [ ] **T03**: Create `lib/Service/WorkflowTemplateLoader.php`. Methods:
+  - `getActiveTemplate(string $caseTypeId): ?array` — calls `ObjectService::findObjects($register, $workflowTemplateSchema, ['caseType' => $caseTypeId, 'isActive' => true])`; returns the single active template (or null) with `transitions` and `steps` already JSON-decoded.
+  - `getTransitionById(string $caseTypeId, string $transitionId): ?array` — convenience accessor.
+  - Per-request in-memory cache keyed by `caseTypeId`. NEVER call frontend-cached templates.
+
+- [ ] **T04**: Create `lib/Service/Transitions/GuardEvaluatorInterface.php` with single method `evaluate(array $guardConfig, array $case, string $userId): GuardResult` where `GuardResult` is a small value class (`passed: bool`, `failureMessage: ?string`, `details: array`).
+
+- [ ] **T05**: Implement four guard evaluators in `lib/Service/Transitions/`:
+  - `ChecklistGuard.php` — loads referenced task via `ObjectService::findObject`, checks all `requiredItems` are `checked: true`; failure message lists missing item labels.
+  - `RequiredFieldGuard.php` — checks `case[$guardConfig['field']]` is not null / empty string / empty array; failure message names the field.
+  - `RequiredDocumentGuard.php` — iterates linked documents (via `case.relations` or `files`), checks at least one has matching `documentType`; failure message names the missing type.
+  - `RoleGuard.php` — checks the current user (via `IUserSession`) has at least one role from `allowedRoles[]` on this case via the existing role mapping; failure message is silent visibility hide (`passed: false, details: ['silent' => true]`).
+  All guards MUST derive user identity from `IUserSession`, NEVER from request body.
+
+- [ ] **T06**: Create `lib/Service/Transitions/GuardRegistry.php`. Constructor takes an array of `GuardEvaluatorInterface` implementations keyed by guard type. Method `evaluateAll(array $guards, array $case, string $userId): array` returns `[['type', 'passed', 'failureMessage', 'details'], ...]`. Register all four built-in guards via DI (`Application::register`).
+
+- [ ] **T07**: Create `lib/Service/Transitions/ActionHandlerInterface.php` with single method `handle(array $actionConfig, array $case, array $transitionContext): ActionResult` where `ActionResult` carries `ok: bool, error: ?string, data: array`. `$transitionContext` includes `fromStatus`, `toStatus`, `transitionLabel`, `userId`, `statusRecordUuid`.
+
+- [ ] **T08**: Implement built-in action handlers in `lib/Service/Transitions/`:
+  - `SendEmailHandler.php` — delegates to `NotificatieService::sendEmail`.
+  - `CreateTaskHandler.php` — delegates to existing tasks service to create a task linked to the case.
+  - `CreateSubCaseHandler.php` — delegates to `ZgwService` to create a deelzaak linked via `hoofdzaak`.
+  - `WebhookHandler.php` — outbound HTTP POST via `IClientService` with case payload + transition context; 5s timeout; non-2xx → `ok: false`.
+  - `SetFieldHandler.php` — writes `actionConfig.field` = `actionConfig.value` on the case via `ObjectService::saveObject` (3-arg API).
+  - `NotifyHandler.php` — delegates to `NotificatieService` for in-app notification.
+  All handlers catch `\Throwable`, log via `$this->logger->error()` with full context, return `ActionResult { ok: false, error: <static-message> }` — NEVER bubble exceptions, NEVER include `$e->getMessage()` in `ActionResult.error`.
+
+- [ ] **T09**: Create `lib/Service/Transitions/SideEffectDispatcher.php`. Method `dispatch(array $actions, array $case, array $transitionContext): array` iterates actions **in declaration order**, invokes the handler registered for `actionConfig.type`, collects results into `[{type, ok, error?}, ...]`. Failed handlers SHALL NOT abort the loop. Unregistered action types log a warning and return `{type, ok: false, error: 'unknown_action_type'}`.
+
+- [ ] **T10**: Create `lib/Service/StatusTransitionService.php`. Methods:
+  - `getAvailableTransitions(string $caseId, string $userId): array` — loads case, loads active workflow template via `WorkflowTemplateLoader`, filters `transitions[]` to those where `fromStatus === case.status`, evaluates guards + role visibility for each, returns array of `{id, label, toStatus, guardsPassed, failedGuards}`. If no active template, returns the empty array (admin free-form transitions go through a separate code path).
+  - `execute(string $caseId, string $transitionId, ?string $comment, string $userId): array` — fetches case + transition; re-evaluates ALL guards (defence in depth, throws `GuardFailedException` on any failure); updates `case.status` to `toStatus`; creates `statusRecord` with `fromStatus`, toStatus (via `statusType`), `transitionLabel`, `description = $comment`, `evaluatedGuards`, `dispatchedActions: []`; saves case (refreshes `updatedAt`); dispatches side-effects via `SideEffectDispatcher::dispatch`; updates the `statusRecord` with the actual `dispatchedActions[]` results. Status mutation MUST happen before dispatching; dispatch failures MUST NOT roll back status.
+  - `executeFreeForm(string $caseId, string $toStatusId, ?string $comment, string $userId): array` — admin-only path for caseTypes lacking an active workflow template; validates `toStatusId` belongs to `case.caseType` statusTypes; validates target is not `isFinal: true` UNLESS the caller is in the procest admin group; writes `statusRecord` with `noWorkflowTemplate: true`; NO side-effects dispatched.
+  - `replay(string $caseId): array` — returns `[{ statusRecord }, ...]` ordered by `createdAt asc`; reconstructs state-progression view; does NOT re-fire side-effects.
+  All methods derive user identity from `IUserSession` when `$userId` is not explicitly passed. Catch `\Throwable` boundaries, log with `$this->logger->error()`, return static error messages to controller.
+
+---
+
+## Backend: Controller
+
+- [ ] **T11**: Create `lib/Controller/StatusTransitionController.php`. Endpoints:
+  - `GET /api/case/{caseId}/available-transitions` — calls `StatusTransitionService::getAvailableTransitions`; returns `{transitions, current: {statusId, statusName}}`.
+  - `POST /api/case/{caseId}/transition` — body `{transitionId, comment?}`; calls `StatusTransitionService::execute`; returns 200 with `{status: 'ok', statusRecord, dispatchedActions}`; returns 409 with static message on `GuardFailedException`; returns 403 with static message on role rejection; returns 404 if transition not found in active template.
+  - `POST /api/case/{caseId}/transition-freeform` — body `{toStatusId, comment?}`; admin-group check via `IGroupManager`; calls `executeFreeForm`.
+  - `GET /api/case/{caseId}/transition-history` — calls `replay`; returns `{history, replayable: true}`.
+  NEVER return `$e->getMessage()` in `JSONResponse`. ALL logs go through `$this->logger->error()`.
+
+- [ ] **T12**: Add routes to `appinfo/routes.php`:
+  ```php
+  ['name' => 'status_transition#available', 'url' => '/api/case/{caseId}/available-transitions', 'verb' => 'GET'],
+  ['name' => 'status_transition#execute',   'url' => '/api/case/{caseId}/transition',             'verb' => 'POST'],
+  ['name' => 'status_transition#freeform',  'url' => '/api/case/{caseId}/transition-freeform',    'verb' => 'POST'],
+  ['name' => 'status_transition#history',   'url' => '/api/case/{caseId}/transition-history',     'verb' => 'GET'],
+  ```
+
+---
+
+## Backend: Backfill of ZgwZrcRulesService
+
+- [ ] **T13**: Slim `lib/Service/ZgwZrcRulesService.php` and `lib/Controller/ZrcController.php`:
+  - `rulesStatussenCreate()` keeps the `zrc-016` ZGW validation (statustype belongs to zaaktype); after validation passes, delegate the actual `case.status` write to `StatusTransitionService::executeFreeForm` so a `statusRecord` is always written.
+  - Move `ZrcController::handleEindstatusEffect()` logic into a `SetFieldHandler`-driven side-effect registered on the seeded standard workflow templates' eindstatus transitions (`einddatum`, snapshot resultaat); remove the inline call.
+  - Move zrc-022 archiefstatus transition validation into a `RequiredFieldGuard` (require `archiefnominatie` + `archiefactiedatum`) on the standard workflow's `Afgehandeld → Gearchiveerd` transition.
+  - Run `composer check:strict` on the slimmed-down service and fix any pre-existing PHPCS/PHPMD/Psalm/PHPStan warnings encountered (per project policy).
+
+---
+
+## Integration Hooks
+
+- [ ] **T14**: Wire `bezwaar-lifecycle` integration point: register the existing bezwaar phase-change actions (advisory case creation, hearing scheduling notification) as `CreateSubCaseHandler` and `NotifyHandler` configurations on the seeded bezwaar workflow template (provided by `workflow-definition-model`). Verify by re-running the bezwaar lifecycle scenarios end-to-end.
+
+- [ ] **T15**: Wire `parafeerroute-engine` integration point: extend the dispatcher to also accept `voorstel`-typed entities for `notify` actions, so parafering step-activation goes through the same dispatcher. Document the typed-entity extension as V1 (the spec leaves an explicit hook in REQ-STE-9).
+
+---
+
+## Frontend
+
+- [ ] **T16**: Register `status-record` entity type in `src/store/store.js` via `createObjectStore('status-record')` with `relationsPlugin`. Type name MUST be kebab-case. Register ONCE.
+
+- [ ] **T17**: Create `src/services/statusTransitionApi.js`. Functions: `getAvailableTransitions(caseId)`, `executeTransition(caseId, transitionId, comment)`, `executeFreeFormTransition(caseId, toStatusId, comment)`, `getTransitionHistory(caseId)`. Use `axios` from `@nextcloud/axios` for ALL calls (CSRF auto-attach). NEVER raw `fetch()`.
+
+- [ ] **T18**: Create `src/views/cases/components/AvailableTransitionsPanel.vue`. Polls `getAvailableTransitions(caseId)` on case open + after any case mutation. Renders one button per available transition. Disabled buttons show tooltip with the first failed guard's failure message. Role-hidden transitions (RoleGuard with `details.silent: true`) are not rendered at all.
+
+- [ ] **T19**: Create `src/views/cases/components/TransitionConfirmDialog.vue`. Triggered on transition-button click; shows: target status name, transition label, list of side-effects to fire (label only, no config detail), optional `comment` textarea, Cancel / Confirm. On confirm, calls `executeTransition`; on success, refreshes the case detail.
+
+- [ ] **T20**: Embed `AvailableTransitionsPanel` into `src/views/cases/CaseDetail.vue` in the status section. Replace any existing ad-hoc status-change UI in that file.
+
+---
+
+## Verification
+
+- [ ] **V01**: All requirements from `openspec/changes/status-transition-engine/specs/status-transition-engine/spec.md` (REQ-STE-1..10) have corresponding implementation in `lib/Service/StatusTransitionService.php`, the guard registry, and the side-effect dispatcher. The pre-existing `openspec/specs/status-transition-engine/spec.md` requirements (Guard Evaluation, Transition Execution, Available Transitions) are subsumed by the new REQs.
+
+- [ ] **V02**: PHPUnit tests cover at minimum: each guard evaluator (pass + fail), `StatusTransitionService::execute` happy path, guard-failure path (no status change, no side-effects), side-effect-failure path (status changed, error logged, statusRecord has `dispatchedActions[*].ok = false`), `replay` chronological ordering, freeform admin transition with `noWorkflowTemplate: true`. `composer check:strict` and `composer test` pass.
+
+- [ ] **V03**: Browser smoke test via Playwright MCP (`browser-1`): open a case with an active workflow template, observe `AvailableTransitionsPanel` renders allowed transitions, click a transition, complete the confirm dialog, observe the case status updates in the UI AND a `statusRecord` is written (visible in transition history). Test guard-disabled tooltip on a transition whose checklist is incomplete.
+
+- [ ] **V04**: End-to-end ZGW API regression: `POST /zaken/v1/statussen` still validates `zrc-016` (statustype belongs to zaaktype); the resulting status change is now recorded as a `statusRecord` with `noWorkflowTemplate: true` (when no workflow template) or via `StatusTransitionService::execute` (when one exists). Existing ZGW Newman collection passes unchanged.


### PR DESCRIPTION
## Summary

Generates the OpenSpec change folder for **status-transition-engine** — the runtime engine that drives every Procest case through its statuses based on `workflowTemplate` data (sibling spec `workflow-definition-model`, generated in parallel).

Spec authoring only — no code, no schema migrations executed.

## What's in the change

- `proposal.md` — Problem, scope, dependencies (consumes `workflow-definition-model`).
- `design.md` — Engine architecture: `StatusTransitionService`, guard registry (4 evaluators), side-effect dispatcher (6 action handlers), file map, API surface, atomicity model, backfill plan for `ZgwZrcRulesService` / `ZrcController`.
- `tasks.md` — 25 tasks: D01 dedup, T01-T20 schema/engine/controller/backfill/frontend, V01-V04 verification.
- `specs/status-transition-engine/spec.md` — Delta spec with **REQ-STE-1..10** (22 Given/When/Then scenarios) covering rule consumption, guard evaluation, available transitions, atomic execution, side-effect dispatching, audit/replay, REST surface, legacy backfill, integration hooks, and no-workflow fallback.
- `hydra.json` — Spec slug + `depends_on: [workflow-definition-model]`.

## Key decisions

- **Single write path**: All `case.status` mutations route through `StatusTransitionService::execute()` — REST, UI, ZGW Zaken API.
- **Atomicity model**: Status update + `statusRecord` write are atomic; side-effects dispatch sequentially post-write and never roll back the status.
- **Pluggable guard/action registries** via DI tagging so `bezwaar-lifecycle` and `parafeerroute-engine` can register handlers without modifying the engine.
- **Free-form admin fallback** for caseTypes without an active workflow template — flagged `noWorkflowTemplate: true` on the `statusRecord`.

## Test plan

- [ ] OpenSpec validation on the change folder.
- [ ] Pre-existing `openspec/specs/status-transition-engine/spec.md` is subsumed by the new REQ-STE set — no contradiction.
- [ ] `workflow-definition-model` PR must merge first (transitions JSON contract).
- [ ] On apply: ZGW Newman regression suite must pass unchanged (REQ-STE-8 contract preservation).