### PR TITLE
chore(openspec): generate voorstel-management spec

### DIFF
--- a/openspec/changes/voorstel-management/design.md
+++ b/openspec/changes/voorstel-management/design.md
@@ -1,0 +1,62 @@
+# Design: voorstel-management
+
+## Context
+
+Voorstellen are the central unit of work in Procest's parafering domain. Every collegeadvies, raadsvoorstel and DT-advies that goes through a Dutch municipality's B&W (College van Burgemeester en Wethouders) signing route is, in our model, one `voorstel` record bound to one parent `case`. The capability was implemented incrementally across two changes — `parafeerroute-engine` (routes, snapshotting, step advancement) and `parafering-actions` (actor decisions, delegation, e-signature) — but never received its own capability spec. This change formalizes what already exists.
+
+## Entity: `voorstel`
+
+Defined in `lib/Settings/procest_register.json` as a Schema.org `CreativeWork`. Required properties: `case`, `type`, `onderwerp`, `steller`, `status`. Selected non-required properties drive the workflow:
+
+| Property | Type | Role |
+|----------|------|------|
+| `case` | UUID (`$ref: case`, `onDelete: CASCADE`) | Parent case |
+| `type` | enum: `dt_advies`, `collegeadvies`, `raadsvoorstel` | Determines default parafeerroute |
+| `onderwerp` | string ≤ 255 | Subject; typically inherited from case title |
+| `steller` | string (NC UID) | Creator |
+| `afdeling` | string | Department of the steller |
+| `portefeuillehouder` | string (NC UID) | Wethouder (portfolio holder) |
+| `status` | enum, 8 values | Lifecycle state (see below) |
+| `parafeerroute` | UUID | Linked parafeerroute |
+| `routeSnapshot` | JSON-encoded array (hidden) | Frozen steps captured at submission |
+| `currentStep` | integer ≥ 0 | 1-based active step, 0 = not yet submitted |
+| `returnedFromStep` | integer (hidden) | Resume marker after teruggestuurd |
+| `document` | string (NC file ID) | Primary voorstel document |
+| `bijlagen` | array<string> | Additional NC file IDs |
+| `behandeling` | enum: `hamerstuk`, `bespreekstuk` | Bestuurlijk treatment hint |
+
+## Lifecycle (status state machine)
+
+```
+concept ──(submit, requires document+route)──► in_parafering
+in_parafering ──(non-final step complete)──► in_parafering (currentStep++)
+in_parafering ──(actor "terugsturen", reason required)──► teruggestuurd
+teruggestuurd ──(steller resubmits)──► in_parafering (resume at returnedFromStep)
+in_parafering ──(final accordering step complete)──► geaccordeerd
+geaccordeerd ──(secretariaat plaatst op agenda)──► aangeboden
+aangeboden ──(RIS records besluit)──► besloten
+besloten ──(retention period reached)──► gearchiveerd
+```
+
+`STATUS_IN_PARAFERING`, `STATUS_GEACCORDEERD`, `STATUS_TERUGGESTUURD`, and `STATUS_TER_ACCORDERING` are surfaced as PHP constants on `ParafeerRouteService` / `ParafeerActieService` — the spec MUST stay aligned with those.
+
+## Relationship map
+
+- **voorstel ↔ case** — `voorstel.case` is required; deleting a case cascades; a case can hold many voorstellen
+- **voorstel ↔ parafeerroute** — at submission, the route's `steps[]` is JSON-frozen onto `voorstel.routeSnapshot` so later route edits do not retroactively change in-flight voorstellen
+- **voorstel ↔ parafeeractie** — each actor decision (advised / parafered / accorded / returned / skipped) is a separate immutable `parafeeractie` referencing the voorstel; advances are driven by `ParafeerRouteService::completeStep()`
+- **voorstel ↔ document / bijlagen** — Nextcloud file IDs; the primary document is the surface for the e-signature annotation when accordering completes
+- **voorstel ↔ besluit (external)** — once `besloten`, the RIS-derived besluit ID is linked back through the `besluitvorming-workflow` capability (out of scope here)
+
+## Security & audit considerations
+
+- **Identity is server-derived**: every status-changing operation derives the user from `IUserSession`; frontend-supplied UIDs are ignored. Re-using the rule already enforced by `ParafeerActieService::recordAction`.
+- **Per-step authorization**: only the actor of `routeSnapshot[currentStep]` (or a valid delegate) may advance the voorstel. Returns are also limited to the current step's actor.
+- **Steller-only edits**: while `status = concept` or `status = teruggestuurd`, only the steller may edit `onderwerp`, `document`, `bijlagen`; once `in_parafering`, voorstel content is locked except for status transitions and route overrides.
+- **Override audit**: route skip / ad-hoc step additions append to `voorstel.auditTrail` (see `ParafeerRouteService::appendAuditTrail`); OpenRegister's automatic per-save audit log captures every change irrespective of caller.
+- **Read scope**: voorstel detail readable by anyone with access to the parent case; this includes the steller, all assigned actors (past and current), and case-shared participants per `case-sharing-collaboration`.
+- **Archiefwet compliance**: `parafeeractie` records and OpenRegister's append-only audit trail together satisfy the legal accountability requirements for municipal proposals.
+
+## Why a GENERATE-style change?
+
+The implementation predates the spec. Rather than retrofitting tasks that "create code that already works", this change records the contract that the existing code already honors. Tasks are scoped to **verification**: schema match, lifecycle match, route coverage, UI presence. If verification reveals a gap, that gap becomes a follow-up change (filed as an issue per the "always file issues for deferred work" rule).

