### PR TITLE
chore(openspec): complete specs/<cap>/spec.md for 5 procest case changes

### DIFF
--- a/openspec/changes/case-dashboard-view/specs/case-dashboard-view/spec.md
+++ b/openspec/changes/case-dashboard-view/specs/case-dashboard-view/spec.md
@@ -1,0 +1,101 @@
+---
+status: implemented
+---
+# case-dashboard-view Specification
+
+## Purpose
+Deliver a polished, responsive, and accessible case detail dashboard that surfaces all relevant case context (status, deadlines, activity, tasks, documents, participants) on a single screen. This change closes the remaining MVP gaps in the existing `case-dashboard-view` capability: tablet/print rendering, per-panel skeleton loading, and a graceful 404 state for missing cases.
+
+## Context
+`CaseDetail.vue` already renders a two-column dashboard composed of panel cards (status timeline, info, deadline, activity, tasks, documents, participants). Tender demos and on-call inspections require the same screen to work on tablets, print cleanly, and signal loading state per-card instead of via a single page-level spinner. The capability is implemented end-to-end in code; this spec documents the contract.
+
+## Requirements
+
+### REQ-CDV-01c: Case Not Found State
+The dashboard MUST display a localized 404 empty state when the requested case cannot be loaded.
+
+#### Scenario CDV-01c-1: Unknown case identifier
+- GIVEN a user navigates to `/cases/does-not-exist`
+- WHEN the fetch resolves with no case object
+- THEN the view MUST render an `NcEmptyContent` with title "Zaak niet gevonden"
+- AND a "Terug naar overzicht" button MUST be visible
+- AND clicking the button MUST navigate the user to the case list view
+
+#### Scenario CDV-01c-2: Case fetch error
+- GIVEN the backend returns an error while loading a case
+- THEN the empty state MUST be shown instead of a broken panel layout
+- AND the action buttons in the page header MUST be hidden
+
+### REQ-CDV-01d: Per-Panel Skeleton Loading
+The dashboard MUST render a skeleton placeholder for each panel card while case data is loading.
+
+#### Scenario CDV-01d-1: Initial render with no data
+- GIVEN a user opens a case detail page for the first time
+- WHEN the case data has not yet resolved
+- THEN each panel card (status timeline, info, deadline, activity, tasks, documents, participants) MUST render a skeleton placeholder with animated bars
+- AND no global page-level spinner MUST be shown
+
+#### Scenario CDV-01d-2: Skeleton replaced on data ready
+- GIVEN the skeleton placeholders are visible
+- WHEN the case data resolves
+- THEN each skeleton MUST be replaced by its real panel content in place
+- AND the page MUST NOT flicker or fully re-mount
+
+### REQ-CDV-07b: Tablet Layout
+The dashboard MUST adapt to a single-column layout at tablet viewport widths.
+
+#### Scenario CDV-07b-1: Viewport at or below 1200px
+- GIVEN a user views the dashboard on a viewport of 1200px or narrower
+- THEN the panels MUST stack vertically in a single column
+- AND the order MUST be: status timeline, case info, deadline, activity, tasks, documents, participants
+- AND no horizontal scrollbar MUST appear on the page body
+
+#### Scenario CDV-07b-2: Touch target sizing
+- GIVEN the tablet layout is active
+- THEN all interactive controls (buttons, dropdowns, selects, status pills) MUST meet a minimum 44x44 CSS pixel touch target
+- AND focus rings MUST remain visible
+
+### REQ-CDV-07c: Print View
+The dashboard MUST render a clean, printable representation when the user prints the page.
+
+#### Scenario CDV-07c-1: Print stylesheet applied
+- GIVEN a user invokes the browser print dialog (e.g., Ctrl+P)
+- THEN `@media print` rules MUST hide navigation, action buttons, save/delete controls, and interactive dropdowns
+- AND backgrounds MUST be forced to white and shadows removed
+- AND the status timeline MUST render as a textual list (not interactive dots)
+
+#### Scenario CDV-07c-2: Print header includes identifier and date
+- GIVEN the dashboard is printed
+- THEN the printed output MUST include a header containing the case identifier and the current print date
+
+### REQ-CDV-DASH-01: Panel Composition
+The dashboard MUST present case data through a fixed set of panel cards.
+
+#### Scenario CDV-DASH-01-1: Default desktop layout
+- GIVEN a user opens a case detail page on a viewport wider than 1200px
+- THEN the dashboard MUST render a two-column layout with a primary column (status timeline, activity, documents) and a secondary column (case info, deadline, tasks, participants)
+- AND each panel MUST be rendered as a `CnDetailCard` (or equivalent panel component) with a clear title
+
+#### Scenario CDV-DASH-01-2: Empty panel handling
+- GIVEN a case has no tasks, documents, or participants
+- THEN each affected panel MUST render an inline empty state with a short Dutch label (e.g., "Geen taken", "Geen documenten", "Geen betrokkenen")
+- AND the panel MUST NOT be hidden entirely
+
+### REQ-CDV-DASH-02: Header Actions Visibility
+Page-level header actions MUST adapt to the dashboard's loading and error states.
+
+#### Scenario CDV-DASH-02-1: Actions during loading
+- GIVEN the dashboard is in skeleton loading state
+- THEN primary header actions (save, status change, delete) MUST be disabled or hidden
+- AND the back link MUST remain available
+
+#### Scenario CDV-DASH-02-2: Actions in not-found state
+- GIVEN the dashboard is in the "Zaak niet gevonden" state
+- THEN all header actions related to the case MUST be hidden
+- AND only the "Terug naar overzicht" navigation MUST be available
+
+## Dependencies
+- `CaseDetail.vue` (Procest) -- host view that composes the panels
+- `@nextcloud/vue` `NcEmptyContent`, `NcLoadingIcon` -- empty/loading primitives
+- `CnDetailCard` from `@conduction/nextcloud-vue` -- panel container
+- Case data store (object store + filesPlugin) -- supplies case, activity, tasks, documents, participants

