### PR TITLE
feat(status-transition-engine): apply spec

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -213,6 +213,16 @@ return [
         ['name' => 'workflowDefinition#active',            'url' => '/api/workflow-definitions/active/{caseTypeId}',  'verb' => 'GET'],
         ['name' => 'workflowDefinition#forCase',           'url' => '/api/workflow-definitions/for-case/{caseId}',    'verb' => 'GET'],
 
+        // ── Status Transition Engine ────────────────────────────────────
+        // Single write-path for case.status. CRUD on statusRecord is rendered
+        // by the manifest (/settings/status-records). Action-style endpoints
+        // live here because guard evaluation + side-effect dispatch are
+        // non-CRUD engine logic.
+        ['name' => 'status_transition#available', 'url' => '/api/case/{caseId}/available-transitions', 'verb' => 'GET'],
+        ['name' => 'status_transition#execute',   'url' => '/api/case/{caseId}/transition',            'verb' => 'POST'],
+        ['name' => 'status_transition#freeform',  'url' => '/api/case/{caseId}/transition-freeform',   'verb' => 'POST'],
+        ['name' => 'status_transition#history',   'url' => '/api/case/{caseId}/transition-history',    'verb' => 'GET'],
+
         // Multi-Tenant SaaS — domain endpoints only. Generic tenant CRUD
         // (list/create/update/destroy) is rendered by the manifest pages
         // at /settings/tenants and proxied directly to OpenRegister; this

--- a/lib/Controller/StatusTransitionController.php
+++ b/lib/Controller/StatusTransitionController.php
@@ -1,0 +1,255 @@
+<?php
+
+/**
+ * Procest Status Transition Controller.
+ *
+ * REST surface for the status-transition engine. CRUD on `statusRecord`
+ * objects is delegated to the manifest renderer (OpenRegister); this
+ * controller exposes only the four engine endpoints:
+ *
+ *  - GET  /api/case/{caseId}/available-transitions
+ *  - POST /api/case/{caseId}/transition           (body {transitionId, comment?})
+ *  - POST /api/case/{caseId}/transition-freeform  (admin only; body {toStatusId, comment?})
+ *  - GET  /api/case/{caseId}/transition-history
+ *
+ * Error responses use static messages — `$e->getMessage()` is NEVER returned.
+ *
+ * @category Controller
+ * @package  OCA\Procest\Controller
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Controller;
+
+use OCA\Procest\Service\StatusTransitionService;
+use OCA\Procest\Service\Transitions\GuardFailedException;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * Controller for status-transition engine endpoints.
+ *
+ * @spec openspec/changes/status-transition-engine/tasks.md#T11
+ */
+class StatusTransitionController extends Controller
+{
+
+    /**
+     * Constructor.
+     *
+     * @param string                  $appName          The app name
+     * @param IRequest                $request          The HTTP request
+     * @param StatusTransitionService $transitionEngine The engine service
+     * @param IUserSession            $userSession      The current session
+     * @param LoggerInterface         $logger           The logger
+     */
+    public function __construct(
+        string $appName,
+        IRequest $request,
+        private readonly StatusTransitionService $transitionEngine,
+        private readonly IUserSession $userSession,
+        private readonly LoggerInterface $logger,
+    ) {
+        parent::__construct(appName: $appName, request: $request);
+    }//end __construct()
+
+    /**
+     * List the transitions available to the current user on a case.
+     *
+     * @param string $caseId The case UUID
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     */
+    public function available(string $caseId): JSONResponse
+    {
+        try {
+            $result = $this->transitionEngine->getAvailableTransitions(caseId: $caseId);
+            return new JSONResponse($result);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'StatusTransitionController: available failed',
+                ['exception' => $e->getMessage(), 'caseId' => $caseId],
+            );
+            return new JSONResponse(
+                ['error' => 'Could not load available transitions'],
+                Http::STATUS_INTERNAL_SERVER_ERROR,
+            );
+        }
+    }//end available()
+
+    /**
+     * Execute a guarded transition.
+     *
+     * @param string $caseId The case UUID
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     */
+    public function execute(string $caseId): JSONResponse
+    {
+        $body          = $this->readJsonBody();
+        $transitionId  = (string) ($body['transitionId'] ?? '');
+        $comment       = isset($body['comment']) === true ? (string) $body['comment'] : null;
+
+        if ($transitionId === '') {
+            return new JSONResponse(
+                ['error' => 'transitionId is required'],
+                Http::STATUS_BAD_REQUEST,
+            );
+        }
+
+        try {
+            $result = $this->transitionEngine->execute(
+                caseId: $caseId,
+                transitionId: $transitionId,
+                comment: $comment,
+            );
+            return new JSONResponse($result);
+        } catch (GuardFailedException $e) {
+            return new JSONResponse(
+                ['error' => 'Transition is not available', 'failedGuards' => $e->getFailedGuards()],
+                Http::STATUS_CONFLICT,
+            );
+        } catch (RuntimeException $e) {
+            $code    = $e->getMessage();
+            $status  = match ($code) {
+                'case_not_found', 'transition_not_found' => Http::STATUS_NOT_FOUND,
+                'forbidden_admin_only'                   => Http::STATUS_FORBIDDEN,
+                default                                  => Http::STATUS_BAD_REQUEST,
+            };
+            $this->logger->info('StatusTransitionController: execute rejected', ['code' => $code]);
+            return new JSONResponse(['error' => 'Could not execute transition'], $status);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'StatusTransitionController: execute failed',
+                ['exception' => $e->getMessage(), 'caseId' => $caseId, 'transitionId' => $transitionId],
+            );
+            return new JSONResponse(
+                ['error' => 'Could not execute transition'],
+                Http::STATUS_INTERNAL_SERVER_ERROR,
+            );
+        }
+    }//end execute()
+
+    /**
+     * Execute an admin-only free-form transition.
+     *
+     * @param string $caseId The case UUID
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     */
+    public function freeform(string $caseId): JSONResponse
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return new JSONResponse(
+                ['error' => 'Authentication required'],
+                Http::STATUS_FORBIDDEN,
+            );
+        }
+
+        $body       = $this->readJsonBody();
+        $toStatusId = (string) ($body['toStatusId'] ?? '');
+        $comment    = isset($body['comment']) === true ? (string) $body['comment'] : null;
+
+        if ($toStatusId === '') {
+            return new JSONResponse(
+                ['error' => 'toStatusId is required'],
+                Http::STATUS_BAD_REQUEST,
+            );
+        }
+
+        try {
+            $result = $this->transitionEngine->executeFreeForm(
+                caseId: $caseId,
+                toStatusId: $toStatusId,
+                comment: $comment,
+            );
+            return new JSONResponse($result);
+        } catch (RuntimeException $e) {
+            $code   = $e->getMessage();
+            $status = match ($code) {
+                'forbidden_admin_only'                => Http::STATUS_FORBIDDEN,
+                'case_not_found', 'case_type_not_found' => Http::STATUS_NOT_FOUND,
+                default                               => Http::STATUS_BAD_REQUEST,
+            };
+            $this->logger->info('StatusTransitionController: freeform rejected', ['code' => $code]);
+            return new JSONResponse(['error' => 'Could not execute free-form transition'], $status);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'StatusTransitionController: freeform failed',
+                ['exception' => $e->getMessage(), 'caseId' => $caseId],
+            );
+            return new JSONResponse(
+                ['error' => 'Could not execute free-form transition'],
+                Http::STATUS_INTERNAL_SERVER_ERROR,
+            );
+        }
+    }//end freeform()
+
+    /**
+     * Return the chronological transition history of a case.
+     *
+     * @param string $caseId The case UUID
+     *
+     * @return JSONResponse
+     *
+     * @NoAdminRequired
+     */
+    public function history(string $caseId): JSONResponse
+    {
+        try {
+            $result = $this->transitionEngine->replay(caseId: $caseId);
+            return new JSONResponse($result);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'StatusTransitionController: history failed',
+                ['exception' => $e->getMessage(), 'caseId' => $caseId],
+            );
+            return new JSONResponse(
+                ['error' => 'Could not load transition history'],
+                Http::STATUS_INTERNAL_SERVER_ERROR,
+            );
+        }
+    }//end history()
+
+    /**
+     * Decode a JSON request body safely.
+     *
+     * @return array<string, mixed>
+     */
+    private function readJsonBody(): array
+    {
+        $content = $this->request->getContent();
+        if ($content === '' || $content === false) {
+            return [];
+        }
+        $decoded = json_decode($content, true);
+        if (is_array($decoded) === true) {
+            return $decoded;
+        }
+        return [];
+    }//end readJsonBody()
+}//end class

