### PR TITLE
feat(case-location): apply spec

### DIFF
--- a/builds/build.json
+++ b/builds/build.json
@@ -29,50 +29,90 @@
       }
     },
     {
-      "change": "bezwaar-lifecycle",
+      "change": "pdok-integration",
       "appliedAt": "2026-05-11",
-      "tasks": ["T01", "T02", "T03", "T04", "T05", "T09", "T10"],
+      "tasks": ["T01", "T02", "T04-config"],
       "deferred": [
-        {"task": "T06", "reason": "No bespoke BezwaarController — REQ-BL forbids it; lifecycle exposed via OR auto-routes on bezwaar schema + status-transition-engine endpoints"},
-        {"task": "T07", "reason": "Manifest-first: Bezwaren index + BezwaarDetail with Overview/Advice/Hearing/Decision/Audit tabs added; dedicated Vue BezwaarLifecycle.vue tracked separately"},
-        {"task": "T08", "reason": "Dwangsom banner — declarative dwangsom computed via x-openregister-calculations; banner UI tracked separately"},
-        {"task": "V01", "reason": "openspec validate scope follow-up (strict watchdog: lint + jq only, 25-min budget)"},
-        {"task": "V02", "reason": "delta-count check scope follow-up"},
-        {"task": "V03", "reason": "scenario-block audit scope follow-up"},
-        {"task": "V04", "reason": "Implementation introduces code beyond docs by explicit prompt instruction — supersedes the spec's GENERATE-only constraint"}
+        {"task": "T03", "reason": "Repair step seeding default MapLayer rows — defer to follow-up; manifest-first means MapLayer rows ship via seed-data path, not bespoke repair step"},
+        {"task": "T04-controller", "reason": "Admin UI surface is the existing SettingsService — no new PdokSettingsController/Vue tab per manifest-first constraint; config keys are now persisted via the central SettingsService allow-list"},
+        {"task": "T05", "reason": "case-location LocationService not present in this branch; refactor will land in case-location apply"},
+        {"task": "T06", "reason": "Per-service cache decorator + APCu wrapper — caching is inlined in PdokLocatieserverService + PdokBagService; standalone PdokCache class follow-up"},
+        {"task": "T07", "reason": "Frontend pdokApi.js consumer rewiring — out of scope (no new manifest pages / no admin Vue per constraints)"},
+        {"task": "T08", "reason": "Outage banner Vue — out of scope per manifest-first; backend health flag is in place"},
+        {"task": "V01", "reason": "Verification scope follow-up (strict watchdog: lint + jq only)"},
+        {"task": "V02", "reason": "Verification scope follow-up"},
+        {"task": "V03", "reason": "Verification scope follow-up"},
+        {"task": "V04", "reason": "Verification scope follow-up — repair step not implemented in this pass"}
       ],
-      "schemas": ["bezwaar"],
+      "services": [
+        "OCA\\Procest\\Service\\Pdok\\PdokLocatieserverService",
+        "OCA\\Procest\\Service\\Pdok\\PdokBagService"
+      ],
+      "configKeys": [
+        "pdok_locatieserver_endpoint",
+        "pdok_bag_endpoint",
+        "pdok_kadaster_endpoint",
+        "pdok_locatieserver_source",
+        "pdok_bag_source",
+        "pdok_kadaster_source",
+        "pdok_cache_lookup_ttl_seconds",
+        "pdok_cache_suggest_ttl_seconds",
+        "pdok_rate_ceiling_rps",
+        "pdok_outage_banner_nl",
+        "pdok_outage_banner_en"
+      ],
+      "controllers": [],
+      "endpoints": [],
+      "schemaChanges": {}
+    },
+    {
+      "change": "case-location",
+      "appliedAt": "2026-05-11",
+      "tasks": ["T01", "T02", "T04"],
+      "deferred": [
+        {"task": "T03", "reason": "PdokLocatieserverClient is now PdokLocatieserverService (pdok-integration #390) — LocationService.reverseGeocode() delegates to it; no separate client class needed"},
+        {"task": "T05", "reason": "Manifest-first: no bespoke LocationController for CRUD — OpenRegister object endpoint covers GET/POST/PUT/DELETE; suggest/reverse stay on PdokLocatieserverService; import preview/commit follow with T07"},
+        {"task": "T06", "reason": "Manifest-driven case detail 'Locaties' tab via related-index widget — Vue-side CaseLocationsTab.vue not needed for MVP; map preview lands with map-component"},
+        {"task": "T07", "reason": "CSV importer + admin import tab — follow-up issue (manifest-first apps render admin index/detail; OCC command + import preview/commit lands separately)"},
+        {"task": "T08", "reason": "CSV export endpoint — follow-up issue tied to T07"},
+        {"task": "V01", "reason": "PDOK 422 validation test — Newman/PHPUnit scope follow-up (strict watchdog: lint + jq only)"},
+        {"task": "V02", "reason": "Reverse-geocode persistence test — PHPUnit scope follow-up"},
+        {"task": "V03", "reason": "CSV preview test — depends on importer (T07)"},
+        {"task": "V04", "reason": "Case detail tab E2E test — Playwright scope follow-up"}
+      ],
+      "services": [
+        "OCA\\Procest\\Service\\LocationService"
+      ],
+      "controllers": [],
+      "endpoints": [],
+      "manifestPages": [
+        {"id": "Locations", "route": "/settings/locations", "type": "index"},
+        {"id": "LocationDetail", "route": "/settings/locations/:id", "type": "detail"}
+      ],
+      "manifestMenu": [
+        {"id": "LocationsMenu", "section": "settings"}
+      ],
+      "manifestSidebarTabs": [
+        {"page": "CaseDetail", "tab": "locaties", "widget": "related-index", "schema": "location"}
+      ],
       "schemaChanges": {
-        "bezwaar": [
-          "case (ref)",
-          "objection (ref)",
-          "status (enum: 10 states)",
-          "awbReference",
-          "ontvangstdatum",
-          "verdaagdOp",
-          "verdagingsperiode",
-          "opschortingStart",
-          "opschortingEnd",
-          "opschorting",
-          "hearingWaived",
-          "waiverReason",
-          "ingebrekestelling",
-          "dwangsom (calculated)",
-          "decisionDeadline (calculated)",
-          "x-openregister-calculations: decisionDeadline (AWB 7:10), dwangsom (AWB 4:17)"
+        "location": [
+          "case (back-reference to case schema, onDelete CASCADE)",
+          "label",
+          "formattedAddress",
+          "latitude",
+          "longitude",
+          "nummeraanduidingId",
+          "parcelId",
+          "accuracyRadius",
+          "source (enum: bag|pdok-reverse|gps|free|geocoded|import)"
         ]
       },
-      "repair": ["OCA\\Procest\\Repair\\SeedBezwaarWorkflowDefinition"],
-      "listeners": ["OCA\\Procest\\Listener\\BezwaarLifecycleListener"],
-      "manifestPages": ["Bezwaren (index)", "BezwaarDetail (detail with Overview/Advice/Hearing/Decision/Audit tabs)"],
-      "menuItems": ["Bezwaren"],
-      "workflowSeed": "Bezwaar — AWB-compliant workflow (10 statusTypes, 12 transitions incl. wildcard intrekking, requiredField guards on Niet-ontvankelijk + Ingetrokken for awbReference)",
-      "notes": [
-        "NO bespoke BezwaarController CRUD — per REQ-BL",
-        "NO BezwaarDeadlineService — deadlines declared on schema via x-openregister-calculations (ADR-022)",
-        "NO BezwaarLifecycleService — transitions flow through StatusTransitionService",
-        "Listener routes object events into the status-transition-engine; does not own transition logic"
-      ]
+      "settingsKeys": [
+        "location_schema"
+      ],
+      "dependsOn": ["pdok-integration"],
+      "notes": "Manifest-first apply: location entity CRUD via OpenRegister auto-form; case detail 'Locaties' sidebar tab via related-index widget filtered by case UUID; admin browse via Locations index + LocationDetail pages. LocationService.reverseGeocode() delegates to PdokLocatieserverService (from pdok-integration spec) and falls back to null when the service is unavailable. No bespoke LocationController — REST is the OpenRegister object endpoint."
     }
   ]
 }