--- a/openspec/changes/case-management/specs/case-management/spec.md
+++ b/openspec/changes/case-management/specs/case-management/spec.md
@@ -1,0 +1,145 @@
+---
+status: implemented
+---
+# case-management Specification
+
+## Purpose
+Define the foundational case lifecycle on top of OpenRegister: creating, reading, updating, deleting, listing, searching, validating, and presenting case objects with their custom properties and required documents. This spec documents the MVP surface implemented by this change set; suspension, sub-cases, and confidentiality enforcement remain out of scope.
+
+## Context
+A `case` (zaak) is the primary domain object in Procest. Cases are stored as OpenRegister objects and rendered through `CaseList.vue` and `CaseDetail.vue` using the shared `createObjectStore` pattern. The list view consumes `_filters` and `_search` query parameters, while detail panels (`CustomPropertiesPanel.vue`, `DocumentChecklist.vue`) read property definitions and document type requirements off the linked case type. Validation rules live in `caseValidation.js`.
+
+## Requirements
+
+### REQ-CM-LIST-01: Case List Filters
+The case list MUST expose filters for handler, priority, and overdue status.
+
+#### Scenario CM-LIST-01-1: Filter by handler
+- GIVEN the case list contains cases assigned to multiple handlers
+- WHEN the user selects a handler from the handler filter dropdown
+- THEN the list MUST refresh with `_filters[handler]` applied via the object store
+- AND only cases assigned to the selected handler MUST be visible
+
+#### Scenario CM-LIST-01-2: Filter by priority
+- WHEN the user selects a priority value (e.g., "high")
+- THEN the list MUST refresh with `_filters[priority]` applied
+- AND only cases matching that priority MUST be visible
+
+#### Scenario CM-LIST-01-3: Filter overdue cases
+- WHEN the user activates the "overdue" toggle
+- THEN the list MUST be filtered to cases whose deadline is in the past and whose status is not final
+
+#### Scenario CM-LIST-01-4: Combined filters
+- WHEN the user combines case type, status, handler, priority, and overdue filters
+- THEN all filters MUST be applied as an AND condition and reflected in the URL query state
+
+### REQ-CM-LIST-02: Case Search
+The case list MUST support keyword search across title, description, and identifier.
+
+#### Scenario CM-LIST-02-1: Search by keyword
+- GIVEN a case "Omgevingsvergunning verbouwing Kerkstraat 12" with identifier "ZAAK-2026-000123"
+- WHEN the user types "Kerkstraat" into the search field
+- THEN the list MUST refresh with `_search=Kerkstraat`
+- AND the matching case MUST appear in the results
+
+#### Scenario CM-LIST-02-2: Search by identifier
+- WHEN the user types a full or partial case identifier
+- THEN matching cases MUST appear in the results regardless of title content
+
+#### Scenario CM-LIST-02-3: Empty search
+- WHEN the search field is cleared
+- THEN the `_search` parameter MUST be removed and the full filtered list MUST return
+
+### REQ-CM-PROP-01: Custom Properties Panel
+The case detail view MUST render a panel showing the case's custom properties as defined by its case type.
+
+#### Scenario CM-PROP-01-1: Render configured properties
+- GIVEN a case whose case type defines properties `["aanvraagdatum", "locatie", "bouwsom"]`
+- WHEN the user opens the case detail view
+- THEN the custom properties panel MUST render each property with its label and current value
+- AND properties not defined on the case type MUST NOT appear
+
+#### Scenario CM-PROP-01-2: Edit a property value
+- WHEN the user edits a property value through the panel and saves
+- THEN the new value MUST be persisted on the case object
+- AND the panel MUST reflect the updated value without a full page reload
+
+#### Scenario CM-PROP-01-3: Property panel with no definitions
+- GIVEN a case whose case type defines no custom properties
+- THEN the panel MUST render an empty state ("Geen aanvullende kenmerken") and remain hidden from primary actions
+
+### REQ-CM-DOC-01: Required Documents Checklist
+The case detail view MUST render a checklist showing required document types and their completion status.
+
+#### Scenario CM-DOC-01-1: Render required documents
+- GIVEN a case whose case type defines document types with `required=true`
+- WHEN the user opens the case detail view
+- THEN the checklist MUST list each required document type with a checkmark when at least one matching case document is present
+
+#### Scenario CM-DOC-01-2: Missing documents flagged
+- GIVEN a required document type with no matching case document
+- THEN the checklist MUST render that row as incomplete with an explicit "Ontbreekt" label
+
+#### Scenario CM-DOC-01-3: Optional documents excluded
+- GIVEN a case type that defines optional document types in addition to required ones
+- THEN only the required types MUST appear in the checklist
+
+### REQ-CM-VAL-01: Strengthened Case Validation
+Case creation and update MUST surface explicit validation errors for case type validity, missing title, and missing case type.
+
+#### Scenario CM-VAL-01-1: Case type not yet valid
+- GIVEN a case type with `validFrom` in the future
+- WHEN the user attempts to create a case using it
+- THEN `caseValidation.js` MUST return an error identifying the case type and its `validFrom` date
+- AND the form MUST display this error inline next to the case type field
+
+#### Scenario CM-VAL-01-2: Case type expired
+- GIVEN a case type with `validTo` in the past
+- WHEN the user attempts to create a case using it
+- THEN validation MUST fail with an explicit "vervallen" error referencing the expiration date
+
+#### Scenario CM-VAL-01-3: Missing required fields
+- GIVEN a case create form without title or case type
+- WHEN the user submits
+- THEN each missing required field MUST be highlighted with a Dutch-language error message
+- AND the save action MUST be blocked until errors are resolved
+
+### REQ-CM-CRUD-01: Case CRUD Foundation
+The system MUST support create, read, update, and delete operations on case objects through the shared object store.
+
+#### Scenario CM-CRUD-01-1: Create case
+- GIVEN a valid case type and title
+- WHEN the user submits the create form
+- THEN a new case object MUST be persisted via `createObjectStore('case').save(...)`
+- AND the user MUST be redirected to the new case's detail view
+
+#### Scenario CM-CRUD-01-2: Update case
+- WHEN the user edits a case field (e.g., description, priority, handler) and saves
+- THEN the update MUST be persisted and the detail view MUST reflect the new value
+
+#### Scenario CM-CRUD-01-3: Delete case in initial status
+- GIVEN a case in its initial status with no dependent links
+- WHEN the user confirms deletion
+- THEN the case object MUST be deleted via the object store
+- AND the user MUST be returned to the case list
+
+### REQ-CM-INT-01: Custom Properties and Document Checklist Integration
+The case detail view MUST integrate the custom properties panel and the document checklist alongside existing panels.
+
+#### Scenario CM-INT-01-1: Panels visible on detail view
+- GIVEN a case with custom properties and required documents
+- WHEN the user opens the detail view
+- THEN both `CustomPropertiesPanel.vue` and `DocumentChecklist.vue` MUST be visible
+- AND they MUST coexist with the status timeline, deadline, activity, and tasks panels without layout overlap
+
+## Non-Requirements
+- Case suspension (out of scope, deferred to V1)
+- Sub-cases / parent-child case relations (deferred to V1)
+- Confidentiality (`vertrouwelijkheidaanduiding`) enforcement at view-time (deferred to V1)
+- Status blocking by missing properties or documents (deferred to V1)
+
+## Dependencies
+- OpenRegister `case` schema and shared `createObjectStore`
+- `CaseList.vue`, `CaseDetail.vue`, `CustomPropertiesPanel.vue`, `DocumentChecklist.vue`
+- `caseValidation.js` validation utility
+- `case-types` capability for property definitions and document type definitions

