### PR TITLE
chore(openspec): complete artifacts for 3 integration changes (email/dossier/dso)

### DIFF
--- a/openspec/changes/case-email-integration/design.md
+++ b/openspec/changes/case-email-integration/design.md
@@ -1,0 +1,121 @@
+# Design: case-email-integration
+
+## Architecture Overview
+
+Email integration adds a correspondence layer on top of the existing case management infrastructure. Outbound mail flows through a `CaseEmailService` that resolves template variables, renders the email, sends via SMTP or Nextcloud Mail, and stores the message as an `emailMessage` object plus a PDF `caseDocument`. Inbound mail flows through an `InboundEmailJob` IMAP poller that auto-links by case number or thread headers, or queues unlinked messages for manual handling. Threading is maintained via RFC 2822 `Message-ID` / `In-Reply-To` headers stored on `emailMessage`, with thread aggregation in `emailThread` objects.
+
+```
+CaseDetail.vue
+├── EmailTab (new sidebar tab)
+│   ├── EmailThread.vue (chronological message view per thread)
+│   └── EmailComposer.vue (send/reply dialog)
+└── ActivityTimeline.vue (existing, extended with email_sent/email_received events)
+
+CaseTypeDetail.vue
+└── EmailTemplateAdmin.vue (template CRUD per case type)
+
+Settings
+├── EmailSettings.vue (SMTP, IMAP, transport choice, test connection)
+
+Inbound (background)
+└── InboundEmailJob (TimedJob, configurable interval/batch)
+    ├── Auto-link by [ZAAK-YYYY-NNNNNN] subject regex
+    ├── Auto-link by In-Reply-To header
+    └── Unlinked queue (manual link via /emails/unlinked)
+```
+
+## File Map
+
+### New Backend Files
+
+| File | Purpose |
+|------|---------|
+| `lib/Service/CaseEmailService.php` | Send outbound, process inbound, resolve template variables, RFC 2822 threading, Docudesk PDF orchestration |
+| `lib/Service/EmailTemplateService.php` | Template CRUD, versioning on edit, variable catalog generation |
+| `lib/Controller/CaseEmailController.php` | Authenticated API: send, list threads, list unlinked, link/discard, template CRUD |
+| `lib/BackgroundJob/InboundEmailJob.php` | TimedJob: IMAP poll, auto-link, batch size limit, duplicate detection via Message-ID |
+| `lib/BackgroundJob/EmailPdfRetryJob.php` | TimedJob: retry failed Docudesk conversions up to 3× with exponential backoff |
+| `lib/Settings/EmailSettings.php` | Admin settings section registration |
+
+### New Frontend Files
+
+| File | Purpose |
+|------|---------|
+| `src/views/cases/components/EmailTab.vue` | Case detail tab grouping messages by thread with count badge |
+| `src/views/cases/components/EmailComposer.vue` | Modal: recipient/CC/BCC, subject, body (rich text), template selector, attachment picker, send confirmation |
+| `src/views/cases/components/EmailThread.vue` | Chronological thread renderer (inbound left, outbound right) with inline expand |
+| `src/views/casetypes/components/EmailTemplateAdmin.vue` | Template CRUD per case type with variable sidebar and live preview |
+| `src/views/emails/UnlinkedQueue.vue` | Standalone view for manual linking of unlinked inbound emails |
+| `src/views/settings/EmailSettings.vue` | SMTP/IMAP/transport config form with connection test |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `lib/Settings/procest_register.json` | Add `emailTemplate`, `emailMessage`, `emailThread` schemas |
+| `lib/Service/SettingsService.php` | Add `email_*` config keys and SLUG_TO_CONFIG_KEY entries |
+| `appinfo/routes.php` | Add email send, template, unlinked queue, settings routes |
+| `src/views/cases/CaseDetail.vue` | Add EmailTab to sidebar tabs and "Verstuur email" header action |
+
+## Data Model
+
+### emailTemplate Schema
+- `name` (string, required) — Template name (e.g., `Ontvangstbevestiging`)
+- `subject` (string, required) — Subject pattern with `{{variable}}` placeholders
+- `body` (string/HTML, required) — Body content with `{{variable}}` placeholders
+- `caseType` (string/reference, required) — Reference to case type
+- `variables` (array of strings) — Available variable names
+- `version` (integer, default 1) — Bumped on edit; previously sent emails retain their version
+- `isActive` (boolean, default true) — Whether template is selectable
+
+### emailMessage Schema
+- `messageId` (string, RFC 2822) — Unique message identifier
+- `inReplyTo` (string, nullable) — Parent message identifier
+- `direction` (enum: inbound/outbound) — Send direction
+- `from` (string) — Sender email address
+- `to` (array of strings) — Primary recipients
+- `cc` (array of strings) — CC recipients
+- `bcc` (array of strings) — BCC recipients
+- `subject` (string) — Subject line including case prefix
+- `body` (string/HTML) — Rendered body
+- `case` (string/reference) — Reference to case object
+- `thread` (string/reference) — Reference to emailThread
+- `pdfPath` (string) — File path of generated PDF in Nextcloud Files
+- `pdfStatus` (enum: pending/completed/failed) — Docudesk conversion status
+- `sentAt` (datetime) — Send/receive timestamp
+- `templateId` (string, nullable) — Reference to emailTemplate used
+- `templateVersion` (integer, nullable) — Version of template at send time
+
+### emailThread Schema
+- `subject` (string) — Thread subject (without RE: prefix)
+- `case` (string/reference) — Reference to case object
+- `messageCount` (integer) — Total messages in thread
+- `firstMessageAt` (datetime) — Timestamp of first message
+- `lastMessageAt` (datetime) — Timestamp of most recent message
+
+## API Design
+
+### Authenticated Endpoints (CaseEmailController)
+- `POST /api/cases/{caseId}/emails` — Send email from case (with optional templateId, attachments, cc/bcc)
+- `GET /api/cases/{caseId}/emails` — List threads and messages for a case
+- `GET /api/emails/unlinked` — List unlinked inbound emails for manual handling
+- `POST /api/emails/unlinked/{id}/link` — Link an email to a case
+- `POST /api/emails/unlinked/{id}/discard` — Mark unlinked email as discarded
+- `GET /api/casetypes/{caseTypeId}/email-templates` — List templates for case type
+- `POST /api/casetypes/{caseTypeId}/email-templates` — Create template
+- `PUT /api/email-templates/{templateId}` — Update template (creates new version)
+
+### Settings Endpoints
+- `GET /api/settings/email` — Current email configuration
+- `PUT /api/settings/email` — Save SMTP/IMAP/transport settings
+- `POST /api/settings/email/test-smtp` — Send test email
+
+## Security & Reliability
+
+- IMAP/SMTP passwords stored via `IAppConfig` with `setSensitive(true)` or Nextcloud credential store
+- Case-number regex anchored as `\[([A-Z]+-\d{4}-\d{6})\]`; subject-only, not body
+- Tenant isolation: lookup of cases by identifier scoped to current organization
+- Background job catches exceptions to avoid deregistration; logs via `LoggerInterface`
+- Duplicate detection by `messageId` indexed lookup before inserting `emailMessage`
+- PDF conversion runs async via job for messages > 5 MB; sync for smaller messages
+- Rate limiting: poller batch size capped (default 50) and configurable

--- a/openspec/changes/case-email-integration/proposal.md
+++ b/openspec/changes/case-email-integration/proposal.md
@@ -1,17 +1,48 @@
-## Why
+# Proposal: case-email-integration
 
-Email communication currently happens outside the case system, breaking the audit trail. This implements email sending from case context with templates, inbound email linking, email-to-PDF conversion, and threading.
+## Summary
 
