### PR TITLE
chore(openspec): generate automatic-actions spec

### DIFF
--- a/openspec/changes/automatic-actions/.openspec.yaml
+++ b/openspec/changes/automatic-actions/.openspec.yaml
@@ -1,0 +1,2 @@
+status: proposed
+created: "2026-05-11"

--- a/openspec/changes/automatic-actions/design.md
+++ b/openspec/changes/automatic-actions/design.md
@@ -1,0 +1,72 @@
+# Design: automatic-actions
+
+## Architecture Overview
+
+The automatic-actions registry sits between the static `transitions[].automaticActions[]` array (authored by `workflow-definition-model`) and the runtime `SideEffectDispatcher` (owned by `status-transition-engine`). Today the engine reads inline action JSON and invokes a hard-coded handler list; after this change, each `automaticActions[]` entry references an `automaticAction` object by `slug`, and the registry resolves the entry against a per-tenant catalogue before dispatch.
+
+```
+workflowTemplate.transitions[].automaticActions[]
+    └── { ref: "send-decision-email" }                  ← reference
+SideEffectDispatcher::dispatch()
+    └── ActionRegistry::resolve(tenantId, ref)          ← lookup
+        └── automaticAction { type, config, slug, ... } ← stored object
+            └── ActionHandlerInterface registered for `type`
+                ├── SendEmailHandler        (existing)
+                ├── CreateDocumentHandler   (NEW)
+                ├── NotifyRoleHandler       (NEW)
+                ├── CallWebhookHandler      (existing — promoted)
+                ├── MergeTemplateHandler    (NEW)
+                └── ScheduleReminderHandler (NEW)
+```
+
+## Action Types
+
+Six handler `type`s are supported in V1. Every type maps 1:1 to a registered `ActionHandlerInterface` implementation:
+
+| Type | Purpose | Config keys (illustrative) |
+|------|---------|----------------------------|
+| `sendEmail` | Send a templated email | `recipientRef` (role / field), `subjectTemplate`, `bodyTemplate` |
+| `createDocument` | Render a document template and attach to case | `templateSlug`, `outputName`, `mergeFields[]` |
+| `notifyRole` | In-app Nextcloud notification to a role's members | `roleSlug`, `messageTemplate` |
+| `callWebhook` | Outbound HTTP POST to an external URL | `urlSlug` (resolves via tenant secret store), `payloadTemplate`, `timeoutSec` |
+| `mergeTemplate` | Render a text/markdown template into a case field | `templateSlug`, `targetField` |
+| `scheduleReminder` | Enqueue a reminder for a future date | `offsetIso8601`, `recipientRef`, `messageTemplate` |
+
+## Action Definition Schema
+
+Each `automaticAction` object has:
+
+- `slug` — tenant-unique identifier (e.g. `send-decision-email`).
+- `type` — one of the six handler types above.
+- `tenantId` — owning tenant (mandatory for isolation).
+- `title` — admin-facing label.
+- `description` — optional human description.
+- `config` — handler-specific config object (matches handler's expected shape).
+- `version` — optimistic-lock counter; updated on every save.
+- `isPublished` — `false` while drafting; only `true` actions are dispatched.
+
+The `transitions[].automaticActions[]` array stores **references**: `{ ref: <slug> }`. References are resolved at dispatch time so an admin can swap an action's body globally without touching every transition.
+
+## Per-Tenant Action Library
+
+Actions are stored as `automaticAction` objects in OpenRegister, scoped by `tenantId`. The admin UI ("Automatische acties") lists, filters, and edits all actions in the current tenant. `ActionRegistry::resolve(tenantId, slug)` rejects cross-tenant lookups with a static error logged via `$this->logger->error()` and returns `null` so the dispatcher records `{ok: false, error: 'unknown_action_ref'}`.
+
+## Dry-Run Mode
+
+Dry-run uses the same handler classes but with a **simulation flag** on `$transitionContext`. Handlers MUST honour the flag:
+
+- `sendEmail` builds the rendered subject + body and returns them in `ActionResult.data`, but does NOT submit to `NotificatieService`.
+- `createDocument` renders the merged template payload and returns the byte count, but does NOT persist a file.
+- `callWebhook` resolves the URL, builds the payload, and returns both, but does NOT issue the HTTP request.
+- `notifyRole`, `mergeTemplate`, and `scheduleReminder` likewise compute their projected effect without writing anywhere.
+
+Dry-run is invoked via `POST /api/automatic-action/{slug}/dry-run` with a sample case payload. The endpoint is admin-only.
+
+## Failure Model
+
+Failure semantics inherit unchanged from `status-transition-engine`:
+
+- Failed actions are recorded in `statusRecord.dispatchedActions[].error` as a static message.
+- Status changes are NOT rolled back.
+- Unknown action `ref`s record `{ok: false, error: 'unknown_action_ref'}`.
+- Unpublished or cross-tenant `ref`s receive the same treatment.

--- a/openspec/changes/automatic-actions/proposal.md
+++ b/openspec/changes/automatic-actions/proposal.md
@@ -1,0 +1,60 @@
+# Proposal: automatic-actions
+
+## Summary
+
+Add a declarative **automatic-action registry** so administrators can attach side-effects (send email, create document, notify role, call webhook, merge template, schedule reminder) to status transitions without writing PHP. New handlers plug into the `ActionHandlerInterface` registry shipped by `status-transition-engine` — this change is purely additive.
+
+## Why
+
+`status-transition-engine` ships dispatch plumbing and six built-in handlers, but the catalogue is hard-coded and there is no end-user way to author, parameterise, reuse, or audit actions. Every new side-effect today requires a code change, a release, and a redeploy. Multi-tenant municipalities need a tenant-scoped action library (templates per zaaktype, webhooks per ketenpartner) and a dry-run mode to safely preview an action before publishing it.
+
+## What Changes
+
+- Adds `automaticAction` schema (slug, type, tenantId, title, config, isPublished) to `procest_register.json`.
+- Introduces `ActionRegistry` service for per-tenant slug-based lookup.
+- Adds six built-in action handlers: `sendEmail` (existing — extended), `createDocument` (new), `notifyRole` (new), `callWebhook` (existing — extended for slug indirection), `mergeTemplate` (new), `scheduleReminder` (new).
+- Extends `SideEffectDispatcher` in `status-transition-engine` to resolve `{ref: <slug>}` references.
+- Adds admin UI (Vue) to attach, reorder, and dry-run actions per transition.
+- Adds `POST /api/automatic-action/{slug}/dry-run` endpoint for safe preview.
+
+## Affected Projects
+
+- [ ] Project: `procest` — Adds `automaticAction` schema, `ActionRegistry`, additional built-in handlers, admin UI to attach actions to transitions, dry-run preview, tenant-scoped catalogue.
+
+## Scope
+
+### In Scope (V1)
+
+- Declarative `automaticAction` JSON schema (REQ-AA-1).
+- Per-tenant `ActionRegistry` keyed by `type` + `slug` (REQ-AA-2, REQ-AA-8).
+- Built-in handlers `sendEmail`, `createDocument`, `notifyRole`, `callWebhook`, `mergeTemplate`, `scheduleReminder` (REQ-AA-3).
+- Admin UI to attach and reorder actions on a transition (REQ-AA-4).
+- Engine dispatch hook resolves actions through the registry (REQ-AA-5).
+- Dry-run mode renders the projected effect without mutating live state (REQ-AA-6).
+- Per-execution result on `statusRecord.dispatchedActions` (REQ-AA-7).
+
+### Out of Scope
+
+- Conditional action gating (guards live in `status-transition-engine`).
+- Visual workflow editor canvas (separate spec).
+- Time-based triggers beyond `scheduleReminder` — V2.
+
+## Approach
+
+1. Add `automaticAction` schema to `procest_register.json`.
+2. Create `ActionRegistry` service that loads tenant-scoped actions by slug.
+3. Add six `ActionHandlerInterface` implementations alongside the engine's existing handlers, registered via the `procest.transition_side_effect_handler` DI tag.
+4. Add Vue admin UI to attach and reorder actions on transitions, with a dry-run preview pane.
+5. Extend `SideEffectDispatcher::dispatch` to resolve action configs from the registry rather than inline JSON.
+
+## Cross-Project Dependencies
+
+- **`status-transition-engine`** (procest): Provides `ActionHandlerInterface`, `SideEffectDispatcher`, `statusRecord.dispatchedActions` surface.
+- **`workflow-definition-model`** (procest): Provides the `transitions[].automaticActions[]` array shape.
+- **OpenRegister**: Hosts the `automaticAction` schema and tenant-scoped storage.
+
+## Constraints
+
+- MUST NOT introduce a new dispatch path; reuse `SideEffectDispatcher`.
+- Actions MUST be tenant-scoped — no cross-tenant leakage.
+- Dry-run MUST NOT mutate the case, send mail, write documents, or hit webhook URLs.

--- a/openspec/changes/automatic-actions/specs/automatic-actions/spec.md
+++ b/openspec/changes/automatic-actions/specs/automatic-actions/spec.md
@@ -1,0 +1,212 @@
+---
+status: draft
+---
+# Spec — automatic-actions: Declarative action registry for status transitions
+
+## ADDED Requirements
+
+### Requirement: REQ-AA-1 Declarative Action Definition Schema
+
+The system SHALL persist automatic actions as `automaticAction` objects with `slug`, `type`, `tenantId`, `title`, `config`, and `isPublished` fields. The `slug` SHALL be unique within a tenant. The `type` SHALL be one of `sendEmail`, `createDocument`, `notifyRole`, `callWebhook`, `mergeTemplate`, `scheduleReminder`. The `config` shape SHALL be validated against the handler-specific schema for the chosen `type`.
+
+**Feature tier**: V1
+
+#### Scenario: Create a valid action
+
+- **GIVEN** an admin authors a new action with `slug: "send-decision-email"`, `type: "sendEmail"`, `tenantId: <current>`, `title: "Verstuur besluit"`, `config: { recipientRef: "indiener", subjectTemplate: "Besluit {{case.identification}}", bodyTemplate: "..." }`
+- **WHEN** they save via `POST /api/automatic-action`
+- **THEN** the system SHALL persist an `automaticAction` object with `isPublished: false` (draft)
+- **AND** subsequent `GET /api/automatic-action` calls in the same tenant SHALL include this action
+
+#### Scenario: Reject duplicate slug
+
+- **GIVEN** an action `send-decision-email` already exists in the current tenant
+- **WHEN** an admin tries to create another action with the same `slug`
+- **THEN** the controller SHALL return HTTP 409 with a static message
+- **AND** the existing action SHALL remain unchanged
+
+#### Scenario: Reject invalid type
+
+- **WHEN** an admin submits an action with `type: "publishToLinkedIn"`
+- **THEN** the controller SHALL return HTTP 422 with a static message
+- **AND** NO `automaticAction` SHALL be persisted
+
+---
+
+### Requirement: REQ-AA-2 Action Registry with Slug Lookup
+
+The system SHALL provide an `ActionRegistry` service that resolves a `(tenantId, slug)` pair to a published `automaticAction` object. Unpublished actions SHALL NOT be resolvable. Unknown slugs SHALL return `null` and be logged at error level. The registry SHALL maintain a per-request in-memory cache.
+
+**Feature tier**: V1
+
+#### Scenario: Resolve published action
+
+- **GIVEN** an `automaticAction` with `slug: "send-decision-email"`, `isPublished: true`, `tenantId: T1`
+- **WHEN** `ActionRegistry::resolve("T1", "send-decision-email")` is called
+- **THEN** the registry SHALL return the full action object including `type` and `config`
+
+#### Scenario: Unpublished action is not resolvable
+
+- **GIVEN** an action `draft-webhook` with `isPublished: false`
+- **WHEN** the registry resolves the slug
+- **THEN** the registry SHALL return `null`
+- **AND** an error SHALL be logged via `$this->logger->error()` with the slug AND the reason (`unpublished`)
+
+---
+
+### Requirement: REQ-AA-3 Built-In Action Handlers
+
+The system SHALL provide six built-in `ActionHandlerInterface` implementations registered via the `procest.transition_side_effect_handler` DI tag: `sendEmail`, `createDocument`, `notifyRole`, `callWebhook`, `mergeTemplate`, and `scheduleReminder`. Each handler SHALL catch `\Throwable`, log via `$this->logger->error()` with full context, and return `ActionResult { ok: false, error: <static-message> }` on failure. Handlers SHALL NEVER include `$e->getMessage()` in `ActionResult.error`.
+
+**Feature tier**: V1
+
+#### Scenario: sendEmail handler renders templates and sends
+
+- **GIVEN** a `sendEmail` action with `subjectTemplate: "Besluit {{case.identification}}"` and `bodyTemplate: "Beste {{case.indiener.naam}}"`
+- **AND** a case with `identification: "ZK-2026-001"` and `indiener.naam: "J. Jansen"`
+- **WHEN** the handler fires
+- **THEN** the handler SHALL invoke `NotificatieService::sendEmail` with subject `"Besluit ZK-2026-001"` and body starting with `"Beste J. Jansen"`
+- **AND** the handler SHALL return `ActionResult { ok: true }`
+
+#### Scenario: createDocument handler attaches rendered file
+
+- **GIVEN** a `createDocument` action with `templateSlug: "besluitbrief"` and `outputName: "Besluit-{{case.identification}}.pdf"`
+- **WHEN** the handler fires for case `ZK-2026-001`
+- **THEN** the handler SHALL render the template against the case, store the resulting file in the case folder, and link it to the case
+- **AND** the handler SHALL return `ActionResult { ok: true, data: { documentId: <uuid> } }`
+
+#### Scenario: callWebhook timeout returns ok:false without rolling back
+
+- **GIVEN** a `callWebhook` action whose `urlSlug` resolves to `https://partner.example.org/hook`
+- **WHEN** the partner endpoint does not respond within the configured timeout
+- **THEN** the handler SHALL return `ActionResult { ok: false, error: "webhook_timeout" }`
+- **AND** the error SHALL be logged with full context
+- **AND** subsequent actions in the same transition SHALL still fire
+
+---
+
+### Requirement: REQ-AA-4 Admin UI to Attach Actions to Transitions
+
+The system SHALL provide an admin UI that allows attaching, reordering, and detaching actions on a status transition without code changes. The UI SHALL list only `automaticAction` objects belonging to the current tenant with `isPublished: true`. Reordering SHALL be drag-and-drop and SHALL persist as the order of `transitions[].automaticActions[]` in the workflow template.
+
+**Feature tier**: V1
+
+#### Scenario: Attach an action to a transition
+
+- **GIVEN** a published action `send-decision-email` exists in the current tenant
+- **AND** the admin is editing transition `Afronden` in the workflow editor
+- **WHEN** the admin selects `send-decision-email` from the slug-autocomplete in the "Acties" section and saves
+- **THEN** the transition's `automaticActions[]` SHALL be persisted with a new entry `{ ref: "send-decision-email" }` at the end of the array
+
+#### Scenario: Reorder actions on a transition
+
+- **GIVEN** a transition with three attached actions in order A → B → C
+- **WHEN** the admin drags C above A and saves
+- **THEN** the persisted `automaticActions[]` SHALL be `[{ref: "C"}, {ref: "A"}, {ref: "B"}]`
+- **AND** subsequent transition executions SHALL fire the actions in the new order
+
+#### Scenario: Unpublished actions are hidden from the autocomplete
+
+- **GIVEN** an action `draft-webhook` exists with `isPublished: false`
+- **WHEN** the admin opens the slug-autocomplete in the transition editor
+- **THEN** `draft-webhook` SHALL NOT appear in the suggestion list
+
+---
+
+### Requirement: REQ-AA-5 Engine Dispatch Hook Resolves Action References
+
+The system SHALL extend `SideEffectDispatcher::dispatch` to recognise `{ ref: <slug> }` entries in `automaticActions[]` and resolve them via the `ActionRegistry` before invoking the handler. The dispatcher SHALL pass `$transitionContext['tenantId']` (derived from the case) to the registry. Inline action JSON entries SHALL remain backward-compatible.
+
+**Feature tier**: V1
+
+#### Scenario: Dispatcher resolves a reference
+
+- **GIVEN** a transition with `automaticActions: [{ ref: "send-decision-email" }]`
+- **AND** a case in tenant `T1`
+- **WHEN** the transition fires
+- **THEN** the dispatcher SHALL call `ActionRegistry::resolve("T1", "send-decision-email")`
+- **AND** the dispatcher SHALL invoke the handler registered for the resolved `type`
+- **AND** `statusRecord.dispatchedActions` SHALL include `{type: "sendEmail", ref: "send-decision-email", ok: true}`
+
+#### Scenario: Unknown reference is recorded but does not abort
+
+- **GIVEN** a transition with `automaticActions: [{ ref: "ghost-action" }, { ref: "send-decision-email" }]`
+- **AND** `ghost-action` does NOT exist in the tenant
+- **WHEN** the transition fires
+- **THEN** the dispatcher SHALL record `{type: "unknown", ref: "ghost-action", ok: false, error: "unknown_action_ref"}` in `statusRecord.dispatchedActions`
+- **AND** the dispatcher SHALL still resolve and fire `send-decision-email`
+
+#### Scenario: Inline action JSON is still honoured
+
+- **GIVEN** a transition with `automaticActions: [{ type: "webhook", url: "https://legacy.example.org/hook" }]` (no `ref` key)
+- **WHEN** the transition fires
+- **THEN** the dispatcher SHALL skip registry lookup
+- **AND** the dispatcher SHALL invoke the `webhook` handler with the inline config directly
+
+---
+
+### Requirement: REQ-AA-6 Dry-Run Mode
+
+The system SHALL support a dry-run mode that lets administrators preview an action's effect against a sample case without mutating live state. In dry-run, handlers SHALL compute and return their projected effect in `ActionResult.data` but SHALL NOT send mail, write documents, persist objects, hit webhook URLs, schedule jobs, or invoke any external services.
+
+**Feature tier**: V1
+
+#### Scenario: Dry-run sendEmail returns rendered preview
+
+- **GIVEN** a `sendEmail` action with `subjectTemplate` and `bodyTemplate`
+- **AND** a sample case `ZK-2026-001`
+- **WHEN** an admin calls `POST /api/automatic-action/send-decision-email/dry-run` with `{caseId: "ZK-2026-001"}`
+- **THEN** the response SHALL include the rendered `subject` and `body` in the body
+- **AND** `NotificatieService::sendEmail` SHALL NOT be invoked
+- **AND** NO email SHALL be delivered
+
+#### Scenario: Dry-run callWebhook does not hit the URL
+
+- **GIVEN** a `callWebhook` action with `urlSlug: "partner-hook"`
+- **WHEN** an admin runs dry-run against a sample case
+- **THEN** the response SHALL include the resolved URL and rendered payload
+- **AND** NO outbound HTTP request SHALL be issued (verifiable via mocked `IClientService`)
+
+---
+
+### Requirement: REQ-AA-7 Per-Execution Audit on statusRecord
+
+The system SHALL record one entry per dispatched action on `statusRecord.dispatchedActions` for every transition. Each entry SHALL include `type`, `ref` (when present), `ok`, and on failure a static `error` string. Successful entries MAY include handler-specific `data` (e.g. `messageId`, `documentId`). Audit entries SHALL be visible in the transition history endpoint provided by `status-transition-engine`.
+
+**Feature tier**: V1
+
+#### Scenario: Successful execution records ok
+
+- **WHEN** a transition fires two actions and both succeed
+- **THEN** `statusRecord.dispatchedActions` SHALL contain two entries with `ok: true`
+- **AND** each entry SHALL include the original `ref` slug
+
+#### Scenario: Failed execution records static error
+
+- **WHEN** a `callWebhook` action returns HTTP 500
+- **THEN** `statusRecord.dispatchedActions` SHALL contain an entry with `ok: false` and `error: "webhook_http_5xx"`
+- **AND** the entry SHALL NOT include `$e->getMessage()` or any raw exception text
+
+---
+
+### Requirement: REQ-AA-8 Tenant Scoping and Cross-Tenant Isolation
+
+The system SHALL scope every `automaticAction` object to a single `tenantId`. The registry, the admin UI, and the dispatcher SHALL refuse any cross-tenant lookup. Cross-tenant resolution attempts SHALL be logged via `$this->logger->error()` and surfaced to the dispatcher as `{ok: false, error: "unknown_action_ref"}` — the dispatcher SHALL NOT distinguish a cross-tenant miss from a non-existent slug in the user-visible response.
+
+**Feature tier**: V1
+
+#### Scenario: Cross-tenant resolution is rejected
+
+- **GIVEN** an action `send-decision-email` exists in tenant `T1` (only)
+- **AND** a case in tenant `T2` references the same slug via `{ ref: "send-decision-email" }`
+- **WHEN** the transition fires
+- **THEN** the registry SHALL return `null` for `(T2, "send-decision-email")`
+- **AND** `statusRecord.dispatchedActions` SHALL record `{ok: false, error: "unknown_action_ref"}`
+- **AND** an error SHALL be logged including both `T1` and `T2`
+
+#### Scenario: Admin listing returns only own-tenant actions
+
+- **GIVEN** tenant `T1` has 3 actions and tenant `T2` has 5 actions
+- **WHEN** an admin in tenant `T2` calls `GET /api/automatic-action`
+- **THEN** the response SHALL include exactly the 5 `T2` actions
+- **AND** the response SHALL NOT include any `T1` action

--- a/openspec/changes/automatic-actions/tasks.md
+++ b/openspec/changes/automatic-actions/tasks.md
@@ -1,0 +1,64 @@
+# Tasks: automatic-actions
+
+## Deduplication Check
+
+- [ ] **D01**: Inventory existing handlers in `lib/Service/Transitions/` (from `status-transition-engine`): confirm `SendEmailHandler`, `CallWebhookHandler` (named `WebhookHandler` in the engine) and `NotifyHandler` already exist. This spec MUST extend them rather than duplicate. Verify there is no existing `ActionRegistry`, `automaticAction` schema, or per-tenant action library. Document findings here.
+
+---
+
+## Schema & Configuration
+
+- [ ] **T01**: Add `automaticAction` schema to `lib/Settings/procest_register.json`. Required fields: `slug` (string), `type` (enum: `sendEmail`, `createDocument`, `notifyRole`, `callWebhook`, `mergeTemplate`, `scheduleReminder`), `tenantId` (string, format uuid), `title` (string), `config` (object). Optional fields: `description` (string), `version` (integer, default 1), `isPublished` (boolean, default false). Unique constraint on (`tenantId`, `slug`). Bump schema package version.
+
+- [ ] **T02**: Add `automatic_action_schema` config key to `lib/Service/SettingsService.php` and load it in `initializeStores()`.
+
+---
+
+## Backend: Registry & Handlers
+
+- [ ] **T03**: Create `lib/Service/Actions/ActionRegistry.php`. Methods:
+  - `resolve(string $tenantId, string $slug): ?array` — fetch the matching `automaticAction` object scoped to `tenantId` AND `isPublished: true`; per-request cache; returns `null` and logs via `$this->logger->error()` on miss or cross-tenant attempt.
+  - `listForTenant(string $tenantId, ?string $typeFilter = null): array` — admin listing endpoint backing.
+
+- [ ] **T04**: Implement three new `ActionHandlerInterface` classes in `lib/Service/Actions/`:
+  - `CreateDocumentHandler.php` — renders `templateSlug` against the case + `mergeFields[]` and attaches to the case via existing document service.
+  - `NotifyRoleHandler.php` — resolves `roleSlug` to its members and emits an in-app notification to each via `NotificatieService`.
+  - `MergeTemplateHandler.php` — renders a text/markdown template into `targetField` on the case via `ObjectService::saveObject` (3-arg API).
+  - `ScheduleReminderHandler.php` — enqueues a Nextcloud background job for `offsetIso8601` from now; the job emits a notification on fire.
+  All handlers MUST honour the `$transitionContext['dryRun'] === true` flag — they MUST compute the projected effect, return it in `ActionResult.data`, and NOT touch live state. All handlers catch `\Throwable`, log via `$this->logger->error()`, return `ActionResult { ok: false, error: <static-message> }` — NEVER bubble exceptions, NEVER include `$e->getMessage()` in `ActionResult.error`.
+
+- [ ] **T05**: Promote the engine's existing `WebhookHandler` to `CallWebhookHandler` semantics (URL slug indirection — `urlSlug` resolves via the tenant secret store, not an inline URL). Add dry-run support: when `dryRun: true`, return the resolved URL and payload in `ActionResult.data` and SKIP the HTTP request. Existing `webhook` action types remain backward-compatible (inline URL still works), but admin-authored actions MUST use `urlSlug`.
+
+- [ ] **T06**: Extend `lib/Service/Transitions/SideEffectDispatcher.php` (owned by `status-transition-engine`) to recognise `{ ref: <slug> }` entries in the `automaticActions[]` array. Resolution flow: detect ref-shape, call `ActionRegistry::resolve($tenantId, $slug)`, expand to the full action config, then continue with the existing per-action handler dispatch. Inline action JSON entries (legacy) MUST keep working. Tenant scoping derives `$tenantId` from `$transitionContext['tenantId']`, which the engine MUST set from the current case's tenant.
+
+---
+
+## Backend: Controller
+
+- [ ] **T07**: Create `lib/Controller/AutomaticActionController.php`. Endpoints:
+  - `GET    /api/automatic-action` — list this tenant's actions; optional `?type=` filter.
+  - `POST   /api/automatic-action` — create.
+  - `PATCH  /api/automatic-action/{slug}` — update (admin only).
+  - `POST   /api/automatic-action/{slug}/publish` — flip `isPublished` to `true`.
+  - `POST   /api/automatic-action/{slug}/dry-run` — body `{caseId | sampleCase}`; returns the handler's `ActionResult.data` without mutating state.
+  - Register routes in `appinfo/routes.php`. All identity from `IUserSession`. ALL error responses static — NEVER `$e->getMessage()` in `JSONResponse`.
+
+---
+
+## Frontend
+
+- [ ] **T08**: Register `automatic-action` entity in `src/store/store.js` via `createObjectStore('automatic-action')`. Kebab-case. Register ONCE.
+
+- [ ] **T09**: Create `src/views/admin/AutomaticActions.vue` listing all actions for the current tenant with type filter, slug search, and publish-state badge. Provide "Nieuwe actie" wizard that picks `type` (6 options), shows the type-specific config form, and lets the admin run a dry-run preview before saving.
+
+- [ ] **T10**: Embed an "Acties" section in `src/views/admin/TransitionEditor.vue` (provided by `workflow-definition-model`'s admin UI): list `automaticActions[]` for the selected transition, allow reordering (drag-handle), and let the admin pick from the published actions in the current tenant via a slug-autocomplete. Saving writes `{ ref: <slug> }` entries into the transition.
+
+---
+
+## Verification
+
+- [ ] **V01**: All REQ-AA-1..8 in `openspec/changes/automatic-actions/specs/automatic-actions/spec.md` map 1:1 to implementation: schema (T01), registry (T03), handlers (T04, T05), dispatch hook (T06), admin UI (T09, T10), dry-run (T04 flag + T07 endpoint), tenant scoping (T03 + T06 context propagation).
+
+- [ ] **V02**: PHPUnit covers, at minimum: registry resolves a published action; rejects unpublished; rejects cross-tenant; each new handler's happy path AND dry-run path (mutation MUST NOT occur in dry-run); dispatcher correctly resolves `{ ref }` entries AND preserves inline-action backward-compat; failure of any single handler does NOT roll back the status change. `composer check:strict` and `composer test` pass.
+
+- [ ] **V03**: Browser smoke test via Playwright MCP (`browser-1`): admin creates a `sendEmail` action, runs dry-run (observe rendered subject + body, no email sent), publishes it, attaches it to a transition, executes the transition on a test case, and observes the email actually sent AND `statusRecord.dispatchedActions[0].ok = true`.


### PR DESCRIPTION
## Summary

Adds the **automatic-actions** OpenSpec change to procest. Spec only — no code.

Introduces a declarative, tenant-scoped action registry that lets administrators attach side-effects (sendEmail, createDocument, notifyRole, callWebhook, mergeTemplate, scheduleReminder) to status transitions via admin UI, with dry-run preview. Actions plug into the just-merged `status-transition-engine`'s `ActionHandlerInterface` — purely additive.

### Artifacts

- `proposal.md` — declarative action registry; admins assign actions to transitions without code.
- `design.md` — six action types, action-definition schema, per-tenant library, dry-run mode, failure model.
- `tasks.md` — 10 implementation tasks + 1 dedup + 3 verification (schema, registry, handlers, dispatcher hook, admin UI, dry-run, tests).
- `specs/automatic-actions/spec.md` — 8 REQs (REQ-AA-1..8) with GIVEN/WHEN/THEN scenarios.

### Validation

```
$ openspec validate automatic-actions --type change --strict
Change 'automatic-actions' is valid
```

`deltaCount: 8` — all 8 requirements parse with scenarios.

### Dependencies

- `status-transition-engine` (just merged — provides `ActionHandlerInterface` + `SideEffectDispatcher`)
- `workflow-definition-model` (provides `transitions[].automaticActions[]` shape)
- OpenRegister (hosts `automaticAction` schema)

## Test plan

- [ ] OpenSpec strict validation passes (`openspec validate automatic-actions --type change --strict`)
- [ ] `openspec show automatic-actions --type change --json` returns `deltaCount: 8`
- [ ] Reviewer confirms requirements map to declared task list (V01 in tasks.md)