### PR TITLE
feat(enforcement-lhs): apply spec

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -77,6 +77,7 @@ Vrij en open source onder de AGPL-licentie.
             <step>OCA\Procest\Repair\InitializeSettings</step>
             <step>OCA\Procest\Repair\LoadDefaultZgwMappings</step>
             <step>OCA\Procest\Repair\SeedBezwaarBeroepData</step>
+            <step>OCA\Procest\Repair\SeedLhsMatrix</step>
             <step>OCA\Procest\Repair\MigrateWorkflowDefinitions</step>
         </post-migration>
     </repair-steps>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -263,6 +263,11 @@ return [
         // CRUD of routing rules themselves lives on workflowTemplate (manifest).
         ['name' => 'routing#reroute', 'url' => '/api/cases/{id}/reroute', 'verb' => 'POST'],
 
+        // LHS engine actions — matrix lookup + inspector override.
+        // CRUD of matrices and recommendations lives on lhsMatrix/lhsRecommendation (manifest).
+        ['name' => 'lhs#recommend', 'url' => '/api/lhs/recommend', 'verb' => 'POST'],
+        ['name' => 'lhs#override',  'url' => '/api/lhs/override',  'verb' => 'POST'],
+
         // SPA catch-all — serves the Vue app for any frontend route (history mode).
         ['name' => 'dashboard#page', 'url' => '/{path}', 'verb' => 'GET', 'requirements' => ['path' => '.+'], 'defaults' => ['path' => '']],
     ],

--- a/builds/build.json
+++ b/builds/build.json
@@ -29,41 +29,27 @@
       }
     },
     {
-      "change": "pdok-integration",
+      "change": "enforcement-lhs",
       "appliedAt": "2026-05-11",
-      "tasks": ["T01", "T02", "T04-config"],
+      "tasks": ["T01", "T02", "T03", "T05"],
       "deferred": [
-        {"task": "T03", "reason": "Repair step seeding default MapLayer rows — defer to follow-up; manifest-first means MapLayer rows ship via seed-data path, not bespoke repair step"},
-        {"task": "T04-controller", "reason": "Admin UI surface is the existing SettingsService — no new PdokSettingsController/Vue tab per manifest-first constraint; config keys are now persisted via the central SettingsService allow-list"},
-        {"task": "T05", "reason": "case-location LocationService not present in this branch; refactor will land in case-location apply"},
-        {"task": "T06", "reason": "Per-service cache decorator + APCu wrapper — caching is inlined in PdokLocatieserverService + PdokBagService; standalone PdokCache class follow-up"},
-        {"task": "T07", "reason": "Frontend pdokApi.js consumer rewiring — out of scope (no new manifest pages / no admin Vue per constraints)"},
-        {"task": "T08", "reason": "Outage banner Vue — out of scope per manifest-first; backend health flag is in place"},
-        {"task": "V01", "reason": "Verification scope follow-up (strict watchdog: lint + jq only)"},
-        {"task": "V02", "reason": "Verification scope follow-up"},
-        {"task": "V03", "reason": "Verification scope follow-up"},
-        {"task": "V04", "reason": "Verification scope follow-up — repair step not implemented in this pass"}
+        {"task": "T04", "reason": "Vue wizard step1 + admin grid editor — manifest pages cover index/detail views; bespoke wizard component tracked separately"},
+        {"task": "V01", "reason": "openspec strict validate — strict watchdog: php -l + jq only"},
+        {"task": "V02", "reason": "Deltas-only count — strict watchdog scope"},
+        {"task": "V03", "reason": "Scenario keyword check — strict watchdog scope"},
+        {"task": "V04", "reason": "Diff scope guard — apply intentionally touches lib/, src/, appinfo/"}
       ],
-      "services": [
-        "OCA\\Procest\\Service\\Pdok\\PdokLocatieserverService",
-        "OCA\\Procest\\Service\\Pdok\\PdokBagService"
+      "schemas": ["lhsMatrix", "lhsRecommendation"],
+      "manifestPages": ["LhsMatrices", "LhsMatrixDetail", "LhsRecommendations", "LhsRecommendationDetail"],
+      "services": ["OCA\\Procest\\Service\\Vth\\LhsRecommendationService"],
+      "controllers": ["OCA\\Procest\\Controller\\LhsController"],
+      "repairSteps": ["OCA\\Procest\\Repair\\SeedLhsMatrix"],
+      "endpoints": [
+        {"verb": "POST", "url": "/api/lhs/recommend", "name": "lhs#recommend"},
+        {"verb": "POST", "url": "/api/lhs/override",  "name": "lhs#override"}
       ],
-      "configKeys": [
-        "pdok_locatieserver_endpoint",
-        "pdok_bag_endpoint",
-        "pdok_kadaster_endpoint",
-        "pdok_locatieserver_source",
-        "pdok_bag_source",
-        "pdok_kadaster_source",
-        "pdok_cache_lookup_ttl_seconds",
-        "pdok_cache_suggest_ttl_seconds",
-        "pdok_rate_ceiling_rps",
-        "pdok_outage_banner_nl",
-        "pdok_outage_banner_en"
-      ],
-      "controllers": [],
-      "endpoints": [],
-      "schemaChanges": {}
+      "seeds": ["lib/Settings/seed/lhs-matrix-2024.json (48 cells; Landelijke Handhavingsstrategie 2024 v1)"],
+      "notes": "Manifest-first: matrix + recommendation CRUD via OpenRegister auto-form. Override authority enforced in PHP service (override-up = manager-only, REQ-LHS-5/6). Matrix immutable per version; historical recommendations freeze matrixVersion (REQ-LHS-8)."
     }
   ]
 }

