### PR TITLE
chore(openspec): generate wms-wfs-layers spec

### DIFF
--- a/openspec/changes/wms-wfs-layers/design.md
+++ b/openspec/changes/wms-wfs-layers/design.md
@@ -1,0 +1,93 @@
+# Design: wms-wfs-layers
+
+## Architecture Overview
+
+`wms-wfs-layers` is a config-driven extension of the existing `map-component`. Admins describe each WMS/WFS endpoint as a `wmsLayer` object; each `caseType` carries an array of subscribed `layerIds`; the `CaseMap` reads the active case type, resolves its layer set, and renders the overlays plus a legend. All network access flows through the existing GIS proxy (REQ-LAYER-03 in the parent `wms-wfs-layers` spec) — this change does not introduce a new backend network path.
+
+```
+Admin
+└── Settings > Kaartlagen (manifest index page on wmsLayer)
+    └── Kaartlaag form (title, type, url, layerName, srs, opacity, attribution, queryable)
+
+Case-type admin
+└── "Kaartlagen" tab (multiselect of wmsLayer objects → caseType.layerIds)
+
+Case/overview map
+└── CaseMap (CnMapPage)
+    ├── layerIds prop (from active caseType)
+    ├── WmsWfsService client (GetMap / GetFeature via /api/gis/proxy)
+    ├── Layer toggle + opacity slider (per-layer)
+    └── Legend renderer (title + colour swatch + attribution)
+```
+
+## File Map
+
+### New Backend Files
+
+| File | Purpose |
+|------|---------|
+| `lib/Service/WmsWfsService.php` | Client for GetCapabilities, GetMap, GetFeature; routes all outbound traffic through `GisProxyController`; parses capabilities XML for admin "test connection" feature |
+
+### New Frontend Files
+
+| File | Purpose |
+|------|---------|
+| `src/components/map/MapLayerLegend.vue` | Legend component: per-layer toggle, opacity slider, attribution line |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `lib/Settings/procest_register.json` | Add `wmsLayer` schema; add `layerIds: array` field to existing `caseType` schema |
+| `lib/Service/SettingsService.php` | Add `wmsLayer` to CONFIG_KEYS and SLUG_TO_CONFIG_KEY |
+| `src/manifest.json` | Add admin `index` page on `wmsLayer` (no `component` key — manifest-driven per ADR-008) |
+| `src/views/caseTypes/CaseTypeDetail.vue` | Add "Kaartlagen" tab with multiselect of available `wmsLayer` objects |
+| `src/components/map/CaseMap.vue` (or `CnMapPage` wrapper) | Add `layerIds` prop; on mount resolve to `wmsLayer` objects; render overlays via `WmsWfsService`; mount `MapLayerLegend` |
+
+## Data Model
+
+### wmsLayer Schema (new)
+
+| Field | Type | Description | Required |
+|-------|------|-------------|----------|
+| `title` | string | Display name in legend and layer switcher | Yes |
+| `type` | enum (`WMS` / `WFS`) | OGC service type | Yes |
+| `url` | string | Service base URL (must match GIS proxy allowlist) | Yes |
+| `layerName` | string | WMS layer name (`LAYERS=` param) or WFS typeName | Yes |
+| `srs` | string | Spatial reference system (default `EPSG:3857`; `EPSG:28992` for RD) | No |
+| `opacity` | number (0.0–1.0) | Default overlay opacity | No (default `0.7`) |
+| `attribution` | string | Attribution text shown in legend | No |
+| `queryable` | boolean | Whether GetFeatureInfo (WMS) or property popup (WFS) is enabled | No (default `false`) |
+| `format` | string | Image format for WMS (e.g. `image/png`) | No (default `image/png`) |
+| `version` | string | OGC version (`1.3.0` for WMS, `2.0.0` for WFS) | No (auto-detect) |
+| `isDefault` | boolean | Show on initial load even without subscription | No (default `false`) |
+
+### caseType Schema (modified)
+
+Add field:
+
+| Field | Type | Description | Required |
+|-------|------|-------------|----------|
+| `layerIds` | array<string (UUID)> | Subscribed `wmsLayer` ids visible on this case type's maps | No (default `[]`) |
+
+## Subscription Resolution
+
+1. `CaseMap` receives a `caseTypeId` (or reads it from the active case).
+2. It fetches the `caseType` object, reads `layerIds`.
+3. It batch-fetches the referenced `wmsLayer` objects from OpenRegister.
+4. It augments with any `wmsLayer` where `isDefault: true` (independent of case type).
+5. It hands the resolved layer set to `MapLayerLegend` and to the Leaflet tile/feature factory.
+
+## Performance Considerations
+
+- **Lazy load**: `WmsWfsService` only fetches tiles/features when a layer is toggled on. Toggling off detaches the layer and cancels in-flight requests.
+- **Tile size cap**: WMS `WIDTH`/`HEIGHT` requested from the proxy is capped at 512×512. Larger viewport areas are tiled by Leaflet (default 256×256 grid).
+- **WFS bbox guard**: GetFeature requests always carry a `BBOX` filter restricted to the visible map extent; if the extent exceeds 50 km × 50 km the layer is dimmed and a "Zoom in voor details" message replaces the features.
+- **Capabilities cache**: Parsed GetCapabilities responses are cached server-side for 1 hour (admin "test connection" refresh button bypasses cache).
+- **Per-tenant**: All `wmsLayer` objects live in the tenant's OpenRegister; no cross-tenant layer leakage.
+
+## Security & Compliance
+
+- Layer URLs MUST resolve to an entry in the GIS proxy allowlist (parent spec REQ-LAYER-03c). Saving a `wmsLayer` with a URL outside the allowlist is rejected at the API layer.
+- `queryable: false` layers MUST NOT issue GetFeatureInfo requests — enforced both in `MapLayerLegend` (no popup binding) and in `WmsWfsService` (proxy parameter validation).
+- Attribution text is rendered as escaped text — no HTML interpolation in the legend.

