### PR TITLE
feat(vth-workflow-templates): apply spec

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -79,6 +79,7 @@ Vrij en open source onder de AGPL-licentie.
             <step>OCA\Procest\Repair\SeedBezwaarBeroepData</step>
             <step>OCA\Procest\Repair\SeedLhsMatrix</step>
             <step>OCA\Procest\Repair\MigrateWorkflowDefinitions</step>
+            <step>OCA\Procest\Repair\SeedVthWorkflowTemplates</step>
         </post-migration>
     </repair-steps>
 

--- a/builds/build.json
+++ b/builds/build.json
@@ -29,27 +29,39 @@
       }
     },
     {
-      "change": "enforcement-lhs",
+      "change": "vth-workflow-templates",
       "appliedAt": "2026-05-11",
-      "tasks": ["T01", "T02", "T03", "T05"],
+      "tasks": ["T01", "T02"],
       "deferred": [
-        {"task": "T04", "reason": "Vue wizard step1 + admin grid editor — manifest pages cover index/detail views; bespoke wizard component tracked separately"},
-        {"task": "V01", "reason": "openspec strict validate — strict watchdog: php -l + jq only"},
-        {"task": "V02", "reason": "Deltas-only count — strict watchdog scope"},
-        {"task": "V03", "reason": "Scenario keyword check — strict watchdog scope"},
-        {"task": "V04", "reason": "Diff scope guard — apply intentionally touches lib/, src/, appinfo/"}
+        {"task": "T03", "reason": "VthWorkflowTemplateCatalogService — manifest-first apply: catalog exposed via repair step + OpenRegister, follow-up change for ad-hoc admin import service"},
+        {"task": "T03b", "reason": "VthWorkflowTemplateCatalogController — follow-up change; out of strict-watchdog scope (no controllers in this apply)"},
+        {"task": "T04", "reason": "Routes registration — follows controller in a follow-up change"},
+        {"task": "T04b", "reason": "Vue store + axios service — Vue work deferred to a separate UI apply"},
+        {"task": "T05", "reason": "VthWorkflowTemplatesTab.vue — manifest-first; UI deferred to a separate UI apply"},
+        {"task": "T06", "reason": "VthWorkflowTemplateDetailDialog.vue — manifest-first; UI deferred to a separate UI apply"},
+        {"task": "T07", "reason": "Selective install / uninstall UX — requires controller and Vue tab from T03b/T05"},
+        {"task": "V01", "reason": "SPDX grep — N/A for files not yet authored (only repair step + catalog JSON in this apply)"},
+        {"task": "V02", "reason": "Service-API grep — partial: covered for repair step (no findObject/saveObject on workflowTemplate); rest covered by follow-up"},
+        {"task": "V03", "reason": "Controller getMessage() grep — controller deferred to follow-up apply"},
+        {"task": "V04", "reason": "Manual QA — strict watchdog: php -l + jq only; QA deferred to verify step"}
       ],
-      "schemas": ["lhsMatrix", "lhsRecommendation"],
-      "manifestPages": ["LhsMatrices", "LhsMatrixDetail", "LhsRecommendations", "LhsRecommendationDetail"],
-      "services": ["OCA\\Procest\\Service\\Vth\\LhsRecommendationService"],
-      "controllers": ["OCA\\Procest\\Controller\\LhsController"],
-      "repairSteps": ["OCA\\Procest\\Repair\\SeedLhsMatrix"],
-      "endpoints": [
-        {"verb": "POST", "url": "/api/lhs/recommend", "name": "lhs#recommend"},
-        {"verb": "POST", "url": "/api/lhs/override",  "name": "lhs#override"}
+      "services": [
+        "OCA\\Procest\\Service\\WorkflowDefinitionService::createDraft"
       ],
-      "seeds": ["lib/Settings/seed/lhs-matrix-2024.json (48 cells; Landelijke Handhavingsstrategie 2024 v1)"],
-      "notes": "Manifest-first: matrix + recommendation CRUD via OpenRegister auto-form. Override authority enforced in PHP service (override-up = manager-only, REQ-LHS-5/6). Matrix immutable per version; historical recommendations freeze matrixVersion (REQ-LHS-8)."
+      "repairSteps": ["OCA\\Procest\\Repair\\SeedVthWorkflowTemplates"],
+      "seedCatalog": {
+        "directory": "lib/Settings/seed/vth-workflow-templates",
+        "templates": [
+          "aanvraag-omgevingsvergunning",
+          "toezichtbezoek",
+          "handhavingstraject",
+          "bezwaar",
+          "klacht-toezicht",
+          "spoedig-herstel"
+        ],
+        "crossLinkOnly": ["bezwaar"]
+      },
+      "notes": "Manifest-first apply: workflow templates are seeded data delivered via Repair step that calls WorkflowDefinitionService::createDraft() + publish(). No new manifest pages or schemas. The bezwaar entry is a cross-link to bezwaar-lifecycle (extra guards documented in JSON; no new workflowTemplate row). Soft-deps on base-register-seed-data — missing caseTypes warn + skip."
     }
   ]
 }

