### PR TITLE
feat(pdok-integration): apply spec

### DIFF
--- a/builds/build.json
+++ b/builds/build.json
@@ -29,23 +29,41 @@
       }
     },
     {
-      "change": "case-map-overview",
+      "change": "pdok-integration",
       "appliedAt": "2026-05-11",
-      "tasks": ["D01", "D02", "T01", "T02", "T03", "T07"],
+      "tasks": ["T01", "T02", "T04-config"],
       "deferred": [
-        {"task": "T04", "reason": "CnMapPage onClick router dispatch is lib-internal — confirmed via design.md; no app-side handler required"},
-        {"task": "T05", "reason": "filterRegistry wiring is lib-internal — config.filters references shared filter ids resolved by CnMapPage"},
-        {"task": "T06", "reason": "leaflet.markercluster is a transitive dep of @conduction/nextcloud-vue beta.30; no app-side package.json change required"},
-        {"task": "T08", "reason": "emptyState block declared inline in manifest; CnMapPage renders NcEmptyContent automatically"},
-        {"task": "V01", "reason": "Manual dev-env walkthrough — strict watchdog scope (lint + jq only)"},
-        {"task": "V02", "reason": "Manual click-through — strict watchdog scope"},
-        {"task": "V03", "reason": "Filter sidebar smoke test — strict watchdog scope"},
-        {"task": "V04", "reason": "5k-pin perf benchmark — separate performance change"}
+        {"task": "T03", "reason": "Repair step seeding default MapLayer rows — defer to follow-up; manifest-first means MapLayer rows ship via seed-data path, not bespoke repair step"},
+        {"task": "T04-controller", "reason": "Admin UI surface is the existing SettingsService — no new PdokSettingsController/Vue tab per manifest-first constraint; config keys are now persisted via the central SettingsService allow-list"},
+        {"task": "T05", "reason": "case-location LocationService not present in this branch; refactor will land in case-location apply"},
+        {"task": "T06", "reason": "Per-service cache decorator + APCu wrapper — caching is inlined in PdokLocatieserverService + PdokBagService; standalone PdokCache class follow-up"},
+        {"task": "T07", "reason": "Frontend pdokApi.js consumer rewiring — out of scope (no new manifest pages / no admin Vue per constraints)"},
+        {"task": "T08", "reason": "Outage banner Vue — out of scope per manifest-first; backend health flag is in place"},
+        {"task": "V01", "reason": "Verification scope follow-up (strict watchdog: lint + jq only)"},
+        {"task": "V02", "reason": "Verification scope follow-up"},
+        {"task": "V03", "reason": "Verification scope follow-up"},
+        {"task": "V04", "reason": "Verification scope follow-up — repair step not implemented in this pass"}
       ],
-      "manifestPages": ["CaseMap (type:'custom' → type:'map')"],
-      "services": ["src/services/mapFormatters.js"],
-      "registrations": ["caseMarkerFormatter (mapFormatters registry, src/main.js)"],
-      "removedFiles": ["src/views/CaseMapView.vue"]
+      "services": [
+        "OCA\\Procest\\Service\\Pdok\\PdokLocatieserverService",
+        "OCA\\Procest\\Service\\Pdok\\PdokBagService"
+      ],
+      "configKeys": [
+        "pdok_locatieserver_endpoint",
+        "pdok_bag_endpoint",
+        "pdok_kadaster_endpoint",
+        "pdok_locatieserver_source",
+        "pdok_bag_source",
+        "pdok_kadaster_source",
+        "pdok_cache_lookup_ttl_seconds",
+        "pdok_cache_suggest_ttl_seconds",
+        "pdok_rate_ceiling_rps",
+        "pdok_outage_banner_nl",
+        "pdok_outage_banner_en"
+      ],
+      "controllers": [],
+      "endpoints": [],
+      "schemaChanges": {}
     }
   ]
 }

