### PR TITLE
feat(process-step-configuration): apply spec — validator + editor (partial)

### DIFF
--- a/lib/Service/StepConfigValidator.php
+++ b/lib/Service/StepConfigValidator.php
@@ -1,0 +1,457 @@
+<?php
+
+/**
+ * Procest Step Config Validator
+ *
+ * Pure-function validator for the additive `config` sub-object on every
+ * embedded WorkflowStep inside a workflowTemplate. Runs at publish time
+ * inside WorkflowDefinitionService::publish() (when wired) and rejects
+ * malformed SLA, unknown action keys, dangling field references, and
+ * escalation rules without an accompanying SLA.
+ *
+ * No DI, no I/O, no Nextcloud APIs. Returns a list of structured
+ * validation errors with keys {path, code, message}. Never returns raw
+ * exception messages — callers log the structured errors via the host
+ * logger and surface a static generic error string to the UI.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service;
+
+/**
+ * Pure-function validator for WorkflowStep.config.
+ *
+ * Implements the seven validation rules from
+ * openspec/changes/process-step-configuration/design.md.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+final class StepConfigValidator
+{
+    /**
+     * Allowed enum values for the `sla.unit` property.
+     *
+     * @var array<int, string>
+     */
+    public const SLA_UNITS = ['hours', 'businessDays', 'calendarDays'];
+
+    /**
+     * Allowed enum values for the `escalationRule.offsetUnit` property.
+     *
+     * @var array<int, string>
+     */
+    public const OFFSET_UNITS = ['hours', 'businessDays'];
+
+    /**
+     * Allowed enum values for the `escalationRule.trigger` property.
+     *
+     * @var array<int, string>
+     */
+    public const TRIGGERS = ['preBreach', 'slaBreached'];
+
+    /**
+     * Upper bound on `sla.value` (inclusive).
+     *
+     * @var int
+     */
+    public const SLA_VALUE_MAX = 10000;
+
+    /**
+     * Maximum recognised auto-action keys.
+     *
+     * Mirrors the action catalog defined by the `automatic-actions` spec.
+     * Kept in sync with that spec by hand for V1; a future change may
+     * inject the catalog via the constructor when the catalog service
+     * exists.
+     *
+     * @var array<int, string>
+     */
+    public const DEFAULT_ACTION_CATALOG = [
+        'sendEmail',
+        'createTask',
+        'createSubCase',
+        'webhook',
+        'setField',
+        'notify',
+        'notifySteller',
+        'logToAuditTrail',
+    ];
+
+    /**
+     * Validate a single step's config block.
+     *
+     * The caller is expected to invoke this once per step entry in the
+     * `steps[]` array of a workflowTemplate during publish. The provided
+     * caseType schema is consulted to verify field/role references; pass
+     * an empty array to skip those checks (useful in unit tests).
+     *
+     * Returns the empty array on success. Each returned error has the
+     * keys `path`, `code`, and `message`. The `message` is an internal
+     * description — callers MUST NOT include it in user-facing responses.
+     *
+     * @param array<string, mixed> $step               The step (with optional `config`).
+     * @param array<string, mixed> $caseTypeSchema     The linked caseType — properties + roleTypes.
+     * @param array<int, string>   $actionCatalog      Optional override of recognised action keys.
+     * @param int                  $stepIndex          The step's index in `steps[]` for path prefix.
+     *
+     * @return array<int, array{path: string, code: string, message: string}>
+     */
+    public static function validate(
+        array $step,
+        array $caseTypeSchema = [],
+        array $actionCatalog = self::DEFAULT_ACTION_CATALOG,
+        int $stepIndex = 0
+    ): array {
+        $errors = [];
+        $config = ($step['config'] ?? null);
+        if ($config === null) {
+            return $errors;
+        }
+
+        if (is_array($config) === false) {
+            $errors[] = self::error(
+                "steps[$stepIndex].config",
+                'malformed_config',
+                'config must be an object'
+            );
+            return $errors;
+        }
+
+        $base = "steps[$stepIndex].config";
+
+        $errors = array_merge(
+            $errors,
+            self::validateSla($config['sla'] ?? null, $base.'.sla')
+        );
+
+        $errors = array_merge(
+            $errors,
+            self::validateRequiredFields(
+                ($config['requiredFields'] ?? null),
+                ($caseTypeSchema['properties'] ?? []),
+                $base.'.requiredFields'
+            )
+        );
+
+        $errors = array_merge(
+            $errors,
+            self::validateAutoActions(
+                ($config['autoActions'] ?? null),
+                $actionCatalog,
+                $base.'.autoActions'
+            )
+        );
+
+        $errors = array_merge(
+            $errors,
+            self::validateEscalationRule(
+                ($config['escalationRule'] ?? null),
+                ($config['sla'] ?? null),
+                ($caseTypeSchema['roleTypes'] ?? []),
+                $base.'.escalationRule'
+            )
+        );
+
+        return $errors;
+    }//end validate()
+
+    /**
+     * Build a structured error record.
+     *
+     * @param string $path    The JSON-pointer-like path to the bad value.
+     * @param string $code    The stable error code (snake_case).
+     * @param string $message An internal description (never user-facing).
+     *
+     * @return array{path: string, code: string, message: string}
+     */
+    private static function error(string $path, string $code, string $message): array
+    {
+        return [
+            'path'    => $path,
+            'code'    => $code,
+            'message' => $message,
+        ];
+    }//end error()
+
+    /**
+     * Validate `config.sla`.
+     *
+     * Rules 1 + 2 from design.md.
+     *
+     * @param mixed  $sla  The raw sla value (object or null).
+     * @param string $path The path prefix for any error.
+     *
+     * @return array<int, array{path: string, code: string, message: string}>
+     */
+    private static function validateSla(mixed $sla, string $path): array
+    {
+        if ($sla === null) {
+            return [];
+        }
+        if (is_array($sla) === false) {
+            return [self::error($path, 'malformed_sla', 'sla must be an object')];
+        }
+
+        $errors = [];
+
+        $value = ($sla['value'] ?? null);
+        if (is_int($value) === false || $value < 1 || $value > self::SLA_VALUE_MAX) {
+            $errors[] = self::error(
+                $path.'.value',
+                'out_of_range',
+                'sla.value must be a positive integer not greater than '
+                .self::SLA_VALUE_MAX
+            );
+        }
+
+        $unit = ($sla['unit'] ?? null);
+        if (is_string($unit) === false || in_array($unit, self::SLA_UNITS, true) === false) {
+            $errors[] = self::error(
+                $path.'.unit',
+                'unknown_sla_unit',
+                'sla.unit must be one of: '.implode(', ', self::SLA_UNITS)
+            );
+        }
+
+        return $errors;
+    }//end validateSla()
+
+    /**
+     * Validate `config.requiredFields`.
+     *
+     * Rule 3 from design.md.
+     *
+     * @param mixed                $fields             The raw requiredFields value.
+     * @param array<string, mixed> $caseTypeProperties Map of property name to definition.
+     * @param string               $path               The path prefix for any error.
+     *
+     * @return array<int, array{path: string, code: string, message: string}>
+     */
+    private static function validateRequiredFields(
+        mixed $fields,
+        array $caseTypeProperties,
+        string $path
+    ): array {
+        if ($fields === null) {
+            return [];
+        }
+        if (is_array($fields) === false) {
+            return [self::error($path, 'malformed_required_fields', 'requiredFields must be an array')];
+        }
+
+        $errors = [];
+        // Skip dangling-reference check when caller supplied no schema.
+        $checkRefs = ($caseTypeProperties !== []);
+
+        foreach ($fields as $index => $field) {
+            if (is_string($field) === false || $field === '') {
+                $errors[] = self::error(
+                    $path."[$index]",
+                    'malformed_required_field',
+                    'requiredFields entries must be non-empty strings'
+                );
+                continue;
+            }
+            if ($checkRefs === true && array_key_exists($field, $caseTypeProperties) === false) {
+                $errors[] = self::error(
+                    $path."[$index]",
+                    'unknown_field_reference',
+                    'requiredFields entry does not resolve to a caseType property'
+                );
+            }
+        }
+
+        return $errors;
+    }//end validateRequiredFields()
+
+    /**
+     * Validate `config.autoActions`.
+     *
+     * Rule 4 from design.md.
+     *
+     * @param mixed              $actions       The raw autoActions value.
+     * @param array<int, string> $actionCatalog Allowed action keys.
+     * @param string             $path          The path prefix for any error.
+     *
+     * @return array<int, array{path: string, code: string, message: string}>
+     */
+    private static function validateAutoActions(
+        mixed $actions,
+        array $actionCatalog,
+        string $path
+    ): array {
+        if ($actions === null) {
+            return [];
+        }
+        if (is_array($actions) === false) {
+            return [self::error($path, 'malformed_auto_actions', 'autoActions must be an array')];
+        }
+
+        $errors = [];
+        foreach ($actions as $index => $action) {
+            if (is_array($action) === false) {
+                $errors[] = self::error(
+                    $path."[$index]",
+                    'malformed_action_ref',
+                    'autoActions entries must be objects with `key` and `parameters`'
+                );
+                continue;
+            }
+            $key = ($action['key'] ?? null);
+            if (is_string($key) === false || $key === '') {
+                $errors[] = self::error(
+                    $path."[$index].key",
+                    'malformed_action_key',
+                    'autoActions[i].key must be a non-empty string'
+                );
+                continue;
+            }
+            if (in_array($key, $actionCatalog, true) === false) {
+                $errors[] = self::error(
+                    $path."[$index].key",
+                    'unknown_action_key',
+                    'autoActions[i].key is not registered in the action catalog'
+                );
+            }
+        }
+
+        return $errors;
+    }//end validateAutoActions()
+
+    /**
+     * Validate `config.escalationRule`.
+     *
+     * Rules 5, 6, and 7 from design.md.
+     *
+     * @param mixed                $rule      The raw escalationRule value.
+     * @param mixed                $sla       The raw sla value (for rules 6 + 7).
+     * @param array<string, mixed> $roleTypes Map of role name/uuid to definition.
+     * @param string               $path      The path prefix for any error.
+     *
+     * @return array<int, array{path: string, code: string, message: string}>
+     */
+    private static function validateEscalationRule(
+        mixed $rule,
+        mixed $sla,
+        array $roleTypes,
+        string $path
+    ): array {
+        if ($rule === null) {
+            return [];
+        }
+        if (is_array($rule) === false) {
+            return [self::error($path, 'malformed_escalation_rule', 'escalationRule must be an object')];
+        }
+
+        $errors = [];
+
+        // Rule 6: escalationRule requires an SLA.
+        if ($sla === null) {
+            $errors[] = self::error(
+                $path,
+                'escalation_requires_sla',
+                'escalationRule cannot be set without a sla'
+            );
+        }
+
+        $trigger = ($rule['trigger'] ?? null);
+        if (is_string($trigger) === false || in_array($trigger, self::TRIGGERS, true) === false) {
+            $errors[] = self::error(
+                $path.'.trigger',
+                'unknown_trigger',
+                'escalationRule.trigger must be one of: '.implode(', ', self::TRIGGERS)
+            );
+        }
+
+        $offset = ($rule['offset'] ?? null);
+        if (is_int($offset) === false || $offset < 0) {
+            $errors[] = self::error(
+                $path.'.offset',
+                'out_of_range',
+                'escalationRule.offset must be a non-negative integer'
+            );
+        }
+
+        $offsetUnit = ($rule['offsetUnit'] ?? null);
+        if (is_string($offsetUnit) === false
+            || in_array($offsetUnit, self::OFFSET_UNITS, true) === false
+        ) {
+            $errors[] = self::error(
+                $path.'.offsetUnit',
+                'unknown_offset_unit',
+                'escalationRule.offsetUnit must be one of: '.implode(', ', self::OFFSET_UNITS)
+            );
+        }
+
+        // Rule 7: preBreach offset cannot exceed sla.value.
+        if ($trigger === 'preBreach'
+            && is_int($offset) === true
+            && is_array($sla) === true
+            && is_int(($sla['value'] ?? null)) === true
+            && $offset > $sla['value']
+        ) {
+            $errors[] = self::error(
+                $path.'.offset',
+                'offset_exceeds_sla',
+                'escalationRule.offset must not exceed sla.value when trigger is preBreach'
+            );
+        }
+
+        // Rule 5: notifyRole + escalateToRole must resolve when roleTypes provided.
+        $checkRoles = ($roleTypes !== []);
+        foreach (['notifyRole', 'escalateToRole'] as $roleKey) {
+            $role = ($rule[$roleKey] ?? null);
+            if ($role === null) {
+                continue;
+            }
+            if (is_string($role) === false || $role === '') {
+                $errors[] = self::error(
+                    $path.'.'.$roleKey,
+                    'malformed_role_reference',
+                    $roleKey.' must be a non-empty role reference'
+                );
+                continue;
+            }
+            if ($checkRoles === true && array_key_exists($role, $roleTypes) === false) {
+                $errors[] = self::error(
+                    $path.'.'.$roleKey,
+                    'unknown_role_reference',
+                    $roleKey.' does not resolve to a roleType on the linked caseType'
+                );
+            }
+        }
+
+        $openIncident = ($rule['openIncident'] ?? null);
+        if ($openIncident !== null && is_bool($openIncident) === false) {
+            $errors[] = self::error(
+                $path.'.openIncident',
+                'malformed_open_incident',
+                'escalationRule.openIncident must be a boolean'
+            );
+        }
+
+        return $errors;
+    }//end validateEscalationRule()
+}//end class

