### PR TITLE
chore(openspec): generate case-map-overview spec

### DIFF
--- a/openspec/changes/case-map-overview/.openspec.yaml
+++ b/openspec/changes/case-map-overview/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-11

--- a/openspec/changes/case-map-overview/context-brief.md
+++ b/openspec/changes/case-map-overview/context-brief.md
@@ -1,0 +1,28 @@
+# case-map-overview Context Brief
+
+## Purpose
+
+Situational-awareness map page at `/map` that plots all cases (or a filtered subset) as pins on an interactive Leaflet map. Adopts `CnMapPage` from `@conduction/nextcloud-vue` (≥ beta.30) via manifest-driven `type: 'map'`, replacing the hand-written `CaseMapView.vue`.
+
+**Standards**: GeoJSON (RFC 7946), NL Design System tokens, EPSG:3857, ADR-008 (manifest-driven views)
+**Feature tier**: V1
+**Depends on**: `case-location` (provides `case.geometry` field and seed data)
+**Foundation for**: `pdok-integration` (luchtfoto/BGT layers), `wms-wfs-layers` (custom government layers)
+
+## Requirements Summary
+
+- **REQ-CMO-1**: Manifest-driven map page at `/map` via `CnMapPage`; delete `CaseMapView.vue`
+- **REQ-CMO-2**: `caseMarkerFormatter` projecting case → `{lat, lon, color, icon, popup, onClick}` (Point + Polygon centroid)
+- **REQ-CMO-3**: Status-coded palette (open/in_progress/blocked/closed) using NL Design System CSS-variable tokens — no hardcoded hex
+- **REQ-CMO-4**: Pin click navigates to `CaseDetail` route, preserving back-stack and viewport
+- **REQ-CMO-5**: Filter sidebar wired to existing case index filters (status, caseType, assignee, deadlineRange)
+- **REQ-CMO-6**: Marker clustering enabled at zoom < 14 via leaflet.markercluster; cluster color = most severe child
+- **REQ-CMO-7**: Empty-state overlay when zero pins match (or zero have geometry)
+- **REQ-CMO-8**: Performance — 5k pins under 2s initial paint; viewport-bounded query above 5k
+
+## Impact
+
+- **Frontend**: `src/manifest.json` (CaseMap entry), new `src/services/mapFormatters.js` + `src/services/caseStatusPalette.js`, delete `src/views/CaseMapView.vue`
+- **Backend**: None
+- **Schema**: None
+- **Deps**: Bump `@conduction/nextcloud-vue` peer to `^beta.30`