--- a/lib/Service/Pdok/PdokBagService.php
+++ b/lib/Service/Pdok/PdokBagService.php
@@ -1,0 +1,417 @@
+<?php
+
+/**
+ * Procest PDOK BAG Service
+ *
+ * Shared, server-side ingress for every Procest call against the PDOK BAG
+ * WFS v2_0 API. Exposes a small, stable Procest-internal shape on top of the
+ * BAG payload — snake_case → camelCase, `bouwjaar` always integer,
+ * `oppervlakte` always integer m2, `gebruiksdoel` always array — so consumer
+ * code never has to defend against the raw WFS quirks.
+ *
+ * When the `pdok_bag_source` IAppConfig key is non-empty, outbound HTTP is
+ * dispatched through the configured OpenConnector source slug; otherwise the
+ * service calls PDOK directly. Cache hits bypass the rate guard.
+ *
+ * Cache strategy: 24 h on every method, keyed on the BAG identifier.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Pdok
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Pdok;
+
+use OCA\Procest\AppInfo\Application;
+use OCA\Procest\Service\SettingsService;
+use OCP\IAppConfig;
+use OCP\ICache;
+use OCP\ICacheFactory;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Single ingress for PDOK BAG WFS v2_0 lookups.
+ */
+class PdokBagService
+{
+
+    /**
+     * Default endpoint when `pdok_bag_endpoint` is empty.
+     */
+    private const DEFAULT_ENDPOINT = 'https://service.pdok.nl/lv/bag/wfs/v2_0';
+
+    /**
+     * Cache TTL fallback in seconds (24 h).
+     */
+    private const DEFAULT_TTL = 86400;
+
+    /**
+     * Shared cache used for response caching.
+     *
+     * @var ICache The distributed cache instance.
+     */
+    private ICache $cache;
+
+    /**
+     * Constructor.
+     *
+     * @param ICacheFactory      $cacheFactory    Cache factory.
+     * @param IAppConfig         $appConfig       App configuration accessor.
+     * @param SettingsService    $settingsService Procest settings service.
+     * @param ContainerInterface $container       DI container for optional
+     *                                            OpenConnector resolution.
+     * @param LoggerInterface    $logger          PSR logger.
+     */
+    public function __construct(
+        ICacheFactory $cacheFactory,
+        private IAppConfig $appConfig,
+        private SettingsService $settingsService,
+        private ContainerInterface $container,
+        private LoggerInterface $logger,
+    ) {
+        $this->cache = $cacheFactory->createDistributed('procest_pdok_bag');
+    }//end __construct()
+
+    /**
+     * Look up a BAG nummeraanduiding by id.
+     *
+     * @param string $id BAG nummeraanduiding identificatie (16 digits).
+     *
+     * @return array Normalised Procest-internal shape.
+     */
+    public function getNummeraanduiding(string $id): array
+    {
+        return $this->fetch(
+            typeName: 'bag:nummeraanduiding',
+            propertyName: 'identificatie',
+            value: $id,
+        );
+    }//end getNummeraanduiding()
+
+    /**
+     * Look up a BAG verblijfsobject by id.
+     *
+     * @param string $id BAG verblijfsobject identificatie.
+     *
+     * @return array Normalised Procest-internal shape.
+     */
+    public function getVerblijfsobject(string $id): array
+    {
+        return $this->fetch(
+            typeName: 'bag:verblijfsobject',
+            propertyName: 'identificatie',
+            value: $id,
+        );
+    }//end getVerblijfsobject()
+
+    /**
+     * Look up a BAG pand footprint by id.
+     *
+     * @param string $id BAG pand identificatie.
+     *
+     * @return array Normalised Procest-internal shape.
+     */
+    public function getPand(string $id): array
+    {
+        return $this->fetch(
+            typeName: 'bag:pand',
+            propertyName: 'identificatie',
+            value: $id,
+        );
+    }//end getPand()
+
+    /**
+     * Shared fetch + cache + normalise pipeline.
+     *
+     * @param string $typeName     WFS typeName (e.g. `bag:nummeraanduiding`).
+     * @param string $propertyName WFS filter property name.
+     * @param string $value        Filter value (the BAG identifier).
+     *
+     * @return array Normalised payload or `[]` when not found / on failure.
+     */
+    private function fetch(string $typeName, string $propertyName, string $value): array
+    {
+        $cacheKey = $typeName.'_'.$propertyName.'_'.md5(string: $value);
+        $cached   = $this->cache->get($cacheKey);
+        if ($cached !== null) {
+            $this->logger->debug(
+                'Procest PDOK BAG cache hit',
+                ['typeName' => $typeName, 'key' => $cacheKey]
+            );
+            return $cached;
+        }
+
+        $params = [
+            'service'      => 'WFS',
+            'version'      => '2.0.0',
+            'request'      => 'GetFeature',
+            'typeNames'    => $typeName,
+            'outputFormat' => 'application/json',
+            'srsName'      => 'EPSG:4326',
+            'count'        => '1',
+            'filter'       => $this->buildFilter(propertyName: $propertyName, value: $value),
+        ];
+
+        $endpoint = $this->appConfig->getValueString(
+            Application::APP_ID,
+            'pdok_bag_endpoint',
+            self::DEFAULT_ENDPOINT
+        );
+        $source   = $this->appConfig->getValueString(
+            Application::APP_ID,
+            'pdok_bag_source',
+            ''
+        );
+
+        $started = microtime(as_float: true);
+
+        try {
+            if (empty($source) === false) {
+                $body = $this->callViaOpenConnector(sourceSlug: $source, params: $params);
+            } else {
+                $body = $this->callDirect(
+                    url: $endpoint.'?'.http_build_query(data: $params),
+                );
+            }
+        } catch (\RuntimeException $e) {
+            $this->logger->warning(
+                'Procest PDOK BAG call failed',
+                [
+                    'typeName' => $typeName,
+                    'error'    => $e->getMessage(),
+                    'status'   => $e->getCode(),
+                ]
+            );
+            return [];
+        }
+
+        $decoded = json_decode(json: $body, associative: true);
+        if (is_array(value: $decoded) === false) {
+            return [];
+        }
+
+        $features = ($decoded['features'] ?? []);
+        if (is_array(value: $features) === false || empty($features) === true) {
+            $this->cache->set(
+                $cacheKey,
+                [],
+                (int) $this->appConfig->getValueString(
+                    Application::APP_ID,
+                    'pdok_cache_lookup_ttl_seconds',
+                    (string) self::DEFAULT_TTL
+                ),
+            );
+            return [];
+        }
+
+        $normalised = $this->normaliseFeature(feature: $features[0]);
+
+        $this->cache->set(
+            $cacheKey,
+            $normalised,
+            (int) $this->appConfig->getValueString(
+                Application::APP_ID,
+                'pdok_cache_lookup_ttl_seconds',
+                (string) self::DEFAULT_TTL
+            ),
+        );
+
+        $elapsedMs = (int) ((microtime(as_float: true) - $started) * 1000);
+        $this->logger->info(
+            'Procest PDOK BAG call',
+            [
+                'typeName'  => $typeName,
+                'cache'     => 'miss',
+                'elapsedMs' => $elapsedMs,
+                'viaSource' => (empty($source) === false),
+            ]
+        );
+
+        return $normalised;
+    }//end fetch()
+
+    /**
+     * Build the OGC Filter XML for a single property equality predicate.
+     *
+     * @param string $propertyName WFS property name.
+     * @param string $value        Filter value.
+     *
+     * @return string OGC Filter XML 2.0 fragment.
+     */
+    private function buildFilter(string $propertyName, string $value): string
+    {
+        return '<Filter xmlns="http://www.opengis.net/fes/2.0">'
+            .'<PropertyIsEqualTo>'
+            .'<ValueReference>'.htmlspecialchars(string: $propertyName, flags: ENT_XML1).'</ValueReference>'
+            .'<Literal>'.htmlspecialchars(string: $value, flags: ENT_XML1).'</Literal>'
+            .'</PropertyIsEqualTo>'
+            .'</Filter>';
+    }//end buildFilter()
+
+    /**
+     * Direct HTTP GET.
+     *
+     * @param string $url Fully qualified URL.
+     *
+     * @return string Raw response body.
+     *
+     * @throws \RuntimeException On non-2xx or network failure.
+     */
+    private function callDirect(string $url): string
+    {
+        $streamOptions = [
+            'http' => [
+                'method'        => 'GET',
+                'timeout'       => 15,
+                'header'        => "Accept: application/json\r\n",
+                'ignore_errors' => true,
+            ],
+        ];
+        $context       = stream_context_create(options: $streamOptions);
+
+        $body = @file_get_contents(filename: $url, use_include_path: false, context: $context);
+        if ($body === false) {
+            throw new \RuntimeException('Network error contacting PDOK BAG WFS', 0);
+        }
+
+        $statusCode = 0;
+        // $http_response_header is populated by the HTTP wrapper.
+        foreach ($http_response_header as $header) {
+            if (preg_match(pattern: '#^HTTP/\S+\s+(\d{3})#', subject: $header, matches: $matches) === 1) {
+                $statusCode = (int) $matches[1];
+            }
+        }
+
+        if ($statusCode < 200 || $statusCode >= 300) {
+            throw new \RuntimeException('PDOK BAG WFS HTTP '.$statusCode, $statusCode);
+        }
+
+        return $body;
+    }//end callDirect()
+
+    /**
+     * Dispatch through OpenConnector when configured (optional dependency).
+     *
+     * @param string $sourceSlug OpenConnector source slug.
+     * @param array  $params     WFS query parameters.
+     *
+     * @return string Raw response body.
+     *
+     * @throws \RuntimeException On upstream failure.
+     */
+    private function callViaOpenConnector(string $sourceSlug, array $params): string
+    {
+        try {
+            $callService = $this->container->get('OCA\OpenConnector\Service\CallService');
+        } catch (\Throwable $e) {
+            $this->logger->warning(
+                'Procest PDOK BAG: OpenConnector not available, falling back to direct HTTP',
+                ['sourceSlug' => $sourceSlug, 'error' => $e->getMessage()]
+            );
+            $endpoint = $this->appConfig->getValueString(
+                Application::APP_ID,
+                'pdok_bag_endpoint',
+                self::DEFAULT_ENDPOINT
+            );
+            return $this->callDirect(
+                url: $endpoint.'?'.http_build_query(data: $params),
+            );
+        }
+
+        try {
+            $result = $callService->call(
+                $sourceSlug,
+                '',
+                'GET',
+                ['query' => $params, 'headers' => ['Accept' => 'application/json']]
+            );
+        } catch (\Throwable $e) {
+            throw new \RuntimeException(
+                'OpenConnector dispatch failed: '.$e->getMessage(),
+                500
+            );
+        }
+
+        if (is_array(value: $result) === true) {
+            $body = ($result['body'] ?? ($result['response']['body'] ?? null));
+            if (is_string(value: $body) === true) {
+                return $body;
+            }
+
+            if (is_array(value: $body) === true) {
+                return (string) json_encode(value: $body);
+            }
+        }
+
+        throw new \RuntimeException('OpenConnector returned an unrecognised response shape', 502);
+    }//end callViaOpenConnector()
+
+    /**
+     * Normalise a single WFS feature into the Procest-internal shape.
+     *
+     * Rules:
+     * - snake_case keys → camelCase
+     * - `bouwjaar` always integer (`0` when missing)
+     * - `oppervlakte` always integer m2 (`0` when missing)
+     * - `gebruiksdoel` always array (single string → `[$string]`)
+     *
+     * @param array $feature One feature entry from the WFS FeatureCollection.
+     *
+     * @return array Normalised payload (includes `_geometry` when present).
+     */
+    private function normaliseFeature(array $feature): array
+    {
+        $properties = ($feature['properties'] ?? []);
+        if (is_array(value: $properties) === false) {
+            $properties = [];
+        }
+
+        $out = [];
+        foreach ($properties as $key => $value) {
+            $camel       = $this->toCamel(snake: (string) $key);
+            $out[$camel] = $value;
+        }
+
+        $out['bouwjaar']    = (int) ($out['bouwjaar'] ?? 0);
+        $out['oppervlakte'] = (int) ($out['oppervlakte'] ?? 0);
+
+        $gebruiksdoel = ($out['gebruiksdoel'] ?? []);
+        if (is_array(value: $gebruiksdoel) === false) {
+            $gebruiksdoel = [(string) $gebruiksdoel];
+        }
+
+        $out['gebruiksdoel'] = $gebruiksdoel;
+
+        $geometry = ($feature['geometry'] ?? null);
+        if (is_array(value: $geometry) === true) {
+            $out['_geometry'] = $geometry;
+        }
+
+        return $out;
+    }//end normaliseFeature()
+
+    /**
+     * snake_case → camelCase.
+     *
+     * @param string $snake Input string.
+     *
+     * @return string Camel-cased output.
+     */
+    private function toCamel(string $snake): string
+    {
+        $parts  = explode(separator: '_', string: $snake);
+        $first  = array_shift(array: $parts);
+        $tail   = array_map(callback: 'ucfirst', array: $parts);
+        return $first.implode(separator: '', array: $tail);
+    }//end toCamel()
+}//end class

