### PR TITLE
chore(openspec): complete artifacts for vth-module + woo-case-type + open-raadsinformatie

### DIFF
--- a/openspec/changes/open-raadsinformatie/design.md
+++ b/openspec/changes/open-raadsinformatie/design.md
@@ -1,0 +1,44 @@
+# Design: open-raadsinformatie
+
+## Architecture
+
+The ORI implementation has two layers:
+
+1. **Storage layer (OpenRegister)** — a public register `ori` with seven entity schemas (vergadering, agendapunt, raadsdocument, stemming, raadslid, fractie, commissie). The register is shipped as `lib/Settings/ori_register.json` in the same OpenAPI 3.0.0 + `x-openregister` extension format already used by `brp_register.json`, `kvk_register.json`, `bag_register.json`, `dso_register.json`. Provisioning is idempotent via `occ openregister:load-register`.
+
+2. **Case-wrapper layer (Procest)** — vergaderingen are surfaced as cases with status (gepland / lopend / afgerond / geannuleerd), deadline alerts (agenda publication T-7), and an audit trail. Agendapunt and raadsdocument objects link to the vergadering case as supporting records.
+
+### Data Ingestion
+
+Data flows in via OpenConnector connectors for iBabs and NotuBiz (handled in the separate `ibabs-notubiz-connector` spec). Source-tracking fields on every ORI schema (`source`, `sourceId`, `sourceUrl`, `lastSyncedAt`) make imported records traceable and incrementally updatable. Demo/mock objects are seeded inside `ori_register.json` so a fresh `clean-env` install boots with at least one full vergadering, six agendapunten, three documenten, a stemming, six raadsleden, and two fracties.
+
+### Public Access
+
+All ORI schemas carry `authorization.read: ["public"]` and `searchable: true`. The OAS exposure is via the existing `OasService` generation mechanism; no bespoke public controller is needed. Per Woo compliance, no authentication is required for read endpoints; write endpoints stay restricted to authenticated council-clerk roles.
+
+### Multi-Gemeente
+
+Each ORI object carries an `organisatie` reference. Filtering by organisatie is the multi-tenant guarantee; the seed register ships with a single organisatie object that operators rename on first boot.
+
+### RSS/Atom
+
+A lightweight `RaadsinformatieFeedController` exposes `GET /apps/procest/feed/ori/{type}.rss` where `{type}` ∈ `{vergaderingen, agendapunten, documenten}`. The controller renders the latest 50 published records per type with proper Atom metadata and links to the public OAS endpoint.
+
+### Data Quality
+
+Validation runs on every write via JSON Schema rules in the register file (enums, formats, maxLength, required). A nightly job flags records missing recommended fields (locatie, voorzitter, fractie) and writes to a `data_quality_issues` log consumable by the admin dashboard.
+
+## Dependencies
+
+- OpenRegister (storage, OAS, public auth model, `@self` slug-based upsert).
+- OpenConnector (iBabs/NotuBiz ingestion — separate spec).
+- Procest case engine (vergadering lifecycle wrapper).
+- Existing `OasService` for public API exposure.
+- `RaadsinformatieFeedController` (new, small).
+
+## Out of Scope
+
+- iBabs/NotuBiz connectors themselves (separate `ibabs-notubiz-connector` spec).
+- SPARQL endpoint / 5-star linked data (future change).
+- Live-streaming integration with vergaderzaal AV-systems.
+- Automatic Woo-publicatie naar PLOOI.

--- a/openspec/changes/open-raadsinformatie/proposal.md
+++ b/openspec/changes/open-raadsinformatie/proposal.md
@@ -1,15 +1,21 @@
+# Proposal: open-raadsinformatie
+
 ## Why
 
-Open Raadsinformatie (ORI) is not yet implemented in Procest. This change proposes adding this capability based on the detailed spec in `specs/open-raadsinformatie/spec.md`.
-
-
+Open Raadsinformatie (ORI) is the Dutch open standard for publishing council information — agendas, meetings, documents, votes, council members, fractions — as linked open data. Roughly 60% of municipalities run iBabs or NotuBiz, but those are closed SaaS silos. Existing ORI options (Open State Foundation aggregator, OpenRaadsinformatie.nl, Argu) are centralised, forcing municipalities to give up data sovereignty. Procest is the natural place to host ORI inside Nextcloud, treating council proceedings as cases with status, deadlines, and an audit trail, while exposing the underlying register publicly.
 
 ## What Changes
 
