### PR TITLE
chore(openspec): generate vth-workflow-templates spec

### DIFF
--- a/openspec/changes/vth-workflow-templates/design.md
+++ b/openspec/changes/vth-workflow-templates/design.md
@@ -1,0 +1,117 @@
+# Design: vth-workflow-templates
+
+## Architecture Overview
+
+Six VTH workflow templates ship as JSON files under `lib/Settings/seed/vth-workflow-templates/`. A repair step imports them as published `workflowTemplate` v1 objects on first install. An admin "Sjablonen-catalogus" tab lists the canonical catalog, surfaces a per-template preview, lets the tenant administrator selectively enable templates, and shows a diff between the tenant's active version and the canonical shipped version.
+
+```
+AdminSettings.vue
+└── VthWorkflowTemplatesTab.vue (catalog list)
+    └── VthWorkflowTemplateDetailDialog.vue
+        ├── StepsPreview (read-only WorkflowStepsEditor)
+        ├── TransitionsPreview (read-only WorkflowTransitionsEditor)
+        ├── DeadlinesPreview (table of statutory deadlines)
+        └── DiffView (canonical vs active)
+
+Backend
+├── lib/Settings/seed/vth-workflow-templates/
+│   ├── aanvraag-omgevingsvergunning.json
+│   ├── toezichtbezoek.json
+│   ├── handhavingstraject.json
+│   ├── bezwaar.json   (cross-link stub → bezwaar-lifecycle)
+│   ├── klacht-toezicht.json
+│   └── spoedig-herstel.json
+├── VthWorkflowTemplateCatalogService.php (catalog read + selective import)
+├── VthWorkflowTemplateCatalogController.php (REST)
+└── Migration/SeedVthWorkflowTemplates.php (repair step)
+```
+
+## Template Catalog
+
+| Slug | Title (nl) | CaseType | Statuses (count) | Statutory Deadline | Primary Role | Notes |
+|------|-----------|---------|------------------|--------------------|--------------|-------|
+| `aanvraag-omgevingsvergunning` | Aanvraag omgevingsvergunning | Omgevingsvergunning (reguliere procedure) | 6 | Awb 4:13 — 8 weken (verlengbaar 6) | Vergunningverlener | Lex silencio positivo bij reguliere procedure |
+| `toezichtbezoek` | Toezichtbezoek | Toezichtbezoek | 5 | — (geen wettelijke beslistermijn) | Toezichthouder | Spawnt `handhavingstraject` bij overtreding |
+| `handhavingstraject` | Handhavingstraject | Handhaving | 7 | Awb 5:24 — redelijke termijn last onder dwangsom | Handhavingsjurist | Voornemen → zienswijze → besluit → invordering |
+| `bezwaar` | Bezwaar (VTH-context) | Bezwaar | 8 | Awb 7:10 — 6 weken (verlengbaar 6) | Behandelaar bezwaar | Cross-link to `bezwaar-lifecycle` — this template only adds VTH-specific guards |
+| `klacht-toezicht` | Klacht over toezichthouder | Klacht | 4 | Awb 9:11 — 6 weken | Klachtbehandelaar | Internal complaint about a toezichthouder's conduct |
+| `spoedig-herstel` | Spoedig herstel / spoedeisende bestuursdwang | Handhaving (spoed) | 4 | — (onmiddellijk) | BOA / Toezichthouder | Awb 5:31 — bestuursdwang zonder voorafgaande last; achteraf besluit |
+
+## Per-Template Structure
+
+Each JSON file produces one `workflowTemplate` object conforming to the schema in `procest_register.json`. The structure of every template:
+
+```jsonc
+{
+  "title": "Aanvraag omgevingsvergunning",
+  "description": "Reguliere procedure conform Omgevingswet ...",
+  "caseType": "<UUID — resolved against the VTH base-register seed at install>",
+  "version": 1,
+  "lifecycleStatus": "published",
+  "isActive": true,
+  "isDraft": false,
+  "steps": [
+    {
+      "id": "<uuid>",
+      "title": "Volledigheidstoets",
+      "status": "<statusType-uuid>",
+      "order": 1,
+      "assigneeRole": "vergunningverlener",
+      "isRequired": true,
+      "checklist": [
+        { "label": "Aanvraagformulier compleet", "required": true },
+        { "label": "Bouwtekening conform NEN 2580", "required": true }
+      ],
+      "automaticActions": []
+    }
+  ],
+  "transitions": [
+    {
+      "id": "<uuid>",
+      "fromStatus": "ontvangen",
+      "toStatus": "in-behandeling",
+      "label": "Start beoordeling",
+      "guards": [
+        { "type": "checklist", "checklistId": "volledigheidstoets" },
+        { "type": "roleGuard", "role": "vergunningverlener" }
+      ],
+      "allowedRoles": ["vergunningverlener"],
+      "automaticActions": [],
+      "deadline": { "duration": "P56D", "source": "Awb 4:13", "escalationRole": "afdelingsmanager" }
+    }
+  ]
+}
+```
+
+Per-template deadlines map to a `transitions[].deadline` block with `duration` (ISO-8601), `source` (Awb / Omgevingswet article), and `escalationRole` for when the deadline elapses. Escalations are surfaced by `status-transition-engine` at runtime but encoded in the template here.
+
+## Seed-Data Delivery via Repair Step
+
+`lib/Migration/SeedVthWorkflowTemplates.php` runs on app upgrade. For each JSON file in `lib/Settings/seed/vth-workflow-templates/`:
+
+1. Resolve `caseType` slug → UUID via the VTH base register (must already exist from `base-register-seed-data`).
+2. Resolve `statusType` slugs in `steps[].status`, `transitions[].fromStatus`, and `transitions[].toStatus` against the caseType's defined statuses.
+3. Generate stable UUIDs for `steps[].id` and `transitions[].id` using a UUID5 namespace derived from the template slug — this keeps re-runs idempotent.
+4. Call `WorkflowDefinitionService::createDraft()` then `publish()` so the immutability invariant from `workflow-definition-model` REQ-WDM-4 is honoured. Skips templates whose canonical UUID (UUID5 of the slug + caseType) already exists.
+5. Set `caseType.workflowDefinition` to the new template only if the caseType has no pinned definition yet.
+
+## Immutability + Versioning Contract
+
+The catalog ships exactly one canonical version per template — `version: 1` — published as `lifecycleStatus: published`. Because `workflow-definition-model` makes published versions immutable, tenant administrators who want to deviate MUST `clone()` the seeded v1 into a new draft (per WDM lifecycle), customise it, and `publish()` it as v2. The seeded v1 remains as a deprecated-but-readable reference. The catalog therefore acts as a "reset to factory" anchor: the tenant can always diff their active version against the immutable v1.
+
+Re-running the repair step is safe: it re-imports only templates whose canonical UUID is not present. It NEVER overwrites a tenant's existing `workflowTemplate` — that would violate the immutability invariant of `workflow-definition-model`.
+
+## Selective Enable per Tenant
+
+The catalog list view shows `Installed` / `Not installed` per template. A tenant administrator may install only the templates relevant to their service portfolio (e.g., a water authority installs `toezichtbezoek` + `handhavingstraject` but not `aanvraag-omgevingsvergunning`). Uninstall is offered only when the template has no open cases bound to it; otherwise the action is replaced with a `Deprecate` button that defers to the WDM lifecycle.
+
+## Diff Against Published Version
+
+For each installed template, the detail dialog computes a structural diff between the tenant's currently active version (which may be v1, v2, v3 …) and the catalog's canonical v1. Changes are listed by type (`steps.added`, `steps.removed`, `transitions.modified`, `deadline.changed`) with a short human-readable summary. The diff is read-only — no "revert" action; the tenant must clone the canonical v1 into a new draft via the WDM admin UI if they want to restore.
+
+## Integration with Other Specs
+
+- `workflow-definition-model`: this change calls only its public service API (`createDraft`, `publish`, `getActiveDefinitionFor`) — never mutates `workflowTemplate` rows directly.
+- `bezwaar-lifecycle`: the `bezwaar` catalog entry references the bezwaar workflow already shipped by `workflow-definition-model` REQ-WDM-9; we add only VTH-specific guards (sectoral grounds for non-ontvankelijkheid).
+- `status-transition-engine`: consumes the new `transitions[].deadline` block to drive deadline countdowns and escalations.
+- `role-based-step-routing`: consumes `assigneeRole` and `allowedRoles` on the seeded templates without modification.

