### PR TITLE
chore(openspec): generate bezwaar-hearing spec

### DIFF
--- a/openspec/changes/bezwaar-hearing/design.md
+++ b/openspec/changes/bezwaar-hearing/design.md
@@ -1,0 +1,93 @@
+# Design: bezwaar-hearing
+
+## Context
+
+The hoorzitting is the most procedurally sensitive step in the Dutch bezwaar process. Under Awb art. 7:2 the bestuursorgaan is obliged to offer the bezwaarmaker an opportunity to be heard before deciding on the objection; under art. 7:3 the right may be waived (afzien van hoorrecht). Surrounding articles tighten the procedure: art. 7:4 grants inspection-of-file with a hard "at least one week before the hearing" deadline, art. 7:6 protects sensitive documents, art. 7:7 obliges minutes (verslag). Failure to comply produces an automatic appeal-success risk at the beroep stage, so the system needs an explicit, auditable capability — not an ad-hoc calendar event.
+
+This change documents that capability as a sister spec to `bezwaar-lifecycle` (statussen + deadlines) and `bezwaar-advisory-committee` (advisory report). Implementation will follow in a separate apply change; this proposal is spec-only.
+
+## Entity: `hearingSession`
+
+Stored as an OpenRegister object on the procest register, Schema.org type `schema:Event`.
+
+| Property | Type | Required | Role |
+|----------|------|----------|------|
+| `case` | UUID (`$ref: case`) | Yes | Parent bezwaar case |
+| `scheduledDate` | datetime | Yes | Hearing date/time |
+| `location` | string | No | Physical location, or `"Online"` |
+| `videoCallUrl` | string (URL) | No | Video conference link |
+| `chairperson` | UUID (role) | Yes | Voorzitter |
+| `members` | array<UUID> | No | Commissie leden present |
+| `invitees` | array<object> | Yes | `{role, name, channel, accessibilityNeeds[]}` |
+| `inspectionAvailableFrom` | date | Yes | First date dossier is available for inspection |
+| `inspectionDeadline` | date | Yes | `scheduledDate − 7 days` (Awb art. 7:4 lid 2) |
+| `attendance` | array<object> | No | Captured at hearing: `{invitee, present, arrivalTime}` |
+| `minutesSummary` | string (text) | No | Short verslag |
+| `minutesDocument` | UUID (file) | No | Full verslag document |
+| `audioRecording` | UUID (file) | No | Optional audio capture, retention-tagged |
+| `recordingConsent` | enum | No | `granted`, `denied`, `not_requested` |
+| `followUpQuestions` | array<object> | No | Post-hearing questions to bezwaarmaker |
+| `status` | enum | Yes | `gepland`, `uitgenodigd`, `dossier_beschikbaar`, `uitgevoerd`, `geannuleerd`, `afgezien` |
+| `hearingWaived` | boolean | No | Set to `true` when art. 7:3 waiver applies |
+| `waiverReason` | string | No | Free-text reason (required when `hearingWaived = true`) |
+
+## Lifecycle
+
+```
+                 ┌──(waiver)──► afgezien
+                 │
+concept (case) ──► gepland ──(invite)──► uitgenodigd
+                                  │
+                                  ▼
+                          dossier_beschikbaar
+                                  │ (≥ scheduledDate − 7 days)
+                                  ▼
+                              uitgevoerd ──► (minutes captured)
+                                  │
+                          geannuleerd (parallel terminal)
+```
+
+`gepland → uitgenodigd` MUST run the invitation flow; `uitgenodigd → dossier_beschikbaar` is automatic when `inspectionAvailableFrom ≤ today`. `uitgevoerd` is set by the voorzitter after the hearing concludes and requires either `minutesSummary` or `minutesDocument`.
+
+## Invitation flow (with accessibility)
+
+Each `invitee` carries a `channel` enum: `berichtenbox`, `email`, `post`, `in_person`. The system picks Berichtenbox when the bezwaarmaker has a connected MijnOverheid account (per `mijn-overheid-integration`); otherwise it falls back to email; otherwise it queues a paper print task.
+
+Accessibility hooks (`invitee.accessibilityNeeds[]` enum: `low_literacy`, `interpreter`, `sign_language`, `physical_access`) drive variants:
+
+- `low_literacy` → invitation rendered with B1-level Dutch template; key facts (date/time/location) repeated in a top callout box
+- `interpreter` → an additional invitation block lists the requested taal, and a tolk-booking task is created on the case
+- `sign_language` → gebarentolk task created
+- `physical_access` → location confirmation task to verify wheelchair / elevator access
+
+Every accessibility need produces an audit trail entry on the case to demonstrate Awb art. 2:1 / art. 7:2 reasonable-accommodation duty.
+
+## Inspection-of-file mechanics (Awb art. 7:4)
+
+`inspectionDeadline` is a hard floor: it MUST be at least 7 calendar days before `scheduledDate`. The system computes it on creation; if the user later shifts `scheduledDate` closer than 7 days the system blocks the save with a Dutch error: `Inzagetermijn (art. 7:4) wordt geschonden — minimaal 7 dagen voor de hoorzitting`. Documents marked as `confidential` (art. 7:6) are excluded from the inspection bundle but listed with a reason placeholder ("Document onthouden op grond van art. 7:6 Awb"). Access events on inspection documents are logged with `inspection-trail` tags so legal can prove compliance.
+
+## Minutes capture
+
+`uitgevoerd` requires either:
+- `minutesSummary` (text, ≥ 1 sentence), OR
+- `minutesDocument` (uploaded verslag file).
+
+`audioRecording` is optional and gated by `recordingConsent = granted` from the bezwaarmaker (Awb compliance + AVG/GDPR Art. 6). If consent is denied the system MUST refuse the upload and write a denial audit entry. Audio files inherit the case's retention regime (typically 5 jaar per Selectielijst gemeenten).
+
+## Follow-up questions
+
+After `uitgevoerd` the voorzitter MAY add `followUpQuestions[]` entries `{question, askedTo, deadline}`. The case status remains `Hoorzitting afgerond` but a separate widget surfaces outstanding follow-ups on the dashboard until each is answered or marked withdrawn. The answers attach to the case dossier as `hearingFollowUp` documents.
+
+## Legal compliance hooks
+
+- Every status transition writes an audit entry tagged `awb-art-7:X` referencing the applicable article
+- `hearingWaived = true` writes a separate `waiver` audit entry with reason and UID
+- The invitation timestamp is preserved as `invitedAt` on each invitee for chain-of-custody
+- Inspection events log per-document access with `actor`, `documentId`, `accessedAt`, `purpose = "art-7:4-inspection"`
+- Recording consent + denial events are written as immutable audit entries
+
+These hooks let beroep dossier export (`bezwaar-beroep-workflow`) prove procedural compliance without manual reconstruction.
+
+## Why a spec-only change?
+
+The hearing capability already has a partial spec but no change record. This change formalizes the contract first so that downstream implementation (UI, services, repair-step seed) lands against a stable, validated specification rather than diverging from it.

