### PR TITLE
chore(openspec): generate role-based-step-routing spec

### DIFF
--- a/openspec/changes/role-based-step-routing/design.md
+++ b/openspec/changes/role-based-step-routing/design.md
@@ -1,0 +1,59 @@
+# Design: role-based-step-routing
+
+## Architecture
+
+The routing engine is a single backend service, `RoleResolverService`, that takes a `RoutingRule` plus a `Case` and returns an ordered set of `Participant` references. It is invoked by:
+
+1. The task list builder when assembling "my work" for a user.
+2. The status-transition engine when evaluating the `roleGuard` on a transition.
+3. The parafeerroute step activator (replaces inline logic in `ParafeerRouteService::activateStep`).
+4. A new admin re-route endpoint, used after delegation changes or manual override.
+
+## Routing Strategies
+
+Each strategy is a class implementing `RoutingStrategyInterface::resolve(RoutingRule $rule, Case $case): array`. Selected via the rule's `strategy` field; registered in a `StrategyRegistry` keyed by strategy name.
+
+| Strategy | Behaviour | Use case |
+|----------|-----------|----------|
+| `single-role` | Returns all participants currently bound to the named `roleType` on the case. | Default for `WorkflowStep.assigneeRole`. |
+| `or-set` | Union over a set of `roleType` UUIDs. | Steps that any of {Behandelaar, Senior} may perform. |
+| `hierarchical` | Tries roles in priority order; returns the first non-empty set. | Falls back to "Afdelingshoofd" when no "Senior" is assigned. |
+| `round-robin` | Rotates across participants of the role using a per-caseType cursor stored in `appconfig`. | Even distribution across a pool of inspectors. |
+| `least-loaded` | Picks the participant whose open task count is lowest. | Workload-aware routing on high-volume zaaktypes. |
+
+`round-robin` and `least-loaded` MAY return a single participant; `single-role`, `or-set`, `hierarchical` MAY return many (all matching). The caller decides whether to assign all or pick one.
+
+## Data Model
+
+A `RoutingRule` is an embedded object on `WorkflowStep` and `StatusTransition`:
+
+```
+{
+  "strategy": "single-role|or-set|hierarchical|round-robin|least-loaded",
+  "roleTypes": ["uuid", ...],     // OR-set, hierarchical (in priority order)
+  "roleType":  "uuid",            // single-role, round-robin, least-loaded
+  "fallback":  "uuid"             // optional roleType when primary set is empty
+}
+```
+
+The existing `assigneeRole`/`allowedRoles` fields remain valid: at read-time they are normalised to `{strategy: "single-role", roleType: <uuid>}` and `{strategy: "or-set", roleTypes: [<uuid>...]}` respectively.
+
+## Delegation & Out-of-Office
+
+The `role` schema gains optional `delegate` (participant) and `delegateFrom`/`delegateUntil` (date) fields. When `RoleResolverService` materialises a participant set, every entry whose `delegateFrom <= now <= delegateUntil` is replaced by its delegate. The original assignment is preserved in `audit.original` for traceability.
+
+## Integration With Other Engines
+
+- `status-transition-engine` — calls `RoleResolverService::canExecute($transition->rule, $case, $userId)` for role-guard evaluation. Reuses the resolver instead of comparing UUIDs directly.
+- `ParafeerRouteService` — T07 replaces its inline `findActorForStep()` with a `RoleResolverService` call; the parafeerroute step keeps its semantics but gets delegation + workload features for free.
+- `skill-routing` (pipelinq) — explicitly out of scope; that engine routes on `skill` taxonomy, not `roleType`. The two engines may compose in V2 but do not share code today.
+
+## Failure Modes
+
+- No matching participants: resolver returns an empty array; callers MUST present the task to the case admin and log `RoleRoutingEmpty` with rule + caseId.
+- Cyclic delegation (A → B → A): detector in resolver, breaks after one hop and logs `RoleRoutingDelegationCycle`.
+- Strategy not registered: resolver throws `RoutingStrategyMissingException`; the admin UI prevents saving rules with unknown strategies.
+
+## Performance
+
+Resolver is hot path (called once per task list render). Cache per `(ruleHash, caseId)` for 60 s in APCu. Invalidate on `role` or `case.assignedRoles` mutation via `\OCP\IEventDispatcher` listener.