--- a/lib/Repair/SeedVthWorkflowTemplates.php
+++ b/lib/Repair/SeedVthWorkflowTemplates.php
@@ -1,0 +1,688 @@
+<?php
+
+/**
+ * Procest Seed VTH Workflow Templates Repair Step
+ *
+ * Repair step that seeds six canonical VTH (Vergunningen, Toezicht &
+ * Handhaving) workflow templates as published `workflowTemplate` v1 objects
+ * via `WorkflowDefinitionService::createDraft()` + `publish()`. Idempotent
+ * on re-run.
+ *
+ * The repair step routes every mutation of a `workflowTemplate` through
+ * `WorkflowDefinitionService` to respect the immutability invariant of
+ * published rows established by `workflow-definition-model`. It NEVER
+ * writes `workflowTemplate` rows directly through `ObjectService`.
+ *
+ * Soft-deps on `base-register-seed-data`: when a caseType slug cannot be
+ * resolved, the template is logged + skipped (warning only), and the rest
+ * of the catalog continues.
+ *
+ * @category Repair
+ * @package  OCA\Procest\Repair
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Repair;
+
+use OCA\Procest\AppInfo\Application;
+use OCA\Procest\Service\SettingsService;
+use OCA\Procest\Service\WorkflowDefinitionService;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Repair step that seeds six canonical VTH workflow templates.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) — needs OpenRegister + WorkflowDefinitionService.
+ */
+class SeedVthWorkflowTemplates implements IRepairStep
+{
+    /**
+     * Catalog directory relative to lib/.
+     */
+    private const CATALOG_DIR = __DIR__.'/../Settings/seed/vth-workflow-templates';
+
+    /**
+     * UUID5 namespace for deterministic step/transition ids derived from
+     * template slug + child slug.
+     */
+    private const NS_UUID = '6ba7b811-9dad-11d1-80b4-00c04fd430c8';
+
+
+    /**
+     * Constructor for SeedVthWorkflowTemplates.
+     *
+     * @param SettingsService           $settingsService           Settings service for OR access
+     * @param WorkflowDefinitionService $workflowDefinitionService Workflow lifecycle service
+     * @param LoggerInterface           $logger                    Logger
+     *
+     * @return void
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+        private readonly WorkflowDefinitionService $workflowDefinitionService,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+
+    /**
+     * Get the name of this repair step.
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'Seed VTH (Vergunningen, Toezicht, Handhaving) workflow templates for Procest';
+    }//end getName()
+
+
+    /**
+     * Run the repair step.
+     *
+     * @param IOutput $output The output interface for progress reporting
+     *
+     * @return void
+     */
+    public function run(IOutput $output): void
+    {
+        $output->info('Seeding VTH workflow templates...');
+
+        if ($this->settingsService->isOpenRegisterAvailable() === false) {
+            $output->warning(
+                'OpenRegister is not available. Skipping VTH workflow templates seed.'
+            );
+            return;
+        }
+
+        if (is_dir(self::CATALOG_DIR) === false) {
+            $output->warning(
+                'VTH workflow templates catalog directory not found at '
+                .self::CATALOG_DIR
+            );
+            return;
+        }
+
+        $files = glob(self::CATALOG_DIR.'/*.json');
+        if ($files === false || $files === []) {
+            $output->warning('No VTH workflow template catalog files found.');
+            return;
+        }
+
+        $summary = [
+            'seeded'    => 0,
+            'skipped'   => 0,
+            'crossLink' => 0,
+            'failed'    => 0,
+        ];
+
+        foreach ($files as $file) {
+            try {
+                $result = $this->processCatalogFile(file: $file, output: $output);
+                $summary[$result] = ($summary[$result] ?? 0) + 1;
+            } catch (\Throwable $e) {
+                $summary['failed']++;
+                $this->logger->error(
+                    'Procest: failed to process VTH workflow template catalog file',
+                    [
+                        'app'       => Application::APP_ID,
+                        'file'      => basename($file),
+                        'exception' => $e->getMessage(),
+                    ]
+                );
+                $output->warning(
+                    'Skipping catalog file '.basename($file)
+                    .' due to processing error (see log).'
+                );
+            }//end try
+        }//end foreach
+
+        $output->info(
+            'VTH workflow templates seed complete: '
+            .$summary['seeded'].' seeded, '
+            .$summary['skipped'].' skipped (already present or unresolved), '
+            .$summary['crossLink'].' cross-link entries logged, '
+            .$summary['failed'].' failed.'
+        );
+    }//end run()
+
+
+    /**
+     * Process a single catalog file.
+     *
+     * @param string  $file   Absolute path to the JSON catalog file
+     * @param IOutput $output The output interface
+     *
+     * @return string One of seeded|skipped|crossLink|failed
+     */
+    private function processCatalogFile(string $file, IOutput $output): string
+    {
+        $raw = file_get_contents($file);
+        if ($raw === false) {
+            $this->logger->error(
+                'Procest: VTH workflow template — unable to read catalog file',
+                ['app' => Application::APP_ID, 'file' => basename($file)]
+            );
+            return 'failed';
+        }
+
+        $data = json_decode($raw, true);
+        if (json_last_error() !== JSON_ERROR_NONE || is_array($data) === false) {
+            $this->logger->error(
+                'Procest: VTH workflow template — invalid JSON in catalog file',
+                ['app' => Application::APP_ID, 'file' => basename($file)]
+            );
+            return 'failed';
+        }
+
+        $slug  = (string) ($data['slug'] ?? '');
+        $title = (string) ($data['title'] ?? '');
+        if ($slug === '' || $title === '') {
+            $this->logger->warning(
+                'Procest: VTH workflow template — missing slug or title',
+                ['app' => Application::APP_ID, 'file' => basename($file)]
+            );
+            return 'failed';
+        }
+
+        // Cross-link entries (e.g. bezwaar) do not create a new
+        // workflowTemplate; they only document VTH-specific guards that
+        // a downstream change should attach to the canonical workflow.
+        if ((bool) ($data['crossLink'] ?? false) === true) {
+            $this->logger->info(
+                'Procest: VTH workflow template — cross-link entry, no new workflow created',
+                [
+                    'app'                      => Application::APP_ID,
+                    'slug'                     => $slug,
+                    'targetWorkflowIdentifier' => (string) ($data['targetWorkflowIdentifier'] ?? ''),
+                ]
+            );
+            $output->info(
+                'VTH catalog: cross-link entry "'.$slug.'" — no new workflow created.'
+            );
+            return 'crossLink';
+        }
+
+        // Resolve caseType slug → UUID (soft-fail).
+        $caseTypeSlug = (string) ($data['caseTypeSlug'] ?? '');
+        if ($caseTypeSlug === '') {
+            $this->logger->warning(
+                'Procest: VTH workflow template — missing caseTypeSlug',
+                ['app' => Application::APP_ID, 'slug' => $slug]
+            );
+            return 'skipped';
+        }
+
+        $caseTypeId = $this->resolveCaseTypeId(slug: $caseTypeSlug);
+        if ($caseTypeId === '') {
+            $this->logger->warning(
+                'Procest: VTH workflow template — caseType not found, skipping',
+                [
+                    'app'          => Application::APP_ID,
+                    'slug'         => $slug,
+                    'caseTypeSlug' => $caseTypeSlug,
+                ]
+            );
+            $output->warning(
+                'VTH catalog: caseType "'.$caseTypeSlug.'" not found for template "'
+                .$slug.'" — skipping (run base-register-seed-data first).'
+            );
+            return 'skipped';
+        }
+
+        // Idempotency: skip if a workflow template with the same title +
+        // caseType is already present.
+        if ($this->isAlreadySeeded(caseTypeId: $caseTypeId, title: $title) === true) {
+            $this->logger->info(
+                'Procest: VTH workflow template already present, skipping',
+                [
+                    'app'      => Application::APP_ID,
+                    'slug'     => $slug,
+                    'caseType' => $caseTypeId,
+                ]
+            );
+            return 'skipped';
+        }
+
+        // Build the name → UUID map for statusTypes belonging to this caseType.
+        $statusMap = $this->buildStatusMap(caseTypeId: $caseTypeId);
+        if ($statusMap === []) {
+            $this->logger->warning(
+                'Procest: VTH workflow template — no statusTypes found for caseType',
+                [
+                    'app'      => Application::APP_ID,
+                    'slug'     => $slug,
+                    'caseType' => $caseTypeId,
+                ]
+            );
+            return 'skipped';
+        }
+
+        // Resolve steps and transitions. On any unresolved status, skip
+        // the entire template (no partial seed).
+        $resolvedSteps = $this->resolveSteps(
+            slug: $slug,
+            rawSteps: ($data['steps'] ?? []),
+            statusMap: $statusMap,
+        );
+        if ($resolvedSteps === null) {
+            $this->logger->warning(
+                'Procest: VTH workflow template — unresolved status in steps, skipping',
+                ['app' => Application::APP_ID, 'slug' => $slug]
+            );
+            return 'skipped';
+        }
+
+        $resolvedTransitions = $this->resolveTransitions(
+            slug: $slug,
+            rawTransitions: ($data['transitions'] ?? []),
+            statusMap: $statusMap,
+        );
+        if ($resolvedTransitions === null) {
+            $this->logger->warning(
+                'Procest: VTH workflow template — unresolved status in transitions, skipping',
+                ['app' => Application::APP_ID, 'slug' => $slug]
+            );
+            return 'skipped';
+        }
+
+        // Create draft via the lifecycle service.
+        $draft = $this->workflowDefinitionService->createDraft(
+            payload: [
+                'title'       => $title,
+                'description' => (string) ($data['description'] ?? ''),
+                'caseType'    => $caseTypeId,
+                'version'     => (int) ($data['version'] ?? 1),
+                'steps'       => $resolvedSteps,
+                'transitions' => $resolvedTransitions,
+            ]
+        );
+
+        if ($draft === null || isset($draft['id']) === false) {
+            $this->logger->error(
+                'Procest: VTH workflow template — createDraft returned null',
+                ['app' => Application::APP_ID, 'slug' => $slug]
+            );
+            return 'failed';
+        }
+
+        // Publish — flips to lifecycleStatus=published, isActive=true and
+        // pins caseType.workflowDefinition only when no previous definition
+        // was pinned (handled inside publish()).
+        $published = $this->workflowDefinitionService->publish(id: (string) $draft['id']);
+        if ($published === null) {
+            $this->logger->error(
+                'Procest: VTH workflow template — publish returned null',
+                ['app' => Application::APP_ID, 'slug' => $slug, 'draftId' => (string) $draft['id']]
+            );
+            return 'failed';
+        }
+
+        $output->info('VTH catalog: seeded "'.$title.'" v'.(int) ($data['version'] ?? 1).'.');
+        return 'seeded';
+    }//end processCatalogFile()
+
+
+    /**
+     * Resolve a caseType by its slug — uses the `identifier` field on the
+     * caseType schema (the canonical slug-like field across procest seed
+     * data). Returns the empty string when not found.
+     *
+     * @param string $slug The caseType slug / identifier
+     *
+     * @return string The caseType UUID or empty string
+     */
+    private function resolveCaseTypeId(string $slug): string
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return '';
+        }
+
+        $register       = $this->settingsService->getConfigValue('register');
+        $caseTypeSchema = $this->settingsService->getConfigValue('case_type_schema');
+
+        if ($register === '' || $caseTypeSchema === '') {
+            return '';
+        }
+
+        // Try `identifier` first (used by bezwaar/beroep seeds), then
+        // `slug` (used by VTH seeds via base-register-seed-data).
+        foreach (['identifier', 'slug'] as $field) {
+            try {
+                $rows = $objectService->findObjects(
+                    $register,
+                    $caseTypeSchema,
+                    [$field => $slug],
+                    [],
+                    5,
+                );
+            } catch (\Throwable $e) {
+                $this->logger->debug(
+                    'Procest: VTH workflow template — caseType lookup failed',
+                    [
+                        'app'       => Application::APP_ID,
+                        'field'     => $field,
+                        'slug'      => $slug,
+                        'exception' => $e->getMessage(),
+                    ]
+                );
+                continue;
+            }
+
+            $id = $this->extractFirstId(rows: $rows);
+            if ($id !== '') {
+                return $id;
+            }
+        }
+
+        return '';
+    }//end resolveCaseTypeId()
+
+
+    /**
+     * Check whether a workflowTemplate with the given title is already
+     * present for the given caseType. Used for idempotency.
+     *
+     * @param string $caseTypeId The caseType UUID
+     * @param string $title      The template title
+     *
+     * @return bool True when an existing template matches
+     */
+    private function isAlreadySeeded(string $caseTypeId, string $title): bool
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return false;
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('workflow_template_schema');
+
+        if ($register === '' || $schema === '') {
+            return false;
+        }
+
+        try {
+            $rows = $objectService->findObjects(
+                $register,
+                $schema,
+                [
+                    'caseType' => $caseTypeId,
+                    'title'    => $title,
+                ],
+                [],
+                1,
+            );
+        } catch (\Throwable $e) {
+            $this->logger->debug(
+                'Procest: VTH workflow template — idempotency lookup failed',
+                [
+                    'app'       => Application::APP_ID,
+                    'caseType'  => $caseTypeId,
+                    'title'     => $title,
+                    'exception' => $e->getMessage(),
+                ]
+            );
+            return false;
+        }
+
+        return $this->extractFirstId(rows: $rows) !== '';
+    }//end isAlreadySeeded()
+
+
+    /**
+     * Build a status name → UUID map for the statusTypes belonging to a
+     * given caseType.
+     *
+     * @param string $caseTypeId The caseType UUID
+     *
+     * @return array<string, string> Map of statusType name to UUID
+     */
+    private function buildStatusMap(string $caseTypeId): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return [];
+        }
+
+        $register     = $this->settingsService->getConfigValue('register');
+        $statusSchema = $this->settingsService->getConfigValue('status_type_schema');
+
+        if ($register === '' || $statusSchema === '') {
+            return [];
+        }
+
+        try {
+            $rows = $objectService->findObjects(
+                $register,
+                $statusSchema,
+                ['caseType' => $caseTypeId],
+                [],
+                500,
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Procest: VTH workflow template — statusType listing failed',
+                ['app' => Application::APP_ID, 'exception' => $e->getMessage()]
+            );
+            return [];
+        }
+
+        $map = [];
+        foreach ((is_array($rows) === true ? $rows : []) as $row) {
+            $normalized = $this->normalizeRow(row: $row);
+            if ($normalized === null) {
+                continue;
+            }
+
+            $name = (string) ($normalized['name'] ?? '');
+            $id   = (string) ($normalized['id'] ?? ($normalized['uuid'] ?? ''));
+            if ($name !== '' && $id !== '') {
+                $map[$name] = $id;
+            }
+        }
+
+        return $map;
+    }//end buildStatusMap()
+
+
+    /**
+     * Resolve the steps[] block against the status name → UUID map.
+     * Returns null when any status name does not resolve.
+     *
+     * @param string                          $slug      The template slug (for UUID5 ids)
+     * @param array<int, array<string, mixed>> $rawSteps  Steps from the catalog file
+     * @param array<string, string>           $statusMap Name → UUID map
+     *
+     * @return array<int, array<string, mixed>>|null Resolved steps, or null
+     */
+    private function resolveSteps(string $slug, array $rawSteps, array $statusMap): ?array
+    {
+        $resolved = [];
+        foreach ($rawSteps as $step) {
+            if (is_array($step) === false) {
+                continue;
+            }
+
+            $statusName = (string) ($step['statusName'] ?? '');
+            if ($statusName === '' || isset($statusMap[$statusName]) === false) {
+                return null;
+            }
+
+            $stepSlug = (string) ($step['slug'] ?? '');
+            $resolved[] = [
+                'id'           => $this->deterministicId(template: $slug, child: 'step-'.$stepSlug),
+                'slug'         => $stepSlug,
+                'title'        => (string) ($step['title'] ?? ''),
+                'status'       => $statusMap[$statusName],
+                'statusName'   => $statusName,
+                'order'        => (int) ($step['order'] ?? 0),
+                'isInitial'    => (bool) ($step['isInitial'] ?? false),
+                'isFinal'      => (bool) ($step['isFinal'] ?? false),
+                'assigneeRole' => ($step['assigneeRole'] ?? null),
+                'description'  => (string) ($step['description'] ?? ''),
+            ];
+        }//end foreach
+
+        return $resolved;
+    }//end resolveSteps()
+
+
+    /**
+     * Resolve the transitions[] block against the status name → UUID map.
+     * Accepts "*" as a wildcard for fromStatus (any status). Returns null
+     * when any non-wildcard status name does not resolve.
+     *
+     * @param string                          $slug           The template slug (for UUID5 ids)
+     * @param array<int, array<string, mixed>> $rawTransitions Transitions from the catalog file
+     * @param array<string, string>           $statusMap      Name → UUID map
+     *
+     * @return array<int, array<string, mixed>>|null Resolved transitions, or null
+     */
+    private function resolveTransitions(string $slug, array $rawTransitions, array $statusMap): ?array
+    {
+        $resolved = [];
+        foreach ($rawTransitions as $transition) {
+            if (is_array($transition) === false) {
+                continue;
+            }
+
+            $fromName = (string) ($transition['fromStatus'] ?? '');
+            $toName   = (string) ($transition['toStatus'] ?? '');
+
+            if ($toName === '' || isset($statusMap[$toName]) === false) {
+                return null;
+            }
+
+            if ($fromName === '*') {
+                $fromId = '*';
+            } elseif ($fromName === '' || isset($statusMap[$fromName]) === false) {
+                return null;
+            } else {
+                $fromId = $statusMap[$fromName];
+            }
+
+            $transitionSlug = (string) ($transition['slug'] ?? '');
+            $resolved[] = [
+                'id'               => $this->deterministicId(template: $slug, child: 'transition-'.$transitionSlug),
+                'slug'             => $transitionSlug,
+                'label'            => (string) ($transition['label'] ?? ''),
+                'fromStatus'       => $fromId,
+                'fromStatusName'   => $fromName,
+                'toStatus'         => $statusMap[$toName],
+                'toStatusName'     => $toName,
+                'allowedRoles'     => ($transition['allowedRoles'] ?? []),
+                'guards'           => ($transition['guards'] ?? []),
+                'automaticActions' => ($transition['automaticActions'] ?? []),
+                'deadline'         => ($transition['deadline'] ?? null),
+            ];
+        }//end foreach
+
+        return $resolved;
+    }//end resolveTransitions()
+
+
+    /**
+     * Generate a deterministic UUID5 from a template slug + child slug.
+     * Re-running the repair step therefore produces stable step / transition
+     * ids per template.
+     *
+     * @param string $template The template slug
+     * @param string $child    The child slug (e.g. "step-ontvangen")
+     *
+     * @return string The deterministic UUID5
+     */
+    private function deterministicId(string $template, string $child): string
+    {
+        $namespace = str_replace('-', '', self::NS_UUID);
+        $nameBytes = hex2bin($namespace).$template.':'.$child;
+        $hash      = sha1($nameBytes);
+
+        return sprintf(
+            '%08s-%04s-%04x-%04x-%12s',
+            substr($hash, 0, 8),
+            substr($hash, 8, 4),
+            (hexdec(substr($hash, 12, 4)) & 0x0fff) | 0x5000,
+            (hexdec(substr($hash, 16, 4)) & 0x3fff) | 0x8000,
+            substr($hash, 20, 12)
+        );
+    }//end deterministicId()
+
+
+    /**
+     * Extract the first row id from an OpenRegister result set.
+     *
+     * @param mixed $rows Raw result from findObjects
+     *
+     * @return string The first id or empty string
+     */
+    private function extractFirstId(mixed $rows): string
+    {
+        if (is_array($rows) === false) {
+            return '';
+        }
+
+        // Handle paginated `{ results: [...] }` shape.
+        if (isset($rows['results']) === true && is_array($rows['results']) === true) {
+            $rows = $rows['results'];
+        }
+
+        foreach ($rows as $row) {
+            $normalized = $this->normalizeRow(row: $row);
+            if ($normalized === null) {
+                continue;
+            }
+
+            $id = (string) ($normalized['id'] ?? ($normalized['uuid'] ?? ''));
+            if ($id !== '') {
+                return $id;
+            }
+        }
+
+        return '';
+    }//end extractFirstId()
+
+
+    /**
+     * Coerce an OpenRegister result row to an associative array.
+     *
+     * @param mixed $row Result row from ObjectService
+     *
+     * @return array<string, mixed>|null
+     */
+    private function normalizeRow(mixed $row): ?array
+    {
+        if (is_array($row) === true) {
+            return $row;
+        }
+
+        if (is_object($row) === true && method_exists($row, 'jsonSerialize') === true) {
+            $serialized = $row->jsonSerialize();
+            if (is_array($serialized) === true) {
+                return $serialized;
+            }
+        }
+
+        if (is_object($row) === true && method_exists($row, 'getId') === true) {
+            return ['id' => (string) $row->getId()];
+        }
+
+        return null;
+    }//end normalizeRow()
+
+
+}//end class

