### PR TITLE
chore(openspec): complete artifacts for roles-decisions + 3 governance changes

### DIFF
--- a/openspec/changes/complaint-management/design.md
+++ b/openspec/changes/complaint-management/design.md
@@ -1,0 +1,38 @@
+# Complaint Management Design
+
+## Architecture
+Complaints are first-class entities stored in OpenRegister, distinct from `zaak`. The complaint lifecycle is enforced by a status machine layered on top of the existing status-record infrastructure; only the deadline math and a few specialized flows (hearing, disposition, escalation) require new code. n8n drives email intake, deadline monitoring, and notification fan-out.
+
+## Data Model
+Four new OpenRegister schemas in `procest_register.json`:
+- **complaint** — core entity (`klachtnummer`, `klager`, `onderwerp`, `omschrijving`, `ontvangstdatum`, `ontvangstkanaal`, `categorie`, `betrokkenMedewerker`, `betrokkenAfdeling`, `status`, `behandelaar`, `prioriteit`, `ontvangstbevestigingDeadline`, `afhandelDeadline`, `verdagingMogelijk`, `geescaleerdeZaak`).
+- **hearing** — linked to complaint (`datum`, `locatie`, `deelnemers`, `type`, `verslag`, `conclusie`, `datumAfgerond`, optional Talk room URL).
+- **complaintDisposition** — `oordeel` enum, `toelichting`, `maatregelen[]`, `afsluitdatum`, `afsluitbrief`, optional approver.
+- **complaintCategory** — `name`, `description`, `defaultHandler` (user or group), `slaOverride` (working-day count).
+
+## Components
+1. **ComplaintList.vue** — handler inbox; filters by status, category, handler, date range, priority; overdue items pinned in red.
+2. **ComplaintDetail.vue** — header with `klachtnummer` and status, deadline panel (reuses `DeadlinePanel.vue`), hearing tab, disposition form, escalation action, communication tab, activity timeline.
+3. **ComplaintDashboardWidget.vue** — "Mijn klachten" widget showing open count, overdue count, next 5 working-day deadlines.
+4. **ComplaintAnalyticsDashboard.vue** — manager view with frequency bar charts (category, department, channel), trend lines, disposition pie, KPI cards against tenant targets.
+
+## Backend
+- `ComplaintService` — CRUD, status transitions, Awb deadline computation (working-day helper), verdaging logic, escalation linker.
+- `HearingService` — scheduling, Calendar invitation via `OCP\Calendar\IManager`, Talk integration via `OCP\Talk\IBroker`.
+- `DispositionService` — submission, optional coordinator approval gate, Docudesk template render for the response letter.
+- `ComplaintAnalyticsService` — frequency aggregation, employee threshold alerts (anonymized notifications for HR), systemic-issue detection (>50% quarter-over-quarter increase).
+- `ComplaintController` — REST routes under `/api/complaints` and `/api/complaints/{id}/...`.
+- `SettingsService::SLUG_TO_CONFIG_KEY` extended with `complaint_register`, `complaint_schema`, `hearing_schema`, `disposition_schema`, `complaint_category_schema`.
+
+## n8n Workflows
+- **email-intake** — listens to klachten@gemeente.nl, creates draft complaint, attaches body and files.
+- **deadline-monitor** — daily job sending warnings at T-3 working days (acknowledgment) and T-7 days (resolution); escalates overdue items to coordinator.
+- **attachment-matcher** — links incoming emails whose subject contains a known `klachtnummer` back to the originating complaint.
+
+## Risks & Mitigations
+- Awb working-day math must respect Dutch public holidays — centralize in a `WorkingDayCalculator` helper with a holiday lookup; cover with unit tests.
+- Privacy of `betrokkenMedewerker` data — HR alerts are anonymized in notifications and gated behind a separate ACL; raw data only visible to HR coordinators.
+- Frequency reports risk re-identification with small populations — minimum threshold of 3 complaints per slice before showing employee-level data.
+
+## Standards
+Awb chapter 9, VNG Model Klachtenverordening, ISO 10002:2018, GEMMA klachtafhandeling, ZGW Zaken API (for ketenpartner exchange when needed).

--- a/openspec/changes/complaint-management/proposal.md
+++ b/openspec/changes/complaint-management/proposal.md
@@ -1,16 +1,25 @@
 # Complaint Management Implementation
 