-See `specs/open-raadsinformatie/spec.md` for full requirements and scenarios.
+1. New OpenRegister-backed ORI register seeded from `lib/Settings/ori_register.json`, containing schemas for vergadering, agendapunt, raadsdocument, stemming, raadslid, fractie (and optional commissie/motie/amendement).
+2. Public, unauthenticated read access (`authorization.read: ["public"]`) on all ORI schemas, with `searchable: true` for full-text search.
+3. Demo/mock objects per schema for development, testing, and `clean-env` resets.
+4. Procest case-lifecycle wrapper around vergaderingen: status tracking (gepland/lopend/afgerond/geannuleerd), deadline alerts, agenda-publication workflow.
+5. RSS/Atom feed generation, multi-gemeente support, and source-tracking fields for connector-imported data (iBabs/NotuBiz via the `ibabs-notubiz-connector` spec).
+6. Data-quality validation and a CLI repair step for idempotent provisioning.
 
 ## Impact
 
-- **Code**: New frontend views and/or backend services
-- **Dependencies**: OpenRegister (data storage), Nextcloud platform APIs
-- **Testing**: Unit tests for new services, integration tests for API endpoints
+- **Affected projects**: procest (case wrapper, register seed), openregister (data layer), openconnector (data ingestion — separate spec).
+- **Code surface**: register seed JSON, repair step, OAS exposure, public-access guard, RSS/Atom controller, multi-gemeente filter.
+- **Dependencies**: OpenRegister (storage + OAS), OpenConnector (iBabs/NotuBiz import), Procest case engine.
+- **Standards**: Open State Foundation ORI API, VNG Realisatie raadsinformatie, Popolo, Wet open overheid, JSON Schema validation.

--- a/openspec/changes/open-raadsinformatie/tasks.md
+++ b/openspec/changes/open-raadsinformatie/tasks.md
@@ -1,0 +1,81 @@
+# Tasks: open-raadsinformatie
+
+## 1. Register Provisioning
+
+### Task 1: Ship ori_register.json with all entity schemas
+- **spec_ref**: `openspec/specs/open-raadsinformatie/spec.md#requirement-ori-register-must-be-provisionable-with-all-entity-schemas`
+- **files**: `lib/Settings/ori_register.json`
+- **acceptance_criteria**:
+  - GIVEN a fresh install WHEN `occ openregister:load-register lib/Settings/ori_register.json` runs THEN a register with slug `ori` exists with all 7 schemas
+  - All schemas have `authorization.read: ["public"]` and `searchable: true`
+  - File passes `jq . ori_register.json` cleanly
+- [ ] Author register file with schemas: vergadering, agendapunt, raadsdocument, stemming, raadslid, fractie, commissie
+- [ ] Verify with `jq` and an importer dry run
+
+### Task 2: Add repair step for idempotent provisioning
+- **spec_ref**: `openspec/specs/open-raadsinformatie/spec.md#requirement-ori-register-must-be-provisionable-with-all-entity-schemas`
+- **files**: `lib/Migration/RegisterOriRegister.php`, `appinfo/info.xml`
+- **acceptance_criteria**:
+  - GIVEN a fresh install WHEN repair step runs THEN register is provisioned
+  - GIVEN an existing `ori` register WHEN repair step runs again THEN existing register is updated, not duplicated (via `@self` slug upsert)
+- [ ] Implement RegisterOriRegister migration
+- [ ] Register repair step in info.xml
+
+## 2. Public Access and Search
+
+### Task 3: Expose ORI register OAS publicly
+- **spec_ref**: `openspec/specs/open-raadsinformatie/spec.md#requirement-public-access-and-transparency-woo-compliance`
+- **files**: existing OasService (no new code; verify config)
+- **acceptance_criteria**:
+  - GIVEN ORI register provisioned WHEN unauthenticated client calls `GET /api/registers/ori/oas` THEN endpoint definitions for all ORI schemas returned
+  - All read endpoints are accessible without auth headers
+- [ ] Verify OasService picks up the register
+- [ ] Add integration test confirming unauth read
+
+### Task 4: Wire ORI schemas into search
+- **spec_ref**: `openspec/specs/open-raadsinformatie/spec.md#requirement-search-and-filtering-across-ori-entities`
+- **files**: rely on existing search infra; ensure `searchable: true` everywhere
+- **acceptance_criteria**:
+  - GIVEN seeded mock vergadering "Raadsvergadering 12 juni 2026" WHEN searching "Raad" via `/zoeken` THEN result appears
+  - Filtering by `type=raadsvergadering` returns only matching records
+- [ ] Confirm searchable=true on each schema
+- [ ] Add a Newman smoke test asserting search hits
+
+## 3. Vergadering Case Wrapper
+
+### Task 5: Create VergaderingCaseService
+- **spec_ref**: `openspec/specs/open-raadsinformatie/spec.md#requirement-vergadering-meeting-schema`
+- **files**: `lib/Service/VergaderingCaseService.php`
+- **acceptance_criteria**:
+  - GIVEN a vergadering created with startDatum WHEN saved THEN a linked Procest case is created with status "gepland" and deadline = startDatum - 7 days
+  - GIVEN startDatum reached WHEN nightly job runs THEN status transitions to "lopend"
+- [ ] Implement createForVergadering(), advanceStatus(), checkDeadlines()
+- [ ] Wire into vergadering object save lifecycle
+
+## 4. Demo Data, Multi-Gemeente, Feeds
+
+### Task 6: Seed demo objects in ori_register.json
+- **spec_ref**: `openspec/specs/open-raadsinformatie/spec.md#requirement-demo-mock-data-for-development-and-testing`
+- **files**: `lib/Settings/ori_register.json` (objects section)
+- **acceptance_criteria**:
+  - GIVEN clean-env reset WHEN ORI register imports THEN at least 1 vergadering, 6 agendapunten, 3 documenten, 1 stemming, 6 raadsleden, 2 fracties exist
+  - All demo objects use the `@self` envelope and reference each other correctly
+- [ ] Author demo `components.objects[]` entries
+
+### Task 7: Implement RaadsinformatieFeedController
+- **spec_ref**: `openspec/specs/open-raadsinformatie/spec.md#requirement-rss-atom-feed-generation-for-council-information`
+- **files**: `lib/Controller/RaadsinformatieFeedController.php`, `appinfo/routes.php`
+- **acceptance_criteria**:
+  - GIVEN seeded vergaderingen WHEN GET `/apps/procest/feed/ori/vergaderingen.rss` called THEN valid Atom XML returned with latest 50 entries
+  - GIVEN organisatie filter WHEN `?organisatie=X` provided THEN only that organisatie's records included
+- [ ] Implement controller with feed renderer
+- [ ] Register routes for vergaderingen / agendapunten / documenten feeds
+
+### Task 8: Data quality validation job
+- **spec_ref**: `openspec/specs/open-raadsinformatie/spec.md#requirement-data-quality-validation-for-ori-objects`
+- **files**: `lib/Cron/OriDataQualityCheck.php`
+- **acceptance_criteria**:
+  - GIVEN a vergadering missing locatie/voorzitter WHEN nightly job runs THEN a data_quality_issues entry is written referencing the object
+  - Admin dashboard surfaces the count of outstanding quality issues
+- [ ] Implement nightly job
+- [ ] Surface result on admin dashboard