--- a/openspec/changes/role-based-step-routing/proposal.md
+++ b/openspec/changes/role-based-step-routing/proposal.md
@@ -1,0 +1,42 @@
+# Proposal: role-based-step-routing
+
+## Summary
+Generalise role-based routing into a reusable rule engine that any workflow step or status transition can use to compute its assignee set. Today Procest only resolves "who should act" for B&W parafering (via `ParafeerRouteService`). Cases, tasks and transitions resolve roles ad-hoc in controllers/UI filters, which prevents consistent delegation, out-of-office handling and workload balancing.
+
+## Why
+Today only the B&W parafering workflow has a real routing engine (`ParafeerRouteService`). Cases, tasks and status transitions resolve "who can act" with ad-hoc UUID comparisons scattered across controllers and Vue filters. This blocks out-of-office handover, "namens" delegation and any workload-aware assignment — features that the bezwaar/beroep deadlines and 18 NL/BE tenders all require. One shared resolver, used by every workflow step and every status transition, removes the duplication and unlocks the missing features.
+
+## Motivation
+- Tender coverage: `assigneeRole` and `allowedRoles` are advertised in 18 NL/BE tenders as "automatic task routing" / "geautomatiseerd routeren naar rol".
+- Internal consistency: `WorkflowStep.assigneeRole`, `StatusTransition.allowedRoles`, parafeerStap.actor, and ad-hoc task assignment each apply their own resolution logic — duplicated and divergent.
+- Operational need: out-of-office handover, "namens" delegation, and workload-aware routing are required for the bezwaar/beroep workflows whose hearing-window deadlines cannot drift when a case handler is absent.
+
+## What Changes
+- New `routingRule` field on `workflowStep` and `statusTransition` (procest_register.json).
+- New `delegate`, `delegateFrom`, `delegateUntil` fields on `role`.
+- New `RoleResolverService` + `StrategyRegistry` with five built-in strategies.
+- New `POST /api/cases/{id}/reroute` endpoint.
+- Migration: `ParafeerRouteService::activateStep` calls the resolver instead of inline UUID lookup.
+- Admin UI: routing rule editor inside the workflow step form.
+- APCu cache + invalidation on role mutations.
+
+## Affected Projects
+- [x] Project: `procest` — RoleResolverService, controller hook, admin UI for rule config, ParafeerRouteService back-fill
+
+## Scope
+
+### In Scope
+- Single `RoleResolverService` with a pluggable Strategy registry (single-role, OR-set, hierarchical, round-robin, least-loaded).
+- Routing rule fields on `workflowStep` and `statusTransition` (resolver strategy + parameters).
+- Out-of-office / delegation lookup against the `role` schema (delegate participant + window).
+- Re-route controller endpoint so admins can recompute assignees after a delegation change.
+- Migration: ParafeerRouteService consumes the new resolver instead of its private logic.
+
+### Out of Scope
+- Skill-based routing (different domain — owned by `pipelinq`).
+- External LDAP/AD group expansion (V2; resolver returns participant refs only).
+- Push notifications to delegate; covered by existing notification service.
+
+## Dependencies
+- `workflow-definition-model` — provides `WorkflowStep.assigneeRole` and `StatusTransition.allowedRoles`.
+- `status-transition-engine` — calls the resolver during guard evaluation.