--- a/openspec/changes/case-types/specs/case-types/spec.md
+++ b/openspec/changes/case-types/specs/case-types/spec.md
@@ -1,0 +1,125 @@
+---
+status: implemented
+---
+# case-types Specification
+
+## Purpose
+Define the V1 admin surface for configuring case types (zaaktypen) in Procest: result types, role types, property definitions, document types, the tab layout that hosts them, and the publish-time validation that ensures a case type is usable before it goes live. Status type, deadline, and confidentiality configuration are already shipped via the earlier `zaaktype-configuratie` change; this spec layers the remaining V1 tabs on top.
+
+## Context
+Case types drive every downstream capability: statuses, deadlines, custom properties, required documents, roles, and result/outcome handling. The admin UI is hosted by `CaseTypeDetail.vue`, which composes per-concern tab components. This change introduces the missing V1 tabs (`ResultTypesTab.vue`, `RoleTypesTab.vue`, `PropertiesTab.vue`, `DocumentTypesTab.vue`) and strengthens publish-time validation.
+
+## Requirements
+
+### REQ-CT-RESULT-01: Result Type Management Tab
+The case type admin UI MUST provide a tab for managing result types with archival rules.
+
+#### Scenario CT-RESULT-01-1: List result types
+- GIVEN a case type with one or more configured result types
+- WHEN the admin opens the "Resultaattypen" tab on `CaseTypeDetail.vue`
+- THEN each result type MUST be listed with: name, description, archival classification, and retention period
+
+#### Scenario CT-RESULT-01-2: Create result type
+- WHEN the admin clicks "Resultaattype toevoegen" and submits the form with name, description, and archival rule
+- THEN a new result type MUST be persisted on the case type
+- AND the tab MUST refresh to show the new entry
+
+#### Scenario CT-RESULT-01-3: Edit and delete result type
+- WHEN the admin edits or deletes an existing result type
+- THEN the change MUST be persisted via the object store
+- AND deletion MUST be blocked with a Dutch-language error if any case currently references the result type
+
+### REQ-CT-ROLE-01: Role Type Management Tab
+The case type admin UI MUST provide a tab for managing role types referencing the generic role registry.
+
+#### Scenario CT-ROLE-01-1: List role types
+- WHEN the admin opens the "Roltypen" tab
+- THEN each configured role type MUST be listed with: name, description, generic role (rolomschrijvinggeneriek), and required flag
+
+#### Scenario CT-ROLE-01-2: Create role type with generic role selector
+- WHEN the admin adds a new role type and picks a generic role from the dropdown ("Initiator", "Belanghebbende", "Behandelaar", etc.)
+- THEN the role type MUST be persisted with both the local label and the generic role mapping
+
+#### Scenario CT-ROLE-01-3: Required role validation
+- GIVEN a role type marked as required
+- THEN cases of this case type MUST surface a warning when the required role is not filled
+- AND the role types tab MUST clearly indicate which roles are required
+
+### REQ-CT-PROP-01: Property Definition Management Tab
+The case type admin UI MUST provide a tab for managing property definitions used by the custom properties panel.
+
+#### Scenario CT-PROP-01-1: List property definitions
+- WHEN the admin opens the "Kenmerken" tab
+- THEN each property definition MUST be listed with: key, label, type, required flag, and default value
+
+#### Scenario CT-PROP-01-2: Create property definition
+- WHEN the admin adds a new property definition with key, label, type (text/number/date/select), required flag, and optional default
+- THEN the definition MUST be persisted on the case type
+- AND it MUST become available in the `CustomPropertiesPanel.vue` on cases of this type
+
+#### Scenario CT-PROP-01-3: Edit and delete property definition
+- WHEN the admin edits or deletes a property definition
+- THEN the change MUST be persisted
+- AND existing case property values MUST remain intact; deletion only removes the definition, not historical data
+
+### REQ-CT-DOC-01: Document Type Management Tab
+The case type admin UI MUST provide a tab for managing document types with a direction (incoming/outgoing) and a required flag.
+
+#### Scenario CT-DOC-01-1: List document types
+- WHEN the admin opens the "Documenttypen" tab
+- THEN each document type MUST be listed with: name, description, direction (inkomend/uitgaand/intern), and required flag
+
+#### Scenario CT-DOC-01-2: Create document type
+- WHEN the admin adds a new document type with name, direction, and required flag
+- THEN the document type MUST be persisted on the case type
+- AND required document types MUST appear in `DocumentChecklist.vue` on cases of this type
+
+#### Scenario CT-DOC-01-3: Edit and delete document type
+- WHEN the admin edits or deletes a document type
+- THEN the change MUST be persisted
+- AND existing case documents MUST remain intact; deletion only removes the definition
+
+### REQ-CT-TABS-01: V1 Tab Layout
+`CaseTypeDetail.vue` MUST present all V1 admin concerns through a stable, navigable tab layout.
+
+#### Scenario CT-TABS-01-1: Tab order and labels
+- WHEN the admin opens a case type detail view
+- THEN the tabs MUST be visible in this order: "Algemeen", "Statussen", "Resultaattypen", "Roltypen", "Kenmerken", "Documenttypen", "Besluiten", "Doorlooptijd"
+- AND each tab MUST be labeled in Dutch
+
+#### Scenario CT-TABS-01-2: Deep link to tab
+- WHEN the admin navigates with a URL fragment selecting a tab (e.g., `#documenttypen`)
+- THEN the corresponding tab MUST be active on initial render
+
+### REQ-CT-PUBLISH-01: Publish Validation
+The case type publish action MUST be blocked when minimum configuration requirements are not met.
+
+#### Scenario CT-PUBLISH-01-1: Missing status types
+- GIVEN a case type with no status types configured
+- WHEN the admin clicks "Publiceren"
+- THEN publish MUST be blocked with the error: "Een zaaktype moet minimaal een initiele en een eind-status hebben"
+
+#### Scenario CT-PUBLISH-01-2: Missing initial or final status
+- GIVEN a case type with status types but none marked initial or none marked final
+- THEN publish MUST be blocked with a Dutch-language error identifying the missing flag
+
+#### Scenario CT-PUBLISH-01-3: Validity period
+- GIVEN a case type with `validFrom > validTo`
+- THEN publish MUST be blocked with the error: "Geldig-vanaf datum moet voor geldig-tot datum liggen"
+
+#### Scenario CT-PUBLISH-01-4: Successful publish
+- GIVEN a case type with at least one initial status, one final status, a valid validity period, and a name
+- WHEN the admin clicks "Publiceren"
+- THEN the case type's `status` MUST transition from `draft` to `published`
+- AND it MUST become selectable on the case creation form
+
+## Non-Requirements
+- Versioning of case types across published versions (deferred)
+- Cross-case-type cloning / templating (deferred)
+- Audit history of case-type configuration changes beyond what OpenRegister provides natively
+
+## Dependencies
+- OpenRegister `caseType` schema and related schemas: `resultType`, `roleType`, `propertyDefinition`, `documentType`
+- `CaseTypeDetail.vue` and the per-concern tab components
+- `case-management` capability (consumes property definitions and document types)
+- Existing `zaaktype-configuratie` change (status types, deadlines, confidentiality)