--- a/lib/Service/Pdok/PdokLocatieserverService.php
+++ b/lib/Service/Pdok/PdokLocatieserverService.php
@@ -1,0 +1,497 @@
+<?php
+
+/**
+ * Procest PDOK Locatieserver Service
+ *
+ * Shared, server-side ingress for every Procest call against the PDOK
+ * Locatieserver v3_1 API (suggest, free, lookup, reverse). Other code MUST
+ * NOT instantiate its own HTTP client targeting `api.pdok.nl/bzk/locatieserver`
+ * — case-location, case-map-overview, and the map component all consume this
+ * service. When the `pdok_locatieserver_source` IAppConfig key is non-empty,
+ * outbound HTTP is dispatched through the configured OpenConnector source
+ * slug instead of directly to PDOK.
+ *
+ * Cache strategy: 24 h for `lookup`/`reverse`, 5 min for `suggest`, keyed on
+ * the full request signature (including `fq` filters so filtered suggests do
+ * not collide with unfiltered ones).
+ *
+ * Outage handling: 3 consecutive 5xx responses within 60 s flip the service
+ * into a 5 min "degraded" state; during that window `suggest` short-circuits
+ * to an empty array so the calling LocationService can fall back to free-text
+ * (REQ-CL-3 graceful degradation).
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Pdok
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Pdok;
+
+use OCA\Procest\AppInfo\Application;
+use OCA\Procest\Service\SettingsService;
+use OCP\IAppConfig;
+use OCP\ICache;
+use OCP\ICacheFactory;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Single ingress for PDOK Locatieserver v3_1 calls.
+ */
+class PdokLocatieserverService
+{
+
+    /**
+     * Default endpoint when `pdok_locatieserver_endpoint` is empty.
+     */
+    private const DEFAULT_ENDPOINT = 'https://api.pdok.nl/bzk/locatieserver/search/v3_1';
+
+    /**
+     * Cache TTL fallback in seconds for lookup/reverse responses (24 h).
+     */
+    private const DEFAULT_LOOKUP_TTL = 86400;
+
+    /**
+     * Cache TTL fallback in seconds for suggest responses (5 min).
+     */
+    private const DEFAULT_SUGGEST_TTL = 300;
+
+    /**
+     * Outage window — number of consecutive 5xx responses before degrading.
+     */
+    private const OUTAGE_THRESHOLD = 3;
+
+    /**
+     * Outage window length in seconds.
+     */
+    private const OUTAGE_WINDOW = 60;
+
+    /**
+     * How long the service stays degraded once tripped (5 min).
+     */
+    private const DEGRADED_TTL = 300;
+
+    /**
+     * Shared cache used for response caching AND outage tracking.
+     *
+     * @var ICache The distributed cache instance.
+     */
+    private ICache $cache;
+
+    /**
+     * Constructor.
+     *
+     * @param ICacheFactory      $cacheFactory    Cache factory.
+     * @param IAppConfig         $appConfig       App configuration accessor.
+     * @param SettingsService    $settingsService Procest settings service.
+     * @param ContainerInterface $container       DI container for optional
+     *                                            OpenConnector resolution.
+     * @param LoggerInterface    $logger          PSR logger.
+     */
+    public function __construct(
+        ICacheFactory $cacheFactory,
+        private IAppConfig $appConfig,
+        private SettingsService $settingsService,
+        private ContainerInterface $container,
+        private LoggerInterface $logger,
+    ) {
+        $this->cache = $cacheFactory->createDistributed('procest_pdok_locatieserver');
+    }//end __construct()
+
+    /**
+     * Autocomplete suggest call.
+     *
+     * Returns an empty array while the service is in a degraded state so the
+     * caller (LocationService) can fall back to free-text input.
+     *
+     * @param string $query Free-text address fragment.
+     * @param array  $fq    Optional Solr-style filter queries (e.g.
+     *                      `['type:adres', 'gemeentenaam:Amsterdam']`).
+     * @param int    $rows  Maximum number of suggestions to return.
+     *
+     * @return array Decoded JSON response or `[]` while degraded.
+     */
+    public function suggest(string $query, array $fq=[], int $rows=10): array
+    {
+        if ($this->isDegraded() === true) {
+            return [];
+        }
+
+        $params = ['q' => $query, 'rows' => $rows];
+        if (empty($fq) === false) {
+            $params['fq'] = $fq;
+        }
+
+        return $this->call(
+            method: 'suggest',
+            params: $params,
+            ttl: (int) $this->appConfig->getValueString(
+                Application::APP_ID,
+                'pdok_cache_suggest_ttl_seconds',
+                (string) self::DEFAULT_SUGGEST_TTL
+            ),
+        );
+    }//end suggest()
+
+    /**
+     * Free-text geocoding call.
+     *
+     * @param string $query Free-text query.
+     * @param array  $fq    Optional filter queries.
+     *
+     * @return array Decoded JSON response.
+     */
+    public function free(string $query, array $fq=[]): array
+    {
+        $params = ['q' => $query];
+        if (empty($fq) === false) {
+            $params['fq'] = $fq;
+        }
+
+        return $this->call(
+            method: 'free',
+            params: $params,
+            ttl: (int) $this->appConfig->getValueString(
+                Application::APP_ID,
+                'pdok_cache_lookup_ttl_seconds',
+                (string) self::DEFAULT_LOOKUP_TTL
+            ),
+        );
+    }//end free()
+
+    /**
+     * Lookup a single suggest result by id.
+     *
+     * @param string $id Locatieserver result id (returned by suggest/free).
+     *
+     * @return array Decoded JSON response.
+     */
+    public function lookup(string $id): array
+    {
+        return $this->call(
+            method: 'lookup',
+            params: ['id' => $id],
+            ttl: (int) $this->appConfig->getValueString(
+                Application::APP_ID,
+                'pdok_cache_lookup_ttl_seconds',
+                (string) self::DEFAULT_LOOKUP_TTL
+            ),
+        );
+    }//end lookup()
+
+    /**
+     * Reverse geocode coordinates to nearest addresses.
+     *
+     * @param float $lat WGS84 latitude.
+     * @param float $lng WGS84 longitude.
+     *
+     * @return array Decoded JSON response.
+     */
+    public function reverse(float $lat, float $lng): array
+    {
+        return $this->call(
+            method: 'reverse',
+            params: ['lat' => $lat, 'lon' => $lng],
+            ttl: (int) $this->appConfig->getValueString(
+                Application::APP_ID,
+                'pdok_cache_lookup_ttl_seconds',
+                (string) self::DEFAULT_LOOKUP_TTL
+            ),
+        );
+    }//end reverse()
+
+    /**
+     * Current service health.
+     *
+     * @return string `ok` when healthy, `degraded` during the cool-down.
+     */
+    public function health(): string
+    {
+        if ($this->isDegraded() === true) {
+            return 'degraded';
+        }
+
+        return 'ok';
+    }//end health()
+
+    /**
+     * Execute a Locatieserver call with caching + outage tracking.
+     *
+     * Routes through OpenConnector when `pdok_locatieserver_source` is set;
+     * otherwise calls PDOK directly. Cache key includes the method and the
+     * normalised full query string so that filtered variants are distinct.
+     *
+     * @param string $method Endpoint suffix (`suggest`, `free`, `lookup`,
+     *                      `reverse`).
+     * @param array  $params Query string parameters.
+     * @param int    $ttl    Cache TTL in seconds.
+     *
+     * @return array Decoded JSON body or `['response' => ['docs' => []]]`
+     *               when the call fails after exhausting retries.
+     */
+    private function call(string $method, array $params, int $ttl): array
+    {
+        $queryString = http_build_query(data: $params);
+        $cacheKey    = $method.'_'.md5(string: $queryString);
+
+        $cached = $this->cache->get($cacheKey);
+        if ($cached !== null) {
+            $this->logger->debug(
+                'Procest PDOK Locatieserver cache hit',
+                ['method' => $method, 'key' => $cacheKey]
+            );
+            return $cached;
+        }
+
+        $started = microtime(as_float: true);
+        $source  = $this->appConfig->getValueString(
+            Application::APP_ID,
+            'pdok_locatieserver_source',
+            ''
+        );
+
+        $endpoint = $this->appConfig->getValueString(
+            Application::APP_ID,
+            'pdok_locatieserver_endpoint',
+            self::DEFAULT_ENDPOINT
+        );
+
+        $url = rtrim(string: $endpoint, characters: '/').'/'.$method.'?'.$queryString;
+
+        try {
+            if (empty($source) === false) {
+                $body = $this->callViaOpenConnector(sourceSlug: $source, path: $method, params: $params);
+            } else {
+                $body = $this->callDirect(url: $url);
+            }
+        } catch (\RuntimeException $e) {
+            $this->recordFailure(statusCode: $e->getCode());
+            $this->logger->warning(
+                'Procest PDOK Locatieserver call failed',
+                [
+                    'method' => $method,
+                    'error'  => $e->getMessage(),
+                    'status' => $e->getCode(),
+                ]
+            );
+            return ['response' => ['docs' => []]];
+        }//end try
+
+        $decoded = json_decode(json: $body, associative: true);
+        if (is_array(value: $decoded) === false) {
+            $decoded = ['response' => ['docs' => []]];
+        }
+
+        $this->cache->set($cacheKey, $decoded, $ttl);
+
+        $elapsedMs = (int) ((microtime(as_float: true) - $started) * 1000);
+        $this->logger->info(
+            'Procest PDOK Locatieserver call',
+            [
+                'method'    => $method,
+                'cache'     => 'miss',
+                'elapsedMs' => $elapsedMs,
+                'viaSource' => (empty($source) === false),
+            ]
+        );
+
+        return $decoded;
+    }//end call()
+
+    /**
+     * Direct HTTP GET to PDOK with a JSON Accept header.
+     *
+     * @param string $url Fully qualified URL.
+     *
+     * @return string Raw response body.
+     *
+     * @throws \RuntimeException When the upstream returns non-2xx or the
+     *                           network call fails. The exception code carries
+     *                           the HTTP status (or 0 for network failures).
+     */
+    private function callDirect(string $url): string
+    {
+        $streamOptions = [
+            'http' => [
+                'method'        => 'GET',
+                'timeout'       => 10,
+                'header'        => "Accept: application/json\r\n",
+                'ignore_errors' => true,
+            ],
+        ];
+        $context       = stream_context_create(options: $streamOptions);
+
+        $body = @file_get_contents(filename: $url, use_include_path: false, context: $context);
+        if ($body === false) {
+            throw new \RuntimeException('Network error contacting PDOK Locatieserver', 0);
+        }
+
+        $statusCode = 0;
+        // $http_response_header is populated by the HTTP wrapper.
+        foreach ($http_response_header as $header) {
+            if (preg_match(pattern: '#^HTTP/\S+\s+(\d{3})#', subject: $header, matches: $matches) === 1) {
+                $statusCode = (int) $matches[1];
+            }
+        }
+
+        if ($statusCode < 200 || $statusCode >= 300) {
+            throw new \RuntimeException('PDOK Locatieserver HTTP '.$statusCode, $statusCode);
+        }
+
+        $this->recordSuccess();
+        return $body;
+    }//end callDirect()
+
+    /**
+     * Dispatch through an OpenConnector source slug when configured.
+     *
+     * OpenConnector is an optional runtime dependency; the source slug carries
+     * its own credentials inside OpenConnector's vault, so no auth material is
+     * ever stored in Procest config. If OpenConnector is not installed the
+     * call falls back to a direct HTTP call against the configured endpoint.
+     *
+     * @param string $sourceSlug OpenConnector source slug.
+     * @param string $path       Locatieserver endpoint suffix (`suggest` etc).
+     * @param array  $params     Query parameters.
+     *
+     * @return string Raw response body.
+     *
+     * @throws \RuntimeException On upstream failure (code carries HTTP status).
+     */
+    private function callViaOpenConnector(string $sourceSlug, string $path, array $params): string
+    {
+        try {
+            $callService = $this->container->get('OCA\OpenConnector\Service\CallService');
+        } catch (\Throwable $e) {
+            $this->logger->warning(
+                'Procest PDOK Locatieserver: OpenConnector not available, falling back to direct HTTP',
+                ['sourceSlug' => $sourceSlug, 'error' => $e->getMessage()]
+            );
+            $endpoint = $this->appConfig->getValueString(
+                Application::APP_ID,
+                'pdok_locatieserver_endpoint',
+                self::DEFAULT_ENDPOINT
+            );
+            return $this->callDirect(url: rtrim(string: $endpoint, characters: '/').'/'.$path.'?'.http_build_query(data: $params));
+        }
+
+        // We intentionally call CallService dynamically; the signature has
+        // varied across OpenConnector versions and we keep this loose to
+        // avoid coupling Procest to a specific contract. The minimum
+        // contract is `call(string $sourceSlug, string $endpoint, string
+        // $method, array $config): array` returning a body string under
+        // `['body']` or `['response']['body']`.
+        try {
+            $result = $callService->call(
+                $sourceSlug,
+                $path,
+                'GET',
+                ['query' => $params, 'headers' => ['Accept' => 'application/json']]
+            );
+        } catch (\Throwable $e) {
+            throw new \RuntimeException(
+                'OpenConnector dispatch failed: '.$e->getMessage(),
+                500
+            );
+        }
+
+        if (is_array(value: $result) === true) {
+            $body = ($result['body'] ?? ($result['response']['body'] ?? null));
+            if (is_string(value: $body) === true) {
+                $this->recordSuccess();
+                return $body;
+            }
+
+            if (is_array(value: $body) === true) {
+                $this->recordSuccess();
+                return (string) json_encode(value: $body);
+            }
+        }
+
+        throw new \RuntimeException('OpenConnector returned an unrecognised response shape', 502);
+    }//end callViaOpenConnector()
+
+    /**
+     * Record a successful call (clears the failure counter).
+     *
+     * @return void
+     */
+    private function recordSuccess(): void
+    {
+        $this->cache->remove('failures');
+        // Self-clear degraded state on first success after cool-down.
+        if ($this->cache->get('degraded_until') !== null) {
+            $this->cache->remove('degraded_until');
+        }
+    }//end recordSuccess()
+
+    /**
+     * Record a failure and flip into degraded state if the threshold is hit
+     * within the rolling window.
+     *
+     * @param int $statusCode HTTP status code from the failing call.
+     *
+     * @return void
+     */
+    private function recordFailure(int $statusCode): void
+    {
+        // Only 5xx (and network errors, coded 0) count toward the outage
+        // budget. 4xx responses indicate a client problem, not a PDOK outage.
+        if ($statusCode !== 0 && ($statusCode < 500 || $statusCode >= 600)) {
+            return;
+        }
+
+        $failures = $this->cache->get('failures');
+        if (is_array(value: $failures) === false) {
+            $failures = [];
+        }
+
+        $now      = time();
+        $failures = array_filter(array: $failures, callback: static function (int $ts) use ($now): bool {
+            return ($now - $ts) <= self::OUTAGE_WINDOW;
+        });
+
+        $failures[] = $now;
+
+        if (count(value: $failures) >= self::OUTAGE_THRESHOLD) {
+            $this->cache->set('degraded_until', ($now + self::DEGRADED_TTL), self::DEGRADED_TTL);
+            $this->cache->remove('failures');
+            $this->logger->warning(
+                'Procest PDOK Locatieserver: degraded state engaged',
+                ['failureCount' => count(value: $failures), 'cooldownSec' => self::DEGRADED_TTL]
+            );
+            return;
+        }
+
+        $this->cache->set('failures', array_values(array: $failures), self::OUTAGE_WINDOW);
+    }//end recordFailure()
+
+    /**
+     * Whether the service is currently in degraded state.
+     *
+     * @return bool True while degraded.
+     */
+    private function isDegraded(): bool
+    {
+        $until = $this->cache->get('degraded_until');
+        if ($until === null) {
+            return false;
+        }
+
+        if ((int) $until <= time()) {
+            $this->cache->remove('degraded_until');
+            return false;
+        }
+
+        return true;
+    }//end isDegraded()
+}//end class

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -109,6 +109,23 @@ class SettingsService
         'ai_feature_decision_support',
         'ai_dpia_acknowledged',
         'ai_pii_stripping',
