### PR TITLE
chore(openspec): generate visual-workflow-editor spec

### DIFF
--- a/openspec/changes/visual-workflow-editor/design.md
+++ b/openspec/changes/visual-workflow-editor/design.md
@@ -1,0 +1,88 @@
+# Design: visual-workflow-editor
+
+## Library Choice — vue-flow
+
+**Decision: adopt `@vue-flow/core` 1.x as the graph rendering and interaction library.**
+
+| Option | Verdict | Rationale |
+|--------|---------|-----------|
+| `@vue-flow/core` (1.x) | **Selected** | Native Vue 2.7 + Vue 3 support via the same package; declarative `<VueFlow>` component with slots for custom nodes/edges; built-in pan/zoom, mini-map, controls, and connection handles; MIT licensed; ~40KB gzipped; mature ecosystem (additional add-ons for background, controls, mini-map); actively maintained (last release < 60 days at time of writing). |
+| `svelte-flow` | Rejected | Wrong framework — Procest is Vue 2.7. Would force a second runtime. |
+| `cytoscape.js` | Rejected | General-purpose graph library; lacks first-class Vue bindings; node rendering is canvas-based, not DOM, so embedding Vue form components inside nodes is awkward. Heavier API surface for a UI-focused use case. |
+| `jsplumb-toolkit` | Rejected | Commercial license for the toolkit edition required for the features we need (mini-map, undo, smart routing). |
+| Roll our own SVG canvas | Rejected | Six months of yak-shaving for table-stakes features (pan, zoom, connection handles, edge routing). |
+
+`vue-flow` slots Vue components inside nodes, which means `StatusNode.vue` can host the same inline editors used elsewhere in Procest (badge, step count, validation icon). Edges accept a custom component too, used for the conditional `TransitionEdge` which shows the transition label and guard count inline.
+
+## Architecture
+
+```
+┌── PaletteSidebar ──┐  ┌───── Canvas (<VueFlow>) ─────┐  ┌── PropertiesPanel ──┐
+│  Status            │  │  ┌──────┐    ┌──────┐         │  │  Selected: Status    │
+│  Decision          │  │  │Intake│───►│Behand│──►End    │  │  Title  [Intake   ]  │
+│  Parallel          │  │  └──────┘    └──────┘         │  │  Final  [ ]          │
+│  End               │  │                                │  │  Steps  [ + add  ]   │
+│                    │  │  validation overlays appear    │  │  Routing rule [...]  │
+└────────────────────┘  └────────────────────────────────┘  └──────────────────────┘
+        │                            │                              │
+        └──drag────────►drop on canvas─►mutate working copy ◄──edit──┘
+                                          │
+                                  WorkflowValidator (live)
+                                          │
+                                  WorkflowDefinitionService (save / publish)
+```
+
+The editor holds a single in-memory **working copy** of the `workflowTemplate`. All node/edge mutations write to that working copy synchronously. Saving the copy hits the existing `POST /api/workflow-definition` (draft) or `POST /api/workflow-definition/{id}/publish` endpoints — no new backend routes.
+
+## Node Types
+
+| Type | Maps to | Visual | Behaviour |
+|------|---------|--------|-----------|
+| `status` | `workflowTemplate.steps[].status` (StatusType reference) | Rounded rectangle with header (name) + body (step count badge + validation icon) | Has one input handle (top) and one output handle (bottom). Click selects, double-click renames inline. |
+| `decision` | A `statusTransition` whose `guards` contain a `customExpression` | Diamond | Two output handles labelled "Ja" / "Nee"; renders the guard expression as a chip. |
+| `parallel` | A fork point — multiple transitions out of the same status without guards | Vertical bar with thick stroke | Multiple output handles; renders as AND-split (every outgoing edge fires). |
+| `end` | A status with `isFinal: true` | Rounded rectangle with double border | Only an input handle; no outgoing transitions allowed. |
+
+## Edge Type
+
+A single `transition` edge represents a `statusTransition`. It renders the label inline, a small badge with the guard count, and turns red when validation fails (e.g., dangling at one end). Clicking opens the edge in the properties panel where the existing `RoutingRuleEditor.vue` (from `role-based-step-routing`) is slotted in for `allowedRoles` configuration.
+
+## Save-as-Version Flow
+
+1. The editor opens with the **active published** version loaded read-only (preview mode).
+2. The admin clicks "Edit" → editor enters draft mode, calling `WorkflowDefinitionService::createDraftFrom(activeVersion)`. A new draft `workflowTemplate` is created with `isDraft: true`, `version: active.version + 1`.
+3. Every change auto-saves the working copy to the draft (debounced 2 s).
+4. The admin clicks "Publiceren" → calls `POST /api/workflow-definition/{id}/publish`; the existing service handles the lifecycle transition, deactivates the prior version, and pins new cases to the new version.
+5. The admin may "Verwerpen" → calls `DELETE /api/workflow-definition/{id}` (only allowed while `isDraft`).
+
+In-flight cases keep using their pinned version — guaranteed by the model already.
+
+## Validation Overlay
+
+`WorkflowValidator` is a frontend service (no backend) that mirrors the canonical model rules and emits a list of `{nodeId, level, code, message}` issues whenever the working copy changes:
+
+| Code | Level | Detected When |
+|------|-------|---------------|
+| `ORPHAN_NODE` | warning | Status has no incoming and no outgoing transitions |
+| `NO_FINAL_STATUS` | error | Working copy has zero nodes with `isFinal: true` |
+| `UNREACHABLE_FINAL` | error | At least one final status is not reachable from the initial status |
+| `CYCLE_NO_EXIT` | warning | A cycle exists with no path out to any final status |
+| `DUPLICATE_TRANSITION` | warning | Two transitions share the same `(fromStatus, toStatus)` pair |
+| `MISSING_LABEL` | warning | A transition has no `label` |
+
+Issues are rendered as overlay badges on the affected node/edge and listed in a collapsible "Problemen" panel at the bottom of the canvas. The "Publiceren" button is disabled while any `error`-level issue is present.
+
+## Import / Export
+
+- **Import**: an admin pastes or uploads a JSON document conforming to the `workflowTemplate` schema. The editor validates against the schema, then renders the graph; layout coordinates, if absent, are computed via `dagre` (left-to-right hierarchical layout) and persisted on first save.
+- **Export**: the current working copy is downloaded as a JSON file conforming to the same schema; round-trip-safe with import.
+
+## Layout Persistence
+
+The schema gains an optional `layout` object on the `workflowTemplate`, keyed by node id (`{x, y}` per node). This is consumed only by the visual editor; absent layout triggers `dagre` auto-layout on first open. (No backend changes — the field is already free-form JSON inside the OpenRegister object.)
+
+## Failure Modes
+
+- **Save conflict** (another admin edited the same draft): the API returns 409; the editor shows a diff dialog and lets the user reload-and-discard or attempt to keep their copy.
+- **Invalid JSON on import**: the editor refuses the import and points to the first schema-validation error.
+- **vue-flow runtime error**: the editor falls back to the existing form-based `WorkflowDefinitionsTab.vue` with a banner explaining the fallback; no data loss because the working copy is JSON.