--- a/openspec/changes/role-based-step-routing/specs/role-based-step-routing/spec.md
+++ b/openspec/changes/role-based-step-routing/specs/role-based-step-routing/spec.md
@@ -1,0 +1,150 @@
+## ADDED Requirements
+
+### Requirement: Routing Rule Data Model
+The system SHALL store routing configuration as a `routingRule` object embedded on each `workflowStep` and `statusTransition`. The rule defines which strategy to apply and the role parameters it needs. Legacy `assigneeRole` (UUID) and `allowedRoles` (UUID array) fields SHALL continue to work and SHALL be normalised on read to a `routingRule` with `strategy: "single-role"` and `strategy: "or-set"` respectively.
+
+**Feature tier**: V1
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `strategy` | enum | One of `single-role`, `or-set`, `hierarchical`, `round-robin`, `least-loaded` |
+| `roleType` | UUID | Role type for `single-role`, `round-robin`, `least-loaded` |
+| `roleTypes` | array of UUID | Role types for `or-set` (union) or `hierarchical` (priority order) |
+| `fallback` | UUID | Role type to try when primary resolution yields empty |
+
+#### Scenario: Save a workflow step with a routing rule
+- **WHEN** an administrator saves a `workflowStep` with `routingRule.strategy = "round-robin"` and `routingRule.roleType = <inspector-uuid>`
+- **THEN** the workflowTemplate document SHALL persist the rule unchanged
+- **AND** subsequent task activation SHALL resolve assignees via the round-robin strategy
+
+#### Scenario: Read legacy assigneeRole
+- **WHEN** the API returns a `workflowStep` that has only the legacy `assigneeRole` field set
+- **THEN** the response SHALL include a computed `routingRule` with `strategy: "single-role"` and `roleType: <same uuid>`
+
+#### Scenario: Role schema gains delegation fields
+- **WHEN** a `role` object is created or updated with `delegate`, `delegateFrom`, `delegateUntil`
+- **THEN** the system SHALL persist the values
+- **AND** validate that `delegateFrom <= delegateUntil`
+
+### Requirement: Role Resolver Service
+The system SHALL provide a backend `RoleResolverService` that, given a `routingRule` and a `case`, returns an ordered array of participant references representing the current assignee set. The resolver SHALL apply delegation, detect cyclic delegation, and cache results.
+
+**Feature tier**: V1
+
+#### Scenario: Resolve a single-role rule
+- **WHEN** `resolve()` is called with `strategy: "single-role"` and `roleType: <behandelaar-uuid>` against case ZK-2024-001 which has two `role` records of that type
+- **THEN** the resolver SHALL return both participant references in case-role creation order
+
+#### Scenario: Apply active delegation
+- **WHEN** a participant has `delegate: "piet"`, `delegateFrom: yesterday`, `delegateUntil: tomorrow`
+- **AND** the resolver runs today
+- **THEN** the returned array SHALL contain `piet` in place of the original participant
+- **AND** the audit record on the assignment SHALL carry `original: <participant-uuid>`
+
+#### Scenario: Break cyclic delegation
+- **WHEN** participant A delegates to B and B delegates back to A
+- **AND** the resolver evaluates the rule
+- **THEN** the resolver SHALL break after one hop and SHALL log `RoleRoutingDelegationCycle` with both participant UUIDs
+- **AND** SHALL return the first-hop participant (B) so the case remains assignable
+
+#### Scenario: Resolver cache hit
+- **WHEN** the resolver is called twice in succession for the same `(ruleHash, caseId)` within 60 seconds
+- **THEN** the second call SHALL be served from APCu without hitting OpenRegister
+
+### Requirement: Strategy Registry
+The system SHALL expose a `StrategyRegistry` that holds the five built-in routing strategies and SHALL reject rules referencing an unregistered strategy.
+
+**Feature tier**: V1
+
+#### Scenario: Built-in strategies are registered
+- **WHEN** the registry is queried
+- **THEN** the list SHALL contain exactly `single-role`, `or-set`, `hierarchical`, `round-robin`, `least-loaded`
+
+#### Scenario: Unknown strategy is rejected
+- **WHEN** a `routingRule` with `strategy: "skill-based"` is submitted to the resolver
+- **THEN** the resolver SHALL throw `RoutingStrategyMissingException`
+- **AND** the admin UI SHALL block saving such a rule with the error "Strategie niet gevonden"
+
+#### Scenario: Hierarchical fall-through
+- **WHEN** a rule has `strategy: "hierarchical"` with `roleTypes: ["Senior", "Behandelaar"]`
+- **AND** no participants hold the "Senior" role on the case
+- **THEN** the resolver SHALL try "Behandelaar" and return the participants from that role
+
+#### Scenario: Round-robin rotation persists across calls
+- **WHEN** the round-robin strategy is asked to resolve the same rule three times in a row for a role with three participants
+- **THEN** each call SHALL return a different participant in stable rotation order
+- **AND** the cursor SHALL be persisted in `appconfig` under key `routing.rr.<caseTypeUuid>.<roleTypeUuid>`
+
+#### Scenario: Least-loaded picks the lowest task count
+- **WHEN** the least-loaded strategy is invoked for a role held by three participants with open-task counts 5, 2, 8
+- **THEN** the resolver SHALL return the participant with 2 open tasks
+
+### Requirement: Assignee Recomputation
+The system SHALL recompute `case.assignedTo` and every open step's assignee set whenever a `role` record on the case is created, updated, or deleted, and SHALL invalidate the resolver cache for that case.
+
+**Feature tier**: V1
+
+#### Scenario: Adding a role recomputes assignees
+- **WHEN** a new `role` of type "Behandelaar" is added to case ZK-2024-007 which has an open step with `routingRule.strategy = "single-role"` and `roleType = Behandelaar`
+- **THEN** the open step's assignee set SHALL include the new participant within one event-loop tick
+- **AND** the resolver APCu entry for that case SHALL be evicted
+
+#### Scenario: Deleting the last role triggers admin notification
+- **WHEN** the only `role` matching an open step's rule is deleted
+- **THEN** the resolver SHALL return an empty array
+- **AND** a `RoleRoutingEmpty` log line SHALL be emitted with rule + caseId
+- **AND** the step SHALL be surfaced to the case admin's "Needs attention" list
+
+### Requirement: Manual Re-route Endpoint
+The system SHALL expose `POST /api/cases/{id}/reroute` to recompute the assignee set for every open step on a case, returning the list of affected step ids. The endpoint SHALL require the caller to hold an admin role on the case.
+
+**Feature tier**: V1
+
+#### Scenario: Admin re-routes after delegation change
+- **WHEN** an admin calls `POST /api/cases/ZK-2024-001/reroute`
+- **AND** the case has two open steps
+- **THEN** the response status SHALL be 200
+- **AND** the response body SHALL include `affectedSteps` listing both step ids
+
+#### Scenario: Non-admin is forbidden
+- **WHEN** a user with only the "Behandelaar" role calls the reroute endpoint
+- **THEN** the response status SHALL be 403
+
+### Requirement: Admin Rule Configuration UI
+The system SHALL render a routing rule editor inside the workflow step admin form that lets administrators pick a strategy and configure its parameters.
+
+**Feature tier**: V1
+
+#### Scenario: Strategy dropdown reveals parameters
+- **WHEN** an admin selects strategy "hierarchical" in the routing rule editor
+- **THEN** the form SHALL show an ordered multi-select for `roleTypes`
+- **AND** SHALL hide the single `roleType` field
+
+#### Scenario: Save blocked on unknown strategy
+- **WHEN** an admin manually submits a payload with `strategy: "made-up"`
+- **THEN** the API SHALL return 422 and the UI SHALL show "Strategie niet gevonden"
+
+### Requirement: ParafeerRoute Integration
+The system SHALL route every parafeerroute step that targets a role through `RoleResolverService` rather than the legacy inline lookup, preserving behaviour for routes that do not declare a strategy.
+
+**Feature tier**: V1
+
+#### Scenario: Existing parafeerroute behaves identically
+- **WHEN** a parafeerroute step has actor type `role` and no strategy declared
+- **THEN** `ParafeerRouteService::activateStep` SHALL resolve via `RoleResolverService` with default `strategy: "single-role"`
+- **AND** the resulting actor set SHALL equal what the pre-migration code returned
+
+#### Scenario: Parafering inherits delegation
+- **WHEN** the role actor on a parafeerstap has an active delegate
+- **THEN** the activated parafeertaak SHALL be assigned to the delegate
+- **AND** the audit trail SHALL record the original actor
+
+### Requirement: Resolver Performance Budget
+The system SHALL resolve routing rules with a P95 latency of 5 ms or less for a case with five open steps when the APCu cache is populated.
+
+**Feature tier**: V1
+
+#### Scenario: Benchmark meets budget
+- **WHEN** the benchmark suite calls `RoleResolverService::resolve()` 100 times against a fixture case
+- **THEN** the P95 latency SHALL be 5 ms or less
+- **AND** the result SHALL be recorded in the build log

