### PR TITLE
chore(openspec): generate parafering-audit-trail spec

### DIFF
--- a/openspec/changes/parafering-audit-trail/.openspec.yaml
+++ b/openspec/changes/parafering-audit-trail/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-11

--- a/openspec/changes/parafering-audit-trail/design.md
+++ b/openspec/changes/parafering-audit-trail/design.md
@@ -1,0 +1,125 @@
+# Design: parafering-audit-trail
+
+## Architecture Overview
+
+The parafering audit trail is an append-only, event-sourced ledger of every state transition that occurs on a voorstel during its parafeerroute lifecycle. It is distinct from the operational `parafeeractie` records (which drive routing) and distinct from the per-object OR audit trail (which records raw field diffs). Its purpose is exclusively legal accountability: producing a regulator-grade dossier that demonstrates *who* approved *what content* at *what moment* for *which reason*, sufficient for Awb bezwaar/beroep procedures and Archiefwet handover to the gemeentelijk e-Depot.
+
+```
+ParafeerRouteService.startRoute()       \
+ParafeerRouteService.completeStep()       \
+ParafeerRouteService.skipStep()            ┐
+ParafeerRouteService.addAdHocStep()        │  emits  ParafeerTransitionEvent
+ParafeerActieService.recordAction(parafered)│  ──────────────────────────────►
+ParafeerActieService.recordAction(advised)  │                                  ParaferingAuditListener
+ParafeerActieService.recordAction(returned) ┘                                  ├─ build contentSnapshot
+                                                                                ├─ derive actorRole
+                                                                                ├─ compute auditEntryHash
+                                                                                └─ ObjectService::saveObject(paraferingAuditEntry)
+                                                                                                  │
+                                                                                                  ▼
+                                                                                OR audit-trail-immutable (storage)
+                                                                                                  │
+                            ┌─────────────────────────────────────────────────────────────────────┘
+                            ▼
+              ParaferingAuditExportController  →  GET /api/parafering-audit-trail/export?voorstel={uuid}
+                            ▼
+              Manifest index page (type: 'index')  →  /apps/procest/parafering-audit
+```
+
+## File Map
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `lib/Event/ParafeerTransitionEvent.php` | Domain event raised after every successful parafeerroute transition; carries `voorstelId`, `transitionType`, `step`, `actor`, `reason`, `actorRole` |
+| `lib/Listener/ParaferingAuditListener.php` | Subscribes to `ParafeerTransitionEvent`; builds and persists one `paraferingAuditEntry` per event |
+| `lib/Validator/ParaferingAuditAppendOnlyValidator.php` | Hooks into OR's pre-save pipeline; rejects UPDATE/DELETE on `paraferingAuditEntry` schema with `OCSForbiddenException` carrying the static message `Audit entries are append-only` |
+| `lib/Controller/ParaferingAuditExportController.php` | `GET /api/parafering-audit-trail/export?voorstel={uuid}` — returns JSON export with TMLO/MDTO metadata wrapper |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `lib/Settings/procest_register.json` | Add `paraferingAuditEntry` schema, 3 example seed objects, and a manifest index page (`type: 'index'`) under `components.x-pages[]` |
+| `lib/Service/ParafeerRouteService.php` | Dispatch `ParafeerTransitionEvent` from `startRoute`, `completeStep`, `skipStep`, `addAdHocStep` — REUSE existing methods, do NOT write audit entries directly |
+| `lib/Service/ParafeerActieService.php` | Dispatch `ParafeerTransitionEvent` from `recordAction` after the parafeeractie is saved |
+| `appinfo/routes.php` | Add `parafering_audit_export#index` route — BEFORE any wildcard `{slug}` route |
+| `appinfo/info.xml` | Register `ParaferingAuditListener` against `ParafeerTransitionEvent` via the `<events>` element |
+
+## Data Model
+
+### paraferingAuditEntry (new — Schema.org type: `schema:Action`)
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| voorstel | string (uuid) | Yes | Reference to the voorstel that this transition occurred on |
+| step | integer | No | Step number in the `routeSnapshot` (omitted for `started`, `route-changed`, `completed` if not step-bound) |
+| transitionType | enum | Yes | One of `started`, `paraferd`, `advised`, `terugsturen`, `route-changed`, `completed` |
+| actor | string | Yes | Nextcloud user UID who triggered the transition (always the session user — never request body) |
+| actorRole | string | Yes | Role at the moment of action — `steller`, `adviseur`, `parafeerder`, `accorderend`, `beheerder`, `secretariaat` — derived from the routeSnapshot step or admin override context |
+| timestamp | string (ISO 8601, UTC) | Yes | Server-side timestamp at write moment — never accepted from client |
+| reason | string | Conditional | Mandatory for `terugsturen` and `route-changed`; optional for others |
+| contentSnapshot | object | Yes | Immutable JSON copy of `voorstel.{onderwerp, document, bijlagen, routeSnapshot, currentStep, status}` at transition moment |
+| ipAddress | string | Yes | `IRequest::getRemoteAddress()` at write moment; redacted to /24 (IPv4) or /48 (IPv6) per AVG minimisation |
+| auditEntryHash | string (SHA-256 hex) | Yes | Hash of canonical JSON of the entry (excluding the hash field itself) — for tamper detection |
+
+**Append-only enforcement**: The `ParaferingAuditAppendOnlyValidator` rejects every non-INSERT mutation. Even system administrators cannot UPDATE or DELETE these entries via the API. Storage-level deletion (e.g. SQL `DELETE`) is technically possible — but is detectable via the OR `audit-trail-immutable` capability that records every raw mutation.
+
+### Why a separate schema (vs. extending `parafeeractie`)
+
+`parafeeractie` exists to drive the routing engine — it MUST be updateable by the routing service (e.g. to flag a step as superseded by an ad-hoc insert). The audit trail MUST be append-only and MUST also capture transitions that are NOT actor actions (e.g. `started`, `route-changed`, `completed`). Conflating them into one schema would either weaken append-only guarantees on `parafeeractie` or force every audit-only transition to invent a synthetic `parafeeractie`. Two schemas is the safer model.
+
+## Transition → Audit Entry Mapping
+
+| Origin | Trigger | transitionType | actorRole | reason required |
+|--------|---------|----------------|-----------|-----------------|
+| `ParafeerRouteService::startRoute` | Voorstel submitted | `started` | `steller` | No |
+| `ParafeerActieService::recordAction(parafered)` | Parafeerstap completed | `paraferd` | `parafeerder` | No |
+| `ParafeerActieService::recordAction(advised)` | Advies submitted | `advised` | `adviseur` | No |
+| `ParafeerActieService::recordAction(returned)` | Terugsturen | `terugsturen` | step actor's role | YES |
+| `ParafeerRouteService::skipStep` / `::addAdHocStep` | Route override | `route-changed` | `beheerder` or `secretariaat` | YES |
+| `ParafeerRouteService::completeStep` (final accordering) | Voorstel geaccordeerd | `completed` | `accorderend` | No |
+
+## Archive Export Format
+
+`GET /api/parafering-audit-trail/export?voorstel={uuid}` returns:
+
+```json
+{
+  "metadata": {
+    "schema": "MDTO 1.0",
+    "exportedAt": "2026-05-11T14:23:00Z",
+    "voorstel": "uuid-of-voorstel",
+    "voorstelOnderwerp": "Uitbreiding parkeerterrein Raadhuis",
+    "retentionUntil": "2046-05-11",
+    "selectielijstCategory": "Bestuurlijke besluitvorming — bewaartermijn 20 jaar",
+    "exportedBy": "auditor.uid",
+    "entryCount": 6
+  },
+  "entries": [
+    { /* paraferingAuditEntry 1 — chronological order */ },
+    { /* ... */ }
+  ]
+}
+```
+
+## Retention Policy
+
+- **Decisions** (voorstellen that completed and produced a `Besluit`): retain 20 years from the `completed` transition timestamp, per Selectielijst Gemeenten 2020 category 1.1 "Bestuurlijke besluitvorming".
+- **Non-decisions** (voorstellen that ended in `teruggestuurd` without resubmission, or were withdrawn): retain 7 years per the general administrative-correspondence retention.
+- **Enforcement**: The append-only validator blocks DELETE outright. A future scheduled retention sweeper (out of scope here, filed as separate issue) MAY hard-delete entries whose `timestamp` is older than the retention window AND whose parent voorstel is flagged `gearchiveerd`.
+
+## Reuse Analysis
+
+| Capability | Platform Component | Reuse |
+|------------|--------------------|-------|
+| Persistence | `ObjectService::saveObject()` (3-arg) | Listener delegates all storage to OR — no custom mapper |
+| Immutability primitive | OR `audit-trail-immutable` capability | OR records every raw mutation; the procest validator adds the API-level append-only block on top |
+| Event bus | Nextcloud `OCP\EventDispatcher\IEventDispatcher` | Standard NC event dispatch — no bespoke pub/sub |
+| Manifest index page | OR manifest pattern (`type: 'index'`) | Reused exactly as `parafeerroute` and `legesberekening` did in their manifest refactors |
+| TMLO/MDTO metadata | Static JSON wrapper in the export controller | No external library — the export is JSON-only for V1; XML profiles deferred |
+| IP redaction | Existing `\OCA\Procest\Util\IpRedactor` (if present) OR a 3-line inline helper | TBC during deduplication check D01 |
+| RBAC for export endpoint | `IUserSession` + group check via `IGroupManager` | Standard NC RBAC — no custom role system |
+
+No overlap found with existing procest services for transition-aware audit logging. The custom listener + validator + export controller are justified by the legal-accountability remit, which is not covered by the operational `parafeeractie` flow or by OR's raw-mutation audit-trail-immutable capability.

