### PR TITLE
refactor(legesberekening): adopt manifest pattern — schema CRUD via manifest, keep calc service

### DIFF
--- a/lib/Settings/procest_register.json
+++ b/lib/Settings/procest_register.json
@@ -2389,6 +2389,304 @@
           }
         }
       },
+      "legesverordening": {
+        "slug": "legesverordening",
+        "icon": "CashMultiple",
+        "version": "1.0.0",
+        "x-schema-org-type": "schema:Legislation",
+        "title": "Legesverordening",
+        "description": "A municipal fee regulation (legesverordening) — the legal basis for charging fees on permit cases, containing a versioned set of articles with calculation rules",
+        "type": "object",
+        "required": [
+          "name",
+          "effectiveDate"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 255,
+            "description": "Name of this legesverordening (e.g. Legesverordening 2026)",
+            "x-translatable": true
+          },
+          "description": {
+            "type": "string",
+            "description": "Detailed description of the regulation and its scope",
+            "x-translatable": true
+          },
+          "effectiveDate": {
+            "type": "string",
+            "format": "date",
+            "description": "Date on which this verordening enters into force",
+            "facetable": true
+          },
+          "endDate": {
+            "type": "string",
+            "format": "date",
+            "description": "Date on which this verordening is no longer effective (optional)"
+          },
+          "year": {
+            "type": "integer",
+            "description": "Calendar year this verordening applies to",
+            "facetable": true
+          },
+          "globalMaximum": {
+            "type": "number",
+            "description": "Optional global cap on the total leges calculated under this verordening"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "concept",
+              "vastgesteld",
+              "vervallen"
+            ],
+            "default": "concept",
+            "description": "Lifecycle status of this verordening",
+            "facetable": true
+          },
+          "reference": {
+            "type": "string",
+            "description": "Official reference (raadsbesluit, publication URL, or DROP/CVDR identifier)"
+          },
+          "isActive": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether this verordening is currently the active one for new calculations",
+            "facetable": true
+          }
+        }
+      },
+      "legesartikel": {
+        "slug": "legesartikel",
+        "icon": "FileDocumentOutline",
+        "version": "1.0.0",
+        "x-schema-org-type": "schema:Article",
+        "title": "Legesartikel",
+        "description": "A single article (tariff line) inside a legesverordening, with its calculation rule (vast, percentage, staffel, maximum, combinatie)",
+        "type": "object",
+        "required": [
+          "verordening",
+          "nummer",
+          "type"
+        ],
+        "properties": {
+          "verordening": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Reference to the parent legesverordening",
+            "facetable": true
+          },
+          "nummer": {
+            "type": "string",
+            "maxLength": 50,
+            "description": "Article number (e.g. 2.3.1)",
+            "facetable": true
+          },
+          "omschrijving": {
+            "type": "string",
+            "description": "Description of what this article covers",
+            "x-translatable": true
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "vast",
+              "percentage",
+              "staffel",
+              "maximum",
+              "combinatie"
+            ],
+            "description": "Calculation type for this article",
+            "facetable": true
+          },
+          "grondslagField": {
+            "type": "string",
+            "default": "bouwkosten",
+            "description": "Name of the case-data field used as the calculation base (grondslag)"
+          },
+          "bedrag": {
+            "type": "number",
+            "description": "Fixed amount (used when type is vast)"
+          },
+          "percentage": {
+            "type": "number",
+            "description": "Percentage rate (used when type is percentage)"
+          },
+          "maximum": {
+            "type": "number",
+            "description": "Cap value (used when type is maximum)"
+          },
+          "subType": {
+            "type": "string",
+            "enum": [
+              "vast",
+              "percentage",
+              "staffel"
+            ],
+            "description": "Sub-calculation strategy when type is maximum"
+          },
+          "brackets": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "from": {
+                  "type": "number",
+                  "description": "Lower bound of this bracket (inclusive)"
+                },
+                "to": {
+                  "type": "number",
+                  "description": "Upper bound of this bracket (exclusive); omit for unbounded"
+                },
+                "percentage": {
+                  "type": "number",
+                  "description": "Rate applied within this bracket"
+                }
+              }
+            },
+            "description": "Tiered brackets (used when type is staffel)"
+          },
+          "subArtikelen": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            },
+            "description": "Nested article definitions (used when type is combinatie)"
+          },
+          "category": {
+            "type": "string",
+            "description": "Optional grouping category for display (e.g. Omgevingsvergunning)",
+            "facetable": true
+          },
+          "order": {
+            "type": "integer",
+            "description": "Display order within the verordening"
+          }
+        }
+      },
+      "legesberekening": {
+        "slug": "legesberekening",
+        "icon": "Calculator",
+        "version": "1.0.0",
+        "x-schema-org-type": "schema:MonetaryAmount",
+        "title": "Legesberekening",
+        "description": "A single fee calculation produced for a case under a specific legesverordening, with breakdown per artikel, audit trail and version history",
+        "type": "object",
+        "required": [
+          "case",
+          "verordening",
+          "total",
+          "calculatedBy",
+          "calculatedAt"
+        ],
+        "properties": {
+          "case": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Reference to the case this calculation belongs to",
+            "facetable": true
+          },
+          "verordening": {
+            "type": "string",
+            "description": "Name or reference of the applied verordening at calculation time"
+          },
+          "verordeningId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Reference to the legesverordening object",
+            "facetable": true
+          },
+          "total": {
+            "type": "number",
+            "description": "Total calculated leges amount (after global maximum is applied)"
+          },
+          "breakdown": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "artikel": {
+                  "type": "string",
+                  "description": "Artikel number"
+                },
+                "description": {
+                  "type": "string",
+                  "description": "Artikel description"
+                },
+                "grondslag": {
+                  "type": "number",
+                  "description": "Base amount used"
+                },
+                "amount": {
+                  "type": "number",
+                  "description": "Amount charged for this artikel"
+                },
+                "type": {
+                  "type": "string",
+                  "description": "Calculation type used for this artikel"
+                }
+              }
+            },
+            "description": "Per-artikel breakdown of the total"
+          },
+          "calculatedBy": {
+            "type": "string",
+            "description": "User UID of the person who triggered the calculation"
+          },
+          "calculatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp of the calculation"
+          },
+          "version": {
+            "type": "integer",
+            "default": 1,
+            "description": "Version number; increments on each recalculation"
+          },
+          "previousVersion": {
+            "type": "integer",
+            "description": "Previous version number (when this is a recalculation)"
+          },
+          "previousTotal": {
+            "type": "number",
+            "description": "Total of the previous calculation (when this is a recalculation)"
+          },
+          "difference": {
+            "type": "number",
+            "description": "Difference vs the previous total (positive = higher, negative = lower)"
+          },
+          "correctionReason": {
+            "type": "string",
+            "description": "Reason supplied when this calculation corrects a previous one"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "concept",
+              "opgelegd",
+              "verrekend",
+              "teruggegeven"
+            ],
+            "default": "concept",
+            "description": "Status of the calculation within the billing lifecycle",
+            "facetable": true
+          },
+          "exportedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp of last export to the financial system"
+          },
+          "exportFormat": {
+            "type": "string",
+            "enum": [
+              "csv",
+              "xml",
+              "json"
+            ],
+            "description": "Format used during last export"
+          }
+        }
+      },
       "handhavingsactie": {
         "slug": "handhavingsactie",
         "icon": "Gavel",
@@ -2885,7 +3183,10 @@
           "inspectieRapport",
           "handhavingsactie",
           "inspectieChecklist",
-          "adviesAanvraag"
+          "adviesAanvraag",
+          "legesverordening",
+          "legesartikel",
+          "legesberekening"
         ],
         "tablePrefix": "",
         "folder": "Open Registers/Procest"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -12,6 +12,8 @@
 		{ "id": "Voorstellen", "label": "Voorstellen", "icon": "icon-comment", "route": "Voorstellen", "order": 70 },
 		{ "id": "Documentation", "label": "Documentation", "icon": "icon-info", "href": "https://conduction.gitbook.io/procest-nextcloud", "section": "settings", "order": 90 },
 		{ "id": "CaseTypesMenu", "label": "Case Types", "icon": "icon-category-customization", "route": "CaseTypes", "section": "settings", "order": 95 },
