### PR TITLE
chore(openspec): generate enforcement-lhs spec

### DIFF
--- a/openspec/changes/enforcement-lhs/design.md
+++ b/openspec/changes/enforcement-lhs/design.md
@@ -1,0 +1,63 @@
+# Design: enforcement-lhs
+
+## Context
+
+The Landelijke Handhavingsstrategie Omgevingsrecht (LHS) is a Dutch national reference framework, published by the joint Omgevingsdiensten and codified by IPO/VNG, that prescribes a *proportional* enforcement response. Inspectors do not freely choose sanctions; they pick along two axes — **ernst** (severity of the offence) and **gedrag** (intentionality of the offender) — and the matrix gives the prescribed intervention. In practice a third axis matters: a `burger` who builds an illegal shed should not be treated identically to a `bedrijf` violating an environmental permit, and a `recidivist` should not be treated identically to a first-time offender. Operational omgevingsdiensten express this as four distinct matrices (one per actor type) — which is what this design captures.
+
+## Data structure: 3-D LHS matrix
+
+The `lhsMatrix` schema models the matrix as a versioned object holding a dense cell array of length `len(ernst) * len(gedrag) * len(actorType)`. For the national reference: 3 × 4 × 4 = 48 cells.
+
+| Property | Type | Role |
+|----------|------|------|
+| `name` | string | e.g. "Landelijke Handhavingsstrategie 2024" |
+| `version` | integer | Monotonic; new edits create a new version (immutable history) |
+| `active` | boolean | Exactly one matrix is `active = true` per tenant |
+| `ernstAxis` | array<string> | Ordered: `[gering, aanzienlijk, ernstig]` |
+| `gedragAxis` | array<string> | Ordered: `[goedwillend, onverschillig, calculerend, crimineel]` |
+| `actorTypeAxis` | array<string> | Ordered: `[burger, bedrijf, overheid, recidivist]` |
+| `cells` | array<cell> | Dense; one entry per (ernst, gedrag, actorType) triple |
+| `auditTrail` | array<entry> | Edit log: who, when, which cells changed |
+
+Each `cell` has: `ernst`, `gedrag`, `actorType`, `interventie` (enum: `waarschuwing`, `herstelactie`, `last_onder_dwangsom`, `last_plus_pv`, `bestuursdwang`, `pv_plus_bestuursdwang`), `note` (optional rationale).
+
+## Sanction recommendation service
+
+`SanctionRecommendationService::recommend(ernst, gedrag, actorType, caseId)` is the single entry point used by the wizard, mobile inspection, and complaint intake. It:
+
+1. Loads the `active = true` `lhsMatrix` for the tenant
+2. Looks up the cell matching the input triple (O(1) via a Map keyed `ernst:gedrag:actorType`)
+3. Returns a `sanctionRecommendation` object: input triple, matrix version, recommended interventie, lookup timestamp, server-derived user UID
+4. Persists the recommendation as a `sanctionRecommendation` OpenRegister record linked to `caseId`
+
+When the inspector confirms, a `handhavingsactie` is created from the recommendation. When the inspector overrides, the recommendation captures: `applied` (the chosen interventie), `override = true`, `overrideJustification` (mandatory, free text ≥ 20 chars), and the resulting `handhavingsactie` references the recommendation by ID — preserving the original recommendation even when the case advances on a different sanction.
+
+## Inspector decision UI
+
+The matrix UI extends step 1 of the existing enforcement wizard:
+
+- **Axis selectors**: three radio groups (ernst, gedrag, actorType), with the actor-type pre-filled from the case subject's role classification
+- **Matrix preview**: a 3-D visualisation rendered as a stack of three 3×4 panels (one per actor type), with the cell matching the current selectors highlighted
+- **Recommendation card**: shows the prescribed `interventie`, the matrix name+version it came from, and the per-cell `note`
+- **Override toggle**: when enabled, exposes a sanction dropdown limited to interventions of equal-or-lesser severity (override-up requires manager role), plus a mandatory justification text field
+
+The matrix is read-only from the wizard; configuration lives in **Admin → VTH Instellingen → Handhavingsstrategie**.
+
+## Audit trail integration
+
+Every recommendation and every override appends to two trails:
+
+1. The `sanctionRecommendation` record's own audit trail (immutable per OpenRegister policy)
+2. The parent case timeline (via the existing `vth-module` enforcement workflow), as a new event type `lhs_recommendation` with payload `{ recommendationId, ernst, gedrag, actorType, recommended, applied, override }`
+
+This makes the matrix outcome — and any deviation from it — visible on the same chronological timeline as the constatering, the vooraankondiging and the eventual bezwaar, which is the evidence package a bezwaar committee actually consumes.
+
+## Override authority and security
+
+- Override-down (lighter sanction than recommended): allowed for any inspector with justification
+- Override-up (harsher sanction than recommended): requires manager role; UI hides the higher-severity options for non-managers
+- Identity is server-derived from `IUserSession` on every recommendation and override call — never trusted from request body
+
+## Schema versioning
+
+When an admin edits the matrix, a new `lhsMatrix` version is created (rather than mutating cells in place). In-flight `sanctionRecommendation` records keep referencing the matrix version they used. This is the same pattern as `voorstel.routeSnapshot` — frozen at the moment of decision, immune to retroactive changes.

