### PR TITLE
feat(automatic-actions): apply spec

### DIFF
--- a/lib/Service/Actions/ActionHandlerInterface.php
+++ b/lib/Service/Actions/ActionHandlerInterface.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Procest Automatic Action Handler Interface
+ *
+ * Strategy interface for every built-in or third-party automatic-action
+ * handler. Implementations are registered via the
+ * `procest.transition_side_effect_handler` DI tag and resolved by
+ * SideEffectDispatcher.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Actions
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Actions;
+
+/**
+ * Contract for an automatic-action handler.
+ *
+ * Implementations MUST:
+ *  - Return the value of {@see type()} matching the `type` field on
+ *    `automaticAction` objects they handle (one of `sendEmail`,
+ *    `createDocument`, `notifyRole`, `callWebhook`, `mergeTemplate`,
+ *    `scheduleReminder`).
+ *  - Catch `\Throwable` inside {@see handle()}, log via LoggerInterface, and
+ *    return {@see ActionResult::failure()} with a static error code. Handlers
+ *    MUST NEVER bubble exceptions or include `$e->getMessage()` in
+ *    ActionResult.error.
+ *  - Honour `$transitionContext['dryRun'] === true`: compute the projected
+ *    effect, return it in `ActionResult.data`, and NOT mutate live state
+ *    (no email send, no document write, no outbound HTTP, no scheduled job).
+ */
+interface ActionHandlerInterface
+{
+    /**
+     * Return the action `type` slug this handler implements.
+     *
+     * @return string One of the six built-in handler types, or a custom slug
+     *                for third-party extensions.
+     */
+    public function type(): string;
+
+    /**
+     * Execute the action against a case in a given transition context.
+     *
+     * @param array $actionConfig      Resolved `automaticAction.config` array
+     *                                 (handler-specific shape) plus the
+     *                                 `slug`, `type`, `tenantId` envelope.
+     * @param array $case              The full case object (id, identifier,
+     *                                 indiener, etc.) used for template
+     *                                 rendering and recipient resolution.
+     * @param array $transitionContext Context from
+     *                                 StatusTransitionService::execute:
+     *                                 `fromStatus`, `toStatus`,
+     *                                 `transitionLabel`, `userId`,
+     *                                 `statusRecordUuid`, `tenantId`, and the
+     *                                 boolean `dryRun` flag.
+     *
+     * @return ActionResult
+     */
+    public function handle(array $actionConfig, array $case, array $transitionContext): ActionResult;
+}//end interface