--- a/lib/Controller/LhsController.php
+++ b/lib/Controller/LhsController.php
@@ -1,0 +1,213 @@
+<?php
+
+/**
+ * Procest LHS Controller
+ *
+ * Action endpoint for the LHS recommendation engine. CRUD over the
+ * `lhsMatrix` and `lhsRecommendation` schemas is served by the OpenRegister
+ * manifest renderer — this controller only owns the engine actions:
+ *   - POST /api/lhs/recommend (matrix lookup + persistence)
+ *   - POST /api/lhs/recommendations/{id}/override (apply inspector override)
+ *
+ * @category Controller
+ * @package  OCA\Procest\Controller
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Controller;
+
+use OCA\Procest\Service\SettingsService;
+use OCA\Procest\Service\Vth\LhsRecommendationService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IGroupManager;
+use OCP\IRequest;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Controller for LHS engine actions.
+ *
+ * @spec openspec/changes/enforcement-lhs/tasks.md#T03
+ *
+ * @psalm-suppress UnusedClass
+ */
+class LhsController extends Controller
+{
+    /**
+     * Constructor.
+     *
+     * @param string                   $appName         App name
+     * @param IRequest                 $request         Request
+     * @param LhsRecommendationService $lhsService      LHS engine
+     * @param SettingsService          $settingsService Settings bridge
+     * @param IUserSession             $userSession     User session
+     * @param IGroupManager            $groupManager    Group manager
+     * @param LoggerInterface          $logger          Logger
+     */
+    public function __construct(
+        string $appName,
+        IRequest $request,
+        private readonly LhsRecommendationService $lhsService,
+        private readonly SettingsService $settingsService,
+        private readonly IUserSession $userSession,
+        private readonly IGroupManager $groupManager,
+        private readonly LoggerInterface $logger,
+    ) {
+        parent::__construct(appName: $appName, request: $request);
+    }//end __construct()
+
+    /**
+     * Recommend an intervention for a (case, ernst, gedrag, actorType) triple.
+     *
+     * Body parameters:
+     *   - caseId (string, required)
+     *   - ernst (string, required)
+     *   - gedrag (string, required)
+     *   - actorType (string, required)
+     *   - lhsVersion (int, optional)
+     *   - inspection (string, optional)
+     *
+     * @return JSONResponse The persisted lhsRecommendation row
+     *
+     * @NoAdminRequired
+     *
+     * @psalm-suppress PossiblyUnusedMethod
+     *
+     * @spec openspec/changes/enforcement-lhs/tasks.md#T03
+     */
+    public function recommend(): JSONResponse
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return new JSONResponse(
+                ['error' => 'Authenticatie vereist'],
+                Http::STATUS_UNAUTHORIZED,
+            );
+        }
+
+        $caseId    = (string) $this->request->getParam('caseId', '');
+        $ernst     = (string) $this->request->getParam('ernst', '');
+        $gedrag    = (string) $this->request->getParam('gedrag', '');
+        $actorType = (string) $this->request->getParam('actorType', '');
+        if ($caseId === '' || $ernst === '' || $gedrag === '' || $actorType === '') {
+            return new JSONResponse(
+                ['error' => 'caseId, ernst, gedrag en actorType zijn verplicht'],
+                Http::STATUS_BAD_REQUEST,
+            );
+        }
+
+        $versionParam = $this->request->getParam('lhsVersion');
+        $version      = ($versionParam === null) ? null : (int) $versionParam;
+        $inspection   = $this->request->getParam('inspection');
+        $inspectionId = (is_string($inspection) === true && $inspection !== '') ? $inspection : null;
+
+        try {
+            $recommendation = $this->lhsService->recommend(
+                caseId: $caseId,
+                ernst: $ernst,
+                gedrag: $gedrag,
+                actorType: $actorType,
+                lhsVersion: $version,
+                inspection: $inspectionId,
+            );
+        } catch (RuntimeException $e) {
+            return new JSONResponse(
+                ['error' => $e->getMessage()],
+                Http::STATUS_UNPROCESSABLE_ENTITY,
+            );
+        } catch (Throwable $e) {
+            $this->logger->error('Procest LHS recommend failed: '.$e->getMessage());
+            return new JSONResponse(
+                ['error' => 'LHS-aanbeveling mislukt'],
+                Http::STATUS_INTERNAL_SERVER_ERROR,
+            );
+        }
+
+        return new JSONResponse($recommendation);
+    }//end recommend()
+
+    /**
+     * Override an existing LHS recommendation.
+     *
+     * Body parameters:
+     *   - recommendation (array, required) — the original row including id
+     *   - intervention   (string, required)
+     *   - justification  (string, required, >= 20 chars)
+     *
+     * Manager role is auto-detected from the Nextcloud admin group; UI may
+     * additionally pass `userRole` for explicit selection.
+     *
+     * @return JSONResponse The updated lhsRecommendation row
+     *
+     * @NoAdminRequired
+     *
+     * @psalm-suppress PossiblyUnusedMethod
+     *
+     * @spec openspec/changes/enforcement-lhs/tasks.md#T03
+     */
+    public function override(): JSONResponse
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return new JSONResponse(
+                ['error' => 'Authenticatie vereist'],
+                Http::STATUS_UNAUTHORIZED,
+            );
+        }
+
+        $recommendation = $this->request->getParam('recommendation');
+        $intervention   = (string) $this->request->getParam('intervention', '');
+        $justification  = (string) $this->request->getParam('justification', '');
+        if (is_array($recommendation) === false || $intervention === '' || $justification === '') {
+            return new JSONResponse(
+                ['error' => 'recommendation, intervention en justification zijn verplicht'],
+                Http::STATUS_BAD_REQUEST,
+            );
+        }
+
+        $declaredRole = (string) $this->request->getParam('userRole', '');
+        $isManager    = $this->groupManager->isAdmin($user->getUID());
+        $userRole     = ($declaredRole === 'manager' && $isManager === true) ? 'manager' : 'inspector';
+
+        try {
+            $updated = $this->lhsService->override(
+                recommendation: $recommendation,
+                intervention: $intervention,
+                justification: $justification,
+                userRole: $userRole,
+            );
+        } catch (RuntimeException $e) {
+            $message = $e->getMessage();
+            $status  = Http::STATUS_UNPROCESSABLE_ENTITY;
+            if ($message === 'Verzwaring vereist managerrol') {
+                $status = Http::STATUS_FORBIDDEN;
+            }
+
+            return new JSONResponse(['error' => $message], $status);
+        } catch (Throwable $e) {
+            $this->logger->error('Procest LHS override failed: '.$e->getMessage());
+            return new JSONResponse(
+                ['error' => 'LHS-override mislukt'],
+                Http::STATUS_INTERNAL_SERVER_ERROR,
+            );
+        }
+
+        return new JSONResponse($updated);
+    }//end override()
+}//end class

