### PR TITLE
chore(openspec): generate bezwaar-lifecycle spec

### DIFF
--- a/openspec/changes/bezwaar-lifecycle/design.md
+++ b/openspec/changes/bezwaar-lifecycle/design.md
@@ -1,0 +1,62 @@
+# Design: bezwaar-lifecycle
+
+## Context
+
+Bezwaar is the most legally formal case type Procest handles. Under the Algemene wet bestuursrecht (Awb hoofdstuk 6 + 7), municipalities have six weeks to decide on an objection against a primary decision (art. 7:10 lid 1), extendable once by another six weeks (art. 7:10 lid 3). Missing that deadline triggers automatic dwangsom liability under Wet dwangsom (Awb 4:17): up to € 1 442 per case, with daily increments. The lifecycle therefore needs a strict deadline scheduler, a status state machine that prevents illegal jumps (e.g. recording a beslissing op bezwaar before ontvankelijkheid is determined), and an audit trail that documents every Awb-relevant action. The capability is the spine; advisory-committee, hearing, and decision are vertebrae that compose onto it.
+
+## Entity: bezwaar case (`case` with `zaaktype = Bezwaar`)
+
+Defined in `lib/Settings/procest_register.json`. Bezwaar cases reuse the generic `case` schema but rely on a pre-seeded `caseType` named "Bezwaar" that declares `processingDeadline = P6W`, `extensionAllowed = true`, `extensionPeriod = P6W`, `suspensionAllowed = true`. Linked schemas: `objection` (one), `hearingSession` (0..n), `advisoryReport` (0..1), `decision` with `besluittype = "Beslissing op bezwaar"` (0..1).
+
+## Lifecycle (status state machine)
+
+```
+Ontvangen ──(intake compleet)──► Ontvankelijkheidstoets
+Ontvankelijkheidstoets ──(ontvankelijk)──► In behandeling
+Ontvankelijkheidstoets ──(niet-ontvankelijk, motivering)──► Niet-ontvankelijk [terminal]
+In behandeling ──(hoorzitting ingepland)──► Hoorzitting gepland
+In behandeling ──(hoorrecht afgezien, reden vereist)──► Advies uitgebracht | Beslissing op bezwaar
+Hoorzitting gepland ──(hoorzitting uitgevoerd)──► Hoorzitting afgerond
+Hoorzitting afgerond ──(advies uitgebracht)──► Advies uitgebracht
+Hoorzitting afgerond ──(geen commissie)──► Beslissing op bezwaar
+Advies uitgebracht ──(beslissing op bezwaar genomen)──► Beslissing op bezwaar
+Beslissing op bezwaar ──(verzonden + termijn doorgegeven)──► Afgehandeld [terminal]
+* ──(bezwaarmaker trekt in, art. 6:21)──► Ingetrokken [terminal]
+```
+
+Terminal statuses: `Afgehandeld`, `Niet-ontvankelijk`, `Ingetrokken`. Skip rules: when `objection.hearingWaived = true`, `Hoorzitting gepland` and `Hoorzitting afgerond` are skipped — the audit trail records reason `"Belanghebbende heeft afgezien van het recht te worden gehoord"`. Backward transitions are not permitted; reopening a terminal-status case requires a new case via `beroep-escalation`.
+
+## Deadline rules
+
+| Trigger | Output field | Formula | Awb |
+|---------|--------------|---------|-----|
+| Case created | `ontvangstbevestigingDeadline` | `ontvangstdatum + P1W` | 6:14 |
+| Case created | `afhandelDeadline` | `ontvangstdatum + P6W` | 7:10 lid 1 |
+| Verdaging | `afhandelDeadline` | `afhandelDeadline + extensionPeriod` | 7:10 lid 3 |
+| Opschorting start | `clockStopAt` | `now()` | 7:10 lid 4 |
+| Opschorting end | `afhandelDeadline` | `afhandelDeadline + (clockStartAt − clockStopAt)` | 7:10 lid 4 |
+| Ingebrekestelling | `dwangsomStartDate` | `ingebrekestellingDate + P2W` | 4:17 |
+| Dwangsom day-1 | `dwangsomAccrued` | `min(P6W × € 1442/P6W, € 1442)` | 4:17 |
+
+Deadlines are declared via OpenRegister `x-openregister-calculations` (ADR-022) on the bezwaar `case` schema — not via a procest-specific service. Each rule maps to `{ formula, inputs, outputField }` and is evaluated by OR's `RenderObject::renderCalculations`.
+
+## Escalation triggers
+
+- `afhandelDeadline − 5 workdays`: warning notification + dashboard "at-risk" flag (behandelaar)
+- `afhandelDeadline + 0 days`: case becomes "overdue" — escalation notification to teamlead + bezwaar-coördinator
+- `ingebrekestelling received`: 14-day grace clock starts; if no beslissing within those 14 days, dwangsom accrues automatically
+- `dwangsom accruing`: case banner shows live counter and total liability
+
+## Sister-capability integration
+
+- **bezwaar-advisory-committee** — when the commissie publishes an `advisoryReport`, the lifecycle observer transitions the case to `Advies uitgebracht` and surfaces `deviationFromPrimaryDecision = true` as a behandelaar-attention flag
+- **bezwaar-hearing** — `hearingSession.status = uitgevoerd` triggers transition to `Hoorzitting afgerond`; `hearingSession.hearingWaived = true` allows the lifecycle to skip both hearing statuses
+- **bezwaar-decision** — recording a `decision` with `besluittype = "Beslissing op bezwaar"` transitions the case to `Beslissing op bezwaar`, and once `decisionLetterSent = true` to `Afgehandeld`. `dispositionType = niet_ontvankelijk` short-circuits straight to `Niet-ontvankelijk`
+
+## Audit and compliance
+
+Every status transition writes an audit entry with: `actor` (UID), `fromStatus`, `toStatus`, `reason`, `awbReference` (article ID), `timestamp`. Awb reference is required for any transition that changes the legal posture: ontvankelijkheidsoordeel, verdaging, opschorting, hoorrecht-afzien, niet-ontvankelijk, intrekking. The trail is append-only via OpenRegister's per-save audit log; no admin override. Archiefwet retention follows the parent `case` schema (V20 / V10 depending on dispositionType).
+
+## Why a GENERATE-style change?
+
+The schemas, seed data, and Vue components are already in production via the merged `bezwaar-beroep-workflow` change (archived 2026-03-22). What is missing is the canonical capability spec that the sister capabilities can compose onto. This change captures the contract that the existing code already honours — tasks are scoped to verification, gaps become follow-up issues.