-## Problem
-Dutch municipalities need Awb chapter 9 compliant complaint handling with dedicated lifecycle, escalation to formal cases, disposition tracking, and frequency analysis. No complaint-specific infrastructure exists in Procest.
+## Why
+Dutch municipalities are legally required to handle citizen complaints under Awb chapter 9, with mandated acknowledgment (5 working days), resolution (6 weeks plus an optional 4-week verdaging), the right to be heard (hoorgesprek), and a formal written disposition (oordeel). Currently Procest has no dedicated complaint infrastructure — complaints get logged as generic cases, losing channel-specific intake, deadline math, frequency analysis, and disposition tracking. This makes Awb compliance verifiable only by manual sampling and prevents detection of systemic complaint patterns (e.g., recurring complaints about a single department or employee).
 
-## Proposed Solution
-Implement complaint management as a first-class entity in Procest using OpenRegister schemas for complaints, hearings, and dispositions. Add Vue components for complaint list, detail, and dashboard widgets. Integrate with existing case infrastructure for escalation.
+## What Changes
+1. New OpenRegister schemas: `complaint`, `hearing`, `complaintDisposition`, `complaintCategory`.
+2. `ComplaintList.vue`, `ComplaintDetail.vue`, and `ComplaintDashboardWidget.vue` Vue components for handler workflow.
+3. Awb deadline calculation helper (working-day math, verdaging, escalation) reusing `DeadlinePanel.vue`.
+4. Intake flow for balie, telefoon, email (n8n), brief, website, socialmedia channels.
+5. Bidirectional escalation link between complaints and zaken.
+6. Frequency-analysis dashboard with category, department, and employee-threshold alerts.
+7. Configurable complaint categories per tenant with default-handler routing.
+8. Communication trail (acknowledgment letter via Docudesk, phone-call records, attachment matching by complaint number).
 
-## Scope
-- New OpenRegister schemas: `complaint`, `hearing`, `complaintDisposition`, `complaintCategory`
-- New Vue components: `ComplaintList.vue`, `ComplaintDetail.vue`, `ComplaintDashboardWidget.vue`
-- Backend: Config keys in SettingsService, router entries
-- Integration: DeadlinePanel reuse, ActivityTimeline, case escalation links
+## Impact
+- New schemas, new module, new controllers/services, three new Vue components, dashboard extensions.
+- Reuses existing case infrastructure (status types, roles, document attachments, activity timeline) for the lifecycle.
+- Integrates with n8n (intake + deadline monitoring), Docudesk (letter generation), Nextcloud Calendar (hearings), and Talk (video hearings).
 
 ## Out of Scope
-- Bezwaarschriften, ombudsman case management, AI classification, citizen portal
+- Bezwaarschriften (formal objections — separate workflow).
+- Ombudsman case management and external oversight reporting.
+- AI/NLP-based automatic classification.
+- Citizen-facing complaint submission portal (handled separately).

--- a/openspec/changes/complaint-management/tasks.md
+++ b/openspec/changes/complaint-management/tasks.md
@@ -1,0 +1,12 @@
+# Tasks
+
+- [ ] TASK-CM-01: Add `complaint`, `hearing`, `complaintDisposition`, and `complaintCategory` schemas to `procest_register.json` and register their config keys in `SettingsService::SLUG_TO_CONFIG_KEY`.
+- [ ] TASK-CM-02: Implement `ComplaintService` with CRUD, status-machine transitions, Awb working-day deadline math, and verdaging logic; add unit tests for boundary dates and Dutch holidays.
+- [ ] TASK-CM-03: Implement `HearingService` with Calendar invitations via `OCP\Calendar\IManager` and Talk room creation via `OCP\Talk\IBroker` for `videogesprek` hearings.
+- [ ] TASK-CM-04: Implement `DispositionService` with optional coordinator approval gate and Docudesk-driven response-letter generation.
+- [ ] TASK-CM-05: Implement `ComplaintAnalyticsService` with frequency aggregation, anonymized employee-threshold alerts (>=3 in 6 months), and systemic-issue detection (>50% QoQ increase).
+- [ ] TASK-CM-06: Build `ComplaintController` REST endpoints for complaints, hearings, dispositions, escalation, and analytics.
+- [ ] TASK-CM-07: Create `ComplaintList.vue`, `ComplaintDetail.vue` (reusing `DeadlinePanel.vue` and `ActivityTimeline.vue`), `ComplaintDashboardWidget.vue`, and `ComplaintAnalyticsDashboard.vue`.
+- [ ] TASK-CM-08: Add the three n8n workflows (email-intake, deadline-monitor, attachment-matcher) and document the webhook endpoints they call.
+- [ ] TASK-CM-09: Add tenant-admin UI for complaint categories (CRUD with default handler and SLA override) under `Settings > Klachtcategorieen`.
+- [ ] TASK-CM-10: Add Dutch + English i18n strings for all complaint UI and notification templates.