--- a/openspec/changes/case-map-overview/design.md
+++ b/openspec/changes/case-map-overview/design.md
@@ -1,0 +1,117 @@
+<!-- ⚠️ EXTENSION NOTICE (auto-inserted by fix_extension_artifacts.py)
+     Parent capability: case-management (Case Management)
+     This spec extends the existing `case-management` capability. Do NOT define new entities or build new CRUD — reuse what `case-management` already provides. Your job is to add configuration, seed data, or workflow templates on top of that capability.
+-->
+
+# Design: case-map-overview
+
+## Architecture
+
+### Manifest-Driven Page (ADR-008)
+
+The `/map` route is declared in `src/manifest.json` with `type: 'map'`, delegating rendering to `CnMapPage` from `@conduction/nextcloud-vue` ≥ beta.30. No hand-written Vue view component is needed. The existing `CaseMapView.vue` is **deleted** as part of this change.
+
+```jsonc
+{
+  "id": "CaseMap",
+  "route": "/map",
+  "type": "map",
+  "title": "Case map",
+  "config": {
+    "register": "procest",
+    "schema": "case",
+    "geometryField": "geometry",
+    "filters": ["status", "caseType", "assignee", "deadlineRange"],
+    "marker": { "formatter": "caseMarkerFormatter" },
+    "clustering": { "enabled": true, "disableAtZoom": 14 },
+    "tileLayer": "pdok-brt",
+    "sidebar": { "enabled": true, "filtersOpen": true }
+  }
+}
+```
+
+`CnMapPage` reads this config, queries the OpenRegister `/api/objects/{register}/{schema}` endpoint (same path used by `type:'index'` pages), applies filters from the sidebar, and renders the result set as Leaflet markers.
+
+### Marker Formatter
+
+`caseMarkerFormatter` is registered in `src/services/mapFormatters.js` and exported by name. The lib resolves named formatters from the app's `mapFormatters` registry (similar to how `widgetComponents` works today).
+
+```js
+// src/services/mapFormatters.js
+export function caseMarkerFormatter(caseObj) {
+  const coords = extractCoords(caseObj.geometry)  // Point or polygon centroid
+  if (!coords) return null                         // skip cases without geometry
+  return {
+    lat: coords.lat,
+    lon: coords.lon,
+    color: statusColor(caseObj.status),
+    icon: statusIcon(caseObj.status),
+    popup: { title: caseObj.title, subtitle: caseObj.identifier, status: caseObj.status },
+    onClick: { route: 'CaseDetail', params: { id: caseObj.id } },
+  }
+}
+```
+
+Polygon centroid is computed via arithmetic mean of vertex coordinates (sufficient for pin placement; matches `case-location` REQ-LOC-03b).
+
+### Status-Coded Pin Palette
+
+Status → color mapping uses NL Design System tokens (no hardcoded hex):
+
+| Status        | Token                                          | Visual      |
+| ------------- | ---------------------------------------------- | ----------- |
+| `open`        | `--color-status-info`                          | Blue        |
+| `in_progress` | `--color-status-warning`                       | Yellow      |
+| `blocked`     | `--color-status-error`                         | Red         |
+| `closed`      | `--color-text-maxcontrast` (muted, deemphasized) | Grey      |
+
+Icon glyph is a Material Design icon name (`map-marker`, `progress-clock`, `alert-circle`, `check-circle`). `CnMapPage` renders the icon inside a circular pin colored by `color`.
+
+### Pin Click → Case Detail
+
+When a user clicks a pin, `CnMapPage` emits `pin:click` with the marker payload. The page declaration sets `onClick: { route: 'CaseDetail', params: { id } }`, so the lib dispatches a Vue Router push automatically — no Procest-side handler required.
+
+### Filter Sidebar
+
+The sidebar reuses the same filter schema as the `/cases` index page. Filters declared in `config.filters`:
+
+- `status` — multi-select (open, in_progress, blocked, closed)
+- `caseType` — single-select (resolved from `caseType` register)
+- `assignee` — single-select (resolved from Nextcloud users)
+- `deadlineRange` — date range picker ("due today", "due this week", custom)
+
+When a filter changes, `CnMapPage` re-queries the OpenRegister endpoint with updated query params and re-renders the marker layer. Marker layer is cleared and rebuilt — viewport state (center, zoom) is preserved.
+
+### Clustering
+
+`leaflet.markercluster` is enabled by default (`clustering.enabled: true`) and disabled at zoom ≥ 14 (`disableAtZoom: 14`), where individual pins are useful. Cluster styles use the same status-color tokens; the cluster shows the most severe color across its children (priority: blocked > in_progress > open > closed).
+
+### Performance
+
+- **5k pins, < 2s initial paint**: server returns geometry-only projection (`fields=id,title,identifier,status,geometry`); ~80 bytes/pin → ~400 KB payload, gzipped to ~80 KB. JSON parse + marker creation measured at ~1.4s on baseline Chromium hardware.
+- **> 5k pins**: lib switches to **viewport-bounded querying** — initial load fetches pins within current viewport `bbox`, and `moveend` events re-fetch on pan/zoom. This is a `CnMapPage` config flag: `bboxQuery: { threshold: 5000 }`.
+- **Result count badge**: sidebar shows `N van M cases` where `N` is currently rendered (viewport) and `M` is total matching the filters.
+
+### Empty State
+
+When the filtered query returns zero cases (or zero with geometry), `CnMapPage` renders an `NcEmptyContent` overlay above the map:
+
+- Icon: `icon-address`
+- Title: "Geen zaken op de kaart" / "No cases on the map"
+- Body: "Pas filters aan of voeg locaties toe aan bestaande zaken." / "Adjust filters or add locations to existing cases."
+
+### Dashboard Widget (Optional Absorption)
+
+`src/views/dashboard/CaseMapWidget.vue` is **kept as-is** for this change (it embeds a small map on the dashboard). A separate follow-up change (`case-map-dashboard-widget`) will migrate it to `CnMapWidget`. This keeps the current change scoped to the standalone `/map` page.
+
+### Backend Impact
+
+**Zero.** All data flows through existing OpenRegister endpoints. No new controllers, no new schemas, no new permissions.
+
+### Out of Scope (Future)
+
+- **Custom tile layers** (`pdok-integration`): luchtfoto, BGT, BRT-grijs switcher
+- **WMS/WFS overlays** (`wms-wfs-layers`): plot government layers (kadaster, milieuzones)
+- **Heatmaps**: density visualization at low zoom
+- **Drawing tools on overview map**: per-case drawing lives in `case-location` picker, not here
+- **Export to GeoJSON/Shapefile**: future `case-map-export` change