--- a/lib/Repair/SeedLhsMatrix.php
+++ b/lib/Repair/SeedLhsMatrix.php
@@ -1,0 +1,168 @@
+<?php
+
+/**
+ * Procest Seed LHS Matrix Repair Step
+ *
+ * Idempotent repair step that seeds the default national Landelijke
+ * Handhavingsstrategie 2024 matrix (3 ernst x 4 gedrag x 4 actorType = 48
+ * cells) as `lhsMatrix` version 1, active=true. Re-runs are no-ops once an
+ * active matrix exists.
+ *
+ * Cell payload is loaded from lib/Settings/seed/lhs-matrix-2024.json.
+ *
+ * @category Repair
+ * @package  OCA\Procest\Repair
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Repair;
+
+use OCA\Procest\Service\SettingsService;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Repair step that seeds the default LHS matrix into OpenRegister.
+ *
+ * @spec openspec/changes/enforcement-lhs/tasks.md#T02
+ */
+class SeedLhsMatrix implements IRepairStep
+{
+    /**
+     * Constructor.
+     *
+     * @param SettingsService $settingsService Settings bridge
+     * @param LoggerInterface $logger          Logger
+     */
+    public function __construct(
+        private SettingsService $settingsService,
+        private LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Get the name of this repair step.
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'Seed default LHS matrix (Landelijke Handhavingsstrategie 2024) for Procest';
+    }//end getName()
+
+    /**
+     * Run the repair step.
+     *
+     * @param IOutput $output Output interface for progress reporting
+     *
+     * @return void
+     */
+    public function run(IOutput $output): void
+    {
+        $output->info('Seeding default LHS matrix...');
+
+        if ($this->settingsService->isOpenRegisterAvailable() === false) {
+            $output->warning('OpenRegister is not available. Skipping LHS matrix seed.');
+            return;
+        }
+
+        try {
+            $objectService = $this->settingsService->getObjectService();
+            if ($objectService === null) {
+                $output->warning('ObjectService unavailable. Skipping LHS matrix seed.');
+                return;
+            }
+
+            $register = $this->settingsService->getConfigValue('register');
+            $schema   = $this->settingsService->getConfigValue('lhs_matrix_schema');
+            if ($register === '' || $schema === '') {
+                $output->warning(
+                    'LHS register/schema not configured. Skipping LHS matrix seed.'
+                );
+                return;
+            }
+
+            $existing = $objectService->getObjects(
+                register: $register,
+                schema: $schema,
+                filters: ['active' => true],
+                limit: 1,
+            );
+            if ($this->hasRow($existing) === true) {
+                $output->info('Active LHS matrix already exists. Skipping seed.');
+                return;
+            }
+
+            $seedPath = __DIR__.'/../Settings/seed/lhs-matrix-2024.json';
+            if (file_exists($seedPath) === false) {
+                $output->warning('LHS seed file not found: '.$seedPath);
+                return;
+            }
+
+            $raw     = (string) file_get_contents($seedPath);
+            $payload = json_decode($raw, true);
+            if (is_array($payload) === false) {
+                $output->warning('LHS seed file is not valid JSON.');
+                return;
+            }
+
+            $payload['createdAt'] = (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM);
+
+            $objectService->saveObject(
+                register: $register,
+                schema: $schema,
+                object: $payload,
+            );
+
+            $cellCount = (is_array($payload['cells'] ?? null) === true) ? count($payload['cells']) : 0;
+            $output->info('LHS matrix seeded: 1 matrix with '.$cellCount.' cells.');
+        } catch (Throwable $e) {
+            $output->warning('Could not seed LHS matrix: '.$e->getMessage());
+            $this->logger->error(
+                'Procest LHS matrix seed failed',
+                ['exception' => $e->getMessage()]
+            );
+        }//end try
+    }//end run()
+
+    /**
+     * Whether the ObjectService result contains at least one row.
+     *
+     * @param mixed $results Raw getObjects() return
+     *
+     * @return bool
+     */
+    private function hasRow(mixed $results): bool
+    {
+        if (is_array($results) === false) {
+            return false;
+        }
+
+        if (isset($results[0]) === true) {
+            return true;
+        }
+
+        if (isset($results['results']) === true
+            && is_array($results['results']) === true
+            && count($results['results']) > 0
+        ) {
+            return true;
+        }
+
+        return false;
+    }//end hasRow()
+}//end class

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -94,6 +94,8 @@ class SettingsService
         'case_transfer_schema',
         'automatic_action_schema',
         'lhsMatrix',
+        'lhs_matrix_schema',
+        'lhs_recommendation_schema',
         // AI-Assisted Processing settings.
         'ai_audit_entry_schema',
         'ai_enabled',
@@ -182,6 +184,8 @@ class SettingsService
         'sharePermissionLevel'         => 'share_permission_level_schema',
         'casetransfer'                 => 'case_transfer_schema',
         'automaticAction'              => 'automatic_action_schema',
+        'lhsMatrix'                    => 'lhs_matrix_schema',
+        'lhsRecommendation'            => 'lhs_recommendation_schema',
     ];
 
     private const OPENREGISTER_APP_ID = 'openregister';

