### PR TITLE
feat(map-component): apply spec

### DIFF
--- a/builds/build.json
+++ b/builds/build.json
@@ -27,6 +27,29 @@
         "role": ["delegate", "delegateFrom", "delegateUntil"],
         "workflowTemplate": ["routingRule documented inline on steps/transitions JSON description"]
       }
+    },
+    {
+      "change": "map-component",
+      "appliedAt": "2026-05-11",
+      "tasks": ["T01", "T02"],
+      "deferred": [
+        {"task": "D01", "reason": "Deduplication note: existing src/components/map/CaseMap.vue is the legacy direct-Leaflet wrapper used by CaseMapView and CaseMapWidget; MapComponent is the new CnMapWidget-based wrapper. Consumer migration (T03/T04/T05) belongs to case-location, case-map-overview, and public case page specs respectively."},
+        {"task": "D02", "reason": "Order-of-arrival: mapFormatters registry created here as case-map-overview has not yet landed in main; future spec adoption can import from the same module path."},
+        {"task": "T03", "reason": "Case detail map tab integration — tracked by case-location spec, not this manifest-first MapComponent spec."},
+        {"task": "T04", "reason": "Dashboard CaseMapWidget integration — tracked by case-map-overview spec."},
+        {"task": "T05", "reason": "Public case page integration — tracked by public-case-page spec."},
+        {"task": "V01", "reason": "Unit test scope follow-up (strict watchdog: jq + lint only)."},
+        {"task": "V02", "reason": "Case detail integration verification — bound to T03 follow-up."},
+        {"task": "V03", "reason": "Dashboard clustering verification — bound to T04 follow-up."},
+        {"task": "V04", "reason": "Public read-only axe-core verification — bound to T05 follow-up."}
+      ],
+      "components": [
+        "src/components/map/MapComponent.vue"
+      ],
+      "services": [
+        "src/services/mapFormatters.js"
+      ],
+      "customComponents": ["MapComponent"]
     }
   ]
 }

