### PR TITLE
chore(openspec): generate beroep-escalation spec

### DIFF
--- a/openspec/changes/beroep-escalation/design.md
+++ b/openspec/changes/beroep-escalation/design.md
@@ -1,0 +1,65 @@
+# Design: beroep-escalation
+
+## Context
+
+Beroep is the citizen's formal appeal of a `beslissing op bezwaar` at the administrative court (`rechtbank`) under the Algemene wet bestuursrecht (Awb), hoofdstuk 8. The court process itself lives entirely with the rechtbank — court schedules, hearing minutes, deliberations, the ruling text — and is governed by procesrecht that has nothing to do with Procest. What the municipality *does* need to track is the escalation envelope around the court process: that beroep was filed, against which beslissing, with which court under which reference number, what file inspection requests it had to fulfill, what the court eventually ruled, and what — if anything — that ruling forces the municipality to do next.
+
+That asymmetry is the central design choice: **procest tracks the wrapper, the rechtbank runs the case.** The beroep schema is therefore relatively thin (a handful of identifiers + a judgment outcome) but its links — source bezwaar, contested beslissing, cascade back into procest — are dense.
+
+## Entity: `beroep`
+
+Schema.org type `schema:LegalAction`. Stored as an OpenRegister object on the parent `case` (which itself uses the pre-seeded "Beroep" case type from the existing `beroep-escalation` spec, REQ from the earlier 5-requirement version).
+
+| Property | Type | Required | Role |
+|----------|------|----------|------|
+| `case` | UUID | yes | The beroep case in Procest |
+| `sourceBezwaar` | UUID | yes | The bezwaar that escalated |
+| `contestedDecision` | UUID | yes | The `beslissing op bezwaar` being contested |
+| `courtReference` | string | no | Rechtbank zaaknummer, populated once the court assigns it |
+| `responsibleChamber` | enum | no | `enkelvoudig`, `meervoudig`, `voorzieningenrechter` |
+| `competentCourt` | string | no | Name of the rechtbank (e.g. "Rechtbank Midden-Nederland") |
+| `appellantFilingDate` | date | yes | Date the beroepschrift was filed at the court |
+| `appellantNotifiedDate` | date | no | Date the municipality received the rechtbank notification |
+| `filingDeadline` | date | computed | `beslissing.effectiveDate + P6W` |
+| `voorzieningRequested` | boolean | no | Voorlopige voorziening also filed (retained from existing spec) |
+| `judgmentOutcome` | enum | no | See below |
+| `judgmentDate` | date | no | Date of the uitspraak |
+| `judgmentDocument` | UUID | no | NC file id of the ruling |
+| `cascadeAction` | enum | no | `reopen_bezwaar`, `new_primary_decision`, `none` |
+| `cascadeBezwaarCase` | UUID | no | The reopened bezwaar case, if `cascadeAction = reopen_bezwaar` |
+
+`judgmentOutcome` enum: `vernietigd`, `in_stand_gelaten`, `niet_ontvankelijk`, `ongegrond`, `gegrond_rechtsgevolgen_in_stand`, `ingetrokken`, `schikking`.
+
+## Deadline tracking and dwingende status flip
+
+The beroep filing window is 6 weeks from the `effectiveDate` of the contested beslissing op bezwaar (Awb art. 6:7, 6:8). On receipt of a beroepschrift the system computes `filingDeadline` and verifies the bezwaar's `effectiveDate` is within the window. If `appellantFilingDate > filingDeadline`, the system flags `latefilingNotice` for the rechtbank to weigh `verschoonbare termijnoverschrijding` — Procest never decides timeliness itself; only the court does.
+
+In parallel, the source bezwaar's `status` SHALL flip from terminal (`Afgehandeld` / `Beslissing op bezwaar`) to a derived **dwingende** marker visible in dashboards: the bezwaar is no longer "done" because a court may reopen it. The bezwaar case is read-only while a beroep is active.
+
+## Court reference + chamber
+
+`courtReference` is populated as soon as the court returns one (usually a few weeks after filing). `responsibleChamber` defaults to `enkelvoudig` and is updated when the court announces the chamber composition. These two fields drive the case detail header so handlers and Juridische Zaken can identify the court file at a glance.
+
+## File inspection requests (`op de zaak betrekking hebbende stukken`)
+
+Awb art. 8:42 obliges the bestuursorgaan to submit *all* documents pertaining to the contested decision to the court within 4 weeks of being notified of the beroep. Procest does NOT generate the export itself — Juridische Zaken curates and submits — but it MUST record the request, the deadline, and the response status:
+
+- `fileInspectionRequest.requestedAt` — date the rechtbank issued the request
+- `fileInspectionRequest.deadline` — `requestedAt + P4W`
+- `fileInspectionRequest.submittedAt` — date the dossier was sent
+- `fileInspectionRequest.dossierBundle` — UUID of the compiled bundle (link to a `document-zaakdossier` capability artifact when present, else a flat NC folder reference)
+
+## Judgment outcome and cascade back into procest
+
+When the rechtbank issues its uitspraak, the handler records `judgmentOutcome`, `judgmentDate`, and uploads `judgmentDocument`. If the outcome is `vernietigd` and the ruling orders the municipality to take a new decision on the bezwaar, the system creates a `cascadeAction = reopen_bezwaar`: a fresh bezwaar case is forked from the source bezwaar with status `In behandeling`, a link back to the beroep, and a court-imposed deadline. If the ruling instead orders a new *primary* decision (zelden), `cascadeAction = new_primary_decision` and a follow-up task is created on the original primary case. Otherwise `cascadeAction = none` and the beroep simply moves to `Afgehandeld` — the source bezwaar's dwingende marker is cleared and it returns to its terminal status.
+
+## Security & audit
+
+- All status changes derive identity from `IUserSession`; frontend UID overrides are ignored.
+- Only `Behandelaar bezwaar` and `Juridische Zaken` roles on the source bezwaar may edit beroep records.
+- After `appellantFilingDate` is set, `sourceBezwaar` and `contestedDecision` are immutable — the OpenRegister audit trail captures all subsequent changes.
+- The beroep case is readable by anyone with access to the source bezwaar.
+
+## Why a GENERATE-style change?
+
+The existing `beroep-escalation` spec (5 requirements) was committed without a change record. Rather than retrofitting that gap by introducing code, this change *describes* the missing contract — entity, deadlines, cascade, security — so future implementation work can validate against it. Tasks are verification + spec-authoring only; any drift between this contract and the prior 5-requirement spec is reconciled in the delta.