--- a/openspec/changes/bezwaar-lifecycle/proposal.md
+++ b/openspec/changes/bezwaar-lifecycle/proposal.md
@@ -1,0 +1,56 @@
+# Proposal: Bezwaar Lifecycle
+
+## Summary
+
+Formalize the `bezwaar-lifecycle` capability as a first-class OpenSpec change so the existing canonical spec at `openspec/specs/bezwaar-lifecycle/spec.md` (5 requirements, no traceable change history) is replaced by a fully delta-formatted change with ten REQ-BL-* requirements, an explicit state machine, statutory-deadline rules, and integration hooks into the three sister capabilities — `bezwaar-advisory-committee`, `bezwaar-hearing`, and `bezwaar-decision`. Bezwaar (formal objection under the Algemene wet bestuursrecht, Awb) is the most legally formal case type in Procest: timelines are statutory (Awb 7:10 — 6 weeks initial, 6 weeks verdaging), transitions are gated by ontvankelijkheidstoets and hoorrecht, and the failure mode is automatic dwangsom liability under the Wet dwangsom (Awb 4:17). The capability deserves a single spec that owns the state machine, deadline scheduler, and audit posture, with the three sister capabilities composing onto it.
+
+## Why
+
+The existing canonical spec was committed without a change record, so traceability between spec and implementation is broken; new dependent work (bezwaar-beroep-workflow, document-zaakdossier, archiving) needs a referenceable contract. The three sister specs (advisory-committee, hearing, decision) already exist but they all reference "the bezwaar case status machine" without a single source of truth. Formalizing it now — with the legal deadline rules, ingebrekestelling/dwangsom hooks, and Awb article cross-references in one place — keeps OpenSpec coverage honest, lets reviewers validate against an explicit state diagram, and gives tender responses a traceable spec ID for "AWB-compliant bezwaarafhandeling".
+
+## What Changes
+
+- Adds `bezwaar-lifecycle` change folder under `openspec/changes/` with `proposal.md`, `design.md`, `tasks.md`, and `specs/bezwaar-lifecycle/spec.md`
+- Authors ten REQ-BL-* requirements (delta-format `## ADDED Requirements`) covering case type seeding, status state machine, role types, deadline calculation, ontvankelijkheidstoets, verdaging/opschorting, ingebrekestelling/dwangsom, sister-capability integration, audit trail, and Vue lifecycle view
+- Adds a one-page state-machine diagram + deadline rules + escalation table to `design.md`
+- Tasks (T01–T10) cover schema verification, state-machine guards, deadline scheduler, controller endpoints, Vue lifecycle view, audit-trail integration, and strict validation
+- Does NOT introduce any code changes — implementation lives across `lib/Settings/procest_register.json`, the existing register seeds, and frontend components. Any gap surfaced during verification is filed as a follow-up issue
+- On archive, the spec under `specs/bezwaar-lifecycle/` replaces the unowned spec currently at `openspec/specs/bezwaar-lifecycle/spec.md`
+
+## Affected Projects
+
+- [ ] Project: `procest` — Formalize the `bezwaar-lifecycle` capability with proposal, design, tasks, and a delta-format spec. NO CODE: implementation already exists in the procest register schemas and seed data.
+
+## Scope
+
+### In Scope (V1, verification only)
+
+- **Bezwaar case type seeding** (REQ-BL-1): pre-seeded Awb-compliant zaaktype with 6-week processingDeadline + 6-week extensionPeriod
+- **Status state machine** (REQ-BL-2): 8 ordered statuses + 2 terminal statuses + permitted transitions
+- **Role types** (REQ-BL-3): 7 pre-seeded role types covering all Awb participants
+- **Legal deadline calculation** (REQ-BL-4): ontvangstbevestiging, afhandelDeadline, verdaging, opschorting
+- **Ontvankelijkheidstoets** (REQ-BL-5): timeliness, belanghebbendheid, vormvereisten checks
+- **Verdaging and opschorting** (REQ-BL-6): extension and suspension rules per Awb art. 7:10
+- **Ingebrekestelling and dwangsom** (REQ-BL-7): Wet dwangsom (Awb 4:17) deadline + automatic liability tracking
+- **Sister-capability integration** (REQ-BL-8): hooks into hearing, advisory-committee, and decision capabilities
+- **Audit trail and immutability** (REQ-BL-9): every status transition logged with actor, reason, Awb reference
+- **Vue lifecycle view** (REQ-BL-10): status badges, deadline countdown, transition guard messages
+
+### Out of Scope
+
+- Hearing session management — separate `bezwaar-hearing` capability
+- Advisory committee reports — separate `bezwaar-advisory-committee` capability
+- Decision recording — separate `bezwaar-decision` capability
+- Beroep (appeal) escalation — separate `beroep-escalation` capability
+
+## Approach
+
+This is a **GENERATE-style** change: the schemas and seed data already exist. The change captures the contract in OpenSpec form so the capability becomes traceable, testable, and referenceable by sister capabilities. Verification tasks confirm the schemas, transitions, and deadline rules match the spec.
+
+## Cross-Project Dependencies
+
+- **procest-case-management**: provides the underlying case object and status machine primitives
+- **bezwaar-advisory-committee**: composes onto the lifecycle for advisory-track cases
+- **bezwaar-hearing**: composes onto the lifecycle for hearing scheduling and waiver
+- **bezwaar-decision**: composes onto the lifecycle for beslissing op bezwaar
+- **OpenRegister**: object storage, computed fields (`x-openregister-calculations` per ADR-022), and audit trail

