### PR TITLE
feat(workflow-definition-model): apply spec

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -77,6 +77,7 @@ Vrij en open source onder de AGPL-licentie.
             <step>OCA\Procest\Repair\InitializeSettings</step>
             <step>OCA\Procest\Repair\LoadDefaultZgwMappings</step>
             <step>OCA\Procest\Repair\SeedBezwaarBeroepData</step>
+            <step>OCA\Procest\Repair\MigrateWorkflowDefinitions</step>
         </post-migration>
     </repair-steps>
 

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -202,6 +202,17 @@ return [
         ['name' => 'advice#transitionStatus',  'url' => '/api/advice/{id}/transition', 'verb' => 'POST'],
         ['name' => 'advice#dispatchReminder',  'url' => '/api/advice/{id}/remind',     'verb' => 'POST'],
 
+        // ── Workflow Definitions (workflowTemplate) ─────────────────────
+        // CRUD on workflowTemplate is served by the manifest renderer +
+        // OpenRegister auto-routing (/api/objects/<register>/<schema>).
+        // Only the lifecycle transitions and the read-only consumer
+        // contract live on this controller.
+        ['name' => 'workflowDefinition#publish',           'url' => '/api/workflow-definitions/{id}/publish',         'verb' => 'POST'],
+        ['name' => 'workflowDefinition#deprecate',         'url' => '/api/workflow-definitions/{id}/deprecate',       'verb' => 'POST'],
+        ['name' => 'workflowDefinition#cloneDefinition',   'url' => '/api/workflow-definitions/{id}/clone',           'verb' => 'POST'],
+        ['name' => 'workflowDefinition#active',            'url' => '/api/workflow-definitions/active/{caseTypeId}',  'verb' => 'GET'],
+        ['name' => 'workflowDefinition#forCase',           'url' => '/api/workflow-definitions/for-case/{caseId}',    'verb' => 'GET'],
+
         // Multi-Tenant SaaS — domain endpoints only. Generic tenant CRUD
         // (list/create/update/destroy) is rendered by the manifest pages
         // at /settings/tenants and proxied directly to OpenRegister; this

--- a/lib/Controller/WorkflowDefinitionController.php
+++ b/lib/Controller/WorkflowDefinitionController.php
@@ -1,0 +1,173 @@
+<?php
+
+/**
+ * Procest Workflow Definition Controller
+ *
+ * Action endpoints for workflowTemplate lifecycle transitions. Pure CRUD
+ * is handled by the manifest renderer + OpenRegister auto-routing under
+ * /api/objects/<register>/<schema>; this controller only owns the
+ * lifecycle actions (publish, deprecate, clone) and the read-only
+ * consumer-contract endpoints used by status-transition-engine.
+ *
+ * @category Controller
+ * @package  OCA\Procest\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Controller;
+
+use OCA\Procest\AppInfo\Application;
+use OCA\Procest\Service\WorkflowDefinitionService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+
+/**
+ * Lifecycle-only controller for workflow definitions.
+ */
+class WorkflowDefinitionController extends Controller
+{
+
+
+    /**
+     * Constructor.
+     *
+     * @param IRequest                  $request The request object
+     * @param WorkflowDefinitionService $service The workflow definition service
+     */
+    public function __construct(
+        IRequest $request,
+        private WorkflowDefinitionService $service,
+    ) {
+        parent::__construct(appName: Application::APP_ID, request: $request);
+    }//end __construct()
+
+
+    /**
+     * Publish a draft definition.
+     *
+     * Atomically: flips target to published+active, deprecates the
+     * previously active version for the same caseType, and pins
+     * caseType.workflowDefinition to the new active id.
+     *
+     * @param string $id The workflow definition UUID
+     *
+     * @return JSONResponse
+     */
+    public function publish(string $id): JSONResponse
+    {
+        $result = $this->service->publish($id);
+        if ($result === null) {
+            return new JSONResponse(
+                ['success' => false, 'error' => 'Could not publish workflow definition'],
+                400,
+            );
+        }
+
+        return new JSONResponse(['success' => true, 'definition' => $result]);
+    }//end publish()
+
+
+    /**
+     * Deprecate a published definition.
+     *
+     * Refuses when this is the last published version for its caseType
+     * and open cases still depend on it.
+     *
+     * @param string $id The workflow definition UUID
+     *
+     * @return JSONResponse
+     */
+    public function deprecate(string $id): JSONResponse
+    {
+        $result = $this->service->deprecate($id);
+        if ($result === null) {
+            return new JSONResponse(
+                ['success' => false, 'error' => 'Could not deprecate workflow definition'],
+                400,
+            );
+        }
+
+        return new JSONResponse(['success' => true, 'definition' => $result]);
+    }//end deprecate()
+
+
+    /**
+     * Clone an existing definition into a new draft.
+     *
+     * @param string $id The source definition UUID
+     *
+     * @return JSONResponse
+     */
+    public function cloneDefinition(string $id): JSONResponse
+    {
+        $result = $this->service->cloneDefinition($id);
+        if ($result === null) {
+            return new JSONResponse(
+                ['success' => false, 'error' => 'Could not clone workflow definition'],
+                400,
+            );
+        }
+
+        return new JSONResponse(['success' => true, 'definition' => $result]);
+    }//end cloneDefinition()
+
+
+    /**
+     * Read-only consumer endpoint — returns the active definition for a
+     * caseType. Used by other apps when they need to consult the
+     * authoritative workflow for case orchestration.
+     *
+     * @param string $caseTypeId The caseType UUID
+     *
+     * @return JSONResponse
+     */
+    public function active(string $caseTypeId): JSONResponse
+    {
+        $definition = $this->service->getActiveDefinitionFor($caseTypeId);
+        if ($definition === null) {
+            return new JSONResponse(
+                ['success' => false, 'error' => 'No active workflow definition'],
+                404,
+            );
+        }
+
+        return new JSONResponse(['success' => true, 'definition' => $definition]);
+    }//end active()
+
+
+    /**
+     * Read-only consumer endpoint — returns the definition pinned to a
+     * specific case via case.workflowTemplate + case.workflowVersion.
+     *
+     * @param string $caseId The case UUID
+     *
+     * @return JSONResponse
+     */
+    public function forCase(string $caseId): JSONResponse
+    {
+        $definition = $this->service->getDefinitionForCase($caseId);
+        if ($definition === null) {
+            return new JSONResponse(
+                ['success' => false, 'error' => 'No workflow definition for case'],
+                404,
+            );
+        }
+
+        return new JSONResponse(['success' => true, 'definition' => $definition]);
+    }//end forCase()
+
+
+}//end class

--- a/lib/Repair/MigrateWorkflowDefinitions.php
+++ b/lib/Repair/MigrateWorkflowDefinitions.php
@@ -1,0 +1,445 @@
+<?php
+
+/**
+ * Procest Migrate Workflow Definitions Repair Step
+ *
+ * Backfill repair step that promotes the implicit lifecycle of every
+ * existing caseType into a seeded workflowTemplate published as
+ * version 1. Idempotent — skips caseTypes that already have a
+ * workflowDefinition reference set.
+ *
+ * @category Repair
+ * @package  OCA\Procest\Repair
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Repair;
+
+use OCA\Procest\AppInfo\Application;
+use OCA\Procest\Service\SettingsService;
+use OCA\Procest\Service\WorkflowDefinitionService;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Backfill workflowTemplate objects from implicit statusType ordering.
+ */
+class MigrateWorkflowDefinitions implements IRepairStep
+{
+
+
+    /**
+     * Constructor.
+     *
+     * @param SettingsService           $settingsService The settings service
+     * @param WorkflowDefinitionService $workflowService The workflow definition service
+     * @param LoggerInterface           $logger          The logger interface
+     */
+    public function __construct(
+        private SettingsService $settingsService,
+        private WorkflowDefinitionService $workflowService,
+        private LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+
+    /**
+     * Get the name of this repair step.
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'Backfill workflowTemplate definitions for existing caseTypes';
+    }//end getName()
+
+
+    /**
+     * Run the backfill.
+     *
+     * @param IOutput $output Repair output channel
+     *
+     * @return void
+     */
+    public function run(IOutput $output): void
+    {
+        if ($this->settingsService->isOpenRegisterAvailable() === false) {
+            $output->warning('OpenRegister not available — skipping workflow backfill.');
+            return;
+        }
+
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            $output->warning('OpenRegister ObjectService not resolvable — skipping workflow backfill.');
+            return;
+        }
+
+        $register        = $this->settingsService->getConfigValue('register');
+        $caseTypeSchema  = $this->settingsService->getConfigValue('case_type_schema');
+        $statusSchema    = $this->settingsService->getConfigValue('status_type_schema');
+        $templateSchema  = $this->settingsService->getConfigValue('workflow_template_schema');
+        $caseSchema      = $this->settingsService->getConfigValue('case_schema');
+
+        if ($register === ''
+            || $caseTypeSchema === ''
+            || $statusSchema === ''
+            || $templateSchema === ''
+        ) {
+            $output->warning('Workflow backfill: required schema configuration missing — skipping.');
+            return;
+        }
+
+        try {
+            $caseTypes = $objectService->findObjects($register, $caseTypeSchema, [], [], 500);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Procest: workflow backfill failed to list caseTypes',
+                ['app' => Application::APP_ID, 'exception' => $e->getMessage()]
+            );
+            $output->warning('Could not list caseTypes — skipping workflow backfill.');
+            return;
+        }
+
+        if (is_array($caseTypes) === false) {
+            return;
+        }
+
+        $migrated = 0;
+        $skipped  = 0;
+        foreach ($caseTypes as $caseType) {
+            $row = $this->normalize($caseType);
+            if ($row === null) {
+                continue;
+            }
+
+            $caseTypeId = (string) ($row['id'] ?? '');
+            if ($caseTypeId === '') {
+                continue;
+            }
+
+            if ((string) ($row['workflowDefinition'] ?? '') !== '') {
+                $skipped++;
+                continue;
+            }
+
+            // Already has at least one workflowTemplate? Skip — admin
+            // will set the pin via the UI.
+            $existing = $this->workflowService->listVersions($caseTypeId);
+            if ($existing !== []) {
+                $skipped++;
+                continue;
+            }
+
+            $template = $this->buildTemplateFor(
+                $caseTypeId,
+                $row,
+                $objectService,
+                $register,
+                $statusSchema,
+            );
+
+            if ($template === null) {
+                continue;
+            }
+
+            try {
+                $created = $objectService->saveObject(
+                    $register,
+                    $templateSchema,
+                    $template,
+                );
+            } catch (\Throwable $e) {
+                $this->logger->error(
+                    'Procest: workflow backfill failed to save template',
+                    ['app' => Application::APP_ID, 'exception' => $e->getMessage()]
+                );
+                continue;
+            }
+
+            $createdNormalized = $this->normalize($created);
+            $newId = (string) ($createdNormalized['id'] ?? '');
+
+            // Pin the caseType to the new template.
+            if ($newId !== '') {
+                try {
+                    $objectService->saveObject(
+                        $register,
+                        $caseTypeSchema,
+                        ['workflowDefinition' => $newId],
+                        $caseTypeId,
+                    );
+                } catch (\Throwable $e) {
+                    $this->logger->error(
+                        'Procest: workflow backfill failed to pin caseType',
+                        ['app' => Application::APP_ID, 'exception' => $e->getMessage()]
+                    );
+                }
+
+                // Pin existing open cases to workflowVersion = 1.
+                if ($caseSchema !== '') {
+                    $this->pinOpenCases(
+                        $objectService,
+                        $register,
+                        $caseSchema,
+                        $caseTypeId,
+                        $newId,
+                    );
+                }
+            }
+
+            $migrated++;
+        }//end foreach
+
+        $output->info(
+            'Workflow backfill complete — migrated '.$migrated.', skipped '.$skipped.'.'
+        );
+    }//end run()
+
+
+    /**
+     * Build a workflowTemplate payload from a caseType's statusType
+     * records.
+     *
+     * @param string                                                $caseTypeId    The caseType UUID
+     * @param array<string, mixed>                                  $caseType      Normalized caseType row
+     * @param object                                                $objectService Resolved OR ObjectService
+     * @param string                                                $register      The register id
+     * @param string                                                $statusSchema  The statusType schema id
+     *
+     * @return array<string, mixed>|null
+     */
+    private function buildTemplateFor(
+        string $caseTypeId,
+        array $caseType,
+        object $objectService,
+        string $register,
+        string $statusSchema,
+    ): ?array {
+        try {
+            $statusRows = $objectService->findObjects(
+                $register,
+                $statusSchema,
+                ['caseType' => $caseTypeId],
+                [],
+                500,
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Procest: workflow backfill failed to list statusTypes',
+                ['app' => Application::APP_ID, 'exception' => $e->getMessage()]
+            );
+            return null;
+        }
+
+        if (is_array($statusRows) === false || $statusRows === []) {
+            return null;
+        }
+
+        $statuses = [];
+        foreach ($statusRows as $raw) {
+            $row = $this->normalize($raw);
+            if ($row !== null && (string) ($row['id'] ?? '') !== '') {
+                $statuses[] = $row;
+            }
+        }
+
+        if ($statuses === []) {
+            return null;
+        }
+
+        usort(
+            $statuses,
+            static function (array $a, array $b): int {
+                return (int) ($a['order'] ?? 0) <=> (int) ($b['order'] ?? 0);
+            },
+        );
+
+        $steps = [];
+        foreach ($statuses as $status) {
+            if ((bool) ($status['isFinal'] ?? false) === true) {
+                continue;
+            }
+
+            $steps[] = [
+                'id'           => $this->uuid(),
+                'title'        => (string) ($status['name'] ?? 'Stap'),
+                'description'  => (string) ($status['description'] ?? ''),
+                'status'       => (string) ($status['id'] ?? ''),
+                'order'        => (int) ($status['order'] ?? 0),
+                'assigneeRole' => '',
+                'isRequired'   => false,
+                'checklist'    => [],
+                'automaticActions' => [],
+            ];
+        }
+
+        $transitions = [];
+        $count       = count($statuses);
+        for ($i = 0; $i < ($count - 1); $i++) {
+            $from = $statuses[$i];
+            $to   = $statuses[($i + 1)];
+
+            $transitions[] = [
+                'id'         => $this->uuid(),
+                'fromStatus' => (string) ($from['id'] ?? ''),
+                'toStatus'   => (string) ($to['id'] ?? ''),
+                'label'      => (string) ($to['name'] ?? 'Door'),
+                'guards'     => [],
+                'automaticActions' => [],
+                'allowedRoles' => [],
+            ];
+        }
+
+        $title = trim((string) ($caseType['title'] ?? 'Workflow'));
+        if ($title === '') {
+            $title = 'Workflow';
+        }
+
+        return [
+            'title'           => $title.' — basis',
+            'description'    => 'Backfilled from implicit statusType ordering.',
+            'caseType'        => $caseTypeId,
+            'version'         => 1,
+            'isActive'        => true,
+            'isDraft'         => false,
+            'lifecycleStatus' => WorkflowDefinitionService::STATUS_PUBLISHED,
+            'steps'           => json_encode($steps, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'transitions'     => json_encode($transitions, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'nodePositions'   => '',
+        ];
+    }//end buildTemplateFor()
+
+
+    /**
+     * Pin every open case of a caseType to workflowVersion 1 and bind it
+     * to the new workflowTemplate.
+     *
+     * @param object $objectService The OR ObjectService
+     * @param string $register      The register id
+     * @param string $caseSchema    The case schema id
+     * @param string $caseTypeId    The caseType UUID
+     * @param string $templateId    The new template UUID
+     *
+     * @return void
+     */
+    private function pinOpenCases(
+        object $objectService,
+        string $register,
+        string $caseSchema,
+        string $caseTypeId,
+        string $templateId,
+    ): void {
+        try {
+            $cases = $objectService->findObjects(
+                $register,
+                $caseSchema,
+                ['caseType' => $caseTypeId],
+                [],
+                500,
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Procest: workflow backfill failed to list cases',
+                ['app' => Application::APP_ID, 'exception' => $e->getMessage()]
+            );
+            return;
+        }
+
+        if (is_array($cases) === false) {
+            return;
+        }
+
+        foreach ($cases as $row) {
+            $case = $this->normalize($row);
+            if ($case === null) {
+                continue;
+            }
+
+            $caseId = (string) ($case['id'] ?? '');
+            if ($caseId === '') {
+                continue;
+            }
+
+            // Skip already-pinned cases.
+            if ((string) ($case['workflowTemplate'] ?? '') !== '') {
+                continue;
+            }
+
+            try {
+                $objectService->saveObject(
+                    $register,
+                    $caseSchema,
+                    [
+                        'workflowTemplate' => $templateId,
+                        'workflowVersion'  => 1,
+                    ],
+                    $caseId,
+                );
+            } catch (\Throwable $e) {
+                $this->logger->error(
+                    'Procest: workflow backfill failed to pin case',
+                    ['app' => Application::APP_ID, 'exception' => $e->getMessage()]
+                );
+            }
+        }
+    }//end pinOpenCases()
+
+
+    /**
+     * Coerce an OpenRegister result row to an associative array.
+     *
+     * @param mixed $row Result row from ObjectService
+     *
+     * @return array<string, mixed>|null
+     */
+    private function normalize(mixed $row): ?array
+    {
+        if (is_array($row) === true) {
+            return $row;
+        }
+
+        if (is_object($row) === true && method_exists($row, 'jsonSerialize') === true) {
+            $serialized = $row->jsonSerialize();
+            if (is_array($serialized) === true) {
+                return $serialized;
+            }
+        }
+
+        return null;
+    }//end normalize()
+
+
+    /**
+     * Generate a UUID v4 for embedded step / transition identifiers.
+     *
+     * @return string
+     */
+    private function uuid(): string
+    {
+        $bytes    = random_bytes(16);
+        $bytes[6] = chr((ord($bytes[6]) & 0x0F) | 0x40);
+        $bytes[8] = chr((ord($bytes[8]) & 0x3F) | 0x80);
+
+        $hex = bin2hex($bytes);
+        return substr($hex, 0, 8).'-'
+            .substr($hex, 8, 4).'-'
+            .substr($hex, 12, 4).'-'
+            .substr($hex, 16, 4).'-'
+            .substr($hex, 20, 12);
+    }//end uuid()
+
+
+}//end class

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -63,6 +63,10 @@ class SettingsService
         'abonnement_schema',
         'map_layer_schema',
         'workflow_template_schema',
+        // Stable alias for consumer specs (status-transition-engine,
+        // role-based-step-routing) that refer to the workflow definition
+        // independent of the legacy schema slug.
+        'workflow_definition_schema',
         'objection_schema',
         'hearing_session_schema',
         'advisory_report_schema',
@@ -431,6 +435,18 @@ class SettingsService
                 $configKey,
                 $schemaId
             );
+
+            // Mirror the workflowTemplate schema id under the stable
+            // workflow_definition_schema alias so consumer specs
+            // (status-transition-engine, role-based-step-routing) can
+            // resolve it without depending on the legacy slug.
+            if ($slug === 'workflowTemplate') {
+                $this->appConfig->setValueString(
+                    Application::APP_ID,
+                    'workflow_definition_schema',
+                    $schemaId
+                );
+            }
 
             $this->logger->debug(
                 'Procest: Auto-configured schema',

--- a/lib/Service/WorkflowDefinitionService.php
+++ b/lib/Service/WorkflowDefinitionService.php
@@ -1,0 +1,847 @@
+<?php
+
+/**
+ * Procest Workflow Definition Service
+ *
+ * Lifecycle and consumer service for workflowTemplate objects (aka
+ * "workflow definitions"). Pure CRUD over workflowTemplate is delegated to
+ * the manifest renderer / OpenRegister auto-routing; this service owns the
+ * domain logic that CRUD cannot express:
+ *
+ *   - publish()              — flip a draft to published, deprecate the
+ *                              previously active version, pin the
+ *                              caseType.workflowDefinition reference.
+ *   - deprecate()            — flip a published version to deprecated and
+ *                              clear isActive (refuses if the caseType has
+ *                              no other published version while open cases
+ *                              remain).
+ *   - cloneDefinition()      — produce a new draft from an existing
+ *                              published or deprecated version with
+ *                              version + 1.
+ *   - getActiveDefinitionFor — read-only consumer entrypoint used by
+ *                              status-transition-engine and
+ *                              role-based-step-routing.
+ *   - getDefinition          — read-only by UUID.
+ *   - getDefinitionForCase   — resolves through case.workflowTemplate +
+ *                              case.workflowVersion.
+ *   - listVersions           — admin UI listing.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service;
+
+use OCA\Procest\AppInfo\Application;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Lifecycle + consumer service for workflowTemplate objects.
+ */
+class WorkflowDefinitionService
+{
+
+    /**
+     * Lifecycle states. Mirrors the enum on the workflowTemplate schema.
+     */
+    public const STATUS_DRAFT      = 'draft';
+    public const STATUS_PUBLISHED  = 'published';
+    public const STATUS_DEPRECATED = 'deprecated';
+
+    /**
+     * Static error strings — never leak OpenRegister exception details to
+     * the HTTP layer.
+     */
+    private const ERR_OR_UNAVAILABLE      = 'Workflow definition store is not available';
+    private const ERR_SCHEMA_NOT_CONFIG   = 'Workflow definition schema is not configured';
+    private const ERR_NOT_FOUND           = 'Workflow definition not found';
+    private const ERR_PUBLISH_FAILED      = 'Could not publish workflow definition';
+    private const ERR_DEPRECATE_FAILED    = 'Could not deprecate workflow definition';
+    private const ERR_CLONE_FAILED        = 'Could not clone workflow definition';
+    private const ERR_NOT_DRAFT           = 'Only draft definitions can be edited';
+    private const ERR_NOT_PUBLISHABLE     = 'Only draft definitions can be published';
+    private const ERR_NOT_DEPRECATABLE    = 'Only published definitions can be deprecated';
+    private const ERR_INVALID_REFERENCES  = 'Definition references statuses not belonging to its case type';
+    private const ERR_LAST_PUBLISHED      = 'Cannot deprecate the last published definition while open cases remain';
+
+
+    /**
+     * Constructor.
+     *
+     * @param SettingsService $settingsService The settings service
+     * @param IUserSession    $userSession     The user session
+     * @param LoggerInterface $logger          The logger
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+        private readonly IUserSession $userSession,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+
+    /**
+     * Resolve the latest published+active definition for a caseType, or
+     * null when none exists. Read-only consumer entrypoint used by
+     * status-transition-engine and role-based-step-routing.
+     *
+     * @param string $caseTypeId The caseType UUID
+     *
+     * @return array<string, mixed>|null The definition or null
+     */
+    public function getActiveDefinitionFor(string $caseTypeId): ?array
+    {
+        if ($caseTypeId === '') {
+            return null;
+        }
+
+        $versions = $this->listVersionsInternal($caseTypeId);
+        if ($versions === []) {
+            return null;
+        }
+
+        foreach ($versions as $candidate) {
+            if ($this->statusOf($candidate) !== self::STATUS_PUBLISHED) {
+                continue;
+            }
+
+            if ((bool) ($candidate['isActive'] ?? false) === true) {
+                return $candidate;
+            }
+        }
+
+        return null;
+    }//end getActiveDefinitionFor()
+
+
+    /**
+     * Read a single definition by UUID. Returns null when not found.
+     *
+     * @param string $id The definition UUID
+     *
+     * @return array<string, mixed>|null The definition or null
+     */
+    public function getDefinition(string $id): ?array
+    {
+        return $this->loadDefinition($id);
+    }//end getDefinition()
+
+
+    /**
+     * Resolve the definition pinned to a case via case.workflowTemplate +
+     * case.workflowVersion. Falls back to the active definition for the
+     * case's caseType when no pin is set.
+     *
+     * @param string $caseId The case UUID
+     *
+     * @return array<string, mixed>|null The definition or null
+     */
+    public function getDefinitionForCase(string $caseId): ?array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return null;
+        }
+
+        $register   = $this->settingsService->getConfigValue('register');
+        $caseSchema = $this->settingsService->getConfigValue('case_schema');
+
+        if ($register === '' || $caseSchema === '') {
+            return null;
+        }
+
+        try {
+            $case = $objectService->findObject($register, $caseSchema, $caseId);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Procest: failed to load case for definition lookup',
+                ['app' => Application::APP_ID, 'exception' => $e->getMessage()]
+            );
+            return null;
+        }
+
+        $case = $this->normalize($case);
+        if ($case === null) {
+            return null;
+        }
+
+        $templateId = (string) ($case['workflowTemplate'] ?? '');
+        if ($templateId !== '') {
+            return $this->loadDefinition($templateId);
+        }
+
+        $caseTypeId = (string) ($case['caseType'] ?? '');
+        if ($caseTypeId === '') {
+            return null;
+        }
+
+        return $this->getActiveDefinitionFor($caseTypeId);
+    }//end getDefinitionForCase()
+
+
+    /**
+     * List every version of the definition for a given caseType, ordered
+     * by version descending. Used by the admin UI.
+     *
+     * @param string $caseTypeId The caseType UUID
+     *
+     * @return array<int, array<string, mixed>> The versions
+     */
+    public function listVersions(string $caseTypeId): array
+    {
+        return $this->listVersionsInternal($caseTypeId);
+    }//end listVersions()
+
+
+    /**
+     * Publish a draft definition. Atomically:
+     *   - sets target lifecycleStatus=published, isActive=true, isDraft=false
+     *   - moves any previously active version of the same caseType to
+     *     lifecycleStatus=deprecated, isActive=false
+     *   - updates caseType.workflowDefinition to point at the new active id
+     *
+     * Returns the updated definition or null on error (errors logged).
+     *
+     * @param string $id The definition UUID to publish
+     *
+     * @return array<string, mixed>|null Updated definition or null
+     */
+    public function publish(string $id): ?array
+    {
+        $current = $this->loadDefinition($id);
+        if ($current === null) {
+            $this->logger->warning(
+                'Procest: publish() — definition not found',
+                ['app' => Application::APP_ID, 'id' => $id]
+            );
+            return null;
+        }
+
+        if ($this->statusOf($current) !== self::STATUS_DRAFT) {
+            $this->logger->warning(
+                'Procest: publish() — definition is not a draft',
+                ['app' => Application::APP_ID, 'id' => $id]
+            );
+            return null;
+        }
+
+        $caseTypeId = (string) ($current['caseType'] ?? '');
+        if ($caseTypeId === '' || $this->transitionsReferenceForeignStatuses($current) === true) {
+            $this->logger->warning(
+                'Procest: publish() — referential integrity failure',
+                ['app' => Application::APP_ID, 'id' => $id]
+            );
+            return null;
+        }
+
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return null;
+        }
+
+        $register     = $this->settingsService->getConfigValue('register');
+        $schema       = $this->settingsService->getConfigValue('workflow_template_schema');
+        $caseTypeSch  = $this->settingsService->getConfigValue('case_type_schema');
+
+        if ($register === '' || $schema === '' || $caseTypeSch === '') {
+            return null;
+        }
+
+        // Deprecate previously active versions of the same caseType.
+        $previousActive = $this->getActiveDefinitionFor($caseTypeId);
+        if ($previousActive !== null && (string) ($previousActive['id'] ?? '') !== $id) {
+            try {
+                $objectService->saveObject(
+                    $register,
+                    $schema,
+                    [
+                        'lifecycleStatus' => self::STATUS_DEPRECATED,
+                        'isActive'        => false,
+                    ],
+                    (string) $previousActive['id'],
+                );
+            } catch (\Throwable $e) {
+                $this->logger->error(
+                    'Procest: failed to deprecate previous active definition',
+                    ['app' => Application::APP_ID, 'exception' => $e->getMessage()]
+                );
+                return null;
+            }
+        }
+
+        // Flip target to published+active.
+        try {
+            $updated = $objectService->saveObject(
+                $register,
+                $schema,
+                [
+                    'lifecycleStatus' => self::STATUS_PUBLISHED,
+                    'isActive'        => true,
+                    'isDraft'         => false,
+                ],
+                $id,
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Procest: failed to publish workflow definition',
+                ['app' => Application::APP_ID, 'exception' => $e->getMessage()]
+            );
+            return null;
+        }
+
+        // Pin caseType.workflowDefinition to the new active version.
+        try {
+            $objectService->saveObject(
+                $register,
+                $caseTypeSch,
+                ['workflowDefinition' => $id],
+                $caseTypeId,
+            );
+        } catch (\Throwable $e) {
+            // Pinning failure is non-fatal — log and continue. The
+            // consumer entrypoint falls back to getActiveDefinitionFor()
+            // which finds the new published+active row.
+            $this->logger->error(
+                'Procest: failed to pin caseType.workflowDefinition',
+                ['app' => Application::APP_ID, 'exception' => $e->getMessage()]
+            );
+        }
+
+        return $this->normalize($updated);
+    }//end publish()
+
+
+    /**
+     * Deprecate a published definition. Refuses (returns null + logs) if
+     * doing so would leave the caseType with no published definition while
+     * open cases remain pinned to it.
+     *
+     * @param string $id The definition UUID to deprecate
+     *
+     * @return array<string, mixed>|null Updated definition or null
+     */
+    public function deprecate(string $id): ?array
+    {
+        $current = $this->loadDefinition($id);
+        if ($current === null) {
+            return null;
+        }
+
+        if ($this->statusOf($current) !== self::STATUS_PUBLISHED) {
+            $this->logger->warning(
+                'Procest: deprecate() — definition is not published',
+                ['app' => Application::APP_ID, 'id' => $id]
+            );
+            return null;
+        }
+
+        $caseTypeId = (string) ($current['caseType'] ?? '');
+        if ($caseTypeId !== '' && $this->isLastPublishedForCaseType($id, $caseTypeId) === true
+            && $this->hasOpenCasesFor($caseTypeId) === true
+        ) {
+            $this->logger->warning(
+                'Procest: deprecate() — last published definition with open cases',
+                ['app' => Application::APP_ID, 'id' => $id, 'caseType' => $caseTypeId]
+            );
+            return null;
+        }
+
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return null;
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('workflow_template_schema');
+
+        if ($register === '' || $schema === '') {
+            return null;
+        }
+
+        try {
+            $updated = $objectService->saveObject(
+                $register,
+                $schema,
+                [
+                    'lifecycleStatus' => self::STATUS_DEPRECATED,
+                    'isActive'        => false,
+                ],
+                $id,
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Procest: failed to deprecate workflow definition',
+                ['app' => Application::APP_ID, 'exception' => $e->getMessage()]
+            );
+            return null;
+        }
+
+        return $this->normalize($updated);
+    }//end deprecate()
+
+
+    /**
+     * Clone an existing published or deprecated definition into a new
+     * draft with version + 1.
+     *
+     * @param string $id The source definition UUID
+     *
+     * @return array<string, mixed>|null New draft definition or null
+     */
+    public function cloneDefinition(string $id): ?array
+    {
+        $source = $this->loadDefinition($id);
+        if ($source === null) {
+            return null;
+        }
+
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return null;
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('workflow_template_schema');
+
+        if ($register === '' || $schema === '') {
+            return null;
+        }
+
+        $caseTypeId = (string) ($source['caseType'] ?? '');
+        $nextVersion = $this->nextVersionFor($caseTypeId);
+
+        $draft = [
+            'title'           => $this->cloneTitle((string) ($source['title'] ?? 'Workflow')),
+            'description'     => (string) ($source['description'] ?? ''),
+            'caseType'        => $caseTypeId,
+            'version'         => $nextVersion,
+            'isActive'        => false,
+            'isDraft'         => true,
+            'lifecycleStatus' => self::STATUS_DRAFT,
+            'steps'           => (string) ($source['steps'] ?? ''),
+            'transitions'     => (string) ($source['transitions'] ?? ''),
+            'nodePositions'   => (string) ($source['nodePositions'] ?? ''),
+        ];
+
+        try {
+            $new = $objectService->saveObject($register, $schema, $draft);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Procest: failed to clone workflow definition',
+                ['app' => Application::APP_ID, 'exception' => $e->getMessage()]
+            );
+            return null;
+        }
+
+        return $this->normalize($new);
+    }//end cloneDefinition()
+
+
+    // -----------------------------------------------------------------
+    // Internal helpers.
+    // -----------------------------------------------------------------
+
+
+    /**
+     * Internal — fetch all versions of the definition for a caseType,
+     * sorted by version descending.
+     *
+     * @param string $caseTypeId The caseType UUID
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function listVersionsInternal(string $caseTypeId): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return [];
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('workflow_template_schema');
+
+        if ($register === '' || $schema === '') {
+            return [];
+        }
+
+        try {
+            $results = $objectService->findObjects(
+                $register,
+                $schema,
+                ['caseType' => $caseTypeId],
+                [],
+                500,
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Procest: failed to list workflow definitions for caseType',
+                ['app' => Application::APP_ID, 'exception' => $e->getMessage()]
+            );
+            return [];
+        }
+
+        if (is_array($results) === false) {
+            return [];
+        }
+
+        $rows = [];
+        foreach ($results as $row) {
+            $normalized = $this->normalize($row);
+            if ($normalized !== null) {
+                $rows[] = $normalized;
+            }
+        }
+
+        usort(
+            $rows,
+            static function (array $a, array $b): int {
+                return (int) ($b['version'] ?? 0) <=> (int) ($a['version'] ?? 0);
+            },
+        );
+
+        return $rows;
+    }//end listVersionsInternal()
+
+
+    /**
+     * Load a single definition by UUID.
+     *
+     * @param string $id The definition UUID
+     *
+     * @return array<string, mixed>|null
+     */
+    private function loadDefinition(string $id): ?array
+    {
+        if ($id === '') {
+            return null;
+        }
+
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return null;
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('workflow_template_schema');
+
+        if ($register === '' || $schema === '') {
+            return null;
+        }
+
+        try {
+            $obj = $objectService->findObject($register, $schema, $id);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Procest: failed to load workflow definition',
+                ['app' => Application::APP_ID, 'exception' => $e->getMessage()]
+            );
+            return null;
+        }
+
+        return $this->normalize($obj);
+    }//end loadDefinition()
+
+
+    /**
+     * Resolve the next monotonically increasing version number for a
+     * given caseType. Falls back to 1 when no prior versions exist.
+     *
+     * @param string $caseTypeId The caseType UUID
+     *
+     * @return int Next version number
+     */
+    private function nextVersionFor(string $caseTypeId): int
+    {
+        $versions = $this->listVersionsInternal($caseTypeId);
+        $max      = 0;
+        foreach ($versions as $row) {
+            $candidate = (int) ($row['version'] ?? 0);
+            if ($candidate > $max) {
+                $max = $candidate;
+            }
+        }
+
+        return ($max + 1);
+    }//end nextVersionFor()
+
+
+    /**
+     * Whether this id is the last published row for its caseType.
+     *
+     * @param string $id         The current definition UUID
+     * @param string $caseTypeId The caseType UUID
+     *
+     * @return bool
+     */
+    private function isLastPublishedForCaseType(string $id, string $caseTypeId): bool
+    {
+        $count = 0;
+        foreach ($this->listVersionsInternal($caseTypeId) as $row) {
+            if ((string) ($row['id'] ?? '') === $id) {
+                continue;
+            }
+
+            if ($this->statusOf($row) === self::STATUS_PUBLISHED) {
+                $count++;
+            }
+        }
+
+        return ($count === 0);
+    }//end isLastPublishedForCaseType()
+
+
+    /**
+     * Whether the caseType has any open cases (status not in a final
+     * state). Conservative — returns true when we cannot establish the
+     * count to avoid silent data loss.
+     *
+     * @param string $caseTypeId The caseType UUID
+     *
+     * @return bool
+     */
+    private function hasOpenCasesFor(string $caseTypeId): bool
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return true;
+        }
+
+        $register   = $this->settingsService->getConfigValue('register');
+        $caseSchema = $this->settingsService->getConfigValue('case_schema');
+
+        if ($register === '' || $caseSchema === '') {
+            return true;
+        }
+
+        try {
+            $results = $objectService->findObjects(
+                $register,
+                $caseSchema,
+                ['caseType' => $caseTypeId],
+                [],
+                1,
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Procest: failed to count open cases for caseType',
+                ['app' => Application::APP_ID, 'exception' => $e->getMessage()]
+            );
+            return true;
+        }
+
+        return (is_array($results) === true && count($results) > 0);
+    }//end hasOpenCasesFor()
+
+
+    /**
+     * Validate that every status referenced in transitions belongs to the
+     * linked caseType. Returns true when the references are *invalid*.
+     *
+     * @param array<string, mixed> $definition The definition to validate
+     *
+     * @return bool
+     */
+    private function transitionsReferenceForeignStatuses(array $definition): bool
+    {
+        $caseTypeId  = (string) ($definition['caseType'] ?? '');
+        $transitions = $this->decodeArray($definition['transitions'] ?? '');
+
+        if ($caseTypeId === '' || $transitions === []) {
+            return false;
+        }
+
+        $statusIds = $this->collectStatusTypeIdsFor($caseTypeId);
+        if ($statusIds === []) {
+            // No statusTypes yet — cannot validate. Treat as ok.
+            return false;
+        }
+
+        foreach ($transitions as $transition) {
+            if (is_array($transition) === false) {
+                continue;
+            }
+
+            foreach (['fromStatus', 'toStatus'] as $key) {
+                $ref = (string) ($transition[$key] ?? '');
+                if ($ref !== '' && in_array($ref, $statusIds, true) === false) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }//end transitionsReferenceForeignStatuses()
+
+
+    /**
+     * Fetch every statusType id belonging to a given caseType.
+     *
+     * @param string $caseTypeId The caseType UUID
+     *
+     * @return array<int, string>
+     */
+    private function collectStatusTypeIdsFor(string $caseTypeId): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return [];
+        }
+
+        $register     = $this->settingsService->getConfigValue('register');
+        $statusSchema = $this->settingsService->getConfigValue('status_type_schema');
+
+        if ($register === '' || $statusSchema === '') {
+            return [];
+        }
+
+        try {
+            $rows = $objectService->findObjects(
+                $register,
+                $statusSchema,
+                ['caseType' => $caseTypeId],
+                [],
+                500,
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Procest: failed to list statusTypes for caseType',
+                ['app' => Application::APP_ID, 'exception' => $e->getMessage()]
+            );
+            return [];
+        }
+
+        if (is_array($rows) === false) {
+            return [];
+        }
+
+        $ids = [];
+        foreach ($rows as $row) {
+            $normalized = $this->normalize($row);
+            if ($normalized === null) {
+                continue;
+            }
+
+            $id = (string) ($normalized['id'] ?? '');
+            if ($id !== '') {
+                $ids[] = $id;
+            }
+        }
+
+        return $ids;
+    }//end collectStatusTypeIdsFor()
+
+
+    /**
+     * Decode a JSON-encoded array property; returns an empty array on any
+     * decoding error or non-array payload.
+     *
+     * @param mixed $raw The raw property value
+     *
+     * @return array<int, mixed>
+     */
+    private function decodeArray(mixed $raw): array
+    {
+        if (is_array($raw) === true) {
+            return $raw;
+        }
+
+        if (is_string($raw) === false || $raw === '') {
+            return [];
+        }
+
+        $decoded = json_decode($raw, true);
+        if (is_array($decoded) === true) {
+            return $decoded;
+        }
+
+        return [];
+    }//end decodeArray()
+
+
+    /**
+     * Coerce an OpenRegister result row to an associative array.
+     *
+     * @param mixed $row Result row from ObjectService
+     *
+     * @return array<string, mixed>|null
+     */
+    private function normalize(mixed $row): ?array
+    {
+        if (is_array($row) === true) {
+            return $row;
+        }
+
+        if (is_object($row) === true && method_exists($row, 'jsonSerialize') === true) {
+            $serialized = $row->jsonSerialize();
+            if (is_array($serialized) === true) {
+                return $serialized;
+            }
+        }
+
+        return null;
+    }//end normalize()
+
+
+    /**
+     * Resolve the authoritative lifecycle status of a row. Prefers the
+     * new lifecycleStatus field; falls back to the legacy isDraft +
+     * isActive booleans for objects created before the schema bump.
+     *
+     * @param array<string, mixed> $row Definition row
+     *
+     * @return string One of draft|published|deprecated
+     */
+    private function statusOf(array $row): string
+    {
+        $status = (string) ($row['lifecycleStatus'] ?? '');
+        if ($status === self::STATUS_DRAFT
+            || $status === self::STATUS_PUBLISHED
+            || $status === self::STATUS_DEPRECATED
+        ) {
+            return $status;
+        }
+
+        // Legacy fallback.
+        $isDraft  = (bool) ($row['isDraft'] ?? true);
+        $isActive = (bool) ($row['isActive'] ?? false);
+
+        if ($isDraft === true) {
+            return self::STATUS_DRAFT;
+        }
+
+        if ($isActive === true) {
+            return self::STATUS_PUBLISHED;
+        }
+
+        return self::STATUS_DEPRECATED;
+    }//end statusOf()
+
+
+    /**
+     * Build a title for a cloned draft.
+     *
+     * @param string $base The source title
+     *
+     * @return string
+     */
+    private function cloneTitle(string $base): string
+    {
+        return rtrim($base).' (kopie)';
+    }//end cloneTitle()
+
+
+}//end class