--- a/openspec/changes/voorstel-management/proposal.md
+++ b/openspec/changes/voorstel-management/proposal.md
@@ -1,0 +1,64 @@
+# Proposal: Voorstel Management
+
+## Summary
+
+Formalize the `voorstel-management` capability as a first-class OpenSpec change so that the existing implementation (delivered via PRs #331 / #332 — `parafeerroute-engine` and `parafering-actions`) has explicit, validatable specification coverage. Voorstellen (council/B&W proposals) are the central unit of work in Procest's parafering domain — every collegeadvies, raadsvoorstel and DT-advies flows through a voorstel lifecycle — yet the capability currently lives only implicitly across two adjacent change specs. This change introduces an explicit `voorstel-management` capability spec that documents the voorstel entity, its lifecycle, and the operations that act on it, with the live code as the reference implementation.
+
+## Why
+
+Voorstellen are central to Procest — every parafering route, every council decision, every B&W signing flow is anchored to a voorstel record. The implementation already exists and is exercised in production via PRs #331 and #332, but it has never been described in a single canonical capability spec. New work (besluitvorming-workflow, document-zaakdossier, archive integration) needs a stable spec to reference; reviewers need an explicit lifecycle diagram and a property contract to validate against; tender responses need a traceable spec ID. Formalizing the capability now — before more changes layer on top — keeps the OpenSpec coverage honest and makes follow-up changes easy to scope.
+
+## Problem
+
+The `voorstel` schema, status machine, and CRUD/lifecycle operations are present in production code (`procest_register.json`, `ParafeerRouteService`, `ParafeerActieService`, `appinfo/routes.php`) and partially described in adjacent change specs (`parafeerroute-engine`, `parafering-actions`, `bw-parafering`). However:
+
+- No single capability spec describes the voorstel entity, its required properties, or its 8-state lifecycle as the canonical contract
+- The `openspec/specs/voorstel-management/spec.md` file already exists but was committed without a corresponding change record, so traceability between spec and implementation is broken
+- Newer changes that touch voorstellen (besluitvorming-workflow, bw-parafering, document-zaakdossier) cannot cleanly reference the capability because it has no formal change history
+
+## What Changes
+
+- Adds the `voorstel-management` capability spec under this change's `specs/` directory (delta-format `## ADDED Requirements`, eight REQ-VM-* requirements with Given/When/Then scenarios)
+- Adds a one-page lifecycle diagram + property contract to `design.md` for review and future onboarding
+- Adds verification-only tasks (T01–T09) covering schema, lifecycle, route binding, multi-voorstel-per-case, and `openspec validate --strict` gate
+- Does NOT introduce any code changes — implementation is already live via PRs #331 (parafeerroute-engine) and #332 (parafering-actions)
+- On archive, the spec under `specs/voorstel-management/` replaces the unowned spec currently at `openspec/specs/voorstel-management/spec.md`
+
+## Affected Projects
+
+- [ ] Project: `procest` — Formalize the existing `voorstel-management` capability as an OpenSpec change with proposal, design, tasks, and a delta-format spec. NO CODE changes: implementation already exists.
+
+## Scope
+
+### In Scope (V1, verification only)
+
+- **Voorstel entity formalization** (REQ-VM-1): canonical property list, schema reference, required fields
+- **Voorstel lifecycle** (REQ-VM-2): the eight statuses (`concept`, `in_parafering`, `ter_accordering`, `geaccordeerd`, `aangeboden`, `besloten`, `gearchiveerd`, `teruggestuurd`) and allowed transitions
+- **Create voorstel from case** (REQ-VM-3): voorstel inherits case context (onderwerp, afdeling, portefeuillehouder)
+- **Voorstel-parafeerroute binding** (REQ-VM-4): selection of route by `voorstelType`, snapshot at submission
+- **Voorstel detail view** (REQ-VM-5): metadata header, document preview, parafering progress, action history
+- **Multiple voorstellen per case** (REQ-VM-6): independent status per voorstel on the same case
+- **Voorstel audit & immutability** (REQ-VM-7): OpenRegister audit trail, no destructive edits after submission
+- **Voorstel security & authorization** (REQ-VM-8): steller / actor / case-participant access boundaries
+
+### Out of Scope
+
+- Bestuurlijk (College B&W) treatment — handled by external RIS (iBabs/NotuBiz) per `bw-parafering` spec
+- Besluit creation — separate `besluitvorming-workflow` change
+- Parallel parafering steps — V2, tracked in `parafeerroute-engine` V2 backlog
+- Voorstel templates / boilerplate — separate `template-library` change
+
+## Approach
+
+This is a **GENERATE-style** change: the implementation already exists and is the reference. The change captures it in OpenSpec form so the capability becomes traceable, testable, and referenceable.
+
+1. **Proposal + design + tasks** — author this change directory describing what is being formalized and how to verify it
+2. **Delta spec** — replace the unowned `openspec/specs/voorstel-management/spec.md` with a delta-format `## ADDED Requirements` spec under this change's `specs/voorstel-management/spec.md`; on archive it will merge back as the canonical capability spec
+3. **Verification tasks** — confirm schema, lifecycle, routes, and UI components match the spec; no source-code modifications are introduced by this change
+
+## Cross-Project Dependencies
+
+- **parafeerroute-engine** (already merged): provides the parafeerroute schema and routing engine that voorstellen depend on
+- **parafering-actions** (already merged): provides the actor-facing action recording on top of voorstellen
+- **OpenRegister**: object storage and audit trail for voorstel entities
+- **bw-parafering** (archived): historical context for the broader 10-step ambtelijk + bestuurlijk flow

--- a/openspec/changes/voorstel-management/specs/voorstel-management/spec.md
+++ b/openspec/changes/voorstel-management/specs/voorstel-management/spec.md
@@ -1,0 +1,179 @@
+## ADDED Requirements
+
+### Requirement: Voorstel Entity and Schema Registration
+
+The system SHALL register a `voorstel` schema in the Procest OpenRegister configuration. The schema SHALL declare the properties `case`, `type`, `onderwerp`, `steller`, `afdeling`, `portefeuillehouder`, `status`, `parafeerroute`, `routeSnapshot`, `currentStep`, `returnedFromStep`, `document`, `bijlagen`, and `behandeling`. The required-property list SHALL be exactly `[case, type, onderwerp, steller, status]`. The `type` enum SHALL be exactly `[dt_advies, collegeadvies, raadsvoorstel]`. The Schema.org type SHALL be `schema:CreativeWork`. A voorstel is the central unit of work for B&W parafering and SHALL be the only entity that owns a parafering lifecycle.
+
+**Feature tier**: V1
+**Schema.org type**: `schema:CreativeWork`
+**ZGW mapping**: bridges to `Besluit` only after the bestuurlijk phase completes; voorstellen themselves have no direct ZGW equivalent.
+
+#### Scenario: Schema is registered after app install
+
+- **WHEN** the Procest app is installed or updated via the repair step
+- **THEN** the `voorstel` schema SHALL exist in the Procest register
+- **AND** the schema SHALL enforce the required properties `case`, `type`, `onderwerp`, `steller`, `status`
+- **AND** the `type` enum SHALL be exactly `[dt_advies, collegeadvies, raadsvoorstel]`
+
+#### Scenario: Voorstel rejects unknown type
+
+- **GIVEN** the steller posts a new voorstel with `type = "bestemmingsplan"` (not in the enum)
+- **WHEN** the create request is validated
+- **THEN** OpenRegister SHALL reject the object with a schema validation error
+- **AND** no voorstel SHALL be persisted
+
+### Requirement: Voorstel Status Lifecycle
+
+The system SHALL maintain a voorstel through an eight-state lifecycle: `concept`, `in_parafering`, `ter_accordering`, `geaccordeerd`, `aangeboden`, `besloten`, `gearchiveerd`, and `teruggestuurd`. The default status on creation SHALL be `concept`. Transitions SHALL be driven exclusively by the parafering services (`ParafeerRouteService`, `ParafeerActieService`) and SHALL never be applied via raw schema writes from the frontend.
+
+**Feature tier**: V1
+
+#### Scenario: Submit voorstel for parafering
+
+- **GIVEN** a voorstel with `status = concept`, a non-empty `document`, and a `parafeerroute` reference
+- **WHEN** the steller calls `POST /api/parafeer-route/voorstel/{voorstelId}/start`
+- **THEN** `status` SHALL transition to `in_parafering`
+- **AND** `currentStep` SHALL be set to `1`
+- **AND** `routeSnapshot` SHALL contain the parafeerroute's `steps[]` array as a JSON-encoded string
+
+#### Scenario: Voorstel returned to steller
+
+- **GIVEN** a voorstel with `status = in_parafering` at step 2
+- **WHEN** the current step actor records `action = returned` with a non-empty reason
+- **THEN** `status` SHALL transition to `teruggestuurd`
+- **AND** `returnedFromStep` SHALL be set to 2
+- **AND** `currentStep` SHALL remain at 2 (no routing advance)
+- **AND** the steller SHALL receive a Nextcloud notification carrying the return reason
+
+#### Scenario: Voorstel reaches final endorsement
+
+- **GIVEN** a voorstel with `status = in_parafering` whose `currentStep` is the final step of `routeSnapshot` and the step type is `accordering`
+- **WHEN** the final actor records `action = accorded`
+- **THEN** `status` SHALL transition to `geaccordeerd`
+- **AND** no further parafering steps SHALL be activated
+
+### Requirement: Create Voorstel from Case
+
+The system SHALL support creating a voorstel from within a case context. The voorstel SHALL be linked to the parent case via `case` and SHALL pre-fill `onderwerp`, `afdeling`, and `portefeuillehouder` from the case context when available. `steller` SHALL be set to the authenticated user's UID derived from `IUserSession` — never from request body input.
+
+**Feature tier**: V1
+
+#### Scenario: Create collegeadvies voorstel from case detail
+
+- **GIVEN** a case "Bestemmingsplan Centrum" with an `afdeling` and `portefeuillehouder` configured on its case type
+- **WHEN** the steller posts to `POST /api/parafering/voorstellen` with `case = <caseId>` and `type = collegeadvies`
+- **THEN** the system SHALL create a voorstel with `status = concept`
+- **AND** `onderwerp` SHALL default to the case title when no explicit onderwerp is supplied
+- **AND** `steller` SHALL equal the authenticated user's UID
+- **AND** `afdeling` and `portefeuillehouder` SHALL be inherited from the case type configuration
+
+#### Scenario: Steller cannot impersonate another user
+
+- **GIVEN** user K. Vermeulen is authenticated
+- **WHEN** the request body sets `steller = "p.janssen"` (a different UID)
+- **THEN** the saved voorstel SHALL still record `steller = "k.vermeulen"` (the session UID)
+- **AND** the request SHALL NOT be rejected for that field — the value SHALL simply be ignored
+
+### Requirement: Voorstel ↔ Parafeerroute Binding with Snapshot
+
+The system SHALL allow exactly one `parafeerroute` reference per voorstel. At submission time the route's ordered `steps[]` SHALL be copied into `voorstel.routeSnapshot` as a JSON-encoded array. The snapshot SHALL be the single source of truth for subsequent step advancement, so that later edits to the source parafeerroute do NOT retroactively change in-flight voorstellen.
+
+**Feature tier**: V1
+
+#### Scenario: Snapshot is frozen at submission
+
+- **GIVEN** a voorstel of `type = dt_advies` linked to parafeerroute R1 which has three steps
+- **WHEN** the steller submits the voorstel for parafering
+- **THEN** `routeSnapshot` SHALL be a JSON-encoded array of three step objects matching R1 at that moment
+- **AND** if the administrator subsequently adds a fourth step to R1, the voorstel's `routeSnapshot` SHALL remain three entries
+
+#### Scenario: Cannot delete an in-use parafeerroute
+
+- **GIVEN** at least one voorstel with `status = in_parafering` referencing parafeerroute R1
+- **WHEN** an administrator calls `DELETE` on R1
+- **THEN** the request SHALL be rejected with HTTP 409 / 422 carrying the message `Route is in gebruik door actieve voorstellen`
+- **AND** R1 SHALL remain persisted
+
+### Requirement: Voorstel Detail View
+
+The system SHALL provide a dedicated detail view for a voorstel that renders header metadata, the linked document, parafering progress, and the action history timeline. The detail view SHALL surface action controls only when the current authenticated user is the actor of the current step (or a valid delegate).
+
+**Feature tier**: V1
+
+#### Scenario: View renders voorstel metadata and document
+
+- **WHEN** an authorized case participant opens the voorstel detail view
+- **THEN** the view SHALL display `onderwerp`, `type`, `status`, `steller`, `afdeling`, and `portefeuillehouder`
+- **AND** the `document` SHALL be viewable inline (Nextcloud preview or download link)
+- **AND** all `bijlagen` SHALL be listed and downloadable
+- **AND** a back-link to the parent case SHALL be present
+
+#### Scenario: Progress indicator reflects routeSnapshot
+
+- **GIVEN** a voorstel with a five-step `routeSnapshot` where steps 1–3 are completed, step 4 is active, step 5 is pending
+- **WHEN** the detail view renders the progress indicator
+- **THEN** steps 1–3 SHALL render as completed with actor name and date
+- **AND** step 4 SHALL render as active with actor name
+- **AND** step 5 SHALL render as pending with actor name
+
+#### Scenario: Action controls hidden for non-actors
+
+- **GIVEN** a voorstel with `status = in_parafering` whose current-step actor is M. Bakker
+- **WHEN** user P. Janssen (not the actor and not a delegate) opens the detail view
+- **THEN** the "Actie nemen" and "Terugsturen" controls SHALL NOT be rendered
+- **AND** the action history timeline SHALL still be visible read-only
+
+### Requirement: Multiple Voorstellen per Case
+
+The system SHALL support multiple voorstellen on a single case. Each voorstel SHALL maintain an independent `status`, `parafeerroute`, `routeSnapshot`, and `currentStep`. Status transitions on one voorstel SHALL NOT affect any sibling voorstel.
+
+**Feature tier**: V1
+
+#### Scenario: Independent status per voorstel
+
+- **GIVEN** a case with two voorstellen: V1 (`type = dt_advies`, `status = besloten`) and V2 (`type = collegeadvies`, `status = concept`)
+- **WHEN** the steller submits V2 for parafering
+- **THEN** V2's `status` SHALL transition to `in_parafering`
+- **AND** V1's `status` SHALL remain `besloten`
+- **AND** both voorstellen SHALL appear in the case detail's voorstellen list
+
+### Requirement: Voorstel Audit Trail and Immutability After Submission
+
+The system SHALL record every voorstel mutation in the OpenRegister automatic audit trail. After a voorstel transitions out of `concept` (or `teruggestuurd` after edits), the content fields `onderwerp`, `document`, and `bijlagen` SHALL be locked against modification — only lifecycle services may continue to update `status`, `currentStep`, `routeSnapshot`, `returnedFromStep`, and append-only audit entries. Route overrides (skip / ad-hoc step) SHALL append entries to the voorstel `auditTrail` field with actor, timestamp, and reason.
+
+**Feature tier**: V1
+
+#### Scenario: Content lock after submission
+
+- **GIVEN** a voorstel with `status = in_parafering`
+- **WHEN** any caller other than `ParafeerRouteService` or `ParafeerActieService` attempts to update `onderwerp`, `document`, or `bijlagen`
+- **THEN** the update SHALL be rejected with HTTP 409 carrying a Dutch message such as `Voorstel is in parafering en kan niet worden bewerkt`
+- **AND** the OpenRegister audit log SHALL still capture the attempt
+
+#### Scenario: Route override is auditable
+
+- **GIVEN** an authorized manager skips step 2 of an in-flight voorstel via `POST /api/parafeer-route/voorstel/{id}/skip-step` with reason "Spoedprocedure"
+- **WHEN** the skip is applied
+- **THEN** an entry SHALL be appended to `voorstel.auditTrail` containing the actor UID, timestamp, step number, and reason
+- **AND** the OpenRegister per-save audit log SHALL also record the change
+
+### Requirement: Voorstel Security and Authorization
+
+The system SHALL derive the acting user identity exclusively from `IUserSession` for every voorstel-mutating endpoint. Read access SHALL be limited to participants of the parent case (including externally shared participants per `case-sharing-collaboration`). Write access SHALL be limited to: the steller (while `status ∈ {concept, teruggestuurd}`), the current step actor (or a valid delegate), or an authorized manager performing a route override.
+
+**Feature tier**: V1
+
+#### Scenario: Unrelated user cannot read voorstel
+
+- **GIVEN** a voorstel on case Z1 and an authenticated user U2 who is not a participant of Z1
+- **WHEN** U2 calls `GET /api/parafering/voorstellen/{voorstelId}`
+- **THEN** the system SHALL return HTTP 403
+- **AND** no voorstel content SHALL be disclosed in the response body
+
+#### Scenario: Non-actor cannot advance the route
+
+- **GIVEN** a voorstel with `status = in_parafering` and a current-step actor M. Bakker
+- **WHEN** user P. Janssen calls `POST /api/parafeer-actie` with a `parafered` action for that voorstel
+- **THEN** the system SHALL return HTTP 403 with `{"message": "Not authorized for this parafering step"}`
+- **AND** no `parafeeractie` SHALL be created
+- **AND** the voorstel's `currentStep` SHALL remain unchanged

--- a/openspec/changes/voorstel-management/tasks.md
+++ b/openspec/changes/voorstel-management/tasks.md
@@ -1,0 +1,34 @@
+# Tasks: voorstel-management
+
+This is a **GENERATE-style** change: the implementation already exists (PRs #331 parafeerroute-engine, #332 parafering-actions). Tasks here verify that the live code matches the formalized capability spec. No code changes are introduced; any gap found is filed as a follow-up issue rather than fixed inside this change.
+
+## Schema documentation
+
+- [ ] **T01**: Confirm `voorstel` schema in `lib/Settings/procest_register.json` declares — at minimum — properties `case`, `type`, `onderwerp`, `steller`, `afdeling`, `portefeuillehouder`, `status`, `parafeerroute`, `routeSnapshot`, `currentStep`, `returnedFromStep`, `document`, `bijlagen`, `behandeling`; required list contains `case`, `type`, `onderwerp`, `steller`, `status`; `type` enum is exactly `[dt_advies, collegeadvies, raadsvoorstel]`; `status` enum is exactly `[concept, in_parafering, ter_accordering, geaccordeerd, aangeboden, besloten, gearchiveerd, teruggestuurd]`. Record any drift in this task block and open a follow-up issue if found.
+
+## Capability verification
+
+- [ ] **T02**: Verify lifecycle — load each `STATUS_*` constant referenced in `lib/Service/ParafeerRouteService.php` and `lib/Service/ParafeerActieService.php`; assert every constant value is one of the eight statuses listed in T01. If a status constant exists in code but not in the schema enum (or vice versa), record + file issue.
+
+- [ ] **T03**: Verify create-from-case path — `POST /api/parafering/voorstellen` (route `parafering#createVoorstel` in `appinfo/routes.php`) accepts a case ID and produces a voorstel with `status = concept`. Confirm onderwerp/afdeling/portefeuillehouder defaults are applied when the case carries those fields. Record current behavior; file issue if a default field is missing.
+
+- [ ] **T04**: Verify route snapshotting — call `ParafeerRouteService::startParafering($voorstelId)` against a voorstel with `parafeerroute` set and confirm: `routeSnapshot` is populated with the linked route's `steps[]` as a JSON string, `currentStep` becomes `1`, `status` becomes `in_parafering`. Verify that later edits to the source parafeerroute do NOT mutate `routeSnapshot` of in-flight voorstellen.
+
+- [ ] **T05**: Verify multiple-voorstellen-per-case — create two voorstellen on the same case (one `dt_advies`, one `collegeadvies`), advance one to `in_parafering`, leave the other as `concept`, assert their statuses remain independent and that the case detail view lists both.
+
+## Doc & test polish
+
+- [ ] **T06**: Add a "Voorstel lifecycle" diagram (text/ASCII or Mermaid) to `docs/ARCHITECTURE.md` (or the closest existing architecture doc) reflecting the eight statuses and allowed transitions from `design.md`. Cross-link to this change and to `parafeerroute-engine` / `parafering-actions`.
+
+- [ ] **T07**: Cross-reference check — open `openspec/changes/bw-parafering`, `openspec/changes/parafeerroute-engine`, `openspec/changes/parafering-actions`, `openspec/changes/besluitvorming-workflow`, and add a "See also: `voorstel-management`" line in their proposal.md `Cross-Project Dependencies` sections (only the ones that currently lack the link). Skip changes already archived (do not modify archived directories).
+
+- [ ] **T08**: Ensure PHPUnit coverage for the lifecycle — confirm there is at least one test in `tests/Unit/Service/` exercising each of the four critical transitions: `concept → in_parafering`, `in_parafering → in_parafering` (step advance), `in_parafering → teruggestuurd`, and `final-step → geaccordeerd`. If any transition lacks a test, file an issue against the relevant service test file rather than authoring the test in this change.
+
+- [ ] **T09**: Run `openspec validate voorstel-management --type change --strict` from the procest repo root and confirm it passes. Re-run `openspec list` and confirm the change appears with task progress.
+
+## Pre-commit verification
+
+- [ ] **V01**: `openspec validate voorstel-management --type change --strict` → exit code 0
+- [ ] **V02**: `openspec change show voorstel-management --json --deltas-only | jq '.deltaCount'` → ≥ 8 (one delta per REQ-VM-1..8)
+- [ ] **V03**: Every REQ-VM-* in `specs/voorstel-management/spec.md` carries at least one `#### Scenario:` block (grep: `### Requirement:` count == `#### Scenario:` count is NOT required, but each Requirement section MUST contain at least one Scenario subsection)
+- [ ] **V04**: No code files modified outside `openspec/changes/voorstel-management/` and the optional `docs/ARCHITECTURE.md` update from T06 (verify with `git diff --name-only origin/development...HEAD`)


### PR DESCRIPTION
## Summary

Formalize the **voorstel-management** capability as a first-class OpenSpec change. Voorstellen are the central unit of work in Procest's parafering domain (every collegeadvies / raadsvoorstel / DT-advies), but the capability has lived only implicitly across PR #331 (`parafeerroute-engine`) and PR #332 (`parafering-actions`). This change records the canonical contract so the capability becomes traceable, testable, and referenceable.

**GENERATE-style** — no code changes. The live implementation is the reference; this change adds the spec around it.

## What's in the change

- **proposal.md** — scope, rationale, explicit `## Why` and `## What Changes` sections
- **design.md** — voorstel entity property contract, 8-state lifecycle diagram, relationship map (case / parafeerroute / parafeeractie / document / besluit), security & audit considerations
- **tasks.md** — T01 (schema doc) + T02-T05 (capability verification) + T06-T09 (doc/test polish + strict validate gate); V01-V04 pre-commit checks
- **specs/voorstel-management/spec.md** — 8 requirements (REQ-VM-1..8) with Given/When/Then scenarios:
  - VM-1 Voorstel entity & schema registration
  - VM-2 Status lifecycle (concept → in_parafering → ter_accordering → geaccordeerd → aangeboden → besloten → gearchiveerd; teruggestuurd return state)
  - VM-3 Create voorstel from case (steller derived from `IUserSession`)
  - VM-4 Voorstel ↔ parafeerroute binding with `routeSnapshot` freeze
  - VM-5 Voorstel detail view (metadata, document, progress, history)
  - VM-6 Multiple voorstellen per case with independent status
  - VM-7 Audit trail and content immutability after submission
  - VM-8 Per-step authorization (server-derived identity)

## Validation

```
$ openspec validate voorstel-management --type change --strict
Change 'voorstel-management' is valid

$ openspec show voorstel-management --type change --json --deltas-only | jq '.deltaCount'
8
```

## Test plan

- [x] `openspec validate voorstel-management --type change --strict` passes
- [x] Delta count = 8 via `jq`
- [x] Every requirement has at least one `#### Scenario:` block
- [x] No code files outside `openspec/changes/voorstel-management/` modified
- [ ] Follow-up: T06 (lifecycle diagram in `docs/ARCHITECTURE.md`) and T07 (cross-link from adjacent changes) — handled when this change goes through `opsx-apply`