--- a/openspec/changes/my-work/specs/my-work/spec.md
+++ b/openspec/changes/my-work/specs/my-work/spec.md
@@ -1,0 +1,119 @@
+---
+status: implemented
+---
+# my-work Specification
+
+## Purpose
+Document the polish layer applied to the existing "Mijn werk" view in Procest: case-type name display on case items, ARIA labels and keyboard navigation for WCAG AA conformance, and a responsive layout for narrow viewports. The personal workload aggregation and filtering surface itself was shipped earlier and is captured in the canonical `my-work` capability spec; this change formalizes the non-functional requirements applied on top.
+
+## Context
+`MyWork.vue` renders a per-user list of cases and tasks grouped by urgency (overdue, today, this week, later). Items previously showed only entity type and title, with limited keyboard support. This change resolves case type names at mount, attaches ARIA semantics to tabs and items, exposes keyboard activation, and stacks rows on narrow viewports.
+
+## Requirements
+
+### REQ-MYWORK-CT-01: Case Type Name on Case Items
+Case items in the "Mijn werk" view MUST display the case type name as a subtitle.
+
+#### Scenario MYWORK-CT-01-1: Case type resolved from cached collection
+- GIVEN a user opens "Mijn werk"
+- WHEN the view mounts
+- THEN `objectStore.fetchCollection('caseType')` MUST be invoked once to build a lookup map from case type id to title
+- AND each case item MUST display the resolved case type title (e.g., "Omgevingsvergunning") below its title
+
+#### Scenario MYWORK-CT-01-2: Unknown or missing case type
+- GIVEN a case item references a case type id not present in the lookup
+- THEN the subtitle MUST render an empty placeholder (no broken label, no console error)
+
+#### Scenario MYWORK-CT-01-3: Task items unaffected
+- GIVEN a mix of case and task items
+- THEN only case items MUST show the case-type subtitle
+- AND task items MUST continue to show their existing subtitle (e.g., linked case reference)
+
+### REQ-MYWORK-A11Y-01: ARIA Semantics
+The "Mijn werk" view MUST expose ARIA semantics that allow screen readers to announce structure and state.
+
+#### Scenario MYWORK-A11Y-01-1: Filter tabs use tab pattern
+- GIVEN the filter bar at the top of the view
+- THEN the container MUST have `role="tablist"`
+- AND each filter button MUST have `role="tab"` with `aria-selected` reflecting the active state
+
+#### Scenario MYWORK-A11Y-01-2: Section headers expose heading role
+- GIVEN grouped sections "Overdue", "Today", "This week", "Later"
+- THEN each section header MUST have `role="heading"` with an appropriate `aria-level`
+
+#### Scenario MYWORK-A11Y-01-3: Item aria-label
+- GIVEN a case item with title "Bouwvergunning Kerkstraat" that is overdue
+- THEN the item MUST have an `aria-label` announcing entity type, title, and urgency status (e.g., "Zaak: Bouwvergunning Kerkstraat, te laat")
+
+#### Scenario MYWORK-A11Y-01-4: Live region for overdue
+- GIVEN urgency text that changes (e.g., when the day rolls over)
+- THEN the overdue indicator MUST be in an `aria-live="polite"` region so updates are announced without stealing focus
+
+### REQ-MYWORK-KB-01: Keyboard Navigation
+The "Mijn werk" view MUST be fully operable from the keyboard.
+
+#### Scenario MYWORK-KB-01-1: Tab to items
+- GIVEN the view is rendered
+- THEN every item row MUST have `tabindex="0"`
+- AND pressing Tab MUST move focus through items in their visual order
+
+#### Scenario MYWORK-KB-01-2: Activate item with Enter/Space
+- GIVEN an item row has keyboard focus
+- WHEN the user presses Enter or Space
+- THEN the same navigation MUST occur as a mouse click on the item
+
+#### Scenario MYWORK-KB-01-3: Activate filter tab with Enter/Space
+- GIVEN a filter tab has keyboard focus
+- WHEN the user presses Enter or Space
+- THEN the corresponding filter MUST become active and `aria-selected` MUST update
+
+### REQ-MYWORK-RWD-01: Responsive Layout
+The "Mijn werk" view MUST remain readable on narrow viewports.
+
+#### Scenario MYWORK-RWD-01-1: Stack rows at 768px or below
+- GIVEN a viewport of 768 CSS pixels or narrower
+- THEN item rows MUST stack their content vertically (title on top, priority and deadline below)
+- AND padding MUST reduce to remain comfortable on mobile
+
+#### Scenario MYWORK-RWD-01-2: Filter tabs remain operable
+- GIVEN the mobile layout is active
+- THEN filter tabs MUST remain visible and tappable
+- AND each tap target MUST be at least 44x44 CSS pixels
+
+### REQ-MYWORK-FOCUS-01: Focus Management
+The "Mijn werk" view MUST manage focus predictably when items, filters, or sections change.
+
+#### Scenario MYWORK-FOCUS-01-1: Focus preserved across filter change
+- GIVEN a filter tab has keyboard focus
+- WHEN the user activates a different filter
+- THEN focus MUST remain on the newly active filter tab
+- AND the focus ring MUST be visible
+
+#### Scenario MYWORK-FOCUS-01-2: Focus visible on item
+- GIVEN an item row receives keyboard focus
+- THEN the row MUST render a clearly visible focus indicator that meets WCAG AA contrast requirements
+- AND the indicator MUST NOT rely on colour alone
+
+#### Scenario MYWORK-FOCUS-01-3: Skip duplicate focusables
+- GIVEN an item that contains nested interactive controls (e.g., a quick-action button)
+- THEN the outer row MUST be focusable as a single stop
+- AND tabbing into the row MUST NOT trap the user in repeated nested stops
+
+### REQ-MYWORK-INT-01: Backwards-Compatible Integration
+The polish layer MUST NOT regress existing "Mijn werk" behaviour.
+
+#### Scenario MYWORK-INT-01-1: Existing sections preserved
+- GIVEN the existing grouped sections, filters, and counts
+- WHEN this change is applied
+- THEN those affordances MUST continue to work unchanged
+- AND no new dependencies on additional stores or APIs MUST be introduced beyond the existing object store
+
+#### Scenario MYWORK-INT-01-2: Single fetch on mount
+- GIVEN the case-type lookup is built on mount
+- THEN the fetch MUST occur at most once per view mount
+- AND subsequent renders MUST reuse the cached lookup
+
+## Dependencies
+- `src/views/MyWork.vue`
+- Shared object store (`createObjectStore('caseType')`)
+- Existing canonical `my-work` capability spec (`openspec/specs/my-work/spec.md`) for the underlying workload, filter, sort, and grouping behaviour