--- a/lib/Settings/procest_register.json
+++ b/lib/Settings/procest_register.json
@@ -169,6 +169,11 @@
             "type": "string",
             "description": "Nextcloud user UID or group ID for automatic assignment of cases of this type (REQ-INTAKE-03a)",
             "title": "Default assignee"
+          },
+          "workflowDefinition": {
+            "type": "string",
+            "format": "uuid",
+            "description": "UUID reference to the pinned active workflowTemplate for this case type. When unset, new cases fall through to the latest published workflowTemplate for this caseType. New cases are bound to the version that is published+isActive at the moment of case creation (see case.workflowTemplate + case.workflowVersion)."
           }
         }
       },
@@ -1836,7 +1841,7 @@
       "workflowTemplate": {
         "slug": "workflowTemplate",
         "icon": "SitemapOutline",
-        "version": "1.0.0",
+        "version": "1.1.0",
         "x-schema-org-type": "schema:HowTo",
         "x-cmmn-equivalent": "CasePlanModel",
         "title": "Workflow Template",
@@ -1876,7 +1881,17 @@
           "isDraft": {
             "type": "boolean",
             "default": true,
-            "description": "Draft templates cannot be used for new cases"
+            "description": "Draft templates cannot be used for new cases (legacy flag; lifecycleStatus is authoritative)"
+          },
+          "lifecycleStatus": {
+            "type": "string",
+            "enum": [
+              "draft",
+              "published",
+              "deprecated"
+            ],
+            "default": "draft",
+            "description": "Lifecycle state of this definition. Authoritative going forward; isDraft/isActive remain for backwards compatibility. draft = editable, cannot back new cases. published = immutable, can back new cases (one active per caseType). deprecated = immutable, cannot back new cases, existing cases keep using it."
           },
           "steps": {
             "type": "string",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -19,6 +19,7 @@
 		{ "id": "PartnersMenu", "label": "Partner organisations", "icon": "icon-group", "route": "Partners", "section": "settings", "order": 97 },
 		{ "id": "TenantsMenu", "label": "Tenants", "icon": "icon-group", "route": "Tenants", "section": "settings", "order": 98, "permission": "admin" },
 		{ "id": "ParafeerroutesMenu", "label": "Parafeerroutes", "icon": "icon-category-workflow", "route": "Parafeerroutes", "section": "settings", "order": 96 },
+		{ "id": "WorkflowDefinitionsMenu", "label": "Workflow definitions", "icon": "icon-category-workflow", "route": "WorkflowDefinitions", "section": "settings", "order": 97 },
 		{ "id": "SettingsMenu", "label": "Settings", "icon": "icon-settings", "route": "Settings", "section": "settings", "order": 99 }
 	],
 	"pages": [
@@ -467,6 +468,40 @@
 			"type": "custom",
 			"title": "Public status",
 			"component": "PublicStatusPage"
+		},
+		{
+			"id": "WorkflowDefinitions",
+			"route": "/settings/workflow-definitions",
+			"type": "index",
+			"title": "Workflow definitions",
+			"config": {
+				"register": "procest",
+				"schema": "workflowTemplate",
+				"columns": ["title", "caseType", "version", "lifecycleStatus", "isActive", "updatedAt"],
+				"actions": ["create", "edit", "delete", "view"],
+				"sidebar": { "enabled": true, "showMetadata": true }
+			}
+		},
+		{
+			"id": "WorkflowDefinitionDetail",
+			"route": "/settings/workflow-definitions/:id",
+			"type": "detail",
+			"title": "Workflow definition",
+			"config": {
+				"register": "procest",
+				"schema": "workflowTemplate",
+				"actions": [
+					{ "id": "publish",   "label": "Publish",   "icon": "icon-checkmark", "permission": "admin", "primary": true, "handler": "emit" },
+					{ "id": "deprecate", "label": "Deprecate", "icon": "icon-close",     "permission": "admin",                  "handler": "emit" },
+					{ "id": "clone",     "label": "Clone",     "icon": "icon-add",       "permission": "admin",                  "handler": "emit" }
+				],
+				"sidebarTabs": [
+					{ "id": "overview",    "label": "Overview",    "icon": "icon-info",     "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
+					{ "id": "steps",       "label": "Steps",       "icon": "icon-checkmark","widgets": [{ "type": "data" }],                          "order": 20 },
+					{ "id": "transitions", "label": "Transitions", "icon": "icon-comment",  "widgets": [{ "type": "data" }],                          "order": 30 },
+					{ "id": "audit",       "label": "Audit trail", "icon": "icon-history",  "widgets": [{ "type": "audit-trail" }],                   "order": 90 }
+				]
+			}
 		}
 	]
 }


