### PR TITLE
chore(openspec): generate process-step-configuration spec

### DIFF
--- a/openspec/changes/process-step-configuration/design.md
+++ b/openspec/changes/process-step-configuration/design.md
@@ -1,0 +1,129 @@
+# Design: process-step-configuration
+
+## Architecture Overview
+
+This change is additive on top of `workflow-definition-model`. It introduces a single new shape — `StepConfig` — that hangs off each `WorkflowStep` inside a published `workflowTemplate`. Validation is a pure helper; persistence reuses the existing `WorkflowDefinitionService`. Two consumers (`status-transition-engine` and the runtime task creator) read the new fields. One repair step backfills the existing seeded bezwaar workflow. No new top-level OpenRegister schema; no new controller routes.
+
+```
+WorkflowDefinitionDialog.vue (existing)
+└── WorkflowStepsEditor.vue (existing)
+    └── StepConfigPanel.vue (new, per-step collapsible)
+        ├── SlaInput.vue (hours / business-days toggle)
+        ├── RequiredFieldsPicker.vue (multi-select from caseType fields)
+        ├── AutoActionsList.vue (existing automatic-actions catalog)
+        └── EscalationRuleEditor.vue (target role + offset)
+
+Backend
+├── WorkflowDefinitionService::publish() (existing)
+│   └── StepConfigValidator::validate(step.config) (new)  ← rejects malformed config
+├── StatusTransitionService::getAvailableTransitions() (existing)
+│   ├── reads step.config.requiredFields as implicit guard
+│   └── triggers step.config.autoActions via existing pipeline
+├── TaskCreatorService::createForStep() (existing)
+│   ├── stamps task.dueAt from step.config.sla
+│   └── stamps task.escalationAt + escalationTarget from step.config.escalationRule
+└── Migration/BackfillBezwaarStepConfig.php (new repair step)
+```
+
+## Entity Model
+
+`WorkflowStep.config` (new, optional sub-object on every embedded step in `workflowTemplate.steps`):
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `sla` | object | `{ value: integer, unit: enum(hours|businessDays|calendarDays) }` — soft deadline; absence = no SLA |
+| `requiredFields` | array<string> | Case-field property paths that MUST be populated to complete the step |
+| `autoActions` | array<ActionRef> | Action keys + parameters fired on step completion |
+| `escalationRule` | object | `{ trigger: enum(slaBreached|preBreach), offset: integer, offsetUnit: enum(hours|businessDays), notifyRole: reference, escalateToRole: reference, openIncident: boolean }` |
+
+All four properties are optional. An empty `config` (or absent `config`) preserves today's V1 behaviour (no SLA, no implicit field guards, no auto-actions, no escalation). The shape is additive and backwards-compatible: existing seeded templates without `config` continue to work.
+
+### ActionRef
+
+Already defined by the `automatic-actions` spec. Reused verbatim: `{ key: string (enum from action catalog), parameters: object }`. No new action keys are introduced by this change.
+
+## Validation Contract (`StepConfigValidator`)
+
+Pure function. No I/O. Inputs: the `WorkflowStep` and the parent `caseType` (for field-reference resolution). Outputs: an array of structured validation errors with `path` + `code` + `message` keys.
+
+Rules:
+
+1. `sla.value` MUST be a positive integer ≤ 10000.
+2. `sla.unit` MUST be one of the three enum values.
+3. Every `requiredFields[i]` MUST resolve to a property defined on the linked `caseType` schema.
+4. Every `autoActions[i].key` MUST be present in the `automatic-actions` action catalog.
+5. `escalationRule.notifyRole` and `escalateToRole` MUST resolve to roleTypes defined on the linked `caseType`.
+6. `escalationRule` MUST be absent if `sla` is absent (escalation requires a deadline).
+7. `escalationRule.offset` MUST be ≤ `sla.value` when `trigger == preBreach`.
+
+Validation runs on `WorkflowDefinitionService::publish()` — *not* on draft save. Drafts may hold malformed config; publish refuses it.
+
+## Engine Consumption (Read-Only)
+
+`status-transition-engine` already evaluates explicit guards on transitions. This change adds an *implicit* guard derived from the *current step's* `config.requiredFields`: if any required field is empty for the case in flight, exit transitions from that step's status are blocked. The user-facing message format is identical to the existing `requiredField` guard: `"Vereist veld ontbreekt: '<label>'"`.
+
+`config.autoActions` are appended to the existing `automaticActions` pipeline already invoked when a step is completed. Order: step-level auto-actions fire first, then transition-level auto-actions (when the completion also triggers a transition). Failures of individual auto-actions are logged but do NOT roll back the step completion (consistent with `status-transition-engine` REQ — see "Transition triggers automatic actions").
+
+`TaskCreatorService` stamps two new fields onto the created task at activation time:
+
+- `task.dueAt = activatedAt + sla.value [in sla.unit]`
+- `task.escalationAt = task.dueAt - escalationRule.offset [in offsetUnit]` (when `trigger == preBreach`)
+- `task.escalationAt = task.dueAt + escalationRule.offset` (when `trigger == slaBreached`)
+
+A separate background runner (out of scope here, owned by `automatic-actions`) walks tasks whose `escalationAt < now` and fires the configured `notifyRole` / `escalateToRole` / `openIncident` side-effects.
+
+## Storage Decision
+
+`config` is stored inline inside each step entry of the existing `steps` JSON string on `workflowTemplate`. We deliberately do NOT promote `StepConfig` to a top-level OpenRegister schema:
+
+1. The `workflow-definition-model` design decision keeps the whole template as one immutable object on publish; introducing a separate entity would defeat that.
+2. There is no read pattern that wants step configs without the step.
+3. Step configs are never referenced cross-template; co-location is correct.
+
+Trade-off: `config` cannot be edited without rewriting the parent template. Acceptable — the `workflow-definition-model` clone-and-publish cycle covers config edits the same way it covers structural edits.
+
+## Editor UI (Low-Fidelity)
+
+```
+Step: "Toets ontvankelijkheid"  status: Ontvankelijkheidstoets   role: Behandelaar
+  [x] isRequired           [3 checklist items]      ▾ Geavanceerd
+
+  ┌── Geavanceerd ──────────────────────────────────────────────────┐
+  │  SLA:        [  10  ] [ werkdagen ▼ ]                            │
+  │                                                                  │
+  │  Verplichte velden:  [ × isTimely ] [ × belanghebbendheid ]      │
+  │                      [ + Veld toevoegen ▼ ]                      │
+  │                                                                  │
+  │  Automatische acties bij afronden:                                │
+  │    1. notifySteller    parameters: {…}    [edit] [×]            │
+  │    2. logToAuditTrail  parameters: {…}    [edit] [×]            │
+  │    [ + Actie toevoegen ▼ ]                                       │
+  │                                                                  │
+  │  Escalatie:                                                       │
+  │    Trigger:        [ pre-breach ▼ ]                              │
+  │    Marge:          [  2  ] [ werkdagen ▼ ] vóór deadline         │
+  │    Waarschuw:      [ Behandelaar ▼ ]                             │
+  │    Escaleer naar:  [ Afdelingshoofd ▼ ]                          │
+  │    [ ] Maak ook een incident aan                                  │
+  └──────────────────────────────────────────────────────────────────┘
+```
+
+Form-only in V1. Visual escalation designer is V2.
+
+## Integration with Other Specs
+
+- `workflow-definition-model` — owns the parent `workflowTemplate` and its lifecycle; this change adds an additive sub-shape and a publish-time validator.
+- `status-transition-engine` — consumer of `config.requiredFields` (implicit guard) and `config.autoActions` (step-completion side-effects).
+- `automatic-actions` — provides the action catalog that `StepConfigValidator` rule 4 checks against; no new action keys here.
+- `bezwaar-lifecycle` / `bezwaar-decision` — beneficiaries of the seeded SLAs in the repair step.
+
+## Migration Plan
+
+`BackfillBezwaarStepConfig` runs once per upgrade and is idempotent (re-running is a no-op):
+
+1. Load the seeded bezwaar `workflowTemplate` (`isActive: true`, lowest published version).
+2. For each step whose `id` matches a known bezwaar-step key, attach the corresponding `config` block (e.g. "Toets termijn" → `{ sla: { value: 5, unit: businessDays }, requiredFields: ["isTimely"], escalationRule: { trigger: preBreach, offset: 1, offsetUnit: businessDays, notifyRole: "Behandelaar", escalateToRole: "Afdelingshoofd", openIncident: false } }`).
+3. Re-publish the template by bumping its `version` and creating a new published record (NOT mutating the existing one — `workflow-definition-model` guarantees published versions are immutable).
+4. Deprecate the previous version. Open bezwaar cases stay pinned to their existing `workflowVersion` and are unaffected.
+
+Pre-existing SLAs encoded in `BezwaarLifecycleService` constants are removed in the same change after the repair step lands.