--- a/openspec/changes/role-based-step-routing/tasks.md
+++ b/openspec/changes/role-based-step-routing/tasks.md
@@ -1,0 +1,85 @@
+# Tasks: role-based-step-routing
+
+## 1. Data Model
+
+### T01: Add routing rule schema fields
+- **spec_ref**: `openspec/changes/role-based-step-routing/specs/role-based-step-routing/spec.md#requirement-routing-rule-data-model`
+- **files**: `lib/Settings/procest_register.json`
+- **acceptance_criteria**:
+  - GIVEN a workflowTemplate schema WHEN inspected THEN `workflowStep` and `statusTransition` each accept an optional `routingRule` object with `strategy`, `roleTypes`, `roleType`, `fallback` fields.
+  - GIVEN a `role` schema WHEN inspected THEN it has optional `delegate`, `delegateFrom`, `delegateUntil` properties.
+  - GIVEN a workflow saved with the legacy `assigneeRole` UUID WHEN read THEN the API normalises it to a `routingRule` with `strategy: "single-role"`.
+- [ ] Extend `procest_register.json` and a repair step migration.
+
+### T02: RoleResolverService backend
+- **spec_ref**: `openspec/changes/role-based-step-routing/specs/role-based-step-routing/spec.md#requirement-role-resolver-service`
+- **files**: `lib/Service/RoleResolverService.php`
+- **acceptance_criteria**:
+  - GIVEN a rule + case WHEN `resolve()` is called THEN it returns an ordered array of participant references.
+  - GIVEN a participant with active delegation WHEN resolving THEN the delegate replaces the original and `audit.original` is populated.
+  - GIVEN a cyclic delegation chain WHEN resolving THEN the resolver breaks after one hop and logs `RoleRoutingDelegationCycle`.
+- [ ] Implement service with constructor injection of `ObjectService`, `IUserSession`, `LoggerInterface`, `IAppConfig`.
+
+### T03: Strategy registry
+- **spec_ref**: `openspec/changes/role-based-step-routing/specs/role-based-step-routing/spec.md#requirement-strategy-registry`
+- **files**: `lib/Service/Routing/StrategyRegistry.php`, `lib/Service/Routing/Strategy/*.php`
+- **acceptance_criteria**:
+  - GIVEN five strategies registered (single-role, or-set, hierarchical, round-robin, least-loaded) WHEN listed THEN all five names are exposed by `StrategyRegistry::list()`.
+  - GIVEN an unknown strategy name WHEN the registry is asked to resolve it THEN it throws `RoutingStrategyMissingException`.
+- [ ] Implement the five strategies behind `RoutingStrategyInterface`.
+
+### T04: Case.assignedTo updater hook
+- **spec_ref**: `openspec/changes/role-based-step-routing/specs/role-based-step-routing/spec.md#requirement-assignee-recomputation`
+- **files**: `lib/EventListener/RoleMutationListener.php`
+- **acceptance_criteria**:
+  - GIVEN a `role` is created, updated, or deleted on a case WHEN the event fires THEN `case.assignedTo` and every open step's assignee set are recomputed.
+  - GIVEN APCu cache holds resolver results for that case WHEN the event fires THEN the cache entry is invalidated.
+- [ ] Wire the listener to `\OCP\IEventDispatcher` for OpenRegister object events on the `role` schema.
+
+### T05: Re-route controller endpoint
+- **spec_ref**: `openspec/changes/role-based-step-routing/specs/role-based-step-routing/spec.md#requirement-manual-re-route-endpoint`
+- **files**: `lib/Controller/RoutingController.php`, `appinfo/routes.php`
+- **acceptance_criteria**:
+  - POST `/api/cases/{id}/reroute` SHALL recompute every open step's assignees for that case and return the affected step ids.
+  - GIVEN the requester lacks the `admin` role on the case WHEN called THEN it returns 403.
+- [ ] Add controller, route, and OCS auth annotations.
+
+### T06: Admin UI for rule configuration
+- **spec_ref**: `openspec/changes/role-based-step-routing/specs/role-based-step-routing/spec.md#requirement-admin-rule-configuration-ui`
+- **files**: `src/views/admin/CaseTypeWorkflow.vue`, `src/components/routing/RoutingRuleEditor.vue`
+- **acceptance_criteria**:
+  - GIVEN an admin opens a workflow step WHEN editing the routing rule THEN a dropdown lists the five strategies and reveals strategy-specific fields.
+  - GIVEN an admin saves a rule with an unknown strategy WHEN submitted THEN the save is blocked with a "Strategie niet gevonden" error.
+- [ ] Build `RoutingRuleEditor.vue` and slot it into the existing workflow step editor.
+
+### T07: Migrate ParafeerRouteService
+- **spec_ref**: `openspec/changes/role-based-step-routing/specs/role-based-step-routing/spec.md#requirement-parafeerroute-integration`
+- **files**: `lib/Service/ParafeerRouteService.php`
+- **acceptance_criteria**:
+  - GIVEN a parafeerroute step has an actor of type `role` WHEN the step is activated THEN `RoleResolverService` resolves the participant set (previously inline logic).
+  - GIVEN an existing parafeerroute in production data WHEN read after migration THEN behaviour is identical for every step that does not declare a strategy (defaults to `single-role`).
+- [ ] Replace `findActorForStep()` with a resolver call; keep public API stable.
+
+### V01: Unit tests for resolver and strategies
+- **spec_ref**: `openspec/changes/role-based-step-routing/specs/role-based-step-routing/spec.md`
+- **files**: `tests/Unit/Service/RoleResolverServiceTest.php`, `tests/Unit/Service/Routing/*Test.php`
+- **acceptance_criteria**: Each strategy has at least three tests covering empty set, single match, multi match. Resolver tests cover delegation, cycle break, and cache hit.
+- [ ] Achieve ≥85% line coverage on the resolver and strategy classes.
+
+### V02: Integration test for status-transition role guard
+- **spec_ref**: `openspec/changes/role-based-step-routing/specs/role-based-step-routing/spec.md#requirement-role-resolver-service`
+- **files**: `tests/Integration/StatusTransitionRoleGuardTest.php`
+- **acceptance_criteria**: A transition with `allowedRoles` resolves through `RoleResolverService` and respects delegation.
+- [ ] Use OpenRegister fixtures, no live DB.
+
+### V03: Newman re-route endpoint test
+- **spec_ref**: `openspec/changes/role-based-step-routing/specs/role-based-step-routing/spec.md#requirement-manual-re-route-endpoint`
+- **files**: `tests/newman/role-routing.postman_collection.json`
+- **acceptance_criteria**: Newman collection creates a case, adds a delegation, calls `/reroute`, asserts the open step assignee is now the delegate.
+- [ ] Add to CI Newman matrix.
+
+### V04: Performance benchmark
+- **spec_ref**: `openspec/changes/role-based-step-routing/specs/role-based-step-routing/spec.md#requirement-resolver-performance-budget`
+- **files**: `tests/Performance/RoleResolverBenchmark.php`
+- **acceptance_criteria**: P95 resolution time ≤ 5 ms over 100 calls against a case with five open steps and a populated APCu cache.
+- [ ] Run against the dev environment; record baseline in the build log.