--- a/openspec/changes/enforcement-lhs/proposal.md
+++ b/openspec/changes/enforcement-lhs/proposal.md
@@ -1,0 +1,53 @@
+# Proposal: enforcement-lhs
+
+## Summary
+
+Extend Procest with a fully configurable, decision-driven implementation of the **Landelijke Handhavingsstrategie Omgevingsrecht (LHS)** — the Dutch national matrix that maps offence severity (ernst) × offender intentionality (gedrag) → the proportional enforcement intervention. The existing `enforcement-lhs` capability spec describes a static 4×4 matrix and a wizard; this change generalises that into a **3-dimensional matrix** (ernst × gedrag × actor-type) with explicit override-with-justification, a sanction-recommendation service, and a first-class audit-trail integration so every recommendation, override and inspector decision becomes traceable evidence for the bezwaar/beroep phase.
+
+## Why
+
+VTH tenders consistently require the LHS as a hard "moeten-eis" (must-have). The current 4×4 form treats every offender the same regardless of whether they are a private citizen, a regulated company, or a repeat offender — but real omgevingsdiensten apply a softer scale for citizens and a sharper scale for industry. Inspectors today work around this in spreadsheets, losing the auditability that the LHS exists to provide. By adding the actor-type axis, formalising the recommendation service, and wiring overrides into the case timeline, Procest covers the LHS use-case end-to-end and produces the legal-quality evidence trail that bezwaar committees require.
+
+## Problem
+
+- The existing spec assumes a single 4×4 matrix; LHS in practice varies by actor type (burger / bedrijf / overheid / recidivist)
+- There is no dedicated `SanctionRecommendationService` — recommendation logic is currently entangled with the wizard UI, making it untestable and unusable from other entry points (mobile inspection, complaint intake)
+- Overrides ("inspector chose a milder/harsher sanction than the matrix proposed") are not first-class objects with mandatory justification, so the audit trail records *that* the case advanced but not *why* the matrix was overruled
+- Matrix lookups are not surfaced on the case timeline alongside the inspection rapport, so reviewers cannot reconstruct the decision chain
+
+## What Changes
+
+- Adds 8 new requirements (REQ-LHS-1..8) extending the existing `enforcement-lhs` capability
+- Introduces an `lhsMatrix` schema with a 3-D cell array (ernst × gedrag × actorType) and version/active flags
+- Introduces a `sanctionRecommendation` schema capturing input axes, recommended intervention, applied intervention, override flag and justification
+- Specifies a backend `SanctionRecommendationService` consumed by the wizard, the mobile inspection flow, and the complaint-intake flow
+- Integrates recommendation + override events into the existing `vth-module` enforcement workflow audit trail
+- NO code in this change — this is a spec-only generation step; implementation follows in a separate apply change
+
+## Affected Projects
+
+- [x] Project: `procest` — Spec-only addition under `openspec/changes/enforcement-lhs/`; live spec lives under `openspec/specs/enforcement-lhs/`
+
+## Scope
+
+### In Scope (V1)
+
+- 3-D LHS matrix schema with actor-type axis
+- Seed import of the national LHS reference matrix
+- `SanctionRecommendationService` (deterministic lookup + override capture)
+- Inspector decision UI: matrix display, axis selectors, override field with mandatory justification
+- Audit-trail integration with the existing `vth-module` enforcement workflow
+
+### Out of Scope
+
+- AI-suggested ernst/gedrag classification — separate `ai-assisted-processing` change
+- Predictive recidivism scoring — Enterprise tier, not in V1
+- Cross-municipality matrix federation — future work
+- Migration of existing `handhavingsactie` records to the new schema (separate data-migration change)
+
+## Cross-Project Dependencies
+
+- **vth-module** (existing spec): provides the enforcement workflow that consumes the recommendation
+- **inspection-checklists** (existing spec): supplies the constatering that triggers the LHS lookup
+- **mobiel-inspectie** (in flight): second entry-point for the LHS recommendation service
+- **OpenRegister**: stores `lhsMatrix` and `sanctionRecommendation` objects and provides the audit trail