--- a/lib/Service/WorkflowDefinitionService.php
+++ b/lib/Service/WorkflowDefinitionService.php
@@ -8,6 +8,12 @@
  * the manifest renderer / OpenRegister auto-routing; this service owns the
  * domain logic that CRUD cannot express:
  *
+ *   - createDraft()          — create a new draft definition from a
+ *                              fully-resolved payload (used by seed-data
+ *                              and catalog-import flows; mutations to
+ *                              workflowTemplate MUST go through this
+ *                              service to respect the immutability
+ *                              invariant of published rows).
  *   - publish()              — flip a draft to published, deprecate the
  *                              previously active version, pin the
  *                              caseType.workflowDefinition reference.
@@ -449,6 +455,84 @@ class WorkflowDefinitionService
 
         return $this->normalize($new);
     }//end cloneDefinition()
+
+
+    /**
+     * Create a brand-new draft definition from a fully-resolved payload.
+     * Used by seed-data / catalog import flows where the caller has already
+     * resolved caseType slug → UUID and statusType names → UUIDs.
+     *
+     * The payload SHALL provide:
+     *   - title (string, required)
+     *   - description (string, optional)
+     *   - caseType (UUID string, required)
+     *   - version (int, optional — defaults to next version for caseType)
+     *   - steps (array of step rows, will be JSON-encoded if not already a string)
+     *   - transitions (array of transition rows, will be JSON-encoded if not already a string)
+     *
+     * The method enforces lifecycleStatus=draft, isDraft=true, isActive=false.
+     * Returns the created definition (with id) or null on failure.
+     *
+     * @param array<string, mixed> $payload The fully-resolved draft payload
+     *
+     * @return array<string, mixed>|null The created draft or null on failure
+     */
+    public function createDraft(array $payload): ?array
+    {
+        $caseTypeId = (string) ($payload['caseType'] ?? '');
+        if ($caseTypeId === '' || (string) ($payload['title'] ?? '') === '') {
+            $this->logger->warning(
+                'Procest: createDraft() — missing caseType or title',
+                ['app' => Application::APP_ID]
+            );
+            return null;
+        }
+
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return null;
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('workflow_template_schema');
+
+        if ($register === '' || $schema === '') {
+            return null;
+        }
+
+        $version = (int) ($payload['version'] ?? 0);
+        if ($version <= 0) {
+            $version = $this->nextVersionFor($caseTypeId);
+        }
+
+        $steps       = $payload['steps'] ?? [];
+        $transitions = $payload['transitions'] ?? [];
+
+        $draft = [
+            'title'           => (string) $payload['title'],
+            'description'     => (string) ($payload['description'] ?? ''),
+            'caseType'        => $caseTypeId,
+            'version'         => $version,
+            'isActive'        => false,
+            'isDraft'         => true,
+            'lifecycleStatus' => self::STATUS_DRAFT,
+            'steps'           => is_string($steps) === true ? $steps : json_encode($steps),
+            'transitions'     => is_string($transitions) === true ? $transitions : json_encode($transitions),
+            'nodePositions'   => (string) ($payload['nodePositions'] ?? ''),
+        ];
+
+        try {
+            $new = $objectService->saveObject($register, $schema, $draft);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Procest: failed to create workflow draft',
+                ['app' => Application::APP_ID, 'exception' => $e->getMessage()]
+            );
+            return null;
+        }
+
+        return $this->normalize($new);
+    }//end createDraft()
 
 
     // -----------------------------------------------------------------

