### PR TITLE
chore(openspec): generate pdok-integration spec

### DIFF
--- a/openspec/changes/pdok-integration/design.md
+++ b/openspec/changes/pdok-integration/design.md
@@ -1,0 +1,107 @@
+# Design: pdok-integration
+
+## Architecture Overview
+
+PDOK integration is implemented as three sibling services behind one admin settings tab, all sharing a single cache decorator and a single rate-limit guard. Every consumer in Procest (case-location, case-map-overview, map-component) talks to these services rather than directly to `service.pdok.nl` or `api.pdok.nl`. When the admin configures an OpenConnector source for any PDOK service, all outbound HTTP from that service is rerouted through OpenConnector; otherwise the services call PDOK directly.
+
+```
+Consumers
+├── LocationService            (case-location)
+├── CaseMapOverviewService     (case-map-overview)
+└── MapComponent (Vue)         (map-component, basemap config only)
+
+Services (this change)
+├── PdokLocatieserverService   ── suggest, free, lookup, reverse        (v3_1)
+├── PdokBagService             ── nummeraanduiding, verblijfsobject, pand
+└── PdokKadasterService        ── kadastraal perceel by aanduiding
+
+Decorators
+├── PdokCache (APCu)           ── lookup/reverse/BAG 24 h, suggest 5 min
+└── PdokRateGuard              ── per-service token bucket, default 10 rps
+
+Admin
+└── PdokSettingsTab            ── endpoint overrides + OpenConnector toggles
+```
+
+## File Map
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `lib/Service/Pdok/PdokLocatieserverService.php` | suggest, free, lookup, reverse against v3_1 |
+| `lib/Service/Pdok/PdokBagService.php` | nummeraanduiding lookup, verblijfsobject detail, pand footprint |
+| `lib/Service/Pdok/PdokKadasterService.php` | kadastraal perceel by aanduiding |
+| `lib/Service/Pdok/PdokCache.php` | APCu wrapper, per-method TTL |
+| `lib/Service/Pdok/PdokRateGuard.php` | token bucket, configurable ceiling |
+| `lib/Service/Pdok/PdokSettingsService.php` | reads/writes PDOK endpoint config from IAppConfig |
+| `lib/Controller/PdokController.php` | proxies `/suggest`, `/reverse`, `/bag/*` for the frontend |
+| `lib/Repair/SeedPdokBasemaps.php` | seeds the four default `MapLayer` rows on install/update |
+| `src/views/settings/tabs/PdokSettingsTab.vue` | admin UI for endpoint overrides + outage banner copy |
+| `src/services/pdokApi.js` | frontend client used by autocomplete + map preview |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `lib/Service/LocationService.php` | swap private `PdokLocatieserverClient` for `PdokLocatieserverService` injection |
+| `lib/Settings/procest_register.json` | extend `MapLayer` schema if missing fields surface during seeding |
+| `appinfo/routes.php` | register `/api/pdok/*` routes |
+| `lib/Service/SettingsService.php` | add `pdok_*` config keys (endpoints, OpenConnector sources, cache TTL, rate ceiling) |
+
+## Data Model
+
+### PDOK config (IAppConfig, app namespace `procest`)
+
+| Key | Type | Default | Purpose |
+|-----|------|---------|---------|
+| `pdok_locatieserver_endpoint` | string | `https://api.pdok.nl/bzk/locatieserver/search/v3_1` | base URL for Locatieserver |
+| `pdok_bag_endpoint` | string | `https://service.pdok.nl/lv/bag/wfs/v2_0` | base URL for BAG WFS |
+| `pdok_kadaster_endpoint` | string | `https://service.pdok.nl/kadaster/kadastralekaart/wfs/v5_0` | base URL for Kadaster WFS |
+| `pdok_locatieserver_source` | string | `` | OpenConnector source slug; empty = direct |
+| `pdok_bag_source` | string | `` | idem for BAG |
+| `pdok_kadaster_source` | string | `` | idem for Kadaster |
+| `pdok_cache_lookup_ttl_seconds` | integer | `86400` | TTL for lookup/reverse/BAG |
+| `pdok_cache_suggest_ttl_seconds` | integer | `300` | TTL for suggest |
+| `pdok_rate_ceiling_rps` | integer | `10` | per-service ceiling |
+| `pdok_outage_banner_nl` | string | `Achtergrondkaart tijdelijk niet beschikbaar` | shown when 5xx persists |
+| `pdok_outage_banner_en` | string | `Basemap temporarily unavailable` | i18n companion |
+
+### Seeded `MapLayer` rows (via repair step)
+
+| title | type | isBaseLayer | isDefault | Notes |
+|-------|------|-------------|-----------|-------|
+| BRT Achtergrondkaart | WMTS | true | true | Default base layer |
+| BRT Achtergrondkaart Grijs | WMTS | true | false | Print-friendly fallback |
+| Luchtfoto | WMTS | true | false | Aerial imagery, most recent vintage |
+| NL Design System | WMTS | true | false | Government-themed base, used when `theme = nldesign` |
+
+## API Surface
+
+| Method | URL | Purpose |
+|--------|-----|---------|
+| GET | `/api/pdok/suggest?q=...&fq=...` | Locatieserver suggest passthrough |
+| GET | `/api/pdok/free?q=...` | Locatieserver free passthrough |
+| GET | `/api/pdok/lookup?id=...` | Locatieserver lookup by result id |
+| GET | `/api/pdok/reverse?lat=...&lng=...` | Locatieserver reverse |
+| GET | `/api/pdok/bag/nummeraanduiding/{id}` | BAG nummeraanduiding lookup |
+| GET | `/api/pdok/bag/verblijfsobject/{id}` | BAG verblijfsobject detail |
+| GET | `/api/pdok/bag/pand/{id}` | BAG pand footprint |
+| GET | `/api/pdok/kadaster/perceel?aanduiding=...` | BRK perceel by aanduiding |
+| GET | `/api/pdok/basemaps` | Active basemap config for the map component |
+| GET | `/api/pdok/health` | Liveness check; used by the map component to decide whether to render the outage banner |
+
+## Caching & Rate-Limit Strategy
+
+- Lookup/reverse/BAG/Kadaster responses cached for 24 h keyed on the full request signature.
+- Suggest cached for 5 min keyed on `q` plus active `fq` filters.
+- Cache backend is APCu (already used elsewhere in Procest); a hit bypasses the rate guard.
+- The rate guard uses a token bucket at `pdok_rate_ceiling_rps` per service; bursts are smoothed; a denied call returns the cached fallback when available, otherwise `429 pdok.rate-limited`.
+
+## Outage Handling
+
+The Locatieserver service tracks consecutive 5xx responses in a rolling window. After 3 failures within 60 s the service enters a 5 min "degraded" state: `/api/pdok/health` reports `degraded`, the map component shows the configured outage banner, and `/api/pdok/suggest` short-circuits to an empty result set so the user can still type a free-text address and save the case (which the LocationService will then store with `source = free` instead of `bag`). The service self-clears the degraded state on the first successful response after the cool-down.
+
+## Auth
+
+All PDOK endpoints used here are open, anonymous, and rate-limited by the public IP. No keys are stored. The only auth path is the OpenConnector source slug, which carries its own credentials inside OpenConnector's vault — never duplicated in Procest config.

