### PR TITLE
chore(openspec): generate zgw-api-mapping spec

### DIFF
--- a/openspec/changes/zgw-api-mapping/design.md
+++ b/openspec/changes/zgw-api-mapping/design.md
@@ -1,0 +1,122 @@
+# Design: zgw-api-mapping
+
+## Architecture
+
+Procest ships one `ZgwMappingProfile` per ZGW resource as a JSON document
+in `lib/Settings/zgw_mappings/`, imported into OpenRegister `Mapping` and
+`Endpoint` entities at install via `ConfigurationService::importFromApp()`.
+The runtime engine (`OpenRegister\MappingService`) is unchanged -- this
+change is purely declarative.
+
+## Entity-by-Entity Mapping
+
+| Procest schema (English) | ZGW resource (Dutch) | API | Direction | Notes |
+|---|---|---|---|---|
+| `case` | Zaak | ZRC | both | UUID-keyed; `caseType` -> URL ref to ZaakType |
+| `statusRecord` | Status | ZRC | both | Sub-resource of Zaak; immutable once created |
+| `result` | Resultaat | ZRC | both | One per case at terminal status |
+| `role` | Rol | ZRC | both | `participant` <-> `betrokkene`, `roleType` URL |
+| `caseObject` | ZaakObject | ZRC | both | Generic object link |
+| `caseDocument` | ZaakInformatieObject | ZRC | both | Links case to DRC document |
+| `caseProperty` | ZaakEigenschap | ZRC | both | Custom-property values |
+| `caseType` | ZaakType | ZTC | outbound | `processingDeadline` -> `doorlooptijd` (ISO 8601) |
+| `statusType` | StatusType | ZTC | outbound | `order` -> `volgnummer` |
+| `resultType` | ResultaatType | ZTC | outbound | `archivalPeriod` -> `archiefactietermijn` |
+| `roleType` | RolType | ZTC | outbound | `name` -> `omschrijving` + generic enum |
+| `propertyDefinition` | Eigenschap | ZTC | outbound | `propertyType` -> `specificatie.formaat` |
+| `documentType` | InformatieObjectType | ZTC | outbound | `confidentiality` -> `vertrouwelijkheidaanduiding` |
+| `decisionType` | BesluitType | ZTC | outbound | `caseTypes` -> `zaaktypen` URL list |
+| `catalogus` | Catalogus | ZTC | outbound | `domein` + `rsin` map directly |
+| `document` | EnkelvoudigInformatieObject | DRC | both | `content` base64 or download URL |
+| `usageRights` | GebruiksRechten | DRC | both | Per-document rights window |
+| `decision` | Besluit | BRC | both | `decisionType` -> `besluittype` URL ref |
+| `decisionDocument` | BesluitInformatieObject | BRC | both | Links besluit to DRC document |
+| `kanaal` | Kanaal | NRC | outbound | Derived from procest event registry |
+| `abonnement` | Abonnement | NRC | both | `callbackUrl` + `kanalen` filters |
+
+## URL Identifier Scheme
+
+Procest stores objects by UUID v4 in OpenRegister. ZGW requires absolute
+URL references. The mapping engine resolves both directions:
+
+- **Outbound**: `{{ _baseUrl }}/api/zgw/{api}/v1/{resource}/{{ uuid }}` --
+  rendered via the `MappingExtension` `_baseUrl` runtime variable, which
+  resolves to `scheme://host/index.php/apps/openregister/api/zgw`.
+- **Inbound**: `{{ field | zgw_extract_uuid }}` -- splits on `/`, returns
+  the last path segment. Validates UUID v4 format and rejects URLs whose
+  host does not match the configured ZGW base host (anti-SSRF).
+- **Cross-API**: a Zaak references a ZaakType via `/catalogi/v1/zaaktypen/{uuid}`,
+  not `/zaken/v1/zaaktypen/{uuid}`. Each profile declares its target API
+  prefix explicitly.
+
+## Incoming vs Outgoing Responsibilities
+
+- **Incoming (Dutch -> English, on POST/PUT/PATCH)**: parse ZGW body via
+  inbound `Mapping`, extract UUIDs from URL refs, reverse-translate enums
+  (`vertrouwelijkheidaanduiding` -> `confidentiality`), cast types, validate
+  required fields, persist as procest entity.
+- **Outgoing (English -> Dutch, on GET and response bodies)**: load procest
+  entity, apply outbound `Mapping`, construct URL refs, translate enums
+  forward, format dates as ISO 8601, format durations as `P{n}D`, wrap list
+  responses in HAL pagination via `ZgwPaginationHelper`.
+
+The split lives in the `Endpoint` entity: GET-only endpoints reference
+only `outputMapping`; POST/PUT/PATCH endpoints reference both
+`inputMapping` and `outputMapping` (the response is always re-mapped from
+the persisted entity, not echoed from the request).
+
+## OAuth2 / JWT Authentication
+
+ZGW clients authenticate via JWT bearer tokens issued by an Autorisaties
+API. Procest delegates this to **openconnector**:
+
+- Inbound: `ZgwAuthMiddleware` validates the JWT `client_id`, `iss`,
+  `iat`, and required `autorisaties` claim via openconnector's
+  `JwtValidationService`. The validated `client_id` is set as the
+  organisation context on the OpenRegister request, scoping all queries.
+- Outbound (procest calling external ZGW components, e.g., a Documenten
+  API): procest requests a JWT via openconnector's `JwtIssuerService` and
+  attaches it as `Authorization: Bearer {jwt}` on the outbound HTTP call.
+- Token cache: 5-minute TTL via APCu, keyed by `client_id` + secret hash.
+
+Procest does NOT store JWT secrets directly; all credentials live in
+openconnector's `Source` entities.
+
+## Out-of-Scope Endpoints
+
+- `/api/zgw/zaken/v1/zaken/{uuid}/audittrail` -- covered by
+  `audit-trail-immutable` spec; deferred.
+- `/api/zgw/autorisaties/v1/applicaties` -- Nextcloud auth substitutes.
+- `/api/zgw/catalogi/v1/selectielijstklassen` -- proxied to VNG
+  Selectielijst API by a future `archive` change.
+- `/api/zgw/zaken/v1/_zoek` -- POST-based search; V2.
+- `/api/zgw/documenten/v1/enkelvoudiginformatieobjecten/_zoek` -- V2.
+
+## File Changes
+
+| File | Change |
+|------|--------|
+| `lib/Settings/zgw_mappings/zaak.json` | New: inbound + outbound Mapping |
+| `lib/Settings/zgw_mappings/status.json` | New |
+| `lib/Settings/zgw_mappings/resultaat.json` | New |
+| `lib/Settings/zgw_mappings/rol.json` | New |
+| `lib/Settings/zgw_mappings/zaakobject.json` | New |
+| `lib/Settings/zgw_mappings/zaakinformatieobject.json` | New |
+| `lib/Settings/zgw_mappings/zaakeigenschap.json` | New |
+| `lib/Settings/zgw_mappings/zaaktype.json` | New |
+| `lib/Settings/zgw_mappings/statustype.json` | New |
+| `lib/Settings/zgw_mappings/resultaattype.json` | New |
+| `lib/Settings/zgw_mappings/roltype.json` | New |
+| `lib/Settings/zgw_mappings/eigenschap.json` | New |
+| `lib/Settings/zgw_mappings/informatieobjecttype.json` | New |
+| `lib/Settings/zgw_mappings/besluittype.json` | New |
+| `lib/Settings/zgw_mappings/catalogus.json` | New |
+| `lib/Settings/zgw_mappings/enkelvoudiginformatieobject.json` | New |
+| `lib/Settings/zgw_mappings/gebruiksrechten.json` | New |
+| `lib/Settings/zgw_mappings/besluit.json` | New |
+| `lib/Settings/zgw_mappings/besluitinformatieobject.json` | New |
+| `lib/Settings/zgw_endpoints.json` | New: Endpoint entities for all 19 resources |
+| `lib/Service/ZgwAuthMiddleware.php` | New: JWT validation via openconnector |
+| `lib/Service/ZgwMappingProfile.php` | New: value object describing one profile |
+| `lib/Service/Zgw*RulesService.php` | Deprecated; logic migrated to mapping JSON |
+| `tests/Conformance/ZgwConformanceTest.php` | New: VNG postman collection runner |