--- a/openspec/changes/bezwaar-hearing/proposal.md
+++ b/openspec/changes/bezwaar-hearing/proposal.md
@@ -1,0 +1,27 @@
+# Proposal: Bezwaar Hearing (Hoorzitting)
+
+## Summary
+
+Formalize the `bezwaar-hearing` capability as a first-class OpenSpec change so that the hoorzitting step in the bezwaar lifecycle has explicit, validatable specification coverage. The hoorzitting (Awb art. 7:2–7:7) is the formal step at which a bezwaarmaker is given the opportunity to be heard before a decision on the objection is made. It is a sister spec to `bezwaar-lifecycle` (the case-type configuration and statussen) and `bezwaar-advisory-committee` (the commissie advisory report). This change introduces an explicit `bezwaar-hearing` capability spec covering scheduling, the waiver of the right to be heard, invitations with accessibility safeguards (low-literacy, interpreters), inspection-of-file before the hearing, the attendee list, minutes capture (text + optional audio), and the legal compliance hooks that wire the hearing into the bezwaar audit trail.
+
+## Why
+
+The current `openspec/specs/bezwaar-hearing/spec.md` was committed without a corresponding change record, leaving traceability between spec and implementation broken. Three requirements live there today (session management, waiver, participant access) but they do not cover invitation accessibility, inspection-of-file mechanics, attendee tracking, or audio recording — all of which appear in tender requirements and Awb compliance audits. Formalizing the capability now gives reviewers an explicit lifecycle, gives tender responses a traceable spec ID, and unblocks downstream changes (case-email-integration, mijn-overheid-integration) that need a stable hearing contract to reference.
+
+## What Changes
+
+- Adds the `bezwaar-hearing` capability spec under this change's `specs/` directory with eight `## ADDED Requirements` entries (REQ-BH-1..8) in delta format with Given/When/Then scenarios
+- Adds a hearing lifecycle diagram, inspection-of-file timing, and accessibility hooks to `design.md`
+- Adds verification + authoring tasks (T01–T10), each backed by `openspec validate --strict`
+- NO code changes — implementation belongs to a follow-up apply change
+
+## Affected Projects
+
+- [ ] Project: `procest` — Formalize the `bezwaar-hearing` capability with proposal, design, tasks, and a delta-format spec. NO CODE.
+
+## Cross-Project Dependencies
+
+- **bezwaar-lifecycle** (sister spec): owns case type, statussen, and deadlines that reference hearing transitions
+- **bezwaar-advisory-committee** (sister spec): consumes `hearingSession` UUID on advisory reports
+- **case-email-integration**: outbound invitation channel
+- **mijn-overheid-integration**: Berichtenbox channel for invitations