--- a/openspec/changes/wms-wfs-layers/proposal.md
+++ b/openspec/changes/wms-wfs-layers/proposal.md
@@ -1,0 +1,46 @@
+# Proposal: wms-wfs-layers
+
+## Summary
+
+Add tenant-configurable OGC WMS (Web Map Service) and WFS (Web Feature Service) overlay layers to Procest maps. Administrators register layer endpoints (URL, layer name, type, SRS, opacity, attribution, queryable) as `wmsLayer` objects in OpenRegister, then subscribe specific layers to specific case types. The shared `CaseMap` / `CnMapPage` component reads the subscription, lazily fetches tiles or features through the existing GIS proxy, and renders a legend with toggle/opacity controls. Sister capability to `map-component` (rendering) and `pdok-integration` (presets), bringing the WMS/WFS slice of the existing `map-component` data model under its own manifest-driven admin page and per-case-type association.
+
+## Motivation
+
+Dutch municipalities need to overlay zoning (bestemmingsplannen), environmental (Natura 2000, milieucontouren), infrastructure (kabels & leidingen) and cadastral (Kadaster) data on case maps. Today these layers are hard-coded in the `MapLayer` config or hand-toggled per user. Case handlers for an environmental permit need different overlays than handlers for a building permit. Without per-case-type layer subscriptions, every user sees every layer or none, and admins cannot tailor the map per workflow.
+
+## Affected Projects
+
+- [ ] Project: `procest` — `wmsLayer` schema in `procest_register.json`, admin manifest page, case-type→layer association, `WmsWfsService`, legend renderer, `CaseMap` layer prop wiring
+
+## Scope
+
+### In Scope
+
+- `wmsLayer` schema with WMS/WFS-specific fields (layer-name, srs, queryable, opacity, attribution)
+- Manifest-driven admin index page (`type: 'index'` on `wmsLayer`) for layer CRUD
+- Per-case-type layer subscription (which layers visible for which case types)
+- `WmsWfsService` client (GetCapabilities, GetMap, GetFeature via existing GIS proxy)
+- `CaseMap` layer prop + legend renderer with toggle and opacity slider
+- Lazy load + tile size cap performance guards
+
+### Out of Scope
+
+- Backend GIS proxy itself (lives in `wms-wfs-layers` parent spec REQ-LAYER-03; reused here)
+- PDOK preset catalogue (lives in `pdok-integration`)
+- Per-user layer preferences (future)
+- WMTS-specific tile-matrix handling (base maps only, already in `map-component`)
+- Vector tile / MVT support (future)
+
+## Approach
+
+1. Add `wmsLayer` schema (and `caseTypeLayerSubscription`) to `lib/Settings/procest_register.json`; register config keys in `SettingsService`.
+2. Build `WmsWfsService` (PHP) — thin wrapper that delegates to the existing GIS proxy and parses GetCapabilities for admin assistance.
+3. Author manifest `index` page for `wmsLayer` admin in `src/manifest.json` (no hand-written view).
+4. Add `layerIds` (array) to the `caseType` schema and a "Kaartlagen" tab in case-type admin.
+5. Extend `CaseMap` / `CnMapPage` to read `layerIds` from the active case type, fetch the subscribed layers, and render a legend with toggle + opacity.
+
+## Risks
+
+- WMS/WFS endpoints vary in spec compliance — must tolerate version drift (1.1.1 vs 1.3.0; 2.0.0 vs 1.0.0).
+- Tile request volume can blow up under deep zoom — must enforce tile-size cap and lazy load (no fetch when layer toggled off).
+- Layer subscription must not bypass the proxy URL allowlist (REQ-LAYER-03c in parent spec).