--- a/openspec/changes/visual-workflow-editor/proposal.md
+++ b/openspec/changes/visual-workflow-editor/proposal.md
@@ -1,0 +1,50 @@
+# Proposal: visual-workflow-editor
+
+## Summary
+
+Procest needs a drag-and-drop visual editor so tenant administrators can author workflow definitions without hand-editing JSON. The `workflow-definition-model` and `role-based-step-routing` specs deliver the data contract, but today the only authoring surface is the form-based `WorkflowDefinitionsTab.vue` shipped with V1 of the definition model. Administrators are forced to imagine the graph in their head, type status UUIDs into form fields, and iterate by save-and-refresh. This change introduces `VisualEditor.vue` — a graph-based authoring canvas built on `vue-flow` — that reads and writes the same `workflowTemplate` objects, validates them live against the existing model, and persists changes through the same `WorkflowDefinitionService` lifecycle (draft → published → deprecated).
+
+## Why
+
+- **JSON-editing is hostile to non-developers.** Tenant admins are domain experts (vergunningverleners, bezwaarbehandelaars), not developers — handing them a UUID-laden form blocks adoption of the workflow-definition-model itself.
+- **18 NL/BE tenders require a "no-code workflow editor".** The form UI from V1 ticks the box for *some* configurability but explicitly loses on the "visual / drag-and-drop / process designer" criteria scored in tender requirements.
+- **Validation feedback is invisible in form mode.** Orphan states, missing final status, and circular routes are only caught at save time; admins lose context and trust.
+- **Re-use over rebuild.** Procest already ships Vue 2.7 — the `vue-flow` graph library targets exactly that and is the lowest-cost path to a production-grade canvas; no new framework, no migration.
+
+## What Changes
+
+- New `VisualEditor.vue` route under `Admin > Zaaktypen > {type} > Workflow > Visual`.
+- New `vue-flow` (latest 1.x) frontend dependency.
+- New node-type components (`StatusNode`, `DecisionNode`, `ParallelNode`, `EndNode`) and a single `TransitionEdge` component.
+- New left-side `PaletteSidebar.vue` (draggable node templates) and right-side `PropertiesPanel.vue` (live form for the selected node/edge).
+- New live `WorkflowValidator` service (frontend) wrapping the canonical rules from `workflow-definition-model` and surfacing errors as overlay badges.
+- New import/export round-trip — the editor reads and writes the exact `workflowTemplate` JSON schema; no custom intermediate format.
+- New "Save as new version" flow that re-uses `WorkflowDefinitionService` lifecycle hooks (draft on save, publish via explicit action).
+
+## Affected Projects
+
+- [x] Project: `procest` — Frontend only. Adds `vue-flow`, four node components, two panel components, the editor view, and a frontend validator. No backend changes; persistence goes through the existing `WorkflowDefinitionService` and `WorkflowDefinitionController`.
+
+## Scope
+
+### In Scope (V1)
+
+- Drag-and-drop canvas with status / decision / parallel / end node types and a single conditional transition edge type.
+- Palette + canvas + properties-panel layout, mirrors the data model 1:1.
+- Live validation overlay (errors red, warnings yellow), reusing existing model rules.
+- Save as draft / publish as version flow via existing `WorkflowDefinitionService`.
+- Import existing JSON definition; export current canvas state to JSON.
+- Read-only preview mode for published versions.
+
+### Out of Scope
+
+- **Guard expression IDE** — owned by `status-transition-engine`; the editor surfaces guards as opaque rule objects.
+- **Routing-rule editor inside nodes** — owned by `role-based-step-routing` (T06); the visual editor slots that component in unchanged.
+- **Cross-tenant template marketplace** — Enterprise tier, future spec.
+- **Backend changes** — V1 reuses the existing CRUD + lifecycle service exactly as-is.
+
+## Dependencies
+
+- `workflow-definition-model` — provides the `workflowTemplate` schema, lifecycle, and CRUD service consumed unchanged.
+- `role-based-step-routing` — provides the `RoutingRuleEditor.vue` that slots into the properties panel for steps and transitions.
+- `vue-flow` (new npm dep) — graph library; rationale in `design.md`.