--- a/openspec/changes/parafering-audit-trail/proposal.md
+++ b/openspec/changes/parafering-audit-trail/proposal.md
@@ -1,0 +1,50 @@
+# Proposal: Parafering Audit Trail
+
+## Summary
+
+Introduce a dedicated, immutable, legally-sufficient audit trail for the Procest parafeerroute lifecycle. Every transition on a voorstel — `started`, `paraferd`, `terugsturen`, `advised`, `route-changed`, `completed` — SHALL be persisted as an append-only `paraferingAuditEntry` object that records actor, actor role, timestamp, reason, an immutable content snapshot of the voorstel at the moment of the action, and the originating IP address. The trail is queryable for archive export per Archiefwet retention rules (20 years for B&W decisions) and integrates with OpenRegister's `audit-trail-immutable` capability so that no procest-specific tampering surface is introduced. The sister specs `parafeerroute-engine`, `parafering-actions`, and `voorstel-management` already record `parafeeractie` rows — this spec layers a separate, regulator-grade audit stream on top so that legal accountability does not depend on the operational `parafeeractie` table.
+
+## Problem
+
+The current `parafeeractie` records (introduced by `parafering-actions`) are operational: they exist to drive the routing engine, populate the timeline, and trigger notifications. They are immutable by convention, not by validator. They also do not capture the voorstel content at the moment of action (only references), do not record IP / actor role, and have no archive-export format aligned with the Archiefwet metadata schema (TMLO / MDTO). The retired `parafering-audit-trail` capability points to OR's `audit-trail-immutable` for raw object mutation history, but that is per-object change diffing — not a per-transition legal record with reason, role, and content snapshot. Without this change, municipalities cannot demonstrate Awb-compliant decision provenance during bezwaar/beroep procedures, and archive exports to the gemeentelijk e-Depot lack the mandated 20-year decision dossier shape.
+
+## Affected Projects
+
+- [ ] Project: `procest` — Add `paraferingAuditEntry` schema, append-only validator, audit listener on parafeerroute events, archive-export endpoint, and a manifest-driven index page for auditor browsing.
+
+## Scope
+
+### In Scope (V1)
+
+- **paraferingAuditEntry schema** (REQ-PAT-1): A new OpenRegister schema with `voorstel`, `step`, `action`, `actor`, `actorRole`, `timestamp`, `reason`, `contentSnapshot`, `ipAddress`, and a `transitionType` enum (`started`, `paraferd`, `advised`, `terugsturen`, `route-changed`, `completed`).
+- **Audit listener** (REQ-PAT-2): A single event listener subscribes to all parafeerroute transitions emitted by `ParafeerRouteService` and `ParafeerActieService` and writes one audit entry per transition. The application code does NOT write audit entries directly.
+- **Append-only enforcement** (REQ-PAT-3): A validator rejects any `UPDATE` or `DELETE` operation on `paraferingAuditEntry` objects, including via the generic ObjectService write path. Only INSERT is permitted.
+- **OR audit-trail integration** (REQ-PAT-4): The new entries reuse OR's `audit-trail-immutable` capability for the underlying immutability primitive; the procest spec only adds the transition semantics on top — no custom hashing or chain logic.
+- **Content snapshot** (REQ-PAT-5): At the moment of each transition the listener captures a JSON snapshot of the voorstel's content fields (`onderwerp`, `document`, `bijlagen`, `routeSnapshot`, `currentStep`, `status`) so that the legal record reflects the voorstel state at decision time, not its current state.
+- **Archive export** (REQ-PAT-6): A `GET /api/parafering-audit-trail/export?voorstel={uuid}` endpoint returns an Archiefwet-aligned export (JSON + TMLO/MDTO metadata block) suitable for handover to the gemeentelijk e-Depot.
+- **Manifest index page** (REQ-PAT-7): A manifest page of `type: 'index'` declared in `procest_register.json` so that auditors and beheerders can browse audit entries from the admin UI without bespoke views.
+- **Retention policy** (REQ-PAT-8): Retention SHALL be 20 years from the `completed` transition for voorstellen that became `besluiten`, aligned with the Selectielijst Gemeenten 2020 category "Bestuurlijke besluitvorming". Earlier deletion SHALL be blocked by the append-only validator.
+
+### Out of Scope
+
+- Bespoke cryptographic chain / Merkle-tree audit log — V2 if required by sector-specific audits
+- e-Depot submission automation (push to municipal archive) — separate change
+- Cross-app audit aggregation (combining procest + docudesk + zaakafhandelapp into one regulator dossier) — Hydra-level concern
+- Real-time SIEM streaming — handled by Nextcloud platform `Activity` integration
+- PII redaction in exports for AVG/GDPR DSARs — separate change
+
+## Approach
+
+1. **Schema**: Add `paraferingAuditEntry` to `lib/Settings/procest_register.json` with the 9 properties listed above plus an `auditEntryHash` (SHA-256 of the canonical entry payload) for tamper detection.
+2. **Listener**: Subscribe to `\OCA\Procest\Event\ParafeerTransitionEvent` (a new domain event raised by `ParafeerRouteService` and `ParafeerActieService` after each successful save) and write one audit entry per event. Application services do NOT call the audit service directly — the event bus is the only entry point.
+3. **Validator**: Hook into OR's pre-save validation pipeline and reject any non-INSERT mutation on the `paraferingAuditEntry` schema with `OCSForbiddenException`.
+4. **Manifest page**: Declare `type: 'index'` for `paraferingAuditEntry` under `components.x-pages[]` in `procest_register.json` per the manifest pattern adopted by `parafeerroute` and `legesberekening`.
+5. **Export endpoint**: A new lightweight controller wraps `ObjectService::findObjects` with a TMLO/MDTO metadata wrapper. Output is JSON for V1; XML profiles deferred.
+
+## Cross-Project Dependencies
+
+- **parafeerroute-engine** (required): Emits `ParafeerTransitionEvent` for each `started`, `route-changed`, and `completed` transition.
+- **parafering-actions** (required): Emits the same event for `paraferd`, `advised`, and `terugsturen` transitions.
+- **voorstel-management** (required): The content snapshot reads `onderwerp`, `document`, `bijlagen`, `routeSnapshot`, `currentStep`, `status` — these MUST remain the canonical content fields.
+- **OpenRegister `audit-trail-immutable`**: Provides the immutability primitive (no custom hashing or chain logic introduced here).
+- **ADR-022**: Established that procest delegates audit immutability to OR; this change layers transition semantics, NOT a parallel audit store.