--- a/openspec/changes/pdok-integration/proposal.md
+++ b/openspec/changes/pdok-integration/proposal.md
@@ -1,0 +1,37 @@
+# Proposal: PDOK Integration
+
+## Summary
+
+Introduce a centralised PDOK (Publieke Dienstverlening Op de Kaart) integration layer in Procest that consolidates address autocomplete, free-text + structured geocoding, reverse geocoding, BAG nummeraanduiding/verblijfsobject/pand lookup, kadastraal perceel resolution, and basemap tile configuration behind a small set of server-side services and a single admin settings page. Sister specs (`case-location`, `case-map-overview`, `map-component`) become consumers of these services rather than each carrying their own PDOK client.
+
+## Problem
+
+PDOK access today is scattered: `case-location` ships its own `PdokLocatieserverClient`, `map-component` hard-codes BRT Achtergrondkaart and Luchtfoto tile URLs, and BAG / Kadaster lookups have no canonical home. There is no shared cache, no shared rate limiting, no shared admin surface to switch endpoints between PDOK direct and an OpenConnector proxy, and no plan for degraded operation when PDOK is unreachable (a recurring failure mode for Dutch government apps during PDOK maintenance windows). Without a single integration layer we will duplicate retry/cache/error code across every consumer and force every municipality that requires proxied egress to configure the same source N times.
+
+## Scope -- MVP
+
+**In scope:**
+- `PdokLocatieserverService` (suggest, free, lookup, reverse) — owns the v3_1 contract
+- `PdokBagService` (nummeraanduiding by id, verblijfsobject details, pand footprint by id) via PDOK BAG WFS / OGC API Features
+- `PdokKadasterService` (kadastraal perceel by aanduiding) — read-only
+- Basemap configuration set (BRT Achtergrondkaart, BRT-A Grijs, Luchtfoto, NL Design System default) registered as `MapLayer` rows
+- Admin settings tab "PDOK" — endpoint overrides, OpenConnector source toggles, cache TTL, rate-limit ceiling, outage banner copy
+- Shared APCu cache layer (24 h for lookup/reverse/BAG, 5 min for suggest)
+- Graceful degradation: when PDOK 5xx persists, surface "Achtergrondkaart tijdelijk niet beschikbaar" and short-circuit autocomplete to typed input only
+- Refactor `case-location` to consume `PdokLocatieserverService` instead of its private client (REQ-CL-3 stays satisfied through delegation)
+
+**Out of scope:**
+- Off-line / pre-baked tile bundles for fully air-gapped deployments
+- BGT (Basisregistratie Grootschalige Topografie) and BRO (Bodem/Ondergrond) — future spec
+- Cadastral parcel **geometry** rendering — only the BRK identifier is resolved; geometry remains a follow-up
+- WMS/WFS authoring UX for custom municipal layers (lives in a future `wms-wfs-layers` spec)
+- Writing back to BAG / Kadaster — PDOK is read-only
+
+## Dependencies
+
+- `case-location` (consumer; client refactor lands as part of this change)
+- `case-map-overview` (consumes basemap config)
+- `map-component` (consumes basemap config + cluster colour scheme; not modified by this change)
+- OpenConnector (optional proxied egress source per service)
+- OpenRegister `geo-metadata-kaart` capability (ADR-022) for the `MapLayer` schema home
+- PDOK Locatieserver v3_1, PDOK BAG WFS, PDOK Kadaster WFS — all open, no auth