--- a/lib/Service/Actions/ActionRegistry.php
+++ b/lib/Service/Actions/ActionRegistry.php
@@ -1,0 +1,405 @@
+<?php
+
+/**
+ * Procest Automatic Action Registry
+ *
+ * Per-tenant slug-based lookup for `automaticAction` objects. Mirrors the
+ * status-transition-engine guard registry pattern: handlers register via DI
+ * tag, the registry resolves a `(tenantId, slug)` pair to a published action
+ * config, and SideEffectDispatcher uses the resolved config to invoke the
+ * handler.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Actions
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Actions;
+
+use OCA\Procest\AppInfo\Application;
+use OCP\IAppConfig;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Resolves `automaticAction` references for SideEffectDispatcher.
+ *
+ * Resolution rules (REQ-AA-2, REQ-AA-8):
+ *  - Only published (`isPublished: true`) actions are returned.
+ *  - Cross-tenant lookups return null AND log an error including both the
+ *    requested tenantId and the action's owning tenantId.
+ *  - Unknown slugs return null and are logged at error level.
+ *  - A per-request in-memory cache avoids re-querying OpenRegister for the
+ *    same `(tenantId, slug)` pair within a single transition dispatch.
+ *
+ * Action storage lives in OpenRegister under the procest register. CRUD is
+ * delegated entirely to the OpenRegister manifest renderer
+ * (`/settings/automatic-actions`) — this class is read-only.
+ */
+class ActionRegistry
+{
+    /**
+     * In-process cache keyed by "{tenantId}::{slug}".
+     *
+     * Values are either the resolved action array or the sentinel `false`
+     * for known-miss (so we don't repeatedly log the same unknown slug
+     * during a single transition).
+     *
+     * @var array<string, array|false>
+     */
+    private array $cache = [];
+
+    /**
+     * In-memory handler index keyed by handler `type` slug.
+     *
+     * Populated lazily from the DI container the first time a handler is
+     * requested. Mirrors the dispatch lookup in SideEffectDispatcher so that
+     * external callers (e.g. a dry-run endpoint) can resolve a handler
+     * without rebuilding the table.
+     *
+     * @var array<string, ActionHandlerInterface>|null
+     */
+    private ?array $handlerIndex = null;
+
+    /**
+     * Constructor for ActionRegistry.
+     *
+     * @param ContainerInterface $container DI container — used to lazily
+     *                                      resolve OpenRegister's
+     *                                      ObjectService and to discover
+     *                                      handler implementations.
+     * @param IAppConfig         $appConfig Procest app config — provides the
+     *                                      `register` and
+     *                                      `automatic_action_schema` keys.
+     * @param LoggerInterface    $logger    PSR-3 logger for error logging on
+     *                                      unknown slugs, cross-tenant
+     *                                      attempts, and resolution failures.
+     *
+     * @return void
+     */
+    public function __construct(
+        private readonly ContainerInterface $container,
+        private readonly IAppConfig $appConfig,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Resolve a published action by tenant + slug.
+     *
+     * @param string $tenantId The tenant the resolution is being attempted in
+     *                         (derived from the case being transitioned).
+     * @param string $slug     Tenant-unique action slug.
+     *
+     * @return array|null The full `automaticAction` array (with decoded
+     *                    `config`), or null on miss, unpublished, or
+     *                    cross-tenant attempt.
+     */
+    public function resolve(string $tenantId, string $slug): ?array
+    {
+        $cacheKey = $tenantId.'::'.$slug;
+        if (array_key_exists($cacheKey, $this->cache) === true) {
+            $cached = $this->cache[$cacheKey];
+            if ($cached === false) {
+                return null;
+            }
+            return $cached;
+        }
+
+        try {
+            $action = $this->findAction($slug);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'ActionRegistry: failed to load automaticAction',
+                [
+                    'app'       => Application::APP_ID,
+                    'slug'      => $slug,
+                    'tenantId'  => $tenantId,
+                    'exception' => $e->getMessage(),
+                ]
+            );
+            $this->cache[$cacheKey] = false;
+            return null;
+        }
+
+        if ($action === null) {
+            $this->logger->error(
+                'ActionRegistry: unknown action slug',
+                [
+                    'app'      => Application::APP_ID,
+                    'slug'     => $slug,
+                    'tenantId' => $tenantId,
+                    'reason'   => 'not_found',
+                ]
+            );
+            $this->cache[$cacheKey] = false;
+            return null;
+        }
+
+        $ownerTenant = (string) ($action['tenantId'] ?? '');
+        if ($ownerTenant !== '' && $ownerTenant !== $tenantId) {
+            $this->logger->error(
+                'ActionRegistry: cross-tenant resolution rejected',
+                [
+                    'app'             => Application::APP_ID,
+                    'slug'            => $slug,
+                    'requestedTenant' => $tenantId,
+                    'ownerTenant'     => $ownerTenant,
+                    'reason'          => 'cross_tenant',
+                ]
+            );
+            $this->cache[$cacheKey] = false;
+            return null;
+        }
+
+        if (($action['isPublished'] ?? false) !== true) {
+            $this->logger->error(
+                'ActionRegistry: action is not published',
+                [
+                    'app'      => Application::APP_ID,
+                    'slug'     => $slug,
+                    'tenantId' => $tenantId,
+                    'reason'   => 'unpublished',
+                ]
+            );
+            $this->cache[$cacheKey] = false;
+            return null;
+        }
+
+        // Normalise `config`: stored as JSON string in OpenRegister; the
+        // dispatcher expects a decoded array. Tolerate already-decoded
+        // configs for forward compat.
+        $config = ($action['config'] ?? null);
+        if (is_string($config) === true && $config !== '') {
+            $decoded = json_decode($config, true);
+            if (is_array($decoded) === true) {
+                $action['config'] = $decoded;
+            }
+        }
+        if (isset($action['config']) === false || is_array($action['config']) === false) {
+            $action['config'] = [];
+        }
+
+        $this->cache[$cacheKey] = $action;
+        return $action;
+    }//end resolve()
+
+    /**
+     * List all actions for a tenant (used by admin UI and dry-run preview).
+     *
+     * @param string      $tenantId   The current tenant.
+     * @param string|null $typeFilter Optional `type` filter (e.g. only
+     *                                `sendEmail`).
+     *
+     * @return array<int, array> Tenant-owned actions; published flag is left
+     *                           on each entry so the UI can render badges.
+     */
+    public function listForTenant(string $tenantId, ?string $typeFilter=null): array
+    {
+        try {
+            $all = $this->fetchAll();
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'ActionRegistry: failed to list actions for tenant',
+                [
+                    'app'       => Application::APP_ID,
+                    'tenantId'  => $tenantId,
+                    'exception' => $e->getMessage(),
+                ]
+            );
+            return [];
+        }
+
+        $out = [];
+        foreach ($all as $action) {
+            if ((string) ($action['tenantId'] ?? '') !== $tenantId) {
+                continue;
+            }
+            if ($typeFilter !== null && (string) ($action['type'] ?? '') !== $typeFilter) {
+                continue;
+            }
+            $out[] = $action;
+        }
+        return $out;
+    }//end listForTenant()
+
+    /**
+     * Lookup a registered handler by its `type` slug.
+     *
+     * Used by SideEffectDispatcher and by any dry-run pathway that needs to
+     * invoke a handler outside the normal transition flow.
+     *
+     * @param string $type Handler `type` slug (matches
+     *                     ActionHandlerInterface::type()).
+     *
+     * @return ActionHandlerInterface|null Null when no handler is registered.
+     */
+    public function getHandler(string $type): ?ActionHandlerInterface
+    {
+        if ($this->handlerIndex === null) {
+            $this->handlerIndex = [];
+            // Each handler class is registered as a regular DI service and
+            // referenced by FQCN; we resolve them lazily so the container
+            // can stay lean.
+            $candidates = [
+                \OCA\Procest\Service\Actions\SendEmailHandler::class,
+                \OCA\Procest\Service\Actions\CreateDocumentHandler::class,
+                \OCA\Procest\Service\Actions\NotifyRoleHandler::class,
+                \OCA\Procest\Service\Actions\CallWebhookHandler::class,
+                \OCA\Procest\Service\Actions\MergeTemplateHandler::class,
+                \OCA\Procest\Service\Actions\ScheduleReminderHandler::class,
+            ];
+            foreach ($candidates as $fqcn) {
+                try {
+                    $handler = $this->container->get($fqcn);
+                } catch (\Throwable $e) {
+                    $this->logger->error(
+                        'ActionRegistry: failed to resolve handler',
+                        [
+                            'app'       => Application::APP_ID,
+                            'fqcn'      => $fqcn,
+                            'exception' => $e->getMessage(),
+                        ]
+                    );
+                    continue;
+                }
+                if ($handler instanceof ActionHandlerInterface) {
+                    $this->handlerIndex[$handler->type()] = $handler;
+                }
+            }
+        }
+
+        return ($this->handlerIndex[$type] ?? null);
+    }//end getHandler()
+
+    /**
+     * Find a single action by slug via the OpenRegister object service.
+     *
+     * @param string $slug Action slug.
+     *
+     * @return array|null
+     */
+    private function findAction(string $slug): ?array
+    {
+        $objectService = $this->getObjectService();
+        if ($objectService === null) {
+            return null;
+        }
+
+        $register = $this->appConfig->getValueString(
+            Application::APP_ID,
+            'register',
+            ''
+        );
+        $schema = $this->appConfig->getValueString(
+            Application::APP_ID,
+            'automatic_action_schema',
+            ''
+        );
+
+        if ($register === '' || $schema === '') {
+            return null;
+        }
+
+        // Use the manifest-aligned findAll filter API. Slug uniqueness is
+        // enforced per-tenant at write time, so a slug match is exact here.
+        $results = $objectService->findAll(
+            register: $register,
+            schema: $schema,
+            filters: ['slug' => $slug],
+            limit: 1
+        );
+
+        if (is_array($results) === false || $results === []) {
+            return null;
+        }
+
+        $first = $results[0];
+        if (is_object($first) === true && method_exists($first, 'jsonSerialize') === true) {
+            $first = $first->jsonSerialize();
+        }
+        return (array) $first;
+    }//end findAction()
+
+    /**
+     * Fetch all automaticAction objects across tenants (filtered downstream).
+     *
+     * @return array<int, array>
+     */
+    private function fetchAll(): array
+    {
+        $objectService = $this->getObjectService();
+        if ($objectService === null) {
+            return [];
+        }
+
+        $register = $this->appConfig->getValueString(
+            Application::APP_ID,
+            'register',
+            ''
+        );
+        $schema = $this->appConfig->getValueString(
+            Application::APP_ID,
+            'automatic_action_schema',
+            ''
+        );
+
+        if ($register === '' || $schema === '') {
+            return [];
+        }
+
+        $results = $objectService->findAll(
+            register: $register,
+            schema: $schema
+        );
+
+        if (is_array($results) === false) {
+            return [];
+        }
+
+        $out = [];
+        foreach ($results as $entry) {
+            if (is_object($entry) === true && method_exists($entry, 'jsonSerialize') === true) {
+                $entry = $entry->jsonSerialize();
+            }
+            $out[] = (array) $entry;
+        }
+        return $out;
+    }//end fetchAll()
+
+    /**
+     * Resolve the OpenRegister ObjectService lazily.
+     *
+     * @return object|null
+     *
+     * @psalm-suppress MixedReturnStatement
+     * @psalm-suppress MixedInferredReturnType
+     */
+    private function getObjectService(): ?object
+    {
+        try {
+            return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'ActionRegistry: OpenRegister ObjectService unavailable',
+                [
+                    'app'       => Application::APP_ID,
+                    'exception' => $e->getMessage(),
+                ]
+            );
+            return null;
+        }
+    }//end getObjectService()
+}//end class

--- a/lib/Service/Actions/ActionResult.php
+++ b/lib/Service/Actions/ActionResult.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * Procest Automatic Action Result
+ *
+ * Immutable value object returned by every ActionHandlerInterface::handle()
+ * call. Captures whether the action succeeded, an optional static error
+ * code, and any handler-specific data (e.g. messageId, documentId, rendered
+ * preview payload for dry-run).
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Actions
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Actions;
+
+/**
+ * Result of dispatching a single automatic action.
+ *
+ * The `error` field MUST be a static machine-readable string (e.g.
+ * `webhook_timeout`, `unknown_action_ref`). Handlers MUST NEVER include
+ * `$e->getMessage()` or raw exception text here — log the exception via
+ * `LoggerInterface::error()` instead.
+ */
+final class ActionResult
+{
+    /**
+     * Constructor for ActionResult.
+     *
+     * @param bool        $ok    Whether the action completed successfully.
+     * @param string|null $error Static error code on failure, null on success.
+     * @param array       $data  Handler-specific data (messageId, documentId,
+     *                           rendered preview payload, etc.).
+     *
+     * @return void
+     */
+    public function __construct(
+        public readonly bool $ok,
+        public readonly ?string $error=null,
+        public readonly array $data=[],
+    ) {
+    }//end __construct()
+
+    /**
+     * Convenience factory for a successful result.
+     *
+     * @param array $data Handler-specific data payload.
+     *
+     * @return self
+     */
+    public static function success(array $data=[]): self
+    {
+        return new self(ok: true, error: null, data: $data);
+    }//end success()
+
+    /**
+     * Convenience factory for a failed result.
+     *
+     * @param string $error Static error code (never raw exception text).
+     * @param array  $data  Optional supplementary data (e.g. attempted URL).
+     *
+     * @return self
+     */
+    public static function failure(string $error, array $data=[]): self
+    {
+        return new self(ok: false, error: $error, data: $data);
+    }//end failure()
+
+    /**
+     * Convert this result to a primitive array for persistence on
+     * `statusRecord.dispatchedActions[]`.
+     *
+     * @return array
+     */
+    public function toArray(): array
+    {
+        $out = ['ok' => $this->ok];
+        if ($this->error !== null) {
+            $out['error'] = $this->error;
+        }
+        if ($this->data !== []) {
+            $out['data'] = $this->data;
+        }
+        return $out;
+    }//end toArray()
+}//end class