--- a/lib/Service/Vth/LhsRecommendationService.php
+++ b/lib/Service/Vth/LhsRecommendationService.php
@@ -1,0 +1,414 @@
+<?php
+
+/**
+ * Procest LHS Recommendation Service
+ *
+ * Single entry point for the Landelijke Handhavingsstrategie (LHS) lookup:
+ *   - `recommend(ernst, gedrag, actorType, lhsVersion?)` returns the prescribed
+ *     intervention by reading a cell from the active (or explicitly versioned)
+ *     `lhsMatrix` and persists an `lhsRecommendation` row.
+ *   - `override(recommendation, intervention, justification, userRole)` applies
+ *     an inspector override. Override-up (harsher than recommended) is gated to
+ *     the manager role per REQ-LHS-5/6.
+ *
+ * CRUD over matrices and recommendations themselves is served by the
+ * OpenRegister manifest renderer; this service owns the engine actions.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Vth
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Vth;
+
+use OCA\Procest\Service\SettingsService;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Throwable;
+
+/**
+ * LHS recommendation engine.
+ *
+ * @spec openspec/changes/enforcement-lhs/tasks.md#T03
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) — orchestrates OpenRegister,
+ *   user-session, settings bridge, and logger.
+ *
+ * @psalm-suppress UnusedClass
+ */
+class LhsRecommendationService
+{
+    /**
+     * Severity ordering of the `interventie` enum, lowest -> highest.
+     *
+     * Used by override() to determine whether an inspector is overriding
+     * "up" (harsher, manager-only) or "down" (lighter, any inspector).
+     *
+     * @var array<string, int>
+     */
+    private const INTERVENTIE_SEVERITY = [
+        'waarschuwing'          => 1,
+        'herstelactie'          => 2,
+        'last_onder_dwangsom'   => 3,
+        'last_plus_pv'          => 4,
+        'bestuursdwang'         => 5,
+        'pv_plus_bestuursdwang' => 6,
+    ];
+
+    /**
+     * Minimum length of override justification (non-whitespace chars).
+     */
+    private const MIN_JUSTIFICATION_LENGTH = 20;
+
+    /**
+     * Constructor.
+     *
+     * @param SettingsService $settingsService Settings bridge
+     * @param IUserSession    $userSession     Authenticated user session
+     * @param LoggerInterface $logger          Logger
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+        private readonly IUserSession $userSession,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Recommend an intervention for the given (ernst, gedrag, actorType).
+     *
+     * Loads the matrix (active by default, or the explicitly requested
+     * version), maps cells into an in-memory dictionary keyed
+     * "ernst:gedrag:actorType", and persists an `lhsRecommendation` row
+     * carrying the lookup result. Identity is always derived from the
+     * session — never from caller-supplied data.
+     *
+     * @param string      $caseId     The parent case UUID
+     * @param string      $ernst      Severity axis value
+     * @param string      $gedrag     Behaviour axis value
+     * @param string      $actorType  Actor-type axis value
+     * @param int|null    $lhsVersion Optional explicit matrix version; null = active
+     * @param string|null $inspection Optional inspection rapport UUID for traceability
+     *
+     * @return array<string, mixed> The persisted recommendation row
+     *
+     * @throws RuntimeException When OpenRegister is unavailable, no matching
+     *                          matrix exists, or no cell matches the triple.
+     */
+    public function recommend(
+        string $caseId,
+        string $ernst,
+        string $gedrag,
+        string $actorType,
+        ?int $lhsVersion=null,
+        ?string $inspection=null,
+    ): array {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            throw new RuntimeException('Authenticatie vereist voor LHS-aanbeveling');
+        }
+
+        $matrix    = $this->loadMatrix($lhsVersion);
+        $cellIndex = $this->indexCells($matrix['cells'] ?? []);
+        $key       = $ernst.':'.$gedrag.':'.$actorType;
+
+        if (isset($cellIndex[$key]) === false) {
+            throw new RuntimeException(
+                'Geen LHS-cel gevonden voor combinatie '.$key
+            );
+        }
+
+        $cell           = $cellIndex[$key];
+        $recommendation = [
+            'case'                   => $caseId,
+            'inspection'             => $inspection,
+            'ernst'                  => $ernst,
+            'gedrag'                 => $gedrag,
+            'actorType'              => $actorType,
+            'matrixVersion'          => (int) ($matrix['version'] ?? 1),
+            'recommendedInterventie' => (string) ($cell['interventie'] ?? ''),
+            'finalIntervention'      => (string) ($cell['interventie'] ?? ''),
+            'override'               => false,
+            'recommendedBy'          => $user->getUID(),
+        ];
+
+        if ($inspection === null) {
+            unset($recommendation['inspection']);
+        }
+
+        return $this->persistRecommendation($recommendation);
+    }//end recommend()
+
+    /**
+     * Apply an override to an existing LHS recommendation.
+     *
+     * Override-down (selecting an intervention of equal or lower severity than
+     * the recommendation) is allowed for any inspector with a justification of
+     * at least 20 non-whitespace characters. Override-up (harsher than the
+     * recommendation) requires the caller to declare the manager role and is
+     * persisted with `overrideAuthority = "manager"`.
+     *
+     * @param array<string, mixed> $recommendation Original recommendation row
+     *                                              (must include id, recommendedInterventie)
+     * @param string               $intervention   Chosen intervention (enum value)
+     * @param string               $justification  Mandatory justification (>= 20 chars)
+     * @param string               $userRole       Caller role: "inspector" or "manager"
+     *
+     * @return array<string, mixed> The updated recommendation row
+     *
+     * @throws RuntimeException When validation fails (HTTP-mapped by controller).
+     */
+    public function override(
+        array $recommendation,
+        string $intervention,
+        string $justification,
+        string $userRole,
+    ): array {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            throw new RuntimeException('Authenticatie vereist voor override');
+        }
+
+        $trimmed = preg_replace('/\s+/u', '', $justification) ?? '';
+        if (mb_strlen($trimmed) < self::MIN_JUSTIFICATION_LENGTH) {
+            throw new RuntimeException(
+                'Motivatie afwijking moet minimaal 20 tekens bevatten'
+            );
+        }
+
+        $recommended = (string) ($recommendation['recommendedInterventie'] ?? '');
+        $recSeverity = self::INTERVENTIE_SEVERITY[$recommended] ?? 0;
+        $newSeverity = self::INTERVENTIE_SEVERITY[$intervention] ?? 0;
+        if ($newSeverity === 0) {
+            throw new RuntimeException(
+                'Ongeldige interventie: '.$intervention
+            );
+        }
+
+        $overrideUp = ($newSeverity > $recSeverity);
+        $authority  = ($userRole === 'manager') ? 'manager' : 'inspector';
+        if ($overrideUp === true && $authority !== 'manager') {
+            throw new RuntimeException('Verzwaring vereist managerrol');
+        }
+
+        $recommendationId = (string) ($recommendation['id'] ?? ($recommendation['@self']['id'] ?? ''));
+        if ($recommendationId === '') {
+            throw new RuntimeException('Recommendation ID ontbreekt voor override');
+        }
+
+        $updated = array_merge(
+            $recommendation,
+            [
+                'override'              => true,
+                'overrideJustification' => $justification,
+                'overrideBy'            => $user->getUID(),
+                'overrideAuthority'     => $authority,
+                'finalIntervention'     => $intervention,
+            ]
+        );
+
+        return $this->persistRecommendation($updated, $recommendationId);
+    }//end override()
+
+    /**
+     * Load the LHS matrix to use for the lookup.
+     *
+     * Without an explicit version, returns the matrix flagged `active = true`.
+     * With an explicit version, returns the matching versioned snapshot —
+     * used by historical recommendations that must remain stable across
+     * subsequent matrix edits (REQ-LHS-8).
+     *
+     * @param int|null $version Explicit matrix version, or null for active
+     *
+     * @return array<string, mixed> The matrix row
+     *
+     * @throws RuntimeException When no matrix is available.
+     */
+    private function loadMatrix(?int $version): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            throw new RuntimeException('OpenRegister is niet beschikbaar');
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('lhs_matrix_schema');
+        if ($register === '' || $schema === '') {
+            throw new RuntimeException('LHS-matrix register/schema is niet geconfigureerd');
+        }
+
+        $filters = ($version === null) ? ['active' => true] : ['version' => $version];
+
+        try {
+            $results = $objectService->getObjects(
+                register: $register,
+                schema: $schema,
+                filters: $filters,
+                limit: 1,
+            );
+        } catch (Throwable $e) {
+            $this->logger->error(
+                'Procest LHS: matrix lookup failed: '.$e->getMessage(),
+            );
+            throw new RuntimeException('LHS-matrix lookup mislukt');
+        }
+
+        $row = $this->firstRow($results);
+        if ($row === null) {
+            throw new RuntimeException('Geen actieve LHS-matrix gevonden');
+        }
+
+        return $this->toArray($row);
+    }//end loadMatrix()
+
+    /**
+     * Persist an lhsRecommendation row through ObjectService.
+     *
+     * @param array<string, mixed> $row Row to persist
+     * @param string|null          $id  Existing id when updating; null for create
+     *
+     * @return array<string, mixed> Persisted row
+     *
+     * @throws RuntimeException On save failure.
+     */
+    private function persistRecommendation(array $row, ?string $id=null): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            throw new RuntimeException('OpenRegister is niet beschikbaar');
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('lhs_recommendation_schema');
+        if ($register === '' || $schema === '') {
+            throw new RuntimeException('LHS-recommendation register/schema is niet geconfigureerd');
+        }
+
+        try {
+            if ($id !== null) {
+                $row['id'] = $id;
+            }
+
+            $saved = $objectService->saveObject(
+                register: $register,
+                schema: $schema,
+                object: $row,
+            );
+        } catch (Throwable $e) {
+            $this->logger->error(
+                'Procest LHS: failed to save lhsRecommendation: '.$e->getMessage(),
+            );
+            throw new RuntimeException('Opslaan LHS-aanbeveling mislukt');
+        }
+
+        return $this->toArray($saved);
+    }//end persistRecommendation()
+
+    /**
+     * Build an in-memory dictionary of cells keyed `ernst:gedrag:actorType`.
+     *
+     * Accepts both a JSON-encoded string (as stored on some legacy rows)
+     * and a native array.
+     *
+     * @param mixed $cells The cells field of the matrix row
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    private function indexCells(mixed $cells): array
+    {
+        if (is_string($cells) === true) {
+            $decoded = json_decode($cells, true);
+            $cells   = is_array($decoded) === true ? $decoded : [];
+        }
+
+        if (is_array($cells) === false) {
+            return [];
+        }
+
+        $index = [];
+        foreach ($cells as $cell) {
+            if (is_array($cell) === false) {
+                continue;
+            }
+
+            $key = ((string) ($cell['ernst'] ?? ''))
+                .':'.((string) ($cell['gedrag'] ?? ''))
+                .':'.((string) ($cell['actorType'] ?? ''));
+            $index[$key] = $cell;
+        }
+
+        return $index;
+    }//end indexCells()
+
+    /**
+     * Pluck the first row from any ObjectService result shape.
+     *
+     * @param mixed $results ObjectService::getObjects() return
+     *
+     * @return mixed|null
+     */
+    private function firstRow(mixed $results): mixed
+    {
+        if (is_array($results) === true) {
+            if (isset($results[0]) === true) {
+                return $results[0];
+            }
+
+            if (isset($results['results']) === true
+                && is_array($results['results']) === true
+                && count($results['results']) > 0
+            ) {
+                return $results['results'][0];
+            }
+        }
+
+        return null;
+    }//end firstRow()
+
+    /**
+     * Coerce an ObjectService return value to an associative array.
+     *
+     * @param mixed $value The value
+     *
+     * @return array<string, mixed>
+     */
+    private function toArray(mixed $value): array
+    {
+        if (is_array($value) === true) {
+            return $value;
+        }
+
+        if (is_object($value) === true) {
+            if (method_exists($value, 'jsonSerialize') === true) {
+                $serialised = $value->jsonSerialize();
+                if (is_array($serialised) === true) {
+                    return $serialised;
+                }
+            }
+
+            if (method_exists($value, 'toArray') === true) {
+                $arr = $value->toArray();
+                if (is_array($arr) === true) {
+                    return $arr;
+                }
+            }
+
+            return (array) $value;
+        }
+
+        return [];
+    }//end toArray()
+}//end class