--- a/openspec/changes/zgw-api-mapping/proposal.md
+++ b/openspec/changes/zgw-api-mapping/proposal.md
@@ -1,0 +1,64 @@
+# Proposal: zgw-api-mapping
+
+## Summary
+
+Formalize procest as a ZGW (Zaakgericht Werken) component by replacing the
+ad-hoc `Zgw*RulesService` stack with a declarative mapping layer that
+translates procest's English-named OpenRegister entities into the five VNG
+ZGW API contracts (ZRC, ZTC, DRC, BRC, NRC) and back. The existing
+`ZgwZrcRulesService`, `ZgwZtcRulesService`, `ZgwDrcRulesService`,
+`ZgwBrcRulesService`, `ZgwBusinessRulesService`, and `ZgwMappingService`
+encode mapping logic as PHP business rules; this change replaces them with
+a `ZgwMappingProfile` per resource, wired to the OpenRegister `Mapping`
++ `Endpoint` engine described in `openspec/specs/zgw-api-mapping/spec.md`.
+
+## Motivation
+
+Procest already runs as a ZGW backend in production but its mapping logic
+is scattered across ~7,000 lines of `lib/Service/Zgw*.php` with no formal
+spec linking procest entities to ZGW resources. The canonical spec
+declares HOW mapping works (Twig engine, Endpoint wiring, pagination,
+errors); this change declares WHAT procest maps -- entity-by-entity,
+direction-by-direction. It locks in the URL identifier scheme, the
+incoming-vs-outgoing split, the OAuth2/JWT integration with openconnector,
+and the out-of-scope endpoints (audittrail, Autorisaties API, Selectielijst).
+
+## Affected Projects
+
+- [x] Project: `procest` -- declares ZGW mapping profiles for all 19+ ZGW resources
+- [ ] Project: `openregister` -- consumes mappings via existing engine (no changes)
+- [ ] Project: `openconnector` -- provides OAuth2/JWT for outbound ZGW calls (referenced only)
+
+## Scope
+
+### In Scope (V1)
+
+- **REQ-ZGW-1**: Resource mapping table (procest entity to ZGW resource)
+- **REQ-ZGW-2**: URL identifier scheme (procest UUID to ZGW URL)
+- **REQ-ZGW-3**: Outbound mapping (English to Dutch) per entity
+- **REQ-ZGW-4**: Inbound mapping (Dutch to English) per entity
+- **REQ-ZGW-5**: Sub-resource mapping (status, rol, resultaat, zaakeigenschap)
+- **REQ-ZGW-6**: ZTC catalogus mapping (caseType, statusType, resultType, roleType, decisionType, documentType)
+- **REQ-ZGW-7**: DRC document mapping (document, usageRights)
+- **REQ-ZGW-8**: BRC besluit mapping (decision, decisionDocument)
+- **REQ-ZGW-9**: OAuth2/JWT authentication via openconnector
+- **REQ-ZGW-10**: Conformance tests against VNG reference implementation
+
+### Out of Scope
+
+- Autorisaties API (AC) -- Nextcloud auth handles it
+- Audittrail resource -- separate `audit-trail-immutable` spec
+- Selectielijst API integration -- separate `archive` change
+- NRC subscription persistence -- handled by `notificatie-engine`
+- `_zoek` POST-based search endpoints -- V2
+
+## Approach
+
+1. Author a `ZgwMappingProfile` value object per ZGW resource holding the
+   inbound and outbound `Mapping` reference, the procest schema slug, and
+   the ZGW endpoint path template.
+2. Migrate per-entity logic from `Zgw*RulesService` into declarative
+   mapping JSON files under `lib/Settings/zgw_mappings/`, loaded by
+   `ConfigurationService` into OpenRegister `Mapping` entities at install.
+3. Add a `ZgwConformanceTest` suite exercising each resource against the
+   VNG postman collection in CI.