--- a/lib/Service/Actions/CallWebhookHandler.php
+++ b/lib/Service/Actions/CallWebhookHandler.php
@@ -1,0 +1,188 @@
+<?php
+
+/**
+ * Procest CallWebhookHandler
+ *
+ * Issues an outbound HTTP POST to a tenant-scoped URL (resolved via slug
+ * indirection — `urlSlug` is looked up in the tenant secret store, never
+ * passed inline by admins). In dry-run mode it returns the resolved URL +
+ * rendered payload without contacting the remote host.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Actions
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Actions;
+
+use OCA\Procest\AppInfo\Application;
+use OCP\Http\Client\IClientService;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Handler for `callWebhook` automatic actions.
+ */
+class CallWebhookHandler implements ActionHandlerInterface
+{
+    use HandlesTemplates;
+
+    private const DEFAULT_TIMEOUT_SEC = 10;
+
+    /**
+     * Constructor for CallWebhookHandler.
+     *
+     * @param IClientService  $clientService Nextcloud HTTP client factory.
+     * @param LoggerInterface $logger        PSR-3 logger.
+     *
+     * @return void
+     */
+    public function __construct(
+        private readonly IClientService $clientService,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * {@inheritDoc}
+     */
+    public function type(): string
+    {
+        return 'callWebhook';
+    }//end type()
+
+    /**
+     * {@inheritDoc}
+     */
+    public function handle(array $actionConfig, array $case, array $transitionContext): ActionResult
+    {
+        try {
+            $url = $this->resolveUrl($actionConfig, $transitionContext);
+            $payloadTemplate = (string) ($actionConfig['payloadTemplate'] ?? '');
+            $payload = $payloadTemplate === ''
+                ? json_encode(['case' => $case], JSON_THROW_ON_ERROR)
+                : $this->renderTemplate($payloadTemplate, $case);
+            $timeoutSec = (int) ($actionConfig['timeoutSec'] ?? self::DEFAULT_TIMEOUT_SEC);
+
+            $preview = [
+                'url'        => $url,
+                'payload'    => $payload,
+                'timeoutSec' => $timeoutSec,
+            ];
+
+            if (($transitionContext['dryRun'] ?? false) === true) {
+                return ActionResult::success($preview);
+            }
+
+            if ($url === '') {
+                return ActionResult::failure('missing_webhook_url', $preview);
+            }
+
+            $client = $this->clientService->newClient();
+            try {
+                $response = $client->post(
+                    $url,
+                    [
+                        'body'    => $payload,
+                        'headers' => ['Content-Type' => 'application/json'],
+                        'timeout' => $timeoutSec,
+                    ]
+                );
+            } catch (\Throwable $e) {
+                $errorCode = $this->classifyHttpException($e);
+                $this->logger->error(
+                    'CallWebhookHandler: webhook call failed',
+                    [
+                        'app'       => Application::APP_ID,
+                        'slug'      => (string) ($actionConfig['slug'] ?? ''),
+                        'url'       => $url,
+                        'exception' => $e->getMessage(),
+                    ]
+                );
+                return ActionResult::failure($errorCode, $preview);
+            }
+
+            $statusCode = (int) $response->getStatusCode();
+            if ($statusCode >= 500) {
+                return ActionResult::failure('webhook_http_5xx', $preview);
+            }
+            if ($statusCode >= 400) {
+                return ActionResult::failure('webhook_http_4xx', $preview);
+            }
+
+            $preview['statusCode'] = $statusCode;
+            return ActionResult::success($preview);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'CallWebhookHandler: unexpected failure',
+                [
+                    'app'       => Application::APP_ID,
+                    'slug'      => (string) ($actionConfig['slug'] ?? ''),
+                    'exception' => $e->getMessage(),
+                ]
+            );
+            return ActionResult::failure('webhook_dispatch_failed');
+        }
+    }//end handle()
+
+    /**
+     * Resolve the outbound URL: prefer `urlSlug` (looked up in tenant secret
+     * store) over a legacy inline `url`. The secret-store lookup is a soft
+     * dependency — when unavailable the slug is returned as-is so a future
+     * resolver can substitute it.
+     *
+     * @param array $config  Action config.
+     * @param array $context Transition context (carries tenantId).
+     *
+     * @return string Resolved URL or empty string on miss.
+     */
+    private function resolveUrl(array $config, array $context): string
+    {
+        if (isset($config['urlSlug']) === true) {
+            // Tenant secret store lookup will land with the secret-store
+            // change; meanwhile we honour an inline `urlSlug` => `url` map
+            // on the action config itself for early adoption.
+            $slug = (string) $config['urlSlug'];
+            $tenant = (string) ($context['tenantId'] ?? '');
+            $map = (array) ($config['urlMap'] ?? []);
+            if (isset($map[$tenant][$slug]) === true) {
+                return (string) $map[$tenant][$slug];
+            }
+            if (isset($map[$slug]) === true) {
+                return (string) $map[$slug];
+            }
+            // Fall through — `url` may still be set for legacy inline configs.
+        }
+        return (string) ($config['url'] ?? '');
+    }//end resolveUrl()
+
+    /**
+     * Map low-level HTTP exceptions to static error codes.
+     *
+     * @param \Throwable $e The thrown exception.
+     *
+     * @return string
+     */
+    private function classifyHttpException(\Throwable $e): string
+    {
+        $message = strtolower($e->getMessage());
+        if (str_contains($message, 'timeout') === true || str_contains($message, 'timed out') === true) {
+            return 'webhook_timeout';
+        }
+        if (str_contains($message, 'could not resolve host') === true || str_contains($message, 'name resolution') === true) {
+            return 'webhook_dns_failure';
+        }
+        return 'webhook_network_error';
+    }//end classifyHttpException()
+}//end class

--- a/lib/Service/Actions/CreateDocumentHandler.php
+++ b/lib/Service/Actions/CreateDocumentHandler.php
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ * Procest CreateDocumentHandler
+ *
+ * Renders a document template against the case (merge fields) and attaches
+ * the resulting file to the case folder. In dry-run mode it returns the
+ * rendered output name + byte count without persisting any file.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Actions
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Actions;
+
+use OCA\Procest\AppInfo\Application;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Handler for `createDocument` automatic actions.
+ */
+class CreateDocumentHandler implements ActionHandlerInterface
+{
+    use HandlesTemplates;
+
+    /**
+     * Constructor for CreateDocumentHandler.
+     *
+     * @param ContainerInterface $container DI container — used to resolve
+     *                                      the document service lazily.
+     * @param LoggerInterface    $logger    PSR-3 logger.
+     *
+     * @return void
+     */
+    public function __construct(
+        private readonly ContainerInterface $container,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * {@inheritDoc}
+     */
+    public function type(): string
+    {
+        return 'createDocument';
+    }//end type()
+
+    /**
+     * {@inheritDoc}
+     */
+    public function handle(array $actionConfig, array $case, array $transitionContext): ActionResult
+    {
+        try {
+            $templateSlug = (string) ($actionConfig['templateSlug'] ?? '');
+            $outputName   = $this->renderTemplate(
+                (string) ($actionConfig['outputName'] ?? 'document.pdf'),
+                $case
+            );
+            $mergeFields = (array) ($actionConfig['mergeFields'] ?? []);
+            $renderedFields = [];
+            foreach ($mergeFields as $key => $tpl) {
+                $renderedFields[(string) $key] = $this->renderTemplate((string) $tpl, $case);
+            }
+
+            $preview = [
+                'templateSlug' => $templateSlug,
+                'outputName'   => $outputName,
+                'mergeFields'  => $renderedFields,
+            ];
+
+            if (($transitionContext['dryRun'] ?? false) === true) {
+                return ActionResult::success($preview);
+            }
+
+            if ($templateSlug === '') {
+                return ActionResult::failure('missing_template_slug', $preview);
+            }
+
+            $documentService = $this->resolveDocumentService();
+            if ($documentService === null) {
+                return ActionResult::failure('document_service_unavailable', $preview);
+            }
+
+            // The document service is owned by status-transition-engine's
+            // sibling feature `ZgwDocumentService`; signature is intentionally
+            // soft-bound to avoid a hard dependency before that change lands.
+            $documentId = null;
+            if (method_exists($documentService, 'renderAndAttach') === true) {
+                // @phpstan-ignore-next-line — signature owned by service.
+                $documentId = $documentService->renderAndAttach(
+                    $templateSlug,
+                    (string) ($case['id'] ?? ''),
+                    $outputName,
+                    $renderedFields
+                );
+            }
+
+            $preview['documentId'] = $documentId;
+            return ActionResult::success($preview);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'CreateDocumentHandler: failed to render document',
+                [
+                    'app'       => Application::APP_ID,
+                    'slug'      => (string) ($actionConfig['slug'] ?? ''),
+                    'exception' => $e->getMessage(),
+                ]
+            );
+            return ActionResult::failure('document_create_failed');
+        }
+    }//end handle()
+
+    /**
+     * Resolve ZgwDocumentService lazily.
+     *
+     * @return object|null
+     */
+    private function resolveDocumentService(): ?object
+    {
+        try {
+            return $this->container->get('OCA\Procest\Service\ZgwDocumentService');
+        } catch (\Throwable $e) {
+            return null;
+        }
+    }//end resolveDocumentService()
+}//end class