--- a/openspec/changes/consultation-management/design.md
+++ b/openspec/changes/consultation-management/design.md
@@ -1,0 +1,38 @@
+# Consultation Management Design
+
+## Architecture
+A consultation is a first-class OpenRegister object linked to a parent zaak via a typed relation. It has an independent status lifecycle, its own deadline, and its own document attachments scoped to the consultation (not the entire parent case). Consultations can be parallel or sequential; mandatory consultations participate in milestone gates so that case progression is blocked until all required advice has been received. External advisory bodies that have no Nextcloud account interact via a per-consultation secure response link.
+
+## Data Model
+- **consultation** — `consultationNumber` (`ADV-{year}-{seq}`), `parentZaak`, `adviesInstantie`, `onderwerp`, `vraagstelling`, `uiterlijkeReactiedatum`, `prioriteit`, `status`, `assignee`, `mandatory`, `dependsOn` (array of consultation IDs), `secureToken` (for external bodies).
+- **adviceResponse** — `consultation`, `advies` enum (`positief`, `positief_met_voorwaarden`, `negatief`, `niet_van_toepassing`), `toelichting`, `voorwaarden[]` (each with description + priority), `datum`, `bijlagen[]`.
+- **advisoryBody** — `name`, `type` (`internal`/`external`), `defaultGroup`, `email`, `specializations[]`.
+
+Status machine: `open -> ontvangen -> in_behandeling -> advies_uitgebracht -> afgesloten`, with `ingetrokken` as a side branch and coordinator-only backward transitions for corrections.
+
+## Components
+1. **ConsultationCreateDialog.vue** — invoked from `CaseDetail.vue`; selects advisory body, copies in case documents by reference, sets deadline default to 4 weeks.
+2. **ConsultationPanel.vue** — "Adviezen" tab on case detail; renders consultation cards with progress, deadline, and advice outcomes; surfaces "2/4 adviezen ontvangen" summary.
+3. **ConsultationDashboard.vue** — department-scoped inbox; filters by status, requester, deadline; supports `Oppakken` (claim) and reassignment.
+4. **ConsultationResponseForm.vue** — used by consulted parties; structured response with conditional `voorwaarden` editor.
+5. **ExternalConsultationResponsePage.vue** — public page accessed by secure token for external bodies; same fields minus internal navigation.
+
+## Backend
+- `ConsultationService` — CRUD, status machine, dependency check, mandatory-gate evaluator (queried by milestone-tracking).
+- `ConsultationNotificationService` — emits events for create, acknowledge, deadline warnings (T-5 days), overdue (T+0), extension requests, response submitted.
+- `ConsultationController` — REST under `/api/consultations`, plus `/api/public/consultations/{token}` for external bodies.
+- `AdvisoryBodyService` — registry CRUD with specialization-weighted search.
+- Document linkage uses OpenRegister's `relationsPlugin`; consulted-party access is scoped to consultation-linked documents only (enforced in `ConsultationController`).
+
+## Integration
+- **Milestone-tracking** — exposes `getBlockingConsultations(zaakId)`; mandatory consultations with status != `advies_uitgebracht` block decision milestones with the message listed in spec scenario.
+- **Activity timeline** — `ActivityTimeline.vue` consumes consultation events from a shared event bus so create, acknowledge, response, and overdue events surface on the parent case.
+- **n8n** — daily deadline-monitor workflow; email-fanout workflow for external bodies; bottleneck-detection workflow generating coordinator alerts when a body's overdue rate exceeds 20%.
+
+## Risks & Mitigations
+- Document-scope leakage — consulted parties must NOT see unrelated case documents; enforce at controller level by checking that requested attachments are linked to the consultation, not just the case.
+- Token security for external bodies — tokens are 256-bit, single-purpose, expire on consultation closure, and all access is logged for BIO compliance.
+- Dependency cycles — `dependsOn` is validated at write time to prevent cycles; UI surfaces the dependency graph.
+
+## Standards
+Awb 3:5-3:9, ZGW Zaken API, GEMMA adviesverzoek/adviesreactie, CMMN 1.1 CaseTask/Sentry, Common Ground "verwerken"/"notificeren", BIO access logging.