--- a/openspec/changes/pdok-integration/specs/pdok-integration/spec.md
+++ b/openspec/changes/pdok-integration/specs/pdok-integration/spec.md
@@ -1,0 +1,164 @@
+## ADDED Requirements
+
+### Requirement: REQ-PDOK-1 Centralised Locatieserver Service
+
+The system SHALL provide a single `PdokLocatieserverService` that wraps the PDOK Locatieserver v3_1 endpoints `/suggest`, `/free`, `/lookup`, and `/reverse`. The service SHALL be the sole ingress for every Locatieserver call in Procest; no other class may instantiate an HTTP client targeting the Locatieserver host. When the `pdok_locatieserver_source` IAppConfig key is non-empty, outbound HTTP SHALL be dispatched through the configured OpenConnector source. Each call SHALL emit a structured log line containing method, cache hit/miss, and elapsed milliseconds.
+
+**Feature tier**: V1
+
+#### Scenario: Suggest call routed through OpenConnector when source is configured
+
+- **GIVEN** the admin has set `pdok_locatieserver_source` to a valid OpenConnector source slug
+- **WHEN** a consumer invokes `PdokLocatieserverService::suggest("Keizersgracht")`
+- **THEN** the outbound HTTP request SHALL be dispatched through OpenConnector
+- **AND** the Locatieserver public hostname SHALL NOT appear in the Procest container's outbound HTTP audit
+- **AND** the response SHALL be a non-empty result list
+
+#### Scenario: No other class may bypass the service
+
+- **WHEN** the codebase is scanned for direct references to the Locatieserver public hostname outside `lib/Service/Pdok/`
+- **THEN** zero matches SHALL be found
+- **AND** the legacy `PdokLocatieserverClient` class from the case-location change SHALL no longer exist in the tree
+
+### Requirement: REQ-PDOK-2 BAG Service
+
+The system SHALL provide a `PdokBagService` exposing `getNummeraanduiding(id)`, `getVerblijfsobject(id)`, and `getPand(id)` against the PDOK BAG WFS v2_0. Responses SHALL be normalised to a stable Procest-internal shape: snake_case fields converted to camelCase, `bouwjaar` always an integer, `oppervlakte` always an integer expressed in square metres, and `gebruiksdoel` always an array (even when the upstream returns a single string). When `pdok_bag_source` is non-empty, outbound HTTP SHALL be routed through OpenConnector.
+
+**Feature tier**: V1
+
+#### Scenario: Nummeraanduiding lookup returns normalised shape
+
+- **GIVEN** a known nummeraanduiding id `0363200000406567`
+- **WHEN** `PdokBagService::getNummeraanduiding("0363200000406567")` is called
+- **THEN** the response SHALL contain `bouwjaar` as an integer
+- **AND** `oppervlakte` SHALL be an integer expressed in square metres
+- **AND** `gebruiksdoel` SHALL be an array (length ≥ 1)
+- **AND** all field names SHALL be camelCase
+
+#### Scenario: Unknown nummeraanduiding surfaces as null
+
+- **GIVEN** a malformed or unknown nummeraanduiding id `9999999999999999`
+- **WHEN** the service is queried
+- **THEN** the service SHALL return `null` (not throw) so that the LocationService can translate it into a 422 with `nummeraanduidingId.not-found`
+
+### Requirement: REQ-PDOK-3 Default Basemap Configuration
+
+The system SHALL register, on app install and update, exactly four default `MapLayer` rows: "BRT Achtergrondkaart", "BRT Achtergrondkaart Grijs", "Luchtfoto", and "NL Design System". "BRT Achtergrondkaart" SHALL be `isDefault = true` when the active theme is the standard Nextcloud theme; "NL Design System" SHALL be `isDefault = true` only when the nldesign theme is active. The repair step SHALL be idempotent: re-running it SHALL NOT create duplicate rows and SHALL NOT overwrite admin-edited title, attribution, or order fields.
+
+**Feature tier**: V1
+
+#### Scenario: First install seeds four rows with the correct default
+
+- **GIVEN** a fresh Procest install with the standard theme active
+- **WHEN** `SeedPdokBasemaps::run()` executes
+- **THEN** exactly four `MapLayer` rows SHALL exist with slugs prefixed `pdok-`
+- **AND** the row "BRT Achtergrondkaart" SHALL have `isDefault = true`
+- **AND** the other three rows SHALL have `isDefault = false`
+
+#### Scenario: Repair step preserves admin edits
+
+- **GIVEN** an admin has renamed "BRT Achtergrondkaart" to "Topografische kaart" and changed its display order
+- **WHEN** `SeedPdokBasemaps::run()` executes for the second time
+- **THEN** the row count SHALL remain four
+- **AND** the renamed title and adjusted order SHALL be preserved unchanged
+
+### Requirement: REQ-PDOK-4 Admin Settings Page
+
+The system SHALL expose a "PDOK" tab in the Procest admin settings that surfaces every key documented in `design.md` §PDOK config: three endpoint URLs, three OpenConnector source slugs, two cache TTLs, one rate-limit ceiling, and two outage banner copies (nl + en). Endpoint URLs without a scheme or host SHALL be rejected both client-side and server-side. A "Test verbinding" button per service SHALL call the corresponding `/api/pdok/health` route and surface ok/degraded.
+
+**Feature tier**: V1
+
+#### Scenario: Invalid endpoint URL is rejected server-side
+
+- **GIVEN** an admin submits `pdok_locatieserver_endpoint = "not a url"`
+- **WHEN** the settings controller validates the payload
+- **THEN** the response SHALL be HTTP 422 with error code `endpoint.invalid-url`
+- **AND** the existing value SHALL remain unchanged in IAppConfig
+
+#### Scenario: Test verbinding reflects degraded state
+
+- **GIVEN** the Locatieserver service is currently in degraded state
+- **WHEN** the admin clicks "Test verbinding" for Locatieserver
+- **THEN** the UI SHALL display `degraded` together with the configured outage banner copy
+
+### Requirement: REQ-PDOK-5 Case-Location Consumer Integration
+
+The `LocationService` from the `case-location` change SHALL consume `PdokLocatieserverService` via constructor injection. The legacy `PdokLocatieserverClient` class SHALL be removed from the tree as part of this change. All REQ-CL-3 scenarios from `case-location` SHALL keep passing through the new shared service without any change to their wording.
+
+**Feature tier**: V1
+
+#### Scenario: LocationService delegates suggest to the shared service
+
+- **GIVEN** a consumer of `LocationService` invokes the suggest path used by the case-location autocomplete
+- **WHEN** the call is dispatched
+- **THEN** the only HTTP egress SHALL originate from `PdokLocatieserverService` (or its OpenConnector replacement)
+- **AND** no PDOK URL SHALL be referenced inside `lib/Service/LocationService.php`
+
+#### Scenario: Reverse-geocode path still satisfies REQ-CL-5
+
+- **GIVEN** a payload `{case, source: "pdok-reverse", latitude: 52.3702, longitude: 4.8897}`
+- **WHEN** the LocationService saves the location
+- **THEN** `formattedAddress` and (when within 25 m) `nummeraanduidingId` SHALL be populated by the response of `PdokLocatieserverService::reverse(...)`
+- **AND** the saved row SHALL match the REQ-CL-5 expectations from the case-location spec
+
+### Requirement: REQ-PDOK-6 Shared Cache Layer
+
+The system SHALL provide an APCu-backed cache shared across all PDOK services. Cache TTLs SHALL be configurable via IAppConfig: `pdok_cache_lookup_ttl_seconds` (default 86400) for lookup, reverse, BAG, and Kadaster responses; `pdok_cache_suggest_ttl_seconds` (default 300) for suggest. Cache keys SHALL include the full request signature including filter parameters so that filtered and unfiltered requests do not collide. The cache SHALL be purgeable from the admin settings tab with a single action.
+
+**Feature tier**: V1
+
+#### Scenario: BAG lookup is served from cache on the second call
+
+- **GIVEN** a fresh APCu cache and a call to `GET /api/pdok/bag/nummeraanduiding/0363200000406567`
+- **WHEN** a second call for the same id arrives within 24 hours
+- **THEN** the second response SHALL carry the header `X-Pdok-Cache: hit`
+- **AND** the upstream BAG WFS audit SHALL show exactly one request for the id
+
+#### Scenario: Filtered suggest does not collide with unfiltered suggest
+
+- **GIVEN** an unfiltered cached response for `suggest(q = "Keizersgracht")`
+- **WHEN** a filtered call `suggest(q = "Keizersgracht", fq = "type:adres")` arrives
+- **THEN** the filtered call SHALL not be served from the unfiltered cache entry
+- **AND** the filtered response SHALL be persisted under its own key
+
+### Requirement: REQ-PDOK-7 Outage Handling
+
+When the Locatieserver service receives three or more 5xx responses within a rolling 60 second window, it SHALL enter a `degraded` state for at least 5 minutes. During the degraded window, `GET /api/pdok/health` SHALL report `degraded`, the map component SHALL show the configured outage banner, and `GET /api/pdok/suggest` SHALL short-circuit to an empty array so consumers can still capture user-typed input. The service SHALL self-clear the `degraded` state on the first successful response after the cool-down.
+
+**Feature tier**: V1
+
+#### Scenario: Three upstream 5xx responses flip the service to degraded
+
+- **GIVEN** the service is currently in `ok` state
+- **WHEN** three consecutive Locatieserver calls return HTTP 503 within a 30 second span
+- **THEN** `GET /api/pdok/health` SHALL report `degraded` for the next 5 minutes
+- **AND** `GET /api/pdok/suggest?q=Keizersgracht` SHALL return an empty array during that window
+
+#### Scenario: Free-text save path remains usable during outage
+
+- **GIVEN** the Locatieserver service is in `degraded` state
+- **WHEN** a user saves a case-location with a typed address but no PDOK match
+- **THEN** the LocationService SHALL accept the row with `source = free`
+- **AND** the row SHALL persist with `nummeraanduidingId = null`
+
+### Requirement: REQ-PDOK-8 Rate Limiting
+
+The system SHALL apply a per-service token-bucket rate limiter at the ceiling configured by `pdok_rate_ceiling_rps` (default 10 requests per second). Cache hits SHALL bypass the limiter. When the limiter denies a call and no cached fallback is available, the response SHALL be HTTP 429 with error code `pdok.rate-limited` and a `Retry-After` header.
+
+**Feature tier**: V1
+
+#### Scenario: Rate ceiling enforced on uncached traffic
+
+- **GIVEN** `pdok_rate_ceiling_rps = 5`
+- **AND** an empty cache
+- **WHEN** ten unique suggest calls arrive within a single second
+- **THEN** at least five calls SHALL succeed
+- **AND** the denied calls SHALL respond with HTTP 429, error code `pdok.rate-limited`, and a `Retry-After` header
+
+#### Scenario: Cache hits bypass the limiter
+
+- **GIVEN** `pdok_rate_ceiling_rps = 1`
+- **AND** a cached suggest response for `q = "Keizersgracht"`
+- **WHEN** 50 identical suggest calls arrive within a single second
+- **THEN** every call SHALL succeed with HTTP 200
+- **AND** zero calls SHALL be denied by the limiter