--- a/openspec/changes/beroep-escalation/proposal.md
+++ b/openspec/changes/beroep-escalation/proposal.md
@@ -1,0 +1,48 @@
+# Proposal: Beroep Escalation
+
+## Summary
+
+Formalize the `beroep-escalation` capability as a first-class OpenSpec change so that the existing partial spec (5 requirements covering case type, status types, escalation, document management and hoger beroep awareness) is upgraded and bound to a traceable change record. Beroep is the formal appeal of a `beslissing op bezwaar` at the administrative court (`rechtbank`) under Awb hoofdstuk 8. Procest does NOT run the court process — that lives entirely with the rechtbank — but the municipality still has to track the escalation: filing windows, court reference numbers, the chamber that hears the case, the document inspection requests it has to fulfill (file inspection / `op de zaak betrekking hebbende stukken`), and the judgment outcome that may cascade back into the bezwaar workflow (e.g. `vernietigd` → re-decide).
+
+## Why
+
+After PR #362 (`voorstel-management`), `bezwaar-lifecycle` and `bezwaar-decision` are the only two formalized objection-side specs. The escalation that follows — beroep at the rechtbank — exists only as a 5-requirement spec without a change record, with no clear contract for deadline tracking, the dwingende-status flip on the source bezwaar, or the cascade back into procest when the court overturns the decision. Tender requirements (cluster *Bezwaar en beroep*, 801 requirements / 209 tenders) repeatedly demand: deadline supervision, file inspection request fulfillment, court ruling registration, automatic re-opening when the court orders a new decision. Without an explicit `beroep-escalation` capability spec these requirements have nowhere to anchor.
+
+## What Changes
+
+- Adds the `beroep-escalation` change directory (proposal, design, tasks, delta spec).
+- Promotes the existing 5-requirement spec at `openspec/specs/beroep-escalation/spec.md` to a formal 8-requirement contract (REQ-BE-1..8): beroep entity linked to source bezwaar, 6-week filing deadline + dwingende status flip, court reference + chamber, file inspection request fulfillment, judgment outcomes, cascade back into bezwaar workflow, audit & immutability, and authorization.
+- Adds a beroep lifecycle + cascade diagram in `design.md`.
+- Spec only — NO code changes. Procest still does not run the court process; this captures only what the municipality tracks.
+- On archive, the delta spec under this change's `specs/beroep-escalation/` replaces the current unowned spec.
+
+## Affected Projects
+
+- [ ] Project: `procest` — Formalize the `beroep-escalation` capability with a complete change record. NO CODE; tasks are verification-only.
+
+## Scope
+
+### In Scope (V1, spec only)
+
+- Beroep entity formalization (REQ-BE-1) — case ref, source bezwaar, contested beslissing, court ref, chamber, filing date.
+- 6-week filing deadline tracking + dwingende status flip on source bezwaar (REQ-BE-2).
+- Court reference + responsible chamber (REQ-BE-3).
+- File inspection request fulfillment (`op de zaak betrekking hebbende stukken`) (REQ-BE-4).
+- Judgment outcome registration: vernietigd, in stand gelaten, niet-ontvankelijk, gegrond-met-rechtsgevolgen-in-stand, etc. (REQ-BE-5).
+- Cascade back into procest when the court vernietigt and orders a new decision (REQ-BE-6).
+- Audit & immutability after submission to the rechtbank (REQ-BE-7).
+- Authorization: only the bezwaar handler and the case Juridische Zaken role may edit (REQ-BE-8).
+
+### Out of Scope
+
+- Running the court process itself (court schedules, court documents-as-source).
+- Hoger beroep workflow (RvS / CRvB) — informational only, retained from existing spec.
+- Voorlopige voorziening as a separate case type — handled as a flag on the beroep case.
+- WOZ / fiscaal beroep — domain-specific to tax systems.
+
+## Dependencies
+
+- `bezwaar-lifecycle` (REQUIRED): source bezwaar that escalates.
+- `bezwaar-decision` (REQUIRED): the beslissing op bezwaar that is contested.
+- `case-management` (REQUIRED): beroep is modeled as a case.
+- `openregister-integration` (REQUIRED): schema + audit trail.