--- a/lib/Settings/seed/vth-workflow-templates/aanvraag-omgevingsvergunning.json
+++ b/lib/Settings/seed/vth-workflow-templates/aanvraag-omgevingsvergunning.json
@@ -1,0 +1,113 @@
+{
+  "_format": "procest-vth-workflow-template-v1",
+  "slug": "aanvraag-omgevingsvergunning",
+  "title": "Aanvraag omgevingsvergunning",
+  "description": "Workflow voor reguliere aanvraag omgevingsvergunning onder de Omgevingswet. 8 weken beslistermijn (Awb art. 4:13), verlengbaar met 6 weken (Awb art. 4:14).",
+  "version": 1,
+  "caseTypeSlug": "omgevingsvergunning-bouwactiviteit",
+  "statutoryFramework": "Awb 4:13 + Omgevingswet",
+  "steps": [
+    {
+      "slug": "ontvangen",
+      "title": "Aanvraag ontvangen",
+      "statusName": "Ontvangen",
+      "order": 1,
+      "isInitial": true,
+      "isFinal": false,
+      "assigneeRole": "Behandelaar",
+      "description": "Aanvraag binnengekomen via DSO of handmatig — registratie en ontvangstbevestiging."
+    },
+    {
+      "slug": "ontvankelijkheidstoets",
+      "title": "Ontvankelijkheidstoets",
+      "statusName": "Ontvankelijkheidstoets",
+      "order": 2,
+      "isInitial": false,
+      "isFinal": false,
+      "assigneeRole": "Behandelaar",
+      "description": "Controle op volledigheid en ontvankelijkheid van de aanvraag (Awb 4:5)."
+    },
+    {
+      "slug": "in-behandeling",
+      "title": "In behandeling",
+      "statusName": "In behandeling",
+      "order": 3,
+      "isInitial": false,
+      "isFinal": false,
+      "assigneeRole": "Behandelaar",
+      "description": "Inhoudelijke beoordeling van de aanvraag, eventueel met externe adviezen."
+    },
+    {
+      "slug": "besluit",
+      "title": "Besluit",
+      "statusName": "Besluitvorming",
+      "order": 4,
+      "isInitial": false,
+      "isFinal": false,
+      "assigneeRole": "Teamleider",
+      "description": "Besluit over verlening of weigering van de vergunning."
+    },
+    {
+      "slug": "bekendmaking",
+      "title": "Bekendmaking",
+      "statusName": "Bekendmaking",
+      "order": 5,
+      "isInitial": false,
+      "isFinal": false,
+      "assigneeRole": "Behandelaar",
+      "description": "Bekendmaking van het besluit; bezwaartermijn start."
+    },
+    {
+      "slug": "afgehandeld",
+      "title": "Afgehandeld",
+      "statusName": "Afgehandeld",
+      "order": 6,
+      "isInitial": false,
+      "isFinal": true,
+      "assigneeRole": null,
+      "description": "Aanvraag is afgehandeld; bezwaartermijn verstreken of bezwaar separaat gestart."
+    }
+  ],
+  "transitions": [
+    {
+      "slug": "ontvangen-naar-ontvankelijkheid",
+      "fromStatus": "Ontvangen",
+      "toStatus": "Ontvankelijkheidstoets",
+      "label": "Start ontvankelijkheidstoets",
+      "allowedRoles": ["Behandelaar"]
+    },
+    {
+      "slug": "ontvankelijkheid-naar-in-behandeling",
+      "fromStatus": "Ontvankelijkheidstoets",
+      "toStatus": "In behandeling",
+      "label": "Ontvankelijk verklaren en in behandeling nemen",
+      "allowedRoles": ["Behandelaar"]
+    },
+    {
+      "slug": "in-behandeling-naar-besluit",
+      "fromStatus": "In behandeling",
+      "toStatus": "Besluitvorming",
+      "label": "Besluit nemen",
+      "allowedRoles": ["Teamleider"],
+      "deadline": {
+        "duration": "P56D",
+        "source": "Awb 4:13",
+        "escalationRole": "afdelingsmanager"
+      }
+    },
+    {
+      "slug": "besluit-naar-bekendmaking",
+      "fromStatus": "Besluitvorming",
+      "toStatus": "Bekendmaking",
+      "label": "Besluit bekendmaken",
+      "allowedRoles": ["Behandelaar"]
+    },
+    {
+      "slug": "bekendmaking-naar-afgehandeld",
+      "fromStatus": "Bekendmaking",
+      "toStatus": "Afgehandeld",
+      "label": "Afhandelen",
+      "allowedRoles": ["Behandelaar"]
+    }
+  ]
+}