--- a/openspec/changes/task-management/specs/task-management/spec.md
+++ b/openspec/changes/task-management/specs/task-management/spec.md
@@ -1,0 +1,135 @@
+---
+status: implemented
+---
+# task-management Specification
+
+## Purpose
+Define the MVP task surface in Procest: validated task creation against a parent case, lifecycle state transitions with explicit error feedback, a filterable and searchable task list, overdue highlighting, anatomy of task cards, and reliable completion-date handling. Tasks are first-class work items linked to cases and surfaced both in `TaskList.vue`/`TaskDetail.vue` and in the `my-work` view.
+
+## Context
+Procest tasks are OpenRegister objects with a parent case reference, an assignee, a status (`new`/`in-progress`/`blocked`/`done`/`cancelled`), an optional due date, and a priority. Earlier changes shipped the schema and the basic CRUD; this change closes MVP gaps in validation, lifecycle feedback, list ergonomics, and card anatomy.
+
+## Requirements
+
+### REQ-TASK-VAL-01: Case Reference Validation on Task Creation
+Task creation MUST validate that the parent case reference exists and is usable before persisting the task.
+
+#### Scenario TASK-VAL-01-1: Missing case reference
+- GIVEN a user opens `TaskCreateDialog.vue` and submits without selecting a case
+- WHEN `taskValidation.js` runs
+- THEN the form MUST highlight the case field with the error "Selecteer een zaak"
+- AND save MUST be blocked
+
+#### Scenario TASK-VAL-01-2: Unknown case reference
+- GIVEN a user submits a task referencing a case id that does not resolve via the object store
+- THEN validation MUST fail with "Zaak niet gevonden"
+- AND no task object MUST be persisted
+
+#### Scenario TASK-VAL-01-3: Required core fields
+- GIVEN a task with no title
+- THEN validation MUST fail with "Titel is verplicht" before any backend call is made
+
+### REQ-TASK-LC-01: Lifecycle Transition Error Feedback
+`TaskDetail.vue` MUST surface explicit error messages when a lifecycle status transition is rejected.
+
+#### Scenario TASK-LC-01-1: Invalid transition
+- GIVEN a task currently in status `done`
+- WHEN the user attempts to set the status back to `new`
+- THEN the UI MUST display a Dutch-language error explaining that the transition is not allowed
+- AND the task status MUST remain unchanged
+
+#### Scenario TASK-LC-01-2: Backend rejection surfaced
+- GIVEN the backend returns a 4xx error on a status update
+- THEN the error message from the response MUST be surfaced near the status control
+- AND the status select MUST revert to its previous value
+
+#### Scenario TASK-LC-01-3: Transition success clears prior errors
+- WHEN a transition succeeds after a prior failure
+- THEN any previously displayed transition error MUST be cleared
+
+### REQ-TASK-LIST-01: Task List Filters and Search
+`TaskList.vue` MUST expose filters for status, assignee, and priority, plus keyword search.
+
+#### Scenario TASK-LIST-01-1: Filter by status
+- GIVEN the task list contains tasks in multiple statuses
+- WHEN the user selects a status from the status filter
+- THEN the list MUST refresh with `_filters[status]` applied
+- AND only matching tasks MUST be visible
+
+#### Scenario TASK-LIST-01-2: Filter by assignee
+- WHEN the user selects an assignee from the assignee filter
+- THEN the list MUST refresh with `_filters[assignee]` applied
+
+#### Scenario TASK-LIST-01-3: Filter by priority
+- WHEN the user selects a priority value
+- THEN the list MUST refresh with `_filters[priority]` applied
+
+#### Scenario TASK-LIST-01-4: Keyword search
+- GIVEN a task with title "Documenten verzamelen voor advies"
+- WHEN the user types "advies" into the search field
+- THEN the list MUST refresh with `_search=advies` and the matching task MUST appear
+
+### REQ-TASK-LIST-02: Overdue Highlighting
+`TaskList.vue` MUST visually highlight overdue tasks.
+
+#### Scenario TASK-LIST-02-1: Overdue row styling
+- GIVEN a task with a `dueDate` in the past and a non-final status
+- THEN the row MUST render with an explicit overdue visual treatment (red accent or icon)
+- AND the due date MUST be labeled "Te laat" or equivalent Dutch term
+
+#### Scenario TASK-LIST-02-2: Completed tasks not flagged
+- GIVEN a task that is in status `done` or `cancelled` even with a past `dueDate`
+- THEN no overdue styling MUST be applied
+
+### REQ-TASK-CARD-01: Task Card Anatomy
+Task cards in both the list and the my-work view MUST display a consistent, recognizable anatomy.
+
+#### Scenario TASK-CARD-01-1: Required card content
+- GIVEN any task card
+- THEN the card MUST display: title, parent case reference (identifier + truncated case title), assignee, priority indicator, status pill, and due date
+
+#### Scenario TASK-CARD-01-2: Missing case reference
+- GIVEN a task whose parent case can not be resolved at render time
+- THEN the case reference area MUST show a neutral placeholder rather than an empty space, without breaking the layout
+
+#### Scenario TASK-CARD-01-3: Clickable card navigates to task detail
+- WHEN the user clicks anywhere on the card (outside interactive controls)
+- THEN the app MUST navigate to the task detail view
+
+### REQ-TASK-COMP-01: Completion Date on Completion
+Tasks transitioning to `done` MUST have their `completedDate` set automatically.
+
+#### Scenario TASK-COMP-01-1: Auto-set completedDate
+- GIVEN a task transitioning from any status to `done`
+- WHEN the update is persisted
+- THEN the task object MUST contain a `completedDate` set to the transition timestamp
+- AND the value MUST be set even if the client did not explicitly send it
+
+#### Scenario TASK-COMP-01-2: Re-opening clears completion
+- GIVEN a task previously in `done`
+- WHEN the user reopens it via an allowed transition (e.g., to `in-progress`)
+- THEN `completedDate` MUST be cleared on the persisted object
+
+#### Scenario TASK-COMP-01-3: Cancelled tasks
+- GIVEN a task transitioning to `cancelled`
+- THEN `completedDate` MUST NOT be set (only `done` transitions trigger it)
+
+### REQ-TASK-INT-01: Integration with Case Detail and My Work
+Task changes MUST stay coherent with the case detail and my-work surfaces.
+
+#### Scenario TASK-INT-01-1: Reflected on case detail
+- GIVEN a task linked to a case
+- WHEN the task is created, updated, or completed
+- THEN the case detail tasks panel MUST reflect the change on next render
+
+#### Scenario TASK-INT-01-2: Reflected in my-work
+- GIVEN a task assigned to the current user
+- WHEN the task transitions, becomes overdue, or completes
+- THEN the my-work view MUST reflect the change on next render and re-apply its grouping
+
+## Dependencies
+- OpenRegister `task` schema and shared `createObjectStore`
+- `src/views/tasks/TaskList.vue`, `src/views/tasks/TaskDetail.vue`, `src/views/tasks/TaskCreateDialog.vue`
+- `src/utils/taskValidation.js`
+- `case-management` capability (parent case references)
+- `my-work` capability (task surface for assigned tasks)