-## What Changes
+Integrate inbound and outbound email directly into the Procest case workflow. Email becomes a first-class case interaction: outbound mail is composed from case context with templates and case-data variable resolution, all sent and received messages are converted to PDF and stored as case documents (`caseDocument`), and threading via RFC 2822 headers keeps conversations grouped per case. The integration supports both Nextcloud Mail accounts and standalone SMTP/IMAP transports, plus a manual queue for unlinked inbound messages.
 
-1. EmailTemplate schema in procest_register.json
-2. CaseEmailService for sending, template variable resolution, inbound processing
-3. EmailComposer Vue component for sending email from case context
-4. EmailTemplateAdmin Vue component for template configuration
-5. EmailThread Vue component for viewing email conversations
-6. Route additions for email sending and template management
+## Motivation
 
-## Impact
+Email remains the primary correspondence channel between municipalities and citizens, applicants, and partner organizations. Today, that correspondence sits in personal mailboxes outside the case system, breaking the audit trail and making it impossible to reconstruct a case after the fact. ZGW and Archiefwet require case correspondence to be archived as informatieobjecten. This change closes the gap: every sent/received email is captured, classified, threaded, and surfaced in the case detail view and the activity timeline.
 
-- New schemas, service, 3 Vue components, route additions
-- Dependencies: Nextcloud Mail or direct SMTP, Docudesk for PDF conversion
+## Affected Projects
+
+- [ ] Project: `procest` — Backend services, controllers, background jobs, schemas, and Vue components for email integration
+
+## Scope
+
+### In Scope
+
+- **Outbound email** — Compose with templates, variable resolution, attachment picker from case documents, CC/BCC, send confirmation
+- **Inbound email** — IMAP polling background job, auto-linking by case-number regex and `In-Reply-To`, unlinked queue with manual link/discard
+- **Email templates per case type** — CRUD, versioning, variable sidebar, default Dutch templates (`Ontvangstbevestiging`, `Informatieverzoek`, `Besluit`)
+- **Threading** — `Message-ID` / `In-Reply-To`, `emailThread` objects, chronological view in case detail
+- **Email-to-PDF** — Docudesk integration, retry on failure, large-email background conversion, storage as `caseDocument`
+- **Activity timeline** — `email_sent` / `email_received` events with timestamps and recipients
+- **Admin settings** — SMTP and IMAP configuration with connection test, Nextcloud Mail transport option
+
+### Out of Scope
+
+- Real-time push notifications from IMAP IDLE (polling only)
+- Calendar/iCalendar handling of meeting invitations
+- Encrypted (S/MIME, PGP) email
+- DMARC/SPF/DKIM authentication of inbound mail (delegated to mail server)
+
+## Approach
+
+1. Add `emailTemplate`, `emailMessage`, `emailThread` schemas to `procest_register.json`
+2. Create `CaseEmailService` for send/receive, template variable resolution, threading, PDF conversion
+3. Create `CaseEmailController` (auth) and routes for compose, template, queue endpoints
+4. Add `InboundEmailJob` `TimedJob` for IMAP polling (configurable interval, batch size)
+5. Vue: `EmailComposer.vue`, `EmailTemplateAdmin.vue`, `EmailThread.vue`, email tab in `CaseDetail.vue`
+6. Extend `SettingsService` with `email_*` config keys (SMTP, IMAP, transport choice)
+
+## Risks
+
+- IMAP credentials must be stored encrypted via Nextcloud credential store
+- Auto-linking regex must not match attacker-controlled subjects from other tenants
+- Docudesk failures must not block email reception — retry asynchronously
+- Large attachments and embedded images can exhaust memory if processed synchronously

--- a/openspec/changes/case-email-integration/tasks.md
+++ b/openspec/changes/case-email-integration/tasks.md
@@ -1,0 +1,52 @@
+# Tasks: case-email-integration
+
+## Implementation Tasks
+
+### Schema & Configuration
+
+- [ ] **T01**: Add `emailTemplate`, `emailMessage`, `emailThread` schemas to `lib/Settings/procest_register.json` with all fields from design (name/subject/body/caseType/variables/version/isActive for template; messageId/inReplyTo/direction/from/to/cc/bcc/subject/body/case/thread/pdfPath/pdfStatus/sentAt/templateId/templateVersion for message; subject/case/messageCount/firstMessageAt/lastMessageAt for thread). Include schema.org annotations (`schema:DigitalDocument`, `schema:EmailMessage`, `schema:Conversation`). Add config keys `email_template_schema`, `email_message_schema`, `email_thread_schema`, plus SMTP/IMAP keys (`email_smtp_host`, `email_smtp_port`, `email_smtp_encryption`, `email_smtp_username`, `email_smtp_password`, `email_from_address`, `email_imap_host`, `email_imap_port`, `email_imap_folder`, `email_transport`, `email_poll_interval`, `email_poll_batch_size`, `email_max_attachment_size`) to `SettingsService.php` CONFIG_KEYS and SLUG_TO_CONFIG_KEY arrays.
+
+### Backend Services
+
+- [ ] **T02**: Create `lib/Service/CaseEmailService.php` — Methods: `sendEmail(caseId, templateId, subject, body, recipients, cc, bcc, attachmentIds)` resolves template variables, generates `Message-ID`, dispatches via configured transport, stores `emailMessage`, triggers PDF conversion, appends `email_sent` activity entry; `processInboundEmail(rawMessage)` parses headers, auto-links by subject regex `\[([A-Z]+-\d{4}-\d{6})\]` or by `In-Reply-To`, stores `emailMessage` and updates/creates `emailThread`, queues unlinked messages; `resolveTemplateVariables(template, case)` returns rendered subject+body with unresolved names listed; `linkUnlinkedEmail(emailId, caseId)` moves an email from queue to case; `discardUnlinkedEmail(emailId, reason)` marks as discarded. Uses ObjectService from OpenRegister, Docudesk for PDF.
+
+- [ ] **T03**: Create `lib/Service/EmailTemplateService.php` — Methods: `createTemplate(caseTypeId, data)` saves new template with `version: 1`; `updateTemplate(templateId, data)` creates a new version object rather than overwriting; `listTemplates(caseTypeId)` returns active templates for case type; `getAvailableVariables(caseTypeId)` returns the variable catalog grouped by source (case, contact, caseType); `seedDefaultTemplates(caseTypeId)` creates `Ontvangstbevestiging`, `Informatieverzoek`, `Besluit`.
+
+### Controllers & Routes
+
+- [ ] **T04**: Create `lib/Controller/CaseEmailController.php` — Authenticated controller with endpoints: `sendEmail(caseId)`, `listEmails(caseId)`, `listUnlinked()`, `linkEmail(emailId)`, `discardEmail(emailId)`, `listTemplates(caseTypeId)`, `createTemplate(caseTypeId)`, `updateTemplate(templateId)`. All methods `@NoAdminRequired`, returns `JSONResponse`.
+
+- [ ] **T05**: Add routes to `appinfo/routes.php` — `POST /api/cases/{caseId}/emails`, `GET /api/cases/{caseId}/emails`, `GET /api/emails/unlinked`, `POST /api/emails/unlinked/{id}/link`, `POST /api/emails/unlinked/{id}/discard`, template CRUD under `/api/casetypes/{caseTypeId}/email-templates` and `/api/email-templates/{templateId}`, settings under `/api/settings/email`. All before SPA catch-all.
+
+### Background Jobs
+
+- [ ] **T06**: Create `lib/BackgroundJob/InboundEmailJob.php` — `TimedJob` with default interval from `email_poll_interval` (default 300 s). Connects to IMAP via `imap_open()` or Nextcloud Mail's account API, fetches unread messages from configured folder (default INBOX), processes up to `email_poll_batch_size` per run (default 50), skips messages whose `Message-ID` already exists, moves processed messages to a "Processed" folder. Catches and logs exceptions without rethrowing.
+
+- [ ] **T07**: Create `lib/BackgroundJob/EmailPdfRetryJob.php` — `TimedJob` (every 15 min) that scans `emailMessage` objects with `pdfStatus: failed` and retries Docudesk conversion up to 3× with exponential backoff (15 min, 1 h, 4 h). Registers both jobs via `IJobList` in `appinfo/info.xml` background-jobs section or `Application::register()`.
+
+### Frontend Components
+
+- [ ] **T08**: Create `src/views/cases/components/EmailComposer.vue` — Modal dialog with recipient (pre-filled from case contact), CC, BCC, subject (pre-filled with `[{{identifier}}]` prefix), rich text body editor, template selector dropdown, attachment picker (case documents), running attachment size, send confirmation step. Validates attachment size against `email_max_attachment_size`. Disabled when case status `isFinal`.
+
+- [ ] **T09**: Create `src/views/cases/components/EmailThread.vue` and `src/views/cases/components/EmailTab.vue` — Tab lists threads grouped collapsible (most recent first) with count badge in tab header; thread renders messages chronologically with direction-distinguished styling (inbound left, outbound right), inline body expand, PDF download link, and per-message Reply action that opens EmailComposer pre-populated.
+
+- [ ] **T10**: Create `src/views/casetypes/components/EmailTemplateAdmin.vue` and `src/views/emails/UnlinkedQueue.vue` — Template admin lists templates per case type with create/edit form, variable sidebar grouped by source (case/contact/caseType), live preview with red-highlighted unresolved variables. UnlinkedQueue lists sender/subject/date/body preview with search-and-link UI plus discard action.
+
+### Settings & Integration
+
+- [ ] **T11**: Create `src/views/settings/EmailSettings.vue` and `lib/Settings/EmailSettings.php` — Admin settings form with SMTP fields (host/port/encryption/username/password/from-address), IMAP fields (host/port/encryption/username/password/folder), transport selector (Nextcloud Mail account picker or standalone SMTP), and "Send test email" button calling `POST /api/settings/email/test-smtp`. Passwords masked and stored via sensitive `IAppConfig` keys. Register settings section in `appinfo/info.xml`.
+
+- [ ] **T12**: Update `src/views/cases/CaseDetail.vue` — Add `EmailTab` to the sidebar tabs in `sidebarProps`. Add "Verstuur email" header action that opens `EmailComposer` (disabled when status `isFinal`). Subscribe to email events to refresh `ActivityTimeline` after send.
+
+## Verification Tasks
+
+- [ ] **V01**: All new schemas valid JSON in `procest_register.json`; load via `openregister:load-register` succeeds
+- [ ] **V02**: Routes registered before SPA catch-all and resolve under `/index.php/apps/procest/api/`
+- [ ] **V03**: Outbound email is sent, `emailMessage` stored, PDF generated, `email_sent` appears in activity timeline
+- [ ] **V04**: Inbound email with `[ZAAK-2026-001234]` subject auto-links to the matching case
+- [ ] **V05**: Inbound reply with `In-Reply-To` header is appended to the existing thread
+- [ ] **V06**: Unlinked email appears in `/emails/unlinked` and can be manually linked
+- [ ] **V07**: Template variables resolve from case data; unresolved variables highlighted red in preview
+- [ ] **V08**: Template edit creates a new version; previously sent messages retain `templateVersion`
+- [ ] **V09**: Docudesk failure marks `pdfStatus: failed` and retry job re-attempts up to 3×
+- [ ] **V10**: SMTP/IMAP passwords stored sensitive; test-email button returns success/failure with specific error