--- a/openspec/changes/consultation-management/proposal.md
+++ b/openspec/changes/consultation-management/proposal.md
@@ -1,17 +1,24 @@
-## Why
+# Consultation Management Implementation
 
-Inter-departmental consultations (adviesaanvragen) currently happen via email, losing auditability. This implements structured consultation as first-class entities with lifecycle, document exchange, structured responses with conditions, timeline integration, and a consultation dashboard.
+## Why
+Inter-departmental and external advisory consultations (adviesaanvragen) are currently exchanged via email, which destroys auditability, version control, and deadline enforcement. Awb articles 3:5-3:9 give consultation a legal status: the decision-maker must verify advice was produced diligently and respect reasonable response deadlines. Without structured consultations, municipalities cannot prove diligence on omgevingsvergunning, monumentenadvies, milieuadvies, or welstandstoets paths, and case workers have no central view of what is outstanding or blocking case completion. ArkCase and Flowable both model this concept as a sub-case linked to a parent — Procest needs the same primitive built on top of OpenRegister.
 
 ## What Changes
-
-1. Consultation schema in procest_register.json
-2. ConsultationService for CRUD, lifecycle management, overdue detection
-3. ConsultationController with REST API
-4. ConsultationPanel Vue component for case detail view
-5. ConsultationDashboard Vue component for pending consultations overview
-6. Route additions
+1. New `consultation`, `advisoryBody`, and `adviceResponse` schemas in `procest_register.json`.
+2. `ConsultationService` for CRUD, lifecycle transitions, overdue detection, extension requests, and dependency enforcement.
+3. `ConsultationController` REST API with routes for parent-case consultations, the consulted-party inbox, and external secure-link responses.
+4. `ConsultationPanel.vue` (case-detail tab) and `ConsultationDashboard.vue` (department inbox) Vue components.
+5. Parallel and sequential consultation patterns with mandatory-gate enforcement at the milestone level.
+6. External advisory-body email path with secure response links for bodies without Nextcloud accounts.
+7. Notifications, deadline monitoring, and activity-timeline integration via n8n.
 
 ## Impact
+- Case detail view gains an "Adviezen" tab and a consultation summary badge.
+- Dashboard gains a "Openstaande adviesaanvragen" widget and consultation performance KPIs.
+- Mandatory consultations block case progression to decision milestones until completed.
+- New cross-cutting integration with `milestone-tracking` for mandatory gates.
 
-- New schema, service, controller, 2 Vue components, route additions
-- Extends case detail view with consultations panel
+## Out of Scope
+- Public participation / inspraak (citizen consultation on policy decisions).
+- AI-generated advice drafting.
+- Legal advice management with advocaat-client privilege.

--- a/openspec/changes/consultation-management/tasks.md
+++ b/openspec/changes/consultation-management/tasks.md
@@ -1,0 +1,12 @@
+# Tasks
+
+- [ ] TASK-CN-01: Add `consultation`, `adviceResponse`, and `advisoryBody` schemas to `procest_register.json` and register config keys in `SettingsService::SLUG_TO_CONFIG_KEY`.
+- [ ] TASK-CN-02: Implement `ConsultationService` with CRUD, status machine, deadline/extension logic, dependency-cycle validation, and `getBlockingConsultations(zaakId)` for milestone gates.
+- [ ] TASK-CN-03: Implement `AdvisoryBodyService` with specialization-weighted search and external-body email path including secure-token issuance.
+- [ ] TASK-CN-04: Implement `ConsultationController` REST endpoints plus the public `/api/public/consultations/{token}` route with audited access logging (BIO).
+- [ ] TASK-CN-05: Create `ConsultationCreateDialog.vue`, `ConsultationPanel.vue` (case-detail "Adviezen" tab), `ConsultationDashboard.vue` (department inbox), and `ConsultationResponseForm.vue`.
+- [ ] TASK-CN-06: Create `ExternalConsultationResponsePage.vue` for token-based external responses; register route outside the authenticated app shell.
+- [ ] TASK-CN-07: Add caseType admin UI to configure mandatory/optional consultation types per zaaktype with default body, default deadline, and dependencies.
+- [ ] TASK-CN-08: Wire ActivityTimeline integration so consultation lifecycle events surface on the parent case, including the overdue warning event.
+- [ ] TASK-CN-09: Add n8n deadline-monitor, email-fanout, and bottleneck-detection workflows; document webhook contracts.
+- [ ] TASK-CN-10: Add Dutch + English i18n for all consultation UI and notification templates.