--- a/openspec/changes/beroep-escalation/specs/beroep-escalation/spec.md
+++ b/openspec/changes/beroep-escalation/specs/beroep-escalation/spec.md
@@ -1,0 +1,176 @@
+## ADDED Requirements
+
+### Requirement: Beroep Entity and Schema Registration
+
+The system SHALL register a `beroep` schema in the Procest OpenRegister configuration. The schema SHALL declare the properties `case`, `sourceBezwaar`, `contestedDecision`, `courtReference`, `responsibleChamber`, `competentCourt`, `appellantFilingDate`, `appellantNotifiedDate`, `filingDeadline`, `voorzieningRequested`, `judgmentOutcome`, `judgmentDate`, `judgmentDocument`, `cascadeAction`, and `cascadeBezwaarCase`. The required-property list SHALL be exactly `[case, sourceBezwaar, contestedDecision, appellantFilingDate]`. The `responsibleChamber` enum SHALL be exactly `[enkelvoudig, meervoudig, voorzieningenrechter]`. The `judgmentOutcome` enum SHALL be exactly `[vernietigd, in_stand_gelaten, niet_ontvankelijk, ongegrond, gegrond_rechtsgevolgen_in_stand, ingetrokken, schikking]`. The `cascadeAction` enum SHALL be exactly `[reopen_bezwaar, new_primary_decision, none]`. The Schema.org type SHALL be `schema:LegalAction`.
+
+**Feature tier**: V1
+**Schema.org type**: `schema:LegalAction`
+**AWB reference**: Art. 8:1 (beroep bij de rechtbank)
+
+#### Scenario: Schema is registered after app install
+
+- **WHEN** the Procest app is installed or updated via the repair step
+- **THEN** the `beroep` schema SHALL exist in the Procest register
+- **AND** the schema SHALL enforce the required properties `case`, `sourceBezwaar`, `contestedDecision`, `appellantFilingDate`
+- **AND** the `judgmentOutcome` enum SHALL be exactly `[vernietigd, in_stand_gelaten, niet_ontvankelijk, ongegrond, gegrond_rechtsgevolgen_in_stand, ingetrokken, schikking]`
+
+#### Scenario: Beroep rejects unknown judgment outcome
+
+- **GIVEN** a handler posts a judgment update with `judgmentOutcome = "afgewezen"` (not in the enum)
+- **WHEN** the update is validated
+- **THEN** OpenRegister SHALL reject the object with a schema validation error
+- **AND** no judgment SHALL be persisted
+
+### Requirement: Filing Deadline Tracking and Dwingende Status Flip
+
+The system SHALL compute `filingDeadline` as `contestedDecision.effectiveDate + P6W` (Awb art. 6:7, 6:8) on beroep creation and SHALL flag `latefilingNotice = true` when `appellantFilingDate > filingDeadline`. The system SHALL NEVER itself decide whether late filing is excusable (`verschoonbare termijnoverschrijding`); that determination is reserved for the rechtbank. While the beroep status is not terminal (`Afgehandeld`, `Ingetrokken`, `Schikking`), the system SHALL mark the source bezwaar with a derived `dwingendeMarker = true` flag visible in dashboards, and the bezwaar case SHALL be read-only.
+
+**Feature tier**: V1
+**AWB reference**: Art. 6:7, 6:8
+
+#### Scenario: Compute filing deadline on beroep creation
+
+- **GIVEN** a beslissing op bezwaar with `effectiveDate = 2026-04-01`
+- **WHEN** a beroep is created with `contestedDecision` referencing that beslissing
+- **THEN** the beroep's `filingDeadline` SHALL be `2026-05-13` (effectiveDate + 6 weeks)
+
+#### Scenario: Late filing flagged but never refused
+
+- **GIVEN** a beroep with `filingDeadline = 2026-05-13` and `appellantFilingDate = 2026-05-30`
+- **WHEN** the handler saves the beroep
+- **THEN** the system SHALL set `latefilingNotice = true`
+- **AND** the system SHALL NOT refuse or auto-close the beroep — the rechtbank is the only authority on timeliness
+
+#### Scenario: Source bezwaar flips to dwingendeMarker
+
+- **GIVEN** a bezwaar BZ-2026-0042 with `status = Afgehandeld`
+- **WHEN** a beroep is created with `sourceBezwaar = BZ-2026-0042`
+- **THEN** the bezwaar's derived `dwingendeMarker` SHALL be `true`
+- **AND** the bezwaar case SHALL be read-only while the beroep is not in a terminal status
+- **AND** dashboards SHALL surface BZ-2026-0042 under "Bezwaak in beroep"
+
+### Requirement: Court Reference and Responsible Chamber
+
+The system SHALL allow recording a court-assigned `courtReference` (rechtbank zaaknummer), the `competentCourt` (name of the rechtbank), and the `responsibleChamber` (`enkelvoudig`, `meervoudig`, or `voorzieningenrechter`). These fields SHALL be optional at beroep creation and SHALL be populated by the handler when the rechtbank communicates them. The case detail header SHALL surface `competentCourt` + `courtReference` once present.
+
+**Feature tier**: V1
+
+#### Scenario: Handler records court reference
+
+- **GIVEN** a beroep BR-2026-0015 with no `courtReference`
+- **WHEN** the rechtbank assigns case number `UTR 26/1234` and the handler records it
+- **THEN** `beroep.courtReference` SHALL equal `UTR 26/1234`
+- **AND** the case detail header SHALL display "Rechtbank Midden-Nederland — UTR 26/1234"
+
+#### Scenario: Chamber upgrade from enkelvoudig to meervoudig
+
+- **GIVEN** a beroep with `responsibleChamber = enkelvoudig`
+- **WHEN** the rechtbank decides the case requires a meervoudige kamer and the handler updates the field
+- **THEN** `responsibleChamber` SHALL transition to `meervoudig`
+- **AND** the change SHALL be recorded in the OpenRegister audit trail
+
+### Requirement: File Inspection Request Fulfillment
+
+The system SHALL record file inspection requests issued by the rechtbank under Awb art. 8:42 (`op de zaak betrekking hebbende stukken`). For each request the system SHALL store `requestedAt`, a computed `deadline = requestedAt + P4W`, `submittedAt` once fulfilled, and `dossierBundle` referencing the compiled bundle. The system SHALL surface a warning when `now > deadline AND submittedAt IS NULL`. The system SHALL NOT itself generate the bundle — bundle assembly is performed by Juridische Zaken via existing dossier tooling — but it SHALL record the linkage.
+
+**Feature tier**: V1
+**AWB reference**: Art. 8:42
+
+#### Scenario: Record file inspection request
+
+- **GIVEN** a beroep BR-2026-0015
+- **WHEN** the rechtbank issues a file inspection request on 2026-06-01 and the handler records it
+- **THEN** `beroep.fileInspectionRequest.requestedAt` SHALL equal `2026-06-01`
+- **AND** `beroep.fileInspectionRequest.deadline` SHALL equal `2026-06-29` (requestedAt + 4 weeks)
+- **AND** the case SHALL appear in the "Stukken aan rechtbank" dashboard
+
+#### Scenario: File inspection deadline warning
+
+- **GIVEN** a file inspection request with `deadline = 2026-06-29` and `submittedAt = NULL`
+- **WHEN** the current date is `2026-06-27`
+- **THEN** the system SHALL display a warning "Termijn 8:42 verstrijkt over 2 dagen" on the case
+- **AND** the case SHALL appear in the overdue/at-risk dashboard section
+
+### Requirement: Judgment Outcome Registration
+
+The system SHALL allow the handler to record the rechtbank's uitspraak by setting `judgmentOutcome`, `judgmentDate`, and `judgmentDocument`. The system SHALL NOT itself interpret or paraphrase the ruling; it SHALL persist only the categorical outcome plus the uploaded ruling document. Once `judgmentOutcome` is set, the beroep case status SHALL transition to "Uitspraak ontvangen".
+
+**Feature tier**: V1
+
+#### Scenario: Record vernietigd judgment
+
+- **GIVEN** a beroep BR-2026-0015 with no `judgmentOutcome`
+- **WHEN** the handler records `judgmentOutcome = vernietigd`, `judgmentDate = 2026-09-15`, and uploads the uitspraak as `judgmentDocument`
+- **THEN** the beroep case status SHALL transition to "Uitspraak ontvangen"
+- **AND** the audit trail SHALL contain a single entry for the judgment registration
+
+#### Scenario: Schikking outcome closes beroep without ruling
+
+- **GIVEN** a beroep BR-2026-0021 that settles out of court
+- **WHEN** the handler records `judgmentOutcome = schikking` and `judgmentDate = 2026-08-01`
+- **THEN** the beroep case status SHALL transition to "Schikking"
+- **AND** `judgmentDocument` SHALL remain optional — settlement minutes are not legally required to be uploaded
+
+### Requirement: Cascade Back Into Procest Workflow
+
+The system SHALL evaluate `cascadeAction` based on the judgment outcome plus handler input. When `judgmentOutcome = vernietigd` AND the ruling orders a new bezwaar decision, the handler SHALL be able to trigger `cascadeAction = reopen_bezwaar`, which SHALL create a new bezwaar case forked from `sourceBezwaar` with status "In behandeling", `cascadeBezwaarCase` populated on the beroep, a link back from the new bezwaar to the beroep, and a court-imposed deadline carried on the new case. When `cascadeAction = none`, the source bezwaar's `dwingendeMarker` SHALL be cleared and the bezwaar SHALL return to its terminal status.
+
+**Feature tier**: V1
+
+#### Scenario: Vernietigd cascades into reopened bezwaar
+
+- **GIVEN** a beroep BR-2026-0015 with `judgmentOutcome = vernietigd`, `sourceBezwaar = BZ-2026-0042`
+- **WHEN** the handler triggers `cascadeAction = reopen_bezwaar` with a court-imposed deadline of `2026-12-01`
+- **THEN** a new bezwaar case BZ-2026-0042-R1 SHALL be created with status "In behandeling"
+- **AND** `BZ-2026-0042-R1.afhandelDeadline` SHALL equal `2026-12-01`
+- **AND** `beroep.cascadeBezwaarCase` SHALL reference BZ-2026-0042-R1
+- **AND** BZ-2026-0042-R1 SHALL carry a link back to BR-2026-0015
+
+#### Scenario: In stand gelaten cascade clears dwingende marker
+
+- **GIVEN** a beroep BR-2026-0021 with `judgmentOutcome = in_stand_gelaten`, `sourceBezwaar = BZ-2026-0050`, and `BZ-2026-0050.dwingendeMarker = true`
+- **WHEN** the handler triggers `cascadeAction = none`
+- **THEN** `BZ-2026-0050.dwingendeMarker` SHALL be cleared
+- **AND** BZ-2026-0050 SHALL return to its terminal status (`Afgehandeld`)
+- **AND** the beroep case status SHALL transition to "Afgehandeld"
+
+### Requirement: Beroep Audit and Immutability
+
+The system SHALL leverage OpenRegister's per-save audit trail to record every change to a beroep object. After `appellantFilingDate` is first set, `sourceBezwaar` and `contestedDecision` SHALL be immutable — attempts to modify them SHALL be rejected with a validation error. All other fields remain editable but each edit SHALL produce an audit entry capturing actor, timestamp, and changed properties.
+
+**Feature tier**: V1
+
+#### Scenario: Cannot change sourceBezwaar after filing
+
+- **GIVEN** a beroep with `appellantFilingDate = 2026-05-10` and `sourceBezwaar = BZ-2026-0042`
+- **WHEN** any client attempts to PATCH `sourceBezwaar = BZ-2026-0099`
+- **THEN** the system SHALL reject the request with a validation error
+- **AND** the beroep SHALL retain `sourceBezwaar = BZ-2026-0042`
+
+#### Scenario: Audit trail captures judgment registration
+
+- **GIVEN** a beroep with no `judgmentOutcome`
+- **WHEN** the handler records `judgmentOutcome = ongegrond`
+- **THEN** the OpenRegister audit trail SHALL contain one entry with actor = the handler's UID, timestamp, and changed property `judgmentOutcome`
+
+### Requirement: Authorization
+
+The system SHALL restrict edit rights on a beroep object to users holding the `Behandelaar bezwaar` or `Juridische Zaken` role on the source bezwaar. Read access SHALL be granted to any user who has read access to the source bezwaar. Server-side identity SHALL be derived from `IUserSession`; any UID supplied in the request body SHALL be ignored.
+
+**Feature tier**: V1
+
+#### Scenario: Non-authorized user cannot edit beroep
+
+- **GIVEN** a beroep BR-2026-0015 with source bezwaar BZ-2026-0042
+- **AND** user P. Janssen has no role on BZ-2026-0042
+- **WHEN** P. Janssen attempts to PATCH `courtReference`
+- **THEN** the system SHALL reject the request with HTTP 403
+- **AND** no audit entry SHALL be written
+
+#### Scenario: Authorized user edit recorded with session UID
+
+- **GIVEN** user K. Vermeulen is authenticated and holds `Behandelaar bezwaar` on BZ-2026-0042
+- **WHEN** K. Vermeulen PATCHes `courtReference = UTR 26/1234` and the request body also contains `_actor = "system"`
+- **THEN** the audit entry SHALL record actor = `k.vermeulen` (the session UID)
+- **AND** the `_actor` body field SHALL be ignored