--- a/openspec/changes/document-zaakdossier/design.md
+++ b/openspec/changes/document-zaakdossier/design.md
@@ -1,0 +1,116 @@
+# Design: document-zaakdossier
+
+## Architecture Overview
+
+The zaakdossier layer sits between Procest's case views and OpenRegister's file handlers. Every uploaded document becomes both a Nextcloud file (stored at `Open Registers/{Register Title} Register/{objectUuid}/`) and an `informatieobject` register object carrying ZGW DRC metadata. The link to the case is a separate `zaakinformatieobject` join object — this matches the ZGW DRC model and lets a single document be linked to multiple cases without duplication. Documents linked to besluiten use the analogous `besluitinformatieobject` join. A `ZaakdossierService` orchestrates the existing OpenRegister file handlers; access control is enforced by a service-layer guard that checks user clearance against `vertrouwelijkheidaanduiding`. The dossier UI is a tab in `CaseDetail.vue` rendering documents grouped by informatieobjecttype.
+
+```
+CaseDetail.vue
+└── DossierTab (new sidebar tab, count badge)
+    ├── DossierGroup.vue (collapsible group per informatieobjecttype)
+    │   └── DocumentRow.vue (thumbnail, status badge, vertrouwelijkheid badge, actions)
+    ├── DocumentMetadataDialog.vue (drag-drop / upload metadata)
+    ├── VersionHistoryPanel.vue (side panel showing Nextcloud versions)
+    └── BulkActionsBar.vue (status transition, metadata update, ZIP download)
+
+Backend
+├── ZaakdossierService (orchestrator)
+├── InformatieobjectAccessGuard (vertrouwelijkheid enforcement)
+└── ZaakdossierController (REST endpoints)
+```
+
+## File Map
+
+### New Backend Files
+
+| File | Purpose |
+|------|---------|
+| `lib/Service/ZaakdossierService.php` | Orchestrates upload, link, status transitions, integrity hash, dossier listing |
+| `lib/Service/InformatieobjectAccessGuard.php` | Enforces vertrouwelijkheidaanduiding hierarchy on read/share/publish |
+| `lib/Service/ZipManifestBuilder.php` | Builds `manifest.csv` and informatieobjecttype-foldered ZIP via `FilePublishingHandler.createObjectFilesZip()` |
+| `lib/Controller/ZaakdossierController.php` | Authenticated REST: upload, link, status transition, bulk ops, download |
+| `lib/Migration/BackfillInformatieobjectMetadata.php` | Repair step: convert existing linked files to ZGW informatieobject metadata |
+
+### New Frontend Files
+
+| File | Purpose |
+|------|---------|
+| `src/views/cases/components/DossierTab.vue` | Case detail tab with grouped dossier and count badge |
+| `src/views/cases/components/DossierGroup.vue` | Collapsible group per informatieobjecttype with sort/filter |
+| `src/views/cases/components/DocumentRow.vue` | Row: thumbnail, status/vertrouwelijkheid badges, version history button, share/publish action |
+| `src/views/cases/components/DocumentMetadataDialog.vue` | Upload metadata dialog (type, vertrouwelijkheid, titel, beschrijving) |
+| `src/views/cases/components/VersionHistoryPanel.vue` | Side panel exposing Nextcloud versions API |
+| `src/views/cases/components/BulkActionsBar.vue` | Multi-select actions: status transition, metadata update, ZIP export |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `lib/Settings/procest_register.json` | Add `informatieobject`, `zaakinformatieobject`, `besluitinformatieobject`, `informatieobjecttype` schemas |
+| `lib/Service/SettingsService.php` | Add `dossier_*` config keys and SLUG_TO_CONFIG_KEY entries |
+| `appinfo/routes.php` | Add dossier and ZGW DRC download routes |
+| `src/views/cases/CaseDetail.vue` | Replace generic Files tab with DossierTab |
+
+## Data Model
+
+### informatieobject Schema (schema.org `DigitalDocument`)
+- `titel` (string, required) — Document title
+- `bestandsnaam` (string, required) — Filename
+- `bestandsomvang` (integer) — Size in bytes
+- `formaat` (string) — MIME type
+- `vertrouwelijkheidaanduiding` (enum, required) — `openbaar` / `beperkt_openbaar` / `intern` / `zaakvertrouwelijk` / `vertrouwelijk` / `confidentieel` / `geheim` / `zeer_geheim`
+- `auteur` (string) — Display name of author
+- `status` (enum) — `concept` / `definitief` / `gearchiveerd`
+- `informatieobjecttype` (string/reference, required) — Document type from catalog
+- `creatiedatum` (date, ISO 8601)
+- `bronorganisatie` (string) — RSIN of organization
+- `taal` (string, ISO 639-2/B, default `nld`)
+- `beschrijving` (string, optional)
+- `link` (string, optional) — External URI reference
+- `integriteit.algoritme` (string, fixed `sha256`)
+- `integriteit.waarde` (string) — SHA-256 hash
+- `vergrendeldOp` (datetime, optional) — Set when status -> definitief
+- `fileId` (integer) — Nextcloud file ID
+
+### zaakinformatieobject Schema (join)
+- `zaak` (string/reference, required) — Reference to case
+- `informatieobject` (string/reference, required) — Reference to informatieobject
+- `aardRelatieWeergave` (enum) — `Hoort bij, omgekeerd` / `Legt vast, omgekeerd`
+- `registratiedatum` (datetime)
+
+### besluitinformatieobject Schema (join)
+- `besluit` (string/reference, required) — Reference to besluit
+- `informatieobject` (string/reference, required) — Reference to informatieobject
+- `registratiedatum` (datetime)
+
+### informatieobjecttype Schema (catalog)
+- `omschrijving` (string, required) — Type name (e.g. `Advies`)
+- `informatieobjectcategorie` (string)
+- `vertrouwelijkheidaanduiding` (enum) — Default classification
+- `schema` (string) — Schema this type applies to
+- `beginGeldigheid` (date)
+- `eindeGeldigheid` (date, nullable)
+
+## API Design
+
+### Authenticated Endpoints (ZaakdossierController)
+- `GET /api/cases/{caseId}/dossier` — List informatieobjecten grouped by type
+- `POST /api/cases/{caseId}/dossier` — Upload one or many files with metadata
+- `POST /api/cases/{caseId}/dossier/{infoObjectId}/link` — Link existing informatieobject to a case
+- `DELETE /api/cases/{caseId}/dossier/{infoObjectId}/link` — Unlink (preserves informatieobject)
+- `PATCH /api/informatieobjecten/{id}` — Update metadata (titel, beschrijving, type)
+- `PATCH /api/informatieobjecten/{id}/status` — Status transition with validation
+- `POST /api/informatieobjecten/bulk/status` — Bulk status transition
+- `POST /api/cases/{caseId}/dossier/zip` — Generate ZIP with manifest (selected or full)
+- `GET /api/objects/{register}/{schema}/{objectId}/files/{fileId}/download` — Single file download (vertrouwelijkheid-gated)
+- `GET /api/zgw/documenten/v1/enkelvoudiginformatieobjecten/{uuid}/download` — ZGW DRC-compatible download (Range-supported streaming)
+
+## Security & Compliance
+
+- `InformatieobjectAccessGuard.canRead(user, informatieobject)` checks user clearance vs `vertrouwelijkheidaanduiding` (ordinal compare on enum array)
+- Status transitions validated: `concept -> definitief -> gearchiveerd`; reverse transitions return HTTP 400
+- Definitief documents reject `CreateFileHandler.saveFile()` upsert; `DeleteFileHandler` returns HTTP 409
+- SHA-256 integrity hash computed on save via `hash_file('sha256', $path)`
+- Public share rejected when `vertrouwelijkheidaanduiding >= vertrouwelijk`
+- ZGW download endpoint uses `StreamResponse` with HTTP Range support for resumable downloads
+- All operations (upload, status change, publish, delete) recorded in OpenRegister audit trail