--- a/openspec/changes/parafering-audit-trail/specs/parafering-audit-trail/spec.md
+++ b/openspec/changes/parafering-audit-trail/specs/parafering-audit-trail/spec.md
@@ -1,0 +1,195 @@
+## ADDED Requirements
+
+### Requirement: paraferingAuditEntry Schema Registration (REQ-PAT-1)
+
+The system SHALL register a `paraferingAuditEntry` schema in the Procest OpenRegister configuration with the properties `voorstel`, `step`, `transitionType`, `actor`, `actorRole`, `timestamp`, `reason`, `contentSnapshot`, `ipAddress`, and `auditEntryHash`. The required-property list SHALL be exactly `[voorstel, transitionType, actor, actorRole, timestamp, contentSnapshot, ipAddress, auditEntryHash]`. The `transitionType` enum SHALL be exactly `[started, paraferd, advised, terugsturen, route-changed, completed]`. The `actorRole` enum SHALL be exactly `[steller, adviseur, parafeerder, accorderend, beheerder, secretariaat]`. The Schema.org type SHALL be `schema:Action`. A `paraferingAuditEntry` is the canonical legal-accountability record of a single transition on a voorstel and SHALL be the only entity carrying transition-level audit semantics for the parafering lifecycle.
+
+**Feature tier**: V1
+**Schema.org type**: `schema:Action`
+**ZGW mapping**: No direct ZGW counterpart — the audit trail is a procest-internal accountability artefact distinct from `AuditTrail` resources on `Zaak`/`Besluit`.
+
+#### Scenario: Schema is registered after app install
+
+- **WHEN** the Procest app is installed or updated via the repair step
+- **THEN** the `paraferingAuditEntry` schema SHALL exist in the Procest register
+- **AND** the schema SHALL enforce required properties `voorstel`, `transitionType`, `actor`, `actorRole`, `timestamp`, `contentSnapshot`, `ipAddress`, `auditEntryHash`
+- **AND** the `transitionType` enum SHALL accept exactly the 6 listed values
+- **AND** previously imported seed entries SHALL be importable idempotently — no duplicates on re-import (verified by slug match)
+
+#### Scenario: Audit entry rejects unknown transitionType
+
+- **GIVEN** an insert request for a `paraferingAuditEntry` with `transitionType = "submitted"` (not in the enum)
+- **WHEN** the OpenRegister write pipeline validates the object
+- **THEN** OpenRegister SHALL reject the object with a schema validation error
+- **AND** no `paraferingAuditEntry` SHALL be persisted
+
+### Requirement: Event-Sourced Audit Writes Only (REQ-PAT-2)
+
+The system SHALL write `paraferingAuditEntry` records EXCLUSIVELY from a single `ParaferingAuditListener` that subscribes to a `ParafeerTransitionEvent` domain event. Application services SHALL NOT call `ObjectService::saveObject` for the `paraferingAuditEntry` schema directly. Every parafeerroute transition (`startRoute`, `completeStep`, `skipStep`, `addAdHocStep`, `recordAction`) SHALL dispatch the event AFTER the operational save succeeds and BEFORE the originating service method returns.
+
+**Feature tier**: V1
+
+#### Scenario: startRoute dispatches a started transition event
+
+- **GIVEN** a voorstel with `status = concept` and a linked parafeerroute
+- **WHEN** the steller calls `POST /api/parafeer-route/voorstel/{id}/start` and `ParafeerRouteService::startRoute` completes successfully
+- **THEN** `ParafeerRouteService` SHALL dispatch one `ParafeerTransitionEvent` with `transitionType = "started"`, `actor` = the steller UID, `actorRole = "steller"`
+- **AND** the `ParaferingAuditListener` SHALL persist exactly one `paraferingAuditEntry` for this transition within the same request lifecycle
+
+#### Scenario: recordAction dispatches the matching transition event
+
+- **GIVEN** the current step actor records `action = "parafered"` for step 2
+- **WHEN** `ParafeerActieService::recordAction` saves the `parafeeractie` and returns success
+- **THEN** the service SHALL dispatch `ParafeerTransitionEvent` with `transitionType = "paraferd"`, `actor` = the session UID, `actorRole = "parafeerder"`, `step = 2`
+- **AND** a corresponding `paraferingAuditEntry` SHALL exist for that voorstel
+
+#### Scenario: Audit writes never come from outside the listener
+
+- **GIVEN** any code path other than the `ParaferingAuditListener`
+- **WHEN** that code path calls `ObjectService::saveObject` with schema `paraferingAuditEntry`
+- **THEN** the validator (REQ-PAT-3) SHALL reject the write because the `auditEntryHash` was not derived through the canonical listener pipeline
+- **AND** the write SHALL return HTTP 403 with the static body `{"message": "Audit entries are append-only"}`
+
+### Requirement: Append-Only Enforcement (REQ-PAT-3)
+
+The system SHALL enforce append-only semantics on `paraferingAuditEntry` objects via a validator hooked into OpenRegister's pre-save pipeline. Any UPDATE or DELETE operation on an existing `paraferingAuditEntry` SHALL be rejected with HTTP 403 and the static message `Audit entries are append-only`. The static message SHALL NOT include exception details, stack traces, or the schema name of the rejected operation.
+
+**Feature tier**: V1
+
+#### Scenario: UPDATE of audit entry rejected
+
+- **GIVEN** an existing `paraferingAuditEntry` with id E1
+- **WHEN** any authenticated user (including administrators) calls the OpenRegister generic update endpoint with target id E1 and a changed `reason` field
+- **THEN** the validator SHALL reject the request
+- **AND** the response SHALL be HTTP 403 with body `{"message": "Audit entries are append-only"}`
+- **AND** the underlying record SHALL remain byte-identical (verified by `auditEntryHash` match before and after)
+
+#### Scenario: DELETE of audit entry rejected
+
+- **GIVEN** an existing `paraferingAuditEntry` with id E1
+- **WHEN** any authenticated user calls the OpenRegister generic delete endpoint with target id E1
+- **THEN** the validator SHALL reject the request with HTTP 403 and body `{"message": "Audit entries are append-only"}`
+- **AND** the record SHALL remain present in the register
+
+#### Scenario: INSERT requires canonical hash
+
+- **GIVEN** a direct INSERT attempt on `paraferingAuditEntry` (bypassing the listener) carrying a missing or non-64-hex `auditEntryHash`
+- **WHEN** the validator inspects the payload
+- **THEN** the validator SHALL reject with HTTP 400 and static message `Invalid audit hash`
+- **AND** no `paraferingAuditEntry` SHALL be persisted
+
+### Requirement: Reuse of OpenRegister audit-trail-immutable (REQ-PAT-4)
+
+The system SHALL build on top of OpenRegister's `audit-trail-immutable` capability for the underlying mutation log — every save, attempted update, and attempted delete on `paraferingAuditEntry` SHALL be recorded by that OpenRegister capability. The procest spec SHALL NOT introduce a parallel hash-chain, Merkle tree, or custom append store. Tamper detection SHALL rely on the combination of (a) the per-entry `auditEntryHash` and (b) the OpenRegister raw-mutation audit log.
+
+**Feature tier**: V1
+
+#### Scenario: Storage-level tampering is detectable
+
+- **GIVEN** an out-of-band actor mutates a `paraferingAuditEntry` row directly at the database layer (bypassing the API and the validator)
+- **WHEN** an auditor recomputes `sha256` of the canonical JSON of the entry (excluding `auditEntryHash` itself) and compares it to the stored `auditEntryHash`
+- **THEN** the values SHALL differ — proving the row was tampered with
+- **AND** the OpenRegister `audit-trail-immutable` capability SHALL ALSO have recorded the raw row mutation, giving a second independent detection signal
+
+#### Scenario: No custom audit store introduced
+
+- **GIVEN** the procest codebase
+- **WHEN** a reviewer searches `lib/` for any custom audit store, hash chain, or Merkle implementation
+- **THEN** no such code SHALL exist — all persistence flows through `ObjectService` and storage immutability flows through OpenRegister
+
+### Requirement: Content Snapshot at Transition Moment (REQ-PAT-5)
+
+The system SHALL capture an immutable JSON copy of the voorstel content fields at the moment of each transition. The snapshot SHALL contain exactly the fields `onderwerp`, `document`, `bijlagen`, `routeSnapshot`, `currentStep`, and `status` from the voorstel as of the transition. The snapshot SHALL be stored verbatim in `paraferingAuditEntry.contentSnapshot` and SHALL NOT be a reference, lazy proxy, or pointer — subsequent changes to the voorstel MUST NOT alter the captured snapshot.
+
+**Feature tier**: V1
+
+#### Scenario: Snapshot frozen at transition time
+
+- **GIVEN** a voorstel with `onderwerp = "Uitbreiding parkeerterrein Raadhuis"` at the moment step 2 is parafered
+- **WHEN** the `paraferd` transition fires and the listener captures the snapshot
+- **THEN** the audit entry SHALL store `contentSnapshot.onderwerp = "Uitbreiding parkeerterrein Raadhuis"`
+- **AND** if the steller later resubmits with `onderwerp = "Uitbreiding parkeerterrein Raadhuis — herzien"` after a teruggestuurd cycle, the original audit entry SHALL still record the original onderwerp
+
+#### Scenario: Snapshot fields are exactly the canonical content set
+
+- **GIVEN** any transition is being recorded
+- **WHEN** the listener builds the snapshot
+- **THEN** the snapshot SHALL contain exactly six keys: `onderwerp`, `document`, `bijlagen`, `routeSnapshot`, `currentStep`, `status`
+- **AND** the snapshot SHALL NOT contain other voorstel fields (no `parafeerroute` reference, no `behandeling`, no `case` cross-reference) — those are denormalised lookups outside the legal scope
+
+### Requirement: Archive Export Endpoint (REQ-PAT-6)
+
+The system SHALL expose `GET /api/parafering-audit-trail/export?voorstel={uuid}` returning a JSON export containing an MDTO-aligned `metadata` block and a chronologically sorted `entries` array. The endpoint SHALL be limited to members of one of the groups `auditors`, `secretariaat`, or `beheerders`. Non-members SHALL receive HTTP 403 with the static message `Audit export requires auditor role`.
+
+**Feature tier**: V1
+
+#### Scenario: Export shape conforms to MDTO 1.0
+
+- **GIVEN** a voorstel U1 with 6 `paraferingAuditEntry` records (one per transitionType)
+- **WHEN** an auditor in the `auditors` group calls `GET /api/parafering-audit-trail/export?voorstel=U1`
+- **THEN** the response SHALL be HTTP 200 with body `{"metadata": {...}, "entries": [...]}`
+- **AND** `metadata.schema` SHALL be the string `MDTO 1.0`
+- **AND** `metadata.entryCount` SHALL equal `6`
+- **AND** `entries` SHALL be sorted ascending by `timestamp`
+- **AND** `metadata.retentionUntil` SHALL equal the timestamp of the `completed` entry plus 20 years (ISO 8601 date)
+
+#### Scenario: Non-auditor blocked
+
+- **GIVEN** authenticated user U2 who is NOT a member of `auditors`, `secretariaat`, or `beheerders`
+- **WHEN** U2 calls `GET /api/parafering-audit-trail/export?voorstel=U1`
+- **THEN** the response SHALL be HTTP 403 with body `{"message": "Audit export requires auditor role"}`
+- **AND** no audit content SHALL be disclosed in the response body
+
+#### Scenario: Missing voorstel parameter
+
+- **GIVEN** a request `GET /api/parafering-audit-trail/export` without a `voorstel` query parameter
+- **WHEN** the controller validates the request
+- **THEN** the response SHALL be HTTP 400 with body `{"message": "Missing required parameter: voorstel"}`
+
+### Requirement: Manifest Index Page for Auditor Browsing (REQ-PAT-7)
+
+The system SHALL declare a manifest page of `type: 'index'` for the `paraferingAuditEntry` schema in `procest_register.json` so that auditors and beheerders can browse, filter, and sort audit entries through the OpenRegister manifest UI without bespoke Vue components. The index SHALL support filtering by `transitionType`, `actor`, `voorstel`, and timestamp range.
+
+**Feature tier**: V1
+
+#### Scenario: Index page reachable at /apps/procest/parafering-audit
+
+- **GIVEN** the Procest app is installed and the manifest config has been imported
+- **WHEN** an auditor navigates to `/apps/procest/parafering-audit`
+- **THEN** the manifest router SHALL render the index page
+- **AND** the page SHALL list all `paraferingAuditEntry` records with columns `transitionType`, `actor`, `actorRole`, `timestamp`, `voorstel`
+- **AND** filter controls SHALL be available for `transitionType`, `actor`, and timestamp range
+
+#### Scenario: No bespoke Vue view exists
+
+- **GIVEN** the procest frontend source tree
+- **WHEN** a reviewer searches `src/views/` for a custom audit-trail listing component
+- **THEN** no such bespoke view SHALL exist — the manifest pattern alone provides the index
+- **AND** procest-specific labelling SHALL be expressed only via `components.x-pages[].listing.columns[]` overrides in `procest_register.json`
+
+### Requirement: Retention Policy Aligned with Archiefwet (REQ-PAT-8)
+
+The system SHALL apply a retention policy of 20 years from the `completed` transition timestamp for voorstellen that produced a besluit, aligned with Selectielijst Gemeenten 2020 category "Bestuurlijke besluitvorming". For voorstellen that ended without a `completed` transition (withdrawn or permanently teruggestuurd) the retention SHALL be 7 years, aligned with administrative-correspondence retention. The retention window SHALL be surfaced via `metadata.retentionUntil` on the archive export. Deletion before the retention boundary SHALL be impossible because of the append-only validator (REQ-PAT-3); a future automated retention sweeper is out of scope of this change and SHALL be filed as a follow-up issue before any production retention enforcement is enabled.
+
+**Feature tier**: V1
+
+#### Scenario: 20-year retention for decisions
+
+- **GIVEN** a voorstel that completed with a `completed` transition at `2026-05-11T10:00:00Z`
+- **WHEN** the archive export is generated
+- **THEN** `metadata.retentionUntil` SHALL equal `2046-05-11`
+- **AND** `metadata.selectielijstCategory` SHALL equal `Bestuurlijke besluitvorming — bewaartermijn 20 jaar`
+
+#### Scenario: 7-year retention for non-decisions
+
+- **GIVEN** a voorstel that has audit entries but no `completed` transition (e.g. withdrawn at the teruggestuurd stage)
+- **WHEN** the archive export is generated
+- **THEN** `metadata.retentionUntil` SHALL equal the timestamp of the LATEST audit entry plus 7 years (ISO 8601 date)
+- **AND** `metadata.selectielijstCategory` SHALL equal `Administratieve correspondentie — bewaartermijn 7 jaar`
+
+#### Scenario: Deletion blocked irrespective of retention window
+
+- **GIVEN** an audit entry older than 21 years (theoretically past the 20-year window)
+- **WHEN** any caller attempts a DELETE on that entry via the API
+- **THEN** the append-only validator SHALL still reject the request with HTTP 403 and body `{"message": "Audit entries are append-only"}`
+- **AND** the record SHALL remain present until an out-of-scope automated retention sweep removes it