--- a/lib/Service/StatusTransitionService.php
+++ b/lib/Service/StatusTransitionService.php
@@ -1,0 +1,665 @@
+<?php
+
+/**
+ * Procest Status Transition Service.
+ *
+ * The single deterministic write path for `case.status` across Procest. The
+ * REST API, the case detail UI, and the bezwaar/parafering/VTH workflow
+ * specs all funnel transitions through `execute()`. Responsibilities:
+ *
+ *  - load the active workflow template per caseType (via WorkflowTemplateLoader)
+ *  - evaluate every transition's guards (via GuardRegistry)
+ *  - update `case.status` atomically with a `statusRecord` write
+ *  - dispatch automatic actions sequentially (via SideEffectDispatcher)
+ *  - replay transition history from the `statusRecord` chain
+ *
+ * Identity is ALWAYS derived from IUserSession when the caller does not pass
+ * an explicit userId. Static error messages only — never bubble exception
+ * detail to controllers or callers.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service;
+
+use OCA\Procest\Service\Transitions\GuardFailedException;
+use OCA\Procest\Service\Transitions\GuardRegistry;
+use OCA\Procest\Service\Transitions\SideEffectDispatcher;
+use OCP\IGroupManager;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * The status-transition engine.
+ *
+ * @spec openspec/changes/status-transition-engine/tasks.md#T10
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) — orchestrates many collaborators by design
+ */
+class StatusTransitionService
+{
+
+    /**
+     * Group ID used to gate admin-only free-form transitions. Matches the
+     * naming used elsewhere in Procest for the admin role.
+     */
+    public const ADMIN_GROUP_ID = 'procest-admin';
+
+    /**
+     * Constructor.
+     *
+     * @param SettingsService         $settingsService         Bridge to OpenRegister + config
+     * @param WorkflowTemplateLoader  $templateLoader          Active workflowTemplate loader
+     * @param GuardRegistry           $guardRegistry           Guard registry
+     * @param SideEffectDispatcher    $sideEffectDispatcher    Side-effect dispatcher
+     * @param IUserSession            $userSession             Current session
+     * @param IGroupManager           $groupManager            Group manager (admin gate)
+     * @param LoggerInterface         $logger                  Logger
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+        private readonly WorkflowTemplateLoader $templateLoader,
+        private readonly GuardRegistry $guardRegistry,
+        private readonly SideEffectDispatcher $sideEffectDispatcher,
+        private readonly IUserSession $userSession,
+        private readonly IGroupManager $groupManager,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Compute the set of transitions available to a user on a case.
+     *
+     * @param string      $caseId Case UUID
+     * @param string|null $userId Optional explicit user UID; defaults to IUserSession
+     *
+     * @return array{transitions: array<int, array<string, mixed>>, current: array<string, mixed>}
+     */
+    public function getAvailableTransitions(string $caseId, ?string $userId=null): array
+    {
+        $userId = $this->resolveUserId(explicit: $userId);
+        $case   = $this->loadCase(caseId: $caseId);
+        if ($case === null) {
+            return ['transitions' => [], 'current' => []];
+        }
+
+        $caseTypeId = (string) ($case['caseType'] ?? '');
+        $currentId  = (string) ($case['status'] ?? '');
+        $template   = $this->templateLoader->getActiveTemplate(caseTypeId: $caseTypeId);
+
+        $result = [
+            'transitions' => [],
+            'current'     => ['statusId' => $currentId, 'statusName' => $this->lookupStatusName(statusTypeId: $currentId)],
+        ];
+
+        if ($template === null) {
+            return $result;
+        }
+
+        $transitions = $template['transitions'] ?? [];
+        if (is_array($transitions) === false) {
+            return $result;
+        }
+
+        foreach ($transitions as $transition) {
+            if (is_array($transition) === false) {
+                continue;
+            }
+            if ((string) ($transition['fromStatus'] ?? '') !== $currentId) {
+                continue;
+            }
+
+            $guards = $this->extractGuards(transition: $transition);
+            $eval   = $this->guardRegistry->evaluateAll(guards: $guards, case: $case, userId: $userId);
+
+            // Drop transitions whose role guard hides them silently.
+            if ($this->isRoleHidden(evalResults: $eval) === true) {
+                continue;
+            }
+
+            $failed = array_values(array_filter($eval, static fn(array $g): bool => ($g['passed'] ?? false) === false));
+
+            $result['transitions'][] = [
+                'id'            => (string) ($transition['id'] ?? ''),
+                'label'         => (string) ($transition['label'] ?? ''),
+                'toStatus'      => (string) ($transition['toStatus'] ?? ''),
+                'guardsPassed'  => count($failed) === 0,
+                'failedGuards'  => $failed,
+            ];
+        }//end foreach
+
+        return $result;
+    }//end getAvailableTransitions()
+
+    /**
+     * Execute a guarded transition.
+     *
+     * @param string      $caseId       Case UUID
+     * @param string      $transitionId Transition id from the active workflowTemplate
+     * @param string|null $comment      Optional free-form comment
+     * @param string|null $userId       Optional explicit user UID; defaults to IUserSession
+     *
+     * @return array{status: string, statusRecord: array<string, mixed>, dispatchedActions: array<int, array<string, mixed>>}
+     *
+     * @throws GuardFailedException When server-side re-evaluation fails any guard
+     * @throws RuntimeException     When case/transition/template are not found
+     */
+    public function execute(string $caseId, string $transitionId, ?string $comment, ?string $userId=null): array
+    {
+        $userId = $this->resolveUserId(explicit: $userId);
+        $case   = $this->loadCase(caseId: $caseId);
+        if ($case === null) {
+            throw new RuntimeException('case_not_found');
+        }
+
+        $caseTypeId = (string) ($case['caseType'] ?? '');
+        $transition = $this->templateLoader->getTransitionById(caseTypeId: $caseTypeId, transitionId: $transitionId);
+        if ($transition === null) {
+            throw new RuntimeException('transition_not_found');
+        }
+
+        $currentId = (string) ($case['status'] ?? '');
+        $fromStatus = (string) ($transition['fromStatus'] ?? '');
+        if ($fromStatus !== '' && $fromStatus !== $currentId) {
+            throw new RuntimeException('transition_from_status_mismatch');
+        }
+
+        // Defence in depth — re-evaluate guards on the server side.
+        $guards = $this->extractGuards(transition: $transition);
+        $eval   = $this->guardRegistry->evaluateAll(guards: $guards, case: $case, userId: $userId);
+        $failed = array_values(array_filter($eval, static fn(array $g): bool => ($g['passed'] ?? false) === false));
+        if (count($failed) > 0) {
+            $this->logger->info('StatusTransitionService: guards failed', ['caseId' => $caseId, 'transitionId' => $transitionId]);
+            throw new GuardFailedException(failedGuards: $failed);
+        }
+
+        $toStatus = (string) ($transition['toStatus'] ?? '');
+        if ($toStatus === '') {
+            throw new RuntimeException('transition_missing_to_status');
+        }
+
+        // Status mutation BEFORE side-effects per REQ-STE-5-002.
+        $case['status'] = $toStatus;
+        $case           = $this->saveCase(case: $case);
+
+        $label  = (string) ($transition['label'] ?? '');
+        $record = $this->writeStatusRecord(
+            caseId: $caseId,
+            toStatus: $toStatus,
+            fromStatus: $currentId,
+            label: $label,
+            comment: $comment,
+            evaluatedGuards: $eval,
+            noWorkflowTemplate: false,
+        );
+
+        $statusRecordId = (string) ($record['id'] ?? '');
+        $context        = [
+            'fromStatus'       => $currentId,
+            'toStatus'         => $toStatus,
+            'transitionLabel'  => $label,
+            'userId'           => $userId,
+            'statusRecordUuid' => $statusRecordId,
+        ];
+
+        $actions    = $this->extractActions(transition: $transition);
+        $dispatched = $this->sideEffectDispatcher->dispatch(actions: $actions, case: $case, transitionContext: $context);
+
+        // Update the statusRecord with the actual dispatched-action results.
+        if ($statusRecordId !== '') {
+            $record['dispatchedActions'] = $dispatched;
+            try {
+                $record = $this->updateStatusRecord(record: $record);
+            } catch (\Throwable $e) {
+                $this->logger->error(
+                    'StatusTransitionService: dispatchedActions persist failed',
+                    ['exception' => $e->getMessage(), 'statusRecord' => $statusRecordId],
+                );
+            }
+        }
+
+        return [
+            'status'            => 'ok',
+            'statusRecord'      => $record,
+            'dispatchedActions' => $dispatched,
+        ];
+    }//end execute()
+
+    /**
+     * Execute an admin-only free-form transition for caseTypes without an active workflow template.
+     *
+     * @param string      $caseId     Case UUID
+     * @param string      $toStatusId Target statusType UUID
+     * @param string|null $comment    Optional free-form comment
+     * @param string|null $userId     Optional explicit user UID; defaults to IUserSession
+     *
+     * @return array{status: string, statusRecord: array<string, mixed>}
+     *
+     * @throws RuntimeException When the caller is not in the admin group or the target is invalid
+     */
+    public function executeFreeForm(string $caseId, string $toStatusId, ?string $comment, ?string $userId=null): array
+    {
+        $userId = $this->resolveUserId(explicit: $userId);
+        if ($this->isAdmin(userId: $userId) === false) {
+            throw new RuntimeException('forbidden_admin_only');
+        }
+
+        $case = $this->loadCase(caseId: $caseId);
+        if ($case === null) {
+            throw new RuntimeException('case_not_found');
+        }
+
+        $caseTypeId = (string) ($case['caseType'] ?? '');
+        $this->validateStatusBelongsToCaseType(caseTypeId: $caseTypeId, statusTypeId: $toStatusId);
+
+        $currentId        = (string) ($case['status'] ?? '');
+        $case['status']   = $toStatusId;
+        $case             = $this->saveCase(case: $case);
+
+        $record = $this->writeStatusRecord(
+            caseId: $caseId,
+            toStatus: $toStatusId,
+            fromStatus: $currentId,
+            label: 'Free-form transition',
+            comment: $comment,
+            evaluatedGuards: [],
+            noWorkflowTemplate: true,
+        );
+
+        return ['status' => 'ok', 'statusRecord' => $record];
+    }//end executeFreeForm()
+
+    /**
+     * Return the chronological history of transitions for a case.
+     *
+     * @param string $caseId Case UUID
+     *
+     * @return array{history: array<int, array<string, mixed>>, replayable: bool}
+     */
+    public function replay(string $caseId): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return ['history' => [], 'replayable' => false];
+        }
+
+        $register     = $this->settingsService->getConfigValue(key: 'register');
+        $recordSchema = $this->settingsService->getConfigValue(key: 'status_record_schema');
+        if ($register === '' || $recordSchema === '') {
+            return ['history' => [], 'replayable' => false];
+        }
+
+        try {
+            $records = $objectService->findObjects($register, $recordSchema, ['case' => $caseId]);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'StatusTransitionService: replay findObjects failed',
+                ['exception' => $e->getMessage(), 'caseId' => $caseId],
+            );
+            return ['history' => [], 'replayable' => false];
+        }
+
+        $list = [];
+        foreach ((is_array($records) === true ? $records : []) as $record) {
+            $list[] = $this->toArray(value: $record);
+        }
+
+        usort(
+            $list,
+            static function (array $left, array $right): int {
+                $leftAt  = (string) ($left['createdAt'] ?? ($left['@self']['createdAt'] ?? ''));
+                $rightAt = (string) ($right['createdAt'] ?? ($right['@self']['createdAt'] ?? ''));
+                return strcmp($leftAt, $rightAt);
+            },
+        );
+
+        return ['history' => $list, 'replayable' => true];
+    }//end replay()
+
+    /**
+     * Check if the current (or given) user is in the procest admin group.
+     *
+     * @param string $userId UID
+     *
+     * @return bool
+     */
+    public function isAdmin(string $userId): bool
+    {
+        if ($userId === '') {
+            return false;
+        }
+        try {
+            // Accept membership in either the dedicated procest admin group OR the global admin group.
+            if ($this->groupManager->isInGroup($userId, self::ADMIN_GROUP_ID) === true) {
+                return true;
+            }
+            return $this->groupManager->isInGroup($userId, 'admin');
+        } catch (\Throwable $e) {
+            $this->logger->error('StatusTransitionService: admin check failed', ['exception' => $e->getMessage()]);
+            return false;
+        }
+    }//end isAdmin()
+
+    // ------------------------------------------------------------------
+    // Internal helpers
+    // ------------------------------------------------------------------
+
+    /**
+     * Resolve a user UID either from the explicit parameter or IUserSession.
+     *
+     * @param string|null $explicit Caller-supplied UID, or null
+     *
+     * @return string
+     */
+    private function resolveUserId(?string $explicit): string
+    {
+        if ($explicit !== null && $explicit !== '') {
+            return $explicit;
+        }
+        $user = $this->userSession->getUser();
+        return $user === null ? '' : $user->getUID();
+    }//end resolveUserId()
+
+    /**
+     * Load a case from OpenRegister.
+     *
+     * @param string $caseId Case UUID
+     *
+     * @return array<string, mixed>|null
+     */
+    private function loadCase(string $caseId): ?array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return null;
+        }
+        $register   = $this->settingsService->getConfigValue(key: 'register');
+        $caseSchema = $this->settingsService->getConfigValue(key: 'case_schema');
+        if ($register === '' || $caseSchema === '') {
+            return null;
+        }
+        try {
+            return $this->toArray(value: $objectService->findObject($register, $caseSchema, $caseId));
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'StatusTransitionService: loadCase failed',
+                ['exception' => $e->getMessage(), 'caseId' => $caseId],
+            );
+            return null;
+        }
+    }//end loadCase()
+
+    /**
+     * Persist the (mutated) case via ObjectService.
+     *
+     * @param array<string, mixed> $case Case payload
+     *
+     * @return array<string, mixed>
+     */
+    private function saveCase(array $case): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            throw new RuntimeException('storage_unavailable');
+        }
+        $register   = $this->settingsService->getConfigValue(key: 'register');
+        $caseSchema = $this->settingsService->getConfigValue(key: 'case_schema');
+        if ($register === '' || $caseSchema === '') {
+            throw new RuntimeException('case_schema_not_configured');
+        }
+        return $this->toArray(value: $objectService->saveObject($register, $caseSchema, $case));
+    }//end saveCase()
+
+    /**
+     * Write a statusRecord row for a transition.
+     *
+     * @param string                                $caseId             Case UUID
+     * @param string                                $toStatus           Target statusType UUID
+     * @param string                                $fromStatus         Prior statusType UUID
+     * @param string                                $label              Transition label
+     * @param string|null                           $comment            Free-form comment
+     * @param array<int, array<string, mixed>>      $evaluatedGuards    Guard snapshots
+     * @param bool                                  $noWorkflowTemplate Flag for free-form transitions
+     *
+     * @return array<string, mixed>
+     */
+    private function writeStatusRecord(
+        string $caseId,
+        string $toStatus,
+        string $fromStatus,
+        string $label,
+        ?string $comment,
+        array $evaluatedGuards,
+        bool $noWorkflowTemplate,
+    ): array {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            throw new RuntimeException('storage_unavailable');
+        }
+        $register     = $this->settingsService->getConfigValue(key: 'register');
+        $recordSchema = $this->settingsService->getConfigValue(key: 'status_record_schema');
+        if ($register === '' || $recordSchema === '') {
+            throw new RuntimeException('status_record_schema_not_configured');
+        }
+
+        $payload = [
+            'case'               => $caseId,
+            'statusType'         => $toStatus,
+            'transitionLabel'    => $label,
+            'evaluatedGuards'    => $evaluatedGuards,
+            'dispatchedActions'  => [],
+            'noWorkflowTemplate' => $noWorkflowTemplate,
+        ];
+        if ($fromStatus !== '') {
+            $payload['fromStatus'] = $fromStatus;
+        }
+        if ($comment !== null && $comment !== '') {
+            $payload['description'] = $comment;
+        }
+
+        return $this->toArray(value: $objectService->saveObject($register, $recordSchema, $payload));
+    }//end writeStatusRecord()
+
+    /**
+     * Persist an updated statusRecord.
+     *
+     * @param array<string, mixed> $record Current record payload
+     *
+     * @return array<string, mixed>
+     */
+    private function updateStatusRecord(array $record): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return $record;
+        }
+        $register     = $this->settingsService->getConfigValue(key: 'register');
+        $recordSchema = $this->settingsService->getConfigValue(key: 'status_record_schema');
+        if ($register === '' || $recordSchema === '') {
+            return $record;
+        }
+        return $this->toArray(value: $objectService->saveObject($register, $recordSchema, $record));
+    }//end updateStatusRecord()
+
+    /**
+     * Validate that a statusType belongs to the case's caseType.
+     *
+     * @param string $caseTypeId   CaseType UUID
+     * @param string $statusTypeId StatusType UUID
+     *
+     * @return void
+     *
+     * @throws RuntimeException When the statusType is not a child of the caseType
+     */
+    private function validateStatusBelongsToCaseType(string $caseTypeId, string $statusTypeId): void
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            throw new RuntimeException('storage_unavailable');
+        }
+        $register         = $this->settingsService->getConfigValue(key: 'register');
+        $caseTypeSchema   = $this->settingsService->getConfigValue(key: 'case_type_schema');
+        if ($register === '' || $caseTypeSchema === '' || $caseTypeId === '' || $statusTypeId === '') {
+            throw new RuntimeException('case_type_not_configured');
+        }
+
+        try {
+            $caseType = $this->toArray(value: $objectService->findObject($register, $caseTypeSchema, $caseTypeId));
+        } catch (\Throwable $e) {
+            throw new RuntimeException('case_type_not_found');
+        }
+
+        $statuses = $caseType['statusTypes'] ?? ($caseType['statusses'] ?? []);
+        if (is_array($statuses) === false) {
+            $statuses = [];
+        }
+
+        foreach ($statuses as $entry) {
+            $id = is_array($entry) === true ? (string) ($entry['id'] ?? ($entry['uuid'] ?? '')) : (string) $entry;
+            if ($id === $statusTypeId) {
+                return;
+            }
+        }
+
+        throw new RuntimeException('status_type_not_in_case_type');
+    }//end validateStatusBelongsToCaseType()
+
+    /**
+     * Look up a human-readable status name for the case-detail panel header.
+     *
+     * @param string $statusTypeId StatusType UUID
+     *
+     * @return string
+     */
+    private function lookupStatusName(string $statusTypeId): string
+    {
+        if ($statusTypeId === '') {
+            return '';
+        }
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return '';
+        }
+        $register         = $this->settingsService->getConfigValue(key: 'register');
+        $statusTypeSchema = $this->settingsService->getConfigValue(key: 'status_type_schema');
+        if ($register === '' || $statusTypeSchema === '') {
+            return '';
+        }
+        try {
+            $statusType = $this->toArray(value: $objectService->findObject($register, $statusTypeSchema, $statusTypeId));
+        } catch (\Throwable $e) {
+            return '';
+        }
+        return (string) ($statusType['name'] ?? ($statusType['title'] ?? ''));
+    }//end lookupStatusName()
+
+    /**
+     * Extract the guards list from a transition definition (supports both
+     * `guards: []` and a single `guard: {...}` shape).
+     *
+     * @param array<string, mixed> $transition The transition
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function extractGuards(array $transition): array
+    {
+        $guards = $transition['guards'] ?? [];
+        if (is_array($guards) === false) {
+            $guards = [];
+        }
+
+        // Promote allowedRoles[] on the transition itself into a roleGuard entry.
+        $allowedRoles = $transition['allowedRoles'] ?? null;
+        if (is_array($allowedRoles) === true && count($allowedRoles) > 0) {
+            $guards[] = ['type' => 'roleGuard', 'allowedRoles' => $allowedRoles];
+        }
+
+        $list = [];
+        foreach ($guards as $guard) {
+            if (is_array($guard) === true) {
+                $list[] = $guard;
+            }
+        }
+        return $list;
+    }//end extractGuards()
+
+    /**
+     * Extract automaticActions[] from a transition definition.
+     *
+     * @param array<string, mixed> $transition The transition
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function extractActions(array $transition): array
+    {
+        $actions = $transition['automaticActions'] ?? ($transition['actions'] ?? []);
+        if (is_array($actions) === false) {
+            return [];
+        }
+        $list = [];
+        foreach ($actions as $action) {
+            if (is_array($action) === true) {
+                $list[] = $action;
+            }
+        }
+        return $list;
+    }//end extractActions()
+
+    /**
+     * Detect whether the role guard has hidden the transition silently.
+     *
+     * @param array<int, array<string, mixed>> $evalResults Guard evaluation snapshots
+     *
+     * @return bool
+     */
+    private function isRoleHidden(array $evalResults): bool
+    {
+        foreach ($evalResults as $entry) {
+            if (($entry['type'] ?? '') === 'roleGuard'
+                && ($entry['passed'] ?? false) === false
+                && (($entry['details']['silent'] ?? false) === true)
+            ) {
+                return true;
+            }
+        }
+        return false;
+    }//end isRoleHidden()
+
+    /**
+     * Coerce ObjectService results to an array.
+     *
+     * @param mixed $value Raw result
+     *
+     * @return array<string, mixed>
+     */
+    private function toArray(mixed $value): array
+    {
+        if (is_array($value) === true) {
+            return $value;
+        }
+        if (is_object($value) === true) {
+            if (method_exists($value, 'jsonSerialize') === true) {
+                $serialized = $value->jsonSerialize();
+                if (is_array($serialized) === true) {
+                    return $serialized;
+                }
+            }
+        }
+        return [];
+    }//end toArray()
+}//end class