--- a/openspec/changes/document-zaakdossier/proposal.md
+++ b/openspec/changes/document-zaakdossier/proposal.md
@@ -1,15 +1,51 @@
-## Why
+# Proposal: document-zaakdossier
 
-Document en Zaakdossier is not yet implemented in Procest. This change proposes adding this capability based on the detailed spec in `specs/document-zaakdossier/spec.md`.
+## Summary
 
+Implement the ZGW DRC-compliant case dossier (zaakdossier) inside Procest. Every zaak gets a structured document dossier backed by Nextcloud Files, where each linked file is represented as an `informatieobject` with full ZGW metadata (titel, vertrouwelijkheidaanduiding, auteur, status, informatieobjecttype, integriteit) and joined to the case via `zaakinformatieobject`. The dossier groups documents by informatieobjecttype, enforces a `concept -> definitief -> gearchiveerd` status lifecycle, supports drag-and-drop upload with metadata, full-text search, version history, bulk operations, and ZIP export with `manifest.csv`.
 
+## Motivation
 
-## What Changes
+80% of analyzed Dutch government tenders require structured case dossier management and 65% explicitly demand ZGW DRC compliance (informatieobjecten, vertrouwelijkheidaanduiding, document status lifecycle). Procest's current file handling is generic and lacks the ZGW metadata layer, status enforcement, and confidentiality-based access controls that municipalities need. This change builds the dossier layer on top of OpenRegister's existing file handlers without duplicating Nextcloud Files functionality.
 
-See `specs/document-zaakdossier/spec.md` for full requirements and scenarios.
+## Affected Projects
 
-## Impact
+- [ ] Project: `procest` — Backend dossier services, controllers, schemas, and Vue components for case dossier UI
 
-- **Code**: New frontend views and/or backend services
-- **Dependencies**: OpenRegister (data storage), Nextcloud platform APIs
-- **Testing**: Unit tests for new services, integration tests for API endpoints
+## Scope
+
+### In Scope
+
+- **ZGW schemas** — `informatieobject`, `zaakinformatieobject`, `besluitinformatieobject`, `informatieobjecttype`
+- **Status lifecycle** — `concept -> definitief -> gearchiveerd` with immutability enforcement at `definitief`
+- **Vertrouwelijkheidaanduiding** — Access control by ZGW confidentiality enum
+- **Dossier view** — Documents grouped by informatieobjecttype, count badge, filter/sort, thumbnails
+- **Drag-and-drop upload** — Metadata dialog (informatieobjecttype, vertrouwelijkheidaanduiding, titel, beschrijving)
+- **Version history** — Surface Nextcloud Files versions in dossier UI; block versions on definitief
+- **Full-text search** — Dossier-scoped search via `TextExtractionService`
+- **Bulk operations** — ZIP export with `manifest.csv`, bulk status transition, bulk metadata update
+- **Sharing / publishing** — Public share links honoring vertrouwelijkheidaanduiding rules
+- **ZGW DRC download endpoints** — Single, batch, and Range-supported streaming
+
+### Out of Scope
+
+- CMIS integration with external DMS systems
+- MDTO archival (covered by `archivering-vernietiging` spec)
+- BIM / 3D model viewing
+- OCR for scanned image documents (deferred)
+
+## Approach
+
+1. Add ZGW DRC schemas to `procest_register.json` (`informatieobject`, `zaakinformatieobject`, `besluitinformatieobject`, `informatieobjecttype`)
+2. Create `ZaakdossierService` that orchestrates OpenRegister's existing handlers (`CreateFileHandler`, `FileSharingHandler`, `FilePublishingHandler`, `TextExtractionService`)
+3. Add `ZaakdossierController` with REST endpoints for upload, status, bulk ops, and ZGW DRC-compatible download
+4. Vue: `DossierTab.vue`, `DocumentMetadataDialog.vue`, `DossierGroup.vue`, `VersionHistoryPanel.vue`
+5. Extend `SettingsService` with `dossier_*` config keys (per-register file size limit, sub-folder organization toggle)
+6. Add status-transition middleware to enforce immutability and integriteit hash on save
+
+## Risks
+
+- Vertrouwelijkheidaanduiding-based access must be enforced at API layer, not just UI
+- Status immutability must reject both `CreateFileHandler.saveFile()` upsert and direct Nextcloud writes for `definitief` files
+- ZIP export of large dossiers needs streaming to avoid memory exhaustion
+- Existing files already linked to objects must be back-filled with ZGW metadata via repair step