--- a/openspec/changes/vth-module/design.md
+++ b/openspec/changes/vth-module/design.md
@@ -1,0 +1,44 @@
+# Design: vth-module
+
+## Architecture
+
+The VTH module sits as a vertical domain on top of the generic Procest case engine. It does NOT fork case-management; it composes existing primitives (case, statusType, propertyDefinition, role) into VTH-shaped templates and adds VTH-specific services for intake, checklists, advice, and enforcement.
+
+### Service Layout
+
+- `VTHTemplateService` — loads `lib/Settings/templates/vth-*.json` template files and activates them as zaaktypes in OpenRegister (parallels the WOO template-library pattern).
+- `DSOIntakeService` — receives a STAM 2.0 payload (vergunningaanvraag) from OpenConnector and maps it onto an `omgevingsvergunning` case with linked initiator, bouwlocatie, activiteiten, and uploaded documents.
+- `InspectionChecklistService` — CRUD on `inspectionChecklist` (admin) and per-case completion via `inspectionResult` records; exposes endpoints consumed by mobiel-inspectie.
+- `AdviceService` — `requestAdvice()`, `submitAdvice()`, `cancelAdvice()`; each `adviceRequest` is linked to a case, has an `adviseur` user/group, deadline, status (open/reminded/received/overdue/cancelled), and feeds into the case timeline.
+- `LhsLookupService` — pure lookup on the LHS 4x4 matrix (Beoordeling gedrag × Mogelijke gevolgen) returning the recommended interventieladder step.
+
+### Data Model (OpenRegister Schemas, added to procest_register.json)
+
+- `inspectionChecklist` — name, version, caseTypeRef, items[ref], active, validFrom.
+- `checklistItem` — question, type (boolean/enum/text/photo), required, weight, parent (nesting).
+- `inspectionResult` — case ref, checklist ref, completedBy, completedAt, answers[{itemRef, value, photoRef}].
+- `adviceRequest` — case ref, requestedBy, adviseur, deadline, status, vraag, adviesText, addedToFile.
+- `lhsMatrixCell` — gedragRow, gevolgColumn, interventieStep, description.
+
+### API Surface (V1)
+
+- `POST /api/vth/templates/{slug}/activate` — activate VTH template into the active register.
+- `POST /api/vth/dso/intake` — DSO callback endpoint (signed payload).
+- `GET/POST /api/vth/checklists` — admin CRUD.
+- `POST /api/vth/cases/{id}/inspection-result` — submit checklist completion.
+- `POST /api/vth/cases/{id}/advice-requests` — create advice request.
+- `GET /api/vth/lhs/lookup?gedrag=X&gevolg=Y` — LHS lookup.
+
+## Dependencies
+
+- OpenConnector for DSO callback signature validation and inbound routing.
+- OpenRegister for all data storage and schema validation.
+- Existing Procest case engine for status transitions, timeline, deadlines.
+- Future: mobiel-inspectie (checklist completion on tablet), legesberekening (fee on omgevingsvergunning), docudesk (besluit anonymisering).
+
+## Out of Scope (V2+)
+
+- Full LHS-driven sanctiebesluit generator.
+- Automatic koppeling met BAG/BGT for objectreferentie verrijking.
+- DSO outbound (publicatie kennisgeving) — handled by separate change.
+- 4-ogen accordering op handhavingsbesluit.