--- a/openspec/changes/bezwaar-hearing/specs/bezwaar-hearing/spec.md
+++ b/openspec/changes/bezwaar-hearing/specs/bezwaar-hearing/spec.md
@@ -1,0 +1,213 @@
+## ADDED Requirements
+
+### Requirement: Hearing Session Entity and Schema Registration
+
+The system SHALL register a `hearingSession` schema in the Procest OpenRegister configuration as a Schema.org `schema:Event`. The schema SHALL declare the properties `case`, `scheduledDate`, `location`, `videoCallUrl`, `chairperson`, `members`, `invitees`, `inspectionAvailableFrom`, `inspectionDeadline`, `attendance`, `minutesSummary`, `minutesDocument`, `audioRecording`, `recordingConsent`, `followUpQuestions`, `status`, `hearingWaived`, and `waiverReason`. The required-property list SHALL be exactly `[case, scheduledDate, chairperson, invitees, inspectionAvailableFrom, inspectionDeadline, status]`. The `status` enum SHALL be exactly `[gepland, uitgenodigd, dossier_beschikbaar, uitgevoerd, geannuleerd, afgezien]`. A hearing session SHALL be the only entity that owns a hoorzitting lifecycle and SHALL always be linked to exactly one bezwaar case.
+
+**Feature tier**: V1
+**Schema.org type**: `schema:Event`
+**CMMN mapping**: HumanTask within bezwaar CasePlanModel
+**AWB reference**: Art. 7:2 (right to be heard)
+
+#### Scenario: Schema is registered after app install
+
+- **WHEN** the Procest app is installed or updated via the repair step
+- **THEN** the `hearingSession` schema SHALL exist in the Procest register
+- **AND** the schema SHALL enforce required properties `case`, `scheduledDate`, `chairperson`, `invitees`, `inspectionAvailableFrom`, `inspectionDeadline`, `status`
+- **AND** the `status` enum SHALL be exactly `[gepland, uitgenodigd, dossier_beschikbaar, uitgevoerd, geannuleerd, afgezien]`
+
+#### Scenario: HearingSession rejects unknown status
+
+- **GIVEN** a caller posts a hearingSession object with `status = "verdaagd"` (not in the enum)
+- **WHEN** the create request is validated
+- **THEN** OpenRegister SHALL reject the object with a schema validation error
+- **AND** no hearingSession SHALL be persisted
+
+### Requirement: Hearing Scheduling and Waiver
+
+The system SHALL support scheduling a hearing for a bezwaar case and, alternatively, recording the bezwaarmaker's waiver of the right to be heard under Awb art. 7:3. On scheduling, the hearingSession SHALL be created with `status = gepland`. On waiver, the hearingSession SHALL be created with `status = afgezien` and `hearingWaived = true` and a non-empty `waiverReason`. Both transitions SHALL append an audit entry to the parent case audit trail tagged `awb-art-7:2` (scheduling) or `awb-art-7:3` (waiver).
+
+**Feature tier**: V1
+**AWB reference**: Art. 7:2 (hearing), Art. 7:3 (waiver)
+
+#### Scenario: Schedule a hearing for a bezwaar case
+
+- **GIVEN** a bezwaar case BZ-2026-0042 with status "In behandeling"
+- **WHEN** the behandelaar schedules a hearing with `scheduledDate = 2026-06-01T10:00:00Z`
+- **THEN** a hearingSession SHALL be created with `status = gepland`
+- **AND** the case status SHALL transition to "Hoorzitting gepland"
+- **AND** the system SHALL validate that `scheduledDate` is at least 5 working days in the future
+- **AND** an audit entry tagged `awb-art-7:2` SHALL be appended to the case audit trail
+
+#### Scenario: Bezwaarmaker waives the right to be heard
+
+- **GIVEN** a bezwaar case BZ-2026-0042 in status "In behandeling"
+- **WHEN** the behandelaar records a waiver with `waiverReason = "Belanghebbende heeft schriftelijk afgezien van het recht te worden gehoord"`
+- **THEN** a hearingSession SHALL be created with `status = afgezien`, `hearingWaived = true`, and the supplied `waiverReason`
+- **AND** the case SHALL be able to skip the "Hoorzitting gepland" and "Hoorzitting afgerond" statuses
+- **AND** an audit entry tagged `awb-art-7:3` SHALL be appended to the case audit trail
+
+#### Scenario: Waiver cannot be recorded after hearing is completed
+
+- **GIVEN** a hearingSession with `status = uitgevoerd`
+- **WHEN** any caller attempts to set `hearingWaived = true` on that hearingSession
+- **THEN** the system SHALL reject the update with HTTP 409
+- **AND** the response message SHALL be `Hoorzitting heeft reeds plaatsgevonden`
+- **AND** the hearingSession status SHALL remain `uitgevoerd`
+
+### Requirement: Invitation Flow with Accessibility Support
+
+The system SHALL send hearing invitations to every entry in `invitees`. Each invitee carries a `channel` enum (`berichtenbox`, `email`, `post`, `in_person`) and an `accessibilityNeeds[]` array (`low_literacy`, `interpreter`, `sign_language`, `physical_access`). Channel selection SHALL prefer Berichtenbox when the bezwaarmaker has a connected MijnOverheid account, fall back to email, and otherwise queue a paper print task. Each accessibility need SHALL produce a documented variant (B1-level Dutch, tolk-booking task, gebarentolk task, or wheelchair-access verification task) and a case audit entry demonstrating Awb art. 2:1 / art. 7:2 reasonable-accommodation duty.
+
+**Feature tier**: V1
+**AWB reference**: Art. 2:1 (reasonable accommodation), Art. 7:2 (invitation duty)
+
+#### Scenario: Invitation routed via Berichtenbox for MijnOverheid-connected bezwaarmaker
+
+- **GIVEN** a hearingSession with `status = gepland` whose bezwaarmaker invitee has a connected MijnOverheid account
+- **WHEN** the behandelaar triggers the invitation action
+- **THEN** the system SHALL queue a Berichtenbox message for that invitee
+- **AND** the hearingSession status SHALL change to `uitgenodigd`
+- **AND** the invitation SHALL include date, time, location, the subject of the bezwaar, and a notice of the right to bring witnesses per art. 7:8
+
+#### Scenario: Low-literacy invitee gets B1-level template
+
+- **GIVEN** a hearingSession invitee with `accessibilityNeeds = ["low_literacy"]`
+- **WHEN** the invitation is rendered
+- **THEN** the invitation body SHALL use a B1-level Dutch template
+- **AND** the date, time, and location SHALL be repeated in a top callout box
+- **AND** an audit entry tagged `accessibility-b1` SHALL be appended to the case audit trail
+
+#### Scenario: Interpreter-required invitee triggers tolk-booking task
+
+- **GIVEN** a hearingSession invitee with `accessibilityNeeds = ["interpreter"]` and `requestedLanguage = "Tigrinya"`
+- **WHEN** the invitation is sent
+- **THEN** the system SHALL create a "Tolk regelen" task on the case with the requested language
+- **AND** the invitation block SHALL state that an interpreter has been requested
+- **AND** an audit entry tagged `accessibility-interpreter` SHALL be appended to the case audit trail
+
+### Requirement: Inspection of File Before Hearing
+
+The system SHALL enforce Awb art. 7:4 lid 2 by guaranteeing that the bezwaardossier is available for inspection by the bezwaarmaker and their gemachtigde at least seven calendar days before the hearing. On hearingSession creation the system SHALL compute `inspectionDeadline = scheduledDate − 7 days`. If a later edit moves `scheduledDate` closer than seven days from today, the save SHALL be rejected. Documents flagged `confidential` under Awb art. 7:6 SHALL be excluded from the inspection bundle but listed as withheld with a reason placeholder. Every inspection access SHALL be logged with `actor`, `documentId`, `accessedAt`, and `purpose = "art-7:4-inspection"`.
+
+**Feature tier**: V1
+**AWB reference**: Art. 7:4 (inspection of file), Art. 7:6 (confidential documents)
+
+#### Scenario: Inspection deadline is auto-computed
+
+- **WHEN** a hearingSession is created with `scheduledDate = 2026-06-15`
+- **THEN** `inspectionDeadline` SHALL be set to `2026-06-08`
+- **AND** `inspectionAvailableFrom` SHALL be no later than `inspectionDeadline`
+
+#### Scenario: Rescheduling closer than 7 days is blocked
+
+- **GIVEN** a hearingSession with `scheduledDate = 2026-06-15` and today is `2026-06-10`
+- **WHEN** the behandelaar attempts to update `scheduledDate` to `2026-06-12`
+- **THEN** the system SHALL reject the update with HTTP 422
+- **AND** the response message SHALL be `Inzagetermijn (art. 7:4) wordt geschonden — minimaal 7 dagen voor de hoorzitting`
+
+#### Scenario: Confidential document is withheld from inspection bundle
+
+- **GIVEN** a bezwaardossier document flagged `confidential` under art. 7:6
+- **WHEN** the bezwaarmaker requests the inspection bundle
+- **THEN** the document SHALL NOT be included
+- **AND** a placeholder entry SHALL list the document title with the reason `Document onthouden op grond van art. 7:6 Awb`
+- **AND** the withholding event SHALL be logged on the inspection trail
+
+### Requirement: Attendee List and Attendance Tracking
+
+The system SHALL track who was invited and who actually attended. The `invitees` array SHALL be set at scheduling time and frozen at invitation; the `attendance` array SHALL be captured during or immediately after the hearing with `{invitee, present, arrivalTime}` entries. Attendance entries SHALL be appendable up to one hour after the hearing concludes; afterwards the list becomes read-only and any correction SHALL require a documented audit-trail entry.
+
+**Feature tier**: V1
+**AWB reference**: Art. 7:8 (witnesses), Art. 7:7 (verslag)
+
+#### Scenario: Capture attendance after the hearing
+
+- **GIVEN** a hearingSession with three invitees (bezwaarmaker, gemachtigde, primair beslisser)
+- **WHEN** the chairperson records that bezwaarmaker and gemachtigde attended, primair beslisser did not
+- **THEN** the `attendance` array SHALL contain three entries with `present = true|false` per invitee
+- **AND** the absent entry SHALL still be recorded for audit completeness
+- **AND** an arrival timestamp SHALL be captured for each present invitee
+
+#### Scenario: Late correction requires audit reason
+
+- **GIVEN** a hearingSession with `status = uitgevoerd` whose attendance was captured more than one hour ago
+- **WHEN** the behandelaar attempts to mark an invitee as present without a correction reason
+- **THEN** the system SHALL reject the update with HTTP 422
+- **AND** the response message SHALL be `Aanwezigheidscorrectie vereist toelichting in audit trail`
+
+### Requirement: Minutes Capture (Text and Optional Audio)
+
+The system SHALL require that a hearingSession transitioning to `status = uitgevoerd` carries at least one of `minutesSummary` (non-empty text) or `minutesDocument` (uploaded verslag file). Audio recording (`audioRecording`) SHALL be optional and SHALL only be accepted when `recordingConsent = granted` has been recorded for the bezwaarmaker. A consent denial SHALL be persisted and SHALL block subsequent audio upload attempts. Recorded audio files SHALL inherit the parent case's retention regime.
+
+**Feature tier**: V1
+**AWB reference**: Art. 7:7 (verslag duty), AVG/GDPR Art. 6 (lawful basis for audio)
+
+#### Scenario: Minutes summary satisfies the verslag duty
+
+- **GIVEN** a hearingSession with `status = uitgenodigd` after the hearing concludes
+- **WHEN** the chairperson sets `minutesSummary = "Bezwaarmaker lichtte gronden toe, primair beslisser reageerde..."` and marks the session `uitgevoerd`
+- **THEN** the transition SHALL be accepted
+- **AND** the case status SHALL transition to "Hoorzitting afgerond"
+
+#### Scenario: Cannot mark uitgevoerd without verslag
+
+- **GIVEN** a hearingSession with empty `minutesSummary` and no `minutesDocument`
+- **WHEN** the chairperson attempts to set `status = uitgevoerd`
+- **THEN** the system SHALL reject the update with HTTP 422
+- **AND** the response message SHALL be `Verslag (art. 7:7) ontbreekt — vul minutesSummary of upload minutesDocument`
+
+#### Scenario: Audio recording requires explicit consent
+
+- **GIVEN** a hearingSession with `recordingConsent = denied`
+- **WHEN** any caller attempts to upload `audioRecording`
+- **THEN** the system SHALL reject the upload with HTTP 403
+- **AND** the response message SHALL be `Bezwaarmaker heeft geen toestemming gegeven voor audio-opname`
+- **AND** a denial audit entry SHALL be appended to the case audit trail
+
+### Requirement: Follow-Up Questions After the Hearing
+
+The system SHALL allow the chairperson to append follow-up questions to a completed hearingSession. Each entry SHALL carry `{question, askedTo, deadline}`. Outstanding follow-up questions SHALL surface on the bezwaar dashboard widget until each is answered or marked withdrawn. Answers SHALL attach to the case dossier as `hearingFollowUp` documents and SHALL link back to the originating question.
+
+**Feature tier**: V1
+**AWB reference**: Art. 7:9 (renewed hearing on new facts) — informational
+
+#### Scenario: Add a follow-up question
+
+- **GIVEN** a hearingSession with `status = uitgevoerd`
+- **WHEN** the chairperson appends a `followUpQuestions` entry `{ question: "Aanvullende onderbouwing van financiële schade?", askedTo: <bezwaarmakerId>, deadline: "2026-06-22" }`
+- **THEN** the entry SHALL be persisted on the hearingSession
+- **AND** the dashboard widget for the parent case SHALL list the outstanding question with its deadline
+
+#### Scenario: Outstanding follow-up triggers dashboard surfacing
+
+- **GIVEN** a hearingSession with one follow-up question whose `deadline` is in three days and no answer yet
+- **WHEN** the behandelaar opens the bezwaar dashboard
+- **THEN** the case SHALL appear in the "Openstaande hoorzitting-vragen" widget
+- **AND** the widget SHALL show the question text, askedTo party, and remaining days
+
+### Requirement: Legal Compliance Audit Hooks
+
+The system SHALL write structured audit entries for every legally relevant event on a hearingSession so that beroep dossier export can demonstrate Awb compliance without manual reconstruction. The audit entries SHALL be tagged with the applicable Awb article and SHALL include `actor`, `timestamp`, `event`, and event-specific payload. The minimum set of tagged events SHALL be: status transitions (`awb-art-7:2`), waiver (`awb-art-7:3`), invitation timestamps (`awb-art-7:2`), inspection access (`awb-art-7:4`), confidential withholding (`awb-art-7:6`), verslag finalization (`awb-art-7:7`), and recording consent / denial (`avg-art-6`).
+
+**Feature tier**: V1
+**AWB reference**: Art. 7:2, 7:3, 7:4, 7:6, 7:7; AVG/GDPR Art. 6
+
+#### Scenario: Status transition writes tagged audit entry
+
+- **GIVEN** a hearingSession transitioning from `gepland` to `uitgenodigd`
+- **WHEN** the transition is committed
+- **THEN** the case audit trail SHALL gain an entry with `tag = "awb-art-7:2"`, `event = "invitation_sent"`, `actor = <behandelaarUID>`, and a timestamp
+
+#### Scenario: Inspection access is logged per document
+
+- **GIVEN** a bezwaarmaker viewing three documents in the inspection bundle
+- **WHEN** each document is opened
+- **THEN** the inspection trail SHALL gain three entries each carrying `tag = "awb-art-7:4"`, `actor`, `documentId`, `accessedAt`, and `purpose = "art-7:4-inspection"`
+
+#### Scenario: Beroep export includes the compliance audit set
+
+- **GIVEN** a bezwaar case with one completed hearingSession (`uitgevoerd`) and a waiver-less full procedure
+- **WHEN** the dossier export action is triggered for beroep submission
+- **THEN** the export SHALL include the structured audit entries tagged `awb-art-7:2`, `awb-art-7:4`, `awb-art-7:7`, and any `avg-art-6` consent entries
+- **AND** the export SHALL link each entry to its hearingSession and document references