### PR DESCRIPTION
## Summary

Five OpenSpec changes in `openspec/changes/` had `proposal.md`, `design.md`, and `tasks.md` but were missing the `specs/<capability>/spec.md` artifact that documents the capability surface. This PR adds those specs only -- no code changes, no behaviour changes.

## Per-change REQ counts

| Change | REQ count | Coverage |
| --- | --- | --- |
| `case-dashboard-view` | 6 | Not-found state, per-panel skeleton loading, tablet layout, print view, panel composition, header-action visibility |
| `case-management` | 7 | List filters, keyword search, custom properties panel, required documents checklist, validation, CRUD foundation, detail-view integration |
| `case-types` | 6 | Result-type, role-type, property-definition, document-type tabs, V1 tab layout, publish validation |
| `my-work` | 6 | Case-type subtitle, ARIA semantics, keyboard nav, responsive layout, focus management, backwards-compatible integration |
| `task-management` | 7 | Case-reference validation, lifecycle transition errors, list filters/search, overdue highlighting, task card anatomy, completion date, case-detail/my-work integration |

Each REQ has at least one Given/When/Then scenario; existing `delta-spec.md` entries (REQ-CDV-* and REQ-MYWORK-001/A11Y/RWD) are folded into the new spec headers using the established REQ prefix conventions (`CDV`, `CM`, `CT`, `MYWORK`, `TASK`) seen in `openspec/specs/<cap>/spec.md`.

## Out of scope

- No code changes. No `composer check:strict` run (spec-only PR).
- Suspension, sub-cases, and confidentiality enforcement remain explicitly out of scope for `case-management` per the original proposal.
- Spec-validate (`openspec change validate`) was not run because the existing applied artifacts in this repo (e.g., `case-sharing-collaboration`) use the same narrative `## Requirements` / `### REQ-*` shape rather than `## ADDED Requirements` / `#### Scenario:` deltas; mirroring that convention to stay consistent.

## Test plan

- [ ] CI passes (markdown lint / link check, no PHP/JS changes expected)
- [ ] Reviewer skim of each spec confirms the REQ surface matches the per-change proposal/tasks