--- a/openspec/changes/vth-module/proposal.md
+++ b/openspec/changes/vth-module/proposal.md
@@ -1,17 +1,21 @@
+# Proposal: vth-module
+
 ## Why
 
-VTH (Vergunningen, Toezicht, Handhaving) is the highest-value domain for Dutch municipalities. 29% of tenders require VTH capabilities. This implements V1 tier: DSO intake service stub, configurable inspection checklists, and advice management workflow.
+VTH (Vergunningen, Toezicht, Handhaving) is the single highest-value functional domain for Dutch municipalities adopting Procest. 29% of analysed VTH tenders require an integrated permits/supervision/enforcement module, and stock case-management apps do not cover the cross-domain inspection and sanction workflows that a VTH-volwaardige module needs. This change introduces the V1 tier of the Procest VTH module: a DSO/Omgevingsloket intake service stub, configurable inspection checklists, advice management workflow, and the LHS (Landelijke Handhavingsstrategie) enforcement matrix as data, so downstream changes (mobiel-inspectie, legesberekening) can hook into a real VTH zaaktype stack.
 
 ## What Changes
 
-1. VTH case type templates (omgevingsvergunning, toezichtzaak, handhavingszaak)
-2. Inspection checklist schemas and configuration/completion UI
-3. DSO intake service stub for receiving vergunningaanvragen
-4. Advice management service for requesting/tracking specialist advice
-5. LHS enforcement matrix data and lookup utility (V2 foundation)
-6. New schemas in procest_register.json: inspectionChecklist, checklistItem, inspectionResult, adviceRequest
+1. VTH case-type templates: omgevingsvergunning, toezichtzaak, handhavingszaak with full GEMMA-compatible status/property/document/role configuration.
+2. Inspection checklist schemas and configuration/completion UI hooks consumable by mobiel-inspectie.
+3. DSO intake service stub mapping inbound vergunningaanvragen to Procest cases.
+4. Advice management service for requesting and tracking specialist advice (interne/externe adviseur).
+5. LHS enforcement matrix data and lookup utility (V2 foundation).
+6. New OpenRegister schemas in `procest_register.json`: `inspectionChecklist`, `checklistItem`, `inspectionResult`, `adviceRequest`, `lhsMatrixCell`.
 
 ## Impact
 
-- New service classes, Vue components, register schemas, route additions
-- Dependencies: OpenConnector (DSO), OpenRegister
+- **Affected projects**: procest (primary), openconnector (DSO connector), openregister (schemas).
+- **Code surface**: new service classes, Vue admin and detail components, register schemas, route additions, repair step for template seeding.
+- **Dependencies**: OpenConnector (DSO), OpenRegister, Docudesk (optional for besluit redaction), mobiel-inspectie (consumer), legesberekening (consumer).
+- **Standards**: GEMMA VTH-referentiecomponenten (VTH001-VTH119), Omgevingswet/DSO STAM 2.0, LHS 1.7.