--- a/lib/Service/Transitions/ActionHandlerInterface.php
+++ b/lib/Service/Transitions/ActionHandlerInterface.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Procest Action Handler interface.
+ *
+ * Implementations execute one automatic-action type configured on a workflow
+ * transition. Handlers MUST catch \Throwable internally and return a static
+ * ActionResult — they SHALL NOT propagate exceptions, since per the spec
+ * failed side-effects MUST NOT roll back the status change.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Transitions
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Transitions;
+
+/**
+ * Strategy interface for automatic-action handling.
+ *
+ * @spec openspec/changes/status-transition-engine/tasks.md#T07
+ */
+interface ActionHandlerInterface
+{
+
+    /**
+     * Handle a single automatic action.
+     *
+     * @param array<string, mixed> $actionConfig      The action block (`{type, ...config}`)
+     * @param array<string, mixed> $case              The case object as an array
+     * @param array<string, mixed> $transitionContext Snapshot of the transition: fromStatus, toStatus, transitionLabel, userId, statusRecordUuid
+     *
+     * @return ActionResult
+     */
+    public function handle(array $actionConfig, array $case, array $transitionContext): ActionResult;
+}//end interface

--- a/lib/Service/Transitions/ActionHandlerRegistry.php
+++ b/lib/Service/Transitions/ActionHandlerRegistry.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * Procest Action Handler Registry.
+ *
+ * Strategy-pattern registry mapping action `type` strings to the corresponding
+ * ActionHandlerInterface implementations. Built-in handlers are injected via
+ * DI; downstream specs (`bezwaar-lifecycle`, `parafeerroute-engine`) MAY add
+ * additional types via `registerHandler()` in their bootstrap so the engine
+ * itself does not need to know about them at compile time.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Transitions
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Transitions;
+
+/**
+ * Registry of action handlers keyed by action type.
+ *
+ * @spec openspec/changes/status-transition-engine/tasks.md#T09
+ */
+class ActionHandlerRegistry
+{
+
+    /**
+     * Registered handlers keyed by action type.
+     *
+     * @var array<string, ActionHandlerInterface>
+     */
+    private array $handlers = [];
+
+    /**
+     * Constructor — wires the built-in handlers.
+     *
+     * @param SendEmailHandler     $sendEmail     Built-in email handler
+     * @param CreateTaskHandler    $createTask    Built-in task handler
+     * @param CreateSubCaseHandler $createSubCase Built-in sub-case handler
+     * @param WebhookHandler       $webhook       Built-in webhook handler
+     * @param SetFieldHandler      $setField      Built-in field-set handler
+     * @param NotifyHandler        $notify        Built-in notification handler
+     */
+    public function __construct(
+        SendEmailHandler $sendEmail,
+        CreateTaskHandler $createTask,
+        CreateSubCaseHandler $createSubCase,
+        WebhookHandler $webhook,
+        SetFieldHandler $setField,
+        NotifyHandler $notify,
+    ) {
+        $this->handlers = [
+            'sendEmail'     => $sendEmail,
+            'createTask'    => $createTask,
+            'createSubCase' => $createSubCase,
+            'webhook'       => $webhook,
+            'setField'      => $setField,
+            'notify'        => $notify,
+        ];
+    }//end __construct()
+
+    /**
+     * Register an additional handler (DI extension point).
+     *
+     * @param string                  $type    Action type identifier
+     * @param ActionHandlerInterface  $handler Handler implementation
+     *
+     * @return void
+     */
+    public function registerHandler(string $type, ActionHandlerInterface $handler): void
+    {
+        $this->handlers[$type] = $handler;
+    }//end registerHandler()
+
+    /**
+     * Look up a handler by type.
+     *
+     * @param string $type Action type
+     *
+     * @return ActionHandlerInterface|null
+     */
+    public function getHandler(string $type): ?ActionHandlerInterface
+    {
+        return ($this->handlers[$type] ?? null);
+    }//end getHandler()
+
+    /**
+     * Get all registered action types.
+     *
+     * @return array<int, string>
+     */
+    public function getRegisteredTypes(): array
+    {
+        return array_keys($this->handlers);
+    }//end getRegisteredTypes()
+}//end class

--- a/lib/Service/Transitions/ActionResult.php
+++ b/lib/Service/Transitions/ActionResult.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Procest Action Result value object.
+ *
+ * Carries the outcome of a dispatched automatic action: success flag,
+ * optional static error message (never leak exception detail), and
+ * action-specific result data.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Transitions
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Transitions;
+
+/**
+ * Immutable value object returned by every ActionHandler.
+ *
+ * @spec openspec/changes/status-transition-engine/tasks.md#T07
+ */
+final class ActionResult
+{
+
+    /**
+     * Constructor.
+     *
+     * @param bool                 $ok    Whether the action succeeded
+     * @param string|null          $error Static error message (no exception detail)
+     * @param array<string, mixed> $data  Optional structured data from the action
+     */
+    public function __construct(
+        public readonly bool $ok,
+        public readonly ?string $error=null,
+        public readonly array $data=[],
+    ) {
+    }//end __construct()
+
+    /**
+     * Convenience constructor for a successful result.
+     *
+     * @param array<string, mixed> $data Optional result data
+     *
+     * @return self
+     */
+    public static function success(array $data=[]): self
+    {
+        return new self(ok: true, error: null, data: $data);
+    }//end success()
+
+    /**
+     * Convenience constructor for a failed result.
+     *
+     * @param string               $error Static error message
+     * @param array<string, mixed> $data  Optional structured data
+     *
+     * @return self
+     */
+    public static function failure(string $error, array $data=[]): self
+    {
+        return new self(ok: false, error: $error, data: $data);
+    }//end failure()
+}//end class

