### PR TITLE
chore(openspec): generate case-location spec

### DIFF
--- a/openspec/changes/case-location/design.md
+++ b/openspec/changes/case-location/design.md
@@ -1,0 +1,97 @@
+# Design: case-location
+
+## Architecture Overview
+
+Case-location introduces a `location` entity that lives alongside the existing `case` schema in the Procest register. Cases reference 0..N locations through a back-reference on the location object (`location.case = <caseUuid>`), keeping the case schema slim and allowing locations to be added, edited, and removed independently of the case write path. Address validation, reverse geocoding, and BAG resolution are concentrated in a single `LocationService` that delegates outbound HTTP to a `PdokLocatieserverClient`; the client is routed through OpenConnector when the municipality requires a proxied egress.
+
+```
+CaseDetail.vue
+└── CaseLocationsTab.vue           ← lists locations for the case
+    ├── LocationCard.vue           ← per-location row: address, source, accuracy
+    └── LocationEditDialog.vue     ← add / edit one location
+
+AdminSettings.vue
+└── LocationImportTab.vue          ← CSV upload with dry-run + commit
+```
+
+```
+LocationController
+└── LocationService
+    ├── PdokLocatieserverClient    ← /suggest, /lookup, /reverse
+    └── OpenRegister object store  ← persist `location` objects
+```
+
+## File Map
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `lib/Service/LocationService.php` | CRUD, address validation, reverse geocoding, BAG resolution |
+| `lib/Service/PdokLocatieserverClient.php` | Thin HTTP wrapper around PDOK suggest, lookup, reverse endpoints; OpenConnector-aware |
+| `lib/Controller/LocationController.php` | REST: list per case, create, update, delete, suggest (proxied) |
+| `lib/Command/ImportCaseLocations.php` | OCC command for CSV import; powers the admin UI flow |
+| `src/views/cases/components/CaseLocationsTab.vue` | Case-detail tab listing all locations |
+| `src/views/cases/components/LocationCard.vue` | Per-location row |
+| `src/views/cases/components/LocationEditDialog.vue` | Add/edit dialog with PDOK autocomplete and map preview |
+| `src/views/settings/tabs/LocationImportTab.vue` | Admin CSV upload with dry-run + commit |
+| `src/services/locationApi.js` | Frontend client for the location REST endpoints |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `lib/Settings/procest_register.json` | Add `location` schema (slug `location`); add `case_location_schema` config key resolver in `SettingsService` |
+| `lib/Service/SettingsService.php` | Register `case_location_schema` config key alongside the other Procest schema keys |
+| `appinfo/routes.php` | Register `/api/locations` routes |
+| `lib/Repair/EnsureProcestSchemas.php` | Ensure the new `location` schema exists on app install/update |
+
+## Data Model
+
+### `location` schema
+
+- `case` (string, UUID, required) — linked case
+- `nummeraanduidingId` (string, nullable) — BAG nummeraanduiding identifier (16-digit); MUST be present when `source = bag`
+- `formattedAddress` (string, nullable) — `straat huisnummer[+toev], postcode woonplaats`
+- `latitude` (number, nullable) — WGS84 decimal degrees
+- `longitude` (number, nullable) — WGS84 decimal degrees
+- `parcelId` (string, nullable) — BRK kadastrale aanduiding (e.g. `AMR00-G-1234`)
+- `accuracyRadius` (number, nullable) — radius in metres around lat/lng (used when source is gps or free)
+- `source` (enum: `bag` | `pdok-reverse` | `gps` | `free` | `import`, required) — provenance
+- `label` (string, nullable) — short human label shown in the case header (e.g. "Inspectielocatie 1")
+- `createdAt`, `updatedAt` — managed by OpenRegister
+
+A location MUST carry **either** a `nummeraanduidingId` **or** valid `latitude`/`longitude`. Saves that have neither MUST be rejected.
+
+## API Surface
+
+| Method | URL | Purpose |
+|--------|-----|---------|
+| GET | `/api/locations?case={uuid}` | List locations for a case |
+| POST | `/api/locations` | Create a location (server validates against PDOK) |
+| PUT | `/api/locations/{id}` | Update a location |
+| DELETE | `/api/locations/{id}` | Remove a location |
+| GET | `/api/locations/suggest?q=...` | Proxy to PDOK Locatieserver suggest |
+| GET | `/api/locations/reverse?lat=...&lng=...` | Proxy to PDOK Locatieserver reverse |
+| POST | `/api/locations/import/preview` | CSV dry-run, returns parse + validation report |
+| POST | `/api/locations/import/commit` | Commit a previewed import |
+
+## Validation Rules
+
+1. `source = bag` → `nummeraanduidingId` MUST be present and MUST resolve at PDOK Locatieserver `/lookup`.
+2. `source = pdok-reverse` → `latitude`/`longitude` MUST be present; the service MUST attempt reverse geocoding and populate `formattedAddress` + `nummeraanduidingId` when a BAG match is found within 25 metres.
+3. `source = gps` → `latitude`/`longitude` MUST be present; `accuracyRadius` MUST be present.
+4. `source = free` → at least one of `formattedAddress`, `latitude`/`longitude` MUST be present; no BAG resolution is required.
+5. `source = import` → reserved for the CSV importer; downgraded to `bag`, `pdok-reverse`, or `free` per row after validation.
+
+## Performance & External-Service Posture
+
+PDOK Locatieserver is public, free, and rate-limited per source IP. The `PdokLocatieserverClient` MUST cache `/lookup` and `/reverse` responses for 24 hours in APCu keyed on the input. When OpenConnector is configured for outbound traffic, the client MUST delegate to it rather than calling PDOK directly, so that the egress audit trail and rate-limit accounting remain centralised.
+
+## Export & Import
+
+CSV columns for both import and export: `caseIdentifier`, `nummeraanduidingId`, `formattedAddress`, `latitude`, `longitude`, `parcelId`, `accuracyRadius`, `source`, `label`. The importer MUST run in two phases — `preview` returns parse errors and per-row validation outcomes without writing; `commit` is invoked with the preview token and writes only the rows that previewed cleanly.
+
+## Migration & Compatibility
+
+The existing `case.geometry` field stays in place during this change. A follow-up data-migration change SHALL backfill `location` rows from existing `case.geometry` GeoJSON. New cases SHOULD use `location` rows from the start; the case detail UI MUST surface `location` rows in preference to `case.geometry` when both exist.