--- a/openspec/changes/vth-module/tasks.md
+++ b/openspec/changes/vth-module/tasks.md
@@ -1,0 +1,85 @@
+# Tasks: vth-module
+
+## 1. Templates and Schemas
+
+### Task 1: Add VTH register schemas
+- **spec_ref**: `openspec/specs/vth-module/spec.md#req-vth-08-vth-case-type-templates`
+- **files**: `lib/Settings/procest_register.json`
+- **acceptance_criteria**:
+  - GIVEN a fresh install WHEN repair step runs THEN schemas `inspectionChecklist`, `checklistItem`, `inspectionResult`, `adviceRequest`, `lhsMatrixCell` exist
+  - All schemas validate as OpenAPI 3.0.0 + `x-openregister`
+- [ ] Add 5 new schemas to procest_register.json
+- [ ] Update repair step to register schemas
+
+### Task 2: Ship VTH zaaktype templates
+- **spec_ref**: `openspec/specs/vth-module/spec.md#req-vth-08-vth-case-type-templates`
+- **files**: `lib/Settings/templates/vth-omgevingsvergunning.json`, `vth-toezichtzaak.json`, `vth-handhavingszaak.json`
+- **acceptance_criteria**:
+  - GIVEN admin activates "Omgevingsvergunning" WHEN template applied THEN status flow, property defs, document types, role types created
+  - Each template has version metadata and is idempotent on re-activation
+- [ ] Author 3 template JSON files
+- [ ] Register templates in `VTHTemplateService`
+
+## 2. DSO Intake
+
+### Task 3: Create DSOIntakeService
+- **spec_ref**: `openspec/specs/vth-module/spec.md#req-vth-01-dso-omgevingsloket-integration`
+- **files**: `lib/Service/DSOIntakeService.php`, `lib/Controller/DSOIntakeController.php`, `appinfo/routes.php`
+- **acceptance_criteria**:
+  - GIVEN signed STAM 2.0 payload WHEN POST /api/vth/dso/intake THEN omgevingsvergunning case created with mapped fields and documents
+  - GIVEN invalid signature WHEN POST THEN 401 returned and audit log entry written
+- [ ] Implement DSOIntakeService.map(), .createCase()
+- [ ] Implement DSOIntakeController.intake()
+- [ ] Register route
+
+## 3. Inspection Checklists
+
+### Task 4: Create InspectionChecklistService
+- **spec_ref**: `openspec/specs/vth-module/spec.md#req-vth-03-inspection-checklists`
+- **files**: `lib/Service/InspectionChecklistService.php`, `lib/Controller/InspectionChecklistController.php`
+- **acceptance_criteria**:
+  - GIVEN 12-item checklist WHEN 11 items completed THEN progress is 11/12 and case cannot advance
+  - GIVEN niet-conform answer requiring photo WHEN no photo uploaded THEN save blocked with validation error
+- [ ] Implement CRUD on checklists
+- [ ] Implement submitResult() with required-photo validation
+
+### Task 5: Build checklist admin UI
+- **spec_ref**: `openspec/specs/vth-module/spec.md#req-vth-03-inspection-checklists`
+- **files**: `src/views/settings/tabs/ChecklistsTab.vue`, `src/components/InspectionChecklistEditor.vue`
+- **acceptance_criteria**:
+  - Admin can create/edit/delete checklists with nested items
+  - Each item supports type (boolean/enum/text/photo), required, weight
+- [ ] Add ChecklistsTab to settings
+- [ ] Build editor component
+
+## 4. Advice Management
+
+### Task 6: Create AdviceService
+- **spec_ref**: `openspec/specs/vth-module/spec.md#req-vth-06-advice-management-advies`
+- **files**: `lib/Service/AdviceService.php`, `lib/Controller/AdviceController.php`
+- **acceptance_criteria**:
+  - GIVEN behandelaar requests advice with deadline +14 days WHEN created THEN adviseur receives notification and timeline entry appears
+  - GIVEN deadline passed WHEN nightly job runs THEN status becomes "overdue" and reminder sent
+- [ ] Implement requestAdvice, submitAdvice, cancelAdvice
+- [ ] Add overdue cronjob
+
+### Task 7: Build advice request UI
+- **spec_ref**: `openspec/specs/vth-module/spec.md#req-vth-06-advice-management-advies`
+- **files**: `src/views/cases/components/AdviceRequestPanel.vue`
+- **acceptance_criteria**:
+  - Panel renders on VTH case detail showing open/received/overdue advice
+  - "Request advice" dialog with adviseur picker, deadline, vraag textarea
+- [ ] Build AdviceRequestPanel component
+- [ ] Wire into VTH case detail tab
+
+## 5. LHS Enforcement Matrix
+
+### Task 8: Seed LHS matrix and lookup
+- **spec_ref**: `openspec/specs/vth-module/spec.md#req-vth-04-enforcement-strategies-handhaving`
+- **files**: `lib/Settings/lhs_matrix_seed.json`, `lib/Service/LhsLookupService.php`, `lib/Controller/LhsController.php`
+- **acceptance_criteria**:
+  - GIVEN gedrag=B and gevolg=2 WHEN GET /api/vth/lhs/lookup?gedrag=B&gevolg=2 THEN returns interventieStep "Bestuurlijke waarschuwing" with description
+  - All 16 LHS cells seeded on install
+- [ ] Seed 16-cell matrix as repair step data
+- [ ] Implement LhsLookupService.lookup()
+- [ ] Register route and controller