--- a/lib/Service/Transitions/ChecklistGuard.php
+++ b/lib/Service/Transitions/ChecklistGuard.php
@@ -1,0 +1,146 @@
+<?php
+
+/**
+ * Procest Checklist Guard evaluator.
+ *
+ * Guard config shape: `{type: 'checklist', taskId: <uuid>, requiredItems?: [<itemLabel>, ...]}`.
+ * Loads the referenced task and verifies that every required checklist item
+ * is marked `checked: true`. If `requiredItems` is omitted, all items on the
+ * task must be checked.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Transitions
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Transitions;
+
+use OCA\Procest\Service\SettingsService;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Guard: verifies checklist items on a linked task are complete.
+ *
+ * @spec openspec/changes/status-transition-engine/tasks.md#T05
+ */
+class ChecklistGuard implements GuardEvaluatorInterface
+{
+
+    /**
+     * Constructor.
+     *
+     * @param SettingsService $settingsService Bridge to OpenRegister + config
+     * @param LoggerInterface $logger          Logger
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Evaluate the checklist guard.
+     *
+     * @param array<string, mixed> $guardConfig Guard configuration
+     * @param array<string, mixed> $case        Case object (unused here, included for interface parity)
+     * @param string               $userId      Current user UID (unused)
+     *
+     * @return GuardResult
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function evaluate(array $guardConfig, array $case, string $userId): GuardResult
+    {
+        $taskId = (string) ($guardConfig['taskId'] ?? '');
+        if ($taskId === '') {
+            return GuardResult::fail(message: 'Checklist guard missing taskId');
+        }
+
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return GuardResult::fail(message: 'Opslag niet beschikbaar');
+        }
+
+        $register   = $this->settingsService->getConfigValue(key: 'register');
+        $taskSchema = $this->settingsService->getConfigValue(key: 'task_schema');
+        if ($register === '' || $taskSchema === '') {
+            return GuardResult::fail(message: 'Taak-register niet geconfigureerd');
+        }
+
+        try {
+            $task = $objectService->findObject($register, $taskSchema, $taskId);
+            $task = $this->toArray(value: $task);
+        } catch (\Throwable $e) {
+            $this->logger->error('ChecklistGuard: task load failed', ['exception' => $e->getMessage()]);
+            return GuardResult::fail(message: 'Gekoppelde taak niet gevonden');
+        }
+
+        $items = $task['checklist'] ?? ($task['items'] ?? []);
+        if (is_array($items) === false) {
+            $items = [];
+        }
+
+        $required = $guardConfig['requiredItems'] ?? null;
+        $missing  = [];
+        foreach ($items as $item) {
+            if (is_array($item) === false) {
+                continue;
+            }
+            $label   = (string) ($item['label'] ?? ($item['name'] ?? ''));
+            $checked = (bool) ($item['checked'] ?? false);
+
+            if (is_array($required) === true && $required !== []) {
+                if (in_array($label, $required, true) === true && $checked === false) {
+                    $missing[] = $label;
+                }
+            } else {
+                if ($checked === false && $label !== '') {
+                    $missing[] = $label;
+                }
+            }
+        }
+
+        if (count($missing) === 0) {
+            return GuardResult::pass();
+        }
+
+        $first = $missing[0];
+        return GuardResult::fail(
+            message: sprintf("%d checklistitem niet afgevinkt: '%s'", count($missing), $first),
+            details: ['missing' => $missing],
+        );
+    }//end evaluate()
+
+    /**
+     * Coerce ObjectService results to array.
+     *
+     * @param mixed $value Mixed result from ObjectService
+     *
+     * @return array<string, mixed>
+     */
+    private function toArray(mixed $value): array
+    {
+        if (is_array($value) === true) {
+            return $value;
+        }
+        if (is_object($value) === true && method_exists($value, 'jsonSerialize') === true) {
+            $serialized = $value->jsonSerialize();
+            if (is_array($serialized) === true) {
+                return $serialized;
+            }
+        }
+        return [];
+    }//end toArray()
+}//end class

--- a/lib/Service/Transitions/CreateSubCaseHandler.php
+++ b/lib/Service/Transitions/CreateSubCaseHandler.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * Procest createSubCase action handler.
+ *
+ * Action config shape: `{type: 'createSubCase', caseType: '<uuid>', title?, hoofdzaakField?: 'hoofdzaak'}`.
+ * Creates a deelzaak linked to the parent case via `hoofdzaak`.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Transitions
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Transitions;
+
+use OCA\Procest\Service\SettingsService;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Built-in handler for `createSubCase` automatic actions.
+ *
+ * @spec openspec/changes/status-transition-engine/tasks.md#T08
+ */
+class CreateSubCaseHandler implements ActionHandlerInterface
+{
+
+    /**
+     * Constructor.
+     *
+     * @param SettingsService $settingsService Bridge to OpenRegister + config
+     * @param LoggerInterface $logger          Logger
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Handle the createSubCase action.
+     *
+     * @param array<string, mixed> $actionConfig      Action configuration
+     * @param array<string, mixed> $case              Parent case object
+     * @param array<string, mixed> $transitionContext Transition context
+     *
+     * @return ActionResult
+     */
+    public function handle(array $actionConfig, array $case, array $transitionContext): ActionResult
+    {
+        try {
+            $objectService = $this->settingsService->getObjectService();
+            if ($objectService === null) {
+                return ActionResult::failure(error: 'storage_unavailable');
+            }
+
+            $register   = $this->settingsService->getConfigValue(key: 'register');
+            $caseSchema = $this->settingsService->getConfigValue(key: 'case_schema');
+            if ($register === '' || $caseSchema === '') {
+                return ActionResult::failure(error: 'case_schema_not_configured');
+            }
+
+            $parentId = (string) ($case['id'] ?? ($case['uuid'] ?? ''));
+            $subCase  = [
+                'title'     => (string) ($actionConfig['title'] ?? sprintf('Deelzaak na %s', $transitionContext['transitionLabel'] ?? '')),
+                'caseType'  => (string) ($actionConfig['caseType'] ?? ''),
+                'hoofdzaak' => $parentId,
+            ];
+
+            $created  = $objectService->saveObject($register, $caseSchema, $subCase);
+            $subId    = is_array($created) === true ? (string) ($created['id'] ?? '') : '';
+
+            return ActionResult::success(data: ['subCaseId' => $subId]);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'CreateSubCaseHandler failed',
+                ['exception' => $e->getMessage(), 'context' => $transitionContext],
+            );
+            return ActionResult::failure(error: 'create_sub_case_failed');
+        }
+    }//end handle()
+}//end class

--- a/lib/Service/Transitions/CreateTaskHandler.php
+++ b/lib/Service/Transitions/CreateTaskHandler.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * Procest createTask action handler.
+ *
+ * Action config shape: `{type: 'createTask', title?, assignee?, dueIn?: '<duration>'}`.
+ * Creates a task linked to the case via OpenRegister ObjectService.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Transitions
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Transitions;
+
+use OCA\Procest\Service\SettingsService;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Built-in handler for `createTask` automatic actions.
+ *
+ * @spec openspec/changes/status-transition-engine/tasks.md#T08
+ */
+class CreateTaskHandler implements ActionHandlerInterface
+{
+
+    /**
+     * Constructor.
+     *
+     * @param SettingsService $settingsService Bridge to OpenRegister + config
+     * @param LoggerInterface $logger          Logger
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Handle the createTask action.
+     *
+     * @param array<string, mixed> $actionConfig      Action configuration
+     * @param array<string, mixed> $case              Case object
+     * @param array<string, mixed> $transitionContext Transition context
+     *
+     * @return ActionResult
+     */
+    public function handle(array $actionConfig, array $case, array $transitionContext): ActionResult
+    {
+        try {
+            $objectService = $this->settingsService->getObjectService();
+            if ($objectService === null) {
+                return ActionResult::failure(error: 'storage_unavailable');
+            }
+
+            $register   = $this->settingsService->getConfigValue(key: 'register');
+            $taskSchema = $this->settingsService->getConfigValue(key: 'task_schema');
+            if ($register === '' || $taskSchema === '') {
+                return ActionResult::failure(error: 'task_schema_not_configured');
+            }
+
+            $caseId = (string) ($case['id'] ?? ($case['uuid'] ?? ''));
+            $task   = [
+                'title'    => (string) ($actionConfig['title'] ?? sprintf('Taak na transitie %s', $transitionContext['transitionLabel'] ?? '')),
+                'case'     => $caseId,
+                'status'   => 'open',
+                'assignee' => (string) ($actionConfig['assignee'] ?? ''),
+            ];
+
+            $created = $objectService->saveObject($register, $taskSchema, $task);
+            $taskId  = is_array($created) === true ? (string) ($created['id'] ?? '') : '';
+
+            return ActionResult::success(data: ['taskId' => $taskId]);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'CreateTaskHandler failed',
+                ['exception' => $e->getMessage(), 'context' => $transitionContext],
+            );
+            return ActionResult::failure(error: 'create_task_failed');
+        }
+    }//end handle()
+}//end class

--- a/lib/Service/Transitions/GuardEvaluatorInterface.php
+++ b/lib/Service/Transitions/GuardEvaluatorInterface.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Procest Guard Evaluator interface.
+ *
+ * Implementations evaluate a single guard configuration against a case for
+ * a given user, returning a deterministic GuardResult. Guards MUST be
+ * side-effect-free: they only read state.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Transitions
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Transitions;
+
+/**
+ * Strategy interface for guard evaluation.
+ *
+ * @spec openspec/changes/status-transition-engine/tasks.md#T04
+ */
+interface GuardEvaluatorInterface
+{
+
+    /**
+     * Evaluate the guard.
+     *
+     * @param array<string, mixed> $guardConfig The guard configuration block from the workflowTemplate transition
+     * @param array<string, mixed> $case        The case object as an array
+     * @param string               $userId      The current user UID
+     *
+     * @return GuardResult
+     */
+    public function evaluate(array $guardConfig, array $case, string $userId): GuardResult;
+}//end interface