--- a/src/components/map/MapComponent.vue
+++ b/src/components/map/MapComponent.vue
@@ -1,0 +1,248 @@
+<!--
+  - SPDX-License-Identifier: EUPL-1.2
+  - SPDX-FileCopyrightText: 2026 Conduction B.V.
+  -->
+
+<template>
+	<div
+		class="map-component"
+		:class="{ 'map-component--readonly': !interactive }"
+		:role="interactive ? 'application' : 'img'"
+		:aria-label="ariaLabel"
+		:style="containerStyle">
+		<CnMapWidget
+			ref="widget"
+			:locations="resolvedMarkers"
+			:center="center"
+			:zoom="zoom"
+			:tile-layer="tileLayer"
+			:clustering="clustering && interactive"
+			:interactive="interactive"
+			:options="leafletOptions"
+			@marker-click="onMarkerClick"
+			@viewport-change="onViewportChangeRaw"
+			@ready="onReady" />
+	</div>
+</template>
+
+<script>
+import { CnMapWidget } from '@conduction/nextcloud-vue'
+import { resolveFormatter } from '../../services/mapFormatters.js'
+
+/**
+ * Default debounce window for viewport-change emissions. The lib widget
+ * fires `viewport-change` on every `moveend` / `zoomend`; Procest
+ * downstream consumers (case-detail tab cache, dashboard URL sync)
+ * cannot keep up with un-debounced traffic during a long pan.
+ */
+const VIEWPORT_DEBOUNCE_MS = 200
+
+/**
+ * Procest-side wrapper around `CnMapWidget` from `@conduction/nextcloud-vue`.
+ *
+ * One wrapper, three surfaces — case detail map tab, dashboard map
+ * widget, public case page. The wrapper exists to:
+ *
+ *  1. Pin Procest defaults (PDOK BRT tiles, NL centre, case formatter).
+ *  2. Switch ARIA role + Leaflet interaction flags via `interactive` prop.
+ *  3. Resolve `markerFormatter` by name from the `mapFormatters` registry,
+ *     so manifest pages can configure formatters declaratively.
+ *
+ * The component is stateless w.r.t. data: parents own `locations[]` and
+ * listen for `marker-click` / `viewport-change`. Internal state is
+ * limited to the debounce timer.
+ */
+export default {
+	name: 'MapComponent',
+	components: { CnMapWidget },
+	props: {
+		/**
+		 * Geometry-bearing input objects. Each must carry a GeoJSON
+		 * `geometry` field (Point or Polygon). The formatter handles
+		 * polygon-to-centroid reduction.
+		 */
+		locations: {
+			type: Array,
+			default: () => [],
+		},
+		/**
+		 * Initial map centre. Defaults to the Netherlands geographic
+		 * centre so empty maps render in a sensible viewport.
+		 */
+		center: {
+			type: Object,
+			default: () => ({ lat: 52.1326, lon: 5.2913 }),
+		},
+		/** Initial zoom level. */
+		zoom: {
+			type: Number,
+			default: 7,
+		},
+		/**
+		 * When `false`, disables pan/zoom/keyboard and hides zoom
+		 * controls (public read-only mode). Container role switches
+		 * from `application` to `img`.
+		 */
+		interactive: {
+			type: Boolean,
+			default: true,
+		},
+		/**
+		 * Name of a formatter registered in `src/services/mapFormatters.js`.
+		 * Unknown names fall back to `caseMarkerFormatter`.
+		 */
+		markerFormatter: {
+			type: String,
+			default: 'caseMarkerFormatter',
+		},
+		/** Tile layer key resolved inside `CnMapWidget`. */
+		tileLayer: {
+			type: String,
+			default: 'pdok-brt',
+		},
+		/** Enable marker clustering (auto-disabled in read-only mode). */
+		clustering: {
+			type: Boolean,
+			default: true,
+		},
+		/** CSS height for the container; parent typically overrides. */
+		height: {
+			type: String,
+			default: '400px',
+		},
+	},
+	emits: ['marker-click', 'viewport-change', 'ready'],
+	data() {
+		return {
+			viewportDebounceTimer: null,
+		}
+	},
+	computed: {
+		/**
+		 * The resolved formatter function. `markerFormatter` is a
+		 * string so manifest entries can configure it declaratively.
+		 */
+		formatterFn() {
+			return resolveFormatter(this.markerFormatter)
+		},
+		/**
+		 * Pre-format markers up-front so the lib widget receives a
+		 * plain array of marker descriptors plus a reference back to
+		 * the original location for event payloads.
+		 */
+		resolvedMarkers() {
+			const out = []
+			for (const location of this.locations) {
+				const marker = this.formatterFn(location)
+				if (marker) {
+					out.push({ ...marker, __sourceLocation: location })
+				}
+			}
+			return out
+		},
+		ariaLabel() {
+			// Inline fallback strings — `t()` returns the English
+			// source when no l10n bundle is loaded, which is the
+			// repo's standard pattern.
+			return this.interactive
+				? this.t('procest', 'Map with case locations')
+				: this.t('procest', 'Map with case locations (read-only)')
+		},
+		containerStyle() {
+			return { height: this.height }
+		},
+		/**
+		 * Leaflet options forwarded to the lib widget. Read-only mode
+		 * disables every interaction primitive; interactive mode lets
+		 * Leaflet's defaults apply.
+		 */
+		leafletOptions() {
+			if (this.interactive) {
+				return {
+					dragging: true,
+					scrollWheelZoom: true,
+					doubleClickZoom: true,
+					boxZoom: true,
+					keyboard: true,
+					zoomControl: true,
+				}
+			}
+			return {
+				dragging: false,
+				scrollWheelZoom: false,
+				doubleClickZoom: false,
+				boxZoom: false,
+				keyboard: false,
+				zoomControl: false,
+			}
+		},
+	},
+	beforeDestroy() {
+		if (this.viewportDebounceTimer) {
+			clearTimeout(this.viewportDebounceTimer)
+			this.viewportDebounceTimer = null
+		}
+	},
+	methods: {
+		/**
+		 * Re-emit the lib widget's marker-click with the original
+		 * location object the parent passed in. The `__sourceLocation`
+		 * stamp on each formatted marker preserves referential
+		 * equality so parents can compare by identity.
+		 *
+		 * @param {object} marker The formatted marker descriptor.
+		 */
+		onMarkerClick(marker) {
+			const location = marker && marker.__sourceLocation
+				? marker.__sourceLocation
+				: null
+			this.$emit('marker-click', { marker, location })
+		},
+		/**
+		 * Debounce viewport changes to {@link VIEWPORT_DEBOUNCE_MS}.
+		 * The lib widget can fire many `viewport-change` events
+		 * during a single pan; consumers (case-detail tab cache,
+		 * dashboard URL sync) only need the final value.
+		 *
+		 * @param {object} payload `{ center, zoom, bbox }` from the lib.
+		 */
+		onViewportChangeRaw(payload) {
+			if (this.viewportDebounceTimer) {
+				clearTimeout(this.viewportDebounceTimer)
+			}
+			this.viewportDebounceTimer = setTimeout(() => {
+				this.$emit('viewport-change', payload)
+				this.viewportDebounceTimer = null
+			}, VIEWPORT_DEBOUNCE_MS)
+		},
+		/**
+		 * Surface the Leaflet `L.Map` instance for advanced parents.
+		 * This is an escape hatch — most consumers shouldn't need it.
+		 *
+		 * @param {object} payload `{ map }` from the lib.
+		 */
+		onReady(payload) {
+			this.$emit('ready', payload)
+		},
+	},
+}
+</script>
+
+<style scoped>
+.map-component {
+	position: relative;
+	width: 100%;
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius-large, 8px);
+	overflow: hidden;
+}
+
+.map-component:focus-within {
+	outline: 2px solid var(--color-primary-element);
+	outline-offset: 2px;
+}
+
+.map-component--readonly {
+	cursor: default;
+}
+</style>