--- a/openspec/changes/milestone-tracking/design.md
+++ b/openspec/changes/milestone-tracking/design.md
@@ -1,0 +1,50 @@
+# Milestone Tracking Design
+
+## Architecture
+Milestones are a thin business-friendly layer over the existing status pipeline. Milestone *definitions* live on the `caseType` object as an ordered array. Milestone *records* are OpenRegister objects linked to a case, created when a milestone is reached and updated when reversed. The existing `StatusTimeline.vue` continues to show technical status; the new milestone components show business progress alongside it.
+
+Three reach mechanisms feed the same write path:
+1. **n8n webhook** — workflows POST to `/api/cases/{id}/milestones/trigger` with an event name matching a milestone's `triggerEvent`.
+2. **Status transition** — when a case status changes, `MilestoneService::onStatusChanged()` maps mapped milestones to reached.
+3. **Manual** — case workers click a milestone dot and confirm; coordinators can reverse with a mandatory justification.
+
+## Data Model
+
+### Milestone Definition (on caseType)
+Array of objects with: `identifier` (slug), `label` (Dutch), `order` (int), `description`, `triggerEvent` (optional), `mappedStatusType` (optional), `expectedDurationWorkingDays` (optional, integer), `dependsOn` (array of identifiers).
+
+### MilestoneRecord (OpenRegister schema)
+- `case` — reference to parent case.
+- `milestoneIdentifier` — slug from caseType config.
+- `reached` — boolean.
+- `reachedAt` — datetime.
+- `triggerSource` — enum `manual` | `workflow` | `status_transition`.
+- `triggeredBy` — user UID or n8n execution ID.
+- `reversedAt` — datetime, nullable.
+- `reversalReason` — string, nullable.
+
+Schema registered as `milestone_record_schema` in `SettingsService::SLUG_TO_CONFIG_KEY`.
+
+## Components
+1. **MilestoneProgress.vue** — horizontal step indicator on case detail (below the status card). Renders dots per milestone, green for reached, amber within 1 day of deadline, red overdue, current milestone larger. Provides keyboard navigation and `role="progressbar"` with ARIA labels.
+2. **MilestoneProgressBar.vue** — compact 2/6-style bar for case list rows.
+3. **MilestoneConfigTab.vue** — drag-and-drop reorder, label + identifier editor, optional `mappedStatusType` and `triggerEvent` selectors; integrated as a new tab in `CaseTypeDetail.vue`.
+4. **MilestoneDetailPanel.vue** — popover on dot click showing reach metadata and reversal history.
+5. **MilestoneFunnelWidget.vue** — dashboard panel rendering cases-at-stage counts as a funnel.
+6. **MilestoneKpiCard.vue** — "Mijlpaalvoortgang" KPI card on dashboard.
+
+## Backend
+- `MilestoneService` — `reach()`, `reverse()`, `onStatusChanged()`, `evaluateDependencies()`, `computeDurations()`, `computeProgress()`, `findOverdue()`, `findBottlenecks()`.
+- `MilestoneController` — `GET /api/cases/{id}/milestones`, `POST /api/cases/{id}/milestones/{slug}/reach`, `POST /api/cases/{id}/milestones/{slug}/reverse`, `POST /api/cases/{id}/milestones/trigger`, `GET /api/public/cases/{token}/milestones`, plus a ZGW-compatible representation embedded in the existing `ZrcController` status history response.
+- Reversal authorization: only users with role `coordinator` on the case can reverse a milestone; enforced in `MilestoneService::reverse()` and double-checked at controller.
+
+## Public/Citizen API
+Public endpoint strips `triggerSource`, `triggeredBy`, identifiers, and durations. Returns labels, order, reached, and a localized `currentStep` like "Stap 3 van 6: Inhoudelijke beoordeling".
+
+## Risks & Mitigations
+- Drift between status types and milestones when both are configured — the mapping is optional and the spec explicitly allows them to coexist; document the recommended mapping pattern per zaaktype.
+- Reorder breaks historical analytics — milestone records persist their identifier and timestamp; reorder only affects new cases, historical durations recompute from records.
+- Citizen API leakage — explicit allow-list of fields in the public serializer; covered by a serializer unit test.
+
+## Standards
+CMMN 1.1 (Milestone PlanItem, sentries), Flowable MilestoneInstance, ZGW Zaken API (status history mapping), GEMMA voortgangsbewaking / fase concept, WCAG 2.1 AA (progressbar role, ARIA labels, non-color indicators), Schema.org `Event` and `ProgressStatus`.