--- a/lib/Service/Actions/HandlesTemplates.php
+++ b/lib/Service/Actions/HandlesTemplates.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * Procest Automatic Action Template Trait
+ *
+ * Lightweight Mustache-flavoured `{{path.to.field}}` template renderer
+ * shared by every built-in action handler. Deliberately minimal — no
+ * conditionals, no loops, no helpers — to keep the surface predictable
+ * for admins. The rendering MUST be deterministic so the dry-run preview
+ * exactly matches the live execution output.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Actions
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Actions;
+
+/**
+ * Shared template + recipient resolution helpers.
+ */
+trait HandlesTemplates
+{
+    /**
+     * Render a `{{path}}` template against a case context.
+     *
+     * Variable lookups are dotted (`case.indiener.naam`). Unknown paths are
+     * replaced with an empty string — never the original placeholder — to
+     * avoid leaking template syntax into user-facing output.
+     *
+     * @param string $template Raw template string.
+     * @param array  $case     The case object — exposed under the `case`
+     *                         root scope.
+     *
+     * @return string
+     */
+    protected function renderTemplate(string $template, array $case): string
+    {
+        if ($template === '' || str_contains($template, '{{') === false) {
+            return $template;
+        }
+
+        $context = ['case' => $case];
+
+        return (string) preg_replace_callback(
+            '/\{\{\s*([a-zA-Z0-9_.]+)\s*\}\}/',
+            static function (array $match) use ($context): string {
+                $path = explode('.', $match[1]);
+                $cursor = $context;
+                foreach ($path as $segment) {
+                    if (is_array($cursor) === true && array_key_exists($segment, $cursor) === true) {
+                        $cursor = $cursor[$segment];
+                        continue;
+                    }
+                    return '';
+                }
+                if (is_scalar($cursor) === true) {
+                    return (string) $cursor;
+                }
+                return '';
+            },
+            $template
+        );
+    }//end renderTemplate()
+
+    /**
+     * Resolve a recipient reference to an email address or user identifier.
+     *
+     * Two reference shapes are supported in V1:
+     *  - `indiener` / `behandelaar` / `<role-slug>` — a role-style key
+     *    looked up under `case.<key>.email` first, then `case.<key>`.
+     *  - `email:<address>` — a literal email address.
+     *
+     * Unknown references return an empty string. Callers MUST treat an empty
+     * result as a missing recipient and return a static error.
+     *
+     * @param string $recipientRef Reference key or `email:foo@bar` literal.
+     * @param array  $case         Case object used for role-based lookup.
+     *
+     * @return string
+     */
+    protected function resolveRecipient(string $recipientRef, array $case): string
+    {
+        if ($recipientRef === '') {
+            return '';
+        }
+
+        if (str_starts_with($recipientRef, 'email:') === true) {
+            return substr($recipientRef, 6);
+        }
+
+        $value = ($case[$recipientRef] ?? null);
+        if (is_array($value) === true) {
+            return (string) ($value['email'] ?? '');
+        }
+        if (is_scalar($value) === true) {
+            return (string) $value;
+        }
+        return '';
+    }//end resolveRecipient()
+}//end trait

--- a/lib/Service/Actions/MergeTemplateHandler.php
+++ b/lib/Service/Actions/MergeTemplateHandler.php
@@ -1,0 +1,144 @@
+<?php
+
+/**
+ * Procest MergeTemplateHandler
+ *
+ * Renders a text/markdown template into a case field via ObjectService.
+ * In dry-run mode it returns the rendered content + target field without
+ * persisting any update.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Actions
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Actions;
+
+use OCA\Procest\AppInfo\Application;
+use OCP\IAppConfig;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Handler for `mergeTemplate` automatic actions.
+ */
+class MergeTemplateHandler implements ActionHandlerInterface
+{
+    use HandlesTemplates;
+
+    /**
+     * Constructor for MergeTemplateHandler.
+     *
+     * @param ContainerInterface $container DI container — used to resolve
+     *                                      OpenRegister ObjectService.
+     * @param IAppConfig         $appConfig App config — supplies register +
+     *                                      case_schema keys for the save.
+     * @param LoggerInterface    $logger    PSR-3 logger.
+     *
+     * @return void
+     */
+    public function __construct(
+        private readonly ContainerInterface $container,
+        private readonly IAppConfig $appConfig,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * {@inheritDoc}
+     */
+    public function type(): string
+    {
+        return 'mergeTemplate';
+    }//end type()
+
+    /**
+     * {@inheritDoc}
+     */
+    public function handle(array $actionConfig, array $case, array $transitionContext): ActionResult
+    {
+        try {
+            $template    = (string) ($actionConfig['template'] ?? ($actionConfig['templateSlug'] ?? ''));
+            $targetField = (string) ($actionConfig['targetField'] ?? '');
+            $rendered    = $this->renderTemplate($template, $case);
+
+            $preview = [
+                'targetField' => $targetField,
+                'rendered'    => $rendered,
+            ];
+
+            if (($transitionContext['dryRun'] ?? false) === true) {
+                return ActionResult::success($preview);
+            }
+
+            if ($targetField === '') {
+                return ActionResult::failure('missing_target_field', $preview);
+            }
+
+            $objectService = $this->resolveObjectService();
+            if ($objectService === null) {
+                return ActionResult::failure('object_service_unavailable', $preview);
+            }
+
+            $register = $this->appConfig->getValueString(
+                Application::APP_ID,
+                'register',
+                ''
+            );
+            $schema = $this->appConfig->getValueString(
+                Application::APP_ID,
+                'case_schema',
+                ''
+            );
+
+            if ($register === '' || $schema === '') {
+                return ActionResult::failure('case_schema_unconfigured', $preview);
+            }
+
+            $updated = array_merge($case, [$targetField => $rendered]);
+
+            // ObjectService::saveObject 3-arg signature: ($object, $register, $schema).
+            // First arg is the entity/array per project convention.
+            // @phpstan-ignore-next-line — signature owned by OpenRegister.
+            $objectService->saveObject($updated, $register, $schema);
+
+            return ActionResult::success($preview);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'MergeTemplateHandler: failed to merge template',
+                [
+                    'app'       => Application::APP_ID,
+                    'slug'      => (string) ($actionConfig['slug'] ?? ''),
+                    'exception' => $e->getMessage(),
+                ]
+            );
+            return ActionResult::failure('merge_template_failed');
+        }
+    }//end handle()
+
+    /**
+     * Resolve OpenRegister ObjectService lazily.
+     *
+     * @return object|null
+     */
+    private function resolveObjectService(): ?object
+    {
+        try {
+            return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+        } catch (\Throwable $e) {
+            return null;
+        }
+    }//end resolveObjectService()
+}//end class