--- a/openspec/changes/case-location/proposal.md
+++ b/openspec/changes/case-location/proposal.md
@@ -1,0 +1,38 @@
+# Proposal: Case Location
+
+## Summary
+
+Formalise the case ↔ location relationship in Procest by introducing a first-class `location` entity that captures the address, BAG nummeraanduiding ID, parcel reference, latitude/longitude, accuracy radius, and source. Cases gain a 0..N relation to locations so that complex case types (multi-perceel handhaving, area inspections, environmental complaints) can carry more than one geographic anchor without collapsing them into a single GeoJSON blob.
+
+## Problem
+
+Many case types are inherently geographic: a building permit attaches to a perceel, a complaint about a property targets a specific address, an inspection visits one or more locations, and a milieu-melding may span several BAG objects. Today Procest only carries a single `geometry` field on the case (a GeoJSON string) and renders that on a map tab. There is no validated address, no BAG nummeraanduiding reference, no per-location source or accuracy, and no way to attach more than one location to a case. As a result, downstream specs that depend on validated location data — `case-map-overview` (clustering by perceel), `pdok-integration` (reverse geocoding & BAG lookup at the entity boundary), VTH inspection routing, and any future Omgevingsloket sync — have nowhere to anchor.
+
+## Scope -- MVP
+
+**In scope:**
+- `location` schema with `nummeraanduidingId`, `formattedAddress`, `latitude`, `longitude`, `parcelId`, `accuracyRadius`, `source`, `case` (linked case UUID)
+- 0..N locations per case (no cap)
+- PDOK Locatieserver suggest + lookup client (server-side proxy)
+- Address validation service: a saved location MUST resolve to a BAG nummeraanduiding OR be flagged `source: free`
+- Reverse geocoding when only coordinates are provided
+- Case detail "Locaties" component: list, add, edit, remove locations
+- Admin import flow: CSV upload with one row per location, dry-run preview, commit
+- Admin export: CSV of all case locations for reporting (shapefile export is V2)
+
+**Out of scope:**
+- Map overview UI (lives in `case-map-overview`)
+- WMS/WFS layer configuration (lives in `wms-wfs-layers`)
+- Real-time GPS tracking, mobile field capture, 3D coordinates
+- Cadastral parcel geometry rendering — only the BRK parcel identifier is stored
+- Shapefile / GML export (V2 follow-up)
+- Migration of existing `case.geometry` GeoJSON into `location` rows (handled by a separate data-migration change once `location` ships)
+
+## Dependencies
+
+- OpenRegister (entity persistence; ADR-022 `geo-metadata-kaart` capability for annotation-driven geo metadata)
+- PDOK Locatieserver (public, no auth) for address validation and reverse geocoding — routed through OpenConnector when the municipality requires it
+- BAG (Basisregistratie Adressen en Gebouwen) as the authoritative address source
+- BRK (Basisregistratie Kadaster) for parcel identifiers (no parcel geometry fetch in MVP)
+- Existing `case` schema in `lib/Settings/procest_register.json` (the `geometry` field remains for backwards compatibility but is deprecated for new cases once `location` ships)
+- Downstream consumers: `case-map-overview`, `pdok-integration`, `gis-integration` (proposal), VTH inspection flow