--- a/openspec/changes/bezwaar-hearing/tasks.md
+++ b/openspec/changes/bezwaar-hearing/tasks.md
@@ -1,0 +1,22 @@
+# Tasks: bezwaar-hearing
+
+This is a **GENERATE-style** change: spec-only, no code. Tasks below cover authoring the requirements, verifying delta format, and confirming `openspec validate --strict` passes. Implementation lands in a follow-up apply change.
+
+## Spec authoring
+
+- [ ] **T01**: Author `specs/bezwaar-hearing/spec.md` with eight `### Requirement:` blocks (REQ-BH-1..8) in `## ADDED Requirements` delta format. Each requirement carries at least one `#### Scenario:` block with Given/When/Then.
+- [ ] **T02**: Confirm REQ-BH-1 (Hearing Session Entity) declares all fourteen `hearingSession` properties from `design.md` and the six-state status enum.
+- [ ] **T03**: Confirm REQ-BH-2 (Scheduling + Waiver) captures both the `gepland` happy path and the art. 7:3 waiver path with audit-trail entries.
+- [ ] **T04**: Confirm REQ-BH-3 (Invitation Flow + Accessibility) covers channel selection (Berichtenbox / email / post / in_person) and the four `accessibilityNeeds` variants (`low_literacy`, `interpreter`, `sign_language`, `physical_access`).
+- [ ] **T05**: Confirm REQ-BH-4 (Inspection of File) encodes the 7-day floor (Awb art. 7:4 lid 2) as a hard block, plus the art. 7:6 confidential-document exclusion with placeholder.
+- [ ] **T06**: Confirm REQ-BH-5 (Attendee List + Attendance) captures invitee structure, presence tracking, and arrival timestamps.
+- [ ] **T07**: Confirm REQ-BH-6 (Minutes Capture) requires at least one of `minutesSummary` or `minutesDocument` to mark the hearing `uitgevoerd`, and that `audioRecording` is gated by `recordingConsent = granted`.
+- [ ] **T08**: Confirm REQ-BH-7 (Follow-Up Questions) covers post-hearing question entries with deadlines and a dashboard surfacing requirement.
+- [ ] **T09**: Confirm REQ-BH-8 (Legal Compliance Hooks) catalogues the audit-trail entries written for status transitions, waivers, invitation timestamps, inspection access, and recording consent/denial.
+
+## Pre-commit verification
+
+- [ ] **V01**: `openspec validate bezwaar-hearing --type change --strict` → exit code 0
+- [ ] **V02**: `openspec change show bezwaar-hearing --json --deltas-only | jq '.deltaCount'` → ≥ 8 (one delta per REQ-BH-1..8)
+- [ ] **V03**: Every REQ-BH-* in `specs/bezwaar-hearing/spec.md` contains at least one `#### Scenario:` subsection
+- [ ] **V04**: No code files modified — `git diff --name-only origin/development...HEAD` returns only paths under `openspec/changes/bezwaar-hearing/`