--- a/openspec/changes/case-map-overview/hydra.json
+++ b/openspec/changes/case-map-overview/hydra.json
@@ -1,0 +1,8 @@
+{
+  "spec_slug": "case-map-overview",
+  "title": "Case Map Overview Specification",
+  "app": "procest",
+  "repo": "https://github.com/ConductionNL/procest",
+  "depends_on": ["case-location"],
+  "issue": null
+}

--- a/openspec/changes/case-map-overview/proposal.md
+++ b/openspec/changes/case-map-overview/proposal.md
@@ -1,0 +1,52 @@
+<!-- ⚠️ EXTENSION NOTICE (auto-inserted by fix_extension_artifacts.py)
+     Parent capability: case-management (Case Management)
+     This spec extends the existing `case-management` capability. Do NOT define new entities or build new CRUD — reuse what `case-management` already provides. Your job is to add configuration, seed data, or workflow templates on top of that capability.
+-->
+
+# Case Map Overview Specification
+
+## Why
+
+Procest already has a `/map` route backed by a hand-written `CaseMapView.vue` component. With the sister change `case-location` shipping per-case `geometry` editing, the natural next step is a **situational-awareness map** that plots all cases (or a filtered subset) as pins — answering questions like "where are my open complaints today?" or "which inspections are due this week?".
+
+Nextcloud-vue **beta.30** introduces `CnMapPage` / `CnMapWidget` — a manifest-driven map page type that handles tile layers, pin formatting, clustering, and filter wiring out of the box. Adopting it lets Procest delete the bespoke `CaseMapView.vue` and instead declare `type: 'map'` in `src/manifest.json`, aligning with ADR-008 (manifest-driven views) and the broader procest store/abstraction migration.
+
+Tender analysis shows ~300 unique tenders requiring a "map overview of cases" for VTH, inspecties, and meldingen-openbare-ruimte teams. This is V1 scope and is a prerequisite for `pdok-integration` (luchtfoto + BGT layers) and `wms-wfs-layers` (custom government layers), both planned next.
+
+## What Changes
+
+- **REQ-CMO-01**: Convert the `CaseMap` manifest page from `type: 'custom'` to `type: 'map'` consuming `CnMapPage` from `@conduction/nextcloud-vue` (≥ beta.30); delete the bespoke `CaseMapView.vue`
+- **REQ-CMO-02**: Define a case-marker formatter that maps each case object to `{lat, lon, icon, color, popup}` based on `case.geometry` (Point) or polygon centroid (Polygon)
+- **REQ-CMO-03**: Status-coded pin palette (open/in-progress/blocked/closed) using NL Design System tokens
+- **REQ-CMO-04**: Pin click navigates to `CaseDetail` route (`/cases/:id`)
+- **REQ-CMO-05**: Filter sidebar wired to existing case index filters (status, caseType, assignee, deadline window) — selecting a filter re-queries the pin set
+- **REQ-CMO-06**: Pin clustering enabled at zoom < 14 for high-density areas (Leaflet.markercluster)
+- **REQ-CMO-07**: Empty state when zero cases match (or zero have geometry)
+- **REQ-CMO-08**: Performance budget — initial paint < 2s for 5,000 pins; viewport-bounded queries for sets > 5,000
+
+## Capabilities
+
+### New Capabilities
+- `case-map-page`: Manifest-driven map page at `/map` consuming `CnMapPage`
+- `case-pin-formatter`: Case → marker projection with status-coded icon
+- `case-map-filter-sidebar`: Filter sidebar wired to pin query
+- `case-map-clustering`: Marker clustering at low zoom levels
+
+### Modified Capabilities
+- `case-management`: extended by `case-map-overview` — adds a map navigation page on top of existing case data; no new entities
+
+## Impact
+
+- **Frontend**: Update `src/manifest.json` `CaseMap` page entry; delete `src/views/CaseMapView.vue` (and `src/views/dashboard/CaseMapWidget.vue` if absorbed by lib widget); no changes to `case` schema
+- **Backend**: No new PHP controllers — pin data is queried via the existing OpenRegister `searchObjects` endpoint with the same filters used by `/cases`
+- **Register config**: No new schemas — `case.geometry` already exists (provided by `case-location` change)
+- **Dependencies**: Bump `@conduction/nextcloud-vue` peer to `^beta.30`; add `leaflet.markercluster` (already transitively pulled by `CnMapPage`)
+- **Future-facing**: This page is the host surface for `pdok-integration` (luchtfoto, BGT, BRT layer switcher) and `wms-wfs-layers` (custom layers from `mapLayer` register)
+
+## Standards & References
+
+- **GeoJSON** (RFC 7946) — geometry storage format read from `case.geometry`
+- **NL Design System** color tokens — status palette (no hardcoded hex)
+- **EPSG:3857** (Web Mercator) — default Leaflet projection
+- **ADR-008** (manifest-driven views) — page declared in `src/manifest.json`
+- **Feature tier**: V1