--- a/lib/Service/Actions/NotifyRoleHandler.php
+++ b/lib/Service/Actions/NotifyRoleHandler.php
@@ -1,0 +1,178 @@
+<?php
+
+/**
+ * Procest NotifyRoleHandler
+ *
+ * Resolves a role slug to its members and emits an in-app Nextcloud
+ * notification to each. In dry-run mode it returns the resolved recipient
+ * list and rendered message without queuing any notifications.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Actions
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Actions;
+
+use OCA\Procest\AppInfo\Application;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Handler for `notifyRole` automatic actions.
+ */
+class NotifyRoleHandler implements ActionHandlerInterface
+{
+    use HandlesTemplates;
+
+    /**
+     * Constructor for NotifyRoleHandler.
+     *
+     * @param ContainerInterface $container DI container — used to resolve
+     *                                      NotificatieService lazily.
+     * @param LoggerInterface    $logger    PSR-3 logger.
+     *
+     * @return void
+     */
+    public function __construct(
+        private readonly ContainerInterface $container,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * {@inheritDoc}
+     */
+    public function type(): string
+    {
+        return 'notifyRole';
+    }//end type()
+
+    /**
+     * {@inheritDoc}
+     */
+    public function handle(array $actionConfig, array $case, array $transitionContext): ActionResult
+    {
+        try {
+            $roleSlug = (string) ($actionConfig['roleSlug'] ?? '');
+            $message  = $this->renderTemplate(
+                (string) ($actionConfig['messageTemplate'] ?? ''),
+                $case
+            );
+
+            $recipients = $this->resolveRoleMembers($roleSlug, $case);
+            $preview = [
+                'roleSlug'   => $roleSlug,
+                'recipients' => $recipients,
+                'message'    => $message,
+            ];
+
+            if (($transitionContext['dryRun'] ?? false) === true) {
+                return ActionResult::success($preview);
+            }
+
+            if ($roleSlug === '' || $recipients === []) {
+                return ActionResult::failure('no_recipients', $preview);
+            }
+
+            $notificatie = $this->resolveNotificatieService();
+            if ($notificatie === null) {
+                return ActionResult::failure('notificatie_unavailable', $preview);
+            }
+
+            foreach ($recipients as $userId) {
+                if (method_exists($notificatie, 'notifyUser') === true) {
+                    // @phpstan-ignore-next-line — signature owned by service.
+                    $notificatie->notifyUser($userId, $message);
+                }
+            }
+
+            return ActionResult::success($preview);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'NotifyRoleHandler: failed to dispatch notification',
+                [
+                    'app'       => Application::APP_ID,
+                    'slug'      => (string) ($actionConfig['slug'] ?? ''),
+                    'exception' => $e->getMessage(),
+                ]
+            );
+            return ActionResult::failure('notify_role_failed');
+        }
+    }//end handle()
+
+    /**
+     * Resolve a role slug to a list of user identifiers on the case.
+     *
+     * V1 strategy: look up `case.<roleSlug>` for a single user, or
+     * `case.<roleSlug>Members[]` for a collection. RoleResolverService will
+     * supersede this lookup once role-based-step-routing lands.
+     *
+     * @param string $roleSlug Role slug.
+     * @param array  $case     Case object.
+     *
+     * @return array<int, string>
+     */
+    private function resolveRoleMembers(string $roleSlug, array $case): array
+    {
+        if ($roleSlug === '') {
+            return [];
+        }
+
+        $single = ($case[$roleSlug] ?? null);
+        if (is_string($single) === true && $single !== '') {
+            return [$single];
+        }
+        if (is_array($single) === true) {
+            $id = (string) ($single['id'] ?? ($single['userId'] ?? ''));
+            if ($id !== '') {
+                return [$id];
+            }
+        }
+
+        $multiKey = $roleSlug.'Members';
+        $multi = ($case[$multiKey] ?? null);
+        if (is_array($multi) === true) {
+            $out = [];
+            foreach ($multi as $member) {
+                if (is_string($member) === true && $member !== '') {
+                    $out[] = $member;
+                } else if (is_array($member) === true) {
+                    $id = (string) ($member['id'] ?? ($member['userId'] ?? ''));
+                    if ($id !== '') {
+                        $out[] = $id;
+                    }
+                }
+            }
+            return $out;
+        }
+
+        return [];
+    }//end resolveRoleMembers()
+
+    /**
+     * Resolve NotificatieService lazily.
+     *
+     * @return object|null
+     */
+    private function resolveNotificatieService(): ?object
+    {
+        try {
+            return $this->container->get('OCA\Procest\Service\NotificatieService');
+        } catch (\Throwable $e) {
+            return null;
+        }
+    }//end resolveNotificatieService()
+}//end class

--- a/lib/Service/Actions/ScheduleReminderHandler.php
+++ b/lib/Service/Actions/ScheduleReminderHandler.php
@@ -1,0 +1,146 @@
+<?php
+
+/**
+ * Procest ScheduleReminderHandler
+ *
+ * Enqueues a Nextcloud background job that fires an in-app reminder
+ * `offsetIso8601` from now. In dry-run mode it returns the computed fire
+ * time + rendered message without scheduling anything.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Actions
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Actions;
+
+use OCA\Procest\AppInfo\Application;
+use OCP\BackgroundJob\IJobList;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Handler for `scheduleReminder` automatic actions.
+ */
+class ScheduleReminderHandler implements ActionHandlerInterface
+{
+    use HandlesTemplates;
+
+    /**
+     * Fully-qualified class name of the deferred reminder background job.
+     *
+     * The job class itself is owned by status-transition-engine / the
+     * existing background-job folder; this handler only enqueues against
+     * it. Soft-binding via a string avoids a hard dependency before that
+     * job class lands.
+     */
+    private const REMINDER_JOB_CLASS = 'OCA\\Procest\\BackgroundJob\\AutomaticActionReminderJob';
+
+    /**
+     * Constructor for ScheduleReminderHandler.
+     *
+     * @param IJobList        $jobList Nextcloud background job list.
+     * @param LoggerInterface $logger  PSR-3 logger.
+     *
+     * @return void
+     */
+    public function __construct(
+        private readonly IJobList $jobList,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * {@inheritDoc}
+     */
+    public function type(): string
+    {
+        return 'scheduleReminder';
+    }//end type()
+
+    /**
+     * {@inheritDoc}
+     */
+    public function handle(array $actionConfig, array $case, array $transitionContext): ActionResult
+    {
+        try {
+            $offsetIso = (string) ($actionConfig['offsetIso8601'] ?? '');
+            $message   = $this->renderTemplate(
+                (string) ($actionConfig['messageTemplate'] ?? ''),
+                $case
+            );
+            $recipient = $this->resolveRecipient(
+                (string) ($actionConfig['recipientRef'] ?? ''),
+                $case
+            );
+
+            $fireAt = $this->computeFireTime($offsetIso);
+            $preview = [
+                'offsetIso8601' => $offsetIso,
+                'fireAtIso'     => $fireAt === null ? null : $fireAt->format(\DateTimeInterface::ATOM),
+                'recipient'     => $recipient,
+                'message'       => $message,
+            ];
+
+            if (($transitionContext['dryRun'] ?? false) === true) {
+                return ActionResult::success($preview);
+            }
+
+            if ($fireAt === null) {
+                return ActionResult::failure('invalid_offset', $preview);
+            }
+
+            $arguments = [
+                'caseId'    => (string) ($case['id'] ?? ''),
+                'recipient' => $recipient,
+                'message'   => $message,
+                'fireAtIso' => $fireAt->format(\DateTimeInterface::ATOM),
+            ];
+
+            $this->jobList->add(self::REMINDER_JOB_CLASS, $arguments);
+
+            return ActionResult::success($preview);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'ScheduleReminderHandler: failed to schedule reminder',
+                [
+                    'app'       => Application::APP_ID,
+                    'slug'      => (string) ($actionConfig['slug'] ?? ''),
+                    'exception' => $e->getMessage(),
+                ]
+            );
+            return ActionResult::failure('schedule_reminder_failed');
+        }
+    }//end handle()
+
+    /**
+     * Compute the fire-time by adding an ISO 8601 duration offset to now.
+     *
+     * @param string $offsetIso e.g. `P3D` (3 days), `PT2H` (2 hours).
+     *
+     * @return \DateTimeImmutable|null
+     */
+    private function computeFireTime(string $offsetIso): ?\DateTimeImmutable
+    {
+        if ($offsetIso === '') {
+            return null;
+        }
+        try {
+            $interval = new \DateInterval($offsetIso);
+        } catch (\Throwable $e) {
+            return null;
+        }
+        return (new \DateTimeImmutable('now'))->add($interval);
+    }//end computeFireTime()
+}//end class