--- a/lib/Settings/seed/vth-workflow-templates/bezwaar.json
+++ b/lib/Settings/seed/vth-workflow-templates/bezwaar.json
@@ -1,0 +1,33 @@
+{
+  "_format": "procest-vth-workflow-template-v1",
+  "slug": "bezwaar",
+  "title": "Bezwaar (VTH cross-link)",
+  "description": "Cross-link entry: VTH-bezwaar volgt de canonieke bezwaar-lifecycle workflow (zie SeedBezwaarBeroepData). Deze entry voegt VTH-specifieke guards toe voor sectorale niet-ontvankelijkheidsgronden, maar redefinieert de bezwaar-workflow NIET.",
+  "version": 1,
+  "crossLink": true,
+  "targetWorkflowIdentifier": "bezwaar",
+  "caseTypeSlug": "bezwaar",
+  "statutoryFramework": "Awb hoofdstuk 7",
+  "extraGuards": [
+    {
+      "slug": "vth-niet-ontvankelijk-omgevingsplan",
+      "type": "guard",
+      "appliesToTransition": "*",
+      "config": {
+        "expression": "case.properties.bestreden_besluit_grondslag === 'omgevingsplan' && case.subject.belang === false",
+        "message": "Bezwaar niet-ontvankelijk: geen rechtstreeks belang bij omgevingsplan-wijziging (Awb 1:2 j vty)."
+      }
+    },
+    {
+      "slug": "vth-niet-ontvankelijk-handhaving",
+      "type": "guard",
+      "appliesToTransition": "*",
+      "config": {
+        "expression": "case.properties.bestreden_besluit_grondslag === 'handhaving' && case.properties.overtreder_id !== case.subject.id",
+        "message": "Bezwaar niet-ontvankelijk: indiener is geen overtreder/belanghebbende bij dit handhavingsbesluit."
+      }
+    }
+  ],
+  "steps": [],
+  "transitions": []
+}