+		{ "id": "LegesverordeningenMenu", "label": "Legesverordeningen", "icon": "icon-category-office", "route": "Legesverordeningen", "section": "settings", "order": 96 },
+		{ "id": "LegesberekeningenMenu", "label": "Legesberekeningen", "icon": "icon-category-monitoring", "route": "Legesberekeningen", "section": "settings", "order": 97 },
 		{ "id": "SettingsMenu", "label": "Settings", "icon": "icon-settings", "route": "Settings", "section": "settings", "order": 99 }
 	],
 	"pages": [
@@ -175,6 +177,108 @@
 			"type": "custom",
 			"title": "Case types",
 			"component": "AdminRootView"
+		},
+		{
+			"id": "Legesverordeningen",
+			"route": "/legesverordeningen",
+			"type": "index",
+			"title": "Legesverordeningen",
+			"config": {
+				"register": "procest",
+				"schema": "legesverordening",
+				"columns": ["name", "year", "effectiveDate", "status", "isActive"],
+				"actions": ["create", "edit", "delete", "view"],
+				"sidebar": { "enabled": true, "showMetadata": true }
+			}
+		},
+		{
+			"id": "LegesverordeningDetail",
+			"route": "/legesverordeningen/:id",
+			"type": "detail",
+			"title": "Legesverordening",
+			"config": {
+				"register": "procest",
+				"schema": "legesverordening",
+				"sidebarTabs": [
+					{
+						"id": "overview",
+						"label": "Overview",
+						"icon": "icon-info",
+						"widgets": [
+							{ "type": "data" },
+							{ "type": "metadata" }
+						],
+						"order": 10
+					},
+					{
+						"id": "artikelen",
+						"label": "Artikelen",
+						"icon": "icon-file",
+						"widgets": [
+							{
+								"type": "related-index",
+								"config": {
+									"register": "procest",
+									"schema": "legesartikel",
+									"filter": { "verordening": ":id" },
+									"columns": ["nummer", "omschrijving", "type", "category", "order"],
+									"actions": ["create", "edit", "delete"]
+								}
+							}
+						],
+						"order": 20
+					},
+					{
+						"id": "audit",
+						"label": "Audit trail",
+						"icon": "icon-history",
+						"widgets": [{ "type": "audit-trail" }],
+						"order": 90
+					}
+				]
+			}
+		},
+		{
+			"id": "Legesberekeningen",
+			"route": "/legesberekeningen",
+			"type": "index",
+			"title": "Legesberekeningen",
+			"config": {
+				"register": "procest",
+				"schema": "legesberekening",
+				"columns": ["case", "verordening", "total", "version", "status", "calculatedBy", "calculatedAt"],
+				"actions": ["view", "delete"],
+				"sidebar": { "enabled": true, "showMetadata": true }
+			}
+		},
+		{
+			"id": "LegesberekeningDetail",
+			"route": "/legesberekeningen/:id",
+			"type": "detail",
+			"title": "Legesberekening",
+			"config": {
+				"register": "procest",
+				"schema": "legesberekening",
+				"sidebarTabs": [
+					{
+						"id": "overview",
+						"label": "Overview",
+						"icon": "icon-info",
+						"widgets": [
+							{ "type": "data" },
+							{ "type": "metadata" }
+						],
+						"order": 10
+					},
+					{
+						"id": "audit",
+						"label": "Audit trail",
+						"icon": "icon-history",
+						"widgets": [{ "type": "audit-trail" }],
+						"order": 90
+					}
+				]
+			}
 		},
 		{
 			"id": "PublicCase",


### PR DESCRIPTION
## Summary

Aligns the legesberekening surface with the manifest renderer pattern (procest-manifest-v1, #320) and mirrors the parafeerroute refactor. Tariff configuration (legesverordening + legesartikel) and per-case calculation history (legesberekening) now live as OpenRegister schemas with CRUD declared in `src/manifest.json`. The calculation/export domain logic stays exactly where it was.

## Changes

### Schemas added (`lib/Settings/procest_register.json`)

- `legesverordening` — municipal fee regulation: `name`, `year`, `effectiveDate`, `endDate`, `status` (concept/vastgesteld/vervallen), `isActive`, `globalMaximum`, `reference`
- `legesartikel` — tariff line, scoped by `verordening`: `nummer`, `omschrijving`, `type` (`vast` | `percentage` | `staffel` | `maximum` | `combinatie`), `grondslagField`, `bedrag`, `percentage`, `maximum`, `subType`, `brackets[]`, `subArtikelen[]`, `category`, `order`
- `legesberekening` — calculation result on a case: `case`, `verordening`, `verordeningId`, `total`, `breakdown[]`, `calculatedBy`, `calculatedAt`, `version`, `previousVersion`, `previousTotal`, `difference`, `correctionReason`, `status` (concept/opgelegd/verrekend/teruggegeven), `exportedAt`, `exportFormat`

All three registered on the `procest` register — OpenRegister handles CRUD; no bespoke controllers.

### Manifest pages added (`src/manifest.json`)

| Page | Route | Type | Schema |
| ---- | ----- | ---- | ------ |
| `Legesverordeningen` | `/legesverordeningen` | index | legesverordening |
| `LegesverordeningDetail` | `/legesverordeningen/:id` | detail | legesverordening (with Artikelen sub-index tab on legesartikel filtered by verordening) |
| `Legesberekeningen` | `/legesberekeningen` | index | legesberekening |
| `LegesberekeningDetail` | `/legesberekeningen/:id` | detail | legesberekening |

Two new menu entries under the settings section (`LegesverordeningenMenu`, `LegesberekeningenMenu`).

### Preserved (no change)

- `LegesController::calculate`, `recalculate`, `verrekening`, `teruggaaf`, `export` — all five domain endpoints
- `LegesCalculationService` (rules engine: vast / percentage / staffel / maximum / combinatie + verrekening + teruggaaf)
- `LegesExportService` (CSV / XML / JSON export to financial system)
- `/api/leges/*` routes in `appinfo/routes.php`

### Deletions

None required. The pre-existing controller already exposes only domain endpoints — no CRUD methods, no CRUD routes, no Vue list/detail views for leges tariff or history existed prior to this change.

## Test plan

- [x] `jq -e .` parses both modified JSON files
- [x] `node tests/validate-manifest.js` — structural lint PASS, 21 pages
- [x] `php -l` on LegesController, LegesCalculationService, LegesExportService, appinfo/routes.php — clean
- [ ] Smoke: install on Nextcloud dev, register seed creates the three new schemas
- [ ] Manifest renderer surfaces Legesverordeningen + Legesberekeningen index/detail pages
- [ ] `POST /api/leges/calculate` still works end-to-end