--- a/openspec/changes/visual-workflow-editor/specs/visual-workflow-editor/spec.md
+++ b/openspec/changes/visual-workflow-editor/specs/visual-workflow-editor/spec.md
@@ -1,0 +1,187 @@
+## ADDED Requirements
+
+### Requirement: Graph Library Foundation
+The system SHALL adopt `@vue-flow/core` (1.x) as the canvas rendering and interaction library for the visual workflow editor. The dependency SHALL be declared in `package.json` together with the official `@vue-flow/background` and `@vue-flow/controls` add-ons and the `dagre` auto-layout utility. No other graph library SHALL be used for this surface.
+
+**Feature tier**: V1
+
+#### Scenario: Bundle declares vue-flow as a direct dependency
+- **WHEN** a developer inspects `package.json`
+- **THEN** `@vue-flow/core`, `@vue-flow/background`, `@vue-flow/controls`, and `dagre` SHALL appear under `dependencies`
+- **AND** the lockfile SHALL pin a 1.x major version of `@vue-flow/core`
+
+#### Scenario: Production build succeeds without peer-dependency warnings
+- **WHEN** `npm run build` runs in CI
+- **THEN** the build SHALL complete with exit code 0
+- **AND** no `npm WARN` peer-dependency messages SHALL be emitted for `vue-flow`
+
+### Requirement: Editor Route and Shell
+The system SHALL expose a dedicated route at `Admin > Zaaktypen > {type} > Workflow > Visual` rendering `VisualEditor.vue`, which presents a three-pane layout (left palette, centre canvas, right properties panel) for authoring a single `workflowTemplate`.
+
+**Feature tier**: V1
+
+#### Scenario: Route resolves and renders the editor shell
+- **WHEN** an administrator navigates to `Admin > Zaaktypen > Omgevingsvergunning > Workflow > Visual`
+- **THEN** the system SHALL render `VisualEditor.vue` with three visible panes: palette, canvas, properties
+- **AND** the canvas SHALL load the active published `workflowTemplate` for that zaaktype
+
+#### Scenario: Route loads with no published version
+- **WHEN** an administrator opens the editor for a zaaktype that has no published workflow template
+- **THEN** the editor SHALL open in edit mode on a fresh draft with `version: 1`, `isDraft: true`
+- **AND** the canvas SHALL be empty except for an initial status seeded from the zaaktype's first `StatusType`
+
+### Requirement: Node Palette
+The system SHALL provide a left-side `PaletteSidebar.vue` listing exactly four draggable node templates — Status, Decision, Parallel, End — that the administrator drags onto the canvas to insert new nodes.
+
+**Feature tier**: V1
+
+#### Scenario: Palette lists the four node types
+- **WHEN** the editor renders the palette
+- **THEN** the palette SHALL contain exactly four draggable items labelled "Status", "Beslissing", "Parallel", "Eindstatus"
+- **AND** each item SHALL display an icon matching its node type
+
+#### Scenario: Drag-drop from palette adds a node
+- **WHEN** an administrator drags the "Status" template onto an empty area of the canvas
+- **THEN** a new status node SHALL be inserted in the working copy at the drop coordinates
+- **AND** the node SHALL be auto-selected so the properties panel opens for it
+- **AND** the working copy SHALL gain a corresponding `workflowTemplate.steps[].status` entry
+
+### Requirement: Canvas Rendering
+The system SHALL render the working copy of a `workflowTemplate` on a `<VueFlow>` canvas where every status maps to one of the four node component types (`StatusNode`, `DecisionNode`, `ParallelNode`, `EndNode`) and every `statusTransition` maps to a single `TransitionEdge` component.
+
+**Feature tier**: V1
+
+#### Scenario: Template renders as graph
+- **WHEN** a workflow template containing three statuses and two transitions loads
+- **THEN** the canvas SHALL render three nodes and two edges in the corresponding shapes
+- **AND** transition edges SHALL display their `label` and a badge with the number of `guards`
+
+#### Scenario: Connect two nodes by dragging from output to input handle
+- **WHEN** an administrator drags from the bottom output handle of "Intake" to the top input handle of "In behandeling"
+- **THEN** a new `statusTransition` SHALL be added to the working copy with `fromStatus = Intake`, `toStatus = In behandeling`, empty `guards`, and `label = ""`
+- **AND** the new edge SHALL appear immediately on the canvas
+
+#### Scenario: End node cannot have outgoing transitions
+- **WHEN** an administrator attempts to drag a connection out of an End node
+- **THEN** the canvas SHALL refuse the connection
+- **AND** SHALL display the message "Eindstatus heeft geen uitgaande overgangen"
+
+### Requirement: Properties Panel
+The system SHALL provide a right-side `PropertiesPanel.vue` that displays editable fields for the currently selected node or edge, or workflow-level metadata when nothing is selected. Editing SHALL write through to the working copy on blur or after a 500 ms debounce.
+
+**Feature tier**: V1
+
+#### Scenario: Status node properties expose step list and routing rule
+- **WHEN** a status node is selected on the canvas
+- **THEN** the panel SHALL show editable fields `title`, `isFinal`, an ordered list of steps with add / remove / reorder controls, and SHALL slot the existing `RoutingRuleEditor.vue` for the step's `assigneeRole`
+- **AND** editing the title and blurring the field SHALL update the working copy synchronously
+
+#### Scenario: Transition edge properties expose label, guards, and allowedRoles
+- **WHEN** a transition edge is selected on the canvas
+- **THEN** the panel SHALL show editable fields `label` and `guards[]` and SHALL slot `RoutingRuleEditor.vue` for the transition's `allowedRoles`
+- **AND** adding a guard SHALL update the working copy and refresh the badge count on the edge
+
+#### Scenario: No selection shows workflow-level metadata
+- **WHEN** nothing is selected
+- **THEN** the panel SHALL show `title`, `description`, `version`, `isDraft`, and the count of validation issues currently emitted by `WorkflowValidator`
+
+### Requirement: Live Validation
+The system SHALL run `WorkflowValidator` whenever the working copy mutates and SHALL surface issues as overlay badges on affected nodes/edges and as entries in a collapsible "Problemen" panel. The "Publiceren" action SHALL be disabled whenever at least one `error`-level issue is present.
+
+**Feature tier**: V1
+
+The validator SHALL emit issues with codes drawn from the following set:
+
+| Code | Level | Detected when |
+|------|-------|---------------|
+| `ORPHAN_NODE` | warning | A status node has no incoming and no outgoing transitions |
+| `NO_FINAL_STATUS` | error | The working copy contains zero nodes with `isFinal: true` |
+| `UNREACHABLE_FINAL` | error | At least one final status is not reachable from the initial status |
+| `CYCLE_NO_EXIT` | warning | A cycle exists with no path out to any final status |
+| `DUPLICATE_TRANSITION` | warning | Two transitions share the same `(fromStatus, toStatus)` pair |
+| `MISSING_LABEL` | warning | A transition has no `label` |
+
+#### Scenario: Missing final status blocks publish
+- **WHEN** the working copy contains no status with `isFinal: true`
+- **THEN** the canvas SHALL display the banner "Workflow heeft geen eindstatus. Voeg minimaal een eindstatus toe."
+- **AND** the "Publiceren" button SHALL be disabled
+- **AND** the issue SHALL appear in the Problemen panel with code `NO_FINAL_STATUS` and level `error`
+
+#### Scenario: Orphan node receives warning badge
+- **WHEN** a status node "Concept" is added but no transitions connect to it
+- **THEN** an amber warning badge SHALL appear on the node
+- **AND** the tooltip SHALL read "Deze status is niet bereikbaar via een overgang"
+- **AND** the publish action SHALL remain enabled (warning, not error)
+
+#### Scenario: Duplicate transition raises warning
+- **WHEN** two transitions exist between the same `fromStatus` and `toStatus`
+- **THEN** both edges SHALL receive an amber badge
+- **AND** the Problemen panel SHALL list a single `DUPLICATE_TRANSITION` entry referencing both edge ids
+
+### Requirement: Save-as-Version Flow
+The system SHALL persist edits through the existing `WorkflowDefinitionService` lifecycle: opening a published version flips to edit mode by creating a fresh draft; the draft auto-saves on a 2 s debounce; publishing transitions the draft to `isActive: true` and deprecates the prior version. The editor SHALL NOT introduce any new backend route.
+
+**Feature tier**: V1
+
+#### Scenario: Edit mode creates a new draft from the active version
+- **WHEN** an administrator viewing the active published workflow clicks "Bewerken"
+- **AND** no draft currently exists for that zaaktype
+- **THEN** the editor SHALL call `POST /api/workflow-definition` with the active version's payload plus `isDraft: true` and `version: active.version + 1`
+- **AND** subsequent edits SHALL target that new draft
+
+#### Scenario: Auto-save after debounce
+- **WHEN** the administrator makes an edit and remains idle for 2 seconds
+- **THEN** the editor SHALL call `PUT /api/workflow-definition/{draftId}` with the current working copy
+- **AND** the editor SHALL display an "Opgeslagen" indicator next to the save button
+
+#### Scenario: Publish requires no error-level validation issues
+- **WHEN** the administrator clicks "Publiceren"
+- **AND** at least one error-level issue is emitted by `WorkflowValidator`
+- **THEN** the publish action SHALL be blocked and a confirmation dialog SHALL list the blocking issues
+- **AND** the prior published version SHALL remain active
+
+#### Scenario: Publish succeeds and deprecates prior version
+- **WHEN** the administrator clicks "Publiceren" on a draft with no error-level issues
+- **AND** confirms the publish dialog
+- **THEN** the editor SHALL call `POST /api/workflow-definition/{draftId}/publish`
+- **AND** the response SHALL carry `isDraft: false`, `isActive: true`, and the previous active version SHALL be deprecated by the backend service
+- **AND** in-flight cases pinned to the previous version SHALL continue to use that version
+
+### Requirement: Import/Export Round-Trip
+The system SHALL allow administrators to import a `workflowTemplate` JSON document onto the canvas and to export the current working copy as a JSON file conforming to the same schema. The round-trip SHALL preserve all fields covered by the `workflowTemplate` schema.
+
+**Feature tier**: V1
+
+#### Scenario: Import a valid template
+- **WHEN** an administrator uploads a JSON file that validates against the `workflowTemplate` schema
+- **THEN** every status, transition, step, guard, and routing rule in the file SHALL be rendered on the canvas
+- **AND** if the file lacks a `layout` block the editor SHALL auto-layout via `dagre`
+
+#### Scenario: Import refuses invalid JSON
+- **WHEN** an administrator uploads a JSON file that fails schema validation
+- **THEN** the editor SHALL refuse the import
+- **AND** SHALL display the first validation error with the affected JSON pointer
+- **AND** SHALL leave the current working copy unchanged
+
+#### Scenario: Export round-trip is structurally identical
+- **WHEN** an administrator exports the current working copy to JSON
+- **AND** then imports the same file into a fresh editor instance
+- **THEN** the resulting canvas SHALL contain the same nodes, edges, steps, guards, routing rules, and `layout` as the original
+- **AND** the exported and re-exported JSON SHALL be byte-identical after normalising key order
+
+### Requirement: Read-Only Preview of Published Versions
+The system SHALL render any published workflow version in read-only preview mode by default: the palette SHALL be hidden, the canvas SHALL refuse drag/edit/delete interactions, and properties-panel fields SHALL render as disabled. The administrator SHALL flip to edit mode only via an explicit "Bewerken" action that creates a new draft.
+
+**Feature tier**: V1
+
+#### Scenario: Preview mode hides authoring affordances
+- **WHEN** an administrator opens the editor for a zaaktype whose active workflow is published
+- **THEN** the palette SHALL be hidden
+- **AND** the canvas SHALL ignore drag-to-create and connection-drag attempts
+- **AND** the properties panel SHALL render every input as disabled
+
+#### Scenario: Switching to edit mode creates a draft
+- **WHEN** the administrator clicks "Bewerken" in preview mode
+- **AND** no draft currently exists
+- **THEN** the editor SHALL create a fresh draft (see save-as-version flow)
+- **AND** the palette SHALL become visible, the canvas interactive, and the properties panel editable