--- a/openspec/changes/woo-case-type/design.md
+++ b/openspec/changes/woo-case-type/design.md
@@ -1,0 +1,47 @@
+# Design: woo-case-type
+
+## Architecture
+
+WOO is implemented as a domain template on top of the existing Procest case engine, not as a fork. A JSON template file describes the zaaktype (8 statuses, property defs, document types, role types, decision types). A `TemplateLibraryService` activates that template into the active register, materialising it as standard OpenRegister objects. Domain services handle the parts that go beyond plain case-management: WOO deadlines, per-document assessment, and (optional) Docudesk-driven redaction.
+
+### Service Layout
+
+- `TemplateLibraryService` — `listTemplates()`, `previewTemplate(id)`, `activateTemplate(id, overrides)`; reads from `lib/Settings/templates/*.json`; reusable for non-WOO templates.
+- `WOODeadlineService` — calculates `expectedResolution` as receipt + 4 weeks; supports a single `extendDeadline(reason)` of up to 2 weeks; emits warnings at T-7 and overdue events.
+- `WOODocumentAssessmentService` — CRUD on per-document `wooAssessment` records (openbaar/deels openbaar/niet openbaar + weigeringsgrond[] + motivering); guards stage advancement until every collected document is assessed.
+- `WOODecisionService` — assembles the formal besluit referencing all assessments and weigeringsgronden; writes a `decision` object linked to the case.
+
+### Data Model
+
+Most data lives as standard `case`, `statusType`, `documentType`, `decision` objects produced by the template. WOO-specific extensions:
+
+- `wooAssessment` schema (added to `procest_register.json`): caseRef, documentRef, classification (enum), weigeringsgronden (array of WOO Art. 5.1/5.2 codes), motivering (text), assessedBy, assessedAt.
+- Property definitions on the WOO zaaktype: verzoeker_naam, verzoeker_type, onderwerp, periode_van, periode_tot, bestuurlijke_aangelegenheid, kanaal, deadline_verlengd.
+
+### 8-Stage Lifecycle
+
+1. Ontvangst → 2. Beoordeling ontvankelijkheid → 3. Zoeken documenten → 4. Beoordelen documenten → 5. Lakken / Anonimiseren → 6. Besluit → 7. Publicatie → 8. Afgehandeld.
+
+Each transition is enforced by the case engine; stages 4→5 require all `wooAssessment` records present; stage 6 requires every assessment to have a classification + (where needed) weigeringsgrond.
+
+### API Surface
+
+- `GET /api/templates` — list available templates with metadata.
+- `POST /api/templates/{id}/activate` — activate (optionally with field overrides).
+- `POST /api/cases/{id}/woo/assessment` — bulk-upsert assessments.
+- `POST /api/cases/{id}/woo/extend-deadline` — extend with reason.
+- `POST /api/cases/{id}/woo/decision` — assemble the besluit object.
+
+## Dependencies
+
+- OpenRegister (template storage and all WOO objects).
+- Docudesk (optional, for the "lakken" stage; falls back to manual redaction).
+- Procest case engine (status transitions, timeline, deadline panel).
+- Mijn Overheid integration (verzoeker notification — out of scope this change, hooks left).
+
+## Out of Scope
+
+- Automated PLOOI publication.
+- Bezwaar workflow (handled by `bezwaar-beroep-workflow`).
+- Inventarislijst PDF generation (separate doc-gen change).
+- Berichtenbox push notifications (separate Mijn Overheid integration change).

--- a/openspec/changes/woo-case-type/proposal.md
+++ b/openspec/changes/woo-case-type/proposal.md
@@ -1,19 +1,22 @@
+# Proposal: woo-case-type
+
 ## Why
 
-WOO (Wet open overheid) requests are one of the most common case types for Dutch municipalities. Currently, Procest has no pre-configured WOO zaaktype template. This spec adds a ready-to-use WOO zaaktype template with 8-stage lifecycle, WOO-specific intake fields, 4-week deadline with optional 2-week extension, per-document assessment workflow, and weigeringsgrond selection based on WOO Article 5.1/5.2.
+WOO (Wet open overheid) requests are one of the most common, deadline-driven case types Dutch municipalities must handle, yet Procest currently ships no pre-configured WOO zaaktype. Case workers create WOO cases ad hoc, leading to inconsistent stage names, missed 4-week deadlines, undocumented weigeringsgronden, and unredacted personal data being disclosed. This change ships a ready-to-activate WOO zaaktype template plus the supporting UI and services needed to run the statutory 8-stage WOO lifecycle out of the box.
 
 ## What Changes
 
-1. WOO zaaktype template JSON with 8 ordered statuses, property definitions, document types, decision types, role types
-2. Template Library service to load and activate zaaktype templates
-3. Template Library API endpoints
-4. Document Assessment Vue component for per-document disclosure classification
-5. WOO Intake Form Vue component
-6. Template Library admin settings tab
-7. Route additions
+1. WOO zaaktype template JSON (`lib/Settings/templates/woo-verzoek.json`) with 8 ordered statuses, property definitions, document types, decision types, role types, and version metadata.
+2. `TemplateLibraryService` and `TemplateLibraryController` to load, preview, and activate zaaktype templates into the active register; same mechanism reusable by other domain templates.
+3. `WOODeadlineService` enforcing the 4-week response deadline with a single optional 2-week extension per WOO Art. 4.4.
+4. `WOODocumentAssessmentService` for per-document classification (openbaar/deels openbaar/niet openbaar) with weigeringsgrond selection from WOO Art. 5.1/5.2.
+5. Vue components: `WOOIntakeForm`, `DocumentAssessmentTable`, `TemplateLibrary` admin tab.
+6. Optional Docudesk integration hook for the redaction (lakken) stage.
 
 ## Impact
 