--- a/openspec/changes/document-zaakdossier/tasks.md
+++ b/openspec/changes/document-zaakdossier/tasks.md
@@ -1,0 +1,46 @@
+# Tasks: document-zaakdossier
+
+## Implementation Tasks
+
+### Schema & Configuration
+
+- [ ] **T01**: Add `informatieobject`, `zaakinformatieobject`, `besluitinformatieobject`, `informatieobjecttype` schemas to `lib/Settings/procest_register.json` with all ZGW DRC fields from design (titel/bestandsnaam/bestandsomvang/formaat/vertrouwelijkheidaanduiding/auteur/status/informatieobjecttype/creatiedatum/bronorganisatie/taal/beschrijving/integriteit/vergrendeldOp/fileId for informatieobject; zaak/informatieobject/aardRelatieWeergave/registratiedatum for the zaak join; besluit/informatieobject/registratiedatum for the besluit join; omschrijving/informatieobjectcategorie/vertrouwelijkheidaanduiding/schema/beginGeldigheid/eindeGeldigheid for the type catalog). Include schema.org annotations and enum constraints (status, vertrouwelijkheidaanduiding). Add config keys `dossier_informatieobject_schema`, `dossier_zaakinformatieobject_schema`, `dossier_besluitinformatieobject_schema`, `dossier_informatieobjecttype_schema`, `dossier_max_file_size`, `dossier_subfolder_per_type` to `SettingsService.php` CONFIG_KEYS and SLUG_TO_CONFIG_KEY.
+
+### Backend Services
+
+- [ ] **T02**: Create `lib/Service/ZaakdossierService.php` — Methods: `uploadDocument(caseId, file, metadata)` validates file via `FileValidationHandler`, stores via `CreateFileHandler.addFile()`, computes SHA-256 hash, creates `informatieobject` and `zaakinformatieobject` join, tags file with `object:{uuid}` and `doctype:{type}` via `TaggingHandler`, triggers async text extraction via `FileTextExtractionJob`; `linkExistingInformatieobject(caseId, infoObjectId)` creates only the join (deduplicates); `unlinkInformatieobject(caseId, infoObjectId)` deletes only the join; `transitionStatus(infoObjectId, newStatus)` validates transition and sets `vergrendeldOp` on definitief; `getDossierForCase(caseId)` returns informatieobjecten grouped by informatieobjecttype with counts; `bulkTransitionStatus(infoObjectIds, newStatus)` returns per-id success/failure list.
+
+- [ ] **T03**: Create `lib/Service/InformatieobjectAccessGuard.php` — Methods: `canRead(user, informatieobject)` compares user clearance level (from user profile / group claim) against `vertrouwelijkheidaanduiding` enum ordinal; `canPublish(informatieobject)` rejects if classification >= `vertrouwelijk`; `filterDossierForUser(user, informatieobjecten)` removes records above clearance; throws `\OCP\AppFramework\Http\Attribute\NotPermittedException` on denial. Hooked into `ZaakdossierController::download` and `FilePublishingHandler::publishFile()` via service guard.
+
+- [ ] **T04**: Create `lib/Service/ZipManifestBuilder.php` — Builds `manifest.csv` (columns: bestandsnaam, titel, informatieobjecttype, status, vertrouwelijkheidaanduiding, creatiedatum, auteur) and organizes files into informatieobjecttype sub-folders. Extends `FilePublishingHandler.createObjectFilesZip()` by streaming entries (ZipStream) so large dossiers don't load into memory. Excludes documents above caller clearance.
+
+### Controllers & Routes
+
+- [ ] **T05**: Create `lib/Controller/ZaakdossierController.php` — Authenticated controller with endpoints: `listDossier(caseId)`, `uploadDocument(caseId)`, `linkExisting(caseId, infoObjectId)`, `unlinkDocument(caseId, infoObjectId)`, `updateMetadata(infoObjectId)`, `transitionStatus(infoObjectId)`, `bulkTransitionStatus()`, `bulkUpdateMetadata()`, `downloadZip(caseId)`, `downloadFile(register, schema, objectId, fileId)`, `downloadZgwDocumenten(uuid)`. All `@NoAdminRequired`; ZGW endpoint uses `StreamResponse` with Range support. Register routes in `appinfo/routes.php` before SPA catch-all; add `/api/zgw/documenten/v1/enkelvoudiginformatieobjecten/{uuid}/download` for ZGW DRC compatibility.
+
+### Frontend Components
+
+- [ ] **T06**: Create `src/views/cases/components/DossierTab.vue`, `DossierGroup.vue`, and `DocumentRow.vue` — Tab with count badge in header, groups documents by `informatieobjecttype` in collapsible sections, each row shows thumbnail (via Nextcloud preview API `/index.php/core/preview?fileId={id}&x=64&y=64`), titel, status badge (orange/green/grey), creatiedatum, auteur, bestandsomvang, vertrouwelijkheidaanduiding badge, action menu (open in Nextcloud Files, share, publish, version history, delete-if-concept). Sort/filter controls per column. Empty state with upload CTA and drag-and-drop zone indicator.
+
+- [ ] **T07**: Create `src/views/cases/components/DocumentMetadataDialog.vue` and `VersionHistoryPanel.vue` — Metadata dialog appears on drag-drop or upload click: required `informatieobjecttype` dropdown (populated from catalog filtered by schema), required `vertrouwelijkheidaanduiding` dropdown (default from selected type), pre-filled editable `titel`, optional `beschrijving`. Supports multi-file upload with shared metadata and per-file progress. Version history panel fetches Nextcloud versions via `/dav/versions/{userId}/versions/{fileId}`, shows version number/timestamp/uploader with download and restore actions; restore disabled when status `definitief`.
+
+- [ ] **T08**: Create `src/views/cases/components/BulkActionsBar.vue` — Multi-select toolbar on dossier with actions: "Markeer als definitief" (bulk transition), "Wijzig vertrouwelijkheidaanduiding", "Download selectie als ZIP". Posts to bulk endpoints and shows per-item success/failure summary.
+
+### Integration & Migration
+
+- [ ] **T09**: Create `lib/Migration/BackfillInformatieobjectMetadata.php` — Repair step iterating existing object folders, creating `informatieobject` records with sensible defaults (status `concept`, vertrouwelijkheidaanduiding `intern`, auteur from file owner, integriteit hash computed) and `zaakinformatieobject` joins for already-linked files. Registered via `info.xml` repair-steps. Idempotent (skips files that already have an informatieobject).
+
+- [ ] **T10**: Update `src/views/cases/CaseDetail.vue` — Replace generic Files tab with `DossierTab` in `sidebarProps`. Add a `dossierCount` field to the case detail data refresh so the tab badge stays in sync. Wire BulkActionsBar visibility to a selection-state store.
+
+## Verification Tasks
+
+- [ ] **V01**: All four schemas valid JSON; `openregister:load-register` imports them and registers config keys
+- [ ] **V02**: Upload via UI creates `informatieobject` + `zaakinformatieobject`, file lands at `Open Registers/{Register Title} Register/{uuid}/`, SHA-256 hash recorded in `integriteit.waarde`
+- [ ] **V03**: Status transition from `concept` to `definitief` sets `vergrendeldOp`; new version upload to definitief returns HTTP 409
+- [ ] **V04**: Definitief reverse-transition to `concept` rejected with HTTP 400
+- [ ] **V05**: User with `intern` clearance cannot read `vertrouwelijk` document (HTTP 403) and document is filtered out of dossier listing
+- [ ] **V06**: Public share rejected for documents with vertrouwelijkheidaanduiding >= `vertrouwelijk`
+- [ ] **V07**: ZIP export contains `manifest.csv` and informatieobjecttype sub-folders; documents above clearance excluded
+- [ ] **V08**: ZGW DRC download endpoint streams large files and supports HTTP Range requests
+- [ ] **V09**: Dossier tab shows count badge, group-by-type works, drag-drop opens metadata dialog
+- [ ] **V10**: Repair step back-fills existing files with informatieobject metadata; re-run is a no-op