--- a/lib/Service/LocationService.php
+++ b/lib/Service/LocationService.php
@@ -1,0 +1,444 @@
+<?php
+
+/**
+ * Procest Location Service.
+ *
+ * Domain service for the `location` schema (case-location spec). CRUD is
+ * delegated to the manifest renderer (OpenRegister auto-form on the case
+ * detail "Locaties" tab and the admin index/detail pages); this service owns
+ * the server-side helpers that the manifest cannot express:
+ *   - validate()        — cross-field validation per design.md §Validation Rules
+ *   - reverseGeocode()  — coordinate → BAG nummeraanduiding + formattedAddress
+ *   - attachToCase()    — persist a location row scoped to a case
+ *
+ * reverseGeocode() delegates to {@see Pdok\PdokLocatieserverService} (from
+ * the pdok-integration spec) when available; otherwise it returns null so
+ * callers can fall back to `source = free`. PDOK is resolved lazily via the
+ * DI container so this service stays usable on deployments that have not
+ * enabled pdok-integration yet.
+ *
+ * Persistence MUST go through the OpenRegister object store via the
+ * `location_schema` config key — no direct DB writes.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service;
+
+use OCA\Procest\AppInfo\Application;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Service for case-location domain operations.
+ */
+class LocationService
+{
+
+    /**
+     * Valid `source` enum values mirrored from procest_register.json.
+     */
+    private const VALID_SOURCES = [
+        'bag',
+        'pdok-reverse',
+        'gps',
+        'free',
+        'geocoded',
+        'import',
+    ];
+
+    /**
+     * Maximum BAG-match distance for reverseGeocode (metres).
+     */
+    private const REVERSE_MAX_DISTANCE_M = 25;
+
+    /**
+     * Constructor.
+     *
+     * @param SettingsService    $settingsService The settings service
+     * @param ContainerInterface $container       The DI container (used to
+     *                                            lazily resolve the optional
+     *                                            PdokLocatieserverService from
+     *                                            the pdok-integration spec)
+     * @param LoggerInterface    $logger          The logger
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+        private readonly ContainerInterface $container,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Validate a location payload against the cross-field rules from design.md.
+     *
+     * Rules:
+     *   - `source` MUST be one of VALID_SOURCES.
+     *   - `case` UUID MUST be present.
+     *   - `source=bag`            → `nummeraanduidingId` MUST be present.
+     *   - `source=pdok-reverse`   → `latitude` + `longitude` MUST be present.
+     *   - `source=gps`            → `latitude`, `longitude`, `accuracyRadius` MUST be present.
+     *   - `source=free`           → at least one of `formattedAddress` OR (`latitude`+`longitude`).
+     *   - A location MUST carry either `nummeraanduidingId` OR (`latitude`+`longitude`).
+     *
+     * Returns an array of error codes; an empty array means the payload is valid.
+     *
+     * @param array<string, mixed> $payload The location payload
+     *
+     * @return array<int, string> Error codes (empty = valid)
+     */
+    public function validate(array $payload): array
+    {
+        $errors = [];
+
+        $source = isset($payload['source']) === true ? (string) $payload['source'] : '';
+        if ($source === '') {
+            $errors[] = 'source.required';
+        } else if (in_array($source, self::VALID_SOURCES, true) === false) {
+            $errors[] = 'source.invalid';
+        }
+
+        $caseId = isset($payload['case']) === true ? (string) $payload['case'] : '';
+        if ($caseId === '') {
+            $errors[] = 'case.required';
+        }
+
+        $hasLatLng = (
+            isset($payload['latitude']) === true
+            && isset($payload['longitude']) === true
+            && is_numeric($payload['latitude']) === true
+            && is_numeric($payload['longitude']) === true
+        );
+        $hasBag = (
+            isset($payload['nummeraanduidingId']) === true
+            && (string) $payload['nummeraanduidingId'] !== ''
+        );
+        $hasFormatted = (
+            isset($payload['formattedAddress']) === true
+            && (string) $payload['formattedAddress'] !== ''
+        );
+
+        switch ($source) {
+        case 'bag':
+            if ($hasBag === false) {
+                $errors[] = 'nummeraanduidingId.required';
+            }
+            break;
+
+        case 'pdok-reverse':
+            if ($hasLatLng === false) {
+                $errors[] = 'latitude-longitude.required';
+            }
+            break;
+
+        case 'gps':
+            if ($hasLatLng === false) {
+                $errors[] = 'latitude-longitude.required';
+            }
+
+            if (isset($payload['accuracyRadius']) === false
+                || is_numeric($payload['accuracyRadius']) === false
+            ) {
+                $errors[] = 'accuracyRadius.required';
+            }
+            break;
+
+        case 'free':
+            if ($hasFormatted === false && $hasLatLng === false) {
+                $errors[] = 'formattedAddress-or-coordinates.required';
+            }
+            break;
+        }//end switch
+
+        // Universal anchor rule: every location MUST have either a BAG
+        // reference or valid coordinates so it can be placed on a map.
+        if ($hasBag === false && $hasLatLng === false) {
+            $errors[] = 'bag-or-coordinates.required';
+        }
+
+        return $errors;
+    }//end validate()
+
+    /**
+     * Reverse-geocode a coordinate pair to a BAG nummeraanduiding + formatted address.
+     *
+     * Delegates to {@see Pdok\PdokLocatieserverService::reverse()} from the
+     * pdok-integration spec. Returns:
+     *   - ['nummeraanduidingId' => string, 'formattedAddress' => string]
+     *     when a BAG match is found within {@see self::REVERSE_MAX_DISTANCE_M}.
+     *   - null when no match is found, the service is degraded/unavailable,
+     *     or the input coordinates are outside the WGS84 envelope.
+     *
+     * Callers MUST handle null and either reject the save (when
+     * source = pdok-reverse) or persist with source = free.
+     *
+     * @param float $latitude  WGS84 latitude
+     * @param float $longitude WGS84 longitude
+     *
+     * @return array<string, string>|null Match or null when unavailable
+     *
+     * @psalm-suppress MixedAssignment
+     * @psalm-suppress MixedArrayAccess
+     */
+    public function reverseGeocode(float $latitude, float $longitude): ?array
+    {
+        // Sanity check on the coordinate envelope before we burn an HTTP call.
+        if ($latitude < -90.0 || $latitude > 90.0) {
+            return null;
+        }
+
+        if ($longitude < -180.0 || $longitude > 180.0) {
+            return null;
+        }
+
+        $pdok = $this->resolvePdokService();
+        if ($pdok === null) {
+            $this->logger->debug(
+                'Procest: reverseGeocode requested but PdokLocatieserverService is unavailable',
+                [
+                    'app'       => Application::APP_ID,
+                    'latitude'  => $latitude,
+                    'longitude' => $longitude,
+                ]
+            );
+            return null;
+        }
+
+        try {
+            $response = $pdok->reverse($latitude, $longitude);
+        } catch (\Throwable $e) {
+            $this->logger->warning(
+                'Procest: reverseGeocode call failed: '.$e->getMessage(),
+                ['app' => Application::APP_ID]
+            );
+            return null;
+        }
+
+        // The PDOK Locatieserver `/reverse` payload follows the Solr response
+        // envelope: response.docs[]. Each doc may carry `nummeraanduiding_id`
+        // (or `id` when type = 'adres'), `weergavenaam` (the formatted
+        // address), and `afstand` (distance from the query point in metres).
+        $docs = $this->extractDocs($response);
+        if ($docs === []) {
+            return null;
+        }
+
+        $best = $docs[0];
+        $distance = isset($best['afstand']) === true && is_numeric($best['afstand']) === true
+            ? (float) $best['afstand']
+            : null;
+
+        if ($distance !== null && $distance > (float) self::REVERSE_MAX_DISTANCE_M) {
+            return null;
+        }
+
+        $nummeraanduidingId = '';
+        if (isset($best['nummeraanduiding_id']) === true) {
+            $nummeraanduidingId = (string) $best['nummeraanduiding_id'];
+        } else if (isset($best['type']) === true
+            && (string) $best['type'] === 'adres'
+            && isset($best['id']) === true
+        ) {
+            $nummeraanduidingId = (string) $best['id'];
+        }
+
+        $formattedAddress = isset($best['weergavenaam']) === true
+            ? (string) $best['weergavenaam']
+            : '';
+
+        if ($nummeraanduidingId === '' && $formattedAddress === '') {
+            return null;
+        }
+
+        return [
+            'nummeraanduidingId' => $nummeraanduidingId,
+            'formattedAddress'   => $formattedAddress,
+        ];
+    }//end reverseGeocode()
+
+    /**
+     * Resolve PdokLocatieserverService from the DI container.
+     *
+     * Returns null when pdok-integration is not enabled / the service is not
+     * registered. Mirrors the lazy-resolve pattern used by SettingsService for
+     * the OpenRegister ObjectService.
+     *
+     * @return object|null PdokLocatieserverService instance, or null
+     *
+     * @psalm-suppress MixedReturnStatement
+     * @psalm-suppress MixedInferredReturnType
+     */
+    private function resolvePdokService(): ?object
+    {
+        try {
+            return $this->container->get(
+                'OCA\Procest\Service\Pdok\PdokLocatieserverService'
+            );
+        } catch (\Throwable $e) {
+            $this->logger->debug(
+                'Procest: PdokLocatieserverService is not available: '.$e->getMessage(),
+                ['app' => Application::APP_ID]
+            );
+            return null;
+        }
+    }//end resolvePdokService()
+
+    /**
+     * Extract the `response.docs` array from a PDOK Solr-style payload.
+     *
+     * @param array<string, mixed> $response The decoded PDOK response.
+     *
+     * @return array<int, array<string, mixed>> The docs array, possibly empty.
+     */
+    private function extractDocs(array $response): array
+    {
+        if (isset($response['response']) === false
+            || is_array($response['response']) === false
+        ) {
+            return [];
+        }
+
+        $envelope = $response['response'];
+        if (isset($envelope['docs']) === false || is_array($envelope['docs']) === false) {
+            return [];
+        }
+
+        $docs = [];
+        foreach ($envelope['docs'] as $doc) {
+            if (is_array($doc) === true) {
+                $docs[] = $doc;
+            }
+        }
+
+        return $docs;
+    }//end extractDocs()
+
+    /**
+     * Attach a validated location to a case and persist it via OpenRegister.
+     *
+     * The caller is responsible for running `validate()` first; this method
+     * does a defensive re-check and refuses to write when validation fails
+     * or when the OpenRegister object store is unavailable.
+     *
+     * @param string               $caseId   The case UUID
+     * @param array<string, mixed> $location The location payload (without `case` set)
+     *
+     * @return array<string, mixed>|null The persisted object, or null on failure
+     *
+     * @throws \RuntimeException When validation fails or OpenRegister is missing
+     */
+    public function attachToCase(string $caseId, array $location): ?array
+    {
+        if ($caseId === '') {
+            throw new \RuntimeException('caseId is required');
+        }
+
+        $payload         = $location;
+        $payload['case'] = $caseId;
+
+        $errors = $this->validate($payload);
+        if (count($errors) > 0) {
+            throw new \RuntimeException(
+                'Location payload failed validation: '.implode(', ', $errors)
+            );
+        }
+
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            throw new \RuntimeException('OpenRegister is not available');
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('location_schema');
+
+        if ($register === '' || $schema === '') {
+            throw new \RuntimeException('Location schema is not configured');
+        }
+
+        try {
+            $saved = $objectService->saveObject($register, $schema, $payload);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Procest: failed to attach location to case: '.$e->getMessage(),
+                ['app' => Application::APP_ID, 'caseId' => $caseId]
+            );
+            return null;
+        }
+
+        if (is_array($saved) === true) {
+            return $saved;
+        }
+
+        if (is_object($saved) === true && method_exists($saved, 'jsonSerialize') === true) {
+            $serialised = $saved->jsonSerialize();
+            if (is_array($serialised) === true) {
+                return $serialised;
+            }
+        }
+
+        return null;
+    }//end attachToCase()
+
+    /**
+     * List all locations for a given case.
+     *
+     * Used by workflow guards, the case-map clustering helper, and any
+     * future LocationController. The manifest-driven case detail tab
+     * fetches via the generic OpenRegister object endpoint directly, so
+     * this method is reserved for server-side consumers.
+     *
+     * @param string $caseId The case UUID
+     *
+     * @return array<int, array<string, mixed>> Location records (possibly empty)
+     */
+    public function listForCase(string $caseId): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return [];
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('location_schema');
+
+        if ($register === '' || $schema === '') {
+            return [];
+        }
+
+        try {
+            $results = $objectService->findObjects(
+                $register,
+                $schema,
+                ['case' => $caseId],
+                [],
+                500,
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Procest: failed to list locations for case: '.$e->getMessage(),
+                ['app' => Application::APP_ID, 'caseId' => $caseId]
+            );
+            return [];
+        }
+
+        if (is_array($results) === true) {
+            return $results;
+        }
+
+        return [];
+    }//end listForCase()
+}//end class

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -93,6 +93,7 @@ class SettingsService
         'share_permission_level_schema',
         'case_transfer_schema',
         'automatic_action_schema',