--- a/openspec/changes/enforcement-lhs/specs/enforcement-lhs/spec.md
+++ b/openspec/changes/enforcement-lhs/specs/enforcement-lhs/spec.md
@@ -1,0 +1,172 @@
+## ADDED Requirements
+
+### Requirement: REQ-LHS-1 — 3-D LHS matrix schema
+
+The system SHALL register an `lhsMatrix` schema in the Procest OpenRegister configuration that models the Landelijke Handhavingsstrategie as a versioned 3-dimensional matrix indexed by `ernst`, `gedrag`, and `actorType`. The schema SHALL declare the properties `name`, `version`, `active`, `ernstAxis`, `gedragAxis`, `actorTypeAxis`, `cells`, and `auditTrail`. The required list SHALL be exactly `[name, version, active, ernstAxis, gedragAxis, actorTypeAxis, cells]`. Each cell SHALL carry `ernst`, `gedrag`, `actorType`, `interventie`, and an optional `note`. The `interventie` enum SHALL be exactly `[waarschuwing, herstelactie, last_onder_dwangsom, last_plus_pv, bestuursdwang, pv_plus_bestuursdwang]`.
+
+**Feature tier**: V1
+**Schema.org type**: `schema:DecisionMatrix` (custom subtype of `schema:Intangible`)
+**ZGW mapping**: Custom extension (no ZGW equivalent)
+**Standards**: Landelijke Handhavingsstrategie Omgevingsrecht (IPO/VNG, 2024)
+
+#### Scenario: Schema is registered after app install
+
+- **GIVEN** the Procest app is freshly installed
+- **WHEN** the repair step runs `ConfigurationService::importFromApp()`
+- **THEN** the `lhsMatrix` schema SHALL exist in the Procest register
+- **AND** the schema SHALL enforce the required list `[name, version, active, ernstAxis, gedragAxis, actorTypeAxis, cells]`
+- **AND** the `interventie` enum on cells SHALL be exactly the six values listed above
+
+#### Scenario: Invalid interventie rejected
+
+- **GIVEN** an administrator attempts to save an `lhsMatrix` whose `cells[0].interventie = "boete"` (not in the enum)
+- **WHEN** the save is validated against the schema
+- **THEN** OpenRegister SHALL reject the object with a schema validation error
+- **AND** no `lhsMatrix` SHALL be persisted
+
+### Requirement: REQ-LHS-2 — Default national LHS matrix seed
+
+The system SHALL seed exactly one `lhsMatrix` with `version = 1` and `active = true` as part of the VTH case-type seed data. The seeded matrix SHALL contain the three axes (`ernst`, `gedrag`, `actorType`) and a dense `cells` array of length 48 (3 × 4 × 4) matching the national IPO/VNG reference. The seed step SHALL be idempotent: re-running it SHALL NOT create a second `lhsMatrix` record.
+
+**Feature tier**: V1
+
+#### Scenario: Default matrix created on VTH seed
+
+- **GIVEN** a tenant with no existing `lhsMatrix` records
+- **WHEN** the VTH seed step runs
+- **THEN** exactly one `lhsMatrix` record SHALL be created with `name = "Landelijke Handhavingsstrategie 2024"`, `version = 1`, `active = true`
+- **AND** `cells.length` SHALL equal 48
+- **AND** every (ernst, gedrag, actorType) triple from the three axes SHALL appear exactly once in `cells`
+
+#### Scenario: Seed is idempotent
+
+- **GIVEN** the seed step has already run once and an `active = true` `lhsMatrix` exists
+- **WHEN** the seed step runs again
+- **THEN** no new `lhsMatrix` record SHALL be created
+- **AND** the existing record's `cells` SHALL remain unchanged
+
+### Requirement: REQ-LHS-3 — Sanction recommendation service
+
+The system SHALL provide a `SanctionRecommendationService` with a public `recommend(caseId, ernst, gedrag, actorType)` method that looks up the matching cell in the `active = true` `lhsMatrix` and returns a persisted `sanctionRecommendation` object. The service SHALL derive the acting user UID from `IUserSession` and SHALL NOT trust any UID supplied in the request body. The lookup SHALL be deterministic: identical inputs against the same matrix version SHALL always produce the same `recommendedInterventie`.
+
+**Feature tier**: V1
+
+#### Scenario: Recommend looks up matrix cell
+
+- **GIVEN** the active matrix has a cell `{ernst: aanzienlijk, gedrag: onverschillig, actorType: bedrijf, interventie: last_onder_dwangsom}`
+- **WHEN** an inspector calls `recommend(caseId, "aanzienlijk", "onverschillig", "bedrijf")`
+- **THEN** the service SHALL return a `sanctionRecommendation` with `recommendedInterventie = "last_onder_dwangsom"`
+- **AND** the record's `matrixVersion` SHALL equal the active matrix version
+- **AND** `recommendedBy` SHALL equal the authenticated user's UID
+- **AND** the record SHALL be persisted in OpenRegister
+
+#### Scenario: Identity is server-derived
+
+- **GIVEN** authenticated user `k.vermeulen` posts a recommend request whose body sets `recommendedBy = "p.janssen"`
+- **WHEN** the service handles the request
+- **THEN** the persisted record SHALL store `recommendedBy = "k.vermeulen"`
+- **AND** the body-supplied UID SHALL be silently ignored
+
+### Requirement: REQ-LHS-4 — Sanction recommendation schema
+
+The system SHALL register a `sanctionRecommendation` schema with properties `case`, `ernst`, `gedrag`, `actorType`, `matrixVersion`, `recommendedInterventie`, `appliedInterventie`, `override`, `overrideJustification`, and `recommendedBy`. The required list SHALL be exactly `[case, ernst, gedrag, actorType, matrixVersion, recommendedInterventie, recommendedBy]`. When `override = true`, `overrideJustification` SHALL be present and SHALL contain at least 20 non-whitespace characters.
+
+**Feature tier**: V1
+**Schema.org type**: `schema:Recommendation`
+
+#### Scenario: Override without justification rejected
+
+- **GIVEN** an inspector attempts to save a `sanctionRecommendation` with `override = true` and `overrideJustification = "ok"` (3 characters)
+- **WHEN** the save is validated
+- **THEN** the save SHALL be rejected with HTTP 422 and Dutch message `Motivatie afwijking moet minimaal 20 tekens bevatten`
+- **AND** no record SHALL be persisted
+
+#### Scenario: Non-override does not require justification
+
+- **GIVEN** a saved `sanctionRecommendation` with `recommendedInterventie = appliedInterventie = "waarschuwing"`
+- **WHEN** the record is created
+- **THEN** `override` SHALL default to `false`
+- **AND** `overrideJustification` MAY be absent
+
+### Requirement: REQ-LHS-5 — Inspector decision UI with matrix preview
+
+The system SHALL render an inspector decision UI in step 1 of the enforcement wizard that exposes three axis selectors (ernst, gedrag, actorType) and a three-panel matrix preview where each panel corresponds to one actor-type slice. Selecting all three axes SHALL immediately display the recommendation card containing the recommended interventie, the matrix name + version, and the per-cell `note` if present.
+
+**Feature tier**: V1
+
+#### Scenario: Recommendation card updates on axis change
+
+- **GIVEN** an inspector has opened step 1 of the enforcement wizard for a case
+- **WHEN** the inspector selects `ernst = "ernstig"`, `gedrag = "calculerend"`, `actorType = "bedrijf"`
+- **THEN** the recommendation card SHALL display the interventie returned by `SanctionRecommendationService::recommend()` for that triple
+- **AND** the matrix-preview cell at that coordinate SHALL be highlighted in the `bedrijf` panel
+- **AND** the matrix `name` and `version` SHALL be visible on the card
+
+#### Scenario: Actor type pre-fills from case subject
+
+- **GIVEN** a case whose subject is classified as a bedrijf (KvK-bound legal entity)
+- **WHEN** the inspector opens step 1
+- **THEN** the `actorType` selector SHALL be pre-set to `bedrijf`
+- **AND** the inspector SHALL still be able to change it
+
+### Requirement: REQ-LHS-6 — Override with mandatory justification
+
+The system SHALL allow an inspector to override the recommended interventie via an explicit override toggle. When the toggle is engaged, the system SHALL present a sanction dropdown and a `justification` text field. Submitting an override SHALL persist `override = true`, `appliedInterventie`, and `overrideJustification` (≥ 20 characters) on the `sanctionRecommendation` record. An override that selects an interventie of *higher* severity than the recommended one SHALL be permitted only for users carrying the manager role.
+
+**Feature tier**: V1
+
+#### Scenario: Override-down with justification succeeds
+
+- **GIVEN** the matrix recommends `last_onder_dwangsom` for the selected triple
+- **WHEN** the inspector enables the override toggle, picks `waarschuwing` (lower severity), enters a 25-character justification, and submits
+- **THEN** the saved `sanctionRecommendation` SHALL have `override = true`, `appliedInterventie = "waarschuwing"`, and the supplied `overrideJustification`
+- **AND** the resulting `handhavingsactie` SHALL reference the recommendation's ID
+
+#### Scenario: Override-up requires manager role
+
+- **GIVEN** the matrix recommends `waarschuwing` and an inspector without manager role attempts to override to `bestuursdwang`
+- **WHEN** the submission is processed
+- **THEN** the service SHALL return HTTP 403 with the message `Verzwaring vereist managerrol`
+- **AND** the UI SHALL NOT have offered `bestuursdwang` as a selectable option for non-managers
+
+### Requirement: REQ-LHS-7 — Audit-trail integration with vth-module workflow
+
+The system SHALL append an `lhs_recommendation` event to the parent case timeline (as exposed by the `vth-module` enforcement workflow) for every `recommend` and `override` call. The event payload SHALL include `{ recommendationId, ernst, gedrag, actorType, recommended, applied, override }`. The OpenRegister per-save audit log SHALL additionally capture the `sanctionRecommendation` mutation, providing a second, lower-level audit channel.
+
+**Feature tier**: V1
+
+#### Scenario: Recommendation appears on case timeline
+
+- **GIVEN** a case in the enforcement workflow with no prior LHS recommendation
+- **WHEN** an inspector calls `recommend(caseId, "gering", "goedwillend", "burger")` and the service returns `recommendedInterventie = "waarschuwing"`
+- **THEN** an event of type `lhs_recommendation` SHALL appear on the case timeline
+- **AND** the event payload SHALL contain `recommendationId`, `ernst = "gering"`, `gedrag = "goedwillend"`, `actorType = "burger"`, `recommended = "waarschuwing"`, `applied = "waarschuwing"`, `override = false`
+
+#### Scenario: Override produces a second timeline event
+
+- **GIVEN** a case where a recommendation event has already been recorded
+- **WHEN** the inspector later submits an override on the same recommendation
+- **THEN** a second `lhs_recommendation` event SHALL be appended with the same `recommendationId` but `applied` reflecting the new interventie and `override = true`
+- **AND** the chronological order of the two events SHALL be preserved
+
+### Requirement: REQ-LHS-8 — Matrix versioning and snapshot stability
+
+The system SHALL treat the `lhsMatrix` as immutable per version. Edits made by an administrator SHALL create a new `lhsMatrix` record with `version = previousVersion + 1`; the new record SHALL receive `active = true` while the prior matrix SHALL have its `active` flag flipped to `false`. Each `sanctionRecommendation` SHALL store the `matrixVersion` it was looked up against; subsequent matrix edits SHALL NOT mutate the `recommendedInterventie` of prior recommendations.
+
+**Feature tier**: V1
+
+#### Scenario: Edit creates a new version
+
+- **GIVEN** matrix M1 with `version = 1`, `active = true`
+- **WHEN** an administrator saves a cell change via the admin grid editor
+- **THEN** a new matrix M2 SHALL be persisted with `version = 2`, `active = true`
+- **AND** M1 SHALL be updated to `active = false`
+- **AND** at most one `lhsMatrix` SHALL have `active = true` per tenant
+
+#### Scenario: Historical recommendation references frozen version
+
+- **GIVEN** a `sanctionRecommendation` R1 recorded against matrix M1 (`version = 1`, `recommendedInterventie = "herstelactie"`)
+- **WHEN** an administrator publishes M2 in which the same cell now resolves to `"last_onder_dwangsom"`
+- **THEN** R1's `recommendedInterventie` SHALL remain `"herstelactie"`
+- **AND** R1's `matrixVersion` SHALL remain `1`
+- **AND** new recommendations made after the publish SHALL use M2