--- a/openspec/changes/case-location/specs/case-location/spec.md
+++ b/openspec/changes/case-location/specs/case-location/spec.md
@@ -1,0 +1,164 @@
+## ADDED Requirements
+
+### Requirement: REQ-CL-1 Location Entity Schema
+
+The system SHALL register a `location` schema in the Procest OpenRegister configuration. The schema SHALL declare the properties `case`, `nummeraanduidingId`, `formattedAddress`, `latitude`, `longitude`, `parcelId`, `accuracyRadius`, `source`, and `label`. The `required` list SHALL be exactly `[case, source]`. The `source` enum SHALL be exactly `[bag, pdok-reverse, gps, free, import]`. The Schema.org type SHALL be `schema:Place`. The schema SHALL be resolvable at runtime through a new `case_location_schema` config key registered in `SettingsService`.
+
+**Feature tier**: V1
+**Schema.org type**: `schema:Place`
+
+#### Scenario: Schema is registered on app install
+
+- **GIVEN** the Procest app is installed or updated via the repair step
+- **WHEN** `EnsureProcestSchemas::run()` executes
+- **THEN** the `location` schema SHALL exist in the Procest register
+- **AND** the schema SHALL enforce the required properties `case` and `source`
+- **AND** the `source` enum SHALL be exactly `[bag, pdok-reverse, gps, free, import]`
+
+#### Scenario: Schema is resolvable through the settings service
+
+- **WHEN** a service requests `SettingsService::getSchemaId('case_location_schema')`
+- **THEN** the configured UUID of the `location` schema SHALL be returned
+- **AND** the resolved schema SHALL match `slug = location` in the Procest register
+
+### Requirement: REQ-CL-2 Case ↔ Location Relation (0..N)
+
+The system SHALL support 0..N locations per case. Locations SHALL be linked to their parent case through the `location.case` back-reference; the `case` schema SHALL NOT carry an array of location IDs. Adding, editing, or removing a location SHALL NOT trigger a write to the case object.
+
+**Feature tier**: V1
+
+#### Scenario: Multiple locations attached to a single case
+
+- **GIVEN** a case `zaak-1` of zaaktype "Handhaving" with three locations created (two BAG addresses and one GPS pin)
+- **WHEN** `LocationService::listForCase("zaak-1")` is called
+- **THEN** all three locations SHALL be returned
+- **AND** the `case` object SHALL NOT have been mutated by the creation of any of the three locations
+
+#### Scenario: Case with no locations
+
+- **GIVEN** a newly-created case with no location rows
+- **WHEN** `LocationService::listForCase(caseId)` is called
+- **THEN** an empty array SHALL be returned (not an error)
+
+### Requirement: REQ-CL-3 PDOK Locatieserver Client
+
+The system SHALL provide a `PdokLocatieserverClient` that wraps the PDOK Locatieserver v3 endpoints `/suggest`, `/lookup`, and `/reverse`. Responses from `/lookup` and `/reverse` SHALL be cached in APCu for 24 hours, keyed on the request input. When an OpenConnector source for PDOK is configured, all outbound requests SHALL be routed through OpenConnector instead of called directly.
+
+**Feature tier**: V1
+
+#### Scenario: Lookup result is cached for 24 hours
+
+- **GIVEN** the client has just executed `/lookup` for `nummeraanduidingId = 0363200000406567`
+- **WHEN** a second call for the same identifier arrives within 24 hours
+- **THEN** the cached response SHALL be returned without a network call
+- **AND** no entry SHALL appear in the OpenConnector egress log for the second call
+
+#### Scenario: OpenConnector proxying is honoured
+
+- **GIVEN** the admin has configured an OpenConnector source for PDOK Locatieserver
+- **WHEN** the client executes `/suggest`
+- **THEN** the request SHALL be dispatched through the OpenConnector source
+- **AND** the public PDOK hostname SHALL NOT appear in the application's outbound HTTP audit
+
+### Requirement: REQ-CL-4 Address Validation on Save
+
+The `LocationService` SHALL validate every saved location according to its declared `source`. The cross-source rules from `design.md` §Validation Rules SHALL be enforced. A `source = bag` row whose `nummeraanduidingId` does not resolve at PDOK Locatieserver `/lookup` SHALL be rejected with HTTP 422 and an error code of `nummeraanduidingId.not-found`. A row that satisfies neither "has nummeraanduidingId" nor "has both latitude and longitude" SHALL be rejected with `coordinates-or-bag.required`.
+
+**Feature tier**: V1
+
+#### Scenario: BAG-source row with unknown nummeraanduiding is rejected
+
+- **GIVEN** a payload `{case, source: "bag", nummeraanduidingId: "9999999999999999"}` for which PDOK `/lookup` returns no match
+- **WHEN** `POST /api/locations` is invoked
+- **THEN** the response SHALL be HTTP 422 with error code `nummeraanduidingId.not-found`
+- **AND** no `location` object SHALL be persisted
+
+#### Scenario: Row without any anchor is rejected
+
+- **GIVEN** a payload `{case, source: "free", label: "veldje achter zwembad"}` with neither coordinates nor address nor BAG identifier
+- **WHEN** `POST /api/locations` is invoked
+- **THEN** the response SHALL be HTTP 422 with error code `coordinates-or-bag.required`
+
+### Requirement: REQ-CL-5 Reverse Geocoding from Coordinates
+
+When a location is saved with `source = pdok-reverse` and valid `latitude`/`longitude`, the `LocationService` SHALL call PDOK Locatieserver `/reverse` and populate `formattedAddress` from the response. When the best BAG match lies within 25 metres of the input coordinate, the service SHALL also populate `nummeraanduidingId`. The reverse-geocoded fields SHALL come from the service and SHALL NOT be taken from the request body.
+
+**Feature tier**: V1
+
+#### Scenario: Coordinates near a BAG address produce a nummeraanduiding
+
+- **GIVEN** a payload `{case, source: "pdok-reverse", latitude: 52.3702, longitude: 4.8897, formattedAddress: "user-supplied junk"}`
+- **AND** PDOK `/reverse` returns the BAG match "Keizersgracht 100, 1015 AA Amsterdam" at distance 8 m with `nummeraanduidingId = 0363200000406567`
+- **WHEN** the location is saved
+- **THEN** the persisted row's `formattedAddress` SHALL equal "Keizersgracht 100, 1015 AA Amsterdam"
+- **AND** the persisted row's `nummeraanduidingId` SHALL equal "0363200000406567"
+- **AND** the user-supplied `formattedAddress` SHALL be discarded
+
+#### Scenario: Coordinates beyond match radius leave nummeraanduiding unset
+
+- **GIVEN** a payload `{case, source: "pdok-reverse", latitude: 53.0000, longitude: 4.0000}` in a body of water
+- **AND** the nearest BAG match is 1.2 km away
+- **WHEN** the location is saved
+- **THEN** the persisted row SHALL have `nummeraanduidingId = null`
+- **AND** `formattedAddress` MAY be populated with the nearest descriptive label or left null
+
+### Requirement: REQ-CL-6 Case Detail "Locaties" Component
+
+The case detail view SHALL render a "Locaties" tab listing every `location` row for the open case. Each row SHALL show the address (or coordinates when no address is known), the `source` badge, and an accuracy hint when `accuracyRadius` is present. Users with edit rights on the case SHALL be able to add, edit, and remove locations through the tab without leaving the case detail view.
+
+**Feature tier**: V1
+
+#### Scenario: User adds a BAG address via autocomplete
+
+- **GIVEN** the user opens the "Locaties" tab on case `zaak-1` and clicks "Locatie toevoegen"
+- **WHEN** the user types "Keizersgracht 100 Amsterdam" and selects the first suggestion
+- **THEN** the dialog SHALL pre-fill `formattedAddress`, `nummeraanduidingId`, `latitude`, and `longitude` from the PDOK suggest response
+- **AND** clicking "Opslaan" SHALL create the row with `source = bag`
+- **AND** the new row SHALL appear in the tab without a full page reload
+
+#### Scenario: User without edit rights sees read-only tab
+
+- **GIVEN** a user with read-only access to case `zaak-1`
+- **WHEN** they open the "Locaties" tab
+- **THEN** existing locations SHALL be visible
+- **AND** the "Locatie toevoegen", "Bewerken", and "Verwijderen" controls SHALL be hidden
+
+### Requirement: REQ-CL-7 Admin CSV Import
+
+The admin settings UI SHALL expose a CSV import flow for bulk-creating locations. The flow SHALL be two-phase: a `preview` phase that parses the file, validates each row, and returns a report without writing; and a `commit` phase that persists only the rows that previewed cleanly. The CSV columns SHALL be `caseIdentifier`, `nummeraanduidingId`, `formattedAddress`, `latitude`, `longitude`, `parcelId`, `accuracyRadius`, `source`, `label`.
+
+**Feature tier**: V1
+
+#### Scenario: Dry-run reports row-level outcomes without writing
+
+- **GIVEN** an admin uploads a 50-row CSV in which 47 rows are valid and 3 reference unknown case identifiers
+- **WHEN** the admin clicks "Voorbeeld"
+- **THEN** the preview report SHALL show 47 `ok` rows and 3 rows with error code `case-not-found`
+- **AND** no `location` object SHALL have been created at this point
+
+#### Scenario: Commit writes only the previewed-clean rows
+
+- **GIVEN** the preview from the previous scenario
+- **WHEN** the admin clicks "Importeren"
+- **THEN** exactly 47 `location` objects SHALL be created
+- **AND** the 3 case-not-found rows SHALL remain in the report as skipped
+
+### Requirement: REQ-CL-8 CSV Export
+
+The admin UI SHALL expose a CSV export of all case locations. The export SHALL use the same column layout as the importer so that an exported file can be re-imported into a fresh environment.
+
+**Feature tier**: V1
+
+#### Scenario: Export contains every persisted location
+
+- **GIVEN** the environment has 1,200 `location` rows across 800 cases
+- **WHEN** the admin invokes `GET /api/locations/export?format=csv`
+- **THEN** the response SHALL be a `text/csv` body with 1,201 lines (one header + 1,200 rows)
+- **AND** the column order SHALL be `caseIdentifier, nummeraanduidingId, formattedAddress, latitude, longitude, parcelId, accuracyRadius, source, label`
+
+#### Scenario: Shapefile export is out of scope
+
+- **GIVEN** an admin requests `GET /api/locations/export?format=shapefile`
+- **WHEN** the controller resolves the request
+- **THEN** the response SHALL be HTTP 501 with body `{"error": "shapefile-export-not-implemented"}`
+- **AND** the response body SHALL reference the follow-up issue tracking V2 shapefile support

