### PR TITLE
refactor(advice-management): adopt manifest pattern — advice CRUD via manifest, keep workflow + reminder

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -200,12 +200,10 @@ return [
         ['name' => 'leges#export',      'url' => '/api/leges/export',       'verb' => 'POST'],
 
         // ── Advice Management (adviesAanvraag) ──────────────────────────
-        ['name' => 'advice#index',   'url' => '/api/advice',             'verb' => 'GET'],
-        ['name' => 'advice#create',  'url' => '/api/advice',             'verb' => 'POST'],
-        ['name' => 'advice#show',    'url' => '/api/advice/{id}',        'verb' => 'GET'],
-        ['name' => 'advice#update',  'url' => '/api/advice/{id}',        'verb' => 'PUT'],
-        ['name' => 'advice#destroy', 'url' => '/api/advice/{id}',        'verb' => 'DELETE'],
-        ['name' => 'advice#remind',  'url' => '/api/advice/{id}/remind', 'verb' => 'POST'],
+        // CRUD is handled by the manifest renderer via OpenRegister. Only
+        // workflow operations live on this controller.
+        ['name' => 'advice#transitionStatus',  'url' => '/api/advice/{id}/transition', 'verb' => 'POST'],
+        ['name' => 'advice#dispatchReminder',  'url' => '/api/advice/{id}/remind',     'verb' => 'POST'],
 
         // Multi-Tenant SaaS — tenant management endpoints (platform admin scoped).
         ['name' => 'tenant#current',   'url' => '/api/tenants/current',                'verb' => 'GET'],

--- a/lib/BackgroundJob/AdviceDeadlineJob.php
+++ b/lib/BackgroundJob/AdviceDeadlineJob.php
@@ -115,7 +115,7 @@ class AdviceDeadlineJob extends TimedJob
             }
 
             if ($deadlineDate === $reminderOn) {
-                $this->adviceService->sendReminder($adviceId);
+                $this->adviceService->dispatchReminder($adviceId);
                 $this->logger->info(
                     'Procest: advice reminder dispatched',
                     [

--- a/lib/Controller/AdviceController.php
+++ b/lib/Controller/AdviceController.php
@@ -3,7 +3,10 @@
 /**
  * Procest Advice Controller.
  *
- * REST API for managing advice requests (adviesAanvraag) on cases.
+ * Workflow endpoints for advice requests (adviesAanvraag). CRUD is delegated
+ * to the manifest renderer (OpenRegister); this controller exposes only the
+ * domain operations that need server-side side-effects: status transitions
+ * (which trigger notifications) and manual reminder dispatch.
  *
  * @category Controller
  * @package  OCA\Procest\Controller
@@ -25,7 +28,6 @@ declare(strict_types=1);
 namespace OCA\Procest\Controller;
 
 use OCA\Procest\Service\AdviceService;
-use OCA\Procest\Service\SettingsService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
@@ -33,7 +35,7 @@ use OCP\IRequest;
 use Psr\Log\LoggerInterface;
 
 /**
- * Controller for advice request management on cases.
+ * Controller for advice request workflow operations.
  */
 class AdviceController extends Controller
 {
@@ -41,125 +43,33 @@ class AdviceController extends Controller
     /**
      * Constructor.
      *
-     * @param string          $appName         The app name
-     * @param IRequest        $request         The HTTP request
-     * @param AdviceService   $adviceService   The advice service
-     * @param SettingsService $settingsService The settings service
-     * @param LoggerInterface $logger          The logger
+     * @param string          $appName       The app name
+     * @param IRequest        $request       The HTTP request
+     * @param AdviceService   $adviceService The advice service
+     * @param LoggerInterface $logger        The logger
      */
     public function __construct(
         string $appName,
         IRequest $request,
         private readonly AdviceService $adviceService,
-        private readonly SettingsService $settingsService,
         private readonly LoggerInterface $logger,
     ) {
         parent::__construct(appName: $appName, request: $request);
     }//end __construct()
 
     /**
-     * List advice requests for a case.
+     * Transition the status of an advice request.
      *
-     * @param string $case The case UUID (query param)
+     * Drives workflow side-effects (notifications to adviseur / requester)
+     * that the manifest CRUD path cannot perform. The CRUD itself (writing
+     * the object) is still performed by this method via the service so the
+     * notification + persistence remain transactional from the caller's
+     * point of view.
      *
-     * @return JSONResponse List of advice records
-     *
-     * @NoAdminRequired
-     */
-    public function index(string $case = ''): JSONResponse
-    {
-        if ($case === '') {
-            return new JSONResponse(
-                ['error' => 'case parameter is required'],
-                Http::STATUS_BAD_REQUEST,
-            );
-        }
-
-        try {
-            $advice = $this->adviceService->getAdviceForCase($case);
-            return new JSONResponse(['results' => $advice]);
-        } catch (\Throwable $e) {
-            $this->logger->error('Procest: advice index failed: '.$e->getMessage());
-            return new JSONResponse(
-                ['error' => 'Could not list advice requests'],
-                Http::STATUS_INTERNAL_SERVER_ERROR,
-            );
-        }
-    }//end index()
-
-    /**
-     * Create a new advice request.
-     *
-     * @return JSONResponse Created record
-     *
-     * @NoAdminRequired
-     */
-    public function create(): JSONResponse
-    {
-        $data = $this->readJsonBody();
-
-        $caseId = (string) ($data['case'] ?? '');
-
-        try {
-            $advice = $this->adviceService->createAdvice($caseId, $data);
-            return new JSONResponse($advice, Http::STATUS_CREATED);
-        } catch (\RuntimeException $e) {
-            return new JSONResponse(
-                ['error' => $e->getMessage()],
-                Http::STATUS_BAD_REQUEST,
-            );
-        } catch (\Throwable $e) {
-            $this->logger->error('Procest: advice create failed: '.$e->getMessage());
-            return new JSONResponse(
-                ['error' => 'Could not create advice request'],
-                Http::STATUS_INTERNAL_SERVER_ERROR,
-            );
-        }
-    }//end create()
-
-    /**
-     * Show a single advice request.
-     *
-     * @param string $id The advice UUID
-     *
-     * @return JSONResponse Advice record
-     *
-     * @NoAdminRequired
-     */
-    public function show(string $id): JSONResponse
-    {
-        $objectService = $this->settingsService->getObjectService();
-        if ($objectService === null) {
-            return new JSONResponse(
-                ['error' => 'OpenRegister is not available'],
-                Http::STATUS_SERVICE_UNAVAILABLE,
-            );
-        }
-
-        $register = $this->settingsService->getConfigValue('register');
-        $schema   = $this->settingsService->getConfigValue('advies_aanvraag_schema');
-
-        if (empty($register) === true || empty($schema) === true) {
-            return new JSONResponse(
-                ['error' => 'Advice schema is not configured'],
-                Http::STATUS_SERVICE_UNAVAILABLE,
-            );
-        }
-
-        try {
-            $advice = $objectService->findObject($register, $schema, $id);
-            return new JSONResponse($advice);
-        } catch (\Throwable $e) {
-            $this->logger->error('Procest: advice show failed: '.$e->getMessage());
-            return new JSONResponse(
-                ['error' => 'Could not load advice request'],
-                Http::STATUS_NOT_FOUND,
-            );
-        }
-    }//end show()
-
-    /**
-     * Update / mark received an advice request.
+     * Accepted payloads:
+     *   { "to": "aangevraagd" }                  — fire "advies_aangevraagd"
+     *   { "to": "ontvangen", "adviesDocument": "<fileId>" } — mark received
+     *   { "to": "verlopen" }                     — mark expired
      *
      * @param string $id The advice UUID
      *
@@ -167,13 +77,20 @@ class AdviceController extends Controller
      *
      * @NoAdminRequired
      */
-    public function update(string $id): JSONResponse
+    public function transitionStatus(string $id): JSONResponse
     {
-        $data   = $this->readJsonBody();
-        $fileId = (string) ($data['adviesDocument'] ?? ($data['fileId'] ?? ''));
+        $data = $this->readJsonBody();
+        $to   = (string) ($data['to'] ?? '');
+
+        if ($to === '') {
+            return new JSONResponse(
+                ['error' => 'to status is required'],
+                Http::STATUS_BAD_REQUEST,
+            );
+        }
 
         try {
-            $advice = $this->adviceService->receiveAdvice($id, $fileId);
+            $advice = $this->adviceService->transitionStatus($id, $to, $data);
             return new JSONResponse($advice);
         } catch (\RuntimeException $e) {
             return new JSONResponse(
@@ -181,57 +98,16 @@ class AdviceController extends Controller
                 Http::STATUS_BAD_REQUEST,
             );
         } catch (\Throwable $e) {
-            $this->logger->error('Procest: advice update failed: '.$e->getMessage());
+            $this->logger->error('Procest: advice transition failed: '.$e->getMessage());
             return new JSONResponse(
-                ['error' => 'Could not update advice request'],
+                ['error' => 'Could not transition advice request'],
                 Http::STATUS_INTERNAL_SERVER_ERROR,
             );
         }
-    }//end update()
+    }//end transitionStatus()
 
     /**
-     * Delete an advice request.
-     *
-     * @param string $id The advice UUID
-     *
-     * @return JSONResponse Empty success or error
-     *
-     * @NoAdminRequired
-     */
-    public function destroy(string $id): JSONResponse
-    {
-        $objectService = $this->settingsService->getObjectService();
-        if ($objectService === null) {
-            return new JSONResponse(
-                ['error' => 'OpenRegister is not available'],
-                Http::STATUS_SERVICE_UNAVAILABLE,
-            );
-        }
-
-        $register = $this->settingsService->getConfigValue('register');
-        $schema   = $this->settingsService->getConfigValue('advies_aanvraag_schema');
-
-        if (empty($register) === true || empty($schema) === true) {
-            return new JSONResponse(
-                ['error' => 'Advice schema is not configured'],
-                Http::STATUS_SERVICE_UNAVAILABLE,
-            );
-        }
-
-        try {
-            $objectService->deleteObject($register, $schema, $id);
-            return new JSONResponse(['status' => 'deleted']);
-        } catch (\Throwable $e) {
-            $this->logger->error('Procest: advice destroy failed: '.$e->getMessage());
-            return new JSONResponse(
-                ['error' => 'Could not delete advice request'],
-                Http::STATUS_INTERNAL_SERVER_ERROR,
-            );
-        }
-    }//end destroy()
-
-    /**
-     * Send a manual reminder to the adviseur.
+     * Dispatch a manual reminder notification to the adviseur.
      *
      * @param string $id The advice UUID
      *
@@ -239,19 +115,19 @@ class AdviceController extends Controller
      *
      * @NoAdminRequired
      */
-    public function remind(string $id): JSONResponse
+    public function dispatchReminder(string $id): JSONResponse
     {
         try {
-            $this->adviceService->sendReminder($id);
+            $this->adviceService->dispatchReminder($id);
             return new JSONResponse(['status' => 'reminded']);
         } catch (\Throwable $e) {
-            $this->logger->error('Procest: advice remind failed: '.$e->getMessage());
+            $this->logger->error('Procest: advice dispatchReminder failed: '.$e->getMessage());
             return new JSONResponse(
                 ['error' => 'Could not send reminder'],
                 Http::STATUS_INTERNAL_SERVER_ERROR,
             );
         }
-    }//end remind()
+    }//end dispatchReminder()
 
     /**
      * Decode a JSON request body safely.

--- a/lib/Service/AdviceService.php
+++ b/lib/Service/AdviceService.php
@@ -3,9 +3,15 @@
 /**
  * Procest Advice Service.
  *
- * Service for managing advice requests (adviesAanvraag) on cases.
- * Handles CRUD, status transitions, deadline tracking, and notification
- * dispatch for internal and external advice.
+ * Workflow service for advice requests (adviesAanvraag). CRUD is delegated
+ * to the manifest renderer (OpenRegister); this service owns the domain
+ * operations that require server-side side-effects:
+ *   - transitionStatus()    — status transitions with notification dispatch
+ *   - dispatchReminder()    — manual + automated reminder notifications
+ *   - applyWorkflowGuard()  — block downstream steps while advice pending
+ *   - getOpenAdvice()       — used by the deadline cron
+ *   - expireAdvice()        — set status=verlopen (cron)
+ *   - getAdviceForCase()    — used by the guard + case-detail tab
  *
  * @category Service
  * @package  OCA\Procest\Service
@@ -32,7 +38,7 @@ use OCP\Notification\IManager as INotificationManager;
 use Psr\Log\LoggerInterface;
 
 /**
- * Service for advice request (adviesAanvraag) management.
+ * Service for advice request (adviesAanvraag) workflow.
  */
 class AdviceService
 {
@@ -44,14 +50,6 @@ class AdviceService
         'aangevraagd',
         'ontvangen',
         'verlopen',
-    ];
-
-    /**
-     * Valid advice types.
-     */
-    private const VALID_TYPES = [
-        'intern',
-        'extern',
     ];
 
     /**
@@ -71,82 +69,27 @@ class AdviceService
     }//end __construct()
 
     /**
-     * Create a new advice request linked to a case.
+     * Transition an advice request to a new status and fire notifications.
      *
-     * @param string               $caseId The case UUID this advice is for
-     * @param array<string, mixed> $data   Advice data (adviseur, type, onderwerp, deadline, questions)
+     * Supported transitions:
+     *   - to=aangevraagd: notify the adviseur (used right after manifest create).
+     *   - to=ontvangen:   set receivedAt + optional adviesDocument; notify caller.
+     *   - to=verlopen:    mark expired (cron path).
      *
-     * @return array<string, mixed> Created advice record
-     *
-     * @throws \RuntimeException When OpenRegister unavailable or validation fails
-     */
-    public function createAdvice(string $caseId, array $data): array
-    {
-        if ($caseId === '') {
-            throw new \RuntimeException('Case ID is required');
-        }
-
-        $objectService = $this->settingsService->getObjectService();
-        if ($objectService === null) {
-            throw new \RuntimeException('OpenRegister is not available');
-        }
-
-        $register = $this->settingsService->getConfigValue('register');
-        $schema   = $this->settingsService->getConfigValue('advies_aanvraag_schema');
-
-        if (empty($register) === true || empty($schema) === true) {
-            throw new \RuntimeException('Advice schema is not configured');
-        }
-
-        $adviseur = (string) ($data['adviseur'] ?? '');
-        $type     = (string) ($data['type'] ?? '');
-
-        if ($adviseur === '') {
-            throw new \RuntimeException('adviseur is required');
-        }
-
-        if (in_array($type, self::VALID_TYPES, true) === false) {
-            throw new \RuntimeException('Invalid advice type');
-        }
-
-        $payload = [
-            'case'        => $caseId,
-            'adviseur'    => $adviseur,
-            'type'        => $type,
-            'onderwerp'   => (string) ($data['onderwerp'] ?? ''),
-            'deadline'    => (string) ($data['deadline'] ?? ''),
-            'status'      => 'aangevraagd',
-            'requestedAt' => date('c'),
-            'questions'   => (string) ($data['questions'] ?? ''),
-        ];
-
-        try {
-            $advice = $objectService->saveObject($register, $schema, $payload);
-        } catch (\Throwable $e) {
-            $this->logger->error(
-                'Procest: failed to create advice request: '.$e->getMessage(),
-                ['app' => Application::APP_ID]
-            );
-            throw new \RuntimeException('Could not create advice request');
-        }
-
-        $this->notifyAdviseur($adviseur, $caseId, $payload['onderwerp']);
-
-        return $this->normalizeResult($advice);
-    }//end createAdvice()
-
-    /**
-     * Mark an advice request as received (status -> ontvangen).
-     *
-     * @param string $adviceId The advice UUID
-     * @param string $fileId   Nextcloud file ID of the advice document
+     * @param string               $adviceId The advice UUID
+     * @param string               $to       Target status
+     * @param array<string, mixed> $payload  Extra fields (adviesDocument, etc.)
      *
      * @return array<string, mixed> Updated advice record
      *
-     * @throws \RuntimeException When OpenRegister unavailable
+     * @throws \RuntimeException When OpenRegister unavailable / invalid status
      */
-    public function receiveAdvice(string $adviceId, string $fileId): array
+    public function transitionStatus(string $adviceId, string $to, array $payload = []): array
     {
+        if (in_array($to, self::VALID_STATUSES, true) === false) {
+            throw new \RuntimeException('Invalid advice status');
+        }
+
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
             throw new \RuntimeException('OpenRegister is not available');
@@ -159,41 +102,48 @@ class AdviceService
             throw new \RuntimeException('Advice schema is not configured');
         }
 
-        $update = [
-            'status'         => 'ontvangen',
-            'receivedAt'     => date('c'),
-        ];
+        $current = $this->loadAdvice($adviceId);
+        if ($current === null) {
+            throw new \RuntimeException('Advice request not found');
+        }
 
-        if ($fileId !== '') {
-            $update['adviesDocument'] = $fileId;
+        $update = ['status' => $to];
+
+        if ($to === 'ontvangen') {
+            $update['receivedAt'] = date('c');
+            $fileId = (string) ($payload['adviesDocument'] ?? ($payload['fileId'] ?? ''));
+            if ($fileId !== '') {
+                $update['adviesDocument'] = $fileId;
+            }
         }
 
         try {
             $advice = $objectService->saveObject($register, $schema, $update, $adviceId);
         } catch (\Throwable $e) {
             $this->logger->error(
-                'Procest: failed to mark advice received: '.$e->getMessage(),
+                'Procest: failed to transition advice status: '.$e->getMessage(),
                 ['app' => Application::APP_ID]
             );
             throw new \RuntimeException('Could not update advice request');
         }
 
-        $current = $this->getUserId();
-        if ($current !== '') {
-            $this->sendUserNotification($current, 'advies_ontvangen', $adviceId);
-        }
+        $advice = $this->normalizeResult($advice);
 
-        return $this->normalizeResult($advice);
-    }//end receiveAdvice()
+        $this->fireTransitionNotification($to, $current, $adviceId);
+
+        return $advice;
+    }//end transitionStatus()
 
     /**
-     * Send a reminder notification to the adviseur for an advice request.
+     * Dispatch a reminder notification to the adviseur.
+     *
+     * Called by the manual remind endpoint and by the daily deadline cron.
      *
      * @param string $adviceId The advice UUID
      *
      * @return void
      */
-    public function sendReminder(string $adviceId): void
+    public function dispatchReminder(string $adviceId): void
     {
         $advice = $this->loadAdvice($adviceId);
         if ($advice === null) {
@@ -206,10 +156,37 @@ class AdviceService
         }
 
         $this->sendUserNotification($adviseur, 'advies_herinnering', $adviceId);
-    }//end sendReminder()
+    }//end dispatchReminder()
 
     /**
-     * Get all advice requests for a case.
+     * Workflow guard — return pending advice (status=aangevraagd) for a case.
+     *
+     * Callers (case-status transitions, parafering routes) use this to block
+     * downstream steps while advice is still outstanding.
+     *
+     * @param string $caseId The case UUID
+     *
+     * @return array<int, array<string, mixed>> Pending advice records
+     */
+    public function applyWorkflowGuard(string $caseId): array
+    {
+        $all     = $this->getAdviceForCase($caseId);
+        $pending = [];
+
+        foreach ($all as $advice) {
+            $status = (string) ($advice['status'] ?? '');
+            if ($status === 'aangevraagd') {
+                $pending[] = $advice;
+            }
+        }
+
+        return $pending;
+    }//end applyWorkflowGuard()
+
+    /**
+     * Get all advice requests linked to a case.
+     *
+     * Used by the workflow guard and by the case-detail "Adviezen" tab.
      *
      * @param string $caseId The case UUID
      *
@@ -251,28 +228,6 @@ class AdviceService
 
         return [];
     }//end getAdviceForCase()
-
-    /**
-     * Get pending advice (status=aangevraagd) for a case — used as workflow guard.
-     *
-     * @param string $caseId The case UUID
-     *
-     * @return array<int, array<string, mixed>> Pending advice records
-     */
-    public function checkGuard(string $caseId): array
-    {
-        $all     = $this->getAdviceForCase($caseId);
-        $pending = [];
-
-        foreach ($all as $advice) {
-            $status = (string) ($advice['status'] ?? '');
-            if ($status === 'aangevraagd') {
-                $pending[] = $advice;
-            }
-        }
-
-        return $pending;
-    }//end checkGuard()
 
     /**
      * Load all open advice requests across the system (for the deadline job).
@@ -319,31 +274,17 @@ class AdviceService
     /**
      * Mark an advice request as expired (status -> verlopen).
      *
+     * Convenience wrapper used by the deadline cron. Delegates to
+     * transitionStatus() to keep the notification dispatch consistent.
+     *
      * @param string $adviceId The advice UUID
      *
      * @return array<string, mixed> Updated advice record
      */
     public function expireAdvice(string $adviceId): array
     {
-        $objectService = $this->settingsService->getObjectService();
-        if ($objectService === null) {
-            return [];
-        }
-
-        $register = $this->settingsService->getConfigValue('register');
-        $schema   = $this->settingsService->getConfigValue('advies_aanvraag_schema');
-
-        if (empty($register) === true || empty($schema) === true) {
-            return [];
-        }
-
         try {
-            $advice = $objectService->saveObject(
-                $register,
-                $schema,
-                ['status' => 'verlopen'],
-                $adviceId,
-            );
+            return $this->transitionStatus($adviceId, 'verlopen');
         } catch (\Throwable $e) {
             $this->logger->error(
                 'Procest: failed to expire advice: '.$e->getMessage(),
@@ -351,8 +292,6 @@ class AdviceService
             );
             return [];
         }
-
-        return $this->normalizeResult($advice);
     }//end expireAdvice()
 
     /**
@@ -388,6 +327,39 @@ class AdviceService
 
         return $this->normalizeResult($advice);
     }//end loadAdvice()
+
+    /**
+     * Fire the notification that matches a status transition.
+     *
+     * @param string               $to       Target status
+     * @param array<string, mixed> $current  Current advice record (pre-update)
+     * @param string               $adviceId The advice UUID
+     *
+     * @return void
+     */
+    private function fireTransitionNotification(string $to, array $current, string $adviceId): void
+    {
+        if ($to === 'aangevraagd') {
+            $adviseur = (string) ($current['adviseur'] ?? '');
+            if ($adviseur !== '') {
+                $this->sendUserNotification(
+                    $adviseur,
+                    'advies_aangevraagd',
+                    $adviceId,
+                    (string) ($current['onderwerp'] ?? '')
+                );
+            }
+
+            return;
+        }
+
+        if ($to === 'ontvangen') {
+            $caller = $this->getUserId();
+            if ($caller !== '') {
+                $this->sendUserNotification($caller, 'advies_ontvangen', $adviceId);
+            }
+        }
+    }//end fireTransitionNotification()
 
     /**
      * Convert an object/array result to an associative array.
@@ -426,24 +398,6 @@ class AdviceService
 
         return $user->getUID();
     }//end getUserId()
-
-    /**
-     * Notify the adviseur (internal) about a new advice request.
-     *
-     * @param string $adviseur Adviseur identifier (UID for internal)
-     * @param string $caseId   The case UUID
-     * @param string $subject  Subject of the advice request
-     *
-     * @return void
-     */
-    private function notifyAdviseur(string $adviseur, string $caseId, string $subject): void
-    {
-        if ($adviseur === '') {
-            return;
-        }
-
-        $this->sendUserNotification($adviseur, 'advies_aangevraagd', $caseId, $subject);
-    }//end notifyAdviseur()
 
     /**
      * Send a Nextcloud notification to a user.

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,6 +10,7 @@
 		{ "id": "Tasks", "label": "Tasks", "icon": "icon-checkmark", "route": "Tasks", "order": 50 },
 		{ "id": "CaseMap", "label": "Map", "icon": "icon-address", "route": "CaseMap", "order": 60 },
 		{ "id": "Voorstellen", "label": "Voorstellen", "icon": "icon-comment", "route": "Voorstellen", "order": 70 },
+		{ "id": "Advice", "label": "Advice", "icon": "icon-comment", "route": "Advice", "order": 75 },
 		{ "id": "Documentation", "label": "Documentation", "icon": "icon-info", "href": "https://conduction.gitbook.io/procest-nextcloud", "section": "settings", "order": 90 },
 		{ "id": "CaseTypesMenu", "label": "Case Types", "icon": "icon-category-customization", "route": "CaseTypes", "section": "settings", "order": 95 },
 		{ "id": "SettingsMenu", "label": "Settings", "icon": "icon-settings", "route": "Settings", "section": "settings", "order": 99 }
@@ -90,6 +91,7 @@
 					{ "id": "tasks",     "label": "Tasks",       "icon": "icon-checkmark", "component": "CaseTasksTab",                              "order": 20 },
 					{ "id": "decisions", "label": "Decisions",   "icon": "icon-toggle",    "component": "CaseDecisionsTab",                          "order": 30 },
 					{ "id": "documents", "label": "Documents",   "icon": "icon-files",     "component": "CaseDocumentsTab",                          "order": 40 },
+					{ "id": "advies",    "label": "Advies",      "icon": "icon-comment",   "component": "AdviesPanel",                               "order": 50 },
 					{ "id": "audit",     "label": "Audit trail", "icon": "icon-history",   "widgets": [{ "type": "audit-trail" }],                   "order": 90 }
 				]
 			}
@@ -154,6 +156,32 @@
 			"type": "custom",
 			"title": "Voorstel",
 			"component": "VoorstelDetailView"
+		},
+		{
+			"id": "Advice",
+			"route": "/advice",
+			"type": "index",
+			"title": "Advice requests",
+			"config": {
+				"register": "procest",
+				"schema": "adviesAanvraag",
+				"columns": ["onderwerp", "case", "adviseur", "type", "status", "deadline"],
+				"sidebar": { "enabled": true, "showMetadata": true }
+			}
+		},
+		{
+			"id": "AdviceDetail",
+			"route": "/advice/:id",
+			"type": "detail",
+			"title": "Advice request",
+			"config": {
+				"register": "procest",
+				"schema": "adviesAanvraag",
+				"sidebarTabs": [
+					{ "id": "overview", "label": "Overview",    "icon": "icon-info",    "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
+					{ "id": "audit",    "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }],                   "order": 90 }
+				]
+			}
 		},
 		{
 			"id": "Doorlooptijd",

--- a/src/services/adviceApi.js
+++ b/src/services/adviceApi.js
@@ -1,9 +1,18 @@
 /**
  * Advice API service for Procest.
  *
- * Wraps the /api/advice endpoints for advice request (adviesAanvraag)
- * management on cases. Uses @nextcloud/axios so CSRF tokens are attached
- * automatically.
+ * CRUD lives on OpenRegister (manifest renderer pattern):
+ *   GET    /apps/openregister/api/objects/procest/adviesAanvraag
+ *   POST   /apps/openregister/api/objects/procest/adviesAanvraag
+ *   GET    /apps/openregister/api/objects/procest/adviesAanvraag/{id}
+ *   PUT    /apps/openregister/api/objects/procest/adviesAanvraag/{id}
+ *   DELETE /apps/openregister/api/objects/procest/adviesAanvraag/{id}
+ *
+ * Workflow actions stay on the Procest controller:
+ *   POST   /apps/procest/api/advice/{id}/transition  — fires notification
+ *   POST   /apps/procest/api/advice/{id}/remind      — dispatches reminder
+ *
+ * Uses @nextcloud/axios so CSRF tokens are attached automatically.
  *
  * SPDX-License-Identifier: EUPL-1.2
  * SPDX-FileCopyrightText: 2026 Conduction B.V.
@@ -11,91 +20,106 @@
 import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
 
-const APP_BASE = 'apps/procest/api/advice'
+const REGISTER = 'procest'
+const SCHEMA = 'adviesAanvraag'
+const OR_BASE = `apps/openregister/api/objects/${REGISTER}/${SCHEMA}`
+const ACTION_BASE = 'apps/procest/api/advice'
 
 /**
- * Build the base URL for an advice endpoint.
+ * Build an OpenRegister objects URL.
  *
- * @param {string} path Optional sub-path (id or id/action)
+ * @param {string} path Optional sub-path (id)
  * @return {string} Fully qualified Nextcloud URL
  */