--- a/openspec/changes/pdok-integration/tasks.md
+++ b/openspec/changes/pdok-integration/tasks.md
@@ -1,0 +1,34 @@
+# Tasks: pdok-integration
+
+## Implementation Tasks
+
+### Backend: PDOK Services
+
+- [ ] **T01**: Create `lib/Service/Pdok/PdokLocatieserverService.php` wrapping the PDOK Locatieserver v3_1 endpoints `/suggest`, `/free`, `/lookup`, and `/reverse`. The service MUST be the single ingress for every Locatieserver call in Procest; no other class may instantiate an HTTP client targeting `api.pdok.nl/bzk/locatieserver`. When the `pdok_locatieserver_source` IAppConfig key is non-empty, outbound HTTP MUST be dispatched through that OpenConnector source. The service MUST emit a structured log line per call with method, cache hit/miss, and elapsed ms.
+
+- [ ] **T02**: Create `lib/Service/Pdok/PdokBagService.php` exposing `getNummeraanduiding(id)`, `getVerblijfsobject(id)`, and `getPand(id)` against the PDOK BAG WFS v2_0. Responses MUST be normalised to a stable Procest-internal shape (snake → camel, `bouwjaar` always integer, `oppervlakte` always integer m2, `gebruiksdoel` always array). When `pdok_bag_source` is non-empty, route through OpenConnector. Cache hits MUST bypass the rate guard.
+
+- [ ] **T03**: Seed the four default `MapLayer` rows defined in `design.md` §Data Model via a new `lib/Repair/SeedPdokBasemaps.php` repair step. The "BRT Achtergrondkaart" row MUST have `isDefault = true`; the "NL Design System" row MUST have `isDefault = true` ONLY when the nldesign theme is active. The repair step MUST be idempotent — re-running it MUST NOT create duplicate rows nor overwrite admin-edited titles, attributions, or order.
+
+### Backend: Admin Settings & Controller
+
+- [ ] **T04**: Build `src/views/settings/tabs/PdokSettingsTab.vue` and the matching `lib/Controller/PdokSettingsController.php` endpoints. The tab MUST surface every key from `design.md` §PDOK config: three endpoint URLs, three OpenConnector source slugs, two cache TTLs, one rate ceiling, and the two outage banner copies (nl + en). Saving an invalid URL (no scheme, no host) MUST be rejected client-side AND server-side. A "Test verbinding" button per service MUST call `/api/pdok/health` for that service.
+
+- [ ] **T05**: Refactor `lib/Service/LocationService.php` (from the case-location change) to depend on `PdokLocatieserverService` via constructor injection instead of its private `PdokLocatieserverClient`. The private client class MUST be deleted in this change. The existing REQ-CL-3 scenarios MUST keep passing — verified by the case-location V01–V04 tasks running unchanged against the new service.
+
+### Backend: Caching, Rate Limiting, Outage
+
+- [ ] **T06**: Create `lib/Service/Pdok/PdokCache.php` (APCu wrapper) and wire it as a decorator around every method on the three services. TTL MUST come from IAppConfig (`pdok_cache_lookup_ttl_seconds`, `pdok_cache_suggest_ttl_seconds`). Cache keys MUST include the full request signature including filter (`fq`) parameters so that filtered suggests do not collide with unfiltered ones. Cache MUST be purgeable from the admin tab with a single button.
+
+### Frontend: Consumer Wiring
+
+- [ ] **T07**: Replace direct `fetch('https://api.pdok.nl/...')` calls in any existing Vue component with `src/services/pdokApi.js`, which targets `/api/pdok/*`. The map component MUST read its basemap list from `GET /api/pdok/basemaps` instead of carrying hard-coded URLs. The location autocomplete (case-location `LocationEditDialog.vue`) MUST switch from its private suggest call to `pdokApi.suggest(q)`.
+
+- [ ] **T08**: Add an outage banner to `src/views/cases/components/CaseMap.vue` and `src/views/dashboard/CaseMapWidget.vue` driven by `GET /api/pdok/health`. When `health = degraded` the banner MUST be visible with the configured nl/en copy; when `health = ok` the banner MUST be hidden. The banner MUST NOT block map interaction (zoom, pan, marker clicks).
+
+## Verification Tasks
+
+- [ ] **V01**: With `pdok_locatieserver_source` set to a valid OpenConnector source, calling `GET /api/pdok/suggest?q=Keizersgracht` MUST result in zero direct HTTP requests to `api.pdok.nl` from the Procest container (verified via outbound HTTP audit) and a non-empty result list in the response.
+- [ ] **V02**: Calling `GET /api/pdok/bag/nummeraanduiding/0363200000406567` twice within 24 hours MUST result in exactly one upstream BAG WFS request; the second call MUST be served from APCu with a `cache: hit` indicator in the response headers.
+- [ ] **V03**: Simulating three consecutive Locatieserver 5xx responses within 60 s MUST flip `GET /api/pdok/health` to `degraded` for at least 5 min; during that window `GET /api/pdok/suggest` MUST return an empty array and `LocationService::create` MUST accept a payload with `source = free` that would normally have been required to be `source = bag`.
+- [ ] **V04**: Running `SeedPdokBasemaps::run()` twice in a row MUST result in exactly four `MapLayer` rows with `slug` prefixed `pdok-` and the admin edits made between the two runs MUST be preserved (title, attribution, and order fields untouched on the second pass).