--- a/lib/Settings/procest_register.json
+++ b/lib/Settings/procest_register.json
@@ -1836,11 +1836,11 @@
       "workflowTemplate": {
         "slug": "workflowTemplate",
         "icon": "SitemapOutline",
-        "version": "1.0.0",
+        "version": "1.1.0",
         "x-schema-org-type": "schema:HowTo",
         "x-cmmn-equivalent": "CasePlanModel",
         "title": "Workflow Template",
-        "description": "A workflow definition for a case type — defines process steps, status transitions, guards, and automatic actions",
+        "description": "A workflow definition for a case type — defines process steps, status transitions, guards, and automatic actions. v1.1: each step entry MAY carry an additive `config` sub-object ({sla, requiredFields, autoActions, escalationRule}); absent config preserves v1 behaviour (see process-step-configuration spec).",
         "type": "object",
         "required": [
           "title",
@@ -1880,7 +1880,7 @@
           },
           "steps": {
             "type": "string",
-            "description": "JSON-encoded array of WorkflowStep objects. Each step has: id (UUID), title, description, status (UUID ref to statusType), order (integer), assigneeRole (UUID ref to roleType, optional), isRequired (boolean), checklist (array of {id, label, description}), automaticActions (array of ActionRef)"
+            "description": "JSON-encoded array of WorkflowStep objects. Each step has: id (UUID), title, description, status (UUID ref to statusType), order (integer), assigneeRole (UUID ref to roleType, optional), isRequired (boolean), checklist (array of {id, label, description}), automaticActions (array of ActionRef). v1.1 additive: optional `config` sub-object = {sla:{value:int 1-10000, unit:hours|businessDays|calendarDays}, requiredFields:string[] (case-field property paths), autoActions:ActionRef[] fired before transition-level actions on step completion, escalationRule:{trigger:preBreach|slaBreached, offset:int, offsetUnit:hours|businessDays, notifyRole:UUID, escalateToRole:UUID, openIncident:boolean} — requires sla present; preBreach offset must be <= sla.value}. Absent config preserves v1 behaviour."
           },
           "transitions": {
             "type": "string",

--- a/openspec/changes/process-step-configuration/builds/build.json
+++ b/openspec/changes/process-step-configuration/builds/build.json
@@ -1,0 +1,41 @@
+{
+  "phase": "apply",
+  "timestamp": "2026-05-11T00:00:00+00:00",
+  "status": "partial",
+  "reason": "Manifest-first apply. Extended workflowTemplate.steps schema description (T01), added pure-function StepConfigValidator (T02), extended existing StepConfigPanel.vue with Geavanceerd sub-panel for sla / requiredFields / escalationRule (T07) and wired read-only via WorkflowEditor.vue isPublished computed (T08). Validator smoke-tested: empty errors on valid config, 4 expected errors on malformed config (out_of_range sla.value, unknown_sla_unit, unknown_action_key, offset_exceeds_sla).",
+  "applied_files": [
+    "lib/Settings/procest_register.json",
+    "lib/Service/StepConfigValidator.php",
+    "src/views/settings/components/StepConfigPanel.vue",
+    "src/views/settings/WorkflowEditor.vue"
+  ],
+  "tasks_complete": [
+    "T01",
+    "T02",
+    "T07",
+    "T08"
+  ],
+  "tasks_deferred": [
+    "T03 — wire StepConfigValidator into WorkflowDefinitionService::publish(); host service does not exist on development yet (sibling spec workflow-definition-model PR #347 referenced by proposal not landed in this tree). Validator is ready; wiring becomes a one-liner once the service lands.",
+    "T04 — StatusTransitionService::getAvailableTransitions() implicit requiredFields guard; host service does not exist (status-transition-engine #352 not landed).",
+    "T05 — step-level autoActions ordering in StatusTransitionService completion handler; same blocker as T04.",
+    "T06 — TaskCreatorService::createForStep() dueAt + escalationAt stamping; host service does not exist.",
+    "T09 — BackfillBezwaarStepConfig migration; depends on WorkflowDefinitionService::clone()+publish() (not landed) and BezwaarLifecycleService constants (not present).",
+    "T10 — flip spec frontmatter status: implemented; deferred until T03–T09 land."
+  ],
+  "validation": {
+    "php_lint": "pass",
+    "jq": "pass",
+    "spdx_present": "pass",
+    "no_getMessage_in_validator": "pass",
+    "smoke_test_validator": "pass",
+    "composer_check_strict": "deferred per watchdog",
+    "i18n": "deferred per watchdog"
+  },
+  "notes": [
+    "Storage: WorkflowStep.config remains an inline sub-object inside the existing JSON-encoded steps[] string on workflowTemplate. No new register schema introduced. Schema version bumped 1.0.0 → 1.1.0 with additive description for the config sub-object.",
+    "No new manifest pages, no new controller, no new entity — config UI is part of the existing per-step panel inside WorkflowEditor.",
+    "readOnly prop wired via WorkflowEditor.isPublished computed (tpl.isDraft === false). Default false preserves the existing create-flow behaviour when no template is loaded yet.",
+    "StepConfigValidator is pure (no DI, no IUserSession, no I/O); accepts an optional actionCatalog override for forward compatibility with automatic-actions catalog injection."
+  ]
+}

--- a/src/views/settings/WorkflowEditor.vue
+++ b/src/views/settings/WorkflowEditor.vue
@@ -72,6 +72,7 @@
 			v-if="selectedStep"
 			:step="selectedStep"
 			:role-types="roleTypes"
+			:read-only="isPublished"
 			@update="onStepUpdate"
 			@close="selectedStep = null" />
 
@@ -167,6 +168,22 @@ export default {
 		selectedTransitionData() {
 			if (!this.selectedTransition) return null
 			return this.transitions.find((t) => t.id === this.selectedTransition) || null
+		},
+		/**
+		 * True when the loaded workflow template is published (not a draft).
+		 *
+		 * Used to render the step `Geavanceerd` panel read-only per
+		 * process-step-configuration REQ-PSC-7-002. Falls back to false
+		 * (editable) when no template is loaded yet, preserving the
+		 * pre-existing creation flow.
+		 *
+		 * @returns {boolean} Whether the current template is published.
+		 */
+		isPublished() {
+			const tpl = this.workflowStore.currentTemplate || null
+			if (!tpl) return false
+			// isDraft true ⇒ editable; isDraft false ⇒ published/deprecated
+			return tpl.isDraft === false
 		},
 		canvasStyle() {
 			return {

--- a/src/views/settings/components/StepConfigPanel.vue
+++ b/src/views/settings/components/StepConfigPanel.vue
@@ -92,6 +92,158 @@
 				</NcButton>
 			</div>
 
+			<!-- Geavanceerd: SLA / required fields / escalation (process-step-configuration spec) -->
+			<div class="step-config-panel__section">
+				<button
+					type="button"
+					class="step-config-panel__advanced-toggle"
+					@click="advancedOpen = !advancedOpen">
+					<span>{{ t('procest', 'Geavanceerd') }}</span>
+					<span class="step-config-panel__advanced-caret">{{ advancedOpen ? '▾' : '▸' }}</span>
+				</button>
+
+				<div
+					v-if="readOnly"
+					class="step-config-panel__advanced-banner">
+					{{ t('procest', 'Gepubliceerde versies zijn niet bewerkbaar — kloon eerst een nieuwe versie.') }}
+				</div>
+
+				<div v-if="advancedOpen" class="step-config-panel__advanced-body">
+					<!-- SLA -->
+					<div class="step-config-panel__field">
+						<label>{{ t('procest', 'SLA') }}</label>
+						<div class="step-config-panel__sla-row">
+							<input
+								v-model.number="localConfig.sla.value"
+								type="number"
+								min="1"
+								:max="slaValueMax"
+								class="step-config-panel__input step-config-panel__sla-value"
+								:disabled="readOnly"
+								@input="emitUpdate">
+							<select
+								v-model="localConfig.sla.unit"
+								class="step-config-panel__select"
+								:disabled="readOnly"
+								@change="emitUpdate">
+								<option value="">
+									{{ t('procest', 'Geen SLA') }}
+								</option>
+								<option value="hours">
+									{{ t('procest', 'uren') }}
+								</option>
+								<option value="businessDays">
+									{{ t('procest', 'werkdagen') }}
+								</option>
+								<option value="calendarDays">
+									{{ t('procest', 'kalenderdagen') }}
+								</option>
+							</select>
+						</div>
+					</div>
+
+					<!-- Required fields -->
+					<div class="step-config-panel__field">
+						<label>{{ t('procest', 'Verplichte velden bij afronden') }}</label>
+						<div
+							v-for="(field, index) in localConfig.requiredFields"
+							:key="`field-${index}`"
+							class="step-config-panel__required-field">
+							<input
+								v-model="localConfig.requiredFields[index]"
+								type="text"
+								:placeholder="t('procest', 'Veldnaam (property path)')"
+								class="step-config-panel__input"
+								:disabled="readOnly"
+								@input="emitUpdate">
+							<NcButton
+								type="tertiary"
+								:disabled="readOnly"
+								@click="removeRequiredField(index)">
+								<template #icon>
+									<CloseIcon :size="16" />
+								</template>
+							</NcButton>
+						</div>
+						<NcButton
+							type="secondary"
+							:disabled="readOnly"
+							@click="addRequiredField">
+							{{ t('procest', 'Veld toevoegen') }}
+						</NcButton>
+					</div>
+
+					<!-- Escalation -->
+					<div class="step-config-panel__field">
+						<label>
+							<input
+								v-model="escalationEnabled"
+								type="checkbox"
+								:disabled="readOnly"
+								@change="onEscalationToggle">
+							{{ t('procest', 'Escalatie inschakelen') }}
+						</label>
+						<div v-if="escalationEnabled" class="step-config-panel__escalation">
+							<select
+								v-model="localConfig.escalationRule.trigger"
+								class="step-config-panel__select"
+								:disabled="readOnly"
+								@change="emitUpdate">
+								<option value="preBreach">
+									{{ t('procest', 'Vóór deadline (pre-breach)') }}
+								</option>
+								<option value="slaBreached">
+									{{ t('procest', 'Na deadline (sla-breached)') }}
+								</option>
+							</select>
+							<div class="step-config-panel__sla-row">
+								<input
+									v-model.number="localConfig.escalationRule.offset"
+									type="number"
+									min="0"
+									class="step-config-panel__input step-config-panel__sla-value"
+									:disabled="readOnly"
+									@input="emitUpdate">
+								<select
+									v-model="localConfig.escalationRule.offsetUnit"
+									class="step-config-panel__select"
+									:disabled="readOnly"
+									@change="emitUpdate">
+									<option value="hours">
+										{{ t('procest', 'uren') }}
+									</option>
+									<option value="businessDays">
+										{{ t('procest', 'werkdagen') }}
+									</option>
+								</select>
+							</div>
+							<input
+								v-model="localConfig.escalationRule.notifyRole"
+								type="text"
+								:placeholder="t('procest', 'Waarschuw rol (UUID)')"
+								class="step-config-panel__input"
+								:disabled="readOnly"
+								@input="emitUpdate">
+							<input
+								v-model="localConfig.escalationRule.escalateToRole"
+								type="text"
+								:placeholder="t('procest', 'Escaleer naar rol (UUID)')"
+								class="step-config-panel__input"
+								:disabled="readOnly"
+								@input="emitUpdate">
+							<label class="step-config-panel__inline-check">
+								<input
+									v-model="localConfig.escalationRule.openIncident"
+									type="checkbox"
+									:disabled="readOnly"
+									@change="emitUpdate">
+								{{ t('procest', 'Maak ook een incident aan') }}
+							</label>
+						</div>
+					</div>
+				</div>
+			</div>
+
 			<!-- Automatic Actions -->
 			<div class="step-config-panel__section">
 				<h5>{{ t('procest', 'Automatic actions on completion') }}</h5>
@@ -173,6 +325,10 @@ export default {
 			type: Array,
 			default: () => [],
 		},
+		readOnly: {
+			type: Boolean,
+			default: false,
+		},
 	},
 	emits: ['update', 'close'],
 	data() {
@@ -180,6 +336,10 @@ export default {
 			localStep: { ...this.step },
 			localChecklist: this.parseChecklist(this.step.checklist),
 			localActions: this.parseActions(this.step.automaticActions),
+			localConfig: this.parseConfig(this.step.config),
+			advancedOpen: false,
+			escalationEnabled: !!(this.step && this.step.config && this.step.config.escalationRule),
+			slaValueMax: 10000,
 			dragCheckIndex: null,
 		}
 	},
@@ -189,11 +349,78 @@ export default {
 				this.localStep = { ...newStep }
 				this.localChecklist = this.parseChecklist(newStep.checklist)
 				this.localActions = this.parseActions(newStep.automaticActions)
+				this.localConfig = this.parseConfig(newStep.config)
+				this.escalationEnabled = !!(newStep && newStep.config && newStep.config.escalationRule)
 			},
 			deep: true,
 		},
 	},
 	methods: {
+		parseConfig(config) {
+			let raw = config
+			if (typeof raw === 'string') {
+				try { raw = JSON.parse(raw) } catch { raw = null }
+			}
+			const safe = raw && typeof raw === 'object' ? raw : {}
+			return {
+				sla: {
+					value: safe.sla && Number.isFinite(safe.sla.value) ? safe.sla.value : null,
+					unit: safe.sla && typeof safe.sla.unit === 'string' ? safe.sla.unit : '',
+				},
+				requiredFields: Array.isArray(safe.requiredFields) ? [...safe.requiredFields] : [],
+				autoActions: Array.isArray(safe.autoActions) ? [...safe.autoActions] : [],
+				escalationRule: safe.escalationRule && typeof safe.escalationRule === 'object'
+					? {
+						trigger: typeof safe.escalationRule.trigger === 'string' ? safe.escalationRule.trigger : 'preBreach',
+						offset: Number.isFinite(safe.escalationRule.offset) ? safe.escalationRule.offset : 0,
+						offsetUnit: typeof safe.escalationRule.offsetUnit === 'string' ? safe.escalationRule.offsetUnit : 'businessDays',
+						notifyRole: typeof safe.escalationRule.notifyRole === 'string' ? safe.escalationRule.notifyRole : '',
+						escalateToRole: typeof safe.escalationRule.escalateToRole === 'string' ? safe.escalationRule.escalateToRole : '',
+						openIncident: !!safe.escalationRule.openIncident,
+					}
+					: {
+						trigger: 'preBreach',
+						offset: 0,
+						offsetUnit: 'businessDays',
+						notifyRole: '',
+						escalateToRole: '',
+						openIncident: false,
+					},
+			}
+		},
+
+		buildConfigPayload() {
+			const out = {}
+			if (this.localConfig.sla.value != null && this.localConfig.sla.unit !== '') {
+				out.sla = { value: this.localConfig.sla.value, unit: this.localConfig.sla.unit }
+			}
+			const fields = this.localConfig.requiredFields.filter(f => typeof f === 'string' && f.trim() !== '')
+			if (fields.length > 0) {
+				out.requiredFields = fields
+			}
+			if (Array.isArray(this.localConfig.autoActions) && this.localConfig.autoActions.length > 0) {
+				out.autoActions = this.localConfig.autoActions
+			}
+			if (this.escalationEnabled) {
+				out.escalationRule = { ...this.localConfig.escalationRule }
+			}
+			return Object.keys(out).length > 0 ? out : undefined
+		},
+
+		addRequiredField() {
+			this.localConfig.requiredFields.push('')
+			this.emitUpdate()
+		},
+
+		removeRequiredField(index) {
+			this.localConfig.requiredFields.splice(index, 1)
+			this.emitUpdate()
+		},
+
+		onEscalationToggle() {
+			this.emitUpdate()
+		},
+
 		parseChecklist(checklist) {
 			if (!checklist) return []
 			if (typeof checklist === 'string') {
@@ -211,11 +438,18 @@ export default {
 		},
 
 		emitUpdate() {
-			this.$emit('update', {
+			const payload = {
 				...this.localStep,
 				checklist: this.localChecklist,
 				automaticActions: this.localActions,
-			})
+			}
+			const config = this.buildConfigPayload()
+			if (config !== undefined) {
+				payload.config = config
+			} else {
+				delete payload.config
+			}
+			this.$emit('update', payload)
 		},
 
 		addChecklistItem() {
@@ -376,5 +610,70 @@ export default {
 	padding: 8px;
 	background: var(--color-background-dark);
 	border-radius: var(--border-radius);
+}
+
+.step-config-panel__advanced-toggle {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	width: 100%;
+	padding: 6px 0;
+	background: none;
+	border: none;
+	cursor: pointer;
+	font-size: 12px;
+	font-weight: 600;
+	text-transform: uppercase;
+	color: var(--color-text-maxcontrast);
+}
+
+.step-config-panel__advanced-caret {
+	font-size: 14px;
+}
+
+.step-config-panel__advanced-banner {
+	padding: 8px;
+	background: var(--color-warning, #fff4d6);
+	border-radius: var(--border-radius);
+	font-size: 12px;
+	margin-bottom: 8px;
+}
+
+.step-config-panel__advanced-body {
+	margin-top: 8px;
+}
+
+.step-config-panel__sla-row {
+	display: flex;
+	gap: 8px;
+}
+
+.step-config-panel__sla-value {
+	width: 80px;
+	flex: 0 0 80px;
+}
+
+.step-config-panel__required-field {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	margin-bottom: 4px;
+}
+
+.step-config-panel__escalation {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	margin-top: 6px;
+	padding: 8px;
+	background: var(--color-background-dark);
+	border-radius: var(--border-radius);
+}
+
+.step-config-panel__inline-check {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 13px;
 }
 </style>


### PR DESCRIPTION
## Summary

Manifest-first apply of openspec change `process-step-configuration`.

- **Schema (T01)**: `workflowTemplate` bumped 1.0.0 → 1.1.0 with additive documentation of the per-step `config` sub-object (`{sla, requiredFields, autoActions, escalationRule}`). No new top-level register schema.
- **Validator (T02)**: New `lib/Service/StepConfigValidator.php` — pure-function, no DI, no I/O. Implements the seven rules from `design.md` and returns structured `{path, code, message}` errors (never raw exception text).
- **Editor (T07/T08)**: Extended existing `StepConfigPanel.vue` with a collapsible "Geavanceerd" panel for SLA / required fields / escalation rule. Read-only wired from `WorkflowEditor.vue` via new `isPublished` computed (`template.isDraft === false`).

## Deferred (host services not on `development` yet)

- T03 — wire validator into `WorkflowDefinitionService::publish()`
- T04 / T05 — `StatusTransitionService` consumption (implicit `requiredFields` guard + step-level auto-action ordering)
- T06 — `TaskCreatorService::createForStep()` dueAt + escalationAt stamping
- T09 — `BackfillBezwaarStepConfig` repair step
- T10 — flip `openspec/specs/process-step-configuration/spec.md` to `status: implemented`

These all depend on services from sibling specs `workflow-definition-model` (#347) and `status-transition-engine` (#352) that have not yet landed in this tree. The validator is ready; the wiring becomes a one-liner once those services exist.

## Validation

- `php -l lib/Service/StepConfigValidator.php` — pass
- `jq -e .` on `procest_register.json` and `build.json` — pass
- Smoke-tested validator: empty errors on valid config; 4 expected errors on malformed config (out_of_range, unknown_sla_unit, unknown_action_key, offset_exceeds_sla)
- SPDX header present on validator; no `getMessage()` in returned errors
- `composer check:strict` and i18n deferred per STRICT watchdog

## Test plan

- [ ] Open a workflow template in the WorkflowEditor; click a step; expand "Geavanceerd"; verify SLA / required-fields / escalation inputs render
- [ ] Save a draft with SLA `{value: 5, unit: businessDays}` and confirm round-trip via store
- [ ] Open a non-draft template; confirm the "Geavanceerd" inputs are disabled and the banner renders
- [ ] Once the publish hook lands (T03), exercise REQ-PSC-4-001..004 acceptance scenarios