--- a/openspec/changes/visual-workflow-editor/tasks.md
+++ b/openspec/changes/visual-workflow-editor/tasks.md
@@ -1,0 +1,117 @@
+# Tasks: visual-workflow-editor
+
+## 1. Foundation
+
+### T01: Install graph library and pin version
+- **spec_ref**: `openspec/changes/visual-workflow-editor/specs/visual-workflow-editor/spec.md#requirement-graph-library-foundation`
+- **files**: `package.json`, `package-lock.json`
+- **acceptance_criteria**:
+  - GIVEN `package.json` WHEN inspected THEN it declares `@vue-flow/core` at version `^1.x` and the matching `@vue-flow/background` and `@vue-flow/controls` peer add-ons.
+  - GIVEN `npm run build` THEN the bundle includes `vue-flow` and no peer-dep warnings are emitted.
+- [ ] Add `@vue-flow/core`, `@vue-flow/background`, `@vue-flow/controls`, `dagre` to dependencies; run `npm i` and commit lockfile.
+
+### T02: VisualEditor.vue scaffold and routing
+- **spec_ref**: `openspec/changes/visual-workflow-editor/specs/visual-workflow-editor/spec.md#requirement-editor-route-and-shell`
+- **files**: `src/views/admin/VisualEditor.vue`, `src/router/admin.js`
+- **acceptance_criteria**:
+  - GIVEN an admin navigates to `Admin > Zaaktypen > {type} > Workflow > Visual` WHEN the route resolves THEN `VisualEditor.vue` renders with the three-pane layout (palette / canvas / properties).
+  - GIVEN the route loads with a valid `workflowDefinition` id WHEN mounted THEN the active published version is fetched and rendered read-only.
+- [ ] Add the route, lazy-load the view, wire the breadcrumb and tab integration into `CaseTypeWorkflow.vue`.
+
+## 2. Canvas & Palette
+
+### T03: PaletteSidebar component
+- **spec_ref**: `openspec/changes/visual-workflow-editor/specs/visual-workflow-editor/spec.md#requirement-node-palette`
+- **files**: `src/components/visual-editor/PaletteSidebar.vue`
+- **acceptance_criteria**:
+  - GIVEN the palette is rendered WHEN inspected THEN it lists exactly four draggable node templates: Status, Decision, Parallel, End.
+  - GIVEN an admin drags a Status template onto the canvas WHEN dropped THEN a new draft status node is inserted at the drop coordinates.
+- [ ] Implement HTML5 drag-and-drop with type-specific data payloads consumed by the canvas drop handler.
+
+### T04: Canvas with custom node and edge types
+- **spec_ref**: `openspec/changes/visual-workflow-editor/specs/visual-workflow-editor/spec.md#requirement-canvas-rendering`
+- **files**: `src/components/visual-editor/Canvas.vue`, `src/components/visual-editor/nodes/{StatusNode,DecisionNode,ParallelNode,EndNode}.vue`, `src/components/visual-editor/edges/TransitionEdge.vue`
+- **acceptance_criteria**:
+  - GIVEN a workflow template is loaded WHEN rendered THEN every `workflowTemplate.steps[].status` becomes a node and every `transitions[]` becomes a `transition` edge.
+  - GIVEN the admin drags a connection from a node output handle to another node input handle WHEN released THEN a new transition is added to the working copy.
+- [ ] Register the four node types and the single edge type with `<VueFlow>`; implement handles, selection, hover styles.
+
+## 3. Properties Panel
+
+### T05: PropertiesPanel and node/edge editors
+- **spec_ref**: `openspec/changes/visual-workflow-editor/specs/visual-workflow-editor/spec.md#requirement-properties-panel`
+- **files**: `src/components/visual-editor/PropertiesPanel.vue`, `src/components/visual-editor/properties/{StatusProperties,TransitionProperties,DecisionProperties}.vue`
+- **acceptance_criteria**:
+  - GIVEN a status node is selected WHEN the panel renders THEN it shows the editable fields `title`, `isFinal`, the step list with reorder, and slots the existing `RoutingRuleEditor.vue` for `assigneeRole`.
+  - GIVEN a transition edge is selected WHEN the panel renders THEN it shows `label`, `guards[]`, and slots `RoutingRuleEditor.vue` for `allowedRoles`.
+  - GIVEN no selection WHEN the panel renders THEN it shows the workflow-level metadata (`title`, `description`, current version, `isDraft`).
+- [ ] Wire selection state from `VisualEditor.vue` through props; persist edits back to the working copy on blur or debounce.
+
+## 4. Validation & Save
+
+### T06: WorkflowValidator service + overlay
+- **spec_ref**: `openspec/changes/visual-workflow-editor/specs/visual-workflow-editor/spec.md#requirement-live-validation`
+- **files**: `src/services/visual-editor/WorkflowValidator.js`, `src/components/visual-editor/ProblemsPanel.vue`
+- **acceptance_criteria**:
+  - GIVEN the working copy mutates WHEN the validator runs THEN it emits issues for `ORPHAN_NODE`, `NO_FINAL_STATUS`, `UNREACHABLE_FINAL`, `CYCLE_NO_EXIT`, `DUPLICATE_TRANSITION`, `MISSING_LABEL`.
+  - GIVEN at least one `error`-level issue exists WHEN the admin clicks "Publiceren" THEN the action is blocked and the offending node/edge is highlighted.
+- [ ] Pure JS implementation, no backend round-trip; reachability via BFS from the initial status.
+
+### T07: Save, publish, and discard wiring
+- **spec_ref**: `openspec/changes/visual-workflow-editor/specs/visual-workflow-editor/spec.md#requirement-save-as-version-flow`
+- **files**: `src/services/visual-editor/WorkflowDefinitionClient.js`, `src/views/admin/VisualEditor.vue`
+- **acceptance_criteria**:
+  - GIVEN the admin clicks "Bewerken" WHEN no draft exists THEN the client calls `POST /api/workflow-definition` with `isDraft: true` and `version: active.version + 1`.
+  - GIVEN unsaved changes WHEN 2 s elapses since the last edit THEN the draft is auto-saved via `PUT /api/workflow-definition/{id}`.
+  - GIVEN the admin clicks "Publiceren" AND no error-level validation issues exist WHEN confirmed THEN the client calls `POST /api/workflow-definition/{id}/publish` and the prior active version is deprecated.
+- [ ] Use the existing `WorkflowDefinitionController` endpoints; no new backend routes.
+
+## 5. Import / Export / Preview
+
+### T08: JSON import/export
+- **spec_ref**: `openspec/changes/visual-workflow-editor/specs/visual-workflow-editor/spec.md#requirement-import-export-round-trip`
+- **files**: `src/components/visual-editor/ImportExportDialog.vue`, `src/services/visual-editor/JsonRoundTrip.js`
+- **acceptance_criteria**:
+  - GIVEN a valid `workflowTemplate` JSON file WHEN the admin imports it THEN every status, transition, step, and guard appears on the canvas without data loss.
+  - GIVEN the admin exports the current working copy WHEN the file is re-imported into a fresh editor THEN the resulting canvas is structurally identical (round-trip safe).
+  - GIVEN an invalid JSON document WHEN imported THEN the dialog shows the first schema-validation error and refuses the import.
+- [ ] Validate against the `workflowTemplate` schema fetched from OpenRegister at runtime.
+
+### T09: Auto-layout fallback (dagre)
+- **spec_ref**: `openspec/changes/visual-workflow-editor/specs/visual-workflow-editor/spec.md#requirement-auto-layout-when-coordinates-missing`
+- **files**: `src/services/visual-editor/AutoLayout.js`
+- **acceptance_criteria**:
+  - GIVEN a workflow template loads WHEN no `layout` block exists THEN `dagre` computes left-to-right hierarchical coordinates and the canvas renders nodes at those positions.
+  - GIVEN the working copy saves THEN the computed `layout` block is persisted alongside the workflow template.
+- [ ] Use `dagre` from T01; no manual positioning of seeded workflows required.
+
+### T10: Preview (read-only) mode
+- **spec_ref**: `openspec/changes/visual-workflow-editor/specs/visual-workflow-editor/spec.md#requirement-read-only-preview-of-published-versions`
+- **files**: `src/views/admin/VisualEditor.vue`
+- **acceptance_criteria**:
+  - GIVEN the active published version loads WHEN no draft is open THEN the canvas is read-only (no drag/edit/delete), the palette is hidden, and the properties panel shows fields as disabled.
+  - GIVEN the admin clicks "Bewerken" WHEN no draft exists THEN preview mode flips to edit mode by creating a fresh draft.
+- [ ] Single boolean `mode: 'preview' | 'edit'` toggles palette visibility, handle interactivity, and properties-panel disabled state.
+
+## 6. Verification
+
+### V01: Component tests for canvas + palette + properties
+- **spec_ref**: `openspec/changes/visual-workflow-editor/specs/visual-workflow-editor/spec.md`
+- **files**: `tests/unit/visual-editor/*.spec.js`
+- **acceptance_criteria**:
+  - Palette renders four templates and emits drag events with correct payloads.
+  - Canvas renders nodes and edges from a sample working copy; new-edge drag creates the transition.
+  - Properties panel slots `RoutingRuleEditor` for the right contexts.
+- [ ] Use `@vue/test-utils` + `vitest`; mock `vue-flow` where needed.
+
+### V02: WorkflowValidator unit tests
+- **spec_ref**: `openspec/changes/visual-workflow-editor/specs/visual-workflow-editor/spec.md#requirement-live-validation`
+- **files**: `tests/unit/visual-editor/WorkflowValidator.spec.js`
+- **acceptance_criteria**: Each of the six validator codes has at least one positive and one negative test; reachability uses BFS; cycle detection covers self-loops and multi-node cycles.
+- [ ] ≥90% statement coverage on `WorkflowValidator.js`.
+
+### V03: Playwright end-to-end happy path
+- **spec_ref**: `openspec/changes/visual-workflow-editor/specs/visual-workflow-editor/spec.md`
+- **files**: `tests/e2e/visual-workflow-editor.spec.ts`
+- **acceptance_criteria**: An admin opens the editor for a seeded zaaktype, drags two status nodes, connects them, sets the second as final, publishes, and reloads the page to see the published version rendered correctly.
+- [ ] Run against `browser-3` in the shared pool.