-- New service, controller, 3 Vue components, 1 JSON template, route additions
-- APIs: /api/templates (list), /api/templates/{id}/activate (POST)
-- Dependencies: OpenRegister, Docudesk (optional)
+- **Affected projects**: procest (primary), docudesk (optional integration), openregister (template storage).
+- **Code surface**: 1 service group, 1 controller, 3 Vue components, 1 JSON template, route additions, 1 repair-step registration.
+- **APIs**: `GET /api/templates`, `POST /api/templates/{id}/activate`, `POST /api/cases/{id}/woo/assessment`, `POST /api/cases/{id}/woo/extend-deadline`.
+- **Dependencies**: OpenRegister, Docudesk (optional), Mijn Overheid (notification — out of scope this change).
+- **Standards**: Wet open overheid (2022), Awb Art. 6:7 (bezwaar), PLOOI publication, AVG/GDPR.

--- a/openspec/changes/woo-case-type/tasks.md
+++ b/openspec/changes/woo-case-type/tasks.md
@@ -1,0 +1,82 @@
+# Tasks: woo-case-type
+
+## 1. Template Library
+
+### Task 1: Create TemplateLibraryService
+- **spec_ref**: `openspec/specs/woo-case-type/spec.md#requirement-1-woo-zaaktype-template-activation`
+- **files**: `lib/Service/TemplateLibraryService.php`, `lib/Controller/TemplateLibraryController.php`, `appinfo/routes.php`
+- **acceptance_criteria**:
+  - GIVEN a `woo-verzoek.json` template WHEN admin POSTs `/api/templates/woo-verzoek/activate` THEN a zaaktype with 8 statuses is created in the active register
+  - GIVEN re-activation of the same template WHEN POSTed THEN existing zaaktype is updated, not duplicated
+  - GIVEN field overrides in the payload WHEN activated THEN overrides applied while base template stays untouched
+- [ ] Implement listTemplates(), previewTemplate(), activateTemplate()
+- [ ] Implement TemplateLibraryController
+- [ ] Register routes
+
+### Task 2: Ship WOO zaaktype template JSON
+- **spec_ref**: `openspec/specs/woo-case-type/spec.md#requirement-2-woo-lifecycle-stages`
+- **files**: `lib/Settings/templates/woo-verzoek.json`
+- **acceptance_criteria**:
+  - Template contains 8 ordered status types matching the WOO lifecycle
+  - Template includes WOO intake property definitions, document types, role types, decision types, and version metadata
+- [ ] Author template JSON with full 8-stage lifecycle
+- [ ] Validate template via `jq` and OpenRegister importer dry run
+
+## 2. Intake and Lifecycle
+
+### Task 3: Build WOOIntakeForm
+- **spec_ref**: `openspec/specs/woo-case-type/spec.md#requirement-3-woo-specific-intake-form`
+- **files**: `src/views/cases/components/WOOIntakeForm.vue`
+- **acceptance_criteria**:
+  - Form renders verzoeker_naam, contactgegevens, type, onderwerp, periode_van/tot, bestuurlijke_aangelegenheid, kanaal
+  - Required-field validation blocks save until satisfied
+- [ ] Build Vue form bound to property definitions on the WOO zaaktype
+
+### Task 4: Implement WOODeadlineService
+- **spec_ref**: `openspec/specs/woo-case-type/spec.md#requirement-4-woo-deadline-tracking-and-extension`
+- **files**: `lib/Service/WOODeadlineService.php`
+- **acceptance_criteria**:
+  - GIVEN a WOO case created on 2026-05-01 WHEN deadline read THEN expectedResolution = 2026-05-29 (28 days)
+  - GIVEN one extension applied with reason WHEN attempting a second extension THEN error returned
+  - GIVEN deadline-7 reached WHEN nightly job runs THEN warning notification sent to behandelaar
+- [ ] Implement calculate(), extendDeadline(), checkAndWarn()
+- [ ] Wire into existing DeadlinePanel.vue
+
+## 3. Document Assessment and Decision
+
+### Task 5: Implement WOODocumentAssessmentService
+- **spec_ref**: `openspec/specs/woo-case-type/spec.md#requirement-6-per-document-disclosure-assessment`
+- **files**: `lib/Service/WOODocumentAssessmentService.php`, `lib/Controller/WOOAssessmentController.php`
+- **acceptance_criteria**:
+  - GIVEN 12 collected documents WHEN bulk-assess called with 11 classifications THEN advancing to "Lakken" is blocked with "Document 12 needs assessment"
+  - GIVEN classification "deels openbaar" without weigeringsgrond WHEN saved THEN validation error returned
+- [ ] Implement bulkUpsert(), validate(), getOutstanding()
+- [ ] Implement controller endpoint
+
+### Task 6: Build DocumentAssessmentTable
+- **spec_ref**: `openspec/specs/woo-case-type/spec.md#requirement-6-per-document-disclosure-assessment`
+- **files**: `src/views/cases/components/DocumentAssessmentTable.vue`
+- **acceptance_criteria**:
+  - Table renders one row per collected document with classification select and weigeringsgrond multi-select
+  - Saving the table calls the bulkUpsert endpoint
+- [ ] Build Vue table component
+
+### Task 7: Implement WOODecisionService and besluit flow
+- **spec_ref**: `openspec/specs/woo-case-type/spec.md#requirement-8-woo-decision-besluit`
+- **files**: `lib/Service/WOODecisionService.php`
+- **acceptance_criteria**:
+  - GIVEN every document assessed WHEN decision created THEN a `decision` object is linked to the case referencing all assessments
+  - GIVEN unassessed document WHEN decision attempted THEN blocked with explicit error
+- [ ] Implement assembleDecision()
+- [ ] Wire into controller and besluit panel
+
+## 4. Optional Docudesk Integration
+
+### Task 8: Wire Docudesk redaction hook on "Lakken" stage
+- **spec_ref**: `openspec/specs/woo-case-type/spec.md#requirement-7-redaction-via-docudesk-integration`
+- **files**: `lib/Service/WOORedactionService.php`
+- **acceptance_criteria**:
+  - GIVEN Docudesk is installed AND case enters "Lakken / Anonimiseren" WHEN documents are flagged "deels openbaar" THEN they are queued in Docudesk for redaction
+  - GIVEN Docudesk is not installed WHEN stage entered THEN UI falls back to manual upload-redacted-version flow
+- [ ] Implement WOORedactionService with feature detection
+- [ ] Add UI fallback for non-Docudesk installs