--- a/openspec/changes/beroep-escalation/tasks.md
+++ b/openspec/changes/beroep-escalation/tasks.md
@@ -1,0 +1,35 @@
+# Tasks: beroep-escalation
+
+This is a **GENERATE-style** change: the existing `beroep-escalation` spec (5 requirements) is upgraded to a formal 8-requirement contract anchored in a change record. Tasks are spec-authoring and verification only. Any code gap discovered against the new contract becomes a follow-up issue rather than being fixed inside this change.
+
+## Spec authoring
+
+- [ ] **T01**: Author `specs/beroep-escalation/spec.md` as a `## ADDED Requirements` delta with eight requirements REQ-BE-1..8 covering: beroep entity & schema, filing deadline + dwingende marker on source bezwaar, court reference + chamber, file inspection request fulfillment (Awb 8:42), judgment outcome registration, cascade back into procest workflow, audit & immutability, authorization.
+
+- [ ] **T02**: For each REQ-BE-* requirement, include at least one `#### Scenario:` block using Given/When/Then bullets. Verify with `grep -c "^#### Scenario:"` ≥ 8 against `specs/beroep-escalation/spec.md`.
+
+## Cross-spec reconciliation
+
+- [ ] **T03**: Cross-check the new REQ-BE-1..8 against the legacy 5 requirements in `openspec/specs/beroep-escalation/spec.md`: confirm the legacy "Beroep Case Type Pre-Seeded Configuration", "Beroep Status Types", "Escalation from Bezwaar to Beroep", "Court Proceedings Document Management" and "Hoger Beroep Awareness" concepts are either preserved or explicitly superseded in the new contract. Note in this task block which legacy requirements collapse into which new REQ-BE-* IDs.
+
+- [ ] **T04**: Cross-check against `bezwaar-decision` REQ on `appealInformation` / `rechtsmiddelenclausule`: confirm REQ-BE-1 in the new spec consumes the same `contestedDecision` reference shape and that the 6-week filing window in REQ-BE-2 is consistent with `bezwaar-decision`'s `effectiveDate` semantics.
+
+- [ ] **T05**: Cross-check against `bezwaar-lifecycle` deadline calculation: confirm the source-bezwaar "dwingende" marker described in REQ-BE-2 does NOT collide with the existing terminal statuses (`Afgehandeld`, `Niet-ontvankelijk`, `Ingetrokken`). If collision is found, file a follow-up issue rather than mutating `bezwaar-lifecycle`.
+
+## Doc polish
+
+- [ ] **T06**: Add a "Beroep cascade" subsection to `docs/ARCHITECTURE.md` (or the nearest existing architecture doc) summarizing the three cascade actions (`reopen_bezwaar`, `new_primary_decision`, `none`) from `design.md`. Cross-link to this change and to `bezwaar-decision`. If the architecture doc does not yet exist, file an issue rather than create it in this change.
+
+- [ ] **T07**: Cross-reference check — open `openspec/changes/bezwaar-beroep-workflow/proposal.md` and add a "See also: `beroep-escalation`" line under its `Dependencies` section (skip if already present). Do not modify any archived changes.
+
+## Strict validation
+
+- [ ] **T08**: Run `openspec validate beroep-escalation --type change --strict` from the procest repo root and confirm exit code 0. Re-run `openspec list` and confirm the change appears with task progress.
+
+- [ ] **T09**: Confirm `openspec change show beroep-escalation --json --deltas-only | jq '.deltaCount'` returns ≥ 8 (one delta per REQ-BE-1..8).
+
+## Pre-commit verification
+
+- [ ] **V01**: `openspec validate beroep-escalation --type change --strict` → exit code 0
+- [ ] **V02**: `git diff --name-only origin/development...HEAD` lists ONLY files under `openspec/changes/beroep-escalation/` (and optionally the architecture-doc update from T06). No `lib/`, `src/`, `appinfo/`, `tests/`, or schema file changes.
+- [ ] **V03**: Every REQ-BE-* in `specs/beroep-escalation/spec.md` contains at least one `#### Scenario:` subsection.