### PR DESCRIPTION
## Summary
- Generates the OpenSpec change `role-based-step-routing` (proposal, design, tasks, delta spec) — spec authoring only, no code.
- Defines a generic `RoleResolverService` + `StrategyRegistry` (single-role, or-set, hierarchical, round-robin, least-loaded) so any workflow step or status transition can compute its assignee set.
- Adds delegation/out-of-office fields on `role`, an APCu cache, a `POST /api/cases/{id}/reroute` admin endpoint, and a back-fill path for `ParafeerRouteService`.

## Spec Stats
- 8 ADDED Requirements, each with 2-5 Gherkin scenarios.
- 11 tasks (T01-T07 implementation, V01-V04 verification).
- Validated with `openspec validate --changes --strict role-based-step-routing` -> `valid`.

## Sister Specs
- `status-transition-engine` — calls the resolver during role-guard evaluation.
- `workflow-definition-model` — declares the `WorkflowStep.assigneeRole` / `StatusTransition.allowedRoles` fields the rule attaches to (hard dependency).
- `bw-parafering` — `ParafeerRouteService` is migrated to use the resolver (T07).

## Test plan
- [ ] Reviewer skims proposal/design/tasks/spec.md for completeness.
- [ ] `openspec validate --changes --strict role-based-step-routing` passes on the PR branch.
- [ ] Spec aligns with `workflow-definition-model` and `status-transition-engine` REQs (no overlap, no orphan refs).