--- a/openspec/changes/dso-omgevingsloket/design.md
+++ b/openspec/changes/dso-omgevingsloket/design.md
@@ -1,0 +1,114 @@
+# Design: dso-omgevingsloket
+
+## Architecture Overview
+
+DSO integration is split cleanly across two apps. OpenConnector owns the DSO-LV protocol layer (mTLS / PKIoverheid, triggerbericht reception, verzoek ophalen, samenwerken, doorsturen) and writes inbound vergunningaanvragen into OpenRegister via the standard REST API. Procest sits on top of that data layer: it listens for new `vergunningaanvraag` objects, converts them into managed zaken using the `omgevingsvergunning` case type, drives the VTH lifecycle (status transitions, deadlines, beschikking), and emits status events back to OpenConnector for DSO-LV pushback. This change is the Procest side of the integration — the OpenConnector adapter is described in `openconnector/openspec/specs/dso-omgevingsloket/spec.md`.
+
+```
+DSO-LV ─── OpenConnector DSO Adapter ─── OpenRegister vergunningaanvraag
+                                                  │
+                                                  ▼ ObjectCreatedEvent
+                                          Procest DsoCaseService
+                                                  │
+                                                  ▼ create zaak
+                                          Procest zaak (case type = omgevingsvergunning)
+                                                  │
+                            ┌─────────────────────┼─────────────────────┐
+                            ▼                     ▼                     ▼
+                  VthDashboard.vue      DsoDeadlineJob       BeschikkingGenerationService
+                  DsoCaseDetail.vue     (warn 6w/2w)         (Docudesk template → bijlage)
+                            │                     │                     │
+                            └─────────────────────┴─────────────────────┘
+                                                  │
+                                                  ▼ VergunningStatusChangedEvent
+                                          OpenConnector → DSO-LV (status pushback)
+```
+
+## File Map
+
+### New Backend Files
+
+| File | Purpose |
+|------|---------|
+| `lib/Service/DsoCaseService.php` | Convert vergunningaanvraag → zaak, mirror status, calculate deadlines, coordinate forwarding |
+| `lib/Service/BeschikkingGenerationService.php` | Generate beschikking PDF via Docudesk and attach as bijlage |
+| `lib/Service/SamenwerkverzoekService.php` | Initiate / accept / reject samenwerking; coordinate with OpenConnector |
+| `lib/BackgroundJob/DsoDeadlineJob.php` | Daily TimedJob: warn at 6/2 weeks, flag overdue |
+| `lib/Event/VergunningStatusChangedEvent.php` | Typed event consumed by OpenConnector for DSO-LV pushback |
+| `lib/Listener/VergunningaanvraagCreatedListener.php` | Listens for OpenRegister `ObjectCreatedEvent` on vergunningaanvraag schema |
+| `lib/Controller/DsoController.php` | REST endpoints for VTH dashboard, samenwerking, doorstuur, beschikking trigger |
+
+### New Frontend Files
+
+| File | Purpose |
+|------|---------|
+| `src/views/dso/VthDashboard.vue` | Filterable list of all omgevingsvergunningen (activiteitgroep, regelkwalificatie, status, locatie) |
+| `src/views/dso/DsoCaseDetail.vue` | VTH case detail with DSO data (activiteiten, locatie, initiatiefnemer, bijlagen) and lifecycle actions |
+| `src/views/dso/SamenwerkverzoekDialog.vue` | Initiate samenwerkverzoek with bevoegd gezag selector and rationale |
+| `src/views/dso/DoorstuurDialog.vue` | Forward verzoek to another bevoegd gezag with reason |
+| `src/views/dso/BeschikkingDialog.vue` | Choose template (verleend/geweigerd) and motivation before generation |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `lib/Settings/procest_register.json` | Seed `omgevingsvergunning` case type (statuses, reguliere/uitgebreide variants, default templates) |
+| `lib/Service/SettingsService.php` | Add `dso_case_type`, `dso_deadline_warning_weeks`, `dso_beschikking_template_verleend`, `dso_beschikking_template_geweigerd` config keys |
+| `appinfo/routes.php` | Add `/api/dso/` routes for dashboard, samenwerking, doorstuur, beschikking |
+| `appinfo/info.xml` | Register listener and background job |
+
+## Data Model
+
+The structured DSO objects (`vergunningaanvraag`, `activiteit`, `locatie`, `omgevingsdocument`) live in OpenRegister and are defined in the DSO register spec. Procest adds a thin link layer:
+
+### Procest zaak extension fields (on existing case schema)
+- `vergunningaanvraagRef` (string, reference) — Reference to the `vergunningaanvraag` object
+- `procedureType` (enum) — `reguliere` (8 wk) / `uitgebreide` (26 wk)
+- `deadlineDatum` (date) — Computed from `indieningsdatum` + procedure length in working days
+- `bevoegdGezag` (string) — OIN or organization name
+- `samenwerkverzoeken` (array of references) — Samenwerkverzoek objects linked to this zaak
+
+### samenwerkverzoek Schema (new in procest register)
+- `initiatorBevoegdGezag` (string, required) — Initiating organization
+- `aangezochtBevoegdGezag` (string, required) — Receiving organization
+- `vergunningaanvraagRef` (string/reference, required) — Linked vergunningaanvraag
+- `rationale` (string) — Reason for samenwerking
+- `status` (enum) — `aangevraagd` / `geaccepteerd` / `geweigerd` / `afgerond`
+- `advies` (string, optional) — Advice given by aangezochte bevoegd gezag
+- `aangevraagdOp` / `gereageerdOp` (datetime)
+
+## API Design
+
+### Authenticated Endpoints (DsoController)
+- `GET /api/dso/dashboard` — VTH dashboard data with filters (activiteitgroep, regelkwalificatie, status, locatie, gemeenteCode)
+- `POST /api/dso/cases/{caseId}/transition` — Status transition with optional `besluitdatum` and `toelichting`
+- `POST /api/dso/cases/{caseId}/beschikking` — Trigger beschikking generation (template + motivation)
+- `POST /api/dso/cases/{caseId}/samenwerking` — Initiate samenwerkverzoek
+- `PUT /api/dso/samenwerking/{id}` — Accept/reject samenwerkverzoek (with advice)
+- `POST /api/dso/cases/{caseId}/doorstuur` — Forward to another bevoegd gezag
+
+## Event Contracts
+
+### VergunningStatusChangedEvent (dispatched by Procest, consumed by OpenConnector)
+- `vergunningaanvraagRef` — Object reference
+- `oldStatus` / `newStatus` — From DSO status enum
+- `besluitdatum` (optional) — When `verleend` / `geweigerd`
+- `toelichting` (optional) — Decision motivation
+- `userId` — Initiating user (for audit)
+
+## Deadline Calculation
+
+- Reguliere procedure: 8 weeks (40 working days) from `indieningsdatum`
+- Uitgebreide procedure: 26 weeks (130 working days) from `indieningsdatum`
+- Working days exclude weekends and Dutch national holidays (computed via `nl-holidays` table or `IDateTimeZone`)
+- Warning at 6 weeks remaining (reguliere) / 4 weeks remaining (uitgebreide)
+- Critical warning at 2 weeks remaining
+- Overdue flag when `deadlineDatum < today`
+
+## Integration Boundary
+
+- OpenConnector writes vergunningaanvragen into OpenRegister via REST API; no direct DB
+- Procest listens to `ObjectCreatedEvent` for the `vergunningaanvraag` schema and creates zaak through its own service
+- Procest writes status changes to both the OpenRegister vergunningaanvraag and the Procest zaak (single transaction via `DsoCaseService.transitionStatus`)
+- OpenConnector listens to `VergunningStatusChangedEvent` and pushes to DSO-LV (no direct write back to Procest)
+- All cross-app coordination is event-driven; no synchronous calls between apps