--- a/openspec/changes/bezwaar-lifecycle/specs/bezwaar-lifecycle/spec.md
+++ b/openspec/changes/bezwaar-lifecycle/specs/bezwaar-lifecycle/spec.md
@@ -1,0 +1,257 @@
+## ADDED Requirements
+
+### Requirement: Bezwaar Case Type Pre-Seeded Configuration (REQ-BL-1)
+
+The system SHALL provide a pre-seeded "Bezwaar" (objection) case type with Awb hoofdstuk 6/7 compliant configuration. The case type SHALL be imported via the repair step alongside existing case types and SHALL declare statutory deadlines via OpenRegister `x-openregister-calculations` (per ADR-022).
+
+**Feature tier**: V1
+**ZGW mapping**: `zaaktype` with `omschrijving` "Bezwaar"
+**CMMN mapping**: CaseDefinition with TimerEventListeners for legal deadlines
+
+| Property | Value |
+|----------|-------|
+| `title` | Bezwaar |
+| `description` | Bezwaarprocedure conform Awb hoofdstuk 6 en 7 |
+| `processingDeadline` | P6W (Awb art. 7:10 lid 1) |
+| `extensionAllowed` | true |
+| `extensionPeriod` | P6W (Awb art. 7:10 lid 3) |
+| `suspensionAllowed` | true |
+| `origin` | external |
+| `trigger` | Bezwaarschrift van belanghebbende |
+
+#### Scenario: Bezwaar case type is available after installation
+
+- **WHEN** the Procest app repair step runs
+- **THEN** a case type "Bezwaar" SHALL exist in the procest register
+- **AND** the case type SHALL have `processingDeadline = P6W`, `extensionAllowed = true`, `extensionPeriod = P6W`, `suspensionAllowed = true`
+- **AND** the case schema SHALL declare `x-openregister-calculations` rules for `ontvangstbevestigingDeadline`, `afhandelDeadline`, and `dwangsomStartDate`
+
+#### Scenario: Deadline rules use OR computed fields, not procest service
+
+- **WHEN** a developer inspects how deadlines are calculated
+- **THEN** the formulas SHALL live in the case schema's `x-openregister-calculations` annotation
+- **AND** there SHALL NOT be a procest-specific `BezwaarDeadlineService` that duplicates the logic
+- **AND** the implementation SHALL match ADR-022 (procest-adopt-or-abstractions)
+
+### Requirement: Bezwaar Status State Machine (REQ-BL-2)
+
+The system SHALL enforce a strict state machine over bezwaar case status, with eight ordered statuses, two terminal-only statuses, and explicit transition rules grounded in Awb articles.
+
+**Feature tier**: V1
+**ZGW mapping**: `statustype` linked to the bezwaar `zaaktype`
+
+| Order | Status | Awb |
+|-------|--------|-----|
+| 1 | Ontvangen | 6:4 |
+| 2 | Ontvankelijkheidstoets | 6:5, 6:6 |
+| 3 | In behandeling | 7:2 |
+| 4 | Hoorzitting gepland | 7:2 |
+| 5 | Hoorzitting afgerond | 7:7 |
+| 6 | Advies uitgebracht | 7:13 |
+| 7 | Beslissing op bezwaar | 7:11, 7:12 |
+| 8 | Afgehandeld | — |
+| — | Niet-ontvankelijk (terminal) | 6:6 |
+| — | Ingetrokken (terminal) | 6:21 |
+
+#### Scenario: All 10 status types are seeded
+
+- **WHEN** the repair step completes
+- **THEN** exactly 10 status types SHALL exist for the Bezwaar case type
+- **AND** the 8 non-terminal statuses SHALL be ordered 1..8
+- **AND** `Niet-ontvankelijk` and `Ingetrokken` SHALL be flagged as terminal
+
+#### Scenario: Backward transitions are rejected
+
+- **WHEN** a behandelaar attempts to transition a bezwaar case from `In behandeling` back to `Ontvangen`
+- **THEN** the API SHALL respond with HTTP 422 and message `"Backward transitions are not permitted"`
+- **AND** the case status SHALL remain unchanged
+
+#### Scenario: Skip hearing when hoorrecht is waived
+
+- **WHEN** the linked `objection.hearingWaived` is `true` with a non-empty `waiverReason`
+- **THEN** the case SHALL be allowed to transition from `Ontvankelijkheidstoets` or `In behandeling` directly to `Advies uitgebracht` or `Beslissing op bezwaar`
+- **AND** the audit entry SHALL record `reason = "Belanghebbende heeft afgezien van het recht te worden gehoord"`
+
+### Requirement: Bezwaar Role Types (REQ-BL-3)
+
+The system SHALL provide seven pre-seeded role types for the Bezwaar case type covering all Awb-recognized participants.
+
+**Feature tier**: V1
+**ZGW mapping**: `roltype` linked to bezwaar `zaaktype`
+
+| Role Type | Generic Role |
+|-----------|-------------|
+| Bezwaarmaker | initiator |
+| Behandelaar bezwaar | handler |
+| Voorzitter commissie | decision_maker |
+| Lid commissie | advisor |
+| Secretaris commissie | coordinator |
+| Vertegenwoordiger | stakeholder |
+| Primair beslisser | advisor |
+
+#### Scenario: All 7 role types are seeded
+
+- **WHEN** the repair step completes
+- **THEN** 7 role types SHALL exist for the Bezwaar case type
+- **AND** each role type SHALL map to one of the standard generic roles
+
+### Requirement: Statutory Deadline Calculation (REQ-BL-4)
+
+The system SHALL automatically calculate Awb-mandated deadlines on case create/save via OpenRegister `x-openregister-calculations` (ADR-022), with no procest-specific deadline service.
+
+**Feature tier**: V1
+**Awb reference**: art. 6:7, 6:8, 7:10, 7:24
+
+| Trigger | Output | Formula | Awb |
+|---------|--------|---------|-----|
+| Case created | `ontvangstbevestigingDeadline` | `ontvangstdatum + P1W` | 6:14 |
+| Case created | `afhandelDeadline` | `ontvangstdatum + P6W` | 7:10 lid 1 |
+| Verdaging recorded | `afhandelDeadline` | `afhandelDeadline + P6W` | 7:10 lid 3 |
+| Opschorting end | `afhandelDeadline` | `+ (clockStart − clockStop)` | 7:10 lid 4 |
+| Ingebrekestelling | `dwangsomStartDate` | `ingebrekestellingDate + P2W` | 4:17 |
+
+#### Scenario: Initial deadlines on case creation
+
+- **WHEN** a bezwaar case is created with `ontvangstdatum = 2026-03-02` (Monday)
+- **THEN** `ontvangstbevestigingDeadline` SHALL be `2026-03-09`
+- **AND** `afhandelDeadline` SHALL be `2026-04-13`
+- **AND** these values SHALL be persisted on the case object
+
+#### Scenario: Deadline warning within 5 working days
+
+- **WHEN** a non-terminal bezwaar case is within 5 working days of `afhandelDeadline`
+- **THEN** the case SHALL appear in the dashboard "at-risk" section with a yellow flag
+- **AND** the behandelaar SHALL receive a notification `"Bezwaartermijn nadert"`
+
+### Requirement: Ontvankelijkheidstoets (REQ-BL-5)
+
+The system SHALL support the formal admissibility check (ontvankelijkheidstoets) covering timeliness (Awb 6:7-6:8), belanghebbendheid (Awb 1:2), and vormvereisten (Awb 6:5-6:6).
+
+**Feature tier**: V1
+
+#### Scenario: Timeliness check defaults to false on late submission
+
+- **WHEN** the behandelaar opens the ontvankelijkheidstoets on a bezwaar where `receivedDate − contestedDecision.publicationDate > 6 weeks`
+- **THEN** `objection.isTimely` SHALL default to `false`
+- **AND** a warning `"Bezwaartermijn mogelijk overschreden"` SHALL be displayed
+- **AND** the behandelaar SHALL be able to override with a `timelinessAssessment` reason (e.g. verschoonbare termijnoverschrijding per Awb 6:11)
+
+#### Scenario: Niet-ontvankelijk transition requires motivering
+
+- **WHEN** a behandelaar transitions a case from `Ontvankelijkheidstoets` to `Niet-ontvankelijk`
+- **THEN** the API SHALL require a non-empty `timelinessAssessment` OR `vormvereisteReason` OR `belanghebbendheidReason` on the linked `objection`
+- **AND** absence SHALL be rejected with HTTP 422
+
+### Requirement: Verdaging and Opschorting (REQ-BL-6)
+
+The system SHALL support the statutory extension (verdaging, Awb 7:10 lid 3) and suspension (opschorting, Awb 7:10 lid 4) mechanisms, with audit entries and bezwaarmaker notification.
+
+**Feature tier**: V1
+
+#### Scenario: Verdaging extends afhandelDeadline by 6 weeks
+
+- **WHEN** the behandelaar records a verdaging on a case with `afhandelDeadline = 2026-04-13`
+- **THEN** `afhandelDeadline` SHALL be recomputed to `2026-05-25`
+- **AND** the extension SHALL be logged in the audit trail with `awbReference = "Awb 7:10 lid 3"`
+- **AND** the bezwaarmaker SHALL be notified per Awb art. 7:10 lid 3
+
+#### Scenario: Opschorting stops and resumes the clock
+
+- **WHEN** the behandelaar records opschorting with `opschortingStart = 2026-04-01`
+- **AND** later `opschortingEnd = 2026-04-15`
+- **THEN** `afhandelDeadline` SHALL be extended by 14 days
+- **AND** start and end SHALL be logged with `awbReference = "Awb 7:10 lid 4"`
+
+### Requirement: Ingebrekestelling and Dwangsom (REQ-BL-7)
+
+The system SHALL track ingebrekestelling notices and accrue automatic dwangsom liability under Wet dwangsom (Awb 4:17) when the bestuursorgaan misses the bezwaardeadline.
+
+**Feature tier**: V1
+**Awb reference**: art. 4:17, 4:18
+
+#### Scenario: Ingebrekestelling starts 14-day grace clock
+
+- **WHEN** a bezwaarmaker submits an ingebrekestelling on `2026-04-20`
+- **THEN** the case SHALL store `ingebrekestellingDate = 2026-04-20` and `dwangsomStartDate = 2026-05-04`
+- **AND** a red banner SHALL appear on the case detail view showing the 14-day grace clock
+
+#### Scenario: Dwangsom accrues automatically after grace period
+
+- **WHEN** no beslissing op bezwaar is recorded before `dwangsomStartDate`
+- **THEN** the system SHALL begin accruing dwangsom per Awb 4:17 schedule (€ 23/day day 1-14, € 35/day day 15-28, € 45/day day 29-42, capped at € 1 442)
+- **AND** the running `dwangsomAccrued` SHALL be visible on the case detail and dashboard
+- **AND** an escalation notification SHALL be sent to teamlead + bezwaar-coördinator
+
+### Requirement: Sister-Capability Integration (REQ-BL-8)
+
+The system SHALL wire the bezwaar-lifecycle to the three sister capabilities (`bezwaar-hearing`, `bezwaar-advisory-committee`, `bezwaar-decision`) via OpenRegister object-event listeners — no direct controller-to-controller calls.
+
+**Feature tier**: V1
+
+#### Scenario: Hearing completion transitions case status
+
+- **WHEN** a `hearingSession` linked to a bezwaar case is updated with `status = uitgevoerd`
+- **THEN** an event listener SHALL transition the bezwaar case status to `Hoorzitting afgerond`
+- **AND** the audit entry SHALL record `awbReference = "Awb 7:7"`
+
+#### Scenario: Advisory report transitions case status
+
+- **WHEN** an `advisoryReport` linked to a bezwaar case is created
+- **THEN** an event listener SHALL transition the bezwaar case status to `Advies uitgebracht`
+- **AND** if `deviationFromPrimaryDecision = true`, a behandelaar-attention flag SHALL be raised
+
+#### Scenario: Niet-ontvankelijk decision short-circuits the lifecycle
+
+- **WHEN** a `decision` with `besluittype = "Beslissing op bezwaar"` and `dispositionType = niet_ontvankelijk` is recorded
+- **THEN** an event listener SHALL transition the bezwaar case status directly to `Niet-ontvankelijk` (skipping intermediate statuses)
+- **AND** the audit entry SHALL record `awbReference = "Awb 6:6"`
+
+### Requirement: Audit Trail and Immutability (REQ-BL-9)
+
+Every status transition on a bezwaar case SHALL produce an immutable, append-only audit entry; transitions that change legal posture SHALL require an `awbReference`.
+
+**Feature tier**: V1
+
+#### Scenario: Audit entry shape
+
+- **WHEN** a status transition is committed
+- **THEN** the entry SHALL contain `actor` (NC UID), `fromStatus`, `toStatus`, `reason`, `awbReference`, `timestamp`
+- **AND** the entry SHALL be written via OpenRegister's per-save audit log
+- **AND** the entry SHALL NOT be editable or deletable by any user role
+
+#### Scenario: Legal-posture transitions require Awb reference
+
+- **WHEN** a transition involves Ontvankelijkheidstoets outcome, verdaging, opschorting, hoorrecht-afzien, niet-ontvankelijk, or intrekking
+- **AND** the `awbReference` field is empty or missing
+- **THEN** the API SHALL reject the request with HTTP 422 and message `"Awb reference required for this transition"`
+
+### Requirement: Vue Lifecycle View (REQ-BL-10)
+
+The frontend SHALL provide a dedicated bezwaar lifecycle view rendering status timeline, deadline countdown badges, transition guard messages, and ingebrekestelling/dwangsom banners.
+
+**Feature tier**: V1
+
+#### Scenario: Status timeline reflects the 10 status types
+
+- **WHEN** a user opens the bezwaar lifecycle view for a case in `Hoorzitting gepland`
+- **THEN** the timeline SHALL display all 10 status types in order
+- **AND** statuses up to and including the current one SHALL be marked completed/active
+- **AND** terminal statuses SHALL be visually distinct (greyed if not reached)
+
+#### Scenario: Deadline countdown badges follow traffic-light rule
+
+- **WHEN** the view renders `afhandelDeadline`
+- **THEN** the badge SHALL be green when > 5 working days remain
+- **AND** yellow when ≤ 5 working days remain
+- **AND** red when the deadline has passed
+
+#### Scenario: Disallowed transitions are hidden from the action menu
+
+- **WHEN** a behandelaar opens the transition action menu on a case in `Ontvangen`
+- **THEN** only `Ontvankelijkheidstoets` SHALL be offered as a target
+- **AND** transitions to later or earlier statuses SHALL NOT appear in the menu
+
+#### Scenario: Dwangsom banner shows live counter
+
+- **WHEN** `dwangsomAccrued > 0` on the case
+- **THEN** the lifecycle view SHALL display a red banner with the current accrued amount, the days elapsed since `dwangsomStartDate`, and the cap of € 1 442

