### PR TITLE
chore(openspec): generate map-component spec

### DIFF
--- a/openspec/changes/map-component/design.md
+++ b/openspec/changes/map-component/design.md
@@ -1,0 +1,66 @@
+# Design: map-component
+
+## Architecture
+
+### One Wrapper, Three Surfaces
+
+`MapComponent.vue` lives at `src/components/map/MapComponent.vue` and is a thin Procest-side wrapper around `CnMapWidget` from `@conduction/nextcloud-vue`. It exists for three reasons that the lib component alone cannot solve:
+
+1. **Procest-specific defaults** — default tile layer (`pdok-brt`), default centre (Netherlands lat 52.1326, lon 5.2913, zoom 7), default marker formatter (`caseMarkerFormatter` from `src/services/mapFormatters.js`).
+2. **A stable Procest API** — sister specs (`case-location` picker, `case-map-overview` widget, public case pages) all reference `<MapComponent>` rather than the lib component, so a lib upgrade is a single-file change.
+3. **Mode switching** — `interactive` prop toggles read-only vs. read-write panning/zooming, used by the public case page.
+
+The component is **stateless** with respect to data: it owns no store. Parents pass `locations[]` and listen for events. Internal state (current viewport, hover marker) is local component state only.
+
+## Component API
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `locations` | `Array<{ id, geometry, ...meta }>` | `[]` | Objects with GeoJSON `geometry` (Point or Polygon); meta passed back unchanged in events |
+| `center` | `{ lat: number, lon: number }` | `{ lat: 52.1326, lon: 5.2913 }` | Initial map centre |
+| `zoom` | `number` | `7` | Initial zoom level |
+| `interactive` | `boolean` | `true` | When `false`, disables pan/zoom and hides zoom controls (public read-only mode) |
+| `markerFormatter` | `string` | `"caseMarkerFormatter"` | Name of a formatter registered in `app.$mapFormatters` |
+| `tileLayer` | `string` | `"pdok-brt"` | Tile layer key resolved by `CnMapWidget` |
+| `clustering` | `boolean` | `true` | Enable `leaflet.markercluster` at zoom < 14 |
+| `height` | `string` | `"400px"` | CSS height (parent typically overrides) |
+
+### Events
+
+| Event | Payload | When |
+|-------|---------|------|
+| `marker-click` | `{ marker, location }` | User clicks a marker — `marker` is the formatter output, `location` is the original input object |
+| `viewport-change` | `{ center: {lat, lon}, zoom, bbox: [w,s,e,n] }` | Debounced 200 ms after `moveend` / `zoomend` |
+| `ready` | `{ map }` | Leaflet map instance is available (rare escape hatch for advanced parents) |
+
+### Marker Icon Strategy
+
+Markers are rendered by the formatter named in `markerFormatter`. The default `caseMarkerFormatter` (already defined by `case-map-overview` T02) returns `{ lat, lon, color, icon, popup, onClick }`. `MapComponent` itself does **not** define formatters — it merely resolves the name from `app.$mapFormatters`. This keeps the wrapper application-agnostic and avoids duplicating palette logic.
+
+Polygon geometries are reduced to centroid markers by the formatter (same arithmetic-mean centroid as `case-map-overview` REQ-CMO-2). Polygons themselves are **not** drawn in MVP — only their centroid pin. Drawing polygon outlines is a future enhancement tracked under `case-location-picker`.
+
+### NL Design System
+
+All colors come from CSS variable tokens via the formatter (no hardcoded hex in `MapComponent.vue`). Container chrome (border, focus ring, attribution text) uses `--color-border`, `--color-primary-element`, `--color-text-maxcontrast`. Empty state when `locations.length === 0` uses `NcEmptyContent` with `icon-address`.
+
+### Accessibility
+
+- Map container: `role="application"`, `aria-label` from i18n key `map.aria-label` (NL: "Kaart met zaaklocaties"; EN: "Map with case locations").
+- Keyboard: arrow keys pan when focused, `+`/`-` zoom, `Enter` activates the focused marker.
+- Each marker exposes an accessible name via the formatter's `popup.title`.
+- When `interactive: false`, the application role is replaced with `role="img"` and the `aria-label` reads `map.aria-label-readonly`.
+
+### Three Integration Points
+
+1. **Case detail map tab** (`src/views/cases/components/CaseMapTab.vue`) — passes the single case's `[caseObj]`, listens to `marker-click` for nothing (single pin) and `viewport-change` to remember last viewport per case.
+2. **Dashboard `CaseMapWidget`** (`src/views/dashboard/CaseMapWidget.vue`) — passes the dashboard's filtered case list, listens to `marker-click` to route to case detail.
+3. **Public case page** (`src/views/public/PublicCaseView.vue`) — passes `[caseObj]` with `interactive: false`, no event handlers.
+
+### Out of Scope
+
+- **Standalone `/map` page** — owned by `case-map-overview` via `CnMapPage`, which is a different lib component aimed at full-page layout with sidebar. `MapComponent` is the embeddable widget variant.
+- **WMS/WFS layers** — future `wms-wfs-layers` change adds layer-switcher config; `MapComponent` will gain a `layers[]` prop then.
+- **Drawing / editing tools** — future `case-location-picker` change.
+- **Heatmaps, 3D, GPS capture** — not on the procest roadmap.