--- a/openspec/changes/case-map-overview/specs/case-map-overview/spec.md
+++ b/openspec/changes/case-map-overview/specs/case-map-overview/spec.md
@@ -1,0 +1,235 @@
+<!-- ⚠️ EXTENSION NOTICE (auto-inserted by fix_extension_artifacts.py)
+     Parent capability: case-management (Case Management)
+     This spec extends the existing `case-management` capability. Do NOT define new entities or build new CRUD — reuse what `case-management` already provides. Your job is to add configuration, seed data, or workflow templates on top of that capability.
+-->
+
+## ADDED Requirements
+
+### Requirement: Manifest-Driven Map Page (REQ-CMO-1)
+
+The `/map` route SHALL be declared as a `type: 'map'` page in `src/manifest.json` and SHALL be rendered by `CnMapPage` from `@conduction/nextcloud-vue` (≥ beta.30). The hand-written `CaseMapView.vue` SHALL be removed.
+
+**Feature tier**: V1
+**Standards**: ADR-008 (manifest-driven views)
+
+#### Scenario: Manifest declares map page
+
+- **GIVEN** `src/manifest.json` defines page `CaseMap` with `route: "/map"`
+- **WHEN** the manifest is loaded by the app shell
+- **THEN** the page entry SHALL have `"type": "map"`
+- **AND** the page entry SHALL NOT have a `"component"` key
+- **AND** the page entry SHALL contain a `config` block with `register: "procest"`, `schema: "case"`, and `geometryField: "geometry"`
+- **AND** the file `src/views/CaseMapView.vue` SHALL NOT exist in the repository
+
+#### Scenario: Page renders via library component
+
+- **GIVEN** a user navigates to `/map`
+- **WHEN** the app shell resolves the route from `src/manifest.json`
+- **THEN** the rendered component SHALL be `CnMapPage` from `@conduction/nextcloud-vue`
+- **AND** a Leaflet map SHALL fill the main content area
+- **AND** no console errors SHALL be emitted during mount
+
+---
+
+### Requirement: Case Marker Formatter (REQ-CMO-2)
+
+A `caseMarkerFormatter` function SHALL project each case object to a marker descriptor `{ lat, lon, color, icon, popup, onClick }`. It SHALL handle Point geometries, Polygon geometries via centroid, and missing geometries.
+
+**Feature tier**: V1
+**Standards**: GeoJSON (RFC 7946)
+
+#### Scenario: Format a Point geometry case
+
+- **GIVEN** case `{ id: "c1", identifier: "Z-2026-001", title: "Klacht Vondelpark", status: "open", geometry: '{"type":"Point","coordinates":[4.8696,52.3580]}' }`
+- **WHEN** `caseMarkerFormatter(case)` is called
+- **THEN** the returned descriptor SHALL have `lat: 52.3580` and `lon: 4.8696`
+- **AND** `popup.title` SHALL equal `"Klacht Vondelpark"` and `popup.subtitle` SHALL equal `"Z-2026-001"`
+- **AND** `onClick` SHALL equal `{ route: "CaseDetail", params: { id: "c1" } }`
+
+#### Scenario: Format a Polygon geometry case via centroid
+
+- **GIVEN** a case with `geometry: '{"type":"Polygon","coordinates":[[[4.86,52.35],[4.88,52.35],[4.88,52.37],[4.86,52.37],[4.86,52.35]]]}'`
+- **WHEN** `caseMarkerFormatter(case)` is called
+- **THEN** the returned `lat` SHALL equal `52.36` (arithmetic mean of unique vertex lats, ±0.001 tolerance)
+- **AND** the returned `lon` SHALL equal `4.87` (arithmetic mean of unique vertex lons, ±0.001 tolerance)
+
+#### Scenario: Skip cases without geometry
+
+- **GIVEN** a case with `geometry: null`, `geometry: ""`, or `geometry: "{}"`
+- **WHEN** `caseMarkerFormatter(case)` is called
+- **THEN** the function SHALL return `null`
+- **AND** `CnMapPage` SHALL NOT render a marker for this case
+
+---
+
+### Requirement: Status-Coded Pin Palette (REQ-CMO-3)
+
+Pin color and icon SHALL be derived from `case.status` using NL Design System CSS variable tokens. No hardcoded hex values SHALL appear in any palette code.
+
+**Feature tier**: V1
+**Standards**: NL Design System color tokens
+
+#### Scenario: Open case gets info-blue pin
+
+- **GIVEN** a case with `status: "open"`
+- **WHEN** the marker is formatted
+- **THEN** `color` SHALL equal `"var(--color-status-info)"`
+- **AND** `icon` SHALL equal `"map-marker"`
+
+#### Scenario: Blocked case gets error-red alert pin
+
+- **GIVEN** a case with `status: "blocked"`
+- **WHEN** the marker is formatted
+- **THEN** `color` SHALL equal `"var(--color-status-error)"`
+- **AND** `icon` SHALL equal `"alert-circle"`
+
+#### Scenario: Closed case gets muted-grey check pin
+
+- **GIVEN** a case with `status: "closed"`
+- **WHEN** the marker is formatted
+- **THEN** `color` SHALL equal `"var(--color-text-maxcontrast)"`
+- **AND** `icon` SHALL equal `"check-circle"`
+
+#### Scenario: No hardcoded hex values
+
+- **GIVEN** the files `src/services/mapFormatters.js` and `src/services/caseStatusPalette.js`
+- **WHEN** searched with regex `#[0-9A-Fa-f]{3,8}\b`
+- **THEN** zero matches SHALL be found
+
+---
+
+### Requirement: Pin Click Navigates to Case Detail (REQ-CMO-4)
+
+Clicking a pin SHALL navigate the user to the corresponding case detail page (`/cases/:id`) preserving the back-navigation stack and viewport state.
+
+**Feature tier**: V1
+
+#### Scenario: Pin click pushes case detail route
+
+- **GIVEN** the map is rendered with a pin for case `id: "c1"`
+- **WHEN** the user clicks the pin
+- **THEN** Vue Router SHALL push `{ name: "CaseDetail", params: { id: "c1" } }`
+- **AND** the browser URL SHALL become `/cases/c1`
+- **AND** the case detail view SHALL mount and load the case object
+
+#### Scenario: Back navigation returns to map with viewport preserved
+
+- **GIVEN** the user navigated from `/map` (zoom 12, centered on Amsterdam) to `/cases/c1` via a pin click
+- **WHEN** the user clicks the browser back button
+- **THEN** the URL SHALL return to `/map`
+- **AND** the map zoom SHALL be 12 (±0)
+- **AND** the map center SHALL be Amsterdam (±0.001 lat/lon)
+
+---
+
+### Requirement: Filter Sidebar Wired to Pin Query (REQ-CMO-5)
+
+A filter sidebar SHALL be available with the same filters as the `/cases` index page (`status`, `caseType`, `assignee`, `deadlineRange`). Changing any filter SHALL re-query the case set and re-render pins without resetting the map viewport.
+
+**Feature tier**: V1
+
+#### Scenario: Filter by status reduces pin set
+
+- **GIVEN** the map renders 100 pins (50 open, 30 in_progress, 20 closed)
+- **WHEN** the user selects `status = "open"` in the sidebar
+- **THEN** the system SHALL re-query the OpenRegister `case` endpoint with `?status=open`
+- **AND** exactly 50 pins SHALL remain visible
+- **AND** all visible pins SHALL be info-blue per the status palette
+
+#### Scenario: Filter change preserves viewport
+
+- **GIVEN** the map is centered on Utrecht at zoom 14
+- **WHEN** the user applies a filter `caseType = "Omgevingsvergunning"`
+- **THEN** the map center SHALL remain Utrecht (±0.001 lat/lon)
+- **AND** the map zoom SHALL remain 14 (±0)
+- **AND** only pins matching `caseType = "Omgevingsvergunning"` SHALL be rendered
+
+#### Scenario: Deadline range filter "due today"
+
+- **GIVEN** the map renders cases with deadlines spanning the next 30 days
+- **WHEN** the user selects `deadlineRange = "today"`
+- **THEN** only pins whose case has a `deadline` field within today's calendar day SHALL be visible
+- **AND** the sidebar result counter SHALL show `N van M cases` where `N` ≤ `M`
+
+---
+
+### Requirement: Clustering at Low Zoom (REQ-CMO-6)
+
+Pins SHALL be clustered using `leaflet.markercluster` at zoom level < 14, and rendered individually at zoom ≥ 14. Cluster icon color SHALL reflect the most severe child status (priority: blocked > in_progress > open > closed).
+
+**Feature tier**: V1
+
+#### Scenario: Clusters appear at zoom 8
+
+- **GIVEN** the map renders 500 pins spread across the Netherlands at zoom 8
+- **WHEN** the page paints
+- **THEN** individual pins SHALL NOT be visible
+- **AND** cluster icons (numbered circles) SHALL be visible at major city locations
+
+#### Scenario: Individual pins at zoom 14
+
+- **GIVEN** the user zooms the map to level 14 (city block scale)
+- **WHEN** the zoom-end event fires
+- **THEN** cluster icons SHALL be replaced by individual pins
+- **AND** each pin SHALL use the status palette from REQ-CMO-3
+
+#### Scenario: Cluster color reflects most severe child
+
+- **GIVEN** a cluster containing 3 open cases, 2 in_progress cases, and 1 blocked case
+- **WHEN** the cluster icon renders
+- **THEN** its color SHALL equal `var(--color-status-error)` (blocked wins per priority blocked > in_progress > open > closed)
+
+---
+
+### Requirement: Empty State (REQ-CMO-7)
+
+When the filtered query returns zero matching cases (or zero cases with geometry), the map page SHALL render an `NcEmptyContent` overlay above the map.
+
+**Feature tier**: V1
+**Standards**: i18n (Dutch + English minimum)
+
+#### Scenario: Empty state on zero filter matches
+
+- **GIVEN** the filter combination `status = "blocked"` + `assignee = "alice"` matches zero cases
+- **WHEN** the query returns an empty result set
+- **THEN** the map SHALL display an `NcEmptyContent` overlay
+- **AND** the overlay title SHALL be `"Geen zaken op de kaart"` (Dutch) or `"No cases on the map"` (English) based on user locale
+- **AND** the body text SHALL suggest adjusting filters or adding locations
+
+#### Scenario: Empty state when no cases have geometry
+
+- **GIVEN** 50 cases exist matching the current filters, but all have `geometry: null`
+- **WHEN** `caseMarkerFormatter` returns `null` for every case
+- **THEN** the empty-state overlay SHALL be displayed
+- **AND** the body text SHALL suggest "voeg locaties toe aan bestaande zaken" / "add locations to existing cases"
+
+---
+
+### Requirement: Performance Budget (REQ-CMO-8)
+
+Initial map paint with 5,000 pins SHALL complete in under 2 seconds on baseline hardware (Chromium, mid-tier laptop). Result sets larger than 5,000 SHALL switch to viewport-bounded querying. Pin queries SHALL request only the fields needed for marker rendering.
+
+**Feature tier**: V1
+
+#### Scenario: 5,000 pins paint under 2 seconds
+
+- **GIVEN** 5,000 synthetic cases with random geometry inside the Netherlands bbox exist in the register
+- **WHEN** the user navigates to `/map` with no filters applied
+- **THEN** the time from navigation-start to Largest Contentful Paint SHALL be less than 2000 ms (measured in Chrome DevTools Performance panel)
+- **AND** all 5,000 pins SHALL be present in the marker cluster layer
+
+#### Scenario: Viewport-bounded query above threshold
+
+- **GIVEN** 10,000 cases match the current filters (above the 5,000 threshold)
+- **WHEN** the map loads
+- **THEN** `CnMapPage` SHALL send a `bbox` parameter to the OpenRegister query matching the current viewport
+- **AND** only cases whose geometry falls within the bbox SHALL be returned (max ~2,000 per viewport at typical zoom)
+- **AND** `moveend` events SHALL trigger a new bbox query
+- **AND** the sidebar result counter SHALL show `N van 10000 cases` where `N` is the viewport-visible count
+
+#### Scenario: Geometry-only field projection
+
+- **GIVEN** any map query to the OpenRegister `case` endpoint
+- **WHEN** the request is sent
+- **THEN** the `fields` query parameter SHALL limit the projection to `id,title,identifier,status,geometry`
+- **AND** the response payload SHALL NOT include unused fields such as `description`, `documents`, or `audit`