### PR DESCRIPTION
## Summary

Completes OpenSpec artifacts (proposal + design + tasks) for three proposal-only shell changes in `procest`. Existing `specs/<capability>/spec.md` files were already substantive (Given/When/Then scenarios, REQ-* IDs in vth-module, Requirement-* + REQ-ORI-### tables in the other two) and are kept intact. **Spec-only — no PHP/Vue/runtime changes.**

## Per-change result

### vth-module (VTH = Vergunningen Toezicht Handhaving)
- **proposal.md** rewritten (218 words) — V1 tier: DSO intake stub, inspection checklists, advice management, LHS matrix data; 5 new register schemas.
- **design.md** (345 words) — service layout (VTHTemplateService, DSOIntakeService, InspectionChecklistService, AdviceService, LhsLookupService), data model, API surface, scope.
- **tasks.md** — **8 tasks** across templates/schemas, DSO intake, inspection checklists, advice management, LHS matrix.
- **spec.md** (pre-existing, kept) — **11 REQs** (REQ-VTH-01..11) with full Given/When/Then.

### woo-case-type (WOO = Wet Open Overheid)
- **proposal.md** rewritten (245 words) — WOO zaaktype template + TemplateLibraryService + WOODeadlineService + WOODocumentAssessmentService + Docudesk redaction hook.
- **design.md** (392 words) — template-library pattern, 8-stage lifecycle, `wooAssessment` schema, API surface, dependencies, out-of-scope.
- **tasks.md** — **8 tasks** across template library, intake/lifecycle, document assessment, decision, Docudesk integration.
- **spec.md** (pre-existing, kept) — **11 Requirements** with Given/When/Then scenarios covering activation, 8-stage lifecycle, intake, deadline, document workflow, redaction, besluit, publication, bezwaar, reporting.

### open-raadsinformatie (Open council info)
- **proposal.md** rewritten (246 words) — ORI register seed, public OAS access, demo data, vergadering case wrapper, RSS/Atom feeds, multi-gemeente, data quality.
- **design.md** (386 words) — two-layer architecture (OpenRegister storage + Procest case wrapper), data ingestion via OpenConnector, public access, multi-gemeente, RSS/Atom controller.
- **tasks.md** — **8 tasks** across register provisioning, repair step, OAS public access, search wiring, vergadering case service, demo data, feed controller, data-quality job.
- **spec.md** (pre-existing, kept) — **15 Requirements** with embedded REQ-ORI-### tables (REQ-ORI-001..) and Given/When/Then scenarios.

## Flags

- `vth-module` and `open-raadsinformatie` `spec.md` exceed the "REQ-XYZ-1..8" hint (11 and 15) because the specs were pre-existing and substantive; not regressed. Tasks focus V1 scope onto 8 items.
- `open-raadsinformatie/specs/.../spec.md` has front-matter `status: redirect` — preserved as-is; consider revisiting before `opsx-archive`.
- `woo-case-type/specs/.../spec.md` uses "Requirement N: ..." headings rather than `REQ-WOO-NN`; left intact to avoid spec churn. Rename in follow-up if canonical convention is strict.
- No `composer check:strict` run (markdown-only change).

## Test plan

- [ ] `openspec validate vth-module --strict` (and the other two)
- [ ] Visual review of design.md service architecture per change
- [ ] Confirm task spec_refs resolve in the existing spec.md files