--- a/openspec/changes/map-component/proposal.md
+++ b/openspec/changes/map-component/proposal.md
@@ -1,0 +1,34 @@
+# Proposal: Map Component
+
+## Summary
+
+Introduce a single reusable Procest Vue component — `MapComponent` — that wraps `CnMapWidget` from `@conduction/nextcloud-vue` and serves as the shared map surface for every case detail map tab, dashboard map widget, and public case page map. Today three sibling specs (`case-location`, `case-map-overview`, public case pages) each touch maps directly, leading to drift in marker icons, tile layer defaults, accessibility wiring, and event contracts. This change extracts one canonical component with a stable prop and event API so that all three surfaces render the same way.
+
+## Problem
+
+`case-map-overview` consumes `CnMapPage` for the standalone `/map` route, but the case detail "Locaties" tab (REQ-LOC, `case-location`) and the dashboard small-map widget each instantiate Leaflet or `CnMapWidget` independently, with copy-pasted formatter logic, palette tokens, and bbox helpers. Public case pages — once published — will need a third, read-only embedding. Without a shared component, fixes to clustering, RD→WGS84 conversion, marker accessibility, or NL Design System tokens have to land in three places, and the procest-side wrapper around the lib has no single home.
+
+## Scope -- MVP
+
+**In scope:**
+- `src/components/map/MapComponent.vue` — a thin procest wrapper around `CnMapWidget`
+- Props: `locations[]` (geometry-bearing objects), `center` (lat/lon), `zoom`, `interactive` (boolean), `markerFormatter` (named formatter from `mapFormatters` registry), `tileLayer` (default `pdok-brt`), `clustering` (boolean)
+- Events: `marker-click` (payload: marker descriptor + original object), `viewport-change` (payload: `{center, zoom, bbox}`), `ready` (Leaflet map ready)
+- Wired into: case detail "Map" tab (read-write picker mode), dashboard `CaseMapWidget`, public case page (read-only mode)
+- Registered in `customComponents` so manifest pages can reference it by name
+- NL Design System CSS variable tokens only; WCAG AA keyboard + screen reader
+
+**Out of scope:**
+- Standalone `/map` route (owned by `case-map-overview`)
+- Address validation / PDOK suggest (owned by `case-location`)
+- WMS/WFS custom government layers (future `wms-wfs-layers`)
+- Drawing / editing tools (future `case-location-picker` change once needed)
+- Heatmaps, 3D, mobile-only GPS capture
+
+## Dependencies
+
+- `@conduction/nextcloud-vue` ≥ beta.30 (provides `CnMapWidget`)
+- `case-location` REQ-LOC-1..N (provides the `geometry` field this component reads)
+- `case-map-overview` (consumes `mapFormatters` registry — same pattern used here)
+- Existing `customComponents` registration in `src/main.js`
+- NL Design System CSS variable tokens (no hardcoded hex)