### PR DESCRIPTION
## Summary

Formalizes the `bezwaar-hearing` capability as an OpenSpec change. The hoorzitting (Awb art. 7:2-7:7) currently has a partial spec at `openspec/specs/bezwaar-hearing/spec.md` but no change record. This change adds proposal, design, tasks, and a delta-format spec with eight requirements (REQ-BH-1..8). Spec-only - no code changes.

## What's included

- **REQ-BH-1** Hearing Session Entity + schema registration (`hearingSession`, six-state status enum)
- **REQ-BH-2** Scheduling + waiver path (art. 7:2 / art. 7:3) with audit-trail tagging
- **REQ-BH-3** Invitation flow with accessibility hooks (Berichtenbox / email / post / in_person, low_literacy / interpreter / sign_language / physical_access)
- **REQ-BH-4** Inspection of file with hard 7-day floor (art. 7:4 lid 2) and art. 7:6 confidential exclusion
- **REQ-BH-5** Attendee list + attendance tracking (1-hour append window then audit-required correction)
- **REQ-BH-6** Minutes capture (text-or-document required; audio gated by recordingConsent)
- **REQ-BH-7** Follow-up questions after the hearing with dashboard surfacing
- **REQ-BH-8** Legal compliance audit hooks tagged per Awb article + AVG art. 6

## Validation

- `openspec validate bezwaar-hearing --type change --strict` passes
- `deltaCount = 8` (one per REQ-BH-1..8)
- Every requirement carries at least one Given/When/Then scenario

## Sister specs

- `bezwaar-lifecycle` (case type, statussen, deadlines)
- `bezwaar-advisory-committee` (commissie advisory report)

## Test plan

- [ ] Reviewer confirms eight requirements map to scheduling, waiver, invitations/accessibility, inspection-of-file, attendees, minutes, follow-ups, audit hooks
- [ ] Reviewer confirms inspection 7-day floor matches Awb art. 7:4 lid 2
- [ ] Reviewer confirms recordingConsent + AVG art. 6 phrasing acceptable for legal