--- a/lib/Settings/seed/vth-workflow-templates/handhavingstraject.json
+++ b/lib/Settings/seed/vth-workflow-templates/handhavingstraject.json
@@ -1,0 +1,135 @@
+{
+  "_format": "procest-vth-workflow-template-v1",
+  "slug": "handhavingstraject",
+  "title": "Handhavingstraject",
+  "description": "Workflow voor een handhavingstraject conform de Landelijke Handhavingsstrategie (LHS). Volgt de Awb-procedure 5:24 met redelijke termijn voor herstel.",
+  "version": 1,
+  "caseTypeSlug": "handhavingszaak",
+  "statutoryFramework": "Awb 5:24 + LHS",
+  "steps": [
+    {
+      "slug": "voornemen",
+      "title": "Voornemen tot handhaven",
+      "statusName": "Vooraankondiging",
+      "order": 1,
+      "isInitial": true,
+      "isFinal": false,
+      "assigneeRole": "Behandelaar",
+      "description": "Vooraankondiging is verstuurd; overtreder krijgt gelegenheid tot zienswijze (Awb 4:8)."
+    },
+    {
+      "slug": "zienswijze-ontvangen",
+      "title": "Zienswijze ontvangen",
+      "statusName": "Zienswijze",
+      "order": 2,
+      "isInitial": false,
+      "isFinal": false,
+      "assigneeRole": "Behandelaar",
+      "description": "Zienswijze van overtreder is ontvangen en beoordeeld."
+    },
+    {
+      "slug": "besluit",
+      "title": "Handhavingsbesluit",
+      "statusName": "Handhavingsbesluit",
+      "order": 3,
+      "isInitial": false,
+      "isFinal": false,
+      "assigneeRole": "Teamleider",
+      "description": "Handhavingsbesluit (last onder dwangsom of bestuursdwang) is genomen."
+    },
+    {
+      "slug": "bezwaarperiode",
+      "title": "Bezwaarperiode",
+      "statusName": "Begunstigingstermijn",
+      "order": 4,
+      "isInitial": false,
+      "isFinal": false,
+      "assigneeRole": "Behandelaar",
+      "description": "Begunstigings- en bezwaartermijn loopt; overtreder kan bezwaar maken."
+    },
+    {
+      "slug": "in-werking",
+      "title": "Handhaving in werking",
+      "statusName": "Hercontrole",
+      "order": 5,
+      "isInitial": false,
+      "isFinal": false,
+      "assigneeRole": "Inspecteur",
+      "description": "Hercontrole; bij niet-naleving treedt last onder dwangsom in werking."
+    },
+    {
+      "slug": "invordering",
+      "title": "Invordering",
+      "statusName": "Hercontrole",
+      "order": 6,
+      "isInitial": false,
+      "isFinal": false,
+      "assigneeRole": "Behandelaar",
+      "description": "Verbeurde dwangsommen worden ingevorderd (separate invorderingszaak)."
+    },
+    {
+      "slug": "afgehandeld",
+      "title": "Afgehandeld",
+      "statusName": "Afgehandeld",
+      "order": 7,
+      "isInitial": false,
+      "isFinal": true,
+      "assigneeRole": null,
+      "description": "Handhavingstraject is afgehandeld."
+    }
+  ],
+  "transitions": [
+    {
+      "slug": "voornemen-naar-zienswijze",
+      "fromStatus": "Vooraankondiging",
+      "toStatus": "Zienswijze",
+      "label": "Zienswijze ontvangen",
+      "allowedRoles": ["Behandelaar"],
+      "deadline": {
+        "duration": "P14D",
+        "source": "Awb 4:8 (zienswijzetermijn)",
+        "escalationRole": "Teamleider"
+      }
+    },
+    {
+      "slug": "voornemen-naar-besluit",
+      "fromStatus": "Vooraankondiging",
+      "toStatus": "Handhavingsbesluit",
+      "label": "Handhavingsbesluit nemen",
+      "allowedRoles": ["Teamleider"],
+      "deadline": {
+        "duration": "P56D",
+        "source": "Awb 5:24 (redelijke termijn)",
+        "escalationRole": "afdelingsmanager"
+      }
+    },
+    {
+      "slug": "zienswijze-naar-besluit",
+      "fromStatus": "Zienswijze",
+      "toStatus": "Handhavingsbesluit",
+      "label": "Handhavingsbesluit nemen na zienswijze",
+      "allowedRoles": ["Teamleider"]
+    },
+    {
+      "slug": "besluit-naar-bezwaarperiode",
+      "fromStatus": "Handhavingsbesluit",
+      "toStatus": "Begunstigingstermijn",
+      "label": "Bezwaar- en begunstigingstermijn starten",
+      "allowedRoles": ["Behandelaar"]
+    },
+    {
+      "slug": "bezwaarperiode-naar-werking",
+      "fromStatus": "Begunstigingstermijn",
+      "toStatus": "Hercontrole",
+      "label": "Hercontrole uitvoeren",
+      "allowedRoles": ["Inspecteur"]
+    },
+    {
+      "slug": "werking-naar-afgehandeld",
+      "fromStatus": "Hercontrole",
+      "toStatus": "Afgehandeld",
+      "label": "Handhaving afsluiten",
+      "allowedRoles": ["Behandelaar"]
+    }
+  ]
+}