--- a/openspec/changes/map-component/specs/map-component/spec.md
+++ b/openspec/changes/map-component/specs/map-component/spec.md
@@ -1,0 +1,159 @@
+## ADDED Requirements
+
+### Requirement: Reusable Map Component Wrapper (REQ-MC-1)
+
+A single Vue component `MapComponent` SHALL be provided at `src/components/map/MapComponent.vue` as a Procest-side wrapper around `CnMapWidget` from `@conduction/nextcloud-vue` (≥ beta.30). All in-app map embeddings (case detail map tab, dashboard map widget, public case page) SHALL render through this component rather than instantiating `CnMapWidget` or Leaflet directly.
+
+**Feature tier**: V1
+**Standards**: ADR-008 (manifest-driven views), `@conduction/nextcloud-vue` `CnMapWidget`
+
+#### Scenario: Component exists and wraps the lib widget
+
+- **GIVEN** the Procest source tree on the `chore/spec-map-component` branch's implementation
+- **WHEN** the file `src/components/map/MapComponent.vue` is opened
+- **THEN** it SHALL `import { CnMapWidget } from '@conduction/nextcloud-vue'`
+- **AND** its template SHALL render exactly one `<CnMapWidget>` root element
+- **AND** `package.json` peer / dependency on `@conduction/nextcloud-vue` SHALL be `^beta.30` or higher
+
+#### Scenario: All embeddings consume MapComponent
+
+- **GIVEN** the files `src/views/cases/components/CaseMapTab.vue`, `src/views/dashboard/CaseMapWidget.vue`, and `src/views/public/PublicCaseView.vue`
+- **WHEN** each file is searched for direct `CnMapWidget` or `L.map(` (Leaflet) usage
+- **THEN** zero matches SHALL be found
+- **AND** each file SHALL contain at least one `<MapComponent` template reference
+
+---
+
+### Requirement: Component Prop API (REQ-MC-2)
+
+`MapComponent` SHALL expose the following props with defaults: `locations` (array, default `[]`), `center` (`{lat, lon}`, default `{lat: 52.1326, lon: 5.2913}`), `zoom` (number, default `7`), `interactive` (boolean, default `true`), `markerFormatter` (string, default `"caseMarkerFormatter"`), `tileLayer` (string, default `"pdok-brt"`), `clustering` (boolean, default `true`), `height` (string, default `"400px"`).
+
+**Feature tier**: V1
+
+#### Scenario: Default props produce a Netherlands-centred map
+
+- **GIVEN** `<MapComponent />` is mounted with no props
+- **WHEN** the component renders
+- **THEN** the underlying `CnMapWidget` SHALL receive `center.lat: 52.1326`, `center.lon: 5.2913`, `zoom: 7`
+- **AND** the tile layer SHALL be `"pdok-brt"`
+- **AND** clustering SHALL be enabled
+- **AND** the rendered container SHALL have CSS `height: 400px`
+
+#### Scenario: Locations prop drives markers via formatter
+
+- **GIVEN** `<MapComponent :locations="[{ id: 'c1', geometry: {type:'Point', coordinates:[4.87, 52.36]}, title:'Test', status:'open' }]" />`
+- **WHEN** the component mounts and the `caseMarkerFormatter` is registered in `app.$mapFormatters`
+- **THEN** exactly one marker SHALL be rendered on the map
+- **AND** the marker position SHALL be `{lat: 52.36, lon: 4.87}` (±0.0001)
+
+---
+
+### Requirement: Component Events (REQ-MC-3)
+
+`MapComponent` SHALL emit `marker-click`, `viewport-change` (debounced 200 ms), and `ready` events with the payloads defined in `design.md`.
+
+**Feature tier**: V1
+
+#### Scenario: marker-click payload contains marker and original location
+
+- **GIVEN** `MapComponent` is mounted with `locations: [L1]` where `L1.id === "c1"`
+- **WHEN** the user clicks the marker for `L1`
+- **THEN** a `marker-click` event SHALL be emitted exactly once
+- **AND** the event payload SHALL contain `marker` (formatter output: `lat`, `lon`, `color`, `icon`, `popup`, `onClick`)
+- **AND** the event payload SHALL contain `location` referentially equal to `L1` (the original input object)
+
+#### Scenario: viewport-change is debounced
+
+- **GIVEN** `MapComponent` is mounted with `interactive: true`
+- **WHEN** the user pans the map continuously for 1000 ms
+- **THEN** `viewport-change` SHALL be emitted at most 6 times (debounced at 200 ms intervals)
+- **AND** the final emission's `center` SHALL match the final map centre (±0.0001 lat/lon)
+- **AND** the payload SHALL include `bbox` as `[west, south, east, north]`
+
+#### Scenario: ready event exposes the map instance
+
+- **GIVEN** `MapComponent` mounts
+- **WHEN** the underlying Leaflet map instance is constructed
+- **THEN** the `ready` event SHALL be emitted exactly once
+- **AND** the payload SHALL be `{ map }` where `map` is a Leaflet `L.Map` instance
+
+---
+
+### Requirement: Interactive Mode Toggle (REQ-MC-4)
+
+When `interactive: false`, `MapComponent` SHALL disable map dragging, scroll-wheel zoom, double-click zoom, keyboard navigation, and SHALL hide zoom controls. The container `role` SHALL switch from `"application"` to `"img"`.
+
+**Feature tier**: V1
+**Standards**: WCAG AA
+
+#### Scenario: Read-only mode disables all controls
+
+- **GIVEN** `<MapComponent :interactive="false" />`
+- **WHEN** the component renders
+- **THEN** the Leaflet map SHALL be created with `dragging: false`, `scrollWheelZoom: false`, `doubleClickZoom: false`, `boxZoom: false`, `keyboard: false`, `zoomControl: false`
+- **AND** no zoom-control buttons SHALL be present in the rendered DOM
+- **AND** the map container SHALL have `role="img"`
+
+#### Scenario: Interactive mode enables full Leaflet defaults
+
+- **GIVEN** `<MapComponent :interactive="true" />`
+- **WHEN** the component renders
+- **THEN** the Leaflet map SHALL be created with default interaction flags (`dragging: true`, `keyboard: true`, `zoomControl: true`)
+- **AND** the map container SHALL have `role="application"`
+
+---
+
+### Requirement: NL Design System & Accessibility (REQ-MC-5)
+
+`MapComponent` SHALL use NL Design System CSS variable tokens for all colors (no hardcoded hex anywhere in the component) and SHALL meet WCAG AA: keyboard navigation, accessible labels, focus management.
+
+**Feature tier**: V1
+**Standards**: NL Design System color tokens, WCAG AA, i18n (Dutch + English minimum)
+
+#### Scenario: No hardcoded hex values in component
+
+- **GIVEN** the file `src/components/map/MapComponent.vue`
+- **WHEN** searched with regex `#[0-9A-Fa-f]{3,8}\b` excluding comments
+- **THEN** zero matches SHALL be found
+
+#### Scenario: Aria label switches with interactive prop
+
+- **GIVEN** the user locale is Dutch (`nl`)
+- **WHEN** `<MapComponent :interactive="true" />` mounts
+- **THEN** the map container SHALL have `aria-label="Kaart met zaaklocaties"`
+- **AND** when `interactive: false` is set
+- **THEN** the map container SHALL have `aria-label="Kaart met zaaklocaties (alleen-lezen)"`
+- **AND** equivalent English strings SHALL be available via the i18n bundle for locale `en`
+
+#### Scenario: Keyboard navigation in interactive mode
+
+- **GIVEN** `<MapComponent :interactive="true" />` is mounted and focused
+- **WHEN** the user presses `ArrowRight`
+- **THEN** the map centre `lon` SHALL increase
+- **AND** when the user presses `+`
+- **THEN** the map `zoom` SHALL increase by 1
+- **AND** when the user presses `Tab`
+- **THEN** focus SHALL move to the first marker (if any) before leaving the component
+
+---
+
+### Requirement: Registration in customComponents (REQ-MC-6)
+
+`MapComponent` SHALL be registered in the Procest `customComponents` registry in `src/main.js` under the name `"MapComponent"` so that manifest entries and other Procest components MAY reference it by name without explicit imports.
+
+**Feature tier**: V1
+**Standards**: ADR-008 (manifest-driven views)
+
+#### Scenario: Component registered by name
+
+- **GIVEN** the file `src/main.js`
+- **WHEN** the file is opened
+- **THEN** it SHALL import `MapComponent` from `./components/map/MapComponent.vue`
+- **AND** it SHALL register the component in `app.config.globalProperties.$customComponents` (or equivalent registry) under the exact key `"MapComponent"`
+
+#### Scenario: Manifest entry can reference component by name
+
+- **GIVEN** a hypothetical manifest page entry `{ "id": "Demo", "route": "/demo", "type": "custom", "component": "MapComponent" }`
+- **WHEN** the app shell resolves the route
+- **THEN** the registered `MapComponent` SHALL be rendered
+- **AND** no console error SHALL be emitted about an unknown component name