--- a/openspec/changes/wms-wfs-layers/specs/wms-wfs-layers/spec.md
+++ b/openspec/changes/wms-wfs-layers/specs/wms-wfs-layers/spec.md
@@ -1,0 +1,184 @@
+<!-- Delta spec for change `wms-wfs-layers`.
+     Parent capability: map-component (Map Component) — see openspec/specs/map-component/spec.md
+     This delta narrows the WMS/WFS slice of map-component's MapLayer model into a dedicated
+     `wmsLayer` schema with per-case-type subscriptions. It complements (does not replace)
+     the existing `wms-wfs-layers` canonical spec, which describes admin CRUD, proxying,
+     and capabilities parsing. -->
+
+## ADDED Requirements
+
+### Requirement: wmsLayer schema (REQ-WMS-1)
+
+The system SHALL define a `wmsLayer` schema in `lib/Settings/procest_register.json` with the WMS/WFS-specific fields needed to render an overlay: `title`, `type` (enum `WMS` / `WFS`), `url`, `layerName`, `srs`, `opacity` (0.0–1.0), `attribution`, `queryable` (boolean), `format`, `version`, and `isDefault` (boolean).
+
+**Feature tier**: V1
+**Standards**: OGC WMS 1.3.0, OGC WFS 2.0.0
+
+#### Scenario: Create a WMS layer object
+
+- **GIVEN** an admin POSTs `{ title: "Kadastrale kaart", type: "WMS", url: "https://service.pdok.nl/kadaster/kadastralekaart/wms/v5_0", layerName: "Perceel", srs: "EPSG:28992", opacity: 0.6, attribution: "PDOK", queryable: true }` to the wmsLayer collection
+- **WHEN** OpenRegister persists the object
+- **THEN** the response SHALL include a UUID `id`
+- **AND** GET on that id SHALL return the same field values
+- **AND** omitting `opacity` SHALL default it to `0.7`
+- **AND** omitting `queryable` SHALL default it to `false`
+
+---
+
+### Requirement: Manifest-driven layer admin page (REQ-WMS-2)
+
+The `wmsLayer` admin SHALL be declared as a `type: 'index'` page in `src/manifest.json` (per ADR-008). No hand-written admin view component SHALL exist for `wmsLayer`.
+
+**Feature tier**: V1
+**Standards**: ADR-008 (manifest-driven views)
+
+#### Scenario: Manifest declares index page on wmsLayer
+
+- **GIVEN** `src/manifest.json` defines a page with `route: "/settings/wms-layers"`
+- **WHEN** the manifest is loaded by the app shell
+- **THEN** the page entry SHALL have `"type": "index"`
+- **AND** the page entry SHALL NOT have a `"component"` key
+- **AND** the page `config` SHALL declare `register: "procest"` and `schema: "wmsLayer"`
+- **AND** no file `src/views/settings/WmsLayerAdmin.vue` SHALL exist in the repository
+
+---
+
+### Requirement: WmsWfsService client (REQ-WMS-3)
+
+The system SHALL provide a `WmsWfsService` PHP class that issues GetCapabilities, GetMap and GetFeature requests **only through the existing GIS proxy** declared in the parent `wms-wfs-layers` canonical spec (REQ-LAYER-03). Direct outbound HTTP from `WmsWfsService` SHALL be forbidden.
+
+**Feature tier**: V1
+**Standards**: OGC WMS 1.3.0, OGC WFS 2.0.0
+
+#### Scenario: Test connection parses GetCapabilities
+
+- **GIVEN** an admin clicks "Verbinding testen" on a draft `wmsLayer` with `url: "https://service.pdok.nl/lv/bag/wms/v2_0"` and `type: "WMS"`
+- **WHEN** `WmsWfsService::testConnection(url, type)` is invoked
+- **THEN** the service SHALL issue `GET {proxy}?REQUEST=GetCapabilities&SERVICE=WMS&url=...`
+- **AND** the response SHALL include `{ ok: true, layers: [...] }` parsed from the GetCapabilities XML
+- **AND** parsed capabilities SHALL be cached for 1 hour
+
+#### Scenario: URL outside allowlist is rejected
+
+- **GIVEN** an admin attempts to save a `wmsLayer` with `url: "https://evil.example.com/wms"` not present in the GIS proxy allowlist
+- **WHEN** `WmsWfsService` validates the URL prior to any outbound call
+- **THEN** the save SHALL return HTTP 400 with error code `wms.url_not_allowed`
+- **AND** no outbound request SHALL be issued
+
+---
+
+### Requirement: Case-type → layer subscription (REQ-WMS-4)
+
+The `caseType` schema SHALL be extended with a `layerIds: array<string>` field referencing `wmsLayer` UUIDs. The case-type admin SHALL expose a "Kaartlagen" tab where admins multi-select layers for that case type.
+
+**Feature tier**: V1
+**Standards**: Schema.org `additionalProperty`
+
+#### Scenario: Subscribe layers to a case type
+
+- **GIVEN** a `caseType` "Omgevingsvergunning" and two `wmsLayer` objects `L1` (Kadaster) and `L2` (Bestemmingsplan)
+- **WHEN** an admin selects both layers on the case type's "Kaartlagen" tab and saves
+- **THEN** `caseType.layerIds` SHALL equal `[L1.id, L2.id]`
+- **AND** GET on the case type SHALL return the same array
+
+#### Scenario: Subscription persists across reload
+
+- **GIVEN** `caseType.layerIds = [L1, L2]`
+- **WHEN** the case-type detail page is reloaded
+- **THEN** the "Kaartlagen" tab SHALL show both `L1` and `L2` as selected
+- **AND** other `wmsLayer` objects SHALL appear as unselected options
+
+---
+
+### Requirement: Layer prop on CaseMap (REQ-WMS-5)
+
+`CaseMap` (and its `CnMapPage` wrapper used by the case overview) SHALL accept a `layerIds: string[]` prop. On mount and on prop change, it SHALL resolve the ids to `wmsLayer` objects, additionally include any `wmsLayer` with `isDefault: true`, and instantiate Leaflet WMS / WFS layers via `WmsWfsService`.
+
+**Feature tier**: V1
+**Standards**: GeoJSON (RFC 7946), Leaflet 1.9
+
+#### Scenario: Lazy load — toggled-off layer issues no requests
+
+- **GIVEN** a `CaseMap` mounted with `layerIds: [L1, L2]` where both layers are initially toggled off in the legend
+- **WHEN** the map renders
+- **THEN** no tile or feature requests SHALL be issued for `L1` or `L2`
+- **AND** toggling `L1` on SHALL trigger exactly one GetMap (WMS) or GetFeature (WFS) sequence
+- **AND** toggling `L1` off SHALL detach the Leaflet layer and cancel in-flight requests
+
+#### Scenario: Tile size cap
+
+- **GIVEN** a WMS layer `L1` rendered on a 2048×2048 map viewport
+- **WHEN** `WmsWfsService::buildGetMapUrl` constructs tile URLs
+- **THEN** each individual GetMap request SHALL have `WIDTH ≤ 512` and `HEIGHT ≤ 512`
+- **AND** Leaflet SHALL tile the viewport into multiple requests rather than issuing one oversize request
+
+---
+
+### Requirement: Legend renderer (REQ-WMS-6)
+
+A `MapLayerLegend` component SHALL render one row per resolved layer with: checkbox (toggle), title, opacity slider (0–100, default from `wmsLayer.opacity × 100`), and attribution line. Attribution SHALL be rendered as escaped text.
+
+**Feature tier**: V1
+**Standards**: WCAG AA
+
+#### Scenario: Opacity slider updates layer opacity
+
+- **GIVEN** layer `L1` is toggled on with default opacity `0.7`
+- **WHEN** the user moves the opacity slider to `30`
+- **THEN** the Leaflet layer's opacity SHALL update to `0.3` in real time
+- **AND** the slider value SHALL persist in component state for the session
+
+#### Scenario: Attribution is escaped
+
+- **GIVEN** a `wmsLayer` with `attribution: "<script>alert(1)</script>"`
+- **WHEN** the legend renders that layer's row
+- **THEN** the DOM SHALL contain the literal text `<script>alert(1)</script>`
+- **AND** no `<script>` element SHALL be present in the legend subtree
+
+---
+
+### Requirement: Queryable layers and GetFeatureInfo (REQ-WMS-7)
+
+GetFeatureInfo (WMS) and feature popup (WFS) SHALL only be wired up when `wmsLayer.queryable === true`. Non-queryable layers SHALL render overlay-only with no click handler.
+
+**Feature tier**: V1
+**Standards**: OGC WMS 1.3.0 (GetFeatureInfo)
+
+#### Scenario: Queryable WMS layer shows popup on click
+
+- **GIVEN** a WMS layer `L1` with `queryable: true` displayed on the map
+- **WHEN** the user clicks a point on the overlay
+- **THEN** the system SHALL issue `GetFeatureInfo` via the GIS proxy
+- **AND** a popup SHALL display the returned feature attributes
+
+#### Scenario: Non-queryable layer ignores clicks
+
+- **GIVEN** a WMS layer `L2` with `queryable: false`
+- **WHEN** the user clicks the overlay
+- **THEN** no `GetFeatureInfo` request SHALL be issued
+- **AND** no popup SHALL be displayed
+- **AND** the click SHALL fall through to underlying layers (e.g. case marker popups)
+
+---
+
+### Requirement: WFS extent guard (REQ-WMS-8)
+
+WFS GetFeature requests SHALL always carry a `BBOX` parameter restricted to the visible map extent. When the visible extent exceeds 50 km × 50 km, the WFS layer SHALL be dimmed and a "Zoom in voor details" overlay message SHALL be displayed instead of fetching features.
+
+**Feature tier**: V1
+**Standards**: OGC WFS 2.0.0
+
+#### Scenario: WFS request scoped to viewport
+
+- **GIVEN** a WFS layer `L3` toggled on at zoom level 14 with extent ~2 km × 2 km
+- **WHEN** `WmsWfsService::buildGetFeatureUrl` constructs the URL
+- **THEN** the URL SHALL include a `BBOX` parameter matching the visible extent
+- **AND** the request SHALL be issued through the GIS proxy
+
+#### Scenario: WFS suppressed at low zoom
+
+- **GIVEN** a WFS layer `L3` toggled on at zoom level 7 (national view, extent ~300 km × 300 km)
+- **WHEN** the map computes the visible extent (> 50 km × 50 km)
+- **THEN** no WFS GetFeature request SHALL be issued
+- **AND** the legend row for `L3` SHALL display "Zoom in voor details" in Dutch
+- **AND** the overlay SHALL be visually dimmed (opacity halved)