-function url(path = '') {
+function orUrl(path = '') {
 	const suffix = path ? `/${path}` : ''
-	return generateUrl(`/${APP_BASE}${suffix}`)
+	return generateUrl(`/${OR_BASE}${suffix}`)
 }
 
 /**
- * Get advice requests for a case.
+ * Build a Procest workflow-action URL.
+ *
+ * @param {string} path Sub-path (id/action)
+ * @return {string} Fully qualified Nextcloud URL
+ */
+function actionUrl(path) {
+	return generateUrl(`/${ACTION_BASE}/${path}`)
+}
+
+/**
+ * Get advice requests for a case (via manifest renderer / OR filter).
  *
  * @param {string} caseId Case UUID
  * @return {Promise<Array>} List of advice records
  */
 export async function getAdviceForCase(caseId) {
-	const response = await axios.get(url(), { params: { case: caseId } })
-	return response.data?.results || []
+	const response = await axios.get(orUrl(), {
+		params: { _filters: JSON.stringify({ case: caseId }), _limit: 200 },
+	})
+	return response.data?.results || response.data || []
 }
 
 /**
- * Create a new advice request.
+ * Transition the status of an advice request.
  *
- * @param {object} data Advice payload (case, adviseur, type, ...)
- * @return {Promise<object>} Created record
- */
-export async function createAdvice(data) {
-	const response = await axios.post(url(), data)
-	return response.data
-}
-
-/**
- * Get a single advice request.
+ * Use { to: 'aangevraagd' } right after creating an advice object to fire
+ * the notification to the adviseur (workflow side-effect).
  *
- * @param {string} id Advice UUID
- * @return {Promise<object>} Advice record
- */
-export async function getAdvice(id) {
-	const response = await axios.get(url(id))
-	return response.data
-}
-
-/**
- * Update / mark received an advice request.
+ * Use { to: 'ontvangen', adviesDocument: '<fileId>' } to mark received.
  *
  * @param {string} id   Advice UUID
- * @param {object} data Update payload (adviesDocument, etc.)
+ * @param {object} body Transition payload (to, adviesDocument, ...)
  * @return {Promise<object>} Updated record
  */
-export async function updateAdvice(id, data) {
-	const response = await axios.put(url(id), data)
+export async function transitionStatus(id, body) {
+	const response = await axios.post(actionUrl(`${id}/transition`), body)
 	return response.data
 }
 
 /**
- * Delete an advice request.
+ * Dispatch a manual reminder to the adviseur.
  *
  * @param {string} id Advice UUID
  * @return {Promise<object>} Server confirmation
  */
-export async function deleteAdvice(id) {
-	const response = await axios.delete(url(id))
+export async function dispatchReminder(id) {
+	const response = await axios.post(actionUrl(`${id}/remind`))
 	return response.data
 }
 
 /**
- * Send a manual reminder to the adviseur.
+ * Create an advice request (CRUD via manifest renderer) and fire the
+ * "aangevraagd" notification via transitionStatus.
  *
- * @param {string} id Advice UUID
- * @return {Promise<object>} Server confirmation
+ * Kept as a convenience for the case-detail dialog so callers do not need
+ * to chain two requests manually.
+ *
+ * @param {object} data Advice payload (case, adviseur, type, deadline, ...)
+ * @return {Promise<object>} Created record
  */
-export async function sendReminder(id) {
-	const response = await axios.post(url(`${id}/remind`))
-	return response.data
+export async function createAdviceWithNotification(data) {
+	const payload = {
+		...data,
+		status: 'aangevraagd',
+		requestedAt: new Date().toISOString(),
+	}
+	const created = await axios.post(orUrl(), payload)
+	const record = created.data
+	const id = record?.id || record?.uuid
+	if (id) {
+		try {
+			await transitionStatus(id, { to: 'aangevraagd' })
+		} catch (error) {
+			// Persistence already succeeded; surface but do not fail the caller.
+			console.warn('Procest: advice notification dispatch failed', error)
+		}
+	}
+	return record
 }
 
 export default {
 	getAdviceForCase,
-	createAdvice,
-	getAdvice,
-	updateAdvice,
-	deleteAdvice,
-	sendReminder,
+	createAdviceWithNotification,
+	transitionStatus,
+	dispatchReminder,
 }

--- a/src/views/cases/components/AdviesAanvraagDialog.vue
+++ b/src/views/cases/components/AdviesAanvraagDialog.vue
@@ -66,7 +66,7 @@
 
 <script>
 import { NcButton, NcDialog, NcTextField } from '@nextcloud/vue'
-import { createAdvice } from '../../../services/adviceApi.js'
+import { createAdviceWithNotification } from '../../../services/adviceApi.js'
 
 const APP_NAME = 'procest'
 
@@ -130,7 +130,7 @@ export default {
 					deadline: this.form.deadline,
 					questions: this.form.questions.trim(),
 				}
-				await createAdvice(payload)
+				await createAdviceWithNotification(payload)
 				this.$emit('created')
 			} catch (error) {
 				console.error('Procest: failed to create advice', error)

--- a/src/views/cases/components/AdviesPanel.vue
+++ b/src/views/cases/components/AdviesPanel.vue
@@ -77,9 +77,9 @@
 import { NcButton, NcLoadingIcon } from '@nextcloud/vue'
 import { CnEmptyState, CnStatusBadge } from '@conduction/nextcloud-vue'
 import {
+	dispatchReminder,
 	getAdviceForCase,
-	sendReminder,
-	updateAdvice,
+	transitionStatus,
 } from '../../../services/adviceApi.js'
 import AdviesAanvraagDialog from './AdviesAanvraagDialog.vue'
 
@@ -139,14 +139,15 @@ export default {
 		},
 		async onRemind(item) {
 			try {
-				await sendReminder(item.id || item.uuid)
+				await dispatchReminder(item.id || item.uuid)
 			} catch (error) {
 				console.error('Procest: failed to send reminder', error)
 			}
 		},
 		async onMarkReceived(item) {
 			try {
-				await updateAdvice(item.id || item.uuid, {
+				await transitionStatus(item.id || item.uuid, {
+					to: 'ontvangen',
 					adviesDocument: item.adviesDocument || '',
 				})
 				await this.fetchAdvies()


### PR DESCRIPTION
## Summary

Move adviesAanvraag CRUD onto the manifest renderer (OpenRegister) and keep the AdviceController only for workflow operations that fire notifications. Matches the pattern already used elsewhere in procest (cases, tasks).

## Deletions

- **AdviceController**: `index`, `create`, `show`, `update`, `destroy` — pure proxies onto OpenRegister, now served by the manifest renderer.
- **AdviceService**: `createAdvice`, `receiveAdvice` — replaced by a single `transitionStatus(adviceId, to, payload)` method that also fires the matching notification.
- **routes.php**: `advice#index/create/show/update/destroy`.
- **adviceApi.js**: `getAdvice`, `updateAdvice`, `deleteAdvice`, `createAdvice` — replaced by direct OR calls and a `createAdviceWithNotification` helper that chains OR create + `transitionStatus`.

## Kept methods (workflow / cron / detail panel)

- `AdviceController::transitionStatus` — `POST /api/advice/{id}/transition` (status transitions with notification side-effects).
- `AdviceController::dispatchReminder` — `POST /api/advice/{id}/remind` (manual reminder).
- `AdviceService::transitionStatus`, `dispatchReminder`, `applyWorkflowGuard`, `getOpenAdvice`, `expireAdvice`, `getAdviceForCase`.
- `BackgroundJob/AdviceDeadlineJob` — entirely preserved; daily cron now calls `dispatchReminder` (rename only).
- `src/views/cases/components/AdviesPanel.vue` — case-detail sidebar tab (wired via manifest `sidebarTabs`).
- `src/views/cases/components/AdviesAanvraagDialog.vue` — workflow-triggering create form (fires notification).

## New manifest pages

- **Index** `/advice` — admin view across all advice requests (`type: index`, register/schema: `procest/adviesAanvraag`).
- **Detail** `/advice/:id` — requester / advisor view with overview + audit-trail sidebar tabs.
- **CaseDetail** — new `advies` sidebar tab (component: `AdviesPanel`) so per-case lists stay where users expect them.

Schema `adviesAanvraag` in `lib/Settings/procest_register.json` is unchanged (added in procest#351).

## Test plan

- [ ] composer check:strict passes.
- [ ] Frontend builds (npm run build).
- [ ] Advice list at /advice renders via manifest renderer.
- [ ] /advice/:id detail page renders.
- [ ] Case detail page shows the new Advies sidebar tab and AdviesPanel lists per-case advice.
- [ ] Creating an advice request from the panel still emits the advies_aangevraagd notification to the adviseur.
- [ ] Markeer als ontvangen still transitions to ontvangen and stores adviesDocument.
- [ ] Manual Herinnering sturen still sends the reminder notification.
- [ ] AdviceDeadlineJob still expires overdue advice and sends reminders 3 days before deadline.