--- a/openspec/changes/enforcement-lhs/tasks.md
+++ b/openspec/changes/enforcement-lhs/tasks.md
@@ -1,0 +1,28 @@
+# Tasks: enforcement-lhs
+
+This change is **spec-only**; no source code is modified by it. Tasks T01–T05 capture the implementation work that the follow-up apply change will execute; verification tasks V01–V04 gate the spec itself.
+
+## Schema and data
+
+- [ ] **T01**: Add `lhsMatrix` schema to `lib/Settings/procest_register.json` (OpenAPI 3.0 form): properties `name`, `version` (integer), `active` (boolean), `ernstAxis`, `gedragAxis`, `actorTypeAxis` (each `array<string>`), `cells` (array of `{ernst, gedrag, actorType, interventie, note}`), `auditTrail` (array). Add `sanctionRecommendation` schema with: `case` (UUID), `ernst`, `gedrag`, `actorType`, `matrixVersion` (integer), `recommendedInterventie`, `appliedInterventie`, `override` (boolean), `overrideJustification` (string ≥ 20 chars when `override=true`), `recommendedBy` (NC UID). Required lists: `lhsMatrix`: `[name, version, active, ernstAxis, gedragAxis, actorTypeAxis, cells]`; `sanctionRecommendation`: `[case, ernst, gedrag, actorType, matrixVersion, recommendedInterventie, recommendedBy]`.
+
+- [ ] **T02**: Add default national LHS data import to the VTH seed step. The seed SHALL create one `lhsMatrix` with `version = 1`, `active = true`, the three axes filled per `design.md`, and 48 `cells` matching the IPO/VNG reference matrix (per-actor-type variants documented in `design.md` and the appended cell table in `lib/Settings/seed/lhs-matrix-2024.json`). Idempotent: re-running the seed MUST NOT create duplicate matrices.
+
+## Backend service
+
+- [ ] **T03**: Implement `SanctionRecommendationService` in `lib/Service/SanctionRecommendationService.php`. Public methods: `recommend(string $caseId, string $ernst, string $gedrag, string $actorType): sanctionRecommendation`, `override(string $recommendationId, string $appliedInterventie, string $justification): sanctionRecommendation`. Implementation rules: load the `active = true` matrix, map cells into an in-memory dictionary keyed `"ernst:gedrag:actorType"`, derive user UID from `IUserSession`, persist via OpenRegister object service, reject `override` calls where `justification` is shorter than 20 characters or the requested interventie is *more* severe than the recommended one unless the caller has the manager role.
+
+## Frontend
+
+- [ ] **T04**: Update the enforcement wizard step 1 (`src/components/enforcement/EnforcementWizardStep1.vue` or the equivalent existing component) to call `SanctionRecommendationService` via the OpenRegister-backed API endpoint, render the three axis selectors, render the three-panel matrix preview, and show the recommendation card. Wire the override toggle to display the justification field and to disable harsher options for non-managers. Add an admin grid editor under VTH Settings → Handhavingsstrategie that previews all three actor-type panels and saves edits as a new matrix version (active flag transferred).
+
+## Audit & integration
+
+- [ ] **T05**: Wire recommendation and override events into the existing `vth-module` enforcement workflow audit trail. Append an `lhs_recommendation` event to the case timeline whenever `recommend()` or `override()` is called, with payload `{ recommendationId, ernst, gedrag, actorType, recommended, applied, override }`. Confirm the existing per-save OpenRegister audit log also captures the `sanctionRecommendation` mutation.
+
+## Verification (gate this change)
+
+- [ ] **V01**: `openspec validate enforcement-lhs --type change --strict` → exit code 0
+- [ ] **V02**: `openspec change show enforcement-lhs --json --deltas-only | jq '.deltaCount'` → ≥ 8 (one delta per REQ-LHS-1..8)
+- [ ] **V03**: Every REQ-LHS-* in `specs/enforcement-lhs/spec.md` carries at least one `#### Scenario:` block; every Scenario uses Given/When/Then keywords
+- [ ] **V04**: No code files modified outside `openspec/changes/enforcement-lhs/` — verify with `git diff --name-only origin/development...HEAD | grep -v '^openspec/changes/enforcement-lhs/'` returns empty