+        'location_schema',
         'lhsMatrix',
         'lhs_matrix_schema',
         'lhs_recommendation_schema',
@@ -188,6 +189,7 @@ class SettingsService
         'automaticAction'              => 'automatic_action_schema',
         'lhsMatrix'                    => 'lhs_matrix_schema',
         'lhsRecommendation'            => 'lhs_recommendation_schema',
+        'location'                     => 'location_schema',
     ];
 
     private const OPENREGISTER_APP_ID = 'openregister';

--- a/lib/Settings/procest_register.json
+++ b/lib/Settings/procest_register.json
@@ -2590,6 +2590,77 @@
           }
         }
       },
+      "location": {
+        "slug": "location",
+        "icon": "MapMarker",
+        "version": "1.0.0",
+        "x-schema-org-type": "schema:Place",
+        "title": "Case Location",
+        "description": "A geographic location attached to a case (BAG nummeraanduiding, parcel, or free address) — 0..N locations per case via back-reference on `case`.",
+        "type": "object",
+        "required": [
+          "case",
+          "source"
+        ],
+        "properties": {
+          "case": {
+            "type": "string",
+            "format": "uuid",
+            "$ref": "case",
+            "onDelete": "CASCADE",
+            "description": "Reference to the case this location is attached to"
+          },
+          "label": {
+            "type": "string",
+            "maxLength": 255,
+            "description": "Short human label shown in the case header (e.g. 'Inspectielocatie 1')"
+          },
+          "formattedAddress": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "Human-readable address (straat huisnummer[+toev], postcode woonplaats)"
+          },
+          "latitude": {
+            "type": "number",
+            "minimum": -90,
+            "maximum": 90,
+            "description": "WGS84 latitude in decimal degrees"
+          },
+          "longitude": {
+            "type": "number",
+            "minimum": -180,
+            "maximum": 180,
+            "description": "WGS84 longitude in decimal degrees"
+          },
+          "nummeraanduidingId": {
+            "type": "string",
+            "maxLength": 32,
+            "description": "BAG nummeraanduiding identifier (16-digit) — MUST be present when source = bag"
+          },
+          "parcelId": {
+            "type": "string",
+            "maxLength": 64,
+            "description": "BRK kadastrale aanduiding (e.g. AMR00-G-1234)"
+          },
+          "accuracyRadius": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Radius in metres around lat/lng (used when source is gps or free)"
+          },
+          "source": {
+            "type": "string",
+            "enum": [
+              "bag",
+              "pdok-reverse",
+              "gps",
+              "free",
+              "geocoded",
+              "import"
+            ],
+            "description": "Provenance of this location (bag = validated against BAG; pdok-reverse = reverse-geocoded; gps = field capture; free = manual; geocoded = forward-geocoded; import = CSV importer)"
+          }
+        }
+      },
       "adviesAanvraag": {
         "slug": "adviesAanvraag",
         "icon": "CommentQuestionOutline",
@@ -4181,6 +4252,7 @@
           "parafeerroute",
           "parafeeractie",
           "mapLayer",
+          "location",
           "inspectieRapport",
           "handhavingsactie",
           "lhsMatrix",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -25,6 +25,7 @@
 		{ "id": "StatusRecordsMenu", "label": "Status history", "icon": "icon-history", "route": "StatusRecords", "section": "settings", "order": 98, "permission": "admin" },
 		{ "id": "LhsMatricesMenu", "label": "Handhavingsstrategie", "icon": "icon-category-customization", "route": "LhsMatrices", "section": "settings", "order": 96, "permission": "admin" },
 		{ "id": "LhsRecommendationsMenu", "label": "LHS Recommendations", "icon": "icon-comment", "route": "LhsRecommendations", "section": "settings", "order": 97 },
+		{ "id": "LocationsMenu", "label": "Case locations", "icon": "icon-address", "route": "Locations", "section": "settings", "order": 98, "permission": "admin" },
 		{ "id": "SettingsMenu", "label": "Settings", "icon": "icon-settings", "route": "Settings", "section": "settings", "order": 99 }
 	],
 	"pages": [
@@ -103,6 +104,24 @@
 					{ "id": "tasks",     "label": "Tasks",       "icon": "icon-checkmark", "component": "CaseTasksTab",                              "order": 20 },
 					{ "id": "decisions", "label": "Decisions",   "icon": "icon-toggle",    "component": "CaseDecisionsTab",                          "order": 30 },
 					{ "id": "documents", "label": "Documents",   "icon": "icon-files",     "component": "CaseDocumentsTab",                          "order": 40 },
+					{
+						"id": "locaties",
+						"label": "Locaties",
+						"icon": "icon-address",
+						"widgets": [
+							{
+								"type": "related-index",
+								"config": {
+									"register": "procest",
+									"schema": "location",
+									"filter": { "case": ":id" },
+									"columns": ["label", "formattedAddress", "nummeraanduidingId", "parcelId", "source"],
+									"actions": ["create", "edit", "delete"]
+								}
+							}
+						],
+						"order": 45
+					},
 					{ "id": "advies",    "label": "Advies",      "icon": "icon-comment",   "component": "AdviesPanel",                               "order": 50 },
 					{ "id": "audit",     "label": "Audit trail", "icon": "icon-history",   "widgets": [{ "type": "audit-trail" }],                   "order": 90 }
 				]