--- a/openspec/changes/case-location/tasks.md
+++ b/openspec/changes/case-location/tasks.md
@@ -1,0 +1,36 @@
+# Tasks: case-location
+
+## Implementation Tasks
+
+### Schema & Configuration
+
+- [ ] **T01**: Add a `location` schema to `lib/Settings/procest_register.json` with `slug: location`, `x-schema-org-type: schema:Place`, properties as defined in `design.md` (`case`, `nummeraanduidingId`, `formattedAddress`, `latitude`, `longitude`, `parcelId`, `accuracyRadius`, `source`, `label`), and a `required` list of `[case, source]`. Add the `case_location_schema` config key to `lib/Service/SettingsService.php` so the schema UUID is resolvable at runtime. Update `lib/Repair/EnsureProcestSchemas.php` to ensure the schema exists on install/update.
+
+- [ ] **T02**: Document the case ↔ location relation in `procest_register.json` — the `case` property on `location` is the back-reference; the `case` schema is NOT modified in this change (no new property on `case`). Confirm that 0..N locations can hang off a single case purely through OpenRegister object-store queries (no explicit relation array on the case).
+
+### Backend: PDOK Client
+
+- [ ] **T03**: Create `lib/Service/PdokLocatieserverClient.php` wrapping the PDOK Locatieserver v3 endpoints `/suggest`, `/lookup`, and `/reverse`. The client MUST cache `/lookup` and `/reverse` responses in APCu for 24 hours keyed on the input string. When the `openconnector_source` setting is populated, the client MUST route requests through OpenConnector instead of calling PDOK directly.
+
+### Backend: Service & Controller
+
+- [ ] **T04**: Create `lib/Service/LocationService.php` with: `listForCase(caseId)`, `create(caseId, payload)`, `update(locationId, payload)`, `delete(locationId)`, `validate(payload)` (the cross-source rules from `design.md` §Validation Rules), and `reverseGeocode(lat, lng)` (returns `formattedAddress` + best-match `nummeraanduidingId` within 25 m, or null). All persistence MUST go through the OpenRegister object store via the `case_location_schema` config key — no direct DB writes.
+
+- [ ] **T05**: Create `lib/Controller/LocationController.php` exposing the eight routes from `design.md` §API Surface. Suggest and reverse routes are pure pass-throughs to the PDOK client. Import preview / commit are wired in T07.
+
+### Frontend: Case Detail Component
+
+- [ ] **T06**: Build `src/views/cases/components/CaseLocationsTab.vue` (and the `LocationCard.vue` + `LocationEditDialog.vue` children) using the Options-API `createObjectStore` pattern. The tab MUST render in `CaseDetail.vue` as the "Locaties" tab. The edit dialog MUST integrate PDOK autocomplete via `/api/locations/suggest` and MUST show a map preview using the existing `map-component` capability.
+
+### Admin Import / Export
+
+- [ ] **T07**: Build the admin import flow: `lib/Command/ImportCaseLocations.php` (OCC command), the `/import/preview` + `/import/commit` controller endpoints, and `src/views/settings/tabs/LocationImportTab.vue` (CSV upload, dry-run report, commit button). The dry-run MUST report per-row outcomes (`ok`, `bag-not-found`, `case-not-found`, `missing-required`) without writing anything.
+
+- [ ] **T08**: Add a CSV export endpoint `GET /api/locations/export?format=csv` and a button in `LocationImportTab.vue`. Shapefile export is OUT OF SCOPE for this change — file a follow-up issue when this task lands.
+
+## Verification Tasks
+
+- [ ] **V01**: Saving a location with `source = bag` and an unknown `nummeraanduidingId` MUST be rejected with a 422 response carrying a `nummeraanduidingId.not-found` error code; no row is persisted.
+- [ ] **V02**: Saving a location with `source = pdok-reverse` and valid coordinates MUST result in a persisted row whose `formattedAddress` and (when matched) `nummeraanduidingId` are populated by the service, not by the request body.
+- [ ] **V03**: Importing a CSV in preview mode against 50 rows where 47 are valid MUST return a report with 47 `ok` and 3 categorised errors, AND MUST NOT create any location objects.
+- [ ] **V04**: A case with 3 locations MUST surface all 3 in the `CaseLocationsTab` in the order they were created; deleting one MUST leave the other two intact and visible without a page reload.