--- a/openspec/changes/wms-wfs-layers/tasks.md
+++ b/openspec/changes/wms-wfs-layers/tasks.md
@@ -1,0 +1,30 @@
+# Tasks: wms-wfs-layers
+
+## Implementation Tasks
+
+### Schema & Configuration
+
+- [ ] **T01**: Add `wmsLayer` schema to `lib/Settings/procest_register.json` with fields: `title`, `type` (enum WMS/WFS), `url`, `layerName`, `srs`, `opacity` (0.0–1.0), `attribution`, `queryable`, `format`, `version`, `isDefault`. Add `layerIds: array<string>` field to existing `caseType` schema. Register `wmsLayer` in `SettingsService::CONFIG_KEYS` and `SLUG_TO_CONFIG_KEY`. **Feature tier**: V1
+
+### Backend Services
+
+- [ ] **T02**: Create `lib/Service/WmsWfsService.php` — Methods: `getCapabilities(layerObject)` fetches `?REQUEST=GetCapabilities` via the existing GIS proxy and returns parsed layer list / supported SRS / formats (cached 1 h); `buildGetMapUrl(layerObject, bbox, width, height)` returns a proxy URL with WMS params (caps WIDTH/HEIGHT at 512); `buildGetFeatureUrl(layerObject, bbox)` returns a proxy URL with WFS bbox filter; `testConnection(url, type)` admin helper that returns `{ ok, layers[], error }`. MUST verify the URL is on the GIS proxy allowlist before issuing any request. **Feature tier**: V1
+
+### Frontend — Admin
+
+- [ ] **T03**: Add admin page for `wmsLayer` to `src/manifest.json` using `type: 'index'` (no `component` key, per ADR-008). Page title "Kaartlagen", route `/settings/wms-layers`, columns title/type/url/queryable, schema-driven form with "Verbinding testen" button that calls `WmsWfsService::testConnection`. **Feature tier**: V1
+
+- [ ] **T04**: Update `src/views/caseTypes/CaseTypeDetail.vue` — Add "Kaartlagen" tab containing a multiselect of all `wmsLayer` objects. On save, persist selected ids into `caseType.layerIds` via the existing `caseType` object store. Show a preview swatch + attribution line for each selected layer. **Feature tier**: V1
+
+### Frontend — Map
+
+- [ ] **T05**: Extend `src/components/map/CaseMap.vue` (or the `CnMapPage` wrapper used by the case overview) with a `layerIds: string[]` prop. On mount/prop-change: resolve to `wmsLayer` objects (plus any `isDefault: true` layers), instantiate Leaflet WMS / WFS layers via `WmsWfsService`, attach to the map. Toggling a layer off MUST detach it and cancel in-flight requests. WFS layers with visible extent > 50 km × 50 km MUST be dimmed with a "Zoom in voor details" message. **Feature tier**: V1
+
+- [ ] **T06**: Create `src/components/map/MapLayerLegend.vue` — Legend with per-layer row (checkbox, title, opacity slider 0–100, attribution). Escapes attribution text (no HTML). Binds GetFeatureInfo popup only when `layer.queryable === true`. Emits `toggle` and `opacity-change` events the `CaseMap` consumes. **Feature tier**: V1
+
+## Verification Tasks
+
+- [ ] **V01**: `wmsLayer` schema validates against OpenRegister and round-trips through ObjectService (create / list / update / delete).
+- [ ] **V02**: Admin "Verbinding testen" against `https://service.pdok.nl/lv/bag/wms/v2_0` returns the BAG layer list parsed from GetCapabilities.
+- [ ] **V03**: Saving a `wmsLayer` with a URL outside the GIS proxy allowlist returns a 400 error and the object is NOT persisted.
+- [ ] **V04**: On a case-type with 2 subscribed WMS layers and 1 unsubscribed WFS layer, the `CaseMap` renders exactly the 2 WMS overlays in the legend (plus any `isDefault: true` layers) and issues no network requests for the unsubscribed layer.