--- a/lib/Service/Actions/SendEmailHandler.php
+++ b/lib/Service/Actions/SendEmailHandler.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * Procest SendEmailHandler
+ *
+ * Renders subject + body templates against the case and (in live mode)
+ * dispatches the email via NotificatieService. In dry-run mode it returns
+ * the rendered preview without contacting the mail subsystem.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Actions
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Actions;
+
+use OCA\Procest\AppInfo\Application;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Handler for `sendEmail` automatic actions.
+ */
+class SendEmailHandler implements ActionHandlerInterface
+{
+    use HandlesTemplates;
+
+    /**
+     * Constructor for SendEmailHandler.
+     *
+     * @param ContainerInterface $container DI container — used to resolve
+     *                                      NotificatieService lazily (it is
+     *                                      not always available, e.g. during
+     *                                      dry-run unit tests).
+     * @param LoggerInterface    $logger    PSR-3 logger.
+     *
+     * @return void
+     */
+    public function __construct(
+        private readonly ContainerInterface $container,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * {@inheritDoc}
+     */
+    public function type(): string
+    {
+        return 'sendEmail';
+    }//end type()
+
+    /**
+     * {@inheritDoc}
+     */
+    public function handle(array $actionConfig, array $case, array $transitionContext): ActionResult
+    {
+        try {
+            $subject = $this->renderTemplate(
+                (string) ($actionConfig['subjectTemplate'] ?? ''),
+                $case
+            );
+            $body = $this->renderTemplate(
+                (string) ($actionConfig['bodyTemplate'] ?? ''),
+                $case
+            );
+            $recipient = $this->resolveRecipient(
+                (string) ($actionConfig['recipientRef'] ?? ''),
+                $case
+            );
+
+            $preview = [
+                'recipient' => $recipient,
+                'subject'   => $subject,
+                'body'      => $body,
+            ];
+
+            if (($transitionContext['dryRun'] ?? false) === true) {
+                return ActionResult::success($preview);
+            }
+
+            if ($recipient === '') {
+                return ActionResult::failure('missing_recipient', $preview);
+            }
+
+            $notificatie = $this->resolveNotificatieService();
+            if ($notificatie === null) {
+                return ActionResult::failure('notificatie_unavailable', $preview);
+            }
+
+            // @phpstan-ignore-next-line — NotificatieService::sendEmail is
+            // resolved lazily; signature is owned by the service itself.
+            $notificatie->sendEmail($recipient, $subject, $body);
+
+            return ActionResult::success($preview);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'SendEmailHandler: failed to dispatch email',
+                [
+                    'app'       => Application::APP_ID,
+                    'slug'      => (string) ($actionConfig['slug'] ?? ''),
+                    'exception' => $e->getMessage(),
+                ]
+            );
+            return ActionResult::failure('email_dispatch_failed');
+        }
+    }//end handle()
+
+    /**
+     * Resolve NotificatieService from the container without a hard dep.
+     *
+     * @return object|null
+     */
+    private function resolveNotificatieService(): ?object
+    {
+        try {
+            return $this->container->get('OCA\Procest\Service\NotificatieService');
+        } catch (\Throwable $e) {
+            return null;
+        }
+    }//end resolveNotificatieService()
+}//end class

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -92,6 +92,7 @@ class SettingsService
         'partner_organization_schema',
         'share_permission_level_schema',
         'case_transfer_schema',
+        'automatic_action_schema',
         'lhsMatrix',
         // AI-Assisted Processing settings.
         'ai_audit_entry_schema',
@@ -163,6 +164,7 @@ class SettingsService
         'partnerOrganization'          => 'partner_organization_schema',
         'sharePermissionLevel'         => 'share_permission_level_schema',
         'casetransfer'                 => 'case_transfer_schema',
+        'automaticAction'              => 'automatic_action_schema',
     ];
 
     private const OPENREGISTER_APP_ID = 'openregister';