--- a/openspec/changes/map-component/tasks.md
+++ b/openspec/changes/map-component/tasks.md
@@ -1,0 +1,39 @@
+# Tasks: map-component
+
+## Deduplication Check
+
+- [ ] **D01**: Verify no `MapComponent.vue` (or similarly-named wrapper) already exists in `src/components/` — `grep -r "MapComponent" src/` and `find src/ -iname "*map*.vue"`. Document finding: existing `src/views/CaseMapView.vue` is being deleted by `case-map-overview`; the dashboard `CaseMapWidget.vue` currently calls Leaflet directly and is the target consumer of this new component.
+- [ ] **D02**: Confirm `case-location` and `case-map-overview` changes land before this one so `case.geometry`, the `mapFormatters` registry, and `caseMarkerFormatter` exist. Document finding: this change depends on REQ-LOC-* and REQ-CMO-* infrastructure.
+
+---
+
+## Implementation Tasks
+
+### Component
+
+- [ ] **T01**: Create `src/components/map/MapComponent.vue` as a Vue 2 SFC that wraps `CnMapWidget` from `@conduction/nextcloud-vue` (≥ beta.30). Implement the full prop surface from `design.md` (`locations`, `center`, `zoom`, `interactive`, `markerFormatter`, `tileLayer`, `clustering`, `height`) with defaults matching the design table. Emit `marker-click`, `viewport-change` (debounced 200 ms), and `ready` per the event table. No hardcoded hex; no inline styles that override NL Design System tokens. Add JSDoc on the props block. Add `role="application"` / `role="img"` switching based on `interactive` prop, with i18n labels `map.aria-label` and `map.aria-label-readonly` from `src/l10n/`.
+
+### Registration
+
+- [ ] **T02**: Register `MapComponent` in the `customComponents` registry in `src/main.js` under the name `MapComponent` (mirror the registration pattern used by `widgetComponents` and `mapFormatters`). This makes the component referenceable by name from manifest entries and from other Procest components without explicit imports.
+
+### Case Detail Integration
+
+- [ ] **T03**: In `src/views/cases/components/CaseMapTab.vue` (or create it if missing as part of this change), replace any direct Leaflet / `CnMapWidget` usage with `<MapComponent :locations="[caseObj]" :interactive="true" @marker-click="..." />`. Wire `viewport-change` to a local component-state cache keyed on `caseObj.id` so that toggling tabs preserves the last viewport for that case. Remove any inline marker creation code.
+
+### Dashboard Widget Integration
+
+- [ ] **T04**: In `src/views/dashboard/CaseMapWidget.vue`, replace the existing direct Leaflet/`CnMapWidget` block with `<MapComponent :locations="filteredCases" :clustering="true" @marker-click="onPinClick" />`. `onPinClick` SHALL navigate to `/cases/:id` using `$router.push({ name: 'CaseDetail', params: { id: payload.location.id } })`. Delete any duplicated formatter or palette imports from the widget — they now live in the formatter referenced by `MapComponent`.
+
+### Public Case Page Integration
+
+- [ ] **T05**: In `src/views/public/PublicCaseView.vue` (create the read-only public case view file structure if not yet present), embed `<MapComponent :locations="[caseObj]" :interactive="false" :clustering="false" />`. No event handlers — the public page is read-only. Confirm the `role="img"` branch is taken and no pan/zoom controls render. Public access path is `/public/case/:token`.
+
+---
+
+## Verification Tasks
+
+- [ ] **V01**: Mount `MapComponent` in isolation (unit test or Storybook-style page) with three `locations`: one Point, one Polygon (renders centroid), one with `geometry: null` (skipped). Assert exactly two markers render and clicking one emits `marker-click` carrying both the formatter output and the original object.
+- [ ] **V02**: Embed the component in the case detail map tab and confirm: tile layer is PDOK BRT, default centre is the case's marker (not Netherlands default, because the formatter sets initial bounds), keyboard arrow keys pan the map, and `Tab` reaches the marker.
+- [ ] **V03**: Embed in the dashboard widget with 50 seed cases; confirm clustering is active at zoom 8, individual pins appear at zoom 14, and clicking a pin navigates to `/cases/:id`.
+- [ ] **V04**: Embed in the public case page with `interactive: false`; confirm: zoom controls are hidden, dragging the map does not pan, arrow keys do not pan, `role="img"` is present on the map container, and `aria-label` reads the read-only i18n string in both NL and EN locales. Run `axe-core` against the page — zero violations.