--- a/openspec/changes/zgw-api-mapping/specs/zgw-api-mapping/spec.md
+++ b/openspec/changes/zgw-api-mapping/specs/zgw-api-mapping/spec.md
@@ -1,0 +1,273 @@
+# Delta: zgw-api-mapping
+
+This change adds procest-specific declarative mapping profiles on top of
+the existing `zgw-api-mapping` canonical spec. REQ-ZGW-1..10 below
+complement (not replace) the canonical requirements, which define HOW
+mapping works; these requirements define WHAT procest maps.
+
+## Requirements
+
+### Requirement: REQ-ZGW-1 — Procest MUST declare a ZGW mapping profile for every ZGW resource it exposes
+
+Procest MUST ship a `ZgwMappingProfile` per ZGW resource, declaring the
+procest schema slug, the ZGW API prefix, the endpoint path template, and
+the inbound/outbound `Mapping` references.
+
+#### Scenario: Profile registry covers all in-scope ZGW resources
+
+- **GIVEN** the procest install has imported its ZGW configuration
+- **WHEN** `ZgwMappingProfileRegistry::all()` is called
+- **THEN** the registry MUST return one profile per ZRC resource (Zaak,
+  Status, Resultaat, Rol, ZaakObject, ZaakInformatieObject, ZaakEigenschap)
+- **AND** one profile per ZTC resource (ZaakType, StatusType, ResultaatType,
+  RolType, Eigenschap, InformatieObjectType, BesluitType, Catalogus)
+- **AND** one profile per DRC resource (EnkelvoudigInformatieObject,
+  GebruiksRechten)
+- **AND** one profile per BRC resource (Besluit, BesluitInformatieObject)
+
+#### Scenario: Profile declares both directions when the resource is writable
+
+- **GIVEN** the ZRC Zaak resource accepts POST, PUT, PATCH
+- **WHEN** `ZgwMappingProfile::for('zaak')` is inspected
+- **THEN** the profile MUST declare a non-null `inputMappingRef`
+- **AND** a non-null `outputMappingRef`
+
+#### Scenario: Read-only resources omit inbound mapping
+
+- **GIVEN** the ZTC Catalogus resource is exposed only via GET (read-only)
+- **WHEN** `ZgwMappingProfile::for('catalogus')` is inspected
+- **THEN** `inputMappingRef` MUST be `null`
+- **AND** `outputMappingRef` MUST be non-null
+
+### Requirement: REQ-ZGW-2 — Procest MUST translate UUIDs to ZGW URLs bidirectionally
+
+Every reference between procest entities MUST be exposed as an absolute
+URL in ZGW responses, and every URL reference in ZGW requests MUST be
+reduced to a UUID before persistence.
+
+#### Scenario: Outbound URL construction uses _baseUrl
+
+- **GIVEN** a case with `caseType: "abc-123"`
+- **WHEN** the outbound Zaak mapping is applied
+- **THEN** the `zaaktype` field MUST be
+  `{{ _baseUrl }}/catalogi/v1/zaaktypen/abc-123`
+- **AND** `_baseUrl` MUST resolve to the request scheme + host +
+  `/index.php/apps/openregister/api/zgw`
+
+#### Scenario: Inbound URL extraction rejects foreign hosts
+
+- **GIVEN** a POST body with
+  `zaaktype: "https://evil.example.com/catalogi/v1/zaaktypen/abc-123"`
+- **WHEN** the inbound Zaak mapping is applied
+- **THEN** `zgw_extract_uuid` MUST reject the URL because its host does
+  not match the configured ZGW base host
+- **AND** the request MUST return HTTP 400 with VNG error code
+  `invalid-url-reference`
+
+#### Scenario: Cross-API URL references use the correct API prefix
+
+- **GIVEN** a Zaak references its StatusType (a ZTC resource)
+- **WHEN** the outbound Zaak mapping renders the status URL
+- **THEN** the URL MUST use `/catalogi/v1/statustypen/{uuid}` (ZTC prefix)
+- **AND** MUST NOT use `/zaken/v1/statustypen/{uuid}`
+
+### Requirement: REQ-ZGW-3 — Procest MUST map the `case` schema to the ZGW Zaak resource
+
+The procest `case` schema MUST translate to the ZRC Zaak resource fields,
+including required `bronorganisatie`, `verantwoordelijkeOrganisatie`,
+`zaaktype`, `startdatum`, and `registratiedatum`.
+
+#### Scenario: Outbound case-to-zaak mapping
+
+- **GIVEN** a case `{uuid: "z-1", title: "Bouw", caseType: "ct-1", deadline: "2026-06-01", confidentiality: "public", sourceOrganisation: "123456789"}`
+- **WHEN** the outbound mapping is applied
+- **THEN** the response MUST contain `omschrijving: "Bouw"`,
+  `uiterlijkeEinddatumAfdoening: "2026-06-01"`,
+  `vertrouwelijkheidaanduiding: "openbaar"`,
+  `bronorganisatie: "123456789"`, and an absolute `zaaktype` URL
+
+#### Scenario: Inbound zaak-to-case mapping
+
+- **GIVEN** a POST body
+  `{zaaktype: "https://.../catalogi/v1/zaaktypen/ct-1", omschrijving: "Vergunning", vertrouwelijkheidaanduiding: "openbaar"}`
+- **WHEN** the inbound mapping is applied
+- **THEN** the persisted case MUST have `caseType: "ct-1"`,
+  `title: "Vergunning"`, `confidentiality: "public"`
+
+### Requirement: REQ-ZGW-4 — Procest MUST map case sub-resources (Status, Resultaat, Rol, ZaakEigenschap)
+
+The procest sub-resources (`statusRecord`, `result`, `role`, `caseProperty`)
+MUST translate to their ZRC counterparts (Status, Resultaat, Rol,
+ZaakEigenschap), with the parent zaak referenced by URL.
+
+#### Scenario: Status creation extracts zaak UUID from URL
+
+- **GIVEN** a POST to `/api/zgw/zaken/v1/statussen/` with body
+  `{zaak: "https://.../zaken/v1/zaken/z-1", statustype: "https://.../catalogi/v1/statustypen/st-1", datumStatusGezet: "2026-03-19T10:00:00Z"}`
+- **WHEN** the inbound mapping is applied
+- **THEN** the persisted statusRecord MUST have `case: "z-1"` and
+  `statusType: "st-1"`
+
+#### Scenario: Rol generic enum translation
+
+- **GIVEN** a role with `roleType.name: "handler"`
+- **WHEN** the outbound Rol mapping is applied
+- **THEN** `omschrijvingGeneriek` MUST be `"behandelaar"` via
+  `zgw_enum('rolomschrijvingGeneriek', ...)`
+
+### Requirement: REQ-ZGW-5 — Procest MUST map case type schemas to ZTC resources
+
+The procest `caseType`, `statusType`, `resultType`, `roleType`,
+`propertyDefinition`, `documentType`, `decisionType`, and `catalogus`
+schemas MUST translate to their ZTC counterparts. Inbound mapping is
+out-of-scope for v1 (procest is the source of truth for case definitions).
+
+#### Scenario: CaseType processingDeadline becomes doorlooptijd ISO 8601 duration
+
+- **GIVEN** a caseType with `processingDeadline: "P30D"`
+- **WHEN** the outbound ZaakType mapping is applied
+- **THEN** `doorlooptijd` MUST be `"P30D"` (passed through unchanged)
+
+#### Scenario: Virtual Catalogus derived from register
+
+- **GIVEN** the procest register has `name: "VTH"`, `organisation.rsin: "123456789"`, `domein: "VTH"`
+- **WHEN** `GET /api/zgw/catalogi/v1/catalogussen/` is called
+- **THEN** the response MUST include a Catalogus with deterministic UUID
+  derived from the register UUID
+- **AND** the Catalogus MUST contain `domein: "VTH"`,
+  `rsin: "123456789"`, and arrays of contained zaaktypen, besluittypen,
+  informatieobjecttypen URLs
+
+### Requirement: REQ-ZGW-6 — Procest MUST map the `document` schema to EnkelvoudigInformatieObject
+
+The procest `document` schema MUST translate to the DRC
+EnkelvoudigInformatieObject, including base64 content handling and
+Nextcloud Files backing storage.
+
+#### Scenario: Outbound document mapping with base64 content
+
+- **GIVEN** a document with a Nextcloud file backing it
+- **WHEN** `GET /api/zgw/documenten/v1/enkelvoudiginformatieobjecten/{uuid}` is called
+- **THEN** the response MUST include `inhoud` (base64-encoded file bytes),
+  `formaat` (MIME type from file metadata), `bestandsnaam` (original name),
+  `bestandsomvang` (file size in bytes)
+
+#### Scenario: Inbound document upload decodes base64 to Nextcloud file
+
+- **GIVEN** a POST with `inhoud: "{base64}"`, `bestandsnaam: "tekening.pdf"`, `formaat: "application/pdf"`
+- **WHEN** the inbound mapping processes the body
+- **THEN** the base64 content MUST be decoded and stored as a Nextcloud
+  file via `IRootFolder`
+- **AND** the document register object MUST link to the resulting file ID
+
+### Requirement: REQ-ZGW-7 — Procest MUST map the `decision` schema to the BRC Besluit resource
+
+The procest `decision` schema MUST translate to the BRC Besluit resource,
+with linked documents exposed via BesluitInformatieObject.
+
+#### Scenario: Outbound decision-to-besluit mapping
+
+- **GIVEN** a decision with `decisionType: "dt-1"`, `case: "z-1"`, `decisionDate: "2026-03-19"`, `effectiveDate: "2026-04-01"`
+- **WHEN** the outbound mapping is applied
+- **THEN** the response MUST contain absolute URL refs for `besluittype`
+  and `zaak`, and `datum: "2026-03-19"`, `ingangsdatum: "2026-04-01"`
+
+#### Scenario: Inbound besluit derives uiterlijkeReactiedatum
+
+- **GIVEN** a POST with `besluittype` URL referencing a BesluitType with
+  `reactietermijn: "P42D"` and `datum: "2026-03-19"`
+- **WHEN** the inbound mapping processes the body
+- **THEN** `uiterlijkeReactiedatum` MUST be computed as `2026-03-19 + 42 days`
+- **AND** stored on the decision object as `appealDeadline`
+
+### Requirement: REQ-ZGW-8 — Procest MUST authenticate ZGW requests via openconnector JWT
+
+All ZGW endpoints MUST require a valid JWT bearer token validated through
+openconnector's `JwtValidationService`. Outbound ZGW calls MUST attach a
+JWT issued by openconnector's `JwtIssuerService`.
+
+#### Scenario: Missing JWT returns VNG-format 401
+
+- **GIVEN** a request to `/api/zgw/zaken/v1/zaken/` without an
+  `Authorization` header
+- **WHEN** `ZgwAuthMiddleware` processes the request
+- **THEN** the response MUST be HTTP 401 with body
+  `{type: ".../authentication-error", code: "authentication-required", title: "Niet geauthenticeerd.", status: 401, detail: "..."}`
+
+#### Scenario: Validated JWT sets organisation context
+
+- **GIVEN** a valid JWT with `client_id: "vergunning-app"` validated by
+  openconnector
+- **WHEN** the request enters the ZGW controller
+- **THEN** the OpenRegister request context MUST have `organisation` set
+  to the openconnector-mapped organisation for `vergunning-app`
+- **AND** all queries MUST be scoped to that organisation
+
+#### Scenario: Outbound JWT caching
+
+- **GIVEN** procest needs to call an external Documenten API 10 times in
+  under 5 minutes
+- **WHEN** `ZgwHttpClient::request()` is called for each
+- **THEN** the JWT MUST be requested once from openconnector and cached
+  in APCu for 5 minutes
+- **AND** all 10 calls MUST reuse the same token
+
+### Requirement: REQ-ZGW-9 — Out-of-scope ZGW endpoints MUST return HTTP 501
+
+Endpoints not implemented by procest MUST return HTTP 501 with a
+VNG-format error body and a stable error code, so that ZGW clients can
+distinguish "not implemented" from "server error".
+
+#### Scenario: Audittrail endpoint returns 501
+
+- **GIVEN** the audittrail resource is deferred to
+  `audit-trail-immutable`
+- **WHEN** `GET /api/zgw/zaken/v1/zaken/{uuid}/audittrail` is called
+- **THEN** the response MUST be HTTP 501 with body
+  `{type: ".../not-implemented", code: "audittrail-not-implemented", title: "Niet geïmplementeerd.", status: 501, ...}`
+
+#### Scenario: Autorisaties API returns 501
+
+- **GIVEN** authorization is handled by Nextcloud, not via the
+  Autorisaties API
+- **WHEN** any `/api/zgw/autorisaties/v1/*` endpoint is called
+- **THEN** the response MUST be HTTP 501 with code
+  `autorisaties-not-implemented`
+
+#### Scenario: _zoek search endpoints return 501
+
+- **GIVEN** POST-based search is deferred to V2
+- **WHEN** `POST /api/zgw/zaken/v1/_zoek` is called
+- **THEN** the response MUST be HTTP 501 with code `zoek-not-implemented`
+
+### Requirement: REQ-ZGW-10 — Procest MUST run VNG conformance tests in CI
+
+A `ZgwConformanceTest` suite MUST exercise each declared ZGW resource
+against the VNG reference postman collection and OpenAPI documents, and
+MUST run in CI on every push to `development`.
+
+#### Scenario: VNG postman collection runs against fixture data
+
+- **GIVEN** procest is installed with seed data including a catalogus,
+  zaaktypen, and zaken
+- **WHEN** the conformance test runs the VNG ZRC v1.5.1 postman
+  collection
+- **THEN** every assertion MUST pass
+- **AND** every response MUST validate against the published VNG OpenAPI
+  schema for that resource
+
+#### Scenario: Conformance test covers all 19 in-scope resources
+
+- **GIVEN** the conformance test is executed
+- **WHEN** the test discovery phase enumerates profiles
+- **THEN** every profile in `ZgwMappingProfileRegistry::all()` MUST have
+  at least one corresponding conformance test case
+- **AND** absence of a test case MUST fail the suite
+
+#### Scenario: Conformance failures block PR merge
+
+- **GIVEN** a PR modifies a ZGW mapping JSON file
+- **WHEN** CI runs the conformance suite
+- **THEN** any failed assertion MUST mark the CI job as failed
+- **AND** the GitHub branch protection rule MUST block merge until the
+  job passes