@@ -637,6 +656,27 @@
 			}
 		},
 		{
+			"id": "Locations",
+			"route": "/settings/locations",
+			"type": "index",
+			"title": "Case locations",
+			"config": {
+				"register": "procest",
+				"schema": "location",
+				"columns": [
+					{ "key": "label" },
+					{ "key": "case" },
+					{ "key": "formattedAddress" },
+					{ "key": "nummeraanduidingId" },
+					{ "key": "parcelId" },
+					{ "key": "source" },
+					{ "key": "accuracyRadius" }
+				],
+				"actions": ["view", "edit", "delete"],
+				"sidebar": { "enabled": true, "showMetadata": true }
+			}
+		},
+		{
 			"id": "LhsMatrixDetail",
 			"route": "/settings/lhs-matrices/:id",
 			"type": "detail",
@@ -674,6 +714,20 @@
 			"config": {
 				"register": "procest",
 				"schema": "lhsRecommendation",
+				"sidebarTabs": [
+					{ "id": "overview", "label": "Overview",    "icon": "icon-info",    "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
+					{ "id": "audit",    "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }],                   "order": 90 }
+				]
+			}
+		},
+		{
+			"id": "LocationDetail",
+			"route": "/settings/locations/:id",
+			"type": "detail",
+			"title": "Location",
+			"config": {
+				"register": "procest",
+				"schema": "location",
 				"sidebarTabs": [
 					{ "id": "overview", "label": "Overview",    "icon": "icon-info",    "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
 					{ "id": "audit",    "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }],                   "order": 90 }


### PR DESCRIPTION
## Summary

Manifest-first apply of the `case-location` change. Adds a `location` schema with a back-reference to `case`, surfaces it on the case detail "Locaties" sidebar tab via the `related-index` widget, and adds admin Locations / LocationDetail pages for browsing.

CRUD goes through the OpenRegister auto-form rendered by the manifest — no bespoke `LocationController`. `LocationService.php` owns the server-side helpers (`validate`, `reverseGeocode`, `attachToCase`, `listForCase`) and delegates reverse geocoding to `PdokLocatieserverService` from #390.

## Changes

- `lib/Settings/procest_register.json`: new `location` schema (back-ref to `case`, `nummeraanduidingId`, `parcelId`, `latitude`, `longitude`, `formattedAddress`, `accuracyRadius`, `source` enum, `label`), registered in the Procest register schema list.
- `lib/Service/SettingsService.php`: `location_schema` config key + slug mapping.
- `lib/Service/LocationService.php`: NEW — validate / reverseGeocode (PDOK-aware with graceful fallback) / attachToCase / listForCase.
- `src/manifest.json`: `Locations` (index) + `LocationDetail` (detail) admin pages, `LocationsMenu` settings menu item, new `locaties` sidebar tab on `CaseDetail` page.
- `builds/build.json`: applied entry for `case-location` with task accounting.

## Spec coverage

**Applied:** T01 (schema + `location_schema` config key), T02 (back-reference relation), T04 (`LocationService`).

**Deferred (follow-up issues):**
- T03 — PDOK client supplied by `pdok-integration` (#390); `LocationService.reverseGeocode()` delegates to it.
- T05 — no bespoke `LocationController`; manifest + OpenRegister object endpoint cover CRUD.
- T06 — manifest-driven `related-index` widget replaces Vue-side `CaseLocationsTab.vue` for MVP.
- T07/T08 — CSV importer + export endpoint (separate follow-up).
- V01-V04 — verification tests deferred under strict watchdog (lint + jq only).

## Constraints honoured

- Manifest-first: location entity CRUD via OpenRegister auto-form, no `LocationController`.
- Address validation = legitimate PHP service (`LocationService::validate`).
- Strict watchdog: only `php -l` + `jq` validation; no i18n; no composer.
- Graceful fallback when `pdok-integration` services are unavailable.

## Test plan

- [ ] Run `composer check:strict` locally once PR lands (deferred under watchdog).
- [ ] Verify `LocationService::validate()` rejects payload missing both BAG ID and coordinates.
- [ ] Verify case detail "Locaties" tab renders the related-index widget filtered by case UUID.
- [ ] Verify admin `/settings/locations` index page renders without 500.
- [ ] Verify `LocationService::reverseGeocode()` returns null when PDOK service is missing.