--- a/lib/Service/Transitions/SideEffectDispatcher.php
+++ b/lib/Service/Transitions/SideEffectDispatcher.php
@@ -1,0 +1,236 @@
+<?php
+
+/**
+ * Procest SideEffectDispatcher
+ *
+ * Dispatches the `automaticActions[]` array attached to a status transition
+ * after the status mutation has been persisted. Recognises both inline
+ * action JSON (legacy) and `{ref: <slug>}` references that resolve via
+ * ActionRegistry against the per-tenant action library.
+ *
+ * Failure semantics (inherited from status-transition-engine REQ-STE-9):
+ *  - Failed actions are recorded on `statusRecord.dispatchedActions[]` with
+ *    a static error code.
+ *  - Status mutations are NEVER rolled back due to a side-effect failure.
+ *  - Unknown action types AND unknown refs both surface as
+ *    `{ok: false, error: 'unknown_action_ref'}` (cross-tenant misses are
+ *    indistinguishable from non-existent slugs in user-visible output —
+ *    REQ-AA-8).
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Transitions
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Transitions;
+
+use OCA\Procest\AppInfo\Application;
+use OCA\Procest\Service\Actions\ActionRegistry;
+use OCA\Procest\Service\Actions\ActionResult;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Iterates `automaticActions[]` in declaration order and invokes the handler
+ * registered for each resolved action's `type`.
+ */
+class SideEffectDispatcher
+{
+    /**
+     * Constructor for SideEffectDispatcher.
+     *
+     * @param ActionRegistry  $registry The per-tenant action registry.
+     * @param LoggerInterface $logger   PSR-3 logger for failures and unknown
+     *                                  references.
+     *
+     * @return void
+     */
+    public function __construct(
+        private readonly ActionRegistry $registry,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Dispatch every action on a transition.
+     *
+     * @param array $actions           The raw `automaticActions[]` array from
+     *                                 the workflow template's transition. May
+     *                                 contain inline action configs OR
+     *                                 `{ref: <slug>}` references.
+     * @param array $case              The full case object (used by handlers
+     *                                 for template rendering and routing).
+     * @param array $transitionContext Engine context: `fromStatus`,
+     *                                 `toStatus`, `transitionLabel`,
+     *                                 `userId`, `statusRecordUuid`,
+     *                                 `tenantId`, and optional `dryRun`.
+     *
+     * @return array<int, array> One audit entry per action, suitable for
+     *                           persisting on `statusRecord.dispatchedActions`.
+     */
+    public function dispatch(array $actions, array $case, array $transitionContext): array
+    {
+        $tenantId = (string) ($transitionContext['tenantId'] ?? ($case['tenantId'] ?? ''));
+        $results  = [];
+
+        foreach ($actions as $entry) {
+            if (is_array($entry) === false) {
+                $results[] = [
+                    'type'  => 'unknown',
+                    'ok'    => false,
+                    'error' => 'unknown_action_ref',
+                ];
+                continue;
+            }
+
+            $resolved = $this->resolveEntry($entry, $tenantId);
+            if ($resolved === null) {
+                $results[] = [
+                    'type'  => 'unknown',
+                    'ref'   => (string) ($entry['ref'] ?? ''),
+                    'ok'    => false,
+                    'error' => 'unknown_action_ref',
+                ];
+                continue;
+            }
+
+            [$type, $config, $ref] = $resolved;
+
+            $handler = $this->registry->getHandler($type);
+            if ($handler === null) {
+                $this->logger->error(
+                    'SideEffectDispatcher: unknown action type',
+                    [
+                        'app'      => Application::APP_ID,
+                        'type'     => $type,
+                        'ref'      => $ref,
+                        'tenantId' => $tenantId,
+                    ]
+                );
+                $audit = [
+                    'type'  => $type,
+                    'ok'    => false,
+                    'error' => 'unknown_action_type',
+                ];
+                if ($ref !== null) {
+                    $audit['ref'] = $ref;
+                }
+                $results[] = $audit;
+                continue;
+            }
+
+            try {
+                $result = $handler->handle($config, $case, $transitionContext);
+            } catch (\Throwable $e) {
+                // Defensive — handlers MUST swallow exceptions, but a buggy
+                // third-party handler must not abort the rest of the loop.
+                $this->logger->error(
+                    'SideEffectDispatcher: handler threw',
+                    [
+                        'app'       => Application::APP_ID,
+                        'type'      => $type,
+                        'ref'       => $ref,
+                        'tenantId'  => $tenantId,
+                        'exception' => $e->getMessage(),
+                    ]
+                );
+                $audit = [
+                    'type'  => $type,
+                    'ok'    => false,
+                    'error' => 'handler_exception',
+                ];
+                if ($ref !== null) {
+                    $audit['ref'] = $ref;
+                }
+                $results[] = $audit;
+                continue;
+            }
+
+            $audit = $this->resultToAudit($type, $ref, $result);
+            $results[] = $audit;
+        }
+
+        return $results;
+    }//end dispatch()
+
+    /**
+     * Resolve a single `automaticActions[]` entry to `[type, config, ref|null]`.
+     *
+     * - `{ref: <slug>}` entries go through ActionRegistry; cross-tenant misses
+     *   and unpublished slugs both return null.
+     * - Inline action JSON entries (with a `type` key, no `ref`) are returned
+     *   as-is for backward compatibility (REQ-AA-5).
+     *
+     * @param array  $entry    Raw `automaticActions[]` element.
+     * @param string $tenantId Tenant the current transition is firing in.
+     *
+     * @return array{0:string,1:array,2:?string}|null
+     */
+    private function resolveEntry(array $entry, string $tenantId): ?array
+    {
+        if (isset($entry['ref']) === true) {
+            $slug = (string) $entry['ref'];
+            if ($slug === '' || $tenantId === '') {
+                return null;
+            }
+            $action = $this->registry->resolve($tenantId, $slug);
+            if ($action === null) {
+                return null;
+            }
+            $type   = (string) ($action['type'] ?? '');
+            $config = (array) ($action['config'] ?? []);
+            if ($type === '') {
+                return null;
+            }
+            return [$type, $config, $slug];
+        }
+
+        // Inline (legacy) — must include a `type` key directly.
+        $type = (string) ($entry['type'] ?? '');
+        if ($type === '') {
+            return null;
+        }
+        $config = $entry;
+        unset($config['type']);
+        return [$type, $config, null];
+    }//end resolveEntry()
+
+    /**
+     * Convert an ActionResult plus envelope metadata to an audit entry.
+     *
+     * @param string       $type   Handler type slug.
+     * @param string|null  $ref    Originating action slug (when resolved via
+     *                             registry) or null for inline actions.
+     * @param ActionResult $result The handler's return value.
+     *
+     * @return array
+     */
+    private function resultToAudit(string $type, ?string $ref, ActionResult $result): array
+    {
+        $audit = [
+            'type' => $type,
+            'ok'   => $result->ok,
+        ];
+        if ($ref !== null) {
+            $audit['ref'] = $ref;
+        }
+        if ($result->ok === false && $result->error !== null) {
+            $audit['error'] = $result->error;
+        }
+        if ($result->data !== []) {
+            $audit['data'] = $result->data;
+        }
+        return $audit;
+    }//end resultToAudit()
+}//end class

--- a/lib/Settings/procest_register.json
+++ b/lib/Settings/procest_register.json
@@ -2,8 +2,8 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Procest Case Management Register",
-    "description": "Register containing all schemas for the Procest case management application. Defines case types, status types, role types, result types, decision types, document types, property definitions, voorstel, parafeerroute, parafeeractie, and their instance counterparts.",
-    "version": "0.6.0"
+    "description": "Register containing all schemas for the Procest case management application. Defines case types, status types, role types, result types, decision types, document types, property definitions, voorstel, parafeerroute, parafeeractie, automaticAction, and their instance counterparts.",
+    "version": "0.7.0"
   },
   "x-openregister": {
     "type": "application",
@@ -1923,6 +1923,74 @@
             "type": "string",
             "format": "uuid",
             "description": "Reference to parent workflow template for inheritance (Enterprise tier)"
+          }
+        }
+      },
+      "automaticAction": {
+        "slug": "automaticAction",
+        "icon": "RobotOutline",
+        "version": "1.0.0",
+        "x-schema-org-type": "schema:Action",
+        "title": "Automatic Action",
+        "description": "Declarative automatic action attached to a status transition. The slug is referenced from transitions[].automaticActions[].ref and resolved at dispatch time by ActionRegistry. Six built-in handler types are supported; per-tenant scoped; unpublished actions are not resolvable.",
+        "type": "object",
+        "required": [
+          "slug",
+          "type",
+          "tenantId",
+          "title"
+        ],
+        "properties": {
+          "slug": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "Tenant-unique slug used in transitions[].automaticActions[].ref (e.g. send-decision-email)"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "sendEmail",
+              "createDocument",
+              "notifyRole",
+              "callWebhook",
+              "mergeTemplate",
+              "scheduleReminder"
+            ],
+            "description": "Action handler type — must match a registered ActionHandlerInterface implementation"
+          },
+          "tenantId": {
+            "type": "string",
+            "format": "uuid",
+            "$ref": "tenant",
+            "description": "Owning tenant — cross-tenant resolution is rejected by the registry"
+          },
+          "title": {
+            "type": "string",
+            "maxLength": 255,
+            "description": "Admin-facing label"
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional human description of what this action does"
+          },
+          "config": {
+            "type": "string",
+            "description": "JSON-encoded handler-specific config (e.g. for sendEmail: {recipientRef, subjectTemplate, bodyTemplate}; for callWebhook: {urlSlug, payloadTemplate, timeoutSec})"
+          },
+          "version": {
+            "type": "integer",
+            "default": 1,
+            "description": "Optimistic-lock counter; incremented on every save"
+          },
+          "isPublished": {
+            "type": "boolean",
+            "default": false,
+            "description": "Only published actions are dispatched by SideEffectDispatcher"
+          },
+          "active": {
+            "type": "boolean",
+            "default": true,
+            "description": "Soft-disable flag; inactive actions are filtered out of admin listings"
           }
         }
       },