--- a/openspec/changes/vth-workflow-templates/proposal.md
+++ b/openspec/changes/vth-workflow-templates/proposal.md
@@ -1,0 +1,47 @@
+# Proposal: VTH Workflow Templates
+
+## Summary
+
+VTH (Vergunningen, Toezicht & Handhaving) is the Dutch municipal cross-domain process family that covers permits, inspection, and enforcement under the Omgevingswet, the Algemene wet bestuursrecht (Awb), and the various sectoral environmental and building acts. Today, a tenant adopting Procest for VTH has the engine (`workflow-definition-model`, PR #347) and the model, but no out-of-the-box workflow definitions — they would have to draft each one by hand against the AWB / Omgevingswet procedural rules before they can run a single case. This change ships a catalog of six reference `workflowTemplate` definitions covering the dominant VTH lanes: `aanvraag-omgevingsvergunning`, `toezichtbezoek`, `handhavingstraject`, `bezwaar` (cross-link to the existing `bezwaar-lifecycle` spec), `klacht-toezicht`, and `spoedig-herstel`. Each is delivered as seed data via a repair step, exposed in an admin "Sjablonen-catalogus" UI, and selectively enable-able per tenant.
+
+## Problem
+
+`workflow-definition-model` only seeds workflows for `Bezwaar` and `Beroep` (REQ-WDM-9 in PR #347). VTH-specific lifecycles — which carry deadlines (`Awb 4:13` 8-week beslistermijn, `Awb 7:10` 6-week bezwaartermijn, Omgevingsverordening 4-week reguliere termijn), role escalations (toezichthouder → BOA → JZ), and cross-case links (handhaving spawned from toezichtbezoek) — are not in any catalog. Tenants either rebuild them from scratch (high cost, drift between municipalities) or copy from a colleague's tenant with no version anchor. There is no immutability-respecting "factory reset" path either: re-running the repair step today would create v2 drafts rather than re-importing the canonical v1.
+
+## Affected Projects
+
+- [ ] Project: `procest` — Adds a `lib/Settings/seed/vth-workflow-templates/*.json` catalog, a repair step that imports the catalog as published `workflowTemplate` v1 objects, an admin-only `POST /api/vth-workflow-templates/import` endpoint, a "Sjablonen-catalogus" tab + per-template detail/preview component, selective per-tenant enable, and a diff view against the shipped canonical version.
+
+## Scope
+
+### In Scope (V1)
+
+- **Catalog of six VTH workflow templates** (REQ-VWT-1..2): JSON files under `lib/Settings/seed/vth-workflow-templates/`, version-pinned to the shipping app version.
+- **Seed-data repair step** (REQ-VWT-3): imports the catalog as published `workflowTemplate` v1 objects on first install; idempotent on re-run.
+- **Admin-import endpoint** (REQ-VWT-4): `POST /api/vth-workflow-templates/import` for ad-hoc (re-)imports.
+- **Catalog UI** (REQ-VWT-5..6): a list view and per-template detail/preview drawer with steps, transitions, deadlines, and roles.
+- **Selective enable per tenant** (REQ-VWT-7): a tenant administrator can install only the templates they need.
+- **Diff against published version** (REQ-VWT-8): a read-only "what changed since shipped v1?" view that compares the tenant's active version with the canonical catalog version.
+
+### Out of Scope
+
+- **Authoring new templates** — covered by `workflow-definition-model` (PR #347) admin UI.
+- **Guard evaluation engine** — owned by `status-transition-engine`.
+- **Visual editor** — owned by `visual-workflow-editor` (V2).
+- **Template marketplace / cross-tenant share** — Enterprise / V3.
+- **Translation of UI labels into FR/EN** — only `nl` and `en` per company i18n policy; FR/DE deferred.
+
+## Approach
+
+1. Author six JSON template files under `lib/Settings/seed/vth-workflow-templates/`, each conforming to the `workflowTemplate` schema in `procest_register.json`.
+2. Add a `lib/Migration/SeedVthWorkflowTemplates.php` repair step that loads the catalog, creates one published `workflowTemplate` per file (with `version: 1`, `lifecycleStatus: published`, `isActive: true`), and skips templates already present.
+3. Add `VthWorkflowTemplateCatalogController` exposing `GET /api/vth-workflow-templates` (list canonical) and `POST /api/vth-workflow-templates/import` (re-run repair for selected templates).
+4. Build `VthWorkflowTemplatesTab.vue` + `VthWorkflowTemplateDetailDialog.vue` for admin settings: catalog list, per-template detail/preview, install/uninstall toggle, diff drawer.
+
+## Cross-Project Dependencies
+
+- **`workflow-definition-model` (procest)**: PR #347 — defines the `workflowTemplate` entity, its lifecycle, and the `WorkflowDefinitionService::publish()` semantics this change relies on.
+- **`bezwaar-lifecycle` (procest)**: provides the canonical bezwaar workflow this change cross-links rather than redefining.
+- **`role-based-step-routing` (procest)**: consumes `steps[].assigneeRole` and `transitions[].allowedRoles` from the seeded templates.
+- **`status-transition-engine` (procest)**: consumes the deadlines and guards encoded in each seeded template.
+- **`case-types` (procest)**: VTH templates pin to caseTypes from the VTH seed register (separate `base-register-seed-data` change).

--- a/openspec/changes/vth-workflow-templates/specs/vth-workflow-templates/spec.md
+++ b/openspec/changes/vth-workflow-templates/specs/vth-workflow-templates/spec.md
@@ -1,0 +1,194 @@
+---
+status: draft
+---
+# vth-workflow-templates Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Canonical VTH Workflow Catalog (REQ-VWT-1)
+
+The system SHALL ship a canonical catalog of exactly six VTH workflow templates as JSON files under `lib/Settings/seed/vth-workflow-templates/`: `aanvraag-omgevingsvergunning`, `toezichtbezoek`, `handhavingstraject`, `bezwaar`, `klacht-toezicht`, `spoedig-herstel`. Each file SHALL conform to the `workflowTemplate` schema in `procest_register.json`.
+
+**Feature tier**: V1
+
+#### Scenario: Catalog contains exactly six templates
+
+- **GIVEN** a fresh checkout of `procest` at the version that introduces this change
+- **WHEN** the `lib/Settings/seed/vth-workflow-templates/` directory is listed
+- **THEN** the directory SHALL contain exactly six JSON files corresponding to the six template slugs
+- **AND** every JSON file SHALL validate against the `workflowTemplate` JSON schema in `procest_register.json`
+
+#### Scenario: Each template references a seeded VTH caseType
+
+- **GIVEN** the VTH base register has been seeded by `base-register-seed-data`
+- **WHEN** a catalog file is loaded
+- **THEN** its `caseType` slug SHALL resolve to a `caseType` UUID that exists in the VTH register
+- **AND** every `steps[].status`, `transitions[].fromStatus`, and `transitions[].toStatus` slug SHALL resolve to a `statusType` UUID belonging to that caseType
+
+### Requirement: Statutory Deadlines on Transitions (REQ-VWT-2)
+
+Each catalog template SHALL encode statutory deadlines (where applicable) on the relevant `transitions[].deadline` block, with `duration` as an ISO-8601 period, `source` as the citing law article, and `escalationRole` for the user role notified when the deadline elapses.
+
+**Feature tier**: V1
+
+#### Scenario: Aanvraag omgevingsvergunning carries Awb 4:13 deadline
+
+- **GIVEN** the `aanvraag-omgevingsvergunning.json` catalog file
+- **WHEN** the transition from `In behandeling` to `Besluit` is inspected
+- **THEN** the transition SHALL carry `deadline: { duration: "P56D", source: "Awb 4:13", escalationRole: "afdelingsmanager" }`
+
+#### Scenario: Klacht over toezicht carries Awb 9:11 deadline
+
+- **GIVEN** the `klacht-toezicht.json` catalog file
+- **WHEN** the transition from `In behandeling` to `Beoordeeld` is inspected
+- **THEN** the transition SHALL carry `deadline: { duration: "P42D", source: "Awb 9:11", escalationRole: "klachtcoördinator" }`
+
+### Requirement: Idempotent Seed-Data Repair Step (REQ-VWT-3)
+
+The system SHALL provide a repair step `lib/Migration/SeedVthWorkflowTemplates.php` that imports the catalog as published `workflowTemplate` v1 objects via `WorkflowDefinitionService::createDraft()` + `publish()`. The repair step SHALL be idempotent and SHALL NEVER write directly to `workflowTemplate` rows.
+
+**Feature tier**: V1
+
+#### Scenario: Repair step seeds all templates on fresh install
+
+- **GIVEN** a Procest tenant with no existing VTH `workflowTemplate` objects and the VTH caseTypes seeded
+- **WHEN** the repair step runs
+- **THEN** six `workflowTemplate` objects SHALL exist
+- **AND** each SHALL be `lifecycleStatus: published`, `isActive: true`, `version: 1`
+- **AND** each SHALL be linked from the corresponding `caseType.workflowDefinition` (only when that caseType had no pinned definition beforehand)
+
+#### Scenario: Repair step is idempotent on re-run
+
+- **GIVEN** the repair step has already run once and seeded all six templates
+- **WHEN** the repair step runs again
+- **THEN** no new `workflowTemplate` objects SHALL be created
+- **AND** no existing `workflowTemplate` SHALL be modified
+- **AND** the step SHALL complete without raising errors
+
+#### Scenario: Repair step routes mutations through WorkflowDefinitionService
+
+- **GIVEN** the repair step is implementing the seed
+- **WHEN** it creates a new `workflowTemplate`
+- **THEN** it SHALL call `WorkflowDefinitionService::createDraft()` followed by `WorkflowDefinitionService::publish()`
+- **AND** it SHALL NEVER call `ObjectService::saveObject()` directly with a `workflowTemplate` payload
+
+#### Scenario: Repair step skips templates with unresolved status slugs
+
+- **GIVEN** a catalog file references a `statusType` slug that does not exist on the linked caseType
+- **WHEN** the repair step processes that file
+- **THEN** it SHALL log a warning via `$this->logger->error()`
+- **AND** it SHALL skip the template entirely (no partial seed)
+- **AND** it SHALL continue processing the remaining catalog files
+
+### Requirement: Admin-Triggered Catalog Import Endpoint (REQ-VWT-4)
+
+The system SHALL expose `POST /api/vth-workflow-templates/import` accepting a body `{ slugs: [...] }` for ad-hoc selective re-import of catalog entries. The endpoint SHALL be restricted to administrators.
+
+**Feature tier**: V1
+
+#### Scenario: Admin can selectively import a subset of templates
+
+- **GIVEN** a tenant administrator on a system with no `klacht-toezicht` template installed
+- **WHEN** they POST `/api/vth-workflow-templates/import` with body `{ slugs: ["klacht-toezicht"] }`
+- **THEN** the system SHALL invoke the repair-step seeding path for that one slug only
+- **AND** the response SHALL be `{ installed: ["klacht-toezicht"], skipped: [], failed: [] }`
+
+#### Scenario: Non-admin import attempt is rejected
+
+- **GIVEN** a user without the `admin` group membership
+- **WHEN** they POST `/api/vth-workflow-templates/import`
+- **THEN** the request SHALL be rejected with HTTP 403
+
+#### Scenario: Endpoint returns no raw exception messages
+
+- **GIVEN** the import handler raises an unexpected exception
+- **WHEN** the response is built
+- **THEN** the response body SHALL contain only a static error string
+- **AND** the original exception SHALL be logged via `$this->logger->error()`
+- **AND** `$e->getMessage()` SHALL NEVER appear in the response
+
+### Requirement: Catalog List UI (REQ-VWT-5)
+
+The system SHALL render a "Sjablonen-catalogus" tab in admin settings (`VthWorkflowTemplatesTab.vue`) listing the canonical catalog with title, caseType, status count, deadline summary, and an installed-yes-no badge per template.
+
+**Feature tier**: V1
+
+#### Scenario: Catalog tab is visible only to admins
+
+- **GIVEN** a user without admin group membership opens the Procest settings page
+- **WHEN** the tabs are rendered
+- **THEN** the `VTH-sjablonen` tab SHALL NOT be visible
+
+#### Scenario: Catalog rows show installed state
+
+- **GIVEN** the catalog tab is opened on a tenant where `toezichtbezoek` is installed but `klacht-toezicht` is not
+- **WHEN** the row for each template is rendered
+- **THEN** the `toezichtbezoek` row SHALL carry the badge `Geïnstalleerd`
+- **AND** the `klacht-toezicht` row SHALL carry the badge `Niet geïnstalleerd`
+
+### Requirement: Per-Template Detail and Preview (REQ-VWT-6)
+
+The system SHALL render a per-template detail dialog (`VthWorkflowTemplateDetailDialog.vue`) with read-only tabs for `Steps`, `Transitions`, `Deadlines`, and `Diff vs canonical v1`.
+
+**Feature tier**: V1
+
+#### Scenario: Detail dialog renders steps and transitions read-only
+
+- **GIVEN** the detail dialog is opened for `aanvraag-omgevingsvergunning`
+- **WHEN** the `Steps` and `Transitions` tabs are inspected
+- **THEN** both tabs SHALL reuse the read-only mode of `WorkflowStepsEditor` / `WorkflowTransitionsEditor` from `workflow-definition-model`
+- **AND** no edit, save, or delete controls SHALL be present in the dialog
+- **AND** the only mutating actions SHALL be the footer `Installeren` (if not installed) or `Klonen voor wijziging` (if installed)
+
+#### Scenario: Deadlines tab renders statutory deadlines as readable rows
+
+- **GIVEN** the detail dialog is opened for `aanvraag-omgevingsvergunning`
+- **WHEN** the `Deadlines` tab is inspected
+- **THEN** at least one row SHALL render the deadline as `8 weken (Awb 4:13) → afdelingsmanager`
+
+### Requirement: Selective Enable per Tenant (REQ-VWT-7)
+
+The system SHALL allow a tenant administrator to install only the catalog templates relevant to their service portfolio, including a multi-select toolbar action. Uninstall SHALL be offered only when the template's active version has zero open cases bound to it; otherwise the action SHALL be replaced with a link to the WDM `Deprecate` flow.
+
+**Feature tier**: V1
+
+#### Scenario: Multi-select install triggers a single import call
+
+- **GIVEN** the admin selects rows for `toezichtbezoek` and `handhavingstraject` and clicks `Installeer geselecteerde`
+- **WHEN** the action fires
+- **THEN** a single `POST /api/vth-workflow-templates/import` SHALL be dispatched with `{ slugs: ["toezichtbezoek", "handhavingstraject"] }`
+- **AND** the catalog list SHALL refresh after the response
+
+#### Scenario: Uninstall is blocked when open cases reference the template
+
+- **GIVEN** the `handhavingstraject` template has at least one case in a non-final status bound to its active version
+- **WHEN** the admin opens the row's action menu
+- **THEN** the `Uninstall` action SHALL NOT be present
+- **AND** instead a link `Deprecate via beheer` SHALL deep-link into the WDM admin tab
+
+### Requirement: Diff Against Canonical Published Version (REQ-VWT-8)
+
+The system SHALL render a read-only diff view comparing the tenant's currently active `workflowTemplate` for a given caseType against the canonical v1 from the shipped catalog, listing added, removed, and modified steps / transitions / deadlines.
+
+**Feature tier**: V1
+
+#### Scenario: Diff reports added and removed steps
+
+- **GIVEN** the tenant has cloned `aanvraag-omgevingsvergunning` v1 into v2 and added one extra step "Externe consultatie"
+- **WHEN** the diff tab is opened for that template
+- **THEN** the diff SHALL list `steps.added: ["Externe consultatie"]`
+- **AND** the diff SHALL list `steps.removed: []`
+
+#### Scenario: Diff reports modified deadlines
+
+- **GIVEN** the tenant has cloned `aanvraag-omgevingsvergunning` v1 into v2 and changed the Awb 4:13 deadline from 8 weken to 6 weken
+- **WHEN** the diff tab is opened
+- **THEN** the diff SHALL list a `deadline.changed` entry for the `In behandeling → Besluit` transition
+- **AND** the entry SHALL carry the canonical value `P56D` and the tenant value `P42D`
+
+#### Scenario: Diff view is strictly read-only
+
+- **GIVEN** the diff tab is open and shows non-empty changes
+- **WHEN** the rendered DOM is inspected
+- **THEN** no `Revert`, `Apply canonical`, or other write action SHALL be present
+- **AND** the only path to restore canonical behaviour SHALL be via clone-and-publish in the WDM admin UI

--- a/openspec/changes/vth-workflow-templates/tasks.md
+++ b/openspec/changes/vth-workflow-templates/tasks.md
@@ -1,0 +1,93 @@
+# Tasks: vth-workflow-templates
+
+## Deduplication Check
+
+- [ ] **D01**: Confirm no `lib/Settings/seed/vth-workflow-templates/` directory or `VthWorkflowTemplateCatalogService` / `VthWorkflowTemplateCatalogController` already exists in `procest`. Confirm `workflow-definition-model` (PR #347) has merged its `WorkflowDefinitionService` (with `createDraft()` + `publish()` + `getActiveDefinitionFor()`) and that the `workflowTemplate` schema in `lib/Settings/procest_register.json` includes the `lifecycleStatus` enum field (T01 of WDM). Confirm the VTH caseTypes (`Omgevingsvergunning`, `Toezichtbezoek`, `Handhaving`, `Klacht`, `Bezwaar`) are seeded by `base-register-seed-data` ahead of this repair step.
+
+---
+
+## Catalog Files
+
+- [ ] **T01**: Create `lib/Settings/seed/vth-workflow-templates/` and author six JSON catalog files, one per template, conforming to the `workflowTemplate` schema in `procest_register.json`:
+  - `aanvraag-omgevingsvergunning.json` — 6 statuses, 8-week Awb 4:13 deadline on the `In behandeling → Besluit` transition, escalation role `afdelingsmanager`.
+  - `toezichtbezoek.json` — 5 statuses, no statutory deadline, spawn-link to `handhavingstraject` via `automaticActions[].type = "spawnCase"`.
+  - `handhavingstraject.json` — 7 statuses (voornemen, zienswijze ontvangen, besluit, bezwaarperiode, in werking, invordering, afgerond), Awb 5:24 deadline on the `Voornemen → Besluit` transition.
+  - `bezwaar.json` — VTH-specific cross-link entry pointing at the `bezwaar-lifecycle` workflow with two extra `guards[]` for sectoral non-ontvankelijkheid grounds. Does NOT re-define the bezwaar workflow.
+  - `klacht-toezicht.json` — 4 statuses (ontvangen, in behandeling, beoordeeld, afgehandeld), Awb 9:11 6-week deadline.
+  - `spoedig-herstel.json` — 4 statuses (geconstateerd, herstel-uitgevoerd, besluit-achteraf, afgehandeld), no pre-deadline, escalation to BOA on `geconstateerd > 4u`.
+  Each file uses ISO-8601 durations on `transitions[].deadline.duration` and the slug `caseType` (resolved to UUID at install time).
+
+---
+
+## Backend: Service
+
+- [ ] **T02**: Create `lib/Migration/SeedVthWorkflowTemplates.php` repair step. For each JSON file under `lib/Settings/seed/vth-workflow-templates/`:
+  - Resolve `caseType` slug → UUID via `CaseTypeService::findBySlug()`.
+  - Resolve every `status` / `fromStatus` / `toStatus` slug to a `statusType` UUID belonging to the resolved caseType. On miss, log warning and SKIP this template (do not partially seed).
+  - Generate UUID5s for `steps[].id` and `transitions[].id` from a namespace derived from the template slug, so re-runs are idempotent.
+  - Call `WorkflowDefinitionService::createDraft()` then `publish()` to respect the WDM immutability invariant. Never write `workflowTemplate` rows directly.
+  - Skip templates whose canonical UUID (UUID5 of slug + caseType) is already present in OpenRegister.
+  - Set `caseType.workflowDefinition` to the new template UUID only when the caseType has no pinned definition.
+  - Log failures via `$this->logger->error()`; never throw out of the repair step (idempotency requirement).
+
+- [ ] **T03**: Create `lib/Service/VthWorkflowTemplateCatalogService.php` exposing:
+  - `listCatalog(): array` — reads the six JSON files, returns canonical metadata (slug, title, caseType, version, statuses count, deadline, installed-yes-no).
+  - `getCatalogEntry(string $slug): array` — returns one canonical entry plus its full `steps[]` / `transitions[]` for the detail dialog.
+  - `importTemplates(array $slugs): array` — invokes the repair step's per-template path for a subset; returns `{installed: [...], skipped: [...], failed: [...]}`. Admin-only via `IGroupManager`. Logs failures; never returns raw exception messages.
+  - `diffAgainstCanonical(string $caseTypeId): array` — returns `{added, removed, modified}` arrays describing differences between the tenant's active `workflowTemplate` and the canonical v1.
+  Identity from `IUserSession`; logging via `$this->logger->error()`; static error strings only.
+
+---
+
+## Backend: Controller
+
+- [ ] **T03b**: Create `lib/Controller/VthWorkflowTemplateCatalogController.php` exposing:
+  - `GET    /api/vth-workflow-templates` — list canonical catalog with installed-yes-no per template.
+  - `GET    /api/vth-workflow-templates/{slug}` — read canonical detail for one template.
+  - `POST   /api/vth-workflow-templates/import` — body `{ slugs: [...] }`; admin-only; re-runs the repair step for the selected templates. Returns `{installed, skipped, failed}`.
+  - `GET    /api/vth-workflow-templates/{slug}/diff` — diff canonical v1 vs tenant's active version.
+  No raw exception messages — static error strings; `$this->logger->error()` for internals.
+
+---
+
+## Routes
+
+- [ ] **T04**: Register the four endpoints from T03b in `appinfo/routes.php` with PHP controller name `vth_workflow_template_catalog` and kebab-case URL `/api/vth-workflow-templates[/...]`.
+
+---
+
+## Frontend: Store + API
+
+- [ ] **T04b**: Register a `vth-workflow-template` entity type in `src/store/store.js` via `createObjectStore('vth-workflow-template')`. Register ONCE. Add `src/services/vthWorkflowTemplateCatalogApi.js` with calls `listCatalog`, `getCatalogEntry`, `importTemplates`, `diffAgainstCanonical`. Use `@nextcloud/axios` exclusively.
+
+---
+
+## Frontend: Catalog UI
+
+- [ ] **T05**: Create `src/views/settings/components/VthWorkflowTemplatesTab.vue`:
+  - Imports only from `@conduction/nextcloud-vue`.
+  - Table of canonical catalog: title, caseType, status count, deadline, installed badge (`CnStatusBadge`), action column (`Install` | `Open detail`).
+  - Empty state via `CnEmptyState` ("Geen sjablonen beschikbaar — controleer of base-register-seed-data is uitgevoerd").
+  - All strings via `this.t(appName, '...')`; SPDX header on line 1; nl + en translations only.
+
+- [ ] **T06**: Create `src/views/settings/components/VthWorkflowTemplateDetailDialog.vue` (read-only preview + diff):
+  - Tabs: `Steps`, `Transitions`, `Deadlines`, `Diff vs canonical v1`.
+  - `Steps` and `Transitions` tabs reuse the read-only mode of `WorkflowStepsEditor` / `WorkflowTransitionsEditor` from `workflow-definition-model`.
+  - `Deadlines` tab: a table of `transitions[].deadline.{duration, source, escalationRole}` rendered as human-readable rows (e.g., "8 weken (Awb 4:13) → afdelingsmanager").
+  - `Diff` tab: calls `diffAgainstCanonical`; renders `{added, removed, modified}` as three lists; read-only — no revert action.
+  - Footer actions: `Installeren` (if not installed) or `Klonen voor wijziging` (if installed; defers to WDM admin UI). Confirmation via `CnDialog`, never `window.confirm`.
+  - SPDX header; strings via `this.t(appName, '...')`.
+
+- [ ] **T07**: Selective install: the catalog table supports multi-select rows + a `Installeer geselecteerde` toolbar action that calls `importTemplates({slugs: [...]})` and refreshes the catalog list. Per-row install action available too. Uninstall is OFFERED ONLY when the template's active version has zero open cases bound to it; otherwise the action shows `Deprecate` and links into the WDM admin tab.
+
+---
+
+## Verification
+
+- [ ] **V01**: `grep -rL 'SPDX-License-Identifier' lib/Migration/SeedVthWorkflowTemplates.php lib/Service/VthWorkflowTemplateCatalogService.php lib/Controller/VthWorkflowTemplateCatalogController.php src/views/settings/components/VthWorkflowTemplatesTab.vue src/views/settings/components/VthWorkflowTemplateDetailDialog.vue src/services/vthWorkflowTemplateCatalogApi.js` → zero results.
+
+- [ ] **V02**: `grep -rn 'findObject\|saveObject\|findObjects\|deleteObject' lib/Migration/SeedVthWorkflowTemplates.php lib/Service/VthWorkflowTemplateCatalogService.php` → every call uses the 3-positional-arg API; AND every mutation of a `workflowTemplate` goes through `WorkflowDefinitionService` (no direct ObjectService writes to `workflowTemplate`).
+
+- [ ] **V03**: `grep -rn 'getMessage()' lib/Controller/VthWorkflowTemplateCatalogController.php` → zero results. No raw exception messages in responses.
+
+- [ ] **V04**: Manual QA — Fresh install: repair step seeds all six templates as `published`+`isActive`. Re-running the repair step is a no-op (idempotent). Catalog tab lists all six with `installed`. Selecting `klacht-toezicht` only on a fresh install seeds just that one. Opening detail for `aanvraag-omgevingsvergunning` shows the 8-week Awb 4:13 deadline in the `Deadlines` tab. After admin clones v1 and publishes v2 via the WDM UI, the catalog `Diff` tab shows the structural changes between the two.


### PR DESCRIPTION
## Summary

Adds a new openspec change `vth-workflow-templates` — a catalog of six reference VTH (Vergunningen, Toezicht & Handhaving) workflow templates shipped as seed data on top of `workflow-definition-model` (PR #347).

- Catalog: `aanvraag-omgevingsvergunning`, `toezichtbezoek`, `handhavingstraject`, `bezwaar` (cross-link), `klacht-toezicht`, `spoedig-herstel`
- Statutory deadlines encoded on transitions (Awb 4:13 / 7:10 / 5:24 / 9:11) with escalation roles
- Idempotent repair step routes mutations through `WorkflowDefinitionService::createDraft + publish` (respects WDM immutability invariant)
- Admin-only import endpoint, Sjablonen-catalogus UI with detail + diff vs canonical v1, selective install per tenant

## REQ Count

REQ-VWT-1 through REQ-VWT-8 (8 requirements, 21 scenarios).

## Validation

`openspec change validate vth-workflow-templates --strict` → passes.

## Test plan

- [ ] Reviewer: confirm the catalog scope (six templates) matches what VTH tenants need on day one
- [ ] Reviewer: confirm statutory deadline encoding on `transitions[].deadline.{duration, source, escalationRole}` is acceptable shape for `status-transition-engine` to consume
- [ ] Reviewer: confirm cross-link strategy for `bezwaar` (no redefinition; only VTH-specific guards layered on the `bezwaar-lifecycle` workflow) is correct
- [ ] No code in this change — implementation lands via `/opsx-apply` against this spec