### PR TITLE
feat(inspection-checklists): apply spec

### DIFF
--- a/builds/build.json
+++ b/builds/build.json
@@ -29,39 +29,35 @@
       }
     },
     {
-      "change": "vth-workflow-templates",
+      "change": "inspection-checklists",
       "appliedAt": "2026-05-11",
-      "tasks": ["T01", "T02"],
+      "tasks": ["T01", "T02", "T03"],
       "deferred": [
-        {"task": "T03", "reason": "VthWorkflowTemplateCatalogService — manifest-first apply: catalog exposed via repair step + OpenRegister, follow-up change for ad-hoc admin import service"},
-        {"task": "T03b", "reason": "VthWorkflowTemplateCatalogController — follow-up change; out of strict-watchdog scope (no controllers in this apply)"},
-        {"task": "T04", "reason": "Routes registration — follows controller in a follow-up change"},
-        {"task": "T04b", "reason": "Vue store + axios service — Vue work deferred to a separate UI apply"},
-        {"task": "T05", "reason": "VthWorkflowTemplatesTab.vue — manifest-first; UI deferred to a separate UI apply"},
-        {"task": "T06", "reason": "VthWorkflowTemplateDetailDialog.vue — manifest-first; UI deferred to a separate UI apply"},
-        {"task": "T07", "reason": "Selective install / uninstall UX — requires controller and Vue tab from T03b/T05"},
-        {"task": "V01", "reason": "SPDX grep — N/A for files not yet authored (only repair step + catalog JSON in this apply)"},
-        {"task": "V02", "reason": "Service-API grep — partial: covered for repair step (no findObject/saveObject on workflowTemplate); rest covered by follow-up"},
-        {"task": "V03", "reason": "Controller getMessage() grep — controller deferred to follow-up apply"},
-        {"task": "V04", "reason": "Manual QA — strict watchdog: php -l + jq only; QA deferred to verify step"}
+        {"task": "T04", "reason": "Vue settings editor — manifest-first; OpenRegister auto-form renders index + detail for inspectionChecklistTemplate"},
+        {"task": "T05", "reason": "Mobile run UI lives in sister spec mobiel-inspectie (already applied); manifest run detail renders responses/photos/followUp tabs"},
+        {"task": "T06", "reason": "Offline sync queue — frontend scope, see mobiel-inspectie V3"},
+        {"task": "T07", "reason": "Evidence upload pipeline — folder structure documented; file routing follows existing FolderManagementHandler"},
+        {"task": "V01", "reason": "openspec validate scope — strict watchdog: lint + jq only"},
+        {"task": "V02", "reason": "delta count via openspec change show — out of watchdog scope"},
+        {"task": "V03", "reason": "Scenario coverage check — out of watchdog scope"},
+        {"task": "V04", "reason": "git diff scope check — handled by PR review"}
       ],
       "services": [
-        "OCA\\Procest\\Service\\WorkflowDefinitionService::createDraft"
+        "OCA\\Procest\\Service\\Inspection\\ChecklistService"
       ],
-      "repairSteps": ["OCA\\Procest\\Repair\\SeedVthWorkflowTemplates"],
-      "seedCatalog": {
-        "directory": "lib/Settings/seed/vth-workflow-templates",
-        "templates": [
-          "aanvraag-omgevingsvergunning",
-          "toezichtbezoek",
-          "handhavingstraject",
-          "bezwaar",
-          "klacht-toezicht",
-          "spoedig-herstel"
-        ],
-        "crossLinkOnly": ["bezwaar"]
+      "listeners": [
+        "OCA\\Procest\\Listener\\ChecklistRunImmutabilityListener"
+      ],
+      "controllers": [],
+      "endpoints": [],
+      "schemaChanges": {
+        "inspectionChecklistTemplate": ["new schema — name, caseType, version, status (draft|active|retired), active, sections[] with nested items[] (responseType enum [ja_nee_nvt, tekst, getal, meerkeuze, foto, meting], fotoRequired enum [nooit, bij_nee, altijd], numericRange, choices, failureAction with type enum [herinspectie, handhavingstaak, documentVerzoek, geen]), seedKey"],
+        "inspectionChecklistRun": ["new schema — case, inspection, template, templateVersion, templateSnapshot, inspector (server-derived), startedAt, completedAt, submittedAt, status (concept|in_uitvoering|ingediend|gearchiveerd), responses[] with itemId/value/numericValue/choice/comment/photos/audio/syncState, photos[], location, overallResult (conform|niet_conform|deels_conform), syncState (local|queued|synced), followUpType"]
       },
-      "notes": "Manifest-first apply: workflow templates are seeded data delivered via Repair step that calls WorkflowDefinitionService::createDraft() + publish(). No new manifest pages or schemas. The bezwaar entry is a cross-link to bezwaar-lifecycle (extra guards documented in JSON; no new workflowTemplate row). Soft-deps on base-register-seed-data — missing caseTypes warn + skip."
+      "configKeys": [
+        "inspection_checklist_template_schema",
+        "inspection_checklist_run_schema"
+      ]
     }
   ]
 }

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -35,6 +35,7 @@ use OCA\Procest\Dashboard\OverdueCasesWidget;
 use OCA\Procest\Dashboard\StalledCasesWidget;
 use OCA\Procest\Dashboard\TaskRemindersWidget;
 use OCA\Procest\Dashboard\StartCaseWidget;
+use OCA\Procest\Listener\ChecklistRunImmutabilityListener;
 use OCA\Procest\Listener\DeepLinkRegistrationListener;
 use OCA\Procest\Listener\KpiCacheInvalidationListener;
 use OCA\Procest\Listener\RoleMutationListener;
@@ -89,6 +90,12 @@ class Application extends App implements IBootstrap
         $context->registerEventListener(
             event: ObjectDeletedEvent::class,
             listener: KpiCacheInvalidationListener::class
+        );
+
+        // Inspection checklist run append-only enforcement (REQ-IC-8).
+        $context->registerEventListener(
+            event: ObjectUpdatedEvent::class,
+            listener: ChecklistRunImmutabilityListener::class
         );
 
         // Role-routing cache invalidation on role mutations.