### PR DESCRIPTION
## Summary

Generates a new OpenSpec change `map-component` proposing a single reusable `MapComponent.vue` that wraps `CnMapWidget` from `@conduction/nextcloud-vue` (>= beta.30) and serves as the shared map surface for three Procest embeddings:

- Case detail map tab
- Dashboard `CaseMapWidget`
- Public case page (read-only mode)

Sister spec to `case-location` (provides the `geometry` field) and `case-map-overview` (provides the `mapFormatters` registry and the `caseMarkerFormatter`). This is the shared base for all in-app map embeddings; the standalone `/map` page stays with `case-map-overview` and its `CnMapPage`.

**Spec only -- no code.** STRICT validation passes (`openspec change validate map-component --strict`).

## Contents

- `openspec/changes/map-component/proposal.md` -- need / scope / dependencies (case-location + case-map-overview as upstream)
- `openspec/changes/map-component/design.md` -- component API, marker icon strategy, NL Design System tokens, WCAG AA accessibility, three integration points
- `openspec/changes/map-component/tasks.md` -- T01 component, T02 customComponents registration, T03 case detail tab, T04 dashboard widget, T05 public case page; V01-V04 verification
- `openspec/changes/map-component/specs/map-component/spec.md` -- 6 ADDED requirements (REQ-MC-1..6) with 16 Given/When/Then scenarios

## Requirements

- **REQ-MC-1** Reusable wrapper around `CnMapWidget`
- **REQ-MC-2** Component prop API (8 props with documented defaults)
- **REQ-MC-3** Events (`marker-click`, `viewport-change` debounced 200ms, `ready`)
- **REQ-MC-4** Interactive mode toggle (read-only public mode)
- **REQ-MC-5** NL Design System tokens + WCAG AA + i18n NL/EN
- **REQ-MC-6** Registration in `customComponents` registry

## Test plan

- [ ] `openspec change validate map-component --strict` passes (verified locally)
- [ ] PR reviewed for scope boundaries vs. `case-location` and `case-map-overview`
- [ ] No code changes in this PR -- spec only