### PR DESCRIPTION
## Summary

Generates the OpenSpec change artefacts for the `visual-workflow-editor` — a drag-and-drop graph editor that sits on top of the existing `workflow-definition-model` (V1 ships only a form-based UI) and reuses the `role-based-step-routing` rule editor inside its properties panel. No code in this PR — spec only.

- **proposal.md** — JSON-editing is hostile to non-developers; 18 NL/BE tenders require a visual / no-code workflow designer; reuse the V1 backend service unchanged.
- **design.md** — Library choice rationale (`@vue-flow/core` 1.x vs svelte-flow / cytoscape / jsplumb / DIY), node/edge type catalogue (Status, Decision, Parallel, End + a single Transition edge), save-as-version flow, validation overlay, and `dagre` auto-layout fallback.
- **tasks.md** — 10 implementation tasks (T01-T10) + 3 verification tasks (V01-V03).
- **spec.md** — 8 ADDED Requirements (REQ-VWE-1..8) with Given/When/Then scenarios for each.

## Library choice

`@vue-flow/core` 1.x — native Vue 2.7 support, DOM-based node rendering so Vue form components slot directly into nodes, MIT, ~40KB gzipped. Alternatives rejected: `svelte-flow` (wrong framework), `cytoscape.js` (canvas rendering blocks DOM slotting), `jsplumb-toolkit` (commercial license), DIY SVG (cost / table-stakes features).

## Validation

`openspec validate visual-workflow-editor --type change --strict` — passes.

## Test plan

- [ ] `openspec validate visual-workflow-editor --type change --strict` passes locally
- [ ] Proposal references `workflow-definition-model` and `role-based-step-routing` correctly
- [ ] Spec deltas land cleanly into `openspec/specs/visual-workflow-editor/` on archive
- [ ] Tasks file follows the same shape as siblings (acceptance criteria with G/W/T)

Spec-only PR — no runtime code changes.