### PR DESCRIPTION
## Summary

Generate openspec change `wms-wfs-layers` — config-driven WMS/WFS overlay extension to `map-component`. Spec only, no code.

- New `wmsLayer` schema + `caseType.layerIds` field
- Manifest-driven admin index page (ADR-008, no hand-written view)
- `WmsWfsService` proxy-only client (uses existing GIS proxy from parent spec REQ-LAYER-03)
- `CaseMap` `layerIds` prop, legend with toggle + opacity, queryable-aware popups, WFS extent guard

Sister to `map-component` (rendering) and `pdok-integration` (presets). Narrows the WMS/WFS slice of `map-component`'s `MapLayer` model into a dedicated schema with per-case-type subscriptions.

## Requirements

8 requirements with Given/When/Then scenarios:

- REQ-WMS-1: `wmsLayer` schema
- REQ-WMS-2: Manifest-driven admin index page
- REQ-WMS-3: `WmsWfsService` client (proxy-only)
- REQ-WMS-4: Case-type → layer subscription
- REQ-WMS-5: `layerIds` prop on `CaseMap` (lazy load, tile size cap)
- REQ-WMS-6: Legend renderer (toggle, opacity slider, escaped attribution)
- REQ-WMS-7: Queryable layers and GetFeatureInfo
- REQ-WMS-8: WFS extent guard (50 km × 50 km cutoff)

## Validation

`openspec change validate wms-wfs-layers --strict` passes.

## Test plan

- [ ] Reviewer confirms requirements cover admin CRUD, subscription, rendering, and security
- [ ] Reviewer confirms delta does not conflict with existing canonical `wms-wfs-layers` spec
- [ ] `openspec change validate wms-wfs-layers --strict` passes in CI