--- a/lib/Listener/ChecklistRunImmutabilityListener.php
+++ b/lib/Listener/ChecklistRunImmutabilityListener.php
@@ -1,0 +1,225 @@
+<?php
+
+/**
+ * Procest Inspection Checklist Run Immutability Listener
+ *
+ * Enforces REQ-IC-8: once a `inspectionChecklistRun` reaches
+ * status = ingediend (or gearchiveerd), the object becomes append-only.
+ * Any UPDATE that mutates protected fields after submit is rejected with
+ * a RuntimeException whose message ("Checklist run is append-only") is the
+ * canonical spec error string surfaced via REQ-IC-4 / REQ-IC-8 scenarios.
+ *
+ * The listener never blocks the initial create (ObjectCreatedEvent) and
+ * lets a status transition from `in_uitvoering → ingediend` through; only
+ * subsequent edits to a submitted run trigger the rejection.
+ *
+ * @category Listener
+ * @package  OCA\Procest\Listener
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Listener;
+
+use OCA\OpenRegister\Event\ObjectUpdatedEvent;
+use OCA\Procest\Service\SettingsService;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Reject mutations on submitted inspectionChecklistRun objects.
+ *
+ * @implements IEventListener<Event>
+ *
+ * @spec openspec/changes/inspection-checklists/tasks.md#T03
+ */
+class ChecklistRunImmutabilityListener implements IEventListener
+{
+    /**
+     * Statuses past which a run is append-only.
+     *
+     * @var string[]
+     */
+    private const FROZEN_STATUSES = ['ingediend', 'gearchiveerd'];
+
+    /**
+     * Constructor.
+     *
+     * @param SettingsService $settingsService Schema slug bridge
+     * @param LoggerInterface $logger          Logger
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Inspect ObjectUpdatedEvent and reject illegal mutations.
+     *
+     * @param Event $event The dispatched event
+     *
+     * @return void
+     *
+     * @throws RuntimeException When a submitted run is being mutated.
+     */
+    public function handle(Event $event): void
+    {
+        if ($event instanceof ObjectUpdatedEvent === false) {
+            return;
+        }
+
+        try {
+            $new = $this->extractObject(event: $event, method: 'getNewObject');
+            if ($new === null) {
+                return;
+            }
+
+            if ($this->isChecklistRunSchema(object: $new) === false) {
+                return;
+            }
+
+            $old = $this->extractObject(event: $event, method: 'getOldObject');
+            if ($old === null) {
+                return;
+            }
+
+            $oldStatus = (string) ($old['status'] ?? '');
+            $newStatus = (string) ($new['status'] ?? '');
+
+            // Allow first-time transition to ingediend.
+            if (in_array($oldStatus, self::FROZEN_STATUSES, true) === false) {
+                return;
+            }
+
+            // Same frozen status: any change to other fields is rejected.
+            if ($oldStatus === $newStatus && $this->isMaterialChange(old: $old, new: $new) === false) {
+                return;
+            }
+
+            throw new RuntimeException('Checklist run is append-only');
+        } catch (RuntimeException $rejection) {
+            // Re-throw rejection so OpenRegister surfaces it to the caller.
+            throw $rejection;
+        } catch (Throwable $e) {
+            $this->logger->debug(
+                'Procest: checklist immutability listener swallowed exception: '.$e->getMessage(),
+            );
+        }
+    }//end handle()
+
+    /**
+     * Whether the supplied object belongs to the inspectionChecklistRun schema.
+     *
+     * @param array<string, mixed> $object Object payload
+     *
+     * @return bool
+     */
+    private function isChecklistRunSchema(array $object): bool
+    {
+        $expected = $this->settingsService->getConfigValue('inspection_checklist_run_schema');
+        if ($expected === '') {
+            return false;
+        }
+
+        $candidate = (string) (
+            $object['@self']['schema']
+            ?? ($object['schema'] ?? '')
+        );
+
+        return $candidate !== '' && (
+            $candidate === $expected
+            || str_ends_with($candidate, '/'.$expected)
+        );
+    }//end isChecklistRunSchema()
+
+    /**
+     * Compare old/new payloads for material differences.
+     *
+     * Metadata-only refreshes (updatedAt etc.) are ignored; substantive
+     * field mutations are rejected.
+     *
+     * @param array<string, mixed> $old Previous version
+     * @param array<string, mixed> $new New version
+     *
+     * @return bool
+     */
+    private function isMaterialChange(array $old, array $new): bool
+    {
+        $protected = [
+            'responses',
+            'overallResult',
+            'inspector',
+            'templateSnapshot',
+            'templateVersion',
+            'template',
+            'case',
+            'submittedAt',
+            'completedAt',
+            'photos',
+            'followUpType',
+        ];
+
+        foreach ($protected as $field) {
+            $oldVal = $old[$field] ?? null;
+            $newVal = $new[$field] ?? null;
+            if ($oldVal !== $newVal) {
+                return true;
+            }
+        }
+
+        return false;
+    }//end isMaterialChange()
+
+    /**
+     * Extract a payload from an event by accessor method.
+     *
+     * @param Event  $event  Source event
+     * @param string $method Accessor name (getNewObject / getOldObject)
+     *
+     * @return array<string, mixed>|null
+     */
+    private function extractObject(Event $event, string $method): ?array
+    {
+        if (method_exists($event, $method) === false) {
+            return null;
+        }
+
+        $value = $event->{$method}();
+        if (is_array($value) === true) {
+            return $value;
+        }
+
+        if (is_object($value) === true) {
+            if (method_exists($value, 'jsonSerialize') === true) {
+                $serialised = $value->jsonSerialize();
+                if (is_array($serialised) === true) {
+                    return $serialised;
+                }
+            }
+
+            if (method_exists($value, 'toArray') === true) {
+                $arr = $value->toArray();
+                if (is_array($arr) === true) {
+                    return $arr;
+                }
+            }
+        }
+
+        return null;
+    }//end extractObject()
+}//end class