--- a/lib/Settings/seed/vth-workflow-templates/klacht-toezicht.json
+++ b/lib/Settings/seed/vth-workflow-templates/klacht-toezicht.json
@@ -1,0 +1,79 @@
+{
+  "_format": "procest-vth-workflow-template-v1",
+  "slug": "klacht-toezicht",
+  "title": "Klacht over toezicht",
+  "description": "Workflow voor de behandeling van een klacht over gedragingen van een toezichthouder of de uitvoering van het toezicht. 6 weken beslistermijn (Awb 9:11).",
+  "version": 1,
+  "caseTypeSlug": "klacht-toezicht",
+  "statutoryFramework": "Awb 9:11",
+  "steps": [
+    {
+      "slug": "ontvangen",
+      "title": "Klacht ontvangen",
+      "statusName": "Ontvangen",
+      "order": 1,
+      "isInitial": true,
+      "isFinal": false,
+      "assigneeRole": "klachtcoördinator",
+      "description": "Klacht is binnengekomen; ontvangstbevestiging verstuurd."
+    },
+    {
+      "slug": "in-behandeling",
+      "title": "In behandeling",
+      "statusName": "In behandeling",
+      "order": 2,
+      "isInitial": false,
+      "isFinal": false,
+      "assigneeRole": "klachtcoördinator",
+      "description": "Klacht wordt onderzocht; partijen worden gehoord (Awb 9:10)."
+    },
+    {
+      "slug": "beoordeeld",
+      "title": "Beoordeeld",
+      "statusName": "Beoordeeld",
+      "order": 3,
+      "isInitial": false,
+      "isFinal": false,
+      "assigneeRole": "klachtcoördinator",
+      "description": "Klacht is beoordeeld; oordeel met motivering opgesteld."
+    },
+    {
+      "slug": "afgehandeld",
+      "title": "Afgehandeld",
+      "statusName": "Afgehandeld",
+      "order": 4,
+      "isInitial": false,
+      "isFinal": true,
+      "assigneeRole": null,
+      "description": "Klacht is afgehandeld; oordeel verzonden."
+    }
+  ],
+  "transitions": [
+    {
+      "slug": "ontvangen-naar-in-behandeling",
+      "fromStatus": "Ontvangen",
+      "toStatus": "In behandeling",
+      "label": "Klacht in behandeling nemen",
+      "allowedRoles": ["klachtcoördinator"]
+    },
+    {
+      "slug": "in-behandeling-naar-beoordeeld",
+      "fromStatus": "In behandeling",
+      "toStatus": "Beoordeeld",
+      "label": "Oordeel formuleren",
+      "allowedRoles": ["klachtcoördinator"],
+      "deadline": {
+        "duration": "P42D",
+        "source": "Awb 9:11",
+        "escalationRole": "klachtcoördinator"
+      }
+    },
+    {
+      "slug": "beoordeeld-naar-afgehandeld",
+      "fromStatus": "Beoordeeld",
+      "toStatus": "Afgehandeld",
+      "label": "Klacht afhandelen",
+      "allowedRoles": ["klachtcoördinator"]
+    }
+  ]
+}

--- a/lib/Settings/seed/vth-workflow-templates/spoedig-herstel.json
+++ b/lib/Settings/seed/vth-workflow-templates/spoedig-herstel.json
@@ -1,0 +1,84 @@
+{
+  "_format": "procest-vth-workflow-template-v1",
+  "slug": "spoedig-herstel",
+  "title": "Spoedig herstel (Awb 5:31)",
+  "description": "Workflow voor spoedeisende bestuursdwang: het bestuursorgaan herstelt direct en neemt het besluit achteraf (Awb 5:31).",
+  "version": 1,
+  "caseTypeSlug": "handhavingszaak",
+  "statutoryFramework": "Awb 5:31",
+  "steps": [
+    {
+      "slug": "geconstateerd",
+      "title": "Overtreding geconstateerd",
+      "statusName": "Constatering",
+      "order": 1,
+      "isInitial": true,
+      "isFinal": false,
+      "assigneeRole": "Inspecteur",
+      "description": "Acute overtreding ter plaatse vastgesteld; gevaar voor veiligheid/milieu."
+    },
+    {
+      "slug": "herstel-uitgevoerd",
+      "title": "Herstel uitgevoerd",
+      "statusName": "Vooraankondiging",
+      "order": 2,
+      "isInitial": false,
+      "isFinal": false,
+      "assigneeRole": "Behandelaar",
+      "description": "Bestuursdwang is direct uitgevoerd om de overtreding te beëindigen."
+    },
+    {
+      "slug": "besluit-achteraf",
+      "title": "Besluit achteraf",
+      "statusName": "Handhavingsbesluit",
+      "order": 3,
+      "isInitial": false,
+      "isFinal": false,
+      "assigneeRole": "Teamleider",
+      "description": "Schriftelijk besluit wordt zo spoedig mogelijk achteraf opgemaakt (Awb 5:31 lid 2)."
+    },
+    {
+      "slug": "afgehandeld",
+      "title": "Afgehandeld",
+      "statusName": "Afgehandeld",
+      "order": 4,
+      "isInitial": false,
+      "isFinal": true,
+      "assigneeRole": null,
+      "description": "Spoedig-herstel-traject is afgehandeld; eventuele kostenverhaal in separate zaak."
+    }
+  ],
+  "transitions": [
+    {
+      "slug": "geconstateerd-naar-herstel",
+      "fromStatus": "Constatering",
+      "toStatus": "Vooraankondiging",
+      "label": "Spoedeisend herstel uitvoeren",
+      "allowedRoles": ["Inspecteur", "Behandelaar"],
+      "deadline": {
+        "duration": "PT4H",
+        "source": "Awb 5:31 (onverwijld)",
+        "escalationRole": "BOA"
+      }
+    },
+    {
+      "slug": "herstel-naar-besluit",
+      "fromStatus": "Vooraankondiging",
+      "toStatus": "Handhavingsbesluit",
+      "label": "Besluit achteraf opmaken",
+      "allowedRoles": ["Teamleider"],
+      "deadline": {
+        "duration": "P7D",
+        "source": "Awb 5:31 lid 2 (zo spoedig mogelijk)",
+        "escalationRole": "afdelingsmanager"
+      }
+    },
+    {
+      "slug": "besluit-naar-afgehandeld",
+      "fromStatus": "Handhavingsbesluit",
+      "toStatus": "Afgehandeld",
+      "label": "Afhandelen",
+      "allowedRoles": ["Behandelaar"]
+    }
+  ]
+}