### PR DESCRIPTION
## Summary

Generates a spec-only OpenSpec change that extends the existing `enforcement-lhs` capability with a richer model for the Landelijke Handhavingsstrategie Omgevingsrecht (LHS):

- 3-D matrix (ernst x gedrag x actor-type) replacing the 4x4 simplification
- Dedicated `SanctionRecommendationService` shared by wizard, mobile inspection, complaint intake
- First-class override capture with mandatory >=20-char justification and manager-only severity-up
- Audit-trail integration into the existing `vth-module` enforcement workflow timeline
- Matrix versioning snapshot pattern (same approach as `voorstel.routeSnapshot`)

## Contents

- proposal.md (559 words): scope, motivation, what changes, dependencies
- design.md (720 words): schemas, recommendation service, UI, audit, security
- tasks.md: T01-T05 implementation, V01-V04 verification gates
- specs/enforcement-lhs/spec.md: REQ-LHS-1..8 with 16 Given/When/Then scenarios

## Verification

- [x] openspec validate enforcement-lhs --type change --strict -> Change 'enforcement-lhs' is valid
- [x] deltaCount = 8 (one per REQ-LHS-1..8)
- [x] 16 Given/When/Then scenarios, every requirement has at least one scenario
- [x] No code files modified outside openspec/changes/enforcement-lhs/

## Notes for review

- GENERATE-style change: spec only, no code. Implementation follows in a separate apply change.
- The existing canonical openspec/specs/enforcement-lhs/spec.md (4x4 matrix) is retained; on archive, the delta in this change will be merged into the canonical spec.
- Override-up authority rule (manager only) is new and may need confirmation with VTH product owner.