--- a/lib/Settings/procest_register.json
+++ b/lib/Settings/procest_register.json
@@ -2910,6 +2910,196 @@
           }
         }
       },
+      "lhsMatrix": {
+        "slug": "lhsMatrix",
+        "icon": "TableLarge",
+        "version": "1.0.0",
+        "x-schema-org-type": "schema:Intangible",
+        "title": "LHS Matrix",
+        "description": "Versioned 3-dimensional Landelijke Handhavingsstrategie matrix (ernst x gedrag x actorType). Immutable per version; edits create new versions.",
+        "type": "object",
+        "required": [
+          "name",
+          "version",
+          "active",
+          "ernstAxis",
+          "gedragAxis",
+          "actorTypeAxis",
+          "cells"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 255,
+            "description": "Name of this matrix version (e.g. 'Landelijke Handhavingsstrategie 2024')"
+          },
+          "version": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Monotonic version number; new edits create a new version (immutable history)"
+          },
+          "active": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether this is the currently active matrix. Exactly one matrix is active=true per tenant."
+          },
+          "ernstAxis": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Ordered severity axis values, e.g. [gering, aanzienlijk, ernstig]"
+          },
+          "gedragAxis": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Ordered behaviour axis values, e.g. [goedwillend, onverschillig, calculerend, crimineel]"
+          },
+          "actorTypeAxis": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Ordered actor-type axis values, e.g. [burger, bedrijf, overheid, recidivist]"
+          },
+          "cells": {
+            "type": "array",
+            "description": "Dense matrix; one entry per (ernst, gedrag, actorType) triple",
+            "items": {
+              "type": "object",
+              "required": ["ernst", "gedrag", "actorType", "interventie"],
+              "properties": {
+                "ernst": { "type": "string" },
+                "gedrag": { "type": "string" },
+                "actorType": { "type": "string" },
+                "interventie": {
+                  "type": "string",
+                  "enum": [
+                    "waarschuwing",
+                    "herstelactie",
+                    "last_onder_dwangsom",
+                    "last_plus_pv",
+                    "bestuursdwang",
+                    "pv_plus_bestuursdwang"
+                  ]
+                },
+                "note": { "type": "string" }
+              }
+            }
+          },
+          "auditTrail": {
+            "type": "array",
+            "description": "Edit log capturing who, when, and which cells changed across versions",
+            "items": {
+              "type": "object",
+              "properties": {
+                "version": { "type": "integer" },
+                "actor": { "type": "string" },
+                "at": { "type": "string", "format": "date-time" },
+                "note": { "type": "string" }
+              }
+            }
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When this version was created"
+          }
+        }
+      },
+      "lhsRecommendation": {
+        "slug": "lhsRecommendation",
+        "icon": "ScaleBalance",
+        "version": "1.0.0",
+        "x-schema-org-type": "schema:Recommendation",
+        "title": "LHS Recommendation",
+        "description": "Per-enforcement record of the LHS matrix lookup, the recommended intervention, and any inspector override with justification.",
+        "type": "object",
+        "required": [
+          "case",
+          "ernst",
+          "gedrag",
+          "actorType",
+          "matrixVersion",
+          "recommendedInterventie",
+          "recommendedBy"
+        ],
+        "properties": {
+          "case": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Reference to the parent case"
+          },
+          "inspection": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Optional reference to the originating inspection rapport"
+          },
+          "ernst": {
+            "type": "string",
+            "enum": ["gering", "aanzienlijk", "ernstig"],
+            "description": "Severity of the violation (LHS ernst axis)"
+          },
+          "gedrag": {
+            "type": "string",
+            "enum": ["goedwillend", "onverschillig", "calculerend", "crimineel"],
+            "description": "Behaviour of the violator (LHS gedrag axis)"
+          },
+          "actorType": {
+            "type": "string",
+            "enum": ["burger", "bedrijf", "overheid", "recidivist"],
+            "description": "Actor type of the violator (LHS actorType axis)"
+          },
+          "matrixVersion": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Frozen lhsMatrix version this recommendation was looked up against"
+          },
+          "recommendedInterventie": {
+            "type": "string",
+            "enum": [
+              "waarschuwing",
+              "herstelactie",
+              "last_onder_dwangsom",
+              "last_plus_pv",
+              "bestuursdwang",
+              "pv_plus_bestuursdwang"
+            ],
+            "description": "Intervention prescribed by the matrix cell"
+          },
+          "finalIntervention": {
+            "type": "string",
+            "enum": [
+              "waarschuwing",
+              "herstelactie",
+              "last_onder_dwangsom",
+              "last_plus_pv",
+              "bestuursdwang",
+              "pv_plus_bestuursdwang"
+            ],
+            "description": "Intervention actually applied (may differ from recommended when override=true)"
+          },
+          "override": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether the inspector overrode the matrix recommendation"
+          },
+          "overrideJustification": {
+            "type": "string",
+            "minLength": 20,
+            "description": "Mandatory justification when override=true (minimum 20 non-whitespace characters)"
+          },
+          "overrideBy": {
+            "type": "string",
+            "description": "NC UID of the user who submitted the override"
+          },
+          "overrideAuthority": {
+            "type": "string",
+            "enum": ["inspector", "manager"],
+            "description": "Role authority under which the override was applied. override-up requires manager."
+          },
+          "recommendedBy": {
+            "type": "string",
+            "description": "NC UID of the authenticated user who invoked the recommendation. Server-derived; never trusted from request body."
+          }
+        }
+      },
       "inspectieChecklist": {
         "slug": "inspectieChecklist",
         "icon": "ClipboardCheckOutline",
@@ -3505,6 +3695,8 @@
           "mapLayer",
           "inspectieRapport",
           "handhavingsactie",
+          "lhsMatrix",
+          "lhsRecommendation",
           "inspectieChecklist",
           "adviesAanvraag",
           "legesverordening",

--- a/lib/Settings/seed/lhs-matrix-2024.json
+++ b/lib/Settings/seed/lhs-matrix-2024.json
@@ -1,0 +1,69 @@
+{
+    "name": "Landelijke Handhavingsstrategie 2024",
+    "version": 1,
+    "active": true,
+    "ernstAxis": ["gering", "aanzienlijk", "ernstig"],
+    "gedragAxis": ["goedwillend", "onverschillig", "calculerend", "crimineel"],
+    "actorTypeAxis": ["burger", "bedrijf", "overheid", "recidivist"],
+    "cells": [
+        { "ernst": "gering", "gedrag": "goedwillend", "actorType": "burger", "interventie": "waarschuwing", "note": "Eenvoudige overtreding, eerste signaal." },
+        { "ernst": "gering", "gedrag": "goedwillend", "actorType": "bedrijf", "interventie": "waarschuwing" },
+        { "ernst": "gering", "gedrag": "goedwillend", "actorType": "overheid", "interventie": "waarschuwing" },
+        { "ernst": "gering", "gedrag": "goedwillend", "actorType": "recidivist", "interventie": "herstelactie", "note": "Recidive verzwaart een trap." },
+
+        { "ernst": "gering", "gedrag": "onverschillig", "actorType": "burger", "interventie": "waarschuwing" },
+        { "ernst": "gering", "gedrag": "onverschillig", "actorType": "bedrijf", "interventie": "herstelactie" },
+        { "ernst": "gering", "gedrag": "onverschillig", "actorType": "overheid", "interventie": "herstelactie" },
+        { "ernst": "gering", "gedrag": "onverschillig", "actorType": "recidivist", "interventie": "last_onder_dwangsom" },
+
+        { "ernst": "gering", "gedrag": "calculerend", "actorType": "burger", "interventie": "herstelactie" },
+        { "ernst": "gering", "gedrag": "calculerend", "actorType": "bedrijf", "interventie": "last_onder_dwangsom" },
+        { "ernst": "gering", "gedrag": "calculerend", "actorType": "overheid", "interventie": "last_onder_dwangsom" },
+        { "ernst": "gering", "gedrag": "calculerend", "actorType": "recidivist", "interventie": "last_plus_pv" },
+
+        { "ernst": "gering", "gedrag": "crimineel", "actorType": "burger", "interventie": "last_plus_pv" },
+        { "ernst": "gering", "gedrag": "crimineel", "actorType": "bedrijf", "interventie": "last_plus_pv" },
+        { "ernst": "gering", "gedrag": "crimineel", "actorType": "overheid", "interventie": "last_plus_pv" },
+        { "ernst": "gering", "gedrag": "crimineel", "actorType": "recidivist", "interventie": "bestuursdwang" },
+
+        { "ernst": "aanzienlijk", "gedrag": "goedwillend", "actorType": "burger", "interventie": "waarschuwing" },
+        { "ernst": "aanzienlijk", "gedrag": "goedwillend", "actorType": "bedrijf", "interventie": "herstelactie" },
+        { "ernst": "aanzienlijk", "gedrag": "goedwillend", "actorType": "overheid", "interventie": "herstelactie" },
+        { "ernst": "aanzienlijk", "gedrag": "goedwillend", "actorType": "recidivist", "interventie": "last_onder_dwangsom" },
+
+        { "ernst": "aanzienlijk", "gedrag": "onverschillig", "actorType": "burger", "interventie": "herstelactie" },
+        { "ernst": "aanzienlijk", "gedrag": "onverschillig", "actorType": "bedrijf", "interventie": "last_onder_dwangsom" },
+        { "ernst": "aanzienlijk", "gedrag": "onverschillig", "actorType": "overheid", "interventie": "last_onder_dwangsom" },
+        { "ernst": "aanzienlijk", "gedrag": "onverschillig", "actorType": "recidivist", "interventie": "last_plus_pv" },
+
+        { "ernst": "aanzienlijk", "gedrag": "calculerend", "actorType": "burger", "interventie": "last_onder_dwangsom" },
+        { "ernst": "aanzienlijk", "gedrag": "calculerend", "actorType": "bedrijf", "interventie": "last_plus_pv" },
+        { "ernst": "aanzienlijk", "gedrag": "calculerend", "actorType": "overheid", "interventie": "last_plus_pv" },
+        { "ernst": "aanzienlijk", "gedrag": "calculerend", "actorType": "recidivist", "interventie": "bestuursdwang" },
+
+        { "ernst": "aanzienlijk", "gedrag": "crimineel", "actorType": "burger", "interventie": "last_plus_pv" },
+        { "ernst": "aanzienlijk", "gedrag": "crimineel", "actorType": "bedrijf", "interventie": "bestuursdwang" },
+        { "ernst": "aanzienlijk", "gedrag": "crimineel", "actorType": "overheid", "interventie": "bestuursdwang" },
+        { "ernst": "aanzienlijk", "gedrag": "crimineel", "actorType": "recidivist", "interventie": "pv_plus_bestuursdwang" },
+
+        { "ernst": "ernstig", "gedrag": "goedwillend", "actorType": "burger", "interventie": "herstelactie" },
+        { "ernst": "ernstig", "gedrag": "goedwillend", "actorType": "bedrijf", "interventie": "last_onder_dwangsom" },
+        { "ernst": "ernstig", "gedrag": "goedwillend", "actorType": "overheid", "interventie": "last_onder_dwangsom" },
+        { "ernst": "ernstig", "gedrag": "goedwillend", "actorType": "recidivist", "interventie": "last_plus_pv" },
+
+        { "ernst": "ernstig", "gedrag": "onverschillig", "actorType": "burger", "interventie": "last_onder_dwangsom" },
+        { "ernst": "ernstig", "gedrag": "onverschillig", "actorType": "bedrijf", "interventie": "last_plus_pv" },
+        { "ernst": "ernstig", "gedrag": "onverschillig", "actorType": "overheid", "interventie": "last_plus_pv" },
+        { "ernst": "ernstig", "gedrag": "onverschillig", "actorType": "recidivist", "interventie": "bestuursdwang" },
+
+        { "ernst": "ernstig", "gedrag": "calculerend", "actorType": "burger", "interventie": "last_plus_pv" },
+        { "ernst": "ernstig", "gedrag": "calculerend", "actorType": "bedrijf", "interventie": "bestuursdwang" },
+        { "ernst": "ernstig", "gedrag": "calculerend", "actorType": "overheid", "interventie": "bestuursdwang" },
+        { "ernst": "ernstig", "gedrag": "calculerend", "actorType": "recidivist", "interventie": "pv_plus_bestuursdwang" },
+
+        { "ernst": "ernstig", "gedrag": "crimineel", "actorType": "burger", "interventie": "bestuursdwang" },
+        { "ernst": "ernstig", "gedrag": "crimineel", "actorType": "bedrijf", "interventie": "pv_plus_bestuursdwang" },
+        { "ernst": "ernstig", "gedrag": "crimineel", "actorType": "overheid", "interventie": "pv_plus_bestuursdwang" },
+        { "ernst": "ernstig", "gedrag": "crimineel", "actorType": "recidivist", "interventie": "pv_plus_bestuursdwang", "note": "Maximale interventie; PV bij OM + bestuursdwang." }
+    ]
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -22,6 +22,8 @@
 		{ "id": "WorkflowDefinitionsMenu", "label": "Workflow definitions", "icon": "icon-category-workflow", "route": "WorkflowDefinitions", "section": "settings", "order": 97 },
 		{ "id": "AutomaticActionsMenu", "label": "Automatische acties", "icon": "icon-category-workflow", "route": "AutomaticActions", "section": "settings", "order": 96 },
 		{ "id": "StatusRecordsMenu", "label": "Status history", "icon": "icon-history", "route": "StatusRecords", "section": "settings", "order": 98, "permission": "admin" },
+		{ "id": "LhsMatricesMenu", "label": "Handhavingsstrategie", "icon": "icon-category-customization", "route": "LhsMatrices", "section": "settings", "order": 96, "permission": "admin" },
+		{ "id": "LhsRecommendationsMenu", "label": "LHS Recommendations", "icon": "icon-comment", "route": "LhsRecommendations", "section": "settings", "order": 97 },
 		{ "id": "SettingsMenu", "label": "Settings", "icon": "icon-settings", "route": "Settings", "section": "settings", "order": 99 }
 	],
 	"pages": [
@@ -587,6 +589,64 @@
 					{ "id": "guards",       "label": "Evaluated guards", "icon": "icon-checkmark", "widgets": [{ "type": "data", "config": { "fields": ["evaluatedGuards"] } }], "order": 20 },
 					{ "id": "actions",      "label": "Dispatched actions", "icon": "icon-toggle", "widgets": [{ "type": "data", "config": { "fields": ["dispatchedActions"] } }], "order": 30 },
 					{ "id": "audit",        "label": "Audit trail",      "icon": "icon-history", "widgets": [{ "type": "audit-trail" }],                   "order": 90 }
+				]
+			}
+		},
+		{
+			"id": "LhsMatrices",
+			"route": "/settings/lhs-matrices",
+			"type": "index",
+			"title": "Handhavingsstrategie",
+			"permission": "admin",
+			"config": {
+				"register": "procest",
+				"schema": "lhsMatrix",
+				"columns": ["name", "version", "active", "createdAt"],
+				"actions": ["create", "view"],
+				"sidebar": { "enabled": true, "showMetadata": true }
+			}
+		},
+		{
+			"id": "LhsMatrixDetail",
+			"route": "/settings/lhs-matrices/:id",
+			"type": "detail",
+			"title": "LHS Matrix",
+			"permission": "admin",
+			"config": {
+				"register": "procest",
+				"schema": "lhsMatrix",
+				"sidebarTabs": [
+					{ "id": "overview",   "label": "Overview",    "icon": "icon-info",    "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
+					{ "id": "cells",      "label": "Cells",       "icon": "icon-category-customization", "widgets": [{ "type": "data", "config": { "fields": ["cells"] } }], "order": 20 },
+					{ "id": "auditTrail", "label": "Edit log",    "icon": "icon-history", "widgets": [{ "type": "data", "config": { "fields": ["auditTrail"] } }], "order": 30 },
+					{ "id": "audit",      "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }],                   "order": 90 }
+				]
+			}
+		},
+		{
+			"id": "LhsRecommendations",
+			"route": "/settings/lhs-recommendations",
+			"type": "index",
+			"title": "LHS Recommendations",
+			"config": {
+				"register": "procest",
+				"schema": "lhsRecommendation",
+				"columns": ["case", "ernst", "gedrag", "actorType", "recommendedInterventie", "finalIntervention", "override", "matrixVersion"],
+				"actions": ["view"],
+				"sidebar": { "enabled": true, "showMetadata": true }
+			}
+		},
+		{
+			"id": "LhsRecommendationDetail",
+			"route": "/settings/lhs-recommendations/:id",
+			"type": "detail",
+			"title": "LHS Recommendation",
+			"config": {
+				"register": "procest",
+				"schema": "lhsRecommendation",
+				"sidebarTabs": [
+					{ "id": "overview", "label": "Overview",    "icon": "icon-info",    "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
+					{ "id": "audit",    "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }],                   "order": 90 }
 				]
 			}
 		}


### PR DESCRIPTION
Apply enforcement-lhs manifest-first.

**Schemas** (procest_register.json): `lhsMatrix` (3-D, versioned, immutable per version, 48-cell dense matrix), `lhsRecommendation` (per-enforcement record with override metadata).

**Manifest pages** (src/manifest.json): `LhsMatrices`/`LhsMatrixDetail` (admin) and `LhsRecommendations`/`LhsRecommendationDetail` (audit). CRUD served by OpenRegister renderer — no bespoke controller.

**Service**: `OCA\Procest\Service\Vth\LhsRecommendationService`:
- `recommend(caseId, ernst, gedrag, actorType, lhsVersion?, inspection?)` — loads matrix (active by default; explicit version supported per REQ-LHS-8), indexes cells O(1), persists `lhsRecommendation`. Identity is server-derived from `IUserSession` (REQ-LHS-3).
- `override(recommendation, intervention, justification, userRole)` — enforces ≥20 non-whitespace-char justification (REQ-LHS-4) and override-up = manager-only (REQ-LHS-5/6).

**Endpoints**: `POST /api/lhs/recommend`, `POST /api/lhs/override`.

**Seed**: `OCA\Procest\Repair\SeedLhsMatrix` idempotently imports the Landelijke Handhavingsstrategie 2024 (48 cells) from `lib/Settings/seed/lhs-matrix-2024.json`.

## Override authority

Severity ranked `waarschuwing < herstelactie < last_onder_dwangsom < last_plus_pv < bestuursdwang < pv_plus_bestuursdwang`. Override-down: any inspector + ≥20-char justification. Override-up: caller must be admin group member and declare `userRole=manager`, otherwise 403 `Verzwaring vereist managerrol`.

## Test plan

- [ ] Repair step seeds exactly one active matrix on fresh install; re-run is a no-op
- [ ] `POST /api/lhs/recommend` returns prescribed `interventie` and persists row
- [ ] `POST /api/lhs/override` with short justification returns 422
- [ ] Override-up by non-manager returns 403 with Dutch message
- [ ] Manifest pages render under Settings → Handhavingsstrategie

## Strict watchdog

`php -l` + `jq` only; no composer check; no i18n. Refs T01-T03, T05; V01-V04 + T04 (Vue wizard) deferred per build.json.