--- a/openspec/changes/zgw-api-mapping/tasks.md
+++ b/openspec/changes/zgw-api-mapping/tasks.md
@@ -1,0 +1,25 @@
+# Tasks: zgw-api-mapping
+
+## Implementation Tasks
+
+- [ ] **T01**: Define `ZgwMappingProfile` value object (`lib/Service/ZgwMappingProfile.php`) holding profile name, procest schema slug, ZGW API prefix, endpoint path template, inbound Mapping reference, outbound Mapping reference, required fields list, and conformance test tag
+- [ ] **T02**: Author per-entity outbound mapping JSON files for ZRC resources (zaak, status, resultaat, rol, zaakobject, zaakinformatieobject, zaakeigenschap) in `lib/Settings/zgw_mappings/`, each defining English-to-Dutch property translation, enum maps, URL ref templates, and ISO 8601 date formats
+- [ ] **T03**: Author per-entity inbound mapping JSON files for ZRC resources, each using `zgw_extract_uuid`, `zgw_enum_reverse`, and type casts to translate Dutch ZGW request bodies into procest schema objects
+- [ ] **T04**: Author ZTC catalog mapping JSON files (zaaktype, statustype, resultaattype, roltype, eigenschap, informatieobjecttype, besluittype, catalogus) -- outbound only for v1, since procest is the source of truth for case definitions
+- [ ] **T05**: Author DRC document mapping JSON files (enkelvoudiginformatieobject, gebruiksrechten) including base64 content handling, MIME type mapping, and `bestandsomvang` byte-size derivation
+- [ ] **T06**: Author BRC besluit mapping JSON files (besluit, besluitinformatieobject) including `uiterlijkeReactiedatum` derivation from `besluittype.reactietermijn` and `vervalreden` enum translation
+- [ ] **T07**: Author `lib/Settings/zgw_endpoints.json` declaring one Endpoint entity per (resource x HTTP method) combination -- approximately 60 endpoints covering GET-list, GET-detail, POST, PUT, PATCH, DELETE per resource where supported
+- [ ] **T08**: Wire `ConfigurationService::importFromApp()` to load all mapping and endpoint JSON files into OpenRegister at install/upgrade, with idempotent re-import on version bump
+- [ ] **T09**: Implement `ZgwAuthMiddleware` validating JWT bearer tokens via openconnector's `JwtValidationService`, extracting `client_id` as organisation context, and rejecting tokens with HTTP 401 plus VNG-format error body
+- [ ] **T10**: Migrate request signing for outbound ZGW calls into a `ZgwHttpClient` wrapper that requests JWTs from openconnector's `JwtIssuerService` and caches them in APCu with 5-minute TTL
+- [ ] **T11**: Author `tests/Conformance/ZgwConformanceTest.php` running the VNG postman collection (ZRC, ZTC, DRC, BRC) against a fixture-loaded procest, asserting response schemas match VNG OpenAPI documents
+- [ ] **T12**: Deprecate `ZgwZrcRulesService`, `ZgwZtcRulesService`, `ZgwDrcRulesService`, `ZgwBrcRulesService`, and `ZgwBusinessRulesService` -- add `@deprecated` docblocks pointing to the new mapping JSON, retain for one release for backward compatibility
+
+## Verification Tasks
+
+- [ ] **V01**: Each of the 19 ZGW resources in the mapping table has both an inbound (if applicable) and outbound JSON file under `lib/Settings/zgw_mappings/`
+- [ ] **V02**: `zgw_endpoints.json` registers HTTP methods matching the spec table; PATCH endpoints have `passThrough: true`
+- [ ] **V03**: VNG conformance suite passes for ZRC v1.5.1, ZTC v1.3.1, DRC v1.4.3, BRC v1.1.0
+- [ ] **V04**: JWT middleware rejects expired, malformed, and wrong-issuer tokens with VNG-formatted error responses
+- [ ] **V05**: URL refs in outbound responses are absolute and use the configured `_baseUrl`; URL refs in inbound bodies are reduced to UUIDs and rejected if the host does not match
+- [ ] **V06**: Out-of-scope endpoints (audittrail, autorisaties, selectielijstklassen, `_zoek`) return HTTP 501 with VNG-format error body


### PR DESCRIPTION
## Summary

Generates new OpenSpec change `zgw-api-mapping` formalizing procest as a ZGW (Zaakgericht Werken) component. Replaces the ad-hoc `Zgw*RulesService` stack (~7k lines) with a declarative mapping-profile layer that translates procest's English-named OpenRegister entities into the five VNG ZGW API contracts (ZRC, ZTC, DRC, BRC, NRC) and back.

- 10 requirements (REQ-ZGW-1..10) with Given/When/Then scenarios
- Entity-by-entity mapping table covering 19+ ZGW resources
- URL identifier scheme (UUID <-> ZGW URL bidirectional)
- OAuth2/JWT auth via openconnector
- VNG conformance test suite in CI
- 12 implementation tasks + 6 verification tasks

## Test plan

- [ ] OpenSpec validation passes
- [ ] Spec accurately reflects current lib/Service/Zgw* mapping behavior
- [ ] Cross-references to canonical zgw-api-mapping/spec.md are correct
- [ ] Out-of-scope endpoints (audittrail, autorisaties, selectielijst, _zoek) clearly demarcated