### PR DESCRIPTION
## Summary

Generates the openspec change `case-location` (spec-only, no code). The change formalises the case ↔ location relationship by introducing a first-class `location` entity with BAG `nummeraanduidingId`, lat/lng, parcel reference, accuracy radius, and source provenance, and supports 0..N locations per case.

- `proposal.md` — problem, scope, MVP boundaries, dependencies
- `design.md` — entity fields, validation rules, PDOK Locatieserver client, OpenConnector routing, import/export
- `tasks.md` — T01–T08 implementation tasks + V01–V04 verification
- `specs/case-location/spec.md` — REQ-CL-1..8 ADDED requirements with G/W/T scenarios

Foundation for downstream `case-map-overview` (clustering by perceel) and `pdok-integration` (reverse geocoding & BAG lookup at the entity boundary). Existing `case.geometry` field stays in place for backwards compatibility; data migration is deferred to a follow-up change.

`openspec validate case-location --type change --strict` passes.

## Test plan

- [ ] `openspec validate case-location --type change --strict` passes locally
- [ ] Reviewer confirms the eight REQ-CL-* requirements match the change scope
- [ ] Reviewer confirms no overlap with the existing `case-location` capability spec (the existing spec covers map/geometry-on-case; this change introduces the `location` entity that will eventually supersede `case.geometry`)
- [ ] Reviewer confirms shapefile export is correctly deferred (HTTP 501) rather than silently dropped