--- a/openspec/changes/bezwaar-lifecycle/tasks.md
+++ b/openspec/changes/bezwaar-lifecycle/tasks.md
@@ -1,0 +1,38 @@
+# Tasks: bezwaar-lifecycle
+
+This is a **GENERATE-style** change: the schemas, seed data, and frontend components for bezwaar already exist via the archived `bezwaar-beroep-workflow` change (2026-03-22). Tasks here verify that the live code matches the formalized capability spec. No code changes are introduced; any gap found is filed as a follow-up issue rather than fixed inside this change.
+
+## Schema and seed verification
+
+- [ ] **T01**: Confirm `case` schema and `caseType` seed in `lib/Settings/procest_register.json` + `lib/Settings/bezwaar_seed_data.json` declare — at minimum — a `caseType` titled "Bezwaar" with `processingDeadline = P6W`, `extensionAllowed = true`, `extensionPeriod = P6W`, `suspensionAllowed = true`, `origin = external`. Confirm `x-openregister-calculations` (ADR-022) declares deadline formulas for `ontvangstbevestigingDeadline`, `afhandelDeadline`, and `dwangsomStartDate` with the inputs listed in `design.md`. Record any drift; file an issue if found.
+
+- [ ] **T02**: Verify status-type seed — `bezwaar_seed_data.json` declares 10 `statusType` records linked to the Bezwaar `caseType`: 8 ordered (`Ontvangen` 1, `Ontvankelijkheidstoets` 2, `In behandeling` 3, `Hoorzitting gepland` 4, `Hoorzitting afgerond` 5, `Advies uitgebracht` 6, `Beslissing op bezwaar` 7, `Afgehandeld` 8) + 2 terminal (`Niet-ontvankelijk`, `Ingetrokken`). Each status references the Awb article from the spec's table.
+
+- [ ] **T03**: Verify role-type seed — 7 `roleType` records linked to the Bezwaar `caseType`: `Bezwaarmaker`, `Behandelaar bezwaar`, `Voorzitter commissie`, `Lid commissie`, `Secretaris commissie`, `Vertegenwoordiger`, `Primair beslisser`. Each maps to a generic role (initiator, handler, decision_maker, advisor, coordinator, stakeholder, advisor).
+
+## State machine and guards
+
+- [ ] **T04**: Verify state-machine guards — load the case controller transition handler and assert: (a) `Ontvankelijkheidstoets → Niet-ontvankelijk` requires a non-empty `timelinessAssessment` or `vormvereisteReason` on the linked `objection`; (b) `In behandeling → Advies uitgebracht | Beslissing op bezwaar` is only allowed when `objection.hearingWaived = true` with a non-empty `waiverReason` OR when `hearingSession.status = uitgevoerd`; (c) backward transitions to non-terminal statuses are rejected. Use the OpenRegister state-machine plumbing — no procest-specific transition service.
+
+- [ ] **T05**: Verify deadline scheduler — confirm OpenRegister's `RenderObject::renderCalculations` populates `ontvangstbevestigingDeadline`, `afhandelDeadline`, `dwangsomStartDate` on save. Confirm verdaging recomputation: setting `verdaagdOp` to a date recomputes `afhandelDeadline = origDeadline + P6W` and appends an audit entry with `awbReference = "Awb 7:10 lid 3"`. Confirm opschorting: `opschortingStart` stops the clock; `opschortingEnd` adds the elapsed delta to `afhandelDeadline` and writes an audit entry referencing `Awb 7:10 lid 4`.
+
+## Controller and view verification
+
+- [ ] **T06**: Verify controller endpoints — `appinfo/routes.php` exposes `GET /api/cases/{id}/lifecycle` returning current status, deadlines, and allowed transitions; `POST /api/cases/{id}/transition` accepting `{ targetStatus, reason, awbReference }`. Confirm both routes are bound to the case controller and authorized via `case-sharing-collaboration` rules.
+
+- [ ] **T07**: Verify Vue lifecycle view — `src/views/Cases/BezwaarLifecycle.vue` (or equivalent) renders: a status timeline using the 10 status-type ordering, deadline countdown badges (green/yellow/red per the 5-workday rule from REQ-BL-10), a transition action menu that hides disallowed targets, and a verdaging/opschorting modal. Record component names; file an issue if a sub-component is missing.
+
+- [ ] **T08**: Verify ingebrekestelling & dwangsom UI — when `ingebrekestellingDate` is set on the case, the lifecycle view SHALL show a red banner with the dwangsom counter (`dwangsomAccrued`), the 14-day grace clock, and the running total liability up to € 1 442.
+
+## Audit and integration verification
+
+- [ ] **T09**: Verify audit trail integration — every status transition writes an OpenRegister audit entry containing `actor`, `fromStatus`, `toStatus`, `reason`, `awbReference`, `timestamp`. Confirm transitions that change legal posture (Ontvankelijkheidstoets outcome, verdaging, opschorting, hoorrecht-afzien, intrekking) reject empty `awbReference` with HTTP 422.
+
+- [ ] **T10**: Verify sister-capability hooks — confirm: (a) `bezwaar-advisory-committee` writing an `advisoryReport` triggers transition to `Advies uitgebracht`; (b) `bezwaar-hearing` setting `hearingSession.status = uitgevoerd` triggers transition to `Hoorzitting afgerond`; (c) `bezwaar-decision` recording a `decision` with `dispositionType = niet_ontvankelijk` short-circuits to `Niet-ontvankelijk`. Each hook is implemented via OR object-event listeners — record handler class names; file an issue per missing hook.
+
+## Pre-commit verification
+
+- [ ] **V01**: `openspec validate bezwaar-lifecycle --type change --strict` → exit code 0
+- [ ] **V02**: `openspec change show bezwaar-lifecycle --json --deltas-only | jq '.deltaCount'` → ≥ 10 (one delta per REQ-BL-1..10)
+- [ ] **V03**: Every REQ-BL-* in `specs/bezwaar-lifecycle/spec.md` carries at least one `#### Scenario:` block
+- [ ] **V04**: No code files modified outside `openspec/changes/bezwaar-lifecycle/` (verify with `git diff --name-only origin/development...HEAD`)