--- a/lib/Settings/seed/vth-workflow-templates/toezichtbezoek.json
+++ b/lib/Settings/seed/vth-workflow-templates/toezichtbezoek.json
@@ -1,0 +1,101 @@
+{
+  "_format": "procest-vth-workflow-template-v1",
+  "slug": "toezichtbezoek",
+  "title": "Toezichtbezoek",
+  "description": "Workflow voor een toezichtbezoek (inspectie ter plaatse). Geen wettelijke beslistermijn. Bij constatering van een overtreding wordt een handhavingstraject gespawned via automaticAction.",
+  "version": 1,
+  "caseTypeSlug": "toezichtzaak-bouw",
+  "statutoryFramework": "Awb hoofdstuk 5 (toezicht)",
+  "steps": [
+    {
+      "slug": "gepland",
+      "title": "Inspectie gepland",
+      "statusName": "Gepland",
+      "order": 1,
+      "isInitial": true,
+      "isFinal": false,
+      "assigneeRole": "Inspecteur",
+      "description": "Toezichtbezoek is ingepland, datum afgestemd met contactpersoon."
+    },
+    {
+      "slug": "uitgevoerd",
+      "title": "Inspectie uitgevoerd",
+      "statusName": "Inspectie",
+      "order": 2,
+      "isInitial": false,
+      "isFinal": false,
+      "assigneeRole": "Inspecteur",
+      "description": "Inspectie ter plaatse is afgerond, constateringen vastgelegd."
+    },
+    {
+      "slug": "rapport",
+      "title": "Rapport opgesteld",
+      "statusName": "Rapport",
+      "order": 3,
+      "isInitial": false,
+      "isFinal": false,
+      "assigneeRole": "Inspecteur",
+      "description": "Inspectierapport is opgesteld en intern beoordeeld."
+    },
+    {
+      "slug": "opvolging",
+      "title": "Opvolging",
+      "statusName": "Opvolging",
+      "order": 4,
+      "isInitial": false,
+      "isFinal": false,
+      "assigneeRole": "Inspecteur",
+      "description": "Constateringen worden opgevolgd; bij overtreding wordt een handhavingstraject gespawned."
+    },
+    {
+      "slug": "afgehandeld",
+      "title": "Afgehandeld",
+      "statusName": "Afgehandeld",
+      "order": 5,
+      "isInitial": false,
+      "isFinal": true,
+      "assigneeRole": null,
+      "description": "Toezichtbezoek is afgehandeld."
+    }
+  ],
+  "transitions": [
+    {
+      "slug": "gepland-naar-uitgevoerd",
+      "fromStatus": "Gepland",
+      "toStatus": "Inspectie",
+      "label": "Inspectie uitvoeren",
+      "allowedRoles": ["Inspecteur"]
+    },
+    {
+      "slug": "uitgevoerd-naar-rapport",
+      "fromStatus": "Inspectie",
+      "toStatus": "Rapport",
+      "label": "Rapport opstellen",
+      "allowedRoles": ["Inspecteur"]
+    },
+    {
+      "slug": "rapport-naar-opvolging",
+      "fromStatus": "Rapport",
+      "toStatus": "Opvolging",
+      "label": "Opvolging starten",
+      "allowedRoles": ["Inspecteur"],
+      "automaticActions": [
+        {
+          "type": "spawnCase",
+          "config": {
+            "targetWorkflowSlug": "handhavingstraject",
+            "condition": "constatering.severity in ['aanzienlijk', 'ernstig']",
+            "comment": "Spawn handhavingstraject zodra rapport een aanzienlijke of ernstige overtreding bevat."
+          }
+        }
+      ]
+    },
+    {
+      "slug": "opvolging-naar-afgehandeld",
+      "fromStatus": "Opvolging",
+      "toStatus": "Afgehandeld",
+      "label": "Afhandelen",
+      "allowedRoles": ["Inspecteur"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Applies the `vth-workflow-templates` OpenSpec change in a **manifest-first** style: workflow templates are seeded data, not new schemas or manifest pages. Six canonical VTH (Vergunningen, Toezicht & Handhaving) workflow templates ship as JSON catalog entries under `lib/Settings/seed/vth-workflow-templates/` and are installed by an idempotent repair step that routes every mutation through `WorkflowDefinitionService::createDraft()` + `publish()` — respecting the immutability invariant established by `workflow-definition-model`.

### Catalog (6 templates)

- `aanvraag-omgevingsvergunning` — Awb 4:13, 8 weken (verlengbaar 6 weken Awb 4:14)
- `toezichtbezoek` — spawn-link via `automaticActions[].type = "spawnCase"` naar handhavingstraject
- `handhavingstraject` — Awb 5:24 redelijke termijn (P56D op `Vooraankondiging -> Handhavingsbesluit`)
- `bezwaar` — **cross-link**: documenteert twee VTH-specifieke guards op de canonieke `bezwaar-lifecycle` workflow; geen nieuwe workflowTemplate
- `klacht-toezicht` — Awb 9:11, 6 weken (P42D)
- `spoedig-herstel` — Awb 5:31, onverwijld (PT4H + besluit achteraf binnen P7D)

### Changes

- New repair step `lib/Repair/SeedVthWorkflowTemplates.php`, registered as `post-migration` in `appinfo/info.xml` (after `SeedBezwaarBeroepData` and `MigrateWorkflowDefinitions`).
- New `WorkflowDefinitionService::createDraft(array \$payload): ?array` for seed / catalog-import flows. All mutations of `workflowTemplate` continue to route through the service (no direct `ObjectService::saveObject` calls on `workflowTemplate`).
- Catalog files use slug-based references (caseTypeSlug + statusName); the repair step resolves these to UUIDs at install time and skips templates whose caseType is missing (warns; soft-deps on `base-register-seed-data`).
- Deterministic UUID5 ids for steps and transitions guarantee idempotency on re-run.
- `builds/build.json` updated with `vth-workflow-templates` apply entry — tasks T01 + T02 done; T03..T07 + V01..V04 deferred to a follow-up UI apply.

### Constraints honoured

- Manifest-first: no new schemas, no new manifest pages.
- Strict watchdog: `php -l` + `jq` only (no composer check, no i18n).
- Immutability invariant respected: only draft -> published flips via the lifecycle service.
- No Co-Authored-By trailer.

## Test plan

- [ ] Fresh tenant: `php occ maintenance:repair` seeds the six templates as `published`+`isActive`+`version: 1`.
- [ ] Re-running the repair step is a no-op (idempotent).
- [ ] `bezwaar` entry logs as `cross-link` and creates no new `workflowTemplate` row.
- [ ] Templates whose `caseTypeSlug` is missing warn-and-skip rather than fail.
- [ ] `aanvraag-omgevingsvergunning`: transition `In behandeling -> Besluitvorming` carries `deadline.duration = "P56D"` + `deadline.source = "Awb 4:13"`.
- [ ] `klacht-toezicht`: transition `In behandeling -> Beoordeeld` carries `deadline.duration = "P42D"` + `deadline.source = "Awb 9:11"`.

## Deferred (follow-up apply)

T03 (catalog service), T03b (controller), T04 (routes), T04b (Vue store + axios service), T05 (`VthWorkflowTemplatesTab.vue`), T06 (`VthWorkflowTemplateDetailDialog.vue`), T07 (selective install UX), V01..V04 (verification suite). See `builds/build.json` for the full list of deferred items with reasons.