--- a/openspec/changes/milestone-tracking/proposal.md
+++ b/openspec/changes/milestone-tracking/proposal.md
@@ -1,17 +1,24 @@
-## Why
+# Milestone Tracking Implementation
 
-Technical workflow states are meaningless to end users. Milestones translate process progress into language everyone understands. This implements configurable milestone sets per case type, automatic/manual marking, visual progress indicators, duration analytics, and a milestone API.
+## Why
+Technical workflow states (status types, internal step IDs) are meaningless to citizens, managers, and ketenpartners who only want to know "where is my case in the journey?". CMMN 1.1 solves this with first-class milestones; Flowable engines and Dimpact ZAC use them internally but never expose them to end users. Procest needs a business-friendly progress layer that translates the existing status pipeline into ordered, named milestones with timestamps, optional deadlines, dependencies, and progress visualizations that work in case detail, case list, dashboard, and the public citizen view.
 
 ## What Changes
-
-1. Milestone schema in procest_register.json (milestoneDefinition, milestoneRecord)
-2. MilestoneService for milestone CRUD and progress calculation
-3. MilestoneProgress Vue component (step indicator in case detail)
-4. MilestoneProgressBar Vue component (compact progress in case list)
-5. Milestone configuration tab in case type admin
-6. API endpoint for milestone data
+1. New `milestoneRecord` schema in `procest_register.json` storing per-case milestone reach events with trigger source and audit data.
+2. Milestone-set configuration stored as an ordered array on the existing `caseType` schema.
+3. `MilestoneService` for milestone CRUD, automatic reach (n8n webhook, status transition), manual reach, reversal with justification, dependency enforcement, and duration calculation.
+4. `MilestoneProgress.vue` step indicator on case detail and `MilestoneProgressBar.vue` compact bar in case list.
+5. Milestone configuration tab in the CaseType admin (`CaseTypeDetail.vue`).
+6. REST endpoints for authenticated and public/citizen milestone queries, plus a ZGW-compatible status representation.
+7. Dashboard widgets: milestone completion-rate KPI card, funnel visualization, milestone filter in case list.
+8. Bottleneck detection alerts when active cases linger between milestones beyond the average duration.
 
 ## Impact
+- Cases get a "Voortgang" section alongside the existing `StatusTimeline` (both coexist).
+- Coordinators receive overdue and bottleneck notifications.
+- External systems can consume milestone data via the new endpoints; citizen portal can show stripped-down progress.
 
-- New schemas, service, 3 Vue components, route additions
-- Extends case detail view and case list with progress indicators
+## Out of Scope
+- BPMN/CMMN visual model import.
+- Milestone-based contractual SLA enforcement.
+- Per-user milestone notification preferences.

--- a/openspec/changes/milestone-tracking/tasks.md
+++ b/openspec/changes/milestone-tracking/tasks.md
@@ -1,0 +1,12 @@
+# Tasks
+
+- [ ] TASK-MT-01: Add `milestoneRecord` schema to `procest_register.json` and register `milestone_record_schema` in `SettingsService::SLUG_TO_CONFIG_KEY`; extend the `caseType` schema with a `milestones[]` array (identifier, label, order, description, triggerEvent, mappedStatusType, expectedDurationWorkingDays, dependsOn).
+- [ ] TASK-MT-02: Implement `MilestoneService` with `reach`, `reverse`, `onStatusChanged`, `evaluateDependencies`, `computeDurations`, `computeProgress`, `findOverdue`, and `findBottlenecks`; enforce coordinator-only reversal.
+- [ ] TASK-MT-03: Implement `MilestoneController` with authenticated, public/citizen-token, and ZGW-compatible endpoints; integrate the ZGW representation into the existing `ZrcController` status history.
+- [ ] TASK-MT-04: Create `MilestoneProgress.vue` (case detail) and `MilestoneProgressBar.vue` (case list) with WCAG 2.1 AA ARIA roles, keyboard navigation, and non-color status indicators.
+- [ ] TASK-MT-05: Create `MilestoneDetailPanel.vue` showing reach metadata and reversal history; wire it to dot clicks in `MilestoneProgress.vue`.
+- [ ] TASK-MT-06: Add `MilestoneConfigTab.vue` to `CaseTypeDetail.vue` with drag-and-drop reorder, identifier/label editor, optional status-type mapping and trigger-event selector, and dependency picker with cycle validation.
+- [ ] TASK-MT-07: Add `MilestoneKpiCard.vue` and `MilestoneFunnelWidget.vue` to `Dashboard.vue`; add milestone filter to the case list view.
+- [ ] TASK-MT-08: Hook status-change events to `MilestoneService::onStatusChanged()` and document the n8n webhook contract for `/api/cases/{id}/milestones/trigger`.
+- [ ] TASK-MT-09: Add the daily bottleneck-detection job (n8n or system cron) that flags cases lingering >1.5x the average inter-milestone duration and notifies the coordinator.
+- [ ] TASK-MT-10: Add Dutch + English i18n for milestone UI, KPI labels, and notification templates.