--- a/openspec/changes/dso-omgevingsloket/proposal.md
+++ b/openspec/changes/dso-omgevingsloket/proposal.md
@@ -1,15 +1,51 @@
-## Why
+# Proposal: dso-omgevingsloket
 
-DSO Omgevingsloket Integration is not yet implemented in Procest. This change proposes adding this capability based on the detailed spec in `specs/dso-omgevingsloket/spec.md`.
+## Summary
 
+Integrate Procest with the DSO (Digitaal Stelsel Omgevingswet) Omgevingsloket so that municipalities can receive vergunningaanvragen from the national one-stop portal, manage the VTH (Vergunningen, Toezicht, Handhaving) case lifecycle, and push status updates and decisions back to DSO-LV. The change adds Procest-side case management on top of the DSO data layer (`vergunningaanvraag`, `activiteit`, `locatie`, `omgevingsdocument`) already specified in OpenRegister: zaak conversion of inbound verzoeken, deadline tracking against the 8-week reguliere procedure, beschikking generation, samenwerkverzoek and doorstuur handling, and status pushback through OpenConnector's DSO adapter.
 
+## Motivation
 
-## What Changes
+The Omgevingswet (effective January 2024) replaced 26 laws and obliges every Dutch bevoegd gezag to handle environmental permit applications through DSO-LV. 32% of analyzed tenders explicitly require DSO/VTH capabilities; municipalities (Zoetermeer 282155, Westerkwartier 264852) specify detailed VTH010-VTH019 requirements for triggerbericht reception, verzoek ophalen, samenwerkfunctionaliteit, doorstuur, beschikking, and status pushback. Procest needs to convert DSO verzoeken into managed zaken, enforce reguliere/uitgebreide procedure deadlines, and synchronize the resulting decisions back to DSO-LV.
 
-See `specs/dso-omgevingsloket/spec.md` for full requirements and scenarios.
+## Affected Projects
 
-## Impact
+- [ ] Project: `procest` — VTH case-type wiring, deadline service, beschikking generation, status pushback wiring, Vue components
+- [ ] Project: `openconnector` (out-of-repo) — DSO-LV adapter handles triggerbericht / verzoek ophalen / samenwerken / doorsturen (existing spec)
 
-- **Code**: New frontend views and/or backend services
-- **Dependencies**: OpenRegister (data storage), Nextcloud platform APIs
-- **Testing**: Unit tests for new services, integration tests for API endpoints
+## Scope
+
+### In Scope
+
+- **Verzoek-to-zaak conversion** — Convert inbound `vergunningaanvraag` objects into Procest zaken with the `omgevingsvergunning` case type
+- **VTH case type** — Define `omgevingsvergunning` zaaktype with statuses (`ingediend` → `in_behandeling` → `verleend`/`geweigerd`/`ingetrokken`) and reguliere (8 wk) / uitgebreide (26 wk) procedure variants
+- **Deadline tracking** — Background job warning at 6/2 weeks remaining; auto-flag overdue cases
+- **Beschikking generation** — Trigger Docudesk template generation on `verleend` / `geweigerd`, attach as bijlage on the vergunningaanvraag
+- **Status pushback** — Dispatch typed event on status change so OpenConnector pushes update to DSO-LV
+- **Samenwerkverzoek & doorstuur** — Procest UI to initiate, accept, reject samenwerking and to forward to another bevoegd gezag
+- **VTH dashboard** — Procest view of all omgevingsvergunningen with filters on activiteitgroep / regelkwalificatie / status / locatie
+- **Notifications** — New verzoek arrival, approaching-deadline warning, samenwerkverzoek received
+
+### Out of Scope
+
+- DSO-LV protocol implementation (mTLS, PKIoverheid, koppelvlak handlers) — owned by OpenConnector
+- STTR vergunningcheck rule execution — out of scope (referenced for context)
+- 3D / BIM viewer for bouwtekeningen
+- Bezwaar-beroep workflow (covered by `bezwaar-beroep-workflow` spec)
+
+## Approach
+
+1. Add `omgevingsvergunning` case type to seed data with reguliere/uitgebreide variants and the status enum from the spec
+2. Create `DsoCaseService` that converts inbound `vergunningaanvraag` to a Procest zaak, mirrors status, and computes deadlines
+3. Add `DsoDeadlineJob` `TimedJob` (daily) for deadline warnings and overdue flagging
+4. Create `BeschikkingGenerationService` orchestrating Docudesk template + attachment as `bijlage`
+5. Dispatch typed events (`VergunningStatusChangedEvent`) for OpenConnector to listen to
+6. Vue: `DsoCaseDetail.vue`, `SamenwerkverzoekDialog.vue`, `DoorstuurDialog.vue`, `VthDashboard.vue`
+7. Extend `SettingsService` with `dso_*` config keys (case type, deadline thresholds, beschikking templates)
+
+## Risks
+
+- Status drift between OpenRegister `vergunningaanvraag` and Procest zaak must be reconciled by a single owner (Procest writes both via service)
+- Deadline calculation must use working days per Omgevingswet rules (excluding national holidays)
+- Samenwerkverzoek coordination involves multiple bevoegd gezag — Procest must not race OpenConnector on status writes
+- Beschikking templates differ per municipality; Docudesk template selection by case type and decision outcome