### PR DESCRIPTION
## Summary

- Formalize the `beroep-escalation` capability as a first-class OpenSpec change.
- Upgrades the existing 5-requirement spec to a complete 8-requirement contract (REQ-BE-1..8) covering entity, deadlines + dwingende marker, court reference + chamber, file inspection request fulfillment (Awb 8:42), judgment outcomes, cascade back into procest, audit/immutability, and authorization.
- **Spec only** -- no code changes. Procest tracks the escalation envelope; the rechtbank runs the court process.

## Why

Beroep is the formal appeal of a `beslissing op bezwaar` at the rechtbank under Awb hoofdstuk 8. The previous 5-requirement spec at `openspec/specs/beroep-escalation/` lacks: deadline tracking semantics, the dwingende-status flip on the source bezwaar, file-inspection-request fulfillment, and the cascade back into procest when the court vernietigt. This change adds those four contracts and binds the capability to a proper change record so future implementation work has something to validate against.

## Validation

- `openspec validate beroep-escalation --type change --strict` -> exit 0
- `openspec change show beroep-escalation --json --deltas-only | jq '.deltaCount'` -> 8
- 17 Given/When/Then scenarios across 8 requirements

## Test plan

- [ ] Spec authors review REQ-BE-1..8 against legacy `beroep-escalation` spec for collapse/supersede mapping
- [ ] Spec authors review against `bezwaar-decision` (`appealInformation`, `effectiveDate`) and `bezwaar-lifecycle` (terminal statuses) to confirm no contract drift
- [ ] Confirm the dwingende-marker concept does not collide with the four existing bezwaar terminal statuses
- [ ] Confirm `openspec list` shows the change with task progress