--- a/openspec/changes/roles-decisions/specs/roles-decisions/spec.md
+++ b/openspec/changes/roles-decisions/specs/roles-decisions/spec.md
@@ -1,0 +1,89 @@
+---
+status: proposed
+---
+
+# roles-decisions Specification (Change Delta)
+
+## Purpose
+Deliver the case-detail UI gaps for Roles & Decisions: a dedicated Decisions section with CRUD and validity-period display, archival-metadata-aware Result section, and field-level role validation. The canonical capability spec lives at `openspec/specs/roles-decisions/spec.md`; this delta narrows scope to the missing UI affordances and the role/decision linkage rules enforced in the frontend.
+
+## Requirements
+
+### Requirement: REQ-DECISION-001 Decisions section MUST support full CRUD from case detail
+The case-detail view SHALL render a `DecisionsSection.vue` component that lists decisions linked to the current case and supports create, edit, and delete operations subject to permissions.
+
+#### Scenario: Authorized role creates a decision
+- GIVEN a case worker with role `handler` or `decision_maker` opens case `ZAAK-2026-000123`
+- WHEN they click "Besluit toevoegen" in the Decisions section
+- THEN a dialog MUST collect `title`, `description`, `decisionType`, `decidedBy`, `decidedAt`, `effectiveDate`, and `expiryDate`
+- AND on save the decision object MUST be persisted via OpenRegister with `case` set to `ZAAK-2026-000123`
+- AND the new decision MUST appear in the section list without a full page reload
+
+#### Scenario: Unauthorized role cannot create a decision
+- GIVEN a user whose only role on the case is `stakeholder`
+- WHEN the case detail loads
+- THEN the "Besluit toevoegen" action MUST be hidden
+- AND the section MUST be read-only
+
+### Requirement: REQ-DECISION-002 Decision validity period MUST be displayed and computed
+Each decision row SHALL show its validity window based on `effectiveDate` and `expiryDate`, computed in `decisionHelpers.js`.
+
+#### Scenario: Decision is currently valid
+- GIVEN a decision with `effectiveDate` 2026-01-01 and `expiryDate` 2026-12-31
+- WHEN the current date is 2026-05-11
+- THEN the row MUST render a green "Geldig" badge with text "Geldig tot 31-12-2026"
+
+#### Scenario: Decision has expired
+- GIVEN a decision with `expiryDate` 2026-04-01
+- WHEN the current date is 2026-05-11
+- THEN the row MUST render a grey "Verlopen" badge with the expiry date
+
+#### Scenario: Decision has no expiry
+- GIVEN a decision with `effectiveDate` set and `expiryDate` empty
+- THEN the badge MUST read "Geldig (onbepaalde tijd)"
+
+### Requirement: REQ-DECISION-005 Decisions section MUST be present on every case detail view
+The Decisions section SHALL appear on `CaseDetail.vue` between the Result section and the activity timeline regardless of whether decisions exist.
+
+#### Scenario: Case has no decisions
+- GIVEN case `ZAAK-2026-000123` has zero decisions
+- THEN the section MUST render its header and an empty-state hint "Nog geen besluiten genomen"
+- AND the create action MUST remain available to authorized roles
+
+### Requirement: REQ-RESULT-001 Result section MUST display archival metadata
+`ResultSection.vue` SHALL surface the archival action and retention information derived from the linked `resultType`.
+
+#### Scenario: Result with retention rule
+- GIVEN the case has a result whose `resultType` has `archiveAction` `retain` and `retentionPeriod` `P20Y`
+- THEN the section MUST display: "Bewaartermijn: 20 jaar", "Archiefactie: bewaren", and the computed retention end date based on `retentionDateSource`
+
+#### Scenario: Result with destroy action
+- GIVEN `archiveAction` is `destroy` with `retentionPeriod` `P5Y`
+- THEN the section MUST display "Archiefactie: vernietigen" with a tooltip explaining the disposal date
+
+### Requirement: REQ-ROLE-006 Role validation MUST enforce field requirements per role type
+When creating or editing a Role on a case, the form SHALL enforce required fields defined by the linked `roleType.genericRole`.
+
+#### Scenario: Initiator requires participant
+- GIVEN the user selects `roleType` whose `genericRole` is `initiator`
+- WHEN they leave `participant` empty and submit
+- THEN the form MUST block submission with error "Een initiator vereist een deelnemer"
+
+#### Scenario: Decision-maker role gates decision creation
+- GIVEN no user holds a role with `genericRole` `decision_maker` on the case
+- WHEN any user attempts to open the "Besluit toevoegen" dialog
+- THEN the dialog MUST display a warning "Geen besluitnemer toegewezen op deze zaak"
+- AND the save action MUST be disabled until a decision_maker role is assigned
+
+### Requirement: REQ-ROLE-007 Role-to-decision audit trail MUST be preserved
+Every decision write SHALL record the actor's role at the moment of the action, so the audit history reflects which role authorized the decision even if the user's roles change later.
+
+#### Scenario: Audit trail on decision create
+- GIVEN user `alice` holds role `decision_maker` on case `ZAAK-2026-000123`
+- WHEN alice creates a decision
+- THEN the decision's audit entry MUST contain `actor: alice`, `actorRole: decision_maker`, and the timestamp
+- AND a later removal of alice's `decision_maker` role MUST NOT alter the historical audit entry
+
+#### Scenario: Audit trail on decision reversal
+- GIVEN an existing decision is deleted by a `coordinator` role
+- THEN the audit entry MUST record `action: delete`, `actor`, `actorRole: coordinator`, and the original decision payload for traceability