### PR DESCRIPTION
## Summary

GENERATE-style OpenSpec change that formalizes the `bezwaar-lifecycle` capability — the most legally formal case type in Procest. The existing canonical spec at `openspec/specs/bezwaar-lifecycle/spec.md` (5 requirements, no change history) is replaced by a delta-formatted change with 10 REQ-BL-* requirements, an explicit state machine, statutory deadline rules (Awb 7:10), ingebrekestelling/dwangsom hooks (Awb 4:17), and event-driven integration with the three sister capabilities (`bezwaar-hearing`, `bezwaar-advisory-committee`, `bezwaar-decision`).

- REQ-BL-1..10: case type seed, 10-status state machine, 7 role types, deadline calculation via OR x-openregister-calculations (ADR-022), ontvankelijkheidstoets, verdaging/opschorting, ingebrekestelling + dwangsom, sister-capability event hooks, immutable audit trail, Vue lifecycle view
- State machine: 8 ordered statuses + 2 terminal (Niet-ontvankelijk, Ingetrokken); backward transitions rejected; hoorrecht-afzien skip path
- Deadlines: 6-week initial + 6-week verdaging + opschorting clock-stop; 5-workday yellow / overdue red traffic-light; € 1 442 dwangsom cap
- NO CODE: schemas + seed data already exist via the archived `bezwaar-beroep-workflow` change (2026-03-22); verification-only tasks T01-T10 + V01-V04

## Validation

- openspec validate bezwaar-lifecycle --type change --strict — passes
- deltaCount — 10 (one per REQ-BL-*)
- Every requirement carries at least one Scenario block

## Test plan

- [ ] openspec validate bezwaar-lifecycle --type change --strict — exit 0
- [ ] Reviewer confirms the state machine in design.md matches the bezwaar_seed_data.json status types
- [ ] Reviewer confirms the deadline formulas reference Awb articles and OR x-openregister-calculations (ADR-022) rather than a procest-specific service