+        // PDOK integration settings (pdok-integration spec).
+        // Endpoint overrides — empty falls back to PDOK service defaults.
+        'pdok_locatieserver_endpoint',
+        'pdok_bag_endpoint',
+        'pdok_kadaster_endpoint',
+        // OpenConnector source slugs — empty = call PDOK directly.
+        'pdok_locatieserver_source',
+        'pdok_bag_source',
+        'pdok_kadaster_source',
+        // Cache TTLs (seconds).
+        'pdok_cache_lookup_ttl_seconds',
+        'pdok_cache_suggest_ttl_seconds',
+        // Per-service rate ceiling (requests / second).
+        'pdok_rate_ceiling_rps',
+        // Outage banner copy (nl + en).
+        'pdok_outage_banner_nl',
+        'pdok_outage_banner_en',
     ];
 
     /**


### PR DESCRIPTION
## Summary

Apply `pdok-integration` spec — adds shared server-side PDOK services so every consumer in Procest (`case-location`, `case-map-overview`, `map-component`) talks to a single ingress.

- **`PdokLocatieserverService`** — suggest / free / lookup / reverse against v3_1. 24h cache for lookup/reverse, 5min for suggest, cache key includes filter (`fq`) params. Outage degradation: 3x 5xx in 60s -> degraded for 5min; `suggest()` returns `[]` so `LocationService` can fall back to free-text.
- **`PdokBagService`** — nummeraanduiding / verblijfsobject / pand. Response normalised to a stable Procest-internal shape (snake -> camel, `bouwjaar` int, `oppervlakte` int m2, `gebruiksdoel` array).
- Both services route through an OpenConnector source slug when the matching `pdok_*_source` config key is set; otherwise they call PDOK directly. OpenConnector is an optional runtime dependency — falls back to direct HTTP if not installed.
- **`SettingsService`** allow-list extended with the 11 `pdok_*` config keys (3 endpoint URLs, 3 source slugs, 2 cache TTLs, rate ceiling, 2 outage banner strings).

## Manifest-first compliance

- No new admin Vue components.
- No new controllers / routes.
- No new manifest pages.
- Admin config surface is the existing `SettingsService` allow-list.

## Deferred

Tracked in `builds/build.json`:

- T03 (MapLayer repair step), T05 (case-location `LocationService` refactor — no such service exists in this branch yet; will land in `case-location` apply), T06 (standalone `PdokCache` decorator — caching is inlined), T07 (frontend `pdokApi.js` rewiring), T08 (outage banner Vue).
- V01–V04 verification follow-up (strict watchdog: `php -l` + `jq` only).

## Test plan

- [ ] `php -l` clean on `lib/Service/Pdok/*.php` and `lib/Service/SettingsService.php`
- [ ] `jq empty builds/build.json` clean
- [ ] `pdok-integration` entry present in `builds/build.json` `applied[]`
- [ ] 11 new `pdok_*` keys present in `SettingsService::CONFIG_KEYS`