--- a/openspec/changes/process-step-configuration/proposal.md
+++ b/openspec/changes/process-step-configuration/proposal.md
@@ -1,0 +1,45 @@
+# Proposal: Process Step Configuration
+
+## Summary
+
+Extend the existing `process-step-configuration` spec (which today covers only CRUD of steps inside a workflow and step-to-task mapping) with a tenant-admin **per-step configuration surface**: SLA / timeouts, mandatory case-field declarations, on-complete automatic actions, and escalation rules. Today these knobs are hard-coded inside `StatusTransitionService`, `CaseFieldValidator`, and the bezwaar-specific repair step, which means every tenant gets the same SLAs and the same set of required fields per status, and any change requires a developer commit. This change exposes them as declarative `step.config` data hung off each `WorkflowStep` in the `workflowTemplate` schema and consumed read-only by `status-transition-engine` and the runtime task creator.
+
+## Problem
+
+`workflow-definition-model` (just merged via PR #347) introduced `WorkflowStep` as an embedded object but only on the structural axis: which step, which status, which role, ordered, optionally required, with a checklist. The behavioural axis is missing: how long a step may take before it escalates, which case fields must be populated to mark it complete, what automatic actions to fire on completion, and how to escalate when a step runs over its SLA. `status-transition-engine` (PR #352) has placeholders for these but no model to read from. Tenant admins cannot tune step-level behaviour without a developer; the bezwaar-specific 6-week SLA is currently in a constant in `BezwaarLifecycleService`.
+
+## Affected Projects
+
+- [ ] Project: `procest` — Extend `WorkflowStep` with a `config` sub-object in `lib/Settings/procest_register.json`, add `StepConfigValidator` (pure validation, no persistence), wire `StatusTransitionService` to honour `config.sla` / `config.requiredFields` / `config.autoActions` / `config.escalationRule`, add a Vue editor for the config block inside the existing `WorkflowDefinitionDialog`, and migrate the hard-coded bezwaar SLAs into seeded `config` blocks.
+
+## Scope
+
+### In Scope (V1)
+
+- **Per-step `config` sub-object** (REQ-PSC-3): `sla`, `requiredFields[]`, `autoActions[]`, `escalationRule` on every `WorkflowStep`, declarative and optional.
+- **`StepConfigValidator`** (REQ-PSC-4): structural validation at definition-publish time; rejects unknown action keys, out-of-range SLA, dangling field references.
+- **Engine consumption** (REQ-PSC-5..6): `status-transition-engine` reads `requiredFields` and `autoActions`; the runtime task creator stamps a `dueAt` from `sla` and an `escalationAt` from `escalationRule`.
+- **Admin editor** (REQ-PSC-7): Vue panel embedded in the existing step row of `WorkflowDefinitionDialog` — no separate route.
+- **Seed migration** (REQ-PSC-8): repair step lifts the hard-coded bezwaar SLAs and required-field lists into `config` on the seeded bezwaar `workflowTemplate`.
+
+### Out of Scope
+
+- Visual escalation-tree designer — V2.
+- Custom-expression action keys (free-form JSONPath / JS) — Enterprise; V1 ships a closed enum.
+- Tenant-level overrides on a published definition without cloning — explicitly rejected; honours `workflow-definition-model` immutability.
+- Status-level (rather than step-level) configuration — owned by `status-transition-engine`.
+
+## Approach
+
+1. Extend the `WorkflowStep` shape in the existing `workflowTemplate` schema with an optional `config` object (additive, backwards compatible).
+2. Add `lib/Service/StepConfigValidator.php` — a pure-function validator invoked by `WorkflowDefinitionService::publish()` before transition to `published`.
+3. Teach `StatusTransitionService::getAvailableTransitions()` and the task creator to read `config.requiredFields` (as an additional implicit guard) and `config.autoActions` (executed in the existing automatic-action pipeline). Stamp `task.dueAt` from `config.sla`.
+4. Surface the config block in `WorkflowDefinitionDialog.vue` as a collapsible "Geavanceerd" panel per step row; no new dialog.
+5. Repair step `BackfillBezwaarStepConfig` migrates the hard-coded `BezwaarLifecycleService` constants into `config` on the seeded `workflowTemplate`.
+
+## Cross-Project Dependencies
+
+- **`workflow-definition-model` (procest)** — extends the `WorkflowStep` embedded shape; publish-time validation hooks into `WorkflowDefinitionService::publish()`.
+- **`status-transition-engine` (procest)** — consumer; reads `config.requiredFields` and triggers `config.autoActions`.
+- **OpenRegister** — additive schema change to `workflowTemplate`; no new top-level schema.
+- **`automatic-actions` (procest)** — `config.autoActions` items reference action keys already defined by that spec; no new action surface introduced here.

--- a/openspec/changes/process-step-configuration/specs/process-step-configuration/spec.md
+++ b/openspec/changes/process-step-configuration/specs/process-step-configuration/spec.md
@@ -1,0 +1,237 @@
+---
+status: draft
+---
+# process-step-configuration Specification
+
+## Purpose
+
+Extend the existing `process-step-configuration` capability (step CRUD inside a workflow + step-to-task mapping) with a declarative per-step configuration surface — SLA, mandatory case-field declarations, on-complete automatic actions, and escalation rules — that tenant admins can edit per step and that `status-transition-engine` and the runtime task creator consume read-only.
+
+## Context
+
+`workflow-definition-model` (PR #347) introduced `WorkflowStep` as an embedded structural unit: ordered, status-bound, role-bound, optionally required, with a checklist. The behavioural axis — how long the step may take, which fields must be filled to complete it, what side-effects fire on completion, how to escalate when it runs over — is hard-coded today in `StatusTransitionService`, `CaseFieldValidator`, and the bezwaar-specific `BezwaarLifecycleService`. Tenants cannot tune these knobs without a developer release. This change exposes them as an additive `config` sub-object on every `WorkflowStep` and adds the validation, engine consumption, admin editor, and bezwaar backfill needed to put them into production. The shape is additive and backwards-compatible: existing seeded templates without `config` retain V1 behaviour exactly.
+
+## Requirements
+
+---
+
+### REQ-PSC-1: Step Config Sub-Object on WorkflowStep
+
+The system SHALL support an optional `config` sub-object on every embedded `WorkflowStep` inside `workflowTemplate.steps`. The shape is `{ sla?, requiredFields?, autoActions?, escalationRule? }`. All sub-fields SHALL be optional; absent `config` SHALL preserve the V1 behaviour of `workflow-definition-model` exactly.
+
+**Feature tier**: V1
+
+#### REQ-PSC-1-001: Schema accepts step config
+
+- **GIVEN** the Procest app has run the latest repair step extending the `workflowTemplate` schema
+- **WHEN** an administrator saves a `workflowTemplate` draft whose step "Toets ontvankelijkheid" carries `config: { sla: { value: 5, unit: "businessDays" }, requiredFields: ["isTimely"] }`
+- **THEN** the draft SHALL persist without validation errors
+- **AND** reading the draft back SHALL return the `config` sub-object byte-for-byte
+- **AND** other steps in the same draft that omit `config` SHALL remain unchanged
+
+#### REQ-PSC-1-002: Absent config preserves V1 behaviour
+
+- **GIVEN** a published `workflowTemplate` whose every step omits the `config` property
+- **WHEN** a case in that workflow enters the status "In behandeling"
+- **THEN** the runtime SHALL behave identically to V1 of `workflow-definition-model`: no SLA stamping, no implicit field guards, no step-level auto-actions, no escalation tasks
+
+---
+
+### REQ-PSC-2: SLA on a Step
+
+The system SHALL allow an SLA to be expressed per step as `{ value: positive integer, unit: enum("hours" | "businessDays" | "calendarDays") }`. When an SLA is present, the task creator SHALL stamp `task.dueAt` at step activation time and the status-transition engine SHALL surface the deadline on the case detail.
+
+**Feature tier**: V1
+
+#### REQ-PSC-2-001: dueAt stamped from step SLA at activation
+
+- **GIVEN** step "Inhoudelijke beoordeling" has `config.sla = { value: 10, unit: "businessDays" }`
+- **WHEN** case "ZK-2026-0042" enters the status that owns this step at 2026-05-11 09:00 Amsterdam local time
+- **THEN** the system SHALL create a task whose `dueAt` is 10 working days after activation (skipping weekends and Dutch public holidays per the existing platform calendar)
+- **AND** the task detail UI SHALL render the deadline as "Verloopt op …"
+
+#### REQ-PSC-2-002: SLA value bounds enforced at publish
+
+- **GIVEN** an administrator drafts a `workflowTemplate` containing a step with `config.sla.value = 0`
+- **WHEN** the administrator attempts to publish the draft
+- **THEN** the publish SHALL be refused with a generic user-facing error
+- **AND** the structured validation error SHALL be logged with `path: steps[i].config.sla.value` and `code: out_of_range`
+
+---
+
+### REQ-PSC-3: Required-Fields Guard from Step Config
+
+The system SHALL treat each entry of `config.requiredFields[]` on the case's current step as an implicit `requiredField` guard on every exit transition from that step's status. The user-facing block message SHALL match the existing transition-level `requiredField` guard format.
+
+**Feature tier**: V1
+
+#### REQ-PSC-3-001: Missing required field blocks exit transition
+
+- **GIVEN** the case is in the status whose current step has `config.requiredFields = ["resultaat"]`
+- **AND** the case has no value for the field "resultaat"
+- **WHEN** the handler views the case detail
+- **THEN** every exit transition button from that status SHALL be disabled
+- **AND** the tooltip SHALL display `"Vereist veld ontbreekt: 'Resultaat'"` (label resolved via the linked caseType's field metadata)
+
+#### REQ-PSC-3-002: Filled required field unblocks exit transitions
+
+- **GIVEN** the same step and the case now has "resultaat" populated
+- **WHEN** the handler views the case detail
+- **THEN** the exit transitions whose own guards are otherwise satisfied SHALL be enabled
+- **AND** no `"Vereist veld ontbreekt"` tooltip SHALL appear
+
+---
+
+### REQ-PSC-4: StepConfigValidator at Publish
+
+The system SHALL validate every step's `config` at the moment of publishing a `workflowTemplate` draft. Validation SHALL be a pure-function check (no I/O) and SHALL reject malformed config without persisting it. Draft saves SHALL NOT trigger validation.
+
+**Feature tier**: V1
+
+#### REQ-PSC-4-001: Unknown auto-action key refused
+
+- **GIVEN** a draft `workflowTemplate` whose step has `config.autoActions = [{ key: "doesNotExist", parameters: {} }]`
+- **WHEN** the administrator clicks "Publiceren"
+- **THEN** `StepConfigValidator::validate()` SHALL return an error with `code: unknown_action_key`
+- **AND** `WorkflowDefinitionService::publish()` SHALL refuse the lifecycle flip
+- **AND** the response SHALL contain a generic static error string (no raw validator output)
+- **AND** the structured error SHALL be logged via `logger->warning()`
+
+#### REQ-PSC-4-002: Dangling required-field reference refused
+
+- **GIVEN** a draft step references `config.requiredFields = ["thisFieldDoesNotExist"]` and the linked caseType has no such property
+- **WHEN** the administrator clicks "Publiceren"
+- **THEN** the publish SHALL be refused with logged error `code: unknown_field_reference`
+
+#### REQ-PSC-4-003: Escalation without SLA refused
+
+- **GIVEN** a draft step with `config.escalationRule` present but `config.sla` absent
+- **WHEN** the administrator clicks "Publiceren"
+- **THEN** the publish SHALL be refused with logged error `code: escalation_requires_sla`
+
+#### REQ-PSC-4-004: Draft saves bypass validation
+
+- **GIVEN** the same malformed draft from REQ-PSC-4-001
+- **WHEN** the administrator clicks "Opslaan" (draft save) instead of "Publiceren"
+- **THEN** the draft SHALL persist successfully with its malformed `config`
+- **AND** the validator SHALL NOT be invoked
+
+---
+
+### REQ-PSC-5: Step Auto-Actions on Completion
+
+The system SHALL execute `config.autoActions[]` on the current step when the step is completed. Step-level auto-actions SHALL fire BEFORE transition-level auto-actions when the completion event also drives a transition. Failures of individual auto-actions SHALL be logged but SHALL NOT roll back the step completion.
+
+**Feature tier**: V1
+
+#### REQ-PSC-5-001: Step auto-actions fire on completion
+
+- **GIVEN** step "Advies opstellen" has `config.autoActions = [{ key: "notifySteller", parameters: {} }, { key: "logToAuditTrail", parameters: { event: "advice_complete" } }]`
+- **WHEN** the handler marks the step complete
+- **THEN** the platform SHALL invoke "notifySteller" first, then "logToAuditTrail"
+- **AND** both actions SHALL fire BEFORE any transition-level `automaticActions` if the completion also triggers a transition
+
+#### REQ-PSC-5-002: Auto-action failure does not roll back step completion
+
+- **GIVEN** the same step where "notifySteller" raises an exception at runtime
+- **WHEN** the handler marks the step complete
+- **THEN** the step SHALL remain completed in the case state
+- **AND** the failure SHALL be logged via `logger->error()` with the action key and an internal exception id
+- **AND** the next auto-action ("logToAuditTrail") SHALL still execute
+
+---
+
+### REQ-PSC-6: Escalation Rule on a Step
+
+The system SHALL support a per-step `escalationRule` declaring when and how to escalate when the step approaches or breaches its SLA. The rule SHALL include `trigger` (`preBreach` or `slaBreached`), `offset` + `offsetUnit`, `notifyRole`, `escalateToRole`, and `openIncident`. The task creator SHALL stamp `task.escalationAt` at activation time; a downstream runner (owned by `automatic-actions`) drives the actual side-effects.
+
+**Feature tier**: V1
+
+#### REQ-PSC-6-001: escalationAt stamped on activation for preBreach trigger
+
+- **GIVEN** step "Bezwaar afhandelen" has `config.sla = { value: 42, unit: "calendarDays" }` and `config.escalationRule = { trigger: "preBreach", offset: 5, offsetUnit: "calendarDays", notifyRole: "Behandelaar", escalateToRole: "Afdelingshoofd", openIncident: false }`
+- **WHEN** the case enters the status owning this step on 2026-05-11
+- **THEN** the created task SHALL have `dueAt = 2026-06-22` (42 calendar days later)
+- **AND** the task SHALL have `escalationAt = 2026-06-17` (5 calendar days before `dueAt`)
+- **AND** the task SHALL persist the `notifyRole`, `escalateToRole`, and `openIncident` values for the downstream runner
+
+#### REQ-PSC-6-002: escalationAt for slaBreached trigger lands after dueAt
+
+- **GIVEN** the same step but with `escalationRule.trigger = "slaBreached"` and `offset = 2, offsetUnit = "businessDays"`
+- **WHEN** the case enters the status on 2026-05-11 (a Monday)
+- **THEN** the task SHALL have `escalationAt = dueAt + 2 business days`
+
+---
+
+### REQ-PSC-7: Admin Editor Panel per Step
+
+The system SHALL surface step configuration as a collapsible "Geavanceerd" panel rendered inside the existing per-step row of `WorkflowStepsEditor`. The panel SHALL be writable only on `draft` definitions and SHALL render read-only on `published` or `deprecated` definitions. No separate route or dialog SHALL be introduced.
+
+**Feature tier**: V1
+
+#### REQ-PSC-7-001: Editor visible only on draft
+
+- **GIVEN** the administrator opens a `workflowTemplate` in lifecycle status `draft`
+- **WHEN** the administrator expands a step row and clicks "Geavanceerd"
+- **THEN** the SLA / required-fields / auto-actions / escalation inputs SHALL all be editable
+- **AND** saving the draft SHALL persist the new `config` block without invoking the validator
+
+#### REQ-PSC-7-002: Editor read-only on published
+
+- **GIVEN** the administrator opens the same template after publishing it
+- **WHEN** the administrator expands a step row and clicks "Geavanceerd"
+- **THEN** every input SHALL render in a disabled state
+- **AND** the panel SHALL display a banner: "Gepubliceerde versies zijn niet bewerkbaar — kloon eerst een nieuwe versie."
+
+#### REQ-PSC-7-003: Editor strings localised
+
+- **GIVEN** the administrator's Nextcloud locale is `nl_NL`
+- **WHEN** the panel renders
+- **THEN** every label, placeholder, and error message SHALL be loaded via `this.t(appName, '...')` against the Dutch translation catalogue (consistent with `i18n` ADR)
+
+---
+
+### REQ-PSC-8: Backfill Bezwaar Step Config
+
+The system SHALL provide a repair step that migrates the hard-coded SLAs and required-field lists from `BezwaarLifecycleService` into `config` on the seeded bezwaar `workflowTemplate`. The migration SHALL respect `workflow-definition-model` immutability: it SHALL clone the existing published version, attach the `config` blocks, publish the new version, and deprecate the previous version. Open cases pinned to the previous version SHALL be unaffected.
+
+**Feature tier**: V1
+
+#### REQ-PSC-8-001: Seeded bezwaar workflow gets config blocks
+
+- **GIVEN** the Procest app has the seeded bezwaar `workflowTemplate` at `version: 1, lifecycleStatus: published` with hard-coded SLAs in `BezwaarLifecycleService`
+- **WHEN** the repair step runs
+- **THEN** a new `version: 2` of the same template SHALL be created with `config` blocks attached to every known bezwaar step ("Toets termijn", "Toets belanghebbendheid", "Toets besluit-karakter", "Plan hoorzitting", "Stel advies op", "Neem beslissing", "Verstuur besluit")
+- **AND** the new version SHALL be `lifecycleStatus: published, isActive: true`
+- **AND** version 1 SHALL be moved to `lifecycleStatus: deprecated, isActive: false`
+- **AND** `caseType.workflowDefinition` for the Bezwaar case type SHALL point at version 2
+
+#### REQ-PSC-8-002: Open cases stay pinned to the prior version
+
+- **GIVEN** three open bezwaar cases were created against version 1 (with `case.workflowVersion = 1`)
+- **WHEN** the repair step publishes version 2
+- **THEN** the three open cases SHALL still resolve their definition to version 1 via `WorkflowDefinitionService::getDefinitionForCase()`
+- **AND** their behaviour SHALL be unchanged (no new SLAs retroactively applied)
+
+#### REQ-PSC-8-003: Repair step is idempotent
+
+- **GIVEN** the repair step has already run once (version 2 with `config` is active)
+- **WHEN** the repair step runs a second time
+- **THEN** it SHALL detect that the active version already has populated `config` on at least one step
+- **AND** it SHALL exit without creating a version 3 and without modifying any record
+
+## Dependencies
+
+- `workflow-definition-model` (procest) — owns the parent `workflowTemplate` schema and lifecycle; this spec extends its `WorkflowStep` shape additively and hooks into `WorkflowDefinitionService::publish()` for validation
+- `status-transition-engine` (procest) — consumes `config.requiredFields` (implicit guard) and `config.autoActions` (step-completion pipeline)
+- `automatic-actions` (procest) — provides the action catalog `StepConfigValidator` checks against; provides the escalation runner that fires on `task.escalationAt`
+- OpenRegister — additive schema change to `workflowTemplate`; no new top-level schema
+
+## Standards & References
+
+- **ADR-000 (Data Model)**: `workflowTemplate`, `WorkflowStep`, `caseType` definitions — properties MUST match exactly; this change only ADDS `WorkflowStep.config`
+- **ADR-001 (Data Layer)**: All persistence via `ObjectService` (3-positional-arg API); no custom Entity/Mapper for `StepConfig` (it is embedded)
+- **ADR-004 (Frontend)**: Vue 2 Options API; imports only from `@conduction/nextcloud-vue`; `createObjectStore` for the parent `workflow-definition` entity (already registered by `workflow-definition-model`); never `window.confirm`
+- **ADR-015 (Common Patterns)**: SPDX headers on every new file; error handling via `logger` with static user-facing messages — never `getMessage()` in responses; translation keys via `this.t(appName, '...')`
+- **CMMN 1.1**: `config.sla` aligns with the PlanItem deadline concept; `config.autoActions` aligns with the on-complete event listener concept
+- **AWB / Archiefwet**: Bezwaar SLAs preserved by REQ-PSC-8 are legally mandated; the immutable repair step (clone-and-publish, never mutate) keeps the audit trail clean

--- a/openspec/changes/process-step-configuration/tasks.md
+++ b/openspec/changes/process-step-configuration/tasks.md
@@ -1,0 +1,63 @@
+# Tasks: process-step-configuration
+
+## Deduplication Check
+
+- [ ] **D01**: Confirm the existing `process-step-configuration` spec at `openspec/specs/process-step-configuration/spec.md` covers ONLY step CRUD and step-to-task mapping — no SLA, no `config` sub-object, no escalation. Confirm `workflow-definition-model` is merged (PR #347) and `status-transition-engine` exists as a sibling change/spec (#352). Confirm `BezwaarLifecycleService.php` contains hard-coded SLA constants that must be migrated.
+
+---
+
+## Schema Extension
+
+- [ ] **T01**: Extend the `workflowTemplate` schema in `lib/Settings/procest_register.json`. Each entry in the `steps` JSON-string array MAY carry an additional `config` sub-object with shape `{ sla: { value: int, unit: enum }, requiredFields: string[], autoActions: ActionRef[], escalationRule: { trigger, offset, offsetUnit, notifyRole, escalateToRole, openIncident } }`. All sub-fields optional; absent `config` preserves V1 behaviour. Bump the schema `version` field. Document the additive nature in the schema description.
+
+---
+
+## Backend: Validator
+
+- [ ] **T02**: Create `lib/Service/StepConfigValidator.php`. Pure static class; no `use OCP\IUserSession`, no DI, no I/O. Public method: `validate(array $step, array $caseTypeSchema): array`. Returns `[]` on success, otherwise an array of error objects with keys `path`, `code`, `message`. Implements rules 1–7 from `design.md`. SPDX header on line 1. Never returns exception messages.
+
+---
+
+## Backend: Publish Hook
+
+- [ ] **T03**: Wire `StepConfigValidator::validate()` into `WorkflowDefinitionService::publish()`. Before the lifecycle flip from `draft` → `published`, iterate `template.steps[]` and validate each step's `config`. If any error array is non-empty, refuse to publish and return a static error message (no raw error contents in the response — log the structured errors via `$this->logger->warning()`).
+
+---
+
+## Backend: Engine Consumption
+
+- [ ] **T04**: Teach `StatusTransitionService::getAvailableTransitions()` to read `currentStep.config.requiredFields[]` and treat it as an implicit `requiredField` guard on every exit transition from the current step's status. Reuse the existing user-facing message format `"Vereist veld ontbreekt: '<label>'"` — do NOT introduce a new message key.
+
+- [ ] **T05**: Teach the step-completion handler in `StatusTransitionService` to append `currentStep.config.autoActions[]` to the existing automatic-action pipeline. Step-level auto-actions fire BEFORE transition-level auto-actions when the same event completes both. Per ADR, failures are logged via `$this->logger->error()` but do NOT roll back the status change.
+
+- [ ] **T06**: Teach `TaskCreatorService::createForStep()` to stamp `task.dueAt` (computed from `step.config.sla`) and `task.escalationAt` (computed from `step.config.escalationRule.offset` relative to `dueAt`) at activation time. Absent `config.sla` leaves both fields null.
+
+---
+
+## Frontend: Editor
+
+- [ ] **T07**: Create `src/views/settings/components/StepConfigPanel.vue`. Collapsible "Geavanceerd" panel rendered inside the existing per-step row of `WorkflowStepsEditor.vue` (do NOT add a separate dialog). Imports only from `@conduction/nextcloud-vue`. Sub-components: `SlaInput.vue`, `RequiredFieldsPicker.vue` (multi-select sourced from the linked caseType's field list), `AutoActionsList.vue` (sourced from the `automatic-actions` catalog endpoint), `EscalationRuleEditor.vue`. All strings via `this.t(appName, '...')`. SPDX header on line 1. All destructive sub-actions confirmed via `CnDialog`, never `window.confirm`.
+
+- [ ] **T08**: Wire `StepConfigPanel.vue` into `WorkflowStepsEditor.vue` (already created by `workflow-definition-model`). Show the panel only when the parent definition is in `draft` lifecycle status. For `published` / `deprecated` definitions render the panel read-only.
+
+---
+
+## Migration
+
+- [ ] **T09**: Implement repair step `lib/Migration/BackfillBezwaarStepConfig.php`. Loads the seeded bezwaar `workflowTemplate`, attaches the `config` block per known step id (mapping table in `design.md`), publishes a new version via `WorkflowDefinitionService::clone()` + `publish()`, and deprecates the previous active version. Idempotent: skips when the active version already has any step with a populated `config`. Removes the now-redundant SLA constants from `BezwaarLifecycleService.php`.
+
+---
+
+## Documentation
+
+- [ ] **T10**: Update `openspec/specs/process-step-configuration/spec.md` to incorporate the eight new `REQ-PSC-*` requirements. Do NOT delete the two existing requirements; append the new ones after them. Update the spec's `status` frontmatter to `implemented` only after T01–T09 land.
+
+---
+
+## Pre-commit Verification
+
+- [ ] **V01**: `grep -rL 'SPDX-License-Identifier' lib/Service/StepConfigValidator.php lib/Migration/BackfillBezwaarStepConfig.php src/views/settings/components/StepConfigPanel.vue src/views/settings/components/SlaInput.vue src/views/settings/components/RequiredFieldsPicker.vue src/views/settings/components/AutoActionsList.vue src/views/settings/components/EscalationRuleEditor.vue` → zero results.
+
+- [ ] **V02**: `grep -rn 'getMessage()' lib/Service/StepConfigValidator.php lib/Service/StatusTransitionService.php` for the lines added by T03/T04/T05 → zero results. No raw exception messages in responses.
+
+- [ ] **V03**: Manual QA — Publishing a draft with an unknown `autoActions[].key` is refused with a generic error. Editing the same draft to remove the bad key and re-publishing succeeds. A case in a status whose current step has `config.requiredFields: ["resultaat"]` shows transition buttons disabled until `resultaat` is filled, with the standard `"Vereist veld ontbreekt"` toast. A task created for a step with `config.sla: { value: 5, unit: businessDays }` has `dueAt` 5 working days in the future.


### PR DESCRIPTION
## Summary

- Adds the OpenSpec change `process-step-configuration` that extends the existing capability with a per-step `config` sub-object on every `WorkflowStep` inside `workflowTemplate` (sla, requiredFields, autoActions, escalationRule).
- Eight new requirements (REQ-PSC-1..8) cover the shape, SLA / dueAt stamping, implicit required-field guard, publish-time validator, step auto-actions ordering, escalation timing, admin editor panel, and bezwaar repair-step backfill.
- Additive only: existing seeded templates without `config` preserve V1 behaviour exactly. No new top-level OpenRegister schema, no new controller routes.

## Spec-only PR

- This PR contains spec authoring (proposal, design, tasks, spec) under `openspec/changes/process-step-configuration/`. No code, no schema files, no JSON changed.
- 10 tasks (T01 schema extension, T02 StepConfigValidator, T03 publish hook, T04 implicit required-field guard, T05 step auto-actions pipeline, T06 dueAt/escalationAt stamping, T07-T08 Vue editor panel, T09 bezwaar backfill repair step, T10 main-spec append).

## Consumers

- `workflow-definition-model` (PR #347) — extends WorkflowStep shape; hooks `StepConfigValidator` into `WorkflowDefinitionService::publish()`.
- `status-transition-engine` (#352) — reads `config.requiredFields` (implicit guard) and `config.autoActions` (step-completion pipeline).
- `automatic-actions` — action catalog + escalation runner consumer of `task.escalationAt`.

## Test plan

- [ ] OpenSpec dry-validate: change folder layout matches `parafeerroute-engine` reference.
- [ ] Manual scenario walk-through for each REQ-PSC-* in spec.md.
- [ ] Confirm REQ-PSC-1-002 invariant (absent config preserves V1) in implementation phase.

Spec follows the pattern from `parafeerroute-engine` and respects `workflow-definition-model` immutability (clone-and-publish for config edits).