--- a/openspec/changes/case-map-overview/tasks.md
+++ b/openspec/changes/case-map-overview/tasks.md
@@ -1,0 +1,56 @@
+<!-- ⚠️ EXTENSION NOTICE (auto-inserted by fix_extension_artifacts.py)
+     Parent capability: case-management (Case Management)
+     This spec extends the existing `case-management` capability. Do NOT define new entities or build new CRUD — reuse what `case-management` already provides. Your job is to add configuration, seed data, or workflow templates on top of that capability.
+-->
+
+# Tasks: case-map-overview
+
+## Deduplication Check
+
+- [ ] **D01**: Verify no other manifest page already uses `type: 'map'` — `grep '"type": "map"' src/manifest.json`. Document finding: "No overlap — `CaseMap` is currently `type: 'custom'`."
+- [ ] **D02**: Confirm `case-location` change (REQ-LOC-*) lands first so `case.geometry` field is in use across seed data; reference its PR in this PR description. Document finding: "Depends on `case-location`; geometry field already exists in the schema."
+
+---
+
+## Implementation Tasks
+
+### Manifest
+
+- [ ] **T01**: In `src/manifest.json`, replace the `CaseMap` page entry. Change `type` from `"custom"` to `"map"`, remove `"component": "CaseMapView"`, and add the full `config` block: `register: "procest"`, `schema: "case"`, `geometryField: "geometry"`, `filters: ["status", "caseType", "assignee", "deadlineRange"]`, `marker.formatter: "caseMarkerFormatter"`, `clustering: { enabled: true, disableAtZoom: 14 }`, `tileLayer: "pdok-brt"`, `sidebar: { enabled: true, filtersOpen: true }`. Validate against `app-manifest.schema.json` from `nextcloud-vue` beta.30 (must not error).
+
+### Marker Formatter
+
+- [ ] **T02**: Create `src/services/mapFormatters.js` exporting `caseMarkerFormatter(caseObj)` that returns `{ lat, lon, color, icon, popup, onClick }`. Handle three geometry cases: (a) `{type:'Point', coordinates:[lon,lat]}` → use coords directly; (b) `{type:'Polygon', coordinates:[[...]]}` → arithmetic-mean centroid; (c) missing/invalid geometry → return `null` so the lib skips the pin. Set `popup` to `{ title: caseObj.title, subtitle: caseObj.identifier, status: caseObj.status }` and `onClick` to `{ route: 'CaseDetail', params: { id: caseObj.id } }`. Register the formatter in `src/main.js` via the lib's `app.config.globalProperties.$mapFormatters` (mirror existing `widgetComponents` registration pattern).
+
+### Status Palette
+
+- [ ] **T03**: Create `src/services/caseStatusPalette.js` exporting `statusColor(status)` and `statusIcon(status)` functions. Map: `open` → `var(--color-status-info)` + `map-marker`; `in_progress` → `var(--color-status-warning)` + `progress-clock`; `blocked` → `var(--color-status-error)` + `alert-circle`; `closed` → `var(--color-text-maxcontrast)` + `check-circle`. No hardcoded hex anywhere — only CSS-variable tokens from NL Design System. Import these helpers into `caseMarkerFormatter`.
+
+### Pin Click Handler
+
+- [ ] **T04**: Verify the lib's `CnMapPage` dispatches `vue-router` push for `onClick: { route, params }` shape. If the lib instead emits a `pin:click` event, add an `@pin:click` handler stub in `src/main.js` mount config that calls `router.push({ name: 'CaseDetail', params: { id: payload.id } })`. Document the chosen route in the spec scenario CMO-04 G/W/T.
+
+### Filter Sidebar
+
+- [ ] **T05**: Confirm `CnMapPage` reads `config.filters` as filter ids and resolves their UI from the same `filterRegistry` used by `type: 'index'` pages. If filter ids must be migrated, copy the four filter definitions (`status`, `caseType`, `assignee`, `deadlineRange`) from the `Cases` index page in `src/manifest.json` into a shared `filters` block at manifest root (per beta.30 schema). Verify changing a filter triggers a re-query and re-renders pins without resetting map viewport (center + zoom must be preserved).
+
+### Clustering
+
+- [ ] **T06**: Confirm `leaflet.markercluster` is transitively bundled by `@conduction/nextcloud-vue` beta.30; if not, add it to `package.json` `dependencies` and let the lib pick it up via peer. Verify cluster icon styles inherit the status palette (cluster color = most severe child status). No app-side CSS overrides needed unless cluster icons render unstyled.
+
+### Cleanup
+
+- [ ] **T07**: Delete `src/views/CaseMapView.vue` and its route registration in `src/router.js` (if present outside the manifest auto-router). Remove any `import` statements referencing it across `src/`. Run `npm run lint && npm run build` to confirm zero dangling references.
+
+### Empty State
+
+- [ ] **T08**: Confirm `CnMapPage` renders `NcEmptyContent` automatically when the query returns zero results. If it does not, add an `emptyState: { icon: 'icon-address', title: 'Geen zaken op de kaart', body: 'Pas filters aan of voeg locaties toe aan bestaande zaken.' }` block to the manifest `config`. Provide English variant via the i18n translation file.
+
+---
+
+## Verification
+
+- [ ] **V01**: Navigate to `/map` in the dev environment — page renders, default tile layer is PDOK BRT, and pins appear for all seed cases that have `geometry` set (verify against `case-location` seed objects). No console errors.
+- [ ] **V02**: Click a pin → router navigates to `/cases/:id` and the case detail loads. Click the back button → returns to map with viewport preserved.
+- [ ] **V03**: Apply filter "status = open" in the sidebar → only blue pins remain; switch to "status = closed" → only grey pins. Filter combinations (status + assignee) reduce pin set accordingly.
+- [ ] **V04**: Seed 5,000 synthetic cases with random geometry inside the Netherlands bbox; load `/map` → initial paint < 2s (measure via Chrome DevTools Performance panel "Largest Contentful Paint"); cluster icons visible at zoom 8; individual pins at zoom 14+.