--- a/openspec/changes/dso-omgevingsloket/tasks.md
+++ b/openspec/changes/dso-omgevingsloket/tasks.md
@@ -1,0 +1,42 @@
+# Tasks: dso-omgevingsloket
+
+## Implementation Tasks
+
+### Schema & Configuration
+
+- [ ] **T01**: Seed an `omgevingsvergunning` case type in `lib/Settings/procest_register.json` with statuses `ingediend`, `in_behandeling`, `verleend`, `geweigerd`, `ingetrokken`, and procedure variants (reguliere = 8 weeks, uitgebreide = 26 weeks). Add a new `samenwerkverzoek` schema (initiatorBevoegdGezag, aangezochtBevoegdGezag, vergunningaanvraagRef, rationale, status enum, advies, aangevraagdOp, gereageerdOp). Add zaak extension fields (`vergunningaanvraagRef`, `procedureType`, `deadlineDatum`, `bevoegdGezag`, `samenwerkverzoeken`) on the case schema. Add config keys `dso_case_type`, `dso_deadline_warning_weeks_warning`, `dso_deadline_warning_weeks_critical`, `dso_beschikking_template_verleend`, `dso_beschikking_template_geweigerd`, `dso_samenwerkverzoek_schema` to `SettingsService.php` CONFIG_KEYS and SLUG_TO_CONFIG_KEY arrays.
+
+### Backend Services
+
+- [ ] **T02**: Create `lib/Service/DsoCaseService.php` — Methods: `createZaakFromVergunningaanvraag(vergunningaanvraagId)` looks up the object, determines `procedureType` from `activiteiten` (default reguliere; uitgebreide when any activiteit flagged), computes `deadlineDatum` using working-day calculator, creates a Procest zaak via `ObjectService`, stores `vergunningaanvraagRef` on the zaak; `transitionStatus(zaakId, newStatus, besluitdatum, toelichting, userId)` updates both the Procest zaak and the OpenRegister vergunningaanvraag in a single service call, appends activity entry, dispatches `VergunningStatusChangedEvent`; `computeDeadline(indieningsdatum, procedureType)` returns target date excluding weekends and Dutch national holidays.
+
+- [ ] **T03**: Create `lib/Service/BeschikkingGenerationService.php` and `lib/Service/SamenwerkverzoekService.php` — Beschikking service: `generateBeschikking(zaakId, outcome, motivation)` picks template from `dso_beschikking_template_verleend|geweigerd` config, calls Docudesk to render PDF, attaches as `bijlage` with `type: beschikking` on the vergunningaanvraag, stores PDF in case folder, sends notification to behandelaar. Samenwerk service: `initiateSamenwerking(zaakId, aangezochtBevoegdGezag, rationale)` creates `samenwerkverzoek` object and dispatches an `SamenwerkverzoekInitiatedEvent` for OpenConnector to forward; `respondToSamenwerking(samenwerkId, accept, advies)` updates status and dispatches response event.
+
+- [ ] **T04**: Create `lib/Event/VergunningStatusChangedEvent.php` and `lib/Listener/VergunningaanvraagCreatedListener.php` — Typed event carries `vergunningaanvraagRef`, `oldStatus`, `newStatus`, optional `besluitdatum` and `toelichting`, `userId`. Register listener for OpenRegister's `ObjectCreatedEvent` filtered to the vergunningaanvraag schema id (read from `IAppConfig`); on event, calls `DsoCaseService.createZaakFromVergunningaanvraag()`. Register listener and event subscriber in `Application::register()`.
+
+### Background Jobs
+
+- [ ] **T05**: Create `lib/BackgroundJob/DsoDeadlineJob.php` — `TimedJob` (daily). Queries all open omgevingsvergunning zaken (status `ingediend` or `in_behandeling`), computes remaining working days to `deadlineDatum`. Sends warning notification at the configured warning threshold (default 14 working days), critical notification at the critical threshold (default 5 working days), and an overdue flag/notification when past deadline. Uses `INotificationManager`. Catches exceptions per task to avoid full-job failure.
+
+### Controllers & Routes
+
+- [ ] **T06**: Create `lib/Controller/DsoController.php` and register routes — Authenticated controller with endpoints: `dashboard()` returns filterable VTH list (filters: activiteitgroep, regelkwalificatie, status, locatie, gemeenteCode, procedureType, deadlineRange); `transitionStatus(caseId)` -> `DsoCaseService.transitionStatus()`; `generateBeschikking(caseId)` -> beschikking service; `initiateSamenwerking(caseId)`; `respondSamenwerking(samenwerkId)`; `doorsturen(caseId)` dispatches `VergunningDoorgestuurdEvent` for OpenConnector. All `@NoAdminRequired`. Register routes in `appinfo/routes.php` under `/api/dso/` before SPA catch-all.
+
+### Frontend Components
+
+- [ ] **T07**: Create `src/views/dso/VthDashboard.vue` and `src/views/dso/DsoCaseDetail.vue` — Dashboard renders an omgevingsvergunningen list with multi-select filters (activiteitgroep, regelkwalificatie, status, gemeenteCode, procedureType), deadline column with colored indicator (green / yellow / red / overdue), bulk actions (open in detail, export CSV). Detail view shows DSO data sections (Aanvraag, Activiteiten, Locatie, Initiatiefnemer, Bijlagen, Samenwerkverzoeken) sourced from the linked vergunningaanvraag, plus the Procest activity timeline and the case lifecycle action bar (status transition, generate beschikking, initiate samenwerking, forward).
+
+- [ ] **T08**: Create `src/views/dso/SamenwerkverzoekDialog.vue`, `src/views/dso/DoorstuurDialog.vue`, and `src/views/dso/BeschikkingDialog.vue` — Samenwerk dialog: bevoegd-gezag selector (autocomplete from gemeenten/waterschappen/provincies list), rationale textarea, submit calls `/api/dso/cases/{caseId}/samenwerking`. Doorstuur dialog: target bevoegd-gezag selector + reden field; posts to `/api/dso/cases/{caseId}/doorstuur`. Beschikking dialog: outcome selector (verleend/geweigerd), Docudesk template preview, motivation editor (pre-filled per outcome), confirm; posts to `/api/dso/cases/{caseId}/beschikking`.
+
+## Verification Tasks
+
+- [ ] **V01**: New `samenwerkverzoek` schema and zaak extension fields valid JSON; config keys populated after install
+- [ ] **V02**: When OpenConnector writes a new vergunningaanvraag, listener creates a Procest zaak with correct `procedureType` and `deadlineDatum`
+- [ ] **V03**: Status transition on Procest zaak writes both Procest zaak and OpenRegister vergunningaanvraag in one service call
+- [ ] **V04**: `VergunningStatusChangedEvent` is dispatched and observable by a test listener
+- [ ] **V05**: Deadline job sends warning at warning threshold and critical at critical threshold; overdue cases get an overdue flag
+- [ ] **V06**: Working-day calculator excludes weekends and Dutch national holidays
+- [ ] **V07**: Beschikking generation produces a PDF, attaches as `bijlage` with `type: beschikking`, sends notification
+- [ ] **V08**: Samenwerkverzoek can be initiated, accepted with advies, and rejected with rationale; status enum transitions enforced
+- [ ] **V09**: Doorstuur dispatches event; OpenConnector test double receives it with reden
+- [ ] **V10**: VTH dashboard filters by activiteitgroep, regelkwalificatie, status, locatie and shows deadline colour indicator


### PR DESCRIPTION
## Summary

Fill in proposal / design / tasks for three Procest OpenSpec changes that previously existed as proposal-only shells. Specs were already complete, so this PR only adds the missing artifacts — no code is touched.

## Per-change result

### case-email-integration (12 REQ in spec)
- proposal.md (~250 w) — inbound/outbound email on a case with templates, threading, Nextcloud Mail or standalone SMTP/IMAP, Docudesk PDF archival
- design.md — CaseEmailService, EmailTemplateService, InboundEmailJob + EmailPdfRetryJob, EmailComposer.vue, EmailThread.vue, EmailTab.vue, EmailTemplateAdmin.vue, UnlinkedQueue.vue, EmailSettings.vue; new emailTemplate / emailMessage / emailThread schemas
- tasks.md — 12 tasks (T01-T12) + 10 verification items (V01-V10)

### document-zaakdossier (16 REQ in spec)
- proposal.md (~250 w) — ZGW DRC-compliant case dossier on top of OpenRegister file handlers
- design.md — ZaakdossierService, InformatieobjectAccessGuard, ZipManifestBuilder, ZaakdossierController, DossierTab.vue + group/row, DocumentMetadataDialog.vue, VersionHistoryPanel.vue, BulkActionsBar.vue; new informatieobject / zaakinformatieobject / besluitinformatieobject / informatieobjecttype schemas; backfill repair step
- tasks.md — 10 tasks (T01-T10) + 10 verification items (V01-V10)

### dso-omgevingsloket (15 REQ in spec)
- proposal.md (~290 w) — Procest-side DSO Omgevingsloket integration: verzoek-to-zaak conversion, VTH lifecycle, deadlines, beschikking, samenwerken, doorsturen, status pushback via typed event
- design.md — DsoCaseService, BeschikkingGenerationService, SamenwerkverzoekService, DsoDeadlineJob, VergunningStatusChangedEvent, VergunningaanvraagCreatedListener, DsoController; VthDashboard.vue + DsoCaseDetail.vue + dialogs; new samenwerkverzoek schema and omgevingsvergunning case type seed
- tasks.md — 8 tasks (T01-T08) + 10 verification items (V01-V10)

## Notes

- Spec-only PR. Composer check:strict skipped per watchdog rules.
- Specs were already detailed (12, 16, 15 requirements respectively, all with Given/When/Then) — only proposals and missing design/tasks artifacts added.

## Test plan

- [ ] OpenSpec validation passes for all three changes
- [ ] Proposals readable and within 150-300 word target
- [ ] Tasks reference real OpenRegister handlers and Nextcloud APIs