### PR TITLE
chore(openspec): generate bezwaar-advisory-committee spec

### DIFF
--- a/openspec/changes/bezwaar-advisory-committee/design.md
+++ b/openspec/changes/bezwaar-advisory-committee/design.md
@@ -1,0 +1,90 @@
+# Design: bezwaar-advisory-committee
+
+## Context
+
+Under the Dutch Algemene wet bestuursrecht (Awb) Art. 7:13, a council (bestuursorgaan) handling a citizen's objection (`bezwaar`) MAY (and in many municipalities DOES, as a matter of policy) defer the substantive review to an independent advisory committee — the **bezwaaradviescommissie** (commonly abbreviated as **bac**). The committee hears the parties, deliberates, and issues a written advice that the council must consider before issuing its decision-on-objection (`besluit op bezwaar`). The advice is **not binding**: the council may deviate, but any deviation requires explicit motivation. This change formalizes that committee, its lifecycle, and the advice it produces, as a sister capability to the parent `bezwaar-lifecycle` change.
+
+## Entity: `bezwaaradviescommissie`
+
+A committee is a long-lived configuration entity owned by the council, not a per-case entity. Selected properties:
+
+| Property | Type | Role |
+|----------|------|------|
+| `name` | string ≤ 255 | Display name (e.g. "Bezwaarcommissie sociaal domein") |
+| `domain` | enum: `algemeen`, `sociaal_domein`, `wabo`, `belasting`, `personeel` | Optional jurisdiction filter |
+| `chair` | string (NC UID or external party reference) | Committee chair |
+| `members` | array of party refs | All committee members (chair + others) |
+| `secretary` | string (NC UID) | Civil servant secretary (Art. 7:13(2)) |
+| `quorum` | integer ≥ 2 | Minimum members needed to issue advice (default 3) |
+| `term_starts_on` / `term_ends_on` | date | Validity window |
+| `status` | enum: `active`, `archived` | Lifecycle |
+
+A `voorzitter` (chair) plus **at least two** members where **none is a civil servant of the council that took the contested decision** is the Awb Art. 7:13(3) baseline. Member independence is enforced by REQ-BAC-2 at the moment a bezwaar case is assigned to a committee, **not** at committee creation, because the same panel can be valid for one bezwaar and invalid for another (the contested decision's author varies).
+
+## Entity: `bac_advice_request`
+
+A per-bezwaar record that wires one bezwaar case to one committee and tracks the advice deliverable.
+
+| Property | Type | Role |
+|----------|------|------|
+| `bezwaar_case` | UUID (ref → bezwaar case) | The case being reviewed |
+| `committee` | UUID (ref → committee) | The assigned committee |
+| `panel` | array of party refs | Subset of `committee.members` actually sitting on this case |
+| `status` | enum, 3 values | Lifecycle (see below) |
+| `assigned_at` | datetime | When the council referred the bezwaar to the committee |
+| `deadline` | date | Target advice date — defaults to 12 weeks from `assigned_at` (Awb Art. 7:24(1)) |
+| `advice_document` | string (NC file ID or OpenRegister doc ref) | The signed advice |
+| `hearing_report_ref` | string | Link to the hoorzitting report (owned by `bezwaar-lifecycle`) |
+
+## Advice request lifecycle
+
+```
+assigned ──(panel deliberates, hearing report attached)──► in-deliberation
+in-deliberation ──(chair signs advice document, all required content present)──► advice-issued
+```
+
+There is intentionally **no `withdrawn` state**: if the bezwaar is withdrawn upstream, the parent `bezwaar-lifecycle` closes the case and the `bac_advice_request` is left in its last state for audit. There is also **no rejection state**: the committee always produces some advice (even if "bezwaar niet-ontvankelijk verklaren") per Awb Art. 7:13(7).
+
+Transitions:
+
+- **`assigned → in-deliberation`** — triggered when the panel is finalized and the hoorzitting report from `bezwaar-lifecycle` is attached. Independence check (REQ-BAC-2) runs here and MAY block.
+- **`in-deliberation → advice-issued`** — triggered when the chair (or a delegated chair-replacement) signs the advice document; the advice must satisfy the content contract (REQ-BAC-4) and the panel size must meet `committee.quorum`.
+
+## Advice document content contract (Awb Art. 7:13(7))
+
+The advice document is a structured object stored as a Nextcloud file with a JSON sidecar (`advice.json`). Required fields:
+
+- `findings`: factual findings (relevante feiten) — string, ≥ 50 chars
+- `hearing_summary_ref`: pointer to the hoorzittingverslag owned by `bezwaar-lifecycle`
+- `legal_assessment`: legal assessment (juridisch oordeel) — string, ≥ 50 chars
+- `conclusion`: one of `gegrond`, `ongegrond`, `gedeeltelijk_gegrond`, `niet_ontvankelijk`
+- `recommendation`: free-text recommendation to the council
+- `dissenting_opinions`: optional array of `{ member_uid, opinion }` blocks when panel disagreement exists
+- `signed_by_chair_at`: datetime; the chair's signature timestamp
+- `signature_evidence`: ref to e-signature evidence or a wet-ink scan note (Nextcloud file ID)
+
+The JSON sidecar is hidden from end users; the rendered PDF is what gets published. Tasks include verifying that the PDF template renders all required fields.
+
+## Council deviation justification
+
+When the council issues the besluit op bezwaar **and** the decision deviates from the committee's `conclusion`, the besluit object SHALL carry a non-empty `motivatie_afwijking_advies` field. This is enforced by a guard in the `bezwaar-lifecycle` service (out of scope here) — but the spec for that guard lives in REQ-BAC-5 because the requirement originates from the committee capability. The two specs cross-reference each other.
+
+## Audit trail
+
+Every state change on `bac_advice_request` and every mutation of `advice_document` content is recorded by OpenRegister's automatic per-save audit log. Additionally, the following events append explicit entries to a `bac_audit_trail` field on the advice request:
+
+- panel-member-added / panel-member-removed (with reason)
+- independence-check-failed (with the failing member + reason)
+- advice-signed-by-chair (with chair UID + timestamp + signature evidence ref)
+- council-deviation-recorded (with besluit ref + motivatie hash)
+
+Combined with the OpenRegister log, this satisfies Archiefwet (Dutch Public Records Act) accountability for advisory bodies.
+
+## Why a GENERATE-style spec?
+
+The committee is not yet in code. Writing the spec first lets a downstream `opsx-apply` change implement it against a frozen contract, and lets reviewers validate Awb compliance before any PHP is written. If the parent `bezwaar-lifecycle` change ships first, this capability slots in as an extension without invalidating any of `bezwaar-lifecycle`'s requirements.
+
+## Open questions deferred to follow-ups
+
+- **E-signature on the advice document**: the chair's signature is recorded as `signature_evidence`; whether that's a Nextcloud-native e-signature (`signing` app), a Validsign integration, or a scanned wet-ink page is left to a follow-up. Flagged in tasks.
+- **Multi-committee rotation**: large councils run multiple committees and round-robin or domain-route between them. Out of scope V1; tracked as a follow-up issue.

--- a/openspec/changes/bezwaar-advisory-committee/proposal.md
+++ b/openspec/changes/bezwaar-advisory-committee/proposal.md
@@ -1,0 +1,57 @@
+# Proposal: Bezwaar Advisory Committee (Bezwaaradviescommissie)
+
+## Summary
+
+Add a dedicated `bezwaar-advisory-committee` capability to Procest that models the optional independent advisory committee (bezwaaradviescommissie / bac) that, under **Awb Art. 7:13**, reviews a citizen's objection and issues a written advice to the council (bestuursorgaan) before the council takes its decision-on-objection. This sister capability extends the parent `bezwaar-lifecycle` change by formalizing the committee as a first-class entity, capturing its composition (chair + ≥ 2 members, none of whom are civil servants involved in the contested decision), the advice request lifecycle (`assigned → in-deliberation → advice-issued`), the advice document with all Art. 7:13(7) required content, the council's deviation-justification rule, and the per-action audit trail.
+
+## Why
+
+Tenders from HLT, Beverwijk, Winterswijk, Nissewaard, Den Helder and Horst aan de Maas all reference an "adviescommissie bezwaarschriften" track in their bezwaar requirements (the cluster carries 801 requirements across 209 tenders in our intelligence DB). The parent `bezwaar-lifecycle` spec stops at the workflow level — it lists "Advies commissie" as a process step but does not specify how the committee itself is composed, how cases are assigned to committees, what fields the advice document must contain, or how the council records a deviating decision. Without that detail, a municipality cannot prove **Awb-compliant** bezwaar handling and our spec coverage is materially incomplete for the cluster.
+
+Modeling the advisory committee separately (rather than inlining everything into `bezwaar-lifecycle`) keeps the lifecycle spec focused on the statutory deadline + decision flow while letting compliance officers, scheme operators, and audit reviewers find the committee contract in one well-named capability. It also makes the committee re-usable from `complaint-management` and `consultation-management`, which use a similar advisory pattern.
+
+## What Changes
+
+- Adds the `bezwaar-advisory-committee` capability spec with eight requirements (REQ-BAC-1..8) in delta format under this change's `specs/` directory
+- Adds a `design.md` describing the committee entity, advice-request lifecycle, advice document content contract, council deviation justification, and audit trail
+- Adds eight verification + design-only tasks (T01–T08) — schema sketch, lifecycle FSM, advice template, council-deviation rule, audit trail, cross-spec links, validation gate
+- Does **NOT** introduce any code changes — this is a SPEC-ONLY change; implementation is a downstream `opsx-apply` change
+
+## Affected Projects
+
+- [ ] Project: `procest` — Add the `bezwaar-advisory-committee` OpenSpec change with proposal, design, tasks, and delta spec. NO CODE.
+
+## Scope
+
+### In Scope (V1)
+
+- **Committee entity** (REQ-BAC-1): composition rules, chair, members, secretary, term, jurisdiction
+- **Member independence** (REQ-BAC-2): blocking civil servants involved in the contested decision per Awb Art. 7:13(3)
+- **Advice request lifecycle** (REQ-BAC-3): `assigned → in-deliberation → advice-issued`
+- **Advice document content** (REQ-BAC-4): findings, hearing report reference, conclusion, recommendation per Awb Art. 7:13(7)
+- **Council deviation justification** (REQ-BAC-5): mandatory motivation when the council departs from the advice
+- **Advice publication** (REQ-BAC-6): the advice is published with the besluit op bezwaar
+- **Audit trail** (REQ-BAC-7): every committee action recorded immutably for Archiefwet compliance
+- **Authorization model** (REQ-BAC-8): only committee members + bezwaar handler may read; only chair may issue advice
+
+### Out of Scope
+
+- The wider bezwaar lifecycle (handled by sibling `bezwaar-lifecycle` change)
+- Hearing scheduling logistics (handled by `bezwaar-lifecycle` via Nextcloud Calendar)
+- E-signature for the chair's signature on the advice (deferred to a follow-up; flagged in tasks)
+- Workflow templates for non-bezwaar advisory committees (re-use is acknowledged but the abstract version is a later change)
+
+## Approach
+
+GENERATE-style spec change. The committee capability does not yet exist in code; this change writes the contract first so that a follow-up `opsx-apply` change can implement it against a stable spec. No source files are touched by this change.
+
+1. **Proposal + design + tasks** describe what to build and how to verify it
+2. **Delta spec** under `specs/bezwaar-advisory-committee/spec.md` with eight `## ADDED Requirements` entries (REQ-BAC-1..8) each carrying ≥ 1 Given/When/Then scenario
+3. **Pre-commit gate** is `openspec validate bezwaar-advisory-committee --type change --strict`
+
+## Cross-Project Dependencies
+
+- **bezwaar-lifecycle** (sister spec, in progress): the parent objection lifecycle that hands off to this committee
+- **bezwaar-beroep-workflow** (already drafted): the broader bezwaar/beroep workflow context that this capability lives inside
+- **OpenRegister**: object storage and audit trail for committee + advice records
+- **document-zaakdossier**: the advice document and hearing report are stored as case dossier files

--- a/openspec/changes/bezwaar-advisory-committee/specs/bezwaar-advisory-committee/spec.md
+++ b/openspec/changes/bezwaar-advisory-committee/specs/bezwaar-advisory-committee/spec.md
@@ -1,0 +1,180 @@
+## ADDED Requirements
+
+### Requirement: Bezwaaradviescommissie Entity and Composition
+
+The system SHALL register a `bezwaaradviescommissie` schema modeling an independent advisory committee. A committee SHALL declare `name`, `domain` (optional jurisdiction filter), `chair` (the voorzitter), `members` (an array of party references, length ≥ 2 in addition to the chair, satisfying the Awb Art. 7:13(1) "ten minste drie leden" baseline), `secretary` (a council civil servant per Awb Art. 7:13(2)), `quorum` (integer ≥ 2, default 3), `term_starts_on`, `term_ends_on`, and `status` (enum: `active`, `archived`). The committee entity SHALL be a long-lived configuration object — independent of any single bezwaar case — and SHALL be the only entity authorised to issue an `advice` deliverable under this capability.
+
+**Feature tier**: V1
+**Schema.org type**: `schema:Organization` (specialisation: `schema:GovernmentOrganization`)
+**ZGW mapping**: no direct ZGW equivalent; the advice deliverable maps loosely to `Adviesdocument`.
+**Awb reference**: Art. 7:13(1)–(2)
+
+#### Scenario: Committee creation rejects sub-minimum composition
+
+- **GIVEN** an administrator creates a committee with `chair = "j.smit"` and `members = ["j.smit"]` (chair only)
+- **WHEN** the create request is validated
+- **THEN** the system SHALL reject the request with HTTP 422
+- **AND** the response SHALL carry a Dutch message such as `Een bezwaaradviescommissie heeft een voorzitter plus ten minste twee leden nodig (Awb Art. 7:13)`
+- **AND** no committee record SHALL be persisted
+
+#### Scenario: Archived committee cannot be assigned new bezwaren
+
+- **GIVEN** committee C1 has `status = archived`
+- **WHEN** a bezwaar handler tries to assign a new bezwaar case to C1
+- **THEN** the system SHALL reject the assignment with HTTP 409
+- **AND** the response SHALL state that the committee is no longer active
+
+### Requirement: Member Independence Check at Assignment
+
+When a bezwaar case is assigned to a committee (transition `assigned → in-deliberation` on the advice request), the system SHALL verify that **no panel member is a civil servant who was involved in the contested primair besluit**, per Awb Art. 7:13(3). The check SHALL compare each panel member's `nc_uid` against the `steller` and any signatories recorded on the primair besluit. A failing match SHALL block the transition; the bezwaar handler SHALL be required to swap the conflicting member or re-route the case to a different committee.
+
+**Feature tier**: V1
+**Awb reference**: Art. 7:13(3)
+
+#### Scenario: Panel member who signed the primair besluit is rejected
+
+- **GIVEN** a bezwaar case against besluit B1 where `B1.steller = "j.devries"`
+- **AND** committee C1 with `panel = ["a.bakker", "p.janssen", "j.devries"]`
+- **WHEN** the bezwaar handler tries to advance the advice request to `in-deliberation`
+- **THEN** the system SHALL reject the transition with HTTP 409
+- **AND** the response SHALL identify `j.devries` as the conflicting member with reason `Lid was betrokken bij het bestreden besluit (Awb Art. 7:13 lid 3)`
+- **AND** the advice request SHALL remain in `assigned`
+- **AND** an `independence-check-failed` entry SHALL be appended to `bac_audit_trail`
+
+#### Scenario: Independence is re-evaluated per case
+
+- **GIVEN** committee C1 with `panel = ["a.bakker", "p.janssen", "j.devries"]` is valid for bezwaar #A123 (whose primair besluit was signed by `m.kuipers`)
+- **WHEN** the same committee composition is proposed for bezwaar #A124 (whose primair besluit was signed by `j.devries`)
+- **THEN** the system SHALL accept the panel for #A123 and reject it for #A124
+- **AND** the rejection on #A124 SHALL not affect the validity of #A123
+
+### Requirement: Advice Request Lifecycle
+
+The system SHALL maintain a `bac_advice_request` per bezwaar-to-committee referral through a three-state lifecycle: `assigned`, `in-deliberation`, `advice-issued`. The default state on creation SHALL be `assigned`. Transitions SHALL be driven exclusively by the `BacAdviceRequestService` (or equivalent) and SHALL never be applied via raw schema writes from the frontend. The lifecycle SHALL be one-way (no reverse transitions); a withdrawn bezwaar leaves the advice request in its last state for audit.
+
+**Feature tier**: V1
+**Awb reference**: Art. 7:13(1), 7:24
+
+#### Scenario: Default state on creation
+
+- **WHEN** a bezwaar handler creates a `bac_advice_request` for bezwaar case Z1 referring it to committee C1
+- **THEN** the new advice request SHALL have `status = assigned`
+- **AND** `assigned_at` SHALL be the server timestamp at creation
+- **AND** `deadline` SHALL default to `assigned_at + 12 weeks` per Awb Art. 7:24(1)
+
+#### Scenario: Transition to in-deliberation requires hearing report
+
+- **GIVEN** an advice request in state `assigned` with no `hearing_report_ref`
+- **WHEN** the bezwaar handler tries to advance to `in-deliberation`
+- **THEN** the system SHALL reject the transition with HTTP 409
+- **AND** the message SHALL state that a hoorzittingverslag from the parent bezwaar-lifecycle is required
+
+#### Scenario: Transition to advice-issued is irreversible
+
+- **GIVEN** an advice request in state `advice-issued`
+- **WHEN** any caller attempts to set `status` back to `in-deliberation`
+- **THEN** the system SHALL reject the request with HTTP 409
+- **AND** the advice request `status` SHALL remain `advice-issued`
+
+### Requirement: Advice Document Content Contract
+
+The advice document produced by the committee SHALL satisfy the content contract of Awb Art. 7:13(7). The document SHALL be a Nextcloud file with a JSON sidecar exposing the structured fields `findings` (string, ≥ 50 chars), `hearing_summary_ref` (pointer to the hoorzittingverslag in the parent bezwaar-lifecycle), `legal_assessment` (string, ≥ 50 chars), `conclusion` (enum: `gegrond`, `ongegrond`, `gedeeltelijk_gegrond`, `niet_ontvankelijk`), `recommendation` (string, non-empty), `dissenting_opinions` (optional array of `{ member_uid, opinion }` blocks), `signed_by_chair_at` (datetime), and `signature_evidence` (Nextcloud file ID or evidence reference). The transition `in-deliberation → advice-issued` SHALL be blocked if any required field is missing or empty.
+
+**Feature tier**: V1
+**Awb reference**: Art. 7:13(7)
+
+#### Scenario: Missing legal_assessment blocks advice-issued
+
+- **GIVEN** an advice request in `in-deliberation` with a draft advice document where `legal_assessment` is empty
+- **WHEN** the chair tries to sign and transition to `advice-issued`
+- **THEN** the transition SHALL be rejected with HTTP 422
+- **AND** the response SHALL list `legal_assessment` as the missing required field
+- **AND** the advice request SHALL remain in `in-deliberation`
+
+#### Scenario: Conclusion outside enum is rejected
+
+- **GIVEN** a draft advice document with `conclusion = "deels_ontvankelijk"` (not in the enum)
+- **WHEN** the chair signs the advice
+- **THEN** OpenRegister SHALL reject the object with a schema validation error
+- **AND** the advice request SHALL remain in `in-deliberation`
+
+### Requirement: Council Deviation Justification (Motivatie Afwijking Advies)
+
+When the council issues a `besluit op bezwaar` and the besluit's outcome diverges from the linked advice's `conclusion`, the besluit object SHALL carry a non-empty `motivatie_afwijking_advies` field explaining the reason for the deviation. The check SHALL run at the besluit-finalisation step in the parent `bezwaar-lifecycle` capability. If `motivatie_afwijking_advies` is missing or empty, the besluit SHALL NOT be marked final.
+
+**Feature tier**: V1
+**Awb reference**: Art. 7:13(7) (deviation rule rooted in general motivation principle Art. 3:46–3:50)
+
+#### Scenario: Deviation without motivation is blocked
+
+- **GIVEN** an advice with `conclusion = gegrond` linked to bezwaar Z1
+- **AND** a draft besluit op bezwaar with outcome `ongegrond` and empty `motivatie_afwijking_advies`
+- **WHEN** the bezwaar handler tries to finalise the besluit
+- **THEN** the finalisation SHALL be rejected with HTTP 422
+- **AND** the response SHALL state `Motivatie voor afwijken van het advies is verplicht (Awb Art. 7:13)`
+- **AND** the besluit SHALL remain in draft
+
+#### Scenario: Conforming besluit needs no motivation
+
+- **GIVEN** an advice with `conclusion = ongegrond`
+- **AND** a draft besluit with outcome `ongegrond`
+- **WHEN** the bezwaar handler finalises the besluit
+- **THEN** the besluit SHALL be accepted without requiring `motivatie_afwijking_advies`
+
+### Requirement: Advice Publication With Besluit op Bezwaar
+
+When the parent bezwaar-lifecycle publishes the besluit op bezwaar (bekendmaking step), the linked advice document SHALL be included in the publication packet so that interested parties can consult both the besluit and the advice that informed it. The advice SHALL be marked with the same retention class as the besluit and SHALL inherit the besluit's confidentiality classification.
+
+**Feature tier**: V1
+**Awb reference**: Art. 7:13(7) read with Art. 8 Wob/Woo (transparency)
+
+#### Scenario: Publication packet includes the signed advice
+
+- **GIVEN** a bezwaar case with an `advice-issued` advice request and a finalised besluit op bezwaar
+- **WHEN** the parent bezwaar-lifecycle's bekendmaking step publishes the besluit
+- **THEN** the publication packet SHALL include the advice PDF
+- **AND** the advice's retention class SHALL match the besluit's retention class
+- **AND** the advice's `vertrouwelijkheidsaanduiding` SHALL match that of the besluit
+
+### Requirement: Advice Request Audit Trail
+
+The system SHALL record every state change and every mutation of an advice request and its advice document in the OpenRegister automatic per-save audit log. In addition, the system SHALL append explicit, append-only entries to a `bac_audit_trail` field on the advice request for the following events: `panel-member-added`, `panel-member-removed`, `independence-check-failed`, `advice-signed-by-chair`, `council-deviation-recorded`. Each entry SHALL carry the actor UID, server timestamp, and a structured payload (e.g. failing member UID + reason for `independence-check-failed`).
+
+**Feature tier**: V1
+**Compliance basis**: Archiefwet 1995 (Dutch Public Records Act) — accountability for advisory bodies
+
+#### Scenario: Chair signature is auditable
+
+- **GIVEN** a chair signs the advice and the request transitions to `advice-issued`
+- **WHEN** the transition completes
+- **THEN** an `advice-signed-by-chair` entry SHALL be appended to `bac_audit_trail`
+- **AND** the entry SHALL contain the chair's UID, the server timestamp, and the `signature_evidence` reference
+- **AND** the OpenRegister automatic audit log SHALL also record the underlying object update
+
+#### Scenario: Independence failure is auditable
+
+- **GIVEN** a panel containing a member who signed the contested primair besluit
+- **WHEN** the system blocks the transition to `in-deliberation` (per REQ-BAC-2)
+- **THEN** an `independence-check-failed` entry SHALL be appended to `bac_audit_trail`
+- **AND** the entry SHALL identify the failing member and the besluit reference
+
+### Requirement: Advice Request Security and Authorization
+
+The system SHALL derive the acting user identity exclusively from `IUserSession` for every mutating endpoint on the committee, advice request, and advice document. Read access to the advice request and the (unpublished) draft advice SHALL be limited to: the bezwaar handler of the parent case, the assigned committee's members and secretary, and any case-shared participants with explicit access. Write access SHALL be limited to: the bezwaar handler (for assignment and panel composition), the committee secretary (for draft advice content), and the committee chair (for the final signature transitioning the request to `advice-issued`). Once published with the besluit (REQ-BAC-6), the advice SHALL inherit the besluit's public/confidential visibility.
+
+**Feature tier**: V1
+
+#### Scenario: Non-member cannot read the draft advice
+
+- **GIVEN** an advice request in `in-deliberation` for bezwaar Z1 with committee C1
+- **AND** an authenticated user U2 who is neither the bezwaar handler nor a member of C1
+- **WHEN** U2 calls `GET /api/bezwaar/advice-requests/{id}`
+- **THEN** the system SHALL return HTTP 403
+- **AND** no advice content SHALL be disclosed in the response body
+
+#### Scenario: Only the chair can issue the advice
+
+- **GIVEN** an advice request in `in-deliberation` with chair `j.smit` and member `a.bakker`
+- **WHEN** member `a.bakker` calls the sign-and-issue endpoint
+- **THEN** the system SHALL return HTTP 403 with `{"message": "Alleen de voorzitter kan het advies vaststellen"}`
+- **AND** no transition SHALL occur and the request SHALL remain in `in-deliberation`

--- a/openspec/changes/bezwaar-advisory-committee/tasks.md
+++ b/openspec/changes/bezwaar-advisory-committee/tasks.md
@@ -1,0 +1,39 @@
+# Tasks: bezwaar-advisory-committee
+
+This is a **GENERATE-style** (spec-only) change. No PHP, Vue, or schema changes are introduced — implementation is deferred to a downstream `opsx-apply` change against a frozen contract. Tasks below validate the spec's internal coherence and its alignment with Awb Art. 7:13.
+
+## Schema sketch
+
+- [ ] **T01**: Sketch the `bezwaaradviescommissie` and `bac_advice_request` schemas in `design.md` covering the property tables (committee: `name`, `domain`, `chair`, `members`, `secretary`, `quorum`, `term_starts_on`, `term_ends_on`, `status`; advice request: `bezwaar_case`, `committee`, `panel`, `status`, `assigned_at`, `deadline`, `advice_document`, `hearing_report_ref`). Confirm property names align with Procest naming conventions (snake_case → camelCase mapping noted) and OpenRegister schema patterns (`$ref`, `onDelete: CASCADE` for the `bezwaar_case` link). No code, no JSON file — just the documented sketch in design.md.
+
+## Lifecycle modeling
+
+- [ ] **T02**: Verify the three-state advice-request lifecycle (`assigned → in-deliberation → advice-issued`) is fully covered in `design.md` with explicit transition triggers, including: panel-finalization gate (independence check), and chair-signature gate (content-contract + quorum check). Confirm no orphan states or unreachable transitions. Record the rationale for omitting `withdrawn` and `rejected` states.
+
+## Advice document template
+
+- [ ] **T03**: Document the advice document content contract (Awb Art. 7:13(7)) in `design.md`: required fields `findings`, `hearing_summary_ref`, `legal_assessment`, `conclusion` (enum: `gegrond | ongegrond | gedeeltelijk_gegrond | niet_ontvankelijk`), `recommendation`, optional `dissenting_opinions`, `signed_by_chair_at`, `signature_evidence`. Cross-reference REQ-BAC-4. Confirm minimum string lengths (≥ 50 chars on `findings` and `legal_assessment`) are realistic against representative real-world advices. File a follow-up issue if a stricter length is recommended.
+
+## Council deviation rule
+
+- [ ] **T04**: Document REQ-BAC-5 (council deviation justification) in both `design.md` and `specs/bezwaar-advisory-committee/spec.md`. Confirm the rule reads: "when the besluit op bezwaar's outcome differs from `advice.conclusion`, the besluit SHALL carry a non-empty `motivatie_afwijking_advies` field". Cross-link to the sister `bezwaar-lifecycle` change so the guard implementation can be wired there. File a follow-up issue if `bezwaar-lifecycle` has not yet added the guard, so it is tracked rather than left implicit.
+
+## Independence rule
+
+- [ ] **T05**: Document REQ-BAC-2 (member independence under Awb Art. 7:13(3)) — at the moment of panel assignment, no panel member's `nc_uid` may equal the `besluit.steller` or any signatory recorded on the original (contested) primair besluit. Confirm that the rule fires at `assigned → in-deliberation` (not at committee-creation). Record a worked example: a committee containing user `J. de Vries` is valid for bezwaar #A123 but invalid for bezwaar #A124 because `J. de Vries` signed the latter's primair besluit.
+
+## Audit trail
+
+- [ ] **T06**: Document the `bac_audit_trail` field on the advice request: explicit events appended (panel-member-added/removed, independence-check-failed, advice-signed-by-chair, council-deviation-recorded) plus the implicit per-save OpenRegister audit log. Confirm Archiefwet (Dutch Public Records Act) accountability is satisfied by the combination. No implementation — design contract only.
+
+## Cross-spec coordination
+
+- [ ] **T07**: Add a "Cross-Project Dependencies" cross-reference in this change's `proposal.md` pointing to `bezwaar-lifecycle` (sister) and `bezwaar-beroep-workflow` (parent context). Once the sibling `bezwaar-lifecycle` change is merged, file a follow-up issue to add a "See also: `bezwaar-advisory-committee`" line in its proposal.md as well. Skip if already present.
+
+## Pre-commit verification
+
+- [ ] **V01**: `openspec validate bezwaar-advisory-committee --type change --strict` → exit code 0
+- [ ] **V02**: `openspec change show bezwaar-advisory-committee --json --deltas-only | jq '.deltaCount'` → ≥ 8 (one delta per REQ-BAC-1..8)
+- [ ] **V03**: Every REQ-BAC-* in `specs/bezwaar-advisory-committee/spec.md` carries at least one `#### Scenario:` block (per `openspec` strict mode requirement)
+- [ ] **V04**: No files modified outside `openspec/changes/bezwaar-advisory-committee/` (verify with `git diff --name-only origin/development...HEAD`)
+- [ ] **V05**: No `Co-Authored-By` trailer in the commit message (verify with `git log -1 --pretty=%B | grep -i 'co-authored-by'` → empty)


### PR DESCRIPTION
## Summary

Generates the OpenSpec change `bezwaar-advisory-committee` — sister spec to `bezwaar-lifecycle` modeling the independent advisory committee (bezwaaradviescommissie) which reviews Awb objections and issues written advice to the council, under Awb Art. 7:13.

- Committee entity (composition: chair + >= 2 members, secretary, quorum, jurisdiction, term)
- Advice-request lifecycle: assigned -> in-deliberation -> advice-issued
- Awb 7:13(7) advice content contract (findings, hearing summary ref, legal assessment, conclusion enum, recommendation, dissenting opinions, chair signature)
- Council deviation justification rule (motivatie_afwijking_advies required when besluit conclusion deviates from advice)
- Member-independence check at panel assignment (no civil servant involved in contested primair besluit)
- Audit trail for Archiefwet accountability
- Authorization model (handler / members / chair-only signing)

SPEC ONLY — NO CODE. Implementation deferred to downstream opsx-apply.

## Contents

- proposal.md — capability scope + Awb basis (~280 words)
- design.md — committee entity, FSM, content contract, deviation rule, audit (~700 words)
- tasks.md — T01–T07 design/verification + V01–V05 pre-commit gates
- specs/bezwaar-advisory-committee/spec.md — 8 REQ-BAC-* deltas, 16 Given/When/Then scenarios

## Validation

- openspec validate bezwaar-advisory-committee --type change --strict -> PASS
- deltaCount = 8
- Scenarios = 16 across 8 requirements (>= 1 per requirement)
- No code files modified outside openspec/changes/bezwaar-advisory-committee/
- No Co-Authored-By trailer

## Test plan

- [ ] OpenSpec strict validation passes in CI
- [ ] Cross-link with sibling bezwaar-lifecycle PR once that lands
- [ ] Spec review against Awb Art. 7:13 by reviewer