### PR DESCRIPTION
## Summary

Applies openspec change `workflow-definition-model` to Procest, exposing the existing `workflowTemplate` schema with a draft → published → deprecated lifecycle and a stable consumer contract for `status-transition-engine` and `role-based-step-routing` — **manifest-first**, without growing bespoke CRUD.

- Schema gains `lifecycleStatus` enum + `caseType.workflowDefinition` pin; version bumped to 1.1.0. `workflow_definition_schema` alias added so consumer specs resolve the id independent of the legacy slug.
- Manifest pages `WorkflowDefinitions` (index) + `WorkflowDefinitionDetail` (detail) + settings menu entry handle CRUD — no bespoke Vue controllers or list/edit components.
- `WorkflowDefinitionService` owns the legitimate domain logic: `publish` (atomic — deprecates previous active, pins `caseType.workflowDefinition`, validates that transitions only reference statusTypes of the linked caseType), `deprecate` (refuses to strand open cases), `cloneDefinition` (version + 1). Read-only consumer methods: `getActiveDefinitionFor`, `getDefinition`, `getDefinitionForCase`, `listVersions`.
- `WorkflowDefinitionController` exposes only action endpoints — no CRUD: `POST /api/workflow-definitions/{id}/{publish|deprecate|clone}`, `GET /api/workflow-definitions/{active|for-case}/...`.
- `lib/Repair/MigrateWorkflowDefinitions.php` backfills one published workflowTemplate per existing caseType from its statusType ordering, idempotent on re-run.

All errors logged via `LoggerInterface`; controller never returns raw exception messages — static error strings only.

## Test plan

- [ ] `php -l` and `jq empty` pass for all touched files (verified locally).
- [ ] Run `occ maintenance:repair` and confirm the backfill produces one published workflowTemplate per existing caseType with `lifecycleStatus: published` and `caseType.workflowDefinition` pinned.
- [ ] In the Procest UI, navigate to Settings → Workflow definitions; create a draft via the manifest renderer; verify it loads at `/settings/workflow-definitions/:id` with the overview / steps / transitions / audit tabs.
- [ ] Call `POST /api/workflow-definitions/{id}/publish` on a draft; verify `lifecycleStatus` flips to `published`, the previously active version flips to `deprecated`, and `caseType.workflowDefinition` updates to the new id.
- [ ] Call `POST /api/workflow-definitions/{id}/clone` on a published version; verify a new draft appears with `version = previous + 1`.
- [ ] Attempt to publish a draft whose transitions reference a foreign statusType — request rejected, error logged.

Implements openspec change `workflow-definition-model`.