--- a/src/customComponents.js
+++ b/src/customComponents.js
@@ -41,6 +41,11 @@ import CaseDocumentsTab from './components/tabs/CaseDocumentsTab.vue'
 // openspec/changes/visual-workflow-editor/design.md.
 import VisualWorkflowEditor from './components/workflow/VisualWorkflowEditor.vue'
 
+// --- Shared map surface (case detail map tab, dashboard widget, public case page). ---
+// Thin wrapper around CnMapWidget; registered here so manifest entries
+// MAY reference it by string name. See openspec/changes/map-component/.
+import MapComponent from './components/map/MapComponent.vue'
+
 export default {
 	// --- Genuine exceptions: no abstract analogue. ---
 	MyWorkView, // bespoke 4-tab filter UI mixing case + task entities
@@ -67,4 +72,7 @@ export default {
 
 	// --- Visual workflow editor (drag-and-drop, no manifest analogue). ---
 	VisualWorkflowEditor,
+
+	// --- Shared map surface — referenceable from manifest pages. ---
+	MapComponent,
 }

--- a/src/services/mapFormatters.js
+++ b/src/services/mapFormatters.js
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+//
+// Map-formatter registry — shared by every Procest surface that renders
+// the `MapComponent` wrapper around `CnMapWidget`. A formatter takes an
+// input "location" object (case, address, generic geometry-bearing
+// record) and returns a marker descriptor consumable by the lib widget:
+//
+//   {
+//     lat:    Number,
+//     lon:    Number,
+//     color:  String,  // CSS variable token or inherited token
+//     icon:   String,  // material-design-icons name
+//     popup:  { title: String, body?: String },
+//     onClick: Function (optional),
+//   }
+//
+// Polygons are reduced to their arithmetic-mean centroid here so the
+// MapComponent wrapper never has to know about geometry types.
+//
+// Resolution: `MapComponent` reads the registry via the `markerFormatter`
+// prop (a name, not a function reference) so manifest-driven pages can
+// configure formatters by string. The default formatter
+// `caseMarkerFormatter` is appropriate for the bulk of Procest surfaces
+// that show case-shaped objects.
+
+/**
+ * Compute the arithmetic-mean centroid of a polygon ring.
+ *
+ * @param {Array<Array<number>>} ring GeoJSON ring — array of [lon, lat] pairs.
+ * @return {{lat: number, lon: number}|null} Centroid or null when ring is empty.
+ */
+function polygonCentroid(ring) {
+	if (!Array.isArray(ring) || ring.length === 0) {
+		return null
+	}
+	let lonSum = 0
+	let latSum = 0
+	for (const [lon, lat] of ring) {
+		lonSum += lon
+		latSum += lat
+	}
+	return {
+		lon: lonSum / ring.length,
+		lat: latSum / ring.length,
+	}
+}
+
+/**
+ * Extract a {lat, lon} centroid from a GeoJSON geometry. Points return
+ * their own coordinates; polygons reduce to the centroid of their
+ * outer ring; everything else returns null (caller should skip).
+ *
+ * @param {object|null} geometry GeoJSON geometry object.
+ * @return {{lat: number, lon: number}|null}
+ */
+export function geometryCentroid(geometry) {
+	if (!geometry || !geometry.type) {
+		return null
+	}
+	if (geometry.type === 'Point' && Array.isArray(geometry.coordinates)) {
+		const [lon, lat] = geometry.coordinates
+		return { lat, lon }
+	}
+	if (geometry.type === 'Polygon' && Array.isArray(geometry.coordinates) && geometry.coordinates[0]) {
+		return polygonCentroid(geometry.coordinates[0])
+	}
+	return null
+}
+
+/**
+ * Default Procest formatter — turns a case-shaped object into a marker.
+ *
+ * Status-driven palette uses NL Design System tokens (the colour is
+ * resolved by the lib widget against CSS variables; we just name the
+ * token here so changes propagate from the theme, not from a hex).
+ *
+ * @param {object} location Case-shaped object with `geometry` and `status` fields.
+ * @return {object|null} Marker descriptor or null when geometry missing.
+ */
+export function caseMarkerFormatter(location) {
+	if (!location) {
+		return null
+	}
+	const centroid = geometryCentroid(location.geometry)
+	if (!centroid) {
+		return null
+	}
+	const status = (location.status || '').toLowerCase()
+	let color = 'var(--color-primary-element)'
+	if (status === 'closed' || status === 'archived' || status === 'gesloten') {
+		color = 'var(--color-success)'
+	} else if (status === 'overdue' || status === 'verlopen') {
+		color = 'var(--color-error)'
+	} else if (status === 'pending' || status === 'in_progress' || status === 'in_behandeling') {
+		color = 'var(--color-warning)'
+	}
+	return {
+		lat: centroid.lat,
+		lon: centroid.lon,
+		color,
+		icon: 'map-marker',
+		popup: {
+			title: location.title || location.name || location.id || '',
+			body: location.summary || location.description || '',
+		},
+	}
+}
+
+/**
+ * Generic location formatter — minimal, no status-driven palette.
+ * Useful for address-style records that don't carry case status.
+ *
+ * @param {object} location Object with `geometry` and free-form `label`.
+ * @return {object|null}
+ */
+export function locationMarkerFormatter(location) {
+	if (!location) {
+		return null
+	}
+	const centroid = geometryCentroid(location.geometry)
+	if (!centroid) {
+		return null
+	}
+	return {
+		lat: centroid.lat,
+		lon: centroid.lon,
+		color: 'var(--color-primary-element)',
+		icon: 'map-marker',
+		popup: {
+			title: location.label || location.title || '',
+			body: location.body || '',
+		},
+	}
+}
+
+/**
+ * Registry of named formatters. Keys are referenced by string from the
+ * `MapComponent.markerFormatter` prop and from manifest entries.
+ */
+const mapFormatters = {
+	caseMarkerFormatter,
+	locationMarkerFormatter,
+}
+
+/**
+ * Resolve a formatter by name, falling back to `caseMarkerFormatter`
+ * when the name is unknown. Returning a default rather than throwing
+ * keeps the map rendering — bad-name bugs surface as misformatted pins
+ * rather than blank screens.
+ *
+ * @param {string} name Registry key.
+ * @return {Function} Formatter function.
+ */
+export function resolveFormatter(name) {
+	return mapFormatters[name] || mapFormatters.caseMarkerFormatter
+}
+
+export default mapFormatters


### PR DESCRIPTION
## Summary

Manifest-first slice of `openspec/changes/map-component` (T01, T02):

- Adds `src/components/map/MapComponent.vue` — thin Vue 2 wrapper around `CnMapWidget` from `@conduction/nextcloud-vue`. Props: `locations[]`, `center`, `zoom`, `interactive`, `markerFormatter` (string, registry lookup), `tileLayer`, `clustering`, `height`. Events: `marker-click`, `viewport-change` (debounced 200 ms), `ready`. Read-only mode (`:interactive="false"`) switches container role to `img` and disables every Leaflet interaction primitive.
- Adds `src/services/mapFormatters.js` — formatter registry with `caseMarkerFormatter` (status-driven NL Design palette via CSS variables) and `locationMarkerFormatter`; polygons reduced to arithmetic-mean centroid markers (geometry types other than Point/Polygon are skipped).
- Registers `MapComponent` in `src/customComponents.js` so manifest pages MAY mount it by string name.
- Records the change in `builds/build.json` with the consumer migrations (T03-T05) deferred to their owning specs (`case-location`, `case-map-overview`, public case page).

No PHP. No new routes. No manifest pages. No i18n bundle changes (per strict-watchdog scope).

## Test plan

- [ ] Visual smoke: mount the component with one Point geometry and confirm one pin renders.
- [ ] Read-only smoke: re-mount with `:interactive="false"` and confirm container `role="img"` and zoom controls hidden.
- [ ] Registry lookup: confirm `customComponents.MapComponent` resolves at runtime.
- [ ] Note: lib `CnMapWidget` requires `@conduction/nextcloud-vue` >= beta.30; current procest dependency is beta.29 — runtime smoke depends on the lib bump landing.