--- a/lib/Service/Transitions/GuardFailedException.php
+++ b/lib/Service/Transitions/GuardFailedException.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Procest GuardFailedException.
+ *
+ * Thrown by `StatusTransitionService::execute()` when server-side guard
+ * re-evaluation rejects the transition (REQ-STE-4-002). Carries the list of
+ * failed guard snapshots so the caller can render specific messages.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Transitions
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Transitions;
+
+use RuntimeException;
+
+/**
+ * Exception thrown when one or more guards reject a transition.
+ *
+ * @spec openspec/changes/status-transition-engine/tasks.md#T10
+ */
+class GuardFailedException extends RuntimeException
+{
+
+    /**
+     * Snapshots of failed guard evaluations.
+     *
+     * @var array<int, array{type: string, passed: bool, failureMessage: ?string, details: array<string, mixed>}>
+     */
+    private array $failedGuards;
+
+    /**
+     * Constructor.
+     *
+     * @param array<int, array<string, mixed>> $failedGuards The failed guard snapshots
+     * @param string                           $message      Static engine-side message
+     */
+    public function __construct(array $failedGuards, string $message='guard_failed')
+    {
+        parent::__construct($message);
+        $this->failedGuards = $failedGuards;
+    }//end __construct()
+
+    /**
+     * Get the failed guard snapshots.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function getFailedGuards(): array
+    {
+        return $this->failedGuards;
+    }//end getFailedGuards()
+}//end class

--- a/lib/Service/Transitions/GuardRegistry.php
+++ b/lib/Service/Transitions/GuardRegistry.php
@@ -1,0 +1,143 @@
+<?php
+
+/**
+ * Procest Guard Registry.
+ *
+ * Strategy-pattern registry mapping guard `type` strings to the corresponding
+ * GuardEvaluatorInterface implementations. Built-in evaluators are injected
+ * via DI; downstream specs MAY register additional types via
+ * `registerEvaluator()` (e.g. an integration hook in `Application::register()`).
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Transitions
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Transitions;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * Registry of guard evaluators keyed by guard type.
+ *
+ * @spec openspec/changes/status-transition-engine/tasks.md#T06
+ */
+class GuardRegistry
+{
+
+    /**
+     * Registered evaluators keyed by guard type.
+     *
+     * @var array<string, GuardEvaluatorInterface>
+     */
+    private array $evaluators = [];
+
+    /**
+     * Constructor.
+     *
+     * @param ChecklistGuard        $checklist        Built-in checklist evaluator
+     * @param RequiredFieldGuard    $requiredField    Built-in required-field evaluator
+     * @param RequiredDocumentGuard $requiredDocument Built-in required-document evaluator
+     * @param RoleGuard             $roleGuard        Built-in role evaluator
+     * @param LoggerInterface       $logger           Logger for unknown guard types
+     */
+    public function __construct(
+        ChecklistGuard $checklist,
+        RequiredFieldGuard $requiredField,
+        RequiredDocumentGuard $requiredDocument,
+        RoleGuard $roleGuard,
+        private readonly LoggerInterface $logger,
+    ) {
+        $this->evaluators = [
+            'checklist'        => $checklist,
+            'requiredField'    => $requiredField,
+            'requiredDocument' => $requiredDocument,
+            'roleGuard'        => $roleGuard,
+        ];
+    }//end __construct()
+
+    /**
+     * Register an additional evaluator (DI extension point).
+     *
+     * @param string                   $type      Guard type identifier
+     * @param GuardEvaluatorInterface  $evaluator Evaluator implementation
+     *
+     * @return void
+     */
+    public function registerEvaluator(string $type, GuardEvaluatorInterface $evaluator): void
+    {
+        $this->evaluators[$type] = $evaluator;
+    }//end registerEvaluator()
+
+    /**
+     * Evaluate every guard in declaration order and collect snapshots.
+     *
+     * @param array<int, array<string, mixed>> $guards List of guard configs
+     * @param array<string, mixed>             $case   The case
+     * @param string                           $userId Current user UID
+     *
+     * @return array<int, array{type: string, passed: bool, failureMessage: ?string, details: array<string, mixed>}>
+     */
+    public function evaluateAll(array $guards, array $case, string $userId): array
+    {
+        $results = [];
+        foreach ($guards as $guard) {
+            if (is_array($guard) === false) {
+                continue;
+            }
+            $type = (string) ($guard['type'] ?? '');
+            if ($type === '') {
+                continue;
+            }
+            if (isset($this->evaluators[$type]) === false) {
+                $this->logger->warning('Unknown guard type', ['type' => $type]);
+                $results[] = [
+                    'type'           => $type,
+                    'passed'         => false,
+                    'failureMessage' => 'Onbekende guard',
+                    'details'        => ['unknown' => true],
+                ];
+                continue;
+            }
+
+            $result    = $this->evaluators[$type]->evaluate(guardConfig: $guard, case: $case, userId: $userId);
+            $results[] = [
+                'type'           => $type,
+                'passed'         => $result->passed,
+                'failureMessage' => $result->failureMessage,
+                'details'        => $result->details,
+            ];
+        }
+
+        return $results;
+    }//end evaluateAll()
+
+    /**
+     * Check if all guards in the result set passed.
+     *
+     * @param array<int, array{passed: bool}> $results The evaluateAll() output
+     *
+     * @return bool
+     */
+    public function allPassed(array $results): bool
+    {
+        foreach ($results as $result) {
+            if (($result['passed'] ?? false) !== true) {
+                return false;
+            }
+        }
+        return true;
+    }//end allPassed()
+}//end class

--- a/lib/Service/Transitions/GuardResult.php
+++ b/lib/Service/Transitions/GuardResult.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Procest Guard Result value object.
+ *
+ * Carries the outcome of a single guard evaluation: pass flag, optional
+ * failure message, and structured details (e.g. `silent: true` for role
+ * guards that should hide a transition entirely).
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Transitions
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Transitions;
+
+/**
+ * Immutable value object returned by every GuardEvaluator.
+ *
+ * @spec openspec/changes/status-transition-engine/tasks.md#T04
+ */
+final class GuardResult
+{
+
+    /**
+     * Constructor.
+     *
+     * @param bool                 $passed         Whether the guard passed
+     * @param string|null          $failureMessage Optional user-facing failure message
+     * @param array<string, mixed> $details        Structured guard details (e.g. silent role hide)
+     */
+    public function __construct(
+        public readonly bool $passed,
+        public readonly ?string $failureMessage=null,
+        public readonly array $details=[],
+    ) {
+    }//end __construct()
+
+    /**
+     * Convenience constructor for a passing result.
+     *
+     * @param array<string, mixed> $details Optional details
+     *
+     * @return self
+     */
+    public static function pass(array $details=[]): self
+    {
+        return new self(passed: true, failureMessage: null, details: $details);
+    }//end pass()
+
+    /**
+     * Convenience constructor for a failing result.
+     *
+     * @param string               $message User-facing failure message
+     * @param array<string, mixed> $details Optional structured details
+     *
+     * @return self
+     */
+    public static function fail(string $message, array $details=[]): self
+    {
+        return new self(passed: false, failureMessage: $message, details: $details);
+    }//end fail()
+}//end class

--- a/lib/Service/Transitions/NotifyHandler.php
+++ b/lib/Service/Transitions/NotifyHandler.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Procest notify action handler.
+ *
+ * Action config shape: `{type: 'notify', userId?: '<uid>', message?: '<text>'}`.
+ * Dispatches an in-app Nextcloud notification via NotificatieService.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Transitions
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Transitions;
+
+use OCA\Procest\Service\NotificatieService;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Built-in handler for `notify` automatic actions.
+ *
+ * @spec openspec/changes/status-transition-engine/tasks.md#T08
+ */
+class NotifyHandler implements ActionHandlerInterface
+{
+
+    /**
+     * Constructor.
+     *
+     * @param NotificatieService $notificatieService Notification dispatcher
+     * @param LoggerInterface    $logger             Logger
+     */
+    public function __construct(
+        private readonly NotificatieService $notificatieService,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Handle the notify action.
+     *
+     * @param array<string, mixed> $actionConfig      Action configuration
+     * @param array<string, mixed> $case              Case object
+     * @param array<string, mixed> $transitionContext Transition context
+     *
+     * @return ActionResult
+     */
+    public function handle(array $actionConfig, array $case, array $transitionContext): ActionResult
+    {
+        try {
+            $caseId    = (string) ($case['id'] ?? ($case['uuid'] ?? ''));
+            $recipient = (string) ($actionConfig['userId'] ?? ($case['assignee'] ?? ''));
+            $message   = (string) ($actionConfig['message'] ?? sprintf('Status gewijzigd: %s', $transitionContext['transitionLabel'] ?? ''));
+
+            if (method_exists($this->notificatieService, 'notifyUser') === true && $recipient !== '') {
+                $this->notificatieService->notifyUser($recipient, $message, ['caseId' => $caseId]);
+                return ActionResult::success(data: ['userId' => $recipient]);
+            }
+
+            // Fall back to logging — non-fatal.
+            $this->logger->warning('NotifyHandler: NotificatieService::notifyUser missing or recipient empty');
+            return ActionResult::success(data: ['skipped' => true]);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'NotifyHandler failed',
+                ['exception' => $e->getMessage(), 'context' => $transitionContext],
+            );
+            return ActionResult::failure(error: 'notify_failed');
+        }
+    }//end handle()
+}//end class

--- a/lib/Service/Transitions/RequiredDocumentGuard.php
+++ b/lib/Service/Transitions/RequiredDocumentGuard.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * Procest Required Document Guard evaluator.
+ *
+ * Guard config shape: `{type: 'requiredDocument', documentType: 'Besluit'}`.
+ * Passes when at least one document linked to the case has the matching
+ * documentType. Documents are read from `case.documents`, `case.files`, or
+ * `case.relations` (whichever the case schema exposes for attachments).
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Transitions
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Transitions;
+
+/**
+ * Guard: verifies the case has at least one document of the required type.
+ *
+ * @spec openspec/changes/status-transition-engine/tasks.md#T05
+ */
+class RequiredDocumentGuard implements GuardEvaluatorInterface
+{
+
+    /**
+     * Evaluate the required-document guard.
+     *
+     * @param array<string, mixed> $guardConfig Guard configuration
+     * @param array<string, mixed> $case        Case object
+     * @param string               $userId      Current user UID (unused)
+     *
+     * @return GuardResult
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function evaluate(array $guardConfig, array $case, string $userId): GuardResult
+    {
+        $required = (string) ($guardConfig['documentType'] ?? '');
+        if ($required === '') {
+            return GuardResult::fail(message: 'Required-document guard missing documentType');
+        }
+
+        $candidates = [];
+        foreach (['documents', 'files', 'caseDocuments', 'attachments'] as $field) {
+            $value = $case[$field] ?? null;
+            if (is_array($value) === true) {
+                $candidates = array_merge($candidates, $value);
+            }
+        }
+
+        foreach ($candidates as $doc) {
+            if (is_array($doc) === false) {
+                continue;
+            }
+            $type = (string) ($doc['documentType'] ?? ($doc['type'] ?? ''));
+            if ($type === $required) {
+                return GuardResult::pass(details: ['documentType' => $required]);
+            }
+        }
+
+        return GuardResult::fail(
+            message: sprintf('Vereist document ontbreekt: %s', $required),
+            details: ['documentType' => $required],
+        );
+    }//end evaluate()
+}//end class

--- a/lib/Service/Transitions/RequiredFieldGuard.php
+++ b/lib/Service/Transitions/RequiredFieldGuard.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * Procest Required Field Guard evaluator.
+ *
+ * Guard config shape: `{type: 'requiredField', field: 'resultaat'}`.
+ * Passes when `case[field]` is non-null, non-empty-string, non-empty-array.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Transitions
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Transitions;
+
+/**
+ * Guard: verifies a named case field is non-empty.
+ *
+ * @spec openspec/changes/status-transition-engine/tasks.md#T05
+ */
+class RequiredFieldGuard implements GuardEvaluatorInterface
+{
+
+    /**
+     * Evaluate the required-field guard.
+     *
+     * @param array<string, mixed> $guardConfig Guard configuration
+     * @param array<string, mixed> $case        Case object
+     * @param string               $userId      Current user UID (unused)
+     *
+     * @return GuardResult
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function evaluate(array $guardConfig, array $case, string $userId): GuardResult
+    {
+        $field = (string) ($guardConfig['field'] ?? '');
+        if ($field === '') {
+            return GuardResult::fail(message: 'Required-field guard missing field');
+        }
+
+        $value = $case[$field] ?? null;
+        if ($value === null || $value === '' || (is_array($value) === true && count($value) === 0)) {
+            return GuardResult::fail(
+                message: sprintf('Vereist veld ontbreekt: %s', $field),
+                details: ['field' => $field],
+            );
+        }
+
+        return GuardResult::pass(details: ['field' => $field]);
+    }//end evaluate()
+}//end class

--- a/lib/Service/Transitions/RoleGuard.php
+++ b/lib/Service/Transitions/RoleGuard.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * Procest Role Guard evaluator.
+ *
+ * Guard config shape: `{type: 'roleGuard', allowedRoles: ['Behandelaar', 'Afdelingshoofd']}`.
+ * Verifies the current user has at least one of the allowed roles on the
+ * case. Failure is reported with `details.silent: true` so the UI can hide
+ * the transition entirely (REQ-STE-2-003).
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Transitions
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Transitions;
+
+use OCA\Procest\Service\SettingsService;
+use OCP\IGroupManager;
+use OCP\IUserManager;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Guard: verifies the current user has at least one allowed role on the case.
+ *
+ * Role lookup strategy (in order):
+ *  1. `case.roles[]` entries with `{userId, role}`.
+ *  2. Membership in a Nextcloud group named after the role (lowercase).
+ *
+ * @spec openspec/changes/status-transition-engine/tasks.md#T05
+ */
+class RoleGuard implements GuardEvaluatorInterface
+{
+
+    /**
+     * Constructor.
+     *
+     * @param SettingsService $settingsService Bridge to OpenRegister + config
+     * @param IGroupManager   $groupManager    Nextcloud group manager
+     * @param IUserManager    $userManager     Nextcloud user manager
+     * @param LoggerInterface $logger          Logger
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+        private readonly IGroupManager $groupManager,
+        private readonly IUserManager $userManager,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Evaluate the role guard.
+     *
+     * @param array<string, mixed> $guardConfig Guard configuration
+     * @param array<string, mixed> $case        Case object
+     * @param string               $userId      Current user UID (from IUserSession by the caller)
+     *
+     * @return GuardResult
+     */
+    public function evaluate(array $guardConfig, array $case, string $userId): GuardResult
+    {
+        $allowed = $guardConfig['allowedRoles'] ?? [];
+        if (is_array($allowed) === false || count($allowed) === 0) {
+            // No restriction means everyone passes.
+            return GuardResult::pass();
+        }
+
+        if ($userId === '') {
+            return GuardResult::fail(message: 'Niet ingelogd', details: ['silent' => true]);
+        }
+
+        // 1. Direct role assignment on case.roles[].
+        $caseRoles = $case['roles'] ?? ($case['participants'] ?? []);
+        if (is_array($caseRoles) === true) {
+            foreach ($caseRoles as $entry) {
+                if (is_array($entry) === false) {
+                    continue;
+                }
+                $entryUser = (string) ($entry['userId'] ?? ($entry['user'] ?? ''));
+                $entryRole = (string) ($entry['role'] ?? ($entry['roleType'] ?? ''));
+                if ($entryUser === $userId && in_array($entryRole, $allowed, true) === true) {
+                    return GuardResult::pass(details: ['matchedRole' => $entryRole]);
+                }
+            }
+        }
+
+        // 2. Fallback: Nextcloud group membership.
+        try {
+            $user = $this->userManager->get($userId);
+            if ($user !== null) {
+                foreach ($allowed as $role) {
+                    $groupId = strtolower((string) $role);
+                    if ($groupId === '') {
+                        continue;
+                    }
+                    if ($this->groupManager->isInGroup($userId, $groupId) === true) {
+                        return GuardResult::pass(details: ['matchedRole' => $role, 'via' => 'group']);
+                    }
+                }
+            }
+        } catch (\Throwable $e) {
+            $this->logger->error('RoleGuard: group lookup failed', ['exception' => $e->getMessage()]);
+        }
+
+        // Role mismatch — silent so the UI hides the transition entirely.
+        return GuardResult::fail(
+            message: 'Onvoldoende rechten',
+            details: ['silent' => true, 'allowedRoles' => array_values($allowed)],
+        );
+    }//end evaluate()
+}//end class

--- a/lib/Service/Transitions/SendEmailHandler.php
+++ b/lib/Service/Transitions/SendEmailHandler.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * Procest sendEmail action handler.
+ *
+ * Action config shape: `{type: 'sendEmail', to: '<address-or-userId>', template?: '<id>', subject?, body?}`.
+ * Delegates to NotificatieService::sendEmail (where available). Failures are
+ * logged with full context but returned as static error messages.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Transitions
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Transitions;
+
+use OCA\Procest\Service\NotificatieService;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Built-in handler for `sendEmail` automatic actions.
+ *
+ * @spec openspec/changes/status-transition-engine/tasks.md#T08
+ */
+class SendEmailHandler implements ActionHandlerInterface
+{
+
+    /**
+     * Constructor.
+     *
+     * @param NotificatieService $notificatieService Notification dispatcher
+     * @param LoggerInterface    $logger             Logger
+     */
+    public function __construct(
+        private readonly NotificatieService $notificatieService,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Handle the sendEmail action.
+     *
+     * @param array<string, mixed> $actionConfig      Action configuration
+     * @param array<string, mixed> $case              Case object
+     * @param array<string, mixed> $transitionContext Transition context (fromStatus/toStatus/etc.)
+     *
+     * @return ActionResult
+     */
+    public function handle(array $actionConfig, array $case, array $transitionContext): ActionResult
+    {
+        try {
+            $recipient = (string) ($actionConfig['to'] ?? '');
+            if ($recipient === '') {
+                return ActionResult::failure(error: 'send_email_missing_recipient');
+            }
+
+            $payload = [
+                'caseId'     => (string) ($case['id'] ?? ($case['uuid'] ?? '')),
+                'subject'    => (string) ($actionConfig['subject'] ?? ($transitionContext['transitionLabel'] ?? '')),
+                'body'       => (string) ($actionConfig['body'] ?? ''),
+                'template'   => (string) ($actionConfig['template'] ?? ''),
+                'transition' => $transitionContext,
+            ];
+
+            if (method_exists($this->notificatieService, 'sendEmail') === true) {
+                $this->notificatieService->sendEmail($recipient, $payload);
+                return ActionResult::success(data: ['to' => $recipient]);
+            }
+
+            // No mail delivery available — record as success since notification
+            // dispatch is best-effort per spec REQ-STE-5-002 (failures do not
+            // block transitions). Log a warning so the gap is visible.
+            $this->logger->warning('SendEmailHandler: NotificatieService::sendEmail missing — skipping');
+            return ActionResult::success(data: ['to' => $recipient, 'skipped' => true]);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'SendEmailHandler failed',
+                ['exception' => $e->getMessage(), 'context' => $transitionContext],
+            );
+            return ActionResult::failure(error: 'send_email_failed');
+        }
+    }//end handle()
+}//end class

--- a/lib/Service/Transitions/SetFieldHandler.php
+++ b/lib/Service/Transitions/SetFieldHandler.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * Procest setField action handler.
+ *
+ * Action config shape: `{type: 'setField', field: 'einddatum', value: '<value-or-now>'}`.
+ * Writes the named field on the case via OpenRegister ObjectService. Special
+ * `value` macros: `__now__` becomes the current ISO-8601 timestamp.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Transitions
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Transitions;
+
+use DateTimeImmutable;
+use OCA\Procest\Service\SettingsService;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Built-in handler for `setField` automatic actions.
+ *
+ * @spec openspec/changes/status-transition-engine/tasks.md#T08
+ */
+class SetFieldHandler implements ActionHandlerInterface
+{
+
+    /**
+     * Constructor.
+     *
+     * @param SettingsService $settingsService Bridge to OpenRegister + config
+     * @param LoggerInterface $logger          Logger
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Handle the setField action.
+     *
+     * @param array<string, mixed> $actionConfig      Action configuration
+     * @param array<string, mixed> $case              Case object
+     * @param array<string, mixed> $transitionContext Transition context
+     *
+     * @return ActionResult
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function handle(array $actionConfig, array $case, array $transitionContext): ActionResult
+    {
+        try {
+            $field = (string) ($actionConfig['field'] ?? '');
+            if ($field === '') {
+                return ActionResult::failure(error: 'set_field_missing_field');
+            }
+
+            $value = $actionConfig['value'] ?? null;
+            if ($value === '__now__') {
+                $value = (new DateTimeImmutable('now'))->format(\DateTimeInterface::ATOM);
+            }
+
+            $objectService = $this->settingsService->getObjectService();
+            if ($objectService === null) {
+                return ActionResult::failure(error: 'storage_unavailable');
+            }
+
+            $register   = $this->settingsService->getConfigValue(key: 'register');
+            $caseSchema = $this->settingsService->getConfigValue(key: 'case_schema');
+            if ($register === '' || $caseSchema === '') {
+                return ActionResult::failure(error: 'case_schema_not_configured');
+            }
+
+            $case[$field] = $value;
+            $objectService->saveObject($register, $caseSchema, $case);
+
+            return ActionResult::success(data: ['field' => $field]);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'SetFieldHandler failed',
+                ['exception' => $e->getMessage(), 'context' => $transitionContext],
+            );
+            return ActionResult::failure(error: 'set_field_failed');
+        }
+    }//end handle()
+}//end class

--- a/lib/Service/Transitions/SideEffectDispatcher.php
+++ b/lib/Service/Transitions/SideEffectDispatcher.php
@@ -1,31 +1,23 @@
 <?php
 
 /**
- * Procest SideEffectDispatcher
+ * Procest Side-Effect Dispatcher.
  *
- * Dispatches the `automaticActions[]` array attached to a status transition
- * after the status mutation has been persisted. Recognises both inline
- * action JSON (legacy) and `{ref: <slug>}` references that resolve via
- * ActionRegistry against the per-tenant action library.
- *
- * Failure semantics (inherited from status-transition-engine REQ-STE-9):
- *  - Failed actions are recorded on `statusRecord.dispatchedActions[]` with
- *    a static error code.
- *  - Status mutations are NEVER rolled back due to a side-effect failure.
- *  - Unknown action types AND unknown refs both surface as
- *    `{ok: false, error: 'unknown_action_ref'}` (cross-tenant misses are
- *    indistinguishable from non-existent slugs in user-visible output —
- *    REQ-AA-8).
+ * Iterates `automaticActions[]` in declaration order, invokes the registered
+ * handler for each action type, and collects the per-action result. Failed
+ * handlers SHALL NOT abort the loop and SHALL NOT roll back the status
+ * change (REQ-STE-5-002). Unregistered action types are logged and recorded
+ * with `error: 'unknown_action_type'`.
  *
  * @category Service
  * @package  OCA\Procest\Service\Transitions
  *
- * @author    Conduction Development Team <info@conduction.nl>
- * @copyright 2024 Conduction B.V.
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
  * SPDX-License-Identifier: EUPL-1.2
- * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
  *
  * @version GIT: <git-id>
  *
@@ -36,201 +28,71 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service\Transitions;
 
-use OCA\Procest\AppInfo\Application;
-use OCA\Procest\Service\Actions\ActionRegistry;
-use OCA\Procest\Service\Actions\ActionResult;
 use Psr\Log\LoggerInterface;
 
 /**
- * Iterates `automaticActions[]` in declaration order and invokes the handler
- * registered for each resolved action's `type`.
+ * Dispatches automatic actions after a successful transition.
+ *
+ * @spec openspec/changes/status-transition-engine/tasks.md#T09
  */
 class SideEffectDispatcher
 {
+
     /**
-     * Constructor for SideEffectDispatcher.
+     * Constructor.
      *
-     * @param ActionRegistry  $registry The per-tenant action registry.
-     * @param LoggerInterface $logger   PSR-3 logger for failures and unknown
-     *                                  references.
-     *
-     * @return void
+     * @param ActionHandlerRegistry $registry Action handler registry
+     * @param LoggerInterface       $logger   Logger
      */
     public function __construct(
-        private readonly ActionRegistry $registry,
+        private readonly ActionHandlerRegistry $registry,
         private readonly LoggerInterface $logger,
     ) {
     }//end __construct()
 
     /**
-     * Dispatch every action on a transition.
+     * Dispatch all actions sequentially in declaration order.
      *
-     * @param array $actions           The raw `automaticActions[]` array from
-     *                                 the workflow template's transition. May
-     *                                 contain inline action configs OR
-     *                                 `{ref: <slug>}` references.
-     * @param array $case              The full case object (used by handlers
-     *                                 for template rendering and routing).
-     * @param array $transitionContext Engine context: `fromStatus`,
-     *                                 `toStatus`, `transitionLabel`,
-     *                                 `userId`, `statusRecordUuid`,
-     *                                 `tenantId`, and optional `dryRun`.
+     * @param array<int, array<string, mixed>> $actions           Action configs
+     * @param array<string, mixed>             $case              Case object
+     * @param array<string, mixed>             $transitionContext Transition context
      *
-     * @return array<int, array> One audit entry per action, suitable for
-     *                           persisting on `statusRecord.dispatchedActions`.
+     * @return array<int, array{type: string, ok: bool, error?: string}>
      */
     public function dispatch(array $actions, array $case, array $transitionContext): array
     {
-        $tenantId = (string) ($transitionContext['tenantId'] ?? ($case['tenantId'] ?? ''));
-        $results  = [];
-
-        foreach ($actions as $entry) {
-            if (is_array($entry) === false) {
-                $results[] = [
-                    'type'  => 'unknown',
-                    'ok'    => false,
-                    'error' => 'unknown_action_ref',
-                ];
+        $results = [];
+        foreach ($actions as $action) {
+            if (is_array($action) === false) {
+                continue;
+            }
+            $type = (string) ($action['type'] ?? '');
+            if ($type === '') {
                 continue;
             }
 
-            $resolved = $this->resolveEntry($entry, $tenantId);
-            if ($resolved === null) {
-                $results[] = [
-                    'type'  => 'unknown',
-                    'ref'   => (string) ($entry['ref'] ?? ''),
-                    'ok'    => false,
-                    'error' => 'unknown_action_ref',
-                ];
-                continue;
-            }
-
-            [$type, $config, $ref] = $resolved;
-
-            $handler = $this->registry->getHandler($type);
+            $handler = $this->registry->getHandler(type: $type);
             if ($handler === null) {
-                $this->logger->error(
+                $this->logger->warning(
                     'SideEffectDispatcher: unknown action type',
-                    [
-                        'app'      => Application::APP_ID,
-                        'type'     => $type,
-                        'ref'      => $ref,
-                        'tenantId' => $tenantId,
-                    ]
+                    ['type' => $type, 'context' => $transitionContext],
                 );
-                $audit = [
+                $results[] = [
                     'type'  => $type,
                     'ok'    => false,
                     'error' => 'unknown_action_type',
                 ];
-                if ($ref !== null) {
-                    $audit['ref'] = $ref;
-                }
-                $results[] = $audit;
                 continue;
             }
 
-            try {
-                $result = $handler->handle($config, $case, $transitionContext);
-            } catch (\Throwable $e) {
-                // Defensive — handlers MUST swallow exceptions, but a buggy
-                // third-party handler must not abort the rest of the loop.
-                $this->logger->error(
-                    'SideEffectDispatcher: handler threw',
-                    [
-                        'app'       => Application::APP_ID,
-                        'type'      => $type,
-                        'ref'       => $ref,
-                        'tenantId'  => $tenantId,
-                        'exception' => $e->getMessage(),
-                    ]
-                );
-                $audit = [
-                    'type'  => $type,
-                    'ok'    => false,
-                    'error' => 'handler_exception',
-                ];
-                if ($ref !== null) {
-                    $audit['ref'] = $ref;
-                }
-                $results[] = $audit;
-                continue;
+            $result = $handler->handle(actionConfig: $action, case: $case, transitionContext: $transitionContext);
+            $entry  = ['type' => $type, 'ok' => $result->ok];
+            if ($result->ok === false) {
+                $entry['error'] = (string) ($result->error ?? 'action_failed');
             }
-
-            $audit = $this->resultToAudit($type, $ref, $result);
-            $results[] = $audit;
+            $results[] = $entry;
         }
 
         return $results;
     }//end dispatch()
-
-    /**
-     * Resolve a single `automaticActions[]` entry to `[type, config, ref|null]`.
-     *
-     * - `{ref: <slug>}` entries go through ActionRegistry; cross-tenant misses
-     *   and unpublished slugs both return null.
-     * - Inline action JSON entries (with a `type` key, no `ref`) are returned
-     *   as-is for backward compatibility (REQ-AA-5).
-     *
-     * @param array  $entry    Raw `automaticActions[]` element.
-     * @param string $tenantId Tenant the current transition is firing in.
-     *
-     * @return array{0:string,1:array,2:?string}|null
-     */
-    private function resolveEntry(array $entry, string $tenantId): ?array
-    {
-        if (isset($entry['ref']) === true) {
-            $slug = (string) $entry['ref'];
-            if ($slug === '' || $tenantId === '') {
-                return null;
-            }
-            $action = $this->registry->resolve($tenantId, $slug);
-            if ($action === null) {
-                return null;
-            }
-            $type   = (string) ($action['type'] ?? '');
-            $config = (array) ($action['config'] ?? []);
-            if ($type === '') {
-                return null;
-            }
-            return [$type, $config, $slug];
-        }
-
-        // Inline (legacy) — must include a `type` key directly.
-        $type = (string) ($entry['type'] ?? '');
-        if ($type === '') {
-            return null;
-        }
-        $config = $entry;
-        unset($config['type']);
-        return [$type, $config, null];
-    }//end resolveEntry()
-
-    /**
-     * Convert an ActionResult plus envelope metadata to an audit entry.
-     *
-     * @param string       $type   Handler type slug.
-     * @param string|null  $ref    Originating action slug (when resolved via
-     *                             registry) or null for inline actions.
-     * @param ActionResult $result The handler's return value.
-     *
-     * @return array
-     */
-    private function resultToAudit(string $type, ?string $ref, ActionResult $result): array
-    {
-        $audit = [
-            'type' => $type,
-            'ok'   => $result->ok,
-        ];
-        if ($ref !== null) {
-            $audit['ref'] = $ref;
-        }
-        if ($result->ok === false && $result->error !== null) {
-            $audit['error'] = $result->error;
-        }
-        if ($result->data !== []) {
-            $audit['data'] = $result->data;
-        }
-        return $audit;
-    }//end resultToAudit()
 }//end class

--- a/lib/Service/Transitions/WebhookHandler.php
+++ b/lib/Service/Transitions/WebhookHandler.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * Procest webhook action handler.
+ *
+ * Action config shape: `{type: 'webhook', url: '<https-url>', headers?: {...}}`.
+ * Posts a JSON payload `{case, transition}` to the configured URL with a
+ * 5-second timeout. Non-2xx responses produce `ok: false`.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Transitions
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Transitions;
+
+use OCP\Http\Client\IClientService;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Built-in handler for `webhook` automatic actions.
+ *
+ * @spec openspec/changes/status-transition-engine/tasks.md#T08
+ */
+class WebhookHandler implements ActionHandlerInterface
+{
+
+    /**
+     * Constructor.
+     *
+     * @param IClientService  $clientService Nextcloud HTTP client factory
+     * @param LoggerInterface $logger        Logger
+     */
+    public function __construct(
+        private readonly IClientService $clientService,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Handle the webhook action.
+     *
+     * @param array<string, mixed> $actionConfig      Action configuration
+     * @param array<string, mixed> $case              Case object
+     * @param array<string, mixed> $transitionContext Transition context
+     *
+     * @return ActionResult
+     */
+    public function handle(array $actionConfig, array $case, array $transitionContext): ActionResult
+    {
+        try {
+            $url = (string) ($actionConfig['url'] ?? '');
+            if ($url === '' || (str_starts_with($url, 'http://') === false && str_starts_with($url, 'https://') === false)) {
+                return ActionResult::failure(error: 'webhook_invalid_url');
+            }
+
+            $client  = $this->clientService->newClient();
+            $headers = $actionConfig['headers'] ?? [];
+            if (is_array($headers) === false) {
+                $headers = [];
+            }
+
+            $response = $client->post(
+                $url,
+                [
+                    'json'    => [
+                        'case'       => $case,
+                        'transition' => $transitionContext,
+                    ],
+                    'headers' => $headers,
+                    'timeout' => 5,
+                ],
+            );
+
+            $status = (int) $response->getStatusCode();
+            if ($status >= 200 && $status < 300) {
+                return ActionResult::success(data: ['status' => $status]);
+            }
+
+            return ActionResult::failure(error: 'webhook_non_2xx', data: ['status' => $status]);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'WebhookHandler failed',
+                ['exception' => $e->getMessage(), 'context' => $transitionContext],
+            );
+            return ActionResult::failure(error: 'webhook_failed');
+        }
+    }//end handle()
+}//end class

--- a/lib/Service/WorkflowTemplateLoader.php
+++ b/lib/Service/WorkflowTemplateLoader.php
@@ -1,0 +1,204 @@
+<?php
+
+/**
+ * Procest Workflow Template Loader.
+ *
+ * Loads the single active `workflowTemplate` for a given `caseType` from
+ * OpenRegister, decodes `transitions[]` and `steps[]` from JSON, and caches
+ * the result per-request to avoid repeated lookups during a single transition.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * Loads active workflow templates with per-request memoisation.
+ *
+ * @spec openspec/changes/status-transition-engine/tasks.md#T03
+ */
+class WorkflowTemplateLoader
+{
+
+    /**
+     * Per-request cache keyed by caseTypeId. The value is either a decoded
+     * template array, or `false` to indicate a confirmed miss (so we don't
+     * re-query on every lookup).
+     *
+     * @var array<string, array<string, mixed>|false>
+     */
+    private array $cache = [];
+
+    /**
+     * Constructor.
+     *
+     * @param SettingsService $settingsService Bridge to OpenRegister + config
+     * @param LoggerInterface $logger          Logger
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Get the active workflow template for a caseType.
+     *
+     * @param string $caseTypeId The caseType UUID
+     *
+     * @return array<string, mixed>|null The template with `transitions` and `steps` decoded, or null when none active
+     */
+    public function getActiveTemplate(string $caseTypeId): ?array
+    {
+        if ($caseTypeId === '') {
+            return null;
+        }
+        if (isset($this->cache[$caseTypeId]) === true) {
+            return $this->cache[$caseTypeId] === false ? null : $this->cache[$caseTypeId];
+        }
+
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            $this->cache[$caseTypeId] = false;
+            return null;
+        }
+
+        $register       = $this->settingsService->getConfigValue(key: 'register');
+        $templateSchema = $this->settingsService->getConfigValue(key: 'workflow_template_schema');
+        if ($register === '' || $templateSchema === '') {
+            $this->cache[$caseTypeId] = false;
+            return null;
+        }
+
+        try {
+            // ObjectService::findObjects signature varies — use the common 4-arg form.
+            $found = $objectService->findObjects(
+                $register,
+                $templateSchema,
+                ['caseType' => $caseTypeId, 'isActive' => true],
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'WorkflowTemplateLoader: findObjects failed',
+                ['exception' => $e->getMessage(), 'caseType' => $caseTypeId],
+            );
+            $this->cache[$caseTypeId] = false;
+            return null;
+        }
+
+        $templates = $this->normalise(value: $found);
+        if (count($templates) === 0) {
+            $this->cache[$caseTypeId] = false;
+            return null;
+        }
+
+        $template = $templates[0];
+        $this->decodeJsonField(template: $template, field: 'transitions');
+        $this->decodeJsonField(template: $template, field: 'steps');
+
+        $this->cache[$caseTypeId] = $template;
+        return $template;
+    }//end getActiveTemplate()
+
+    /**
+     * Convenience: get a single transition definition by its id.
+     *
+     * @param string $caseTypeId   CaseType UUID
+     * @param string $transitionId Transition id (from the template's transitions[])
+     *
+     * @return array<string, mixed>|null
+     */
+    public function getTransitionById(string $caseTypeId, string $transitionId): ?array
+    {
+        $template = $this->getActiveTemplate(caseTypeId: $caseTypeId);
+        if ($template === null) {
+            return null;
+        }
+        $transitions = $template['transitions'] ?? [];
+        if (is_array($transitions) === false) {
+            return null;
+        }
+        foreach ($transitions as $transition) {
+            if (is_array($transition) === false) {
+                continue;
+            }
+            if ((string) ($transition['id'] ?? '') === $transitionId) {
+                return $transition;
+            }
+        }
+        return null;
+    }//end getTransitionById()
+
+    /**
+     * Clear the per-request cache (call when a template is updated mid-request).
+     *
+     * @return void
+     */
+    public function clearCache(): void
+    {
+        $this->cache = [];
+    }//end clearCache()
+
+    /**
+     * Normalise the result of ObjectService::findObjects() to a list of arrays.
+     *
+     * @param mixed $value Raw result
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function normalise(mixed $value): array
+    {
+        if (is_array($value) === false) {
+            return [];
+        }
+        $list = [];
+        foreach ($value as $item) {
+            if (is_array($item) === true) {
+                $list[] = $item;
+                continue;
+            }
+            if (is_object($item) === true && method_exists($item, 'jsonSerialize') === true) {
+                $serialized = $item->jsonSerialize();
+                if (is_array($serialized) === true) {
+                    $list[] = $serialized;
+                }
+            }
+        }
+        return $list;
+    }//end normalise()
+
+    /**
+     * Decode a JSON-string field on the template in place.
+     *
+     * @param array<string, mixed> $template The template (passed by reference)
+     * @param string               $field    The field name
+     *
+     * @return void
+     */
+    private function decodeJsonField(array &$template, string $field): void
+    {
+        $value = $template[$field] ?? null;
+        if (is_string($value) === true && $value !== '') {
+            $decoded = json_decode($value, true);
+            if (is_array($decoded) === true) {
+                $template[$field] = $decoded;
+            }
+        }
+    }//end decodeJsonField()
+}//end class

--- a/lib/Service/ZgwZrcRulesService.php
+++ b/lib/Service/ZgwZrcRulesService.php
@@ -251,9 +251,18 @@ class ZgwZrcRulesService extends ZgwRulesBase
      * Implements:
      * - zrc-016: Validate that statustype belongs to Zaak.zaaktype.statustypen.
      *
+     * NOTE: From `status-transition-engine` onwards, the actual `case.status`
+     * mutation is owned by `StatusTransitionService`. This method retains
+     * the zrc-016 ZGW request-shape validation only; callers that want a
+     * `statusRecord` written for every status mutation should funnel through
+     * `StatusTransitionService::execute()` or `executeFreeForm()`. The legacy
+     * write path remains for ZGW API contract compatibility.
+     *
      * @param array $body The ZGW request body
      *
      * @return array The validation result
+     *
+     * @spec openspec/changes/status-transition-engine/tasks.md#T13
      *
      * @link https://vng-realisatie.github.io/gemma-zaken/standaard/zaken/
      */

--- a/lib/Settings/procest_register.json
+++ b/lib/Settings/procest_register.json
@@ -920,7 +920,7 @@
       "statusRecord": {
         "slug": "statusRecord",
         "icon": "ProgressClock",
-        "version": "1.0.0",
+        "version": "1.1.0",
         "x-schema-org-type": "schema:Event",
         "x-zgw-equivalent": "Status",
         "title": "Status Record",
@@ -941,11 +941,49 @@
           "statusType": {
             "type": "string",
             "format": "uuid",
-            "description": "Reference to the status type"
+            "description": "Reference to the target status type (toStatus)"
           },
           "description": {
             "type": "string",
-            "description": "Status transition description"
+            "description": "Status transition description / free-form comment"
+          },
+          "transitionLabel": {
+            "type": "string",
+            "description": "Label of the workflowTemplate transition that fired"
+          },
+          "fromStatus": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Reference to the prior status type (absent on first set)"
+          },
+          "evaluatedGuards": {
+            "type": "array",
+            "description": "Snapshot of guards evaluated for this transition",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": { "type": "string" },
+                "passed": { "type": "boolean" },
+                "details": { "type": "object" }
+              }
+            }
+          },
+          "dispatchedActions": {
+            "type": "array",
+            "description": "Snapshot of automatic actions dispatched for this transition",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": { "type": "string" },
+                "ok": { "type": "boolean" },
+                "error": { "type": "string" }
+              }
+            }
+          },
+          "noWorkflowTemplate": {
+            "type": "boolean",
+            "default": false,
+            "description": "True when the transition was admin free-form on a caseType without an active workflowTemplate"
           }
         }
       },

--- a/openspec/changes/status-transition-engine/builds/build.json
+++ b/openspec/changes/status-transition-engine/builds/build.json
@@ -1,0 +1,6 @@
+{
+  "phase": "apply",
+  "timestamp": "2026-05-11T00:00:00+00:00",
+  "scope": "engine + manifest pages",
+  "notes": "Applies status-transition-engine: adds StatusTransitionService engine (PHP), WorkflowTemplateLoader, GuardRegistry with 4 built-in guards (checklist, requiredField, requiredDocument, roleGuard), ActionHandlerRegistry + SideEffectDispatcher with 6 built-in handlers (sendEmail, createTask, createSubCase, webhook, setField, notify), GuardFailedException, REST controller with 4 endpoints, and manifest pages for admin statusRecord browsing/detail. Extends statusRecord schema with transitionLabel, fromStatus, evaluatedGuards, dispatchedActions, noWorkflowTemplate (v1.1.0). Legacy ZgwZrcRulesService::rulesStatussenCreate annotated with engine pointer; full backfill of ZrcController::handleEindstatusEffect deferred to a follow-up to preserve the live ZGW request lifecycle. Strict watchdog (php -l + jq only)."
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -21,6 +21,7 @@
 		{ "id": "ParafeerroutesMenu", "label": "Parafeerroutes", "icon": "icon-category-workflow", "route": "Parafeerroutes", "section": "settings", "order": 96 },
 		{ "id": "WorkflowDefinitionsMenu", "label": "Workflow definitions", "icon": "icon-category-workflow", "route": "WorkflowDefinitions", "section": "settings", "order": 97 },
 		{ "id": "AutomaticActionsMenu", "label": "Automatische acties", "icon": "icon-category-workflow", "route": "AutomaticActions", "section": "settings", "order": 96 },
+		{ "id": "StatusRecordsMenu", "label": "Status history", "icon": "icon-history", "route": "StatusRecords", "section": "settings", "order": 98, "permission": "admin" },
 		{ "id": "SettingsMenu", "label": "Settings", "icon": "icon-settings", "route": "Settings", "section": "settings", "order": 99 }
 	],
 	"pages": [
@@ -535,6 +536,42 @@
 					{ "id": "steps",       "label": "Steps",       "icon": "icon-checkmark","widgets": [{ "type": "data" }],                          "order": 20 },
 					{ "id": "transitions", "label": "Transitions", "icon": "icon-comment",  "widgets": [{ "type": "data" }],                          "order": 30 },
 					{ "id": "audit",       "label": "Audit trail", "icon": "icon-history",  "widgets": [{ "type": "audit-trail" }],                   "order": 90 }
+				]
+			}
+		},
+		{
+			"id": "StatusRecords",
+			"route": "/settings/status-records",
+			"type": "index",
+			"title": "Status history",
+			"config": {
+				"register": "procest",
+				"schema": "statusRecord",
+				"columns": [
+					{ "key": "case" },
+					{ "key": "fromStatus" },
+					{ "key": "statusType", "label": "toStatus" },
+					{ "key": "transitionLabel" },
+					{ "key": "noWorkflowTemplate" },
+					{ "key": "createdAt" }
+				],
+				"actions": ["view"],
+				"sidebar": { "enabled": true, "showMetadata": true }
+			}
+		},
+		{
+			"id": "StatusRecordDetail",
+			"route": "/settings/status-records/:id",
+			"type": "detail",
+			"title": "Status record",
+			"config": {
+				"register": "procest",
+				"schema": "statusRecord",
+				"sidebarTabs": [
+					{ "id": "overview",     "label": "Overview",         "icon": "icon-info",    "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
+					{ "id": "guards",       "label": "Evaluated guards", "icon": "icon-checkmark", "widgets": [{ "type": "data", "config": { "fields": ["evaluatedGuards"] } }], "order": 20 },
+					{ "id": "actions",      "label": "Dispatched actions", "icon": "icon-toggle", "widgets": [{ "type": "data", "config": { "fields": ["dispatchedActions"] } }], "order": 30 },
+					{ "id": "audit",        "label": "Audit trail",      "icon": "icon-history", "widgets": [{ "type": "audit-trail" }],                   "order": 90 }
 				]
 			}
 		}


### PR DESCRIPTION
## Summary

Applies the `status-transition-engine` openspec change in `ConductionNL/procest`.

Introduces the engine that turns `workflowTemplate.transitions[]` into deterministic case state changes — the single write path for `case.status`.

### Engine (PHP services — non-CRUD, manifest-first)
- `StatusTransitionService` — `getAvailableTransitions`, `execute` (with server-side guard re-evaluation per REQ-STE-4-002), `executeFreeForm` (admin-only), `replay`.
- `WorkflowTemplateLoader` — per-request cached active-template lookup.
- `GuardRegistry` + 4 built-in guards (`checklist`, `requiredField`, `requiredDocument`, `roleGuard`); `roleGuard` hides silently via `details.silent`.
- `ActionHandlerRegistry` + `SideEffectDispatcher` + 6 built-in handlers (`sendEmail`, `createTask`, `createSubCase`, `webhook`, `setField`, `notify`); failures logged with static error codes, never roll back the status change (REQ-STE-5-002).
- `GuardFailedException` carries failed-guard snapshots.
- Both registries expose `registerEvaluator` / `registerHandler` extension points so `bezwaar-lifecycle` and `parafeerroute-engine` can plug in via DI (REQ-STE-9).

### REST controller (action-style, not CRUD)
- `GET /api/case/{caseId}/available-transitions`
- `POST /api/case/{caseId}/transition` `{transitionId, comment?}`
- `POST /api/case/{caseId}/transition-freeform` `{toStatusId, comment?}` (admin)
- `GET /api/case/{caseId}/transition-history`
- Static error messages only; controller never returns `$e->getMessage()`.

### Schema + manifest pages (manifest-first)
- `statusRecord` v1.1.0: + `transitionLabel`, `fromStatus`, `evaluatedGuards`, `dispatchedActions`, `noWorkflowTemplate`.
- Manifest pages `StatusRecords` (admin index) + `StatusRecordDetail` (with `Evaluated guards` and `Dispatched actions` tabs). No bespoke statusRecord CRUD controller.

### Backfill posture (T13, partial)
- `ZgwZrcRulesService::rulesStatussenCreate` annotated with engine pointer; zrc-016 validation kept intact.
- Full migration of `ZrcController::handleEindstatusEffect` into a `SetFieldHandler` is deferred to a follow-up to keep the live ZGW request lifecycle untouched in this PR.

### Out of scope
- Frontend `AvailableTransitionsPanel` + `TransitionConfirmDialog` (T18-T20) — admin browsing is via the new manifest pages; case-detail panel will land in a follow-up Vue PR.

## Test plan
- [ ] Validate manifest renders `StatusRecords` admin index after `composer apps:reload`.
- [ ] `GET /api/case/{caseId}/available-transitions` returns guard-evaluated transitions for a case whose `caseType` has an active `workflowTemplate`.
- [ ] `POST /api/case/{caseId}/transition` writes a `statusRecord` with `fromStatus`, `transitionLabel`, `evaluatedGuards`, `dispatchedActions`.
- [ ] Guard re-evaluation returns 409 when a required field is cleared between UI load and request.
- [ ] `POST /api/case/{caseId}/transition-freeform` returns 403 for non-admins; admin transition writes a `statusRecord` with `noWorkflowTemplate: true`.
- [ ] `GET /api/case/{caseId}/transition-history` returns records ordered by `createdAt asc` and does NOT re-fire side-effects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)