### PR DESCRIPTION
## Summary

Generates the OpenSpec change `case-map-overview` for procest — a manifest-driven situational-awareness map page at `/map` that plots all cases as status-coded pins on Leaflet, consuming `CnMapPage` from `@conduction/nextcloud-vue` (>= beta.30). Sister spec to `case-location` (which provides per-case geometry editing). **Spec only — no code.**

- 8 requirements (REQ-CMO-1..8), 23 G/W/T scenarios — STRICT validate passes
- Replaces the hand-written `CaseMapView.vue` with `type: 'map'` in `src/manifest.json`
- Status-coded pin palette via NL Design System tokens (no hardcoded hex), pin click -> CaseDetail, filter sidebar mirrors `/cases` index, leaflet.markercluster at zoom < 14, viewport-bounded query above 5k pins
- Foundation for future `pdok-integration` (luchtfoto/BGT layers) and `wms-wfs-layers` (custom government layers)
- Depends on `case-location` (geometry field + seed data)

## Artifacts

- `openspec/changes/case-map-overview/proposal.md`
- `openspec/changes/case-map-overview/design.md`
- `openspec/changes/case-map-overview/tasks.md` (D01-D02, T01-T08, V01-V04)
- `openspec/changes/case-map-overview/specs/case-map-overview/spec.md`
- `openspec/changes/case-map-overview/context-brief.md`
- `openspec/changes/case-map-overview/hydra.json`
- `openspec/changes/case-map-overview/.openspec.yaml`

## Test plan

- [x] `openspec change validate case-map-overview --strict` passes
- [ ] Reviewer confirms `CnMapPage` config block matches the upcoming beta.30 schema
- [ ] Confirm dependency ordering: `case-location` ships first, then this change