--- a/lib/Service/Inspection/ChecklistService.php
+++ b/lib/Service/Inspection/ChecklistService.php
@@ -1,0 +1,809 @@
+<?php
+
+/**
+ * Procest Inspection Checklist Service
+ *
+ * Orchestrates the lifecycle of inspectionChecklistTemplate + inspectionChecklistRun
+ * objects. Generic CRUD is delegated to the OpenRegister manifest renderer; this
+ * service owns only the operations that the manifest path cannot perform:
+ *
+ *  - createRun(inspection, template): freeze templateSnapshot + templateVersion,
+ *    server-derive inspector identity from IUserSession.
+ *  - submitRun(run, payload): validate responses, derive overallResult,
+ *    dispatch follow-up actions, mark run append-only.
+ *  - aggregateResult(responses, snapshot): pass/fail aggregation per REQ-IC-6.
+ *
+ * Append-only enforcement (REQ-IC-8) lives in ChecklistRunImmutabilityListener
+ * on OpenRegister ObjectUpdatedEvent — this service layers a service-level
+ * check on top so direct callers see the same contract.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Inspection
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Inspection;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use OCA\Procest\Service\SettingsService;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Inspection checklist orchestration service.
+ *
+ * @spec openspec/changes/inspection-checklists/tasks.md#T03
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) — orchestrates ObjectService + IUserSession + follow-up dispatch
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity) — guarded by validateResponse branches per response type
+ */
+class ChecklistService
+{
+    /**
+     * Run status when initially created.
+     */
+    public const STATUS_CONCEPT = 'concept';
+
+    /**
+     * Run status while answers are being entered.
+     */
+    public const STATUS_IN_UITVOERING = 'in_uitvoering';
+
+    /**
+     * Run status once the inspector submits — append-only from here.
+     */
+    public const STATUS_INGEDIEND = 'ingediend';
+
+    /**
+     * Run status when retention has archived the run.
+     */
+    public const STATUS_GEARCHIVEERD = 'gearchiveerd';
+
+    /**
+     * Overall result: every item passes or is N/A.
+     */
+    public const RESULT_CONFORM = 'conform';
+
+    /**
+     * Overall result: at least one failure and no skipped items.
+     */
+    public const RESULT_NIET_CONFORM = 'niet_conform';
+
+    /**
+     * Overall result: at least one failure AND at least one skipped item.
+     */
+    public const RESULT_DEELS_CONFORM = 'deels_conform';
+
+    /**
+     * Follow-up types matching the failureAction.type enum.
+     */
+    public const FOLLOWUP_HERINSPECTIE = 'herinspectie';
+    public const FOLLOWUP_HANDHAVINGSTAAK = 'handhavingstaak';
+    public const FOLLOWUP_DOCUMENT_VERZOEK = 'documentVerzoek';
+    public const FOLLOWUP_GEEN = 'geen';
+
+    /**
+     * Constructor.
+     *
+     * @param SettingsService $settingsService The Procest settings/config bridge to OpenRegister
+     * @param IUserSession    $userSession     The current Nextcloud user session
+     * @param LoggerInterface $logger          The logger instance
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+        private readonly IUserSession $userSession,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Start a new run against a template, freezing the snapshot and inspector identity.
+     *
+     * @param string      $templateId  Template UUID
+     * @param string      $caseId      Parent case UUID
+     * @param string|null $inspectionId Optional parent mobiel-inspectie session id
+     *
+     * @return array<string, mixed> The persisted run
+     *
+     * @throws RuntimeException When configuration is missing, the template
+     *                          cannot be loaded, or persistence fails.
+     */
+    public function createRun(string $templateId, string $caseId, ?string $inspectionId = null): array
+    {
+        [$objectService, $register] = $this->bootstrap();
+        $templateSchema = $this->requireConfig(key: 'inspection_checklist_template_schema');
+        $runSchema      = $this->requireConfig(key: 'inspection_checklist_run_schema');
+
+        $template = $this->toArray(value: $objectService->findObject($register, $templateSchema, $templateId));
+        if ($template === []) {
+            throw new RuntimeException('Inspection checklist template not found');
+        }
+
+        $version  = (int) ($template['version'] ?? 1);
+        $snapshot = [
+            'name'     => (string) ($template['name'] ?? ''),
+            'version'  => $version,
+            'sections' => $template['sections'] ?? [],
+        ];
+
+        $now = (new DateTimeImmutable())->format(DateTimeInterface::ATOM);
+
+        $run = [
+            'case'             => $caseId,
+            'template'         => $templateId,
+            'templateVersion'  => $version,
+            'templateSnapshot' => $snapshot,
+            'inspector'        => $this->requireUserId(),
+            'startedAt'        => $now,
+            'status'           => self::STATUS_CONCEPT,
+            'responses'        => [],
+            'syncState'        => 'synced',
+        ];
+
+        if ($inspectionId !== null && $inspectionId !== '') {
+            $run['inspection'] = $inspectionId;
+        }
+
+        $persisted = $this->toArray(value: $objectService->saveObject($register, $runSchema, $run));
+
+        $this->logger->info(
+            'Procest: created checklist run {runId} for template {templateId} v{version}',
+            [
+                'runId'      => (string) ($persisted['id'] ?? ''),
+                'templateId' => $templateId,
+                'version'    => $version,
+            ]
+        );
+
+        return $persisted;
+    }//end createRun()
+
+    /**
+     * Submit a run: validate, derive overallResult, dispatch follow-ups, lock to append-only.
+     *
+     * @param string               $runId   Run UUID
+     * @param array<string, mixed> $payload {responses?: array, followUpType?: string}
+     *
+     * @return array<string, mixed> The submitted, immutable run
+     *
+     * @throws RuntimeException When the run is already submitted (REQ-IC-8)
+     *                          or persistence fails.
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity) — branches cover validation + follow-up dispatch
+     */
+    public function submitRun(string $runId, array $payload): array
+    {
+        [$objectService, $register] = $this->bootstrap();
+        $runSchema = $this->requireConfig(key: 'inspection_checklist_run_schema');
+
+        $run = $this->toArray(value: $objectService->findObject($register, $runSchema, $runId));
+        if ($run === []) {
+            throw new RuntimeException('Inspection checklist run not found');
+        }
+
+        $this->assertRunMutable(run: $run);
+
+        // User-supplied inspector / overallResult / submittedAt are ignored on submit.
+        $responses = $payload['responses'] ?? ($run['responses'] ?? []);
+        if (is_array($responses) === false) {
+            $responses = [];
+        }
+
+        $snapshot = $run['templateSnapshot'] ?? [];
+        if (is_array($snapshot) === false) {
+            $snapshot = [];
+        }
+
+        $itemsByOrder = $this->indexItemsBySnapshot(snapshot: $snapshot);
+
+        $validResponses = [];
+        foreach ($responses as $response) {
+            if (is_array($response) === false) {
+                continue;
+            }
+
+            $itemId = (string) ($response['itemId'] ?? '');
+            $item   = $itemsByOrder[$itemId] ?? null;
+            if ($item !== null) {
+                $this->validateResponse(item: $item, payload: $response);
+            }
+
+            $validResponses[] = $response;
+        }
+
+        $aggregate = $this->aggregateResult(responses: $validResponses, snapshot: $snapshot);
+
+        $now = (new DateTimeImmutable())->format(DateTimeInterface::ATOM);
+
+        $run['responses']     = $validResponses;
+        $run['status']        = self::STATUS_INGEDIEND;
+        $run['submittedAt']   = $now;
+        $run['completedAt']   = $now;
+        $run['overallResult'] = $aggregate;
+        $run['inspector']     = $this->requireUserId();
+        $run['syncState']     = 'synced';
+
+        $followUp = $this->resolvePrimaryFollowUp(responses: $validResponses, snapshot: $snapshot);
+        if ($followUp !== null) {
+            $run['followUpType'] = $followUp;
+        }
+
+        $persisted = $this->toArray(value: $objectService->saveObject($register, $runSchema, $run));
+
+        try {
+            $this->dispatchFollowUps(run: $persisted);
+        } catch (Throwable $e) {
+            $this->logger->warning(
+                'Procest: checklist follow-up dispatch failed for run {runId}: {msg}',
+                [
+                    'runId' => (string) ($persisted['id'] ?? ''),
+                    'msg'   => $e->getMessage(),
+                ]
+            );
+        }
+
+        return $persisted;
+    }//end submitRun()
+
+    /**
+     * Derive overallResult from responses + frozen template snapshot.
+     *
+     * @param array<int, array<string, mixed>> $responses Submitted responses
+     * @param array<string, mixed>             $snapshot  Frozen template snapshot
+     *
+     * @return string conform | niet_conform | deels_conform
+     */
+    public function aggregateResult(array $responses, array $snapshot): string
+    {
+        $itemsByOrder = $this->indexItemsBySnapshot(snapshot: $snapshot);
+        $fails        = 0;
+        $skipped      = 0;
+
+        foreach ($responses as $response) {
+            if (is_array($response) === false) {
+                continue;
+            }
+
+            $itemId = (string) ($response['itemId'] ?? '');
+            $item   = $itemsByOrder[$itemId] ?? null;
+            $verdict = $this->classifyResponse(response: $response, item: $item);
+
+            if ($verdict === 'fail') {
+                $fails++;
+            } elseif ($verdict === 'skip') {
+                $skipped++;
+            }
+        }
+
+        if ($fails === 0) {
+            return self::RESULT_CONFORM;
+        }
+
+        if ($skipped > 0) {
+            return self::RESULT_DEELS_CONFORM;
+        }
+
+        return self::RESULT_NIET_CONFORM;
+    }//end aggregateResult()
+
+    /**
+     * Validate a single response against its item definition (REQ-IC-3).
+     *
+     * @param array<string, mixed> $item    Frozen item definition
+     * @param array<string, mixed> $payload Submitted response payload
+     *
+     * @return void
+     *
+     * @throws RuntimeException On validation failure with the spec error codes.
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity) — branches cover all response types
+     */
+    public function validateResponse(array $item, array $payload): void
+    {
+        $type = (string) ($item['responseType'] ?? '');
+
+        if ($type === 'ja_nee_nvt') {
+            $value = (string) ($payload['value'] ?? '');
+            if (in_array($value, ['ja', 'nee', 'nvt'], true) === false) {
+                throw new RuntimeException('INVALID_VALUE');
+            }
+        }
+
+        if ($type === 'getal' || $type === 'meting') {
+            $range = $item['numericRange'] ?? null;
+            if (is_array($range) === true && array_key_exists('numericValue', $payload) === true) {
+                $val = (float) $payload['numericValue'];
+                $min = array_key_exists('min', $range) === true ? (float) $range['min'] : null;
+                $max = array_key_exists('max', $range) === true ? (float) $range['max'] : null;
+                if (($min !== null && $val < $min) || ($max !== null && $val > $max)) {
+                    throw new RuntimeException('OUT_OF_RANGE');
+                }
+            }
+        }
+
+        if ($type === 'meerkeuze') {
+            $choices = $item['choices'] ?? [];
+            $choice  = (string) ($payload['choice'] ?? ($payload['value'] ?? ''));
+            if (is_array($choices) === true && in_array($choice, $choices, true) === false) {
+                throw new RuntimeException('INVALID_CHOICE');
+            }
+        }
+
+        if ($type === 'tekst') {
+            $comment = (string) ($payload['value'] ?? ($payload['comment'] ?? ''));
+            if (strlen($comment) > 2000) {
+                throw new RuntimeException('TEXT_TOO_LONG');
+            }
+        }
+
+        if ($type === 'foto') {
+            $photos = $payload['photos'] ?? [];
+            if (is_array($photos) === false || count($photos) < 1) {
+                throw new RuntimeException('PHOTO_REQUIRED');
+            }
+        }
+
+        $fotoGate = (string) ($item['fotoRequired'] ?? 'nooit');
+        $photos   = $payload['photos'] ?? [];
+        $hasPhoto = is_array($photos) === true && count($photos) >= 1;
+        $value    = (string) ($payload['value'] ?? '');
+
+        if ($fotoGate === 'altijd' && $hasPhoto === false) {
+            throw new RuntimeException('PHOTO_REQUIRED');
+        }
+
+        if ($fotoGate === 'bij_nee' && $value === 'nee' && $hasPhoto === false) {
+            throw new RuntimeException('PHOTO_REQUIRED');
+        }
+    }//end validateResponse()
+
+    /**
+     * Dispatch follow-up actions for failed items per REQ-IC-7.
+     *
+     * Creates one task per failed item whose failureAction.type !== geen.
+     * handhavingstaak hands off to the enforcement-lhs handhavingsactie schema
+     * (currently invoked inline; a dedicated EnforcementRecommendationService
+     * is the long-term target).
+     *
+     * @param array<string, mixed> $run The submitted run
+     *
+     * @return array<int, array<string, mixed>> Tasks created
+     */
+    public function dispatchFollowUps(array $run): array
+    {
+        $responses = $run['responses'] ?? [];
+        $snapshot  = $run['templateSnapshot'] ?? [];
+        if (is_array($responses) === false || is_array($snapshot) === false) {
+            return [];
+        }
+
+        $items = $this->indexItemsBySnapshot(snapshot: $snapshot);
+        [$objectService, $register] = $this->bootstrap();
+        $taskSchema = (string) $this->settingsService->getConfigValue('task_schema');
+
+        $created = [];
+        $runId   = (string) ($run['id'] ?? '');
+        $caseId  = (string) ($run['case'] ?? '');
+        $submittedAt = (string) ($run['submittedAt'] ?? (new DateTimeImmutable())->format(DateTimeInterface::ATOM));
+
+        foreach ($responses as $response) {
+            if (is_array($response) === false) {
+                continue;
+            }
+
+            $itemId  = (string) ($response['itemId'] ?? '');
+            $item    = $items[$itemId] ?? null;
+            $verdict = $this->classifyResponse(response: $response, item: $item);
+            if ($verdict !== 'fail' || $item === null) {
+                continue;
+            }
+
+            $action = $item['failureAction'] ?? null;
+            if (is_array($action) === false) {
+                continue;
+            }
+
+            $actionType = (string) ($action['type'] ?? self::FOLLOWUP_GEEN);
+            if ($actionType === self::FOLLOWUP_GEEN || $actionType === '') {
+                continue;
+            }
+
+            $deadlineDays = (int) ($action['deadlineDays'] ?? 0);
+            $deadline = null;
+            if ($deadlineDays > 0) {
+                $deadline = (new DateTimeImmutable($submittedAt))
+                    ->modify('+'.$deadlineDays.' days')
+                    ->format(DateTimeInterface::ATOM);
+            }
+
+            $task = [
+                'case'        => $caseId,
+                'title'       => $this->describeFollowUp(type: $actionType, item: $item),
+                'description' => 'Follow-up automatically created from inspection checklist run',
+                'sourceRun'   => $runId,
+                'sourceItem'  => $itemId,
+                'followUpType' => $actionType,
+            ];
+
+            if ($deadline !== null) {
+                $task['deadline'] = $deadline;
+            }
+
+            if ($actionType === self::FOLLOWUP_HANDHAVINGSTAAK) {
+                $this->createHandhavingsactie(
+                    objectService: $objectService,
+                    register: $register,
+                    caseId: $caseId,
+                    runId: $runId,
+                    itemId: $itemId
+                );
+            }
+
+            if ($taskSchema !== '') {
+                try {
+                    $persisted = $this->toArray(value: $objectService->saveObject($register, $taskSchema, $task));
+                    $created[] = $persisted;
+                } catch (Throwable $e) {
+                    $this->logger->debug(
+                        'Procest: follow-up task save failed: '.$e->getMessage(),
+                    );
+                }
+            } else {
+                $created[] = $task;
+            }
+        }
+
+        return $created;
+    }//end dispatchFollowUps()
+
+    /**
+     * Hand off to the enforcement-lhs recommendation surface.
+     *
+     * Until a dedicated EnforcementRecommendationService is built, this
+     * creates a handhavingsactie object with neutral defaults; the LHS
+     * matrix is filled in by the handhaving handler once the case is
+     * picked up.
+     *
+     * @param object $objectService OpenRegister object service handle
+     * @param string $register      Procest register slug
+     * @param string $caseId        Parent case UUID
+     * @param string $runId         Source run UUID
+     * @param string $itemId        Source item id
+     *
+     * @return void
+     */
+    private function createHandhavingsactie(
+        object $objectService,
+        string $register,
+        string $caseId,
+        string $runId,
+        string $itemId,
+    ): void {
+        $schema = (string) $this->settingsService->getConfigValue('handhavingsactie_schema');
+        if ($schema === '') {
+            return;
+        }
+
+        $payload = [
+            'case'        => $caseId,
+            'type'        => 'waarschuwing',
+            'ernst'       => 'aanzienlijk',
+            'gedrag'      => 'onverschillig',
+            'interventie' => 'Suggested by inspection checklist run '.$runId.' item '.$itemId,
+        ];
+
+        try {
+            $objectService->saveObject($register, $schema, $payload);
+        } catch (Throwable $e) {
+            $this->logger->debug(
+                'Procest: handhavingsactie save failed for run '.$runId.': '.$e->getMessage(),
+            );
+        }
+    }//end createHandhavingsactie()
+
+    /**
+     * Reject any write to a run that has already been submitted (REQ-IC-8).
+     *
+     * @param array<string, mixed> $run The current run
+     *
+     * @return void
+     *
+     * @throws RuntimeException With message "Checklist run is append-only".
+     */
+    public function assertRunMutable(array $run): void
+    {
+        $status = (string) ($run['status'] ?? '');
+        if ($status === self::STATUS_INGEDIEND || $status === self::STATUS_GEARCHIVEERD) {
+            throw new RuntimeException('Checklist run is append-only');
+        }
+    }//end assertRunMutable()
+
+    /**
+     * Classify a single response: pass | fail | skip.
+     *
+     * @param array<string, mixed>      $response Submitted response
+     * @param array<string, mixed>|null $item     Frozen item definition
+     *
+     * @return string
+     */
+    private function classifyResponse(array $response, ?array $item): string
+    {
+        if ($item === null) {
+            return 'pass';
+        }
+
+        $type  = (string) ($item['responseType'] ?? '');
+        $value = (string) ($response['value'] ?? '');
+
+        if ($type === 'ja_nee_nvt') {
+            if ($value === 'nvt') {
+                return 'skip';
+            }
+
+            if ($value === 'nee') {
+                return 'fail';
+            }
+
+            return 'pass';
+        }
+
+        if ($type === 'getal' || $type === 'meting') {
+            $range = $item['numericRange'] ?? null;
+            if (is_array($range) === false || array_key_exists('numericValue', $response) === false) {
+                return 'pass';
+            }
+
+            $val = (float) $response['numericValue'];
+            $min = array_key_exists('min', $range) === true ? (float) $range['min'] : null;
+            $max = array_key_exists('max', $range) === true ? (float) $range['max'] : null;
+            if (($min !== null && $val < $min) || ($max !== null && $val > $max)) {
+                return 'fail';
+            }
+
+            return 'pass';
+        }
+
+        if ($type === 'meerkeuze') {
+            $choices = $item['choices'] ?? [];
+            $choice  = (string) ($response['choice'] ?? $value);
+            if (is_array($choices) === true && in_array($choice, $choices, true) === false) {
+                return 'fail';
+            }
+
+            return 'pass';
+        }
+
+        if ($type === 'foto') {
+            $photos = $response['photos'] ?? [];
+            if (is_array($photos) === false || count($photos) < 1) {
+                return 'fail';
+            }
+
+            return 'pass';
+        }
+
+        return 'pass';
+    }//end classifyResponse()
+
+    /**
+     * Pick the highest-priority follow-up type across failed items.
+     *
+     * @param array<int, array<string, mixed>> $responses Responses
+     * @param array<string, mixed>             $snapshot  Frozen template snapshot
+     *
+     * @return string|null
+     */
+    private function resolvePrimaryFollowUp(array $responses, array $snapshot): ?string
+    {
+        $priority = [
+            self::FOLLOWUP_HANDHAVINGSTAAK => 3,
+            self::FOLLOWUP_HERINSPECTIE    => 2,
+            self::FOLLOWUP_DOCUMENT_VERZOEK => 1,
+            self::FOLLOWUP_GEEN            => 0,
+        ];
+
+        $items = $this->indexItemsBySnapshot(snapshot: $snapshot);
+        $winner = null;
+        $best   = -1;
+
+        foreach ($responses as $response) {
+            if (is_array($response) === false) {
+                continue;
+            }
+
+            $itemId = (string) ($response['itemId'] ?? '');
+            $item   = $items[$itemId] ?? null;
+            if ($item === null) {
+                continue;
+            }
+
+            if ($this->classifyResponse(response: $response, item: $item) !== 'fail') {
+                continue;
+            }
+
+            $action = $item['failureAction'] ?? [];
+            if (is_array($action) === false) {
+                continue;
+            }
+
+            $type = (string) ($action['type'] ?? self::FOLLOWUP_GEEN);
+            $rank = $priority[$type] ?? 0;
+            if ($rank > $best) {
+                $best   = $rank;
+                $winner = $type;
+            }
+        }
+
+        return $winner;
+    }//end resolvePrimaryFollowUp()
+
+    /**
+     * Map snapshot.items[]/sections[].items[] into an itemId-keyed lookup.
+     *
+     * The template can express items[] either flat (legacy) or nested under
+     * sections[] — accept both.
+     *
+     * @param array<string, mixed> $snapshot Frozen template snapshot
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    private function indexItemsBySnapshot(array $snapshot): array
+    {
+        $out = [];
+
+        $collect = static function (array $items) use (&$out): void {
+            foreach ($items as $idx => $item) {
+                if (is_array($item) === false) {
+                    continue;
+                }
+
+                $id = (string) ($item['id'] ?? ($item['order'] ?? (string) $idx));
+                $out[$id] = $item;
+            }
+        };
+
+        if (is_array($snapshot['items'] ?? null) === true) {
+            $collect($snapshot['items']);
+        }
+
+        $sections = $snapshot['sections'] ?? [];
+        if (is_array($sections) === true) {
+            foreach ($sections as $section) {
+                if (is_array($section) === false) {
+                    continue;
+                }
+
+                $items = $section['items'] ?? [];
+                if (is_array($items) === true) {
+                    $collect($items);
+                }
+            }
+        }
+
+        return $out;
+    }//end indexItemsBySnapshot()
+
+    /**
+     * Compose a follow-up task title.
+     *
+     * @param string               $type Follow-up type
+     * @param array<string, mixed> $item Source item
+     *
+     * @return string
+     */
+    private function describeFollowUp(string $type, array $item): string
+    {
+        $label = (string) ($item['label'] ?? 'inspection finding');
+
+        return match ($type) {
+            self::FOLLOWUP_HERINSPECTIE => 'Herinspectie: '.$label,
+            self::FOLLOWUP_HANDHAVINGSTAAK => 'Handhavingstaak: '.$label,
+            self::FOLLOWUP_DOCUMENT_VERZOEK => 'Documentverzoek: '.$label,
+            default => 'Follow-up: '.$label,
+        };
+    }//end describeFollowUp()
+
+    /**
+     * Bootstrap ObjectService + the register slug.
+     *
+     * @return array{0: object, 1: string}
+     *
+     * @throws RuntimeException When OpenRegister is unavailable.
+     */
+    private function bootstrap(): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            throw new RuntimeException('OpenRegister is niet beschikbaar');
+        }
+
+        $register = $this->requireConfig(key: 'register');
+
+        return [$objectService, $register];
+    }//end bootstrap()
+
+    /**
+     * Resolve a required configuration value.
+     *
+     * @param string $key The config key
+     *
+     * @return string
+     *
+     * @throws RuntimeException When the value is empty.
+     */
+    private function requireConfig(string $key): string
+    {
+        $value = $this->settingsService->getConfigValue($key);
+        if ($value === '') {
+            throw new RuntimeException(sprintf('Procest configuration key %s is not set', $key));
+        }
+
+        return $value;
+    }//end requireConfig()
+
+    /**
+     * Resolve the current user UID, refusing anonymous sessions.
+     *
+     * @return string
+     *
+     * @throws RuntimeException When no user is authenticated.
+     */
+    private function requireUserId(): string
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            throw new RuntimeException('Geen geauthenticeerde gebruiker');
+        }
+
+        return $user->getUID();
+    }//end requireUserId()
+
+    /**
+     * Coerce an ObjectService return value to a plain array.
+     *
+     * @param mixed $value The raw return
+     *
+     * @return array<string, mixed>
+     */
+    private function toArray(mixed $value): array
+    {
+        if (is_array($value) === true) {
+            return $value;
+        }
+
+        if (is_object($value) === true) {
+            if (method_exists($value, 'jsonSerialize') === true) {
+                $serialised = $value->jsonSerialize();
+                if (is_array($serialised) === true) {
+                    return $serialised;
+                }
+            }
+
+            if (method_exists($value, 'toArray') === true) {
+                $arr = $value->toArray();
+                if (is_array($arr) === true) {
+                    return $arr;
+                }
+            }
+        }
+
+        return [];
+    }//end toArray()
+}//end class

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -163,6 +163,8 @@ class SettingsService
         'abonnement'                   => 'abonnement_schema',
         'inspectieChecklist'           => 'inspectie_checklist_schema',
         'inspectieRapport'             => 'inspectie_rapport_schema',