### PR DESCRIPTION
## Summary

Completes OpenSpec artifact sets for four procest changes; spec-only, no code.

### roles-decisions
- Added missing `specs/roles-decisions/spec.md` with 7 REQs covering the change scope:
  - **REQ-DECISION-001** Decisions CRUD on case detail (authorized vs unauthorized scenarios)
  - **REQ-DECISION-002** Validity-period badge (valid / expired / open-ended)
  - **REQ-DECISION-005** Decisions section always present (empty state)
  - **REQ-RESULT-001** Result section surfaces archival metadata (retain / destroy)
  - **REQ-ROLE-006** Role validation per generic role type (initiator participant, decision-maker gate)
  - **REQ-ROLE-007** Role-to-decision audit trail (actor + actorRole frozen in audit log)
- proposal.md, design.md, tasks.md were already present.

### complaint-management (Awb chapter 9 klachtafhandeling)
- Expanded proposal.md (was a stub) covering Awb-mandated deadlines, hearing, disposition, escalation, frequency analysis.
- New design.md: four OpenRegister schemas, services, four Vue components, three n8n workflows.
- New tasks.md with 10 tasks (TASK-CM-01..10).
- specs/ already authored with full REQ coverage.

### consultation-management (adviesaanvragen)
- Expanded proposal.md covering parallel/sequential consultation patterns, external secure-token path, milestone-gate integration.
- New design.md: three schemas, independent status machine, document-scope enforcement, BIO access logging.
- New tasks.md with 10 tasks (TASK-CN-01..10).
- specs/ already authored with full REQ coverage.

### milestone-tracking
- Expanded proposal.md covering CMMN-style business-friendly progress layer.
- New design.md: milestoneRecord schema + caseType milestones array, three reach mechanisms, ZGW + citizen API split, six new Vue components.
- New tasks.md with 10 tasks (TASK-MT-01..10).
- specs/ already authored with full REQ coverage.

## Test plan
- [ ] OpenSpec validation passes on all four changes
- [ ] REQ identifiers in roles-decisions delta match those in proposal scope list
- [ ] No source code touched (`git diff --stat` shows only openspec/changes/* files)