### PR DESCRIPTION
## Summary

- Generates a new OpenSpec change `pdok-integration` that consolidates every PDOK touchpoint in Procest into a single integration layer: `PdokLocatieserverService`, `PdokBagService`, `PdokKadasterService`, default `MapLayer` basemap seeding, an admin "PDOK" settings tab, a shared APCu cache, a per-service rate guard, and a degraded-mode outage handler.
- Refactors case-location's private `PdokLocatieserverClient` into the shared service (REQ-PDOK-5) so `case-location`, `case-map-overview`, and `map-component` all consume the same surface — no more duplicate clients, hard-coded tile URLs, or per-app OpenConnector source plumbing.
- Spec only. No PHP, Vue, or config changes in this PR.

## Delta

- 8 new requirements: REQ-PDOK-1 (Locatieserver service), REQ-PDOK-2 (BAG service), REQ-PDOK-3 (default basemaps), REQ-PDOK-4 (admin settings page), REQ-PDOK-5 (case-location consumer), REQ-PDOK-6 (shared cache), REQ-PDOK-7 (outage handling), REQ-PDOK-8 (rate limiting).
- 8 implementation tasks (T01–T08) + 4 verification tasks (V01–V04).
- Strict validation: `openspec validate pdok-integration --strict --type change` passes.

## Test plan

- [ ] `openspec validate pdok-integration --strict` passes locally
- [ ] No code changes in this PR (verified via `git diff --stat`)
- [ ] Existing spec `openspec/specs/pdok-integration/spec.md` is unchanged — this change adds eight new REQ-PDOK-* requirements that will be merged on archive