+        'inspectionChecklistTemplate'  => 'inspection_checklist_template_schema',
+        'inspectionChecklistRun'       => 'inspection_checklist_run_schema',
         'handhavingsactie'             => 'handhavingsactie_schema',
         'adviesAanvraag'               => 'advies_aanvraag_schema',
         'mapLayer'                     => 'map_layer_schema',

--- a/lib/Settings/procest_register.json
+++ b/lib/Settings/procest_register.json
@@ -3296,6 +3296,358 @@
           }
         }
       },
+      "inspectionChecklistTemplate": {
+        "slug": "inspectionChecklistTemplate",
+        "icon": "ClipboardListOutline",
+        "version": "1.0.0",
+        "x-schema-org-type": "schema:HowTo",
+        "title": "Inspection Checklist Template",
+        "description": "Long-lived configuration template for an inspection checklist (REQ-IC-1). Owns sections, items, response-type rules, and follow-up action defaults. Versioned per REQ-IC-8 — published edits create a new version and retire the prior one.",
+        "type": "object",
+        "required": [
+          "name",
+          "version",
+          "status",
+          "sections"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 255,
+            "description": "Template label, e.g. 'Bouwtoezicht — Fundering'"
+          },
+          "caseType": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Optional case-type binding; null means any case type"
+          },
+          "version": {
+            "type": "integer",
+            "minimum": 1,
+            "default": 1,
+            "description": "Monotonic template version, frozen once a run consumes it"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "draft",
+              "active",
+              "retired"
+            ],
+            "default": "draft",
+            "description": "Lifecycle status of this template version"
+          },
+          "active": {
+            "type": "boolean",
+            "default": false,
+            "description": "Convenience flag mirroring status=active for list filtering"
+          },
+          "sections": {
+            "type": "array",
+            "description": "Ordered sections each carrying their own items[]",
+            "items": {
+              "type": "object",
+              "required": ["name"],
+              "properties": {
+                "order": {
+                  "type": "integer",
+                  "description": "Display order"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Section name, e.g. 'Wapening'"
+                },
+                "description": {
+                  "type": "string",
+                  "description": "Optional section guidance text"
+                },
+                "items": {
+                  "type": "array",
+                  "description": "Ordered checklist items in this section",
+                  "items": {
+                    "type": "object",
+                    "required": ["label", "responseType"],
+                    "properties": {
+                      "order": {
+                        "type": "integer",
+                        "description": "Display order of the item"
+                      },
+                      "label": {
+                        "type": "string",
+                        "description": "Question / item label"
+                      },
+                      "helpText": {
+                        "type": "string",
+                        "description": "Optional inspector guidance"
+                      },
+                      "responseType": {
+                        "type": "string",
+                        "enum": [
+                          "ja_nee_nvt",
+                          "tekst",
+                          "getal",
+                          "meerkeuze",
+                          "foto",
+                          "meting"
+                        ],
+                        "description": "Input type — drives validation in REQ-IC-3"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Whether the item must be answered"
+                      },
+                      "fotoRequired": {
+                        "type": "string",
+                        "enum": [
+                          "nooit",
+                          "bij_nee",
+                          "altijd"
+                        ],
+                        "default": "nooit",
+                        "description": "Photo requirement gate (REQ-IC-3)"
+                      },
+                      "numericRange": {
+                        "type": "object",
+                        "description": "Only used when responseType is getal or meting",
+                        "properties": {
+                          "min": {
+                            "type": "number"
+                          },
+                          "max": {
+                            "type": "number"
+                          },
+                          "unit": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "choices": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Allowed values when responseType is meerkeuze"
+                      },
+                      "failureAction": {
+                        "type": "object",
+                        "description": "Conditional follow-up dispatched on failure (REQ-IC-7)",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "herinspectie",
+                              "handhavingstaak",
+                              "documentVerzoek",
+                              "geen"
+                            ],
+                            "default": "geen"
+                          },
+                          "template": {
+                            "type": "string",
+                            "description": "Optional template ref for the follow-up artefact"
+                          },
+                          "deadlineDays": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "description": "Days from submit to follow-up deadline"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "seedKey": {
+            "type": "string",
+            "description": "Idempotent seed identifier when shipped via repair-step seeds"
+          }
+        }
+      },
+      "inspectionChecklistRun": {
+        "slug": "inspectionChecklistRun",
+        "icon": "ClipboardCheckMultipleOutline",
+        "version": "1.0.0",
+        "x-schema-org-type": "schema:Action",
+        "title": "Inspection Checklist Run",
+        "description": "Per-inspection runtime instance of an inspectionChecklistTemplate (REQ-IC-2). Once submitted (status=ingediend) the run is append-only: edits are rejected by REQ-IC-8 enforcement.",
+        "type": "object",
+        "required": [
+          "case",
+          "template",
+          "templateVersion",
+          "inspector",
+          "status"
+        ],
+        "properties": {
+          "case": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Parent case (zaak) reference"
+          },
+          "inspection": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Optional parent inspection reference (mobiel-inspectie session)"
+          },
+          "template": {
+            "type": "string",
+            "format": "uuid",
+            "description": "inspectionChecklistTemplate reference chosen at run start"
+          },
+          "templateVersion": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Template version captured at run start (REQ-IC-8)"
+          },
+          "templateSnapshot": {
+            "type": "object",
+            "description": "Frozen JSON copy of the template sections+items at run start — hidden from default API output",
+            "additionalProperties": true
+          },
+          "inspector": {
+            "type": "string",
+            "description": "NC user UID — server-derived from IUserSession, never accepted from body"
+          },
+          "startedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the run was created"
+          },
+          "completedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the run was submitted"
+          },
+          "submittedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Alias of completedAt; populated on submit"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "concept",
+              "in_uitvoering",
+              "ingediend",
+              "gearchiveerd"
+            ],
+            "default": "concept",
+            "description": "Run lifecycle status"
+          },
+          "responses": {
+            "type": "array",
+            "description": "Per-item responses (append-only post-submit)",
+            "items": {
+              "type": "object",
+              "required": ["itemId"],
+              "properties": {
+                "itemId": {
+                  "type": "string",
+                  "description": "Reference to checklist item id"
+                },
+                "value": {
+                  "type": "string",
+                  "description": "Primary value (ja/nee/nvt, text, choice)"
+                },
+                "numericValue": {
+                  "type": "number",
+                  "description": "Numeric value for getal/meting"
+                },
+                "choice": {
+                  "type": "string",
+                  "description": "Selected option for meerkeuze"
+                },
+                "comment": {
+                  "type": "string",
+                  "maxLength": 2000,
+                  "description": "Free-text comment"
+                },
+                "photos": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Nextcloud file IDs for photos"
+                },
+                "audio": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Nextcloud file IDs for audio recordings"
+                },
+                "respondedAt": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "syncState": {
+                  "type": "string",
+                  "enum": ["local", "queued", "synced"],
+                  "description": "Offline-sync state for this response"
+                }
+              }
+            }
+          },
+          "photos": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "All Nextcloud file IDs of photos attached to this run"
+          },
+          "location": {
+            "type": "object",
+            "properties": {
+              "lat": {
+                "type": "number"
+              },
+              "lng": {
+                "type": "number"
+              },
+              "accuracy": {
+                "type": "number"
+              },
+              "source": {
+                "type": "string"
+              }
+            },
+            "description": "GPS context from mobiel-inspectie"
+          },
+          "overallResult": {
+            "type": "string",
+            "enum": [
+              "conform",
+              "niet_conform",
+              "deels_conform"
+            ],
+            "description": "Aggregate result — derived on submit by ChecklistService::aggregateResult (REQ-IC-6); user-supplied values are ignored"
+          },
+          "syncState": {
+            "type": "string",
+            "enum": [
+              "local",
+              "queued",
+              "synced"
+            ],
+            "default": "local",
+            "description": "Offline-sync state for the whole run (REQ-IC-5)"
+          },
+          "followUpType": {
+            "type": "string",
+            "enum": [
+              "herinspectie",
+              "handhavingstaak",
+              "documentVerzoek",
+              "geen"
+            ],
+            "default": "geen",
+            "description": "Highest-priority follow-up type dispatched on submit (REQ-IC-7)"
+          }
+        }
+      },
       "tenant": {
         "slug": "tenant",
         "icon": "OfficeBuilding",
@@ -3698,6 +4050,8 @@
           "lhsMatrix",
           "lhsRecommendation",
           "inspectieChecklist",
+          "inspectionChecklistTemplate",
+          "inspectionChecklistRun",
           "adviesAanvraag",
           "legesverordening",
           "legesartikel",


### PR DESCRIPTION
## Summary

Applies the `inspection-checklists` OpenSpec change in **manifest-first** style — no bespoke CRUD controller, OpenRegister auto-renders the index + detail pages from the two new schemas.

- **Two new schemas** in `lib/Settings/procest_register.json`:
  - `inspectionChecklistTemplate` (REQ-IC-1): long-lived config — `name`, `caseType`, `version`, `status` (`draft|active|retired`), `sections[]` with nested `items[]` (response-type enum `ja_nee_nvt|tekst|getal|meerkeuze|foto|meting`, `fotoRequired` `nooit|bij_nee|altijd`, `numericRange`, `choices[]`, `failureAction` with type enum `herinspectie|handhavingstaak|documentVerzoek|geen`), `seedKey`.
  - `inspectionChecklistRun` (REQ-IC-2): per-inspection instance — `case`, `inspection`, `template`, `templateVersion`, `templateSnapshot` (frozen), `inspector` (server-derived from `IUserSession`), `responses[]`, `photos[]`, `overallResult`, `syncState`, `followUpType`.
- **Schema config-key bridge** added to `SettingsService::DEFAULT_SCHEMA_CONFIG_KEYS`.
- **`lib/Service/Inspection/ChecklistService.php`** — `createRun()` freezes the snapshot and derives the inspector from `IUserSession`; `submitRun()` validates per item (REQ-IC-3), derives `overallResult` (REQ-IC-6), dispatches follow-ups (REQ-IC-7) including a handhavingsactie hand-off for `handhavingstaak`, and enforces append-only with `"Checklist run is append-only"`.
- **`lib/Listener/ChecklistRunImmutabilityListener.php`** — rejects any `ObjectUpdatedEvent` on a run already in `ingediend` / `gearchiveerd` (REQ-IC-8).
- Listener registered on `ObjectUpdatedEvent` in `Application.php`.
- `builds/build.json` updated.
- Mobile UI lives in sister spec `mobiel-inspectie` (already applied) — **not duplicated**.

## Test plan

- [ ] Repair step runs and schemas are visible at `/api/objects/procest/inspectionChecklistTemplate` and `/api/objects/procest/inspectionChecklistRun`
- [ ] Create a template; submit a run with one `nee` response on a `failureAction.type = herinspectie` item → a herinspectie task is created on the case
- [ ] After a run reaches `ingediend`, an `ObjectUpdatedEvent` mutating `responses` is rejected with `Checklist run is append-only`
- [ ] Body-supplied `inspector` UID is ignored — persisted run carries the authenticated UID

Watchdog ran `php -l` + `jq` only (i18n + composer check out of strict scope).