--- a/openspec/changes/parafering-audit-trail/tasks.md
+++ b/openspec/changes/parafering-audit-trail/tasks.md
@@ -1,0 +1,109 @@
+# Tasks: parafering-audit-trail
+
+## Deduplication Check
+
+- [ ] **D01**: Before writing any new code, search `lib/Service/`, `lib/Listener/`, and `lib/Validator/` for any existing parafering audit handling. Verify no prior `ParaferingAuditListener` exists (expected: only the retired `parafering-audit-trail` capability marker exists in `openspec/specs/`). Confirm OR's `audit-trail-immutable` capability is available in the registered OR version (check `openregister/openspec/specs/audit-trail-immutable/spec.md`). Verify `ParafeerRouteService` and `ParafeerActieService` are reachable from this branch and have completion hooks (the `f5a9450` / `c007575` commits already exposed them). Check `lib/Util/IpRedactor.php` for an existing IP redaction helper — reuse if present, otherwise add a 3-line inline helper. Document all findings in this section before proceeding to T01.
+
+---
+
+## Schema
+
+- [ ] **T01**: Add `paraferingAuditEntry` schema to `lib/Settings/procest_register.json` under `components.schemas`. Properties exactly as in `design.md` Data Model section: `voorstel`, `step`, `transitionType` (enum of 6 values), `actor`, `actorRole` (enum of 6 values), `timestamp` (ISO 8601), `reason`, `contentSnapshot` (object), `ipAddress`, `auditEntryHash`. Required: `voorstel`, `transitionType`, `actor`, `actorRole`, `timestamp`, `contentSnapshot`, `ipAddress`, `auditEntryHash`. Schema.org type: `schema:Action`. Add a manifest index page declaration (`type: 'index'`) under `components.x-pages[]` so the entries are browsable from the admin UI without bespoke views. Add 3 realistic Dutch seed entries (one each for `started`, `paraferd`, `terugsturen`). Slugs: `audit-voorstel-0042-started`, `audit-voorstel-0042-step2-paraferd`, `audit-voorstel-0055-step2-terugsturen`.
+
+---
+
+## Backend: Domain Event
+
+- [ ] **T02**: Create `lib/Event/ParafeerTransitionEvent.php` extending `\OCP\EventDispatcher\Event`. Constructor signature: `__construct(string $voorstelId, string $transitionType, ?int $step, string $actor, string $actorRole, ?string $reason)`. Getters for each. File-level docblock with `SPDX-License-Identifier: EUPL-1.2`, `@author Conduction Development Team <info@conduction.nl>`, `@spec openspec/changes/parafering-audit-trail/tasks.md#T02`.
+
+---
+
+## Backend: Audit Listener
+
+- [ ] **T03**: Create `lib/Listener/ParaferingAuditListener.php` implementing `\OCP\EventDispatcher\IEventListener<ParafeerTransitionEvent>`. In `handle(Event $event)`:
+  1. Reject the event if not an instance of `ParafeerTransitionEvent`.
+  2. Fetch the voorstel via `ObjectService::findObject($register, 'voorstel', $event->getVoorstelId())`.
+  3. Build `contentSnapshot` by copying exactly the fields `onderwerp`, `document`, `bijlagen`, `routeSnapshot`, `currentStep`, `status` from the voorstel — never dereference further (no recursive expansion).
+  4. Derive IP via `IRequest::getRemoteAddress()` and redact to /24 (IPv4) or /48 (IPv6) via `IpRedactor` (or the 3-line inline helper if D01 found none).
+  5. Build the entry array (all 9 schema fields plus `auditEntryHash`).
+  6. Compute `auditEntryHash` as `hash('sha256', json_encode($entryWithoutHash, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE))`.
+  7. Call `ObjectService::saveObject($register, 'paraferingAuditEntry', $entry)` (3 positional args — ADR-001).
+  8. Catch all `\Throwable`, log via `$this->logger->error()` with full exception context, and SWALLOW — the listener MUST NOT propagate exceptions back to the routing service (audit-write failure must not block the operational transition; instead it is detectable via the OR audit-trail-immutable mutation log).
+
+  File carries `@spec openspec/changes/parafering-audit-trail/tasks.md#T03`, `@author Conduction Development Team <info@conduction.nl>`, `@license EUPL-1.2`. Register the listener via `appinfo/info.xml` `<events>` element.
+
+- [ ] **T04**: Dispatch `ParafeerTransitionEvent` from `ParafeerRouteService::startRoute`, `::completeStep`, `::skipStep`, `::addAdHocStep` AFTER the operational save succeeds and BEFORE the method returns. Inject `IEventDispatcher` via constructor — do NOT instantiate listeners directly. Dispatch the same event from `ParafeerActieService::recordAction` after the `parafeeractie` save succeeds. NEVER call the audit listener method directly — always via the event bus, so that a future second listener (e.g. real-time SIEM streaming) attaches without modifying service code.
+
+---
+
+## Backend: Append-Only Validator
+
+- [ ] **T05**: Create `lib/Validator/ParaferingAuditAppendOnlyValidator.php`. Hook into OR's pre-save validation pipeline (verify exact hook name during D01 — likely `OCA\OpenRegister\Event\ObjectBeforeSaveEvent`). Logic:
+  - If the target schema is NOT `paraferingAuditEntry`: no-op (return).
+  - If the operation is INSERT (no existing `id`): allow.
+  - If the operation is UPDATE or DELETE on an existing `paraferingAuditEntry`: throw `\OCP\AppFramework\OCS\OCSForbiddenException` with the static message `'Audit entries are append-only'`. NEVER include exception details in the message.
+  - Also validate on INSERT: `transitionType` is one of the 6 enum values; `actorRole` is one of the 6 enum values; `timestamp` matches ISO 8601 with `Z` suffix (UTC); `auditEntryHash` is exactly 64 lowercase hex characters. Reject with static messages on mismatch (`'Invalid transitionType'`, `'Invalid actorRole'`, `'Timestamp must be UTC ISO 8601'`, `'Invalid audit hash'`).
+
+  Register as an event listener via `appinfo/info.xml`. File carries `@spec`, `@author`, `@license` PHPDoc tags.
+
+---
+
+## Backend: Manifest Index Page (T01 already declares it in the JSON; this task wires the UI hook)
+
+- [ ] **T06**: Verify that the manifest index page declared in T01 renders at `/apps/procest/parafering-audit` via the OR manifest router. NO bespoke Vue component — the manifest pattern provides the index UI generically (filter, sort, paginate by `transitionType`, `actor`, `voorstel`, `timestamp` range). If a procest-specific listing column overlay is needed (e.g. a Dutch label for `transitionType` values), add it via a manifest-aware column override JSON block under `components.x-pages[].listing.columns[]` in `procest_register.json` — do NOT write a custom Vue view.
+
+---
+
+## Backend: Archive Export Endpoint
+
+- [ ] **T07**: Create `lib/Controller/ParaferingAuditExportController.php`. Endpoint:
+  - `GET /api/parafering-audit-trail/export?voorstel={uuid}` — `#[NoAdminRequired]` paired with a manual group check requiring membership of one of: `auditors`, `secretariaat`, `beheerders` (resolve via `IGroupManager`). On missing membership: return 403 with `{"message": "Audit export requires auditor role"}`.
+  - Required query param `voorstel`; return 400 if missing.
+  - Fetch the voorstel; if not found return 404.
+  - Fetch all `paraferingAuditEntry` records for that voorstel via `ObjectService::findObjects` sorted ascending by `timestamp`.
+  - Build the response envelope per `design.md` Archive Export Format section: `metadata` block (schema `MDTO 1.0`, exportedAt, voorstel uuid, voorstelOnderwerp, retentionUntil = timestamp of `completed` entry + 20 years if a `completed` entry exists else 7 years, selectielijstCategory, exportedBy, entryCount) and `entries` array.
+  - Return 200 JSON.
+  - NEVER include `$e->getMessage()` for unexpected exceptions — catch and return 500 with `{"message": "Export failed"}`.
+
+  Add route to `appinfo/routes.php`:
+  ```php
+  ['name' => 'parafering_audit_export#index', 'url' => '/api/parafering-audit-trail/export', 'verb' => 'GET'],
+  ```
+  Place BEFORE any wildcard `{slug}` routes. File carries `@spec openspec/changes/parafering-audit-trail/tasks.md#T07`, `@author`, `@license`.
+
+---
+
+## Translations
+
+- [ ] **T08**: Add the following translation keys to `l10n/en.json` (English source) and `l10n/nl.json` (Dutch translation). All user-visible labels for the manifest index page MUST resolve via `t(appName, '...')` — never hardcoded:
+
+  | English key | Dutch translation |
+  |-------------|-------------------|
+  | `Parafering audit trail` | `Paraferings-audittrail` |
+  | `Transition type` | `Type transitie` |
+  | `Actor role` | `Rol bij actie` |
+  | `Content snapshot` | `Inhoud op moment van actie` |
+  | `Started` | `Gestart` |
+  | `Endorsed (paraferd)` | `Geparafeerd` |
+  | `Advised` | `Geadviseerd` |
+  | `Returned` | `Teruggestuurd` |
+  | `Route changed` | `Route gewijzigd` |
+  | `Completed` | `Voltooid` |
+  | `Audit entries are append-only` | `Audit-vermeldingen zijn alleen toevoegbaar` |
+  | `Audit export requires auditor role` | `Audit-export vereist auditorrol` |
+  | `Export audit trail` | `Audittrail exporteren` |
+  | `Retention until` | `Bewaartermijn tot` |
+
+---
+
+## Pre-commit Verification
+
+- [ ] **V01**: `grep -rL 'SPDX-License-Identifier' lib/Event/ParafeerTransitionEvent.php lib/Listener/ParaferingAuditListener.php lib/Validator/ParaferingAuditAppendOnlyValidator.php lib/Controller/ParaferingAuditExportController.php` → zero results (all files have license header in main docblock per SPDX-in-docblock convention).
+
+- [ ] **V02**: `grep -rn 'getMessage()' lib/Controller/ParaferingAuditExportController.php` → zero results (no raw exception messages in API responses).
+
+- [ ] **V03**: Curl `POST` or `PUT` against the OR generic write endpoint targeting a `paraferingAuditEntry` UPDATE → 403 with `{"message": "Audit entries are append-only"}`. Curl DELETE → same 403. Curl POST a new entry directly (i.e. bypassing the listener) → also rejected because audit entries MUST originate from the listener that computes `auditEntryHash` server-side (validator additionally checks hash format on INSERT).
+
+- [ ] **V04**: End-to-end: submit a voorstel, complete 3 parafering steps, return once, skip a step (route-changed), and finally accord. Verify that 6 `paraferingAuditEntry` records exist for that voorstel, in chronological order, with `transitionType` values `started`, `paraferd`, `paraferd`, `terugsturen`, `route-changed`, `completed`. Verify `contentSnapshot` differs across entries (reflecting voorstel evolution). Verify `auditEntryHash` on every entry matches `sha256(canonical_json(entry_without_hash))`.
+
+- [ ] **V05**: Curl `GET /api/parafering-audit-trail/export?voorstel={uuid}` as a member of `auditors` → 200 with `metadata` (including `retentionUntil` = `completed.timestamp + 20 years`) and `entries` array sorted ascending by `timestamp`. Curl as a non-auditor non-member user → 403 with static message. Curl without `voorstel` param → 400.


### PR DESCRIPTION
## Summary

Generate the `parafering-audit-trail` OpenSpec change. **No code in this PR — spec only.**

Layers a legally-sufficient, append-only audit trail on top of the existing parafeerroute lifecycle (sister to `parafeerroute-engine`, `parafering-actions`, `voorstel-management`). Every state transition (`started`, `paraferd`, `advised`, `terugsturen`, `route-changed`, `completed`) is recorded as a `paraferingAuditEntry` with actor, actor role, timestamp, reason, content snapshot, and IP — sufficient for Awb bezwaar/beroep procedures and Archiefwet handover to the gemeentelijk e-Depot.

## Requirements (8 total, REQ-PAT-1 .. REQ-PAT-8)

| ID | Capability |
|----|------------|
| REQ-PAT-1 | `paraferingAuditEntry` schema registration (10 properties, 2 enums, Schema.org `Action`) |
| REQ-PAT-2 | Event-sourced audit writes only — single listener on `ParafeerTransitionEvent` |
| REQ-PAT-3 | Append-only validator — UPDATE/DELETE rejected with HTTP 403 static message |
| REQ-PAT-4 | Reuse of OpenRegister `audit-trail-immutable` — no parallel hash chain / Merkle tree |
| REQ-PAT-5 | Content snapshot frozen at transition (6 fixed fields, no lazy refs) |
| REQ-PAT-6 | Archive export endpoint with MDTO 1.0 envelope, group-gated to auditors |
| REQ-PAT-7 | Manifest index page (`type: 'index'`) for auditor browsing — no bespoke Vue view |
| REQ-PAT-8 | Retention 20y for decisions / 7y for non-decisions (Selectielijst Gemeenten 2020) |

## Key Design Decisions

- **Separate schema, not extending `parafeeractie`** — `parafeeractie` must remain updateable by the routing service (e.g. step supersession); audit must be append-only. Conflating them weakens both.
- **Event bus, not direct service call** — listener-only writes future-proof for SIEM streaming and remove `parafering-audit-trail` as a hard dependency of the routing service.
- **No custom audit store** — extends ADR-022 by layering transition semantics on top of OR `audit-trail-immutable`; the `auditEntryHash` (SHA-256) provides per-entry tamper detection without a chain.
- **MDTO 1.0 JSON envelope for V1** — XML profiles deferred; e-Depot push automation deferred to follow-up.
- **Retention sweeper out of scope** — the append-only validator blocks deletion outright; production retention enforcement filed as follow-up issue.

## Validation

```
openspec validate --type change --strict parafering-audit-trail
Change 'parafering-audit-trail' is valid
```

## Test plan

- [ ] OpenSpec strict validation passes locally (`openspec validate parafering-audit-trail --type change --strict`)
- [ ] Spec files render correctly in the OpenSpec UI
- [ ] Cross-references to `parafeerroute-engine`, `parafering-actions`, `voorstel-management` resolve
- [ ] ADR-022 alignment confirmed (no parallel audit store introduced)
- [ ] Archiefwet retention windows match Selectielijst Gemeenten 2020