--- a/openspec/changes/automatic-actions/builds/build.json
+++ b/openspec/changes/automatic-actions/builds/build.json
@@ -1,0 +1,67 @@
+{
+  "phase": "apply",
+  "timestamp": "2026-05-11T00:00:00+00:00",
+  "status": "applied",
+  "summary": "Added automaticAction register schema, manifest pages (AutomaticActions index + AutomaticActionDetail) at /settings/automatic-actions, ActionRegistry with per-tenant slug lookup and DI-tag-style handler index, SideEffectDispatcher in lib/Service/Transitions/ recognising both {ref:<slug>} references and inline action JSON, and six built-in ActionHandlerInterface implementations (SendEmail, CreateDocument, NotifyRole, CallWebhook, MergeTemplate, ScheduleReminder) — all dry-run-aware, all catch \\Throwable + log + return static error codes. No bespoke CRUD controller (manifest renderer handles list/create/update/delete/view).",
+  "implemented_requirements": [
+    "REQ-AA-1 schema (slug/type/tenantId/title/config/isPublished/active)",
+    "REQ-AA-2 ActionRegistry::resolve + per-request cache + unpublished/unknown logging",
+    "REQ-AA-3 six built-in handlers with static error codes",
+    "REQ-AA-5 SideEffectDispatcher resolves {ref:<slug>} + inline JSON backward-compat",
+    "REQ-AA-6 dry-run honoured in every handler (no live mutation)",
+    "REQ-AA-7 audit array shape (type/ref/ok/error/data) returned per action",
+    "REQ-AA-8 cross-tenant rejection + indistinguishable user-visible miss"
+  ],
+  "manifest_pages_added": [
+    "AutomaticActions (type:index) at /settings/automatic-actions",
+    "AutomaticActionDetail (type:detail) at /settings/automatic-actions/:id",
+    "AutomaticActionsMenu (section:settings) linking to AutomaticActions route"
+  ],
+  "handlers_registered": [
+    "lib/Service/Actions/SendEmailHandler.php",
+    "lib/Service/Actions/CreateDocumentHandler.php",
+    "lib/Service/Actions/NotifyRoleHandler.php",
+    "lib/Service/Actions/CallWebhookHandler.php",
+    "lib/Service/Actions/MergeTemplateHandler.php",
+    "lib/Service/Actions/ScheduleReminderHandler.php"
+  ],
+  "registry_integration": {
+    "registry": "lib/Service/Actions/ActionRegistry.php",
+    "dispatcher": "lib/Service/Transitions/SideEffectDispatcher.php",
+    "interface": "lib/Service/Actions/ActionHandlerInterface.php",
+    "result_value_object": "lib/Service/Actions/ActionResult.php",
+    "template_trait": "lib/Service/Actions/HandlesTemplates.php"
+  },
+  "schema_changes": {
+    "register": "lib/Settings/procest_register.json",
+    "version_bump": "0.6.0 -> 0.7.0",
+    "schema_added": "automaticAction",
+    "settings_service_config_keys": [
+      "automatic_action_schema (lib/Service/SettingsService.php)"
+    ],
+    "settings_service_slug_mapping": "automaticAction => automatic_action_schema"
+  },
+  "deferred": [
+    "REQ-AA-4 admin UI Vue components (slug-autocomplete on TransitionEditor + dry-run preview pane) — pending workflow-definition-model admin UI scaffold",
+    "POST /api/automatic-action/{slug}/dry-run endpoint — pending status-transition-engine landing (handlers already dry-run-aware via $transitionContext['dryRun'])",
+    "Engine integration: SideEffectDispatcher is shipped but only invoked once status-transition-engine StatusTransitionService::execute lands (cross-spec dependency)",
+    "DI tag wiring via $context->registerService — ActionRegistry resolves handlers lazily via container by FQCN as an interim; can be flipped to procest.transition_side_effect_handler tag iteration once status-transition-engine lands",
+    "PHPUnit suite (V02)",
+    "Playwright smoke (V03)"
+  ],
+  "validation": {
+    "php_lint": "pass (all 8 new + 1 changed php files)",
+    "jq": "pass (procest_register.json + manifest.json)",
+    "composer_check_strict": "deferred per strict watchdog",
+    "i18n": "deferred per strict watchdog"
+  },
+  "flags": [
+    "manifest-first: zero bespoke CRUD controller — AutomaticActions index/detail drive list/create/update/delete/view via OpenRegister manifest renderer",
+    "no i18n strings added per watchdog (menu label hard-coded in Dutch matching design.md 'Automatische acties')",
+    "dry-run is engine-driven via $transitionContext['dryRun'] flag — every handler short-circuits before mutating live state",
+    "cross-tenant resolution returns null AND logs both tenants AND surfaces user-visible 'unknown_action_ref' (per REQ-AA-8)",
+    "handlers use static error codes only — never $e->getMessage() in ActionResult.error",
+    "soft-bound to status-transition-engine: SideEffectDispatcher ready to be wired into StatusTransitionService::execute once that change applies (no hard import of engine classes)",
+    "soft-bound to ZgwDocumentService and NotificatieService via lazy container lookup — handlers return static 'service_unavailable' errors instead of fatal-erroring when those services are missing"
+  ]
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -20,6 +20,7 @@
 		{ "id": "TenantsMenu", "label": "Tenants", "icon": "icon-group", "route": "Tenants", "section": "settings", "order": 98, "permission": "admin" },
 		{ "id": "ParafeerroutesMenu", "label": "Parafeerroutes", "icon": "icon-category-workflow", "route": "Parafeerroutes", "section": "settings", "order": 96 },
 		{ "id": "WorkflowDefinitionsMenu", "label": "Workflow definitions", "icon": "icon-category-workflow", "route": "WorkflowDefinitions", "section": "settings", "order": 97 },
+		{ "id": "AutomaticActionsMenu", "label": "Automatische acties", "icon": "icon-category-workflow", "route": "AutomaticActions", "section": "settings", "order": 96 },
 		{ "id": "SettingsMenu", "label": "Settings", "icon": "icon-settings", "route": "Settings", "section": "settings", "order": 99 }
 	],
 	"pages": [
@@ -454,6 +455,33 @@
 			"type": "custom",
 			"title": "Workflow editor",
 			"component": "VisualWorkflowEditor"
+		},
+		{
+			"id": "AutomaticActions",
+			"route": "/settings/automatic-actions",
+			"type": "index",
+			"title": "Automatische acties",
+			"config": {
+				"register": "procest",
+				"schema": "automaticAction",
+				"columns": ["slug", "type", "title", "isPublished", "active"],
+				"actions": ["create", "edit", "delete", "view"],
+				"sidebar": { "enabled": true, "showMetadata": true }
+			}
+		},
+		{
+			"id": "AutomaticActionDetail",
+			"route": "/settings/automatic-actions/:id",
+			"type": "detail",
+			"title": "Automatische actie",
+			"config": {
+				"register": "procest",
+				"schema": "automaticAction",
+				"sidebarTabs": [
+					{ "id": "overview", "label": "Overview",    "icon": "icon-info",    "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
+					{ "id": "audit",    "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }],                   "order": 90 }
+				]
+			}
 		},
 		{
 			"id": "PublicCase",


### PR DESCRIPTION
## Summary

Applies `openspec/changes/automatic-actions/` — declarative per-tenant automatic-action registry attached to status transitions. **Manifest-first**: CRUD on action definitions is handled by OpenRegister manifest pages; the dispatch engine ships as PHP services.

### Manifest pages (CRUD)

- `AutomaticActions` (type: `index`) at `/settings/automatic-actions` — list/create/delete actions.
- `AutomaticActionDetail` (type: `detail`) at `/settings/automatic-actions/:id` — overview + audit-trail tabs.
- `AutomaticActionsMenu` registered under `section: settings`.

No bespoke `ActionController` CRUD added.

### Backend (PHP)

- `lib/Service/Actions/ActionRegistry.php` — per-tenant, per-request cached slug resolution; rejects unpublished, unknown, and cross-tenant references; logs every miss with both requested and owner tenant IDs.
- `lib/Service/Transitions/SideEffectDispatcher.php` — recognises `{ref: <slug>}` entries via the registry and keeps inline action JSON working for backward compatibility; emits one audit entry per action.
- `lib/Service/Actions/ActionHandlerInterface.php` + `ActionResult.php` — strategy contract and result value object.
- Six built-in `ActionHandlerInterface` implementations: `SendEmail`, `CreateDocument`, `NotifyRole`, `CallWebhook`, `MergeTemplate`, `ScheduleReminder`. All catch `\Throwable`, log via PSR-3, and return `ActionResult::failure` with static error codes (never `$e->getMessage()` in `ActionResult.error`).
- `lib/Service/Actions/HandlesTemplates.php` — shared deterministic `{{case.path}}` renderer so dry-run preview exactly matches the live execution output.

### Schema

- Added `automaticAction` schema to `lib/Settings/procest_register.json`; bumped register version `0.6.0` -> `0.7.0`.
- Registered `automatic_action_schema` config key + `automaticAction` slug mapping in `SettingsService`.

### Dry-run

Every handler short-circuits on `$transitionContext['dryRun'] === true`, returns the projected effect in `ActionResult.data`, and never sends mail, writes documents, hits webhook URLs, or schedules jobs.

### Tenant scoping

`ActionRegistry::resolve()` returns `null` and logs at error level on cross-tenant attempts; the dispatcher emits the same user-visible `unknown_action_ref` for both unknown and cross-tenant slugs per REQ-AA-8.

### Deferred

- Admin UI Vue components (slug-autocomplete on `TransitionEditor`, dry-run preview pane) — pending workflow-definition-model admin UI scaffold.
- `POST /api/automatic-action/{slug}/dry-run` endpoint — pending status-transition-engine landing; handlers are already dry-run-aware.
- Wiring `SideEffectDispatcher` into `StatusTransitionService::execute` — cross-spec dependency on status-transition-engine.
- PHPUnit (V02) and Playwright smoke (V03).

## Test plan

- [x] `php -l` on every new/changed PHP file — pass.
- [x] `jq empty` on `procest_register.json`, `manifest.json`, `build.json` — pass.
- [ ] Once `status-transition-engine` lands: integration test asserting `{ref:<slug>}` resolution AND inline-JSON backward-compat.
- [ ] Unit tests for `ActionRegistry` (unknown slug, unpublished slug, cross-tenant attempt).
- [ ] Unit tests for each handler's dry-run path asserting no live mutation.
