### PR TITLE
feat(bezwaar-advisory-committee): apply spec

### DIFF
--- a/builds/build.json
+++ b/builds/build.json
@@ -64,6 +64,44 @@
       "controllers": [],
       "endpoints": [],
       "schemaChanges": {}
+    },
+    {
+      "change": "bezwaar-advisory-committee",
+      "appliedAt": "2026-05-11",
+      "tasks": ["T01", "T02", "T03", "T04", "T05", "T06", "T07"],
+      "deferred": [
+        {"task": "V01", "reason": "openspec validate not part of strict watchdog (php -l + jq only); deferred to opsx-verify"},
+        {"task": "V02", "reason": "deltaCount jq verification covered by openspec validate; deferred"},
+        {"task": "V03", "reason": "Scenario coverage check covered by openspec validate strict; deferred"}
+      ],
+      "schemas": [
+        "bezwaaradviescommissie",
+        "bacAdviceRequest"
+      ],
+      "manifestPages": [
+        "BezwaarCommittees",
+        "BezwaarCommitteeDetail",
+        "BezwaarAdviceRequests",
+        "BezwaarAdviceRequestDetail"
+      ],
+      "menuEntries": [
+        "BezwaarAdviceRequests",
+        "BezwaarCommitteesMenu"
+      ],
+      "services": [
+        "OCA\\Procest\\Service\\Bezwaar\\AdvisoryCommitteeService"
+      ],
+      "listeners": [
+        "OCA\\Procest\\Listener\\BezwaarAdviceRequestedListener"
+      ],
+      "controllers": [],
+      "endpoints": [],
+      "configKeys": [
+        "bezwaaradviescommissie_schema",
+        "bac_advice_request_schema",
+        "bac_default_committee"
+      ],
+      "notes": "Manifest-first: CRUD via OpenRegister auto-forms. Independence check (Awb 7:13(3)) + advice lifecycle FSM live in AdvisoryCommitteeService. Listener auto-assigns default committee when bezwaar.status='Advies aangevraagd'. Depends on bezwaar-lifecycle landing for the council-deviation guard hook on besluit finalisation; the recordCouncilDeviation() entry-point is in place to be called from that service."
     }
   ]
 }

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -35,6 +35,7 @@ use OCA\Procest\Dashboard\OverdueCasesWidget;
 use OCA\Procest\Dashboard\StalledCasesWidget;
 use OCA\Procest\Dashboard\TaskRemindersWidget;
 use OCA\Procest\Dashboard\StartCaseWidget;
+use OCA\Procest\Listener\BezwaarAdviceRequestedListener;
 use OCA\Procest\Listener\DeepLinkRegistrationListener;
 use OCA\Procest\Listener\KpiCacheInvalidationListener;
 use OCA\Procest\Listener\RoleMutationListener;
@@ -103,6 +104,13 @@ class Application extends App implements IBootstrap
         $context->registerEventListener(
             event: ObjectDeletedEvent::class,
             listener: RoleMutationListener::class
+        );
+
+        // Bezwaar-advisory-committee auto-assignment when a bezwaar case
+        // enters status "Advies aangevraagd".
+        $context->registerEventListener(
+            event: ObjectUpdatedEvent::class,
+            listener: BezwaarAdviceRequestedListener::class
         );
 
         $context->registerMiddleware(class: ZgwAuthMiddleware::class);

--- a/lib/Listener/BezwaarAdviceRequestedListener.php
+++ b/lib/Listener/BezwaarAdviceRequestedListener.php
@@ -1,0 +1,225 @@
+<?php
+
+/**
+ * Procest Bezwaar Advice Requested Listener.
+ *
+ * Watches OpenRegister `case` object updates for the bezwaar status
+ * transition to "Advies aangevraagd" and triggers the auto-assignment of
+ * the default bezwaaradviescommissie via AdvisoryCommitteeService. This
+ * realises the spec workflow step where the council formally refers the
+ * objection to its independent advisory committee (Awb Art. 7:13(1)).
+ *
+ * The listener intentionally swallows infrastructure errors: failure to
+ * auto-assign SHALL NOT block the parent bezwaar transition; operators
+ * fall back to manual assignment via the BAC index page.
+ *
+ * @category Listener
+ * @package  OCA\Procest\Listener
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Listener;
+
+use OCA\OpenRegister\Event\ObjectUpdatedEvent;
+use OCA\Procest\Service\Bezwaar\AdvisoryCommitteeService;
+use OCA\Procest\Service\SettingsService;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Auto-assigns the default BAC when bezwaar enters "Advies aangevraagd".
+ *
+ * @implements IEventListener<Event>
+ *
+ * @spec openspec/changes/bezwaar-advisory-committee/specs/bezwaar-advisory-committee/spec.md
+ */
+class BezwaarAdviceRequestedListener implements IEventListener
+{
+    private const TRIGGER_STATUS = 'Advies aangevraagd';
+
+    /**
+     * Constructor.
+     *
+     * @param AdvisoryCommitteeService $bacService      The BAC service
+     * @param SettingsService          $settingsService Schema slug bridge
+     * @param LoggerInterface          $logger          Logger
+     */
+    public function __construct(
+        private readonly AdvisoryCommitteeService $bacService,
+        private readonly SettingsService $settingsService,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Handle a case update event.
+     *
+     * Filters: must be a `case` schema object, must have transitioned to
+     * the trigger status (`status` changed in the update payload).
+     *
+     * @param Event $event The dispatched event
+     *
+     * @return void
+     */
+    public function handle(Event $event): void
+    {
+        if ($event instanceof ObjectUpdatedEvent === false) {
+            return;
+        }
+
+        try {
+            $object = $this->extractObject($event);
+            if ($object === null) {
+                return;
+            }
+
+            if ($this->isCaseSchema(object: $object) === false) {
+                return;
+            }
+
+            $status = (string) ($object['status'] ?? '');
+            if ($status !== self::TRIGGER_STATUS) {
+                return;
+            }
+
+            // Avoid re-triggering: only act on the actual transition.
+            $previous = $this->extractPreviousStatus(event: $event);
+            if ($previous === self::TRIGGER_STATUS) {
+                return;
+            }
+
+            $caseId = (string) (
+                $object['@self']['id']
+                ?? ($object['id'] ?? ($object['uuid'] ?? ''))
+            );
+            if ($caseId === '') {
+                return;
+            }
+
+            $this->bacService->autoAssignDefaultCommittee(
+                bezwaarCaseId: $caseId
+            );
+        } catch (Throwable $e) {
+            $this->logger->debug(
+                'Procest BAC: advice-requested listener swallowed '
+                .'exception: '.$e->getMessage(),
+            );
+        }
+    }//end handle()
+
+    /**
+     * Whether the object belongs to the `case` schema.
+     *
+     * @param array<string, mixed> $object The object payload
+     *
+     * @return bool
+     */
+    private function isCaseSchema(array $object): bool
+    {
+        $schemaSlug = $this->settingsService->getConfigValue(key: 'case_schema');
+        if ($schemaSlug === '') {
+            return false;
+        }
+
+        $candidate = (string) (
+            $object['@self']['schema']
+            ?? ($object['schema'] ?? '')
+        );
+
+        return $candidate !== '' && (
+            $candidate === $schemaSlug
+            || str_ends_with($candidate, '/'.$schemaSlug)
+        );
+    }//end isCaseSchema()
+
+    /**
+     * Extract the new object payload from the update event.
+     *
+     * @param Event $event The event
+     *
+     * @return array<string, mixed>|null
+     */
+    private function extractObject(Event $event): ?array
+    {
+        foreach (['getNewObject', 'getObject'] as $method) {
+            if (method_exists($event, $method) === false) {
+                continue;
+            }
+
+            $value = $event->{$method}();
+            $array = $this->normalise(value: $value);
+            if ($array !== null) {
+                return $array;
+            }
+        }
+
+        return null;
+    }//end extractObject()
+
+    /**
+     * Extract the previous status from the old object payload (if any).
+     *
+     * @param Event $event The event
+     *
+     * @return string Previous status or empty string when unknown
+     */
+    private function extractPreviousStatus(Event $event): string
+    {
+        if (method_exists($event, 'getOldObject') === false) {
+            return '';
+        }
+
+        $array = $this->normalise(value: $event->getOldObject());
+        if ($array === null) {
+            return '';
+        }
+
+        return (string) ($array['status'] ?? '');
+    }//end extractPreviousStatus()
+
+    /**
+     * Normalise a getter return value to an associative array.
+     *
+     * @param mixed $value The raw value
+     *
+     * @return array<string, mixed>|null
+     */
+    private function normalise(mixed $value): ?array
+    {
+        if (is_array($value) === true) {
+            return $value;
+        }
+
+        if (is_object($value) === true) {
+            if (method_exists($value, 'jsonSerialize') === true) {
+                $serialised = $value->jsonSerialize();
+                if (is_array($serialised) === true) {
+                    return $serialised;
+                }
+            }
+
+            if (method_exists($value, 'toArray') === true) {
+                $arr = $value->toArray();
+                if (is_array($arr) === true) {
+                    return $arr;
+                }
+            }
+        }
+
+        return null;
+    }//end normalise()
+}//end class

--- a/lib/Service/Bezwaar/AdvisoryCommitteeService.php
+++ b/lib/Service/Bezwaar/AdvisoryCommitteeService.php
@@ -1,0 +1,597 @@
+<?php
+
+/**
+ * Procest Bezwaar Advisory Committee Service.
+ *
+ * Domain service for the bezwaaradviescommissie (BAC) capability under
+ * Awb Art. 7:13. Owns the legitimate domain operations that cannot be
+ * handled by the manifest-driven CRUD path:
+ *
+ *  - assignToCommittee()          — referral with independence check
+ *                                   (Awb Art. 7:13(3))
+ *  - transitionAdviceStatus()     — one-way lifecycle transitions
+ *                                   (assigned → in-deliberation → advice-issued)
+ *  - autoAssignDefaultCommittee() — listener entry point used when a bezwaar
+ *                                   case enters status "Advies aangevraagd"
+ *
+ * Per the per-app convention every mutation goes through OpenRegister via
+ * the manifest renderer; this service composes those calls and writes the
+ * append-only `auditTrail` entries that satisfy Archiefwet 1995.
+ *
+ * Identity is ALWAYS derived from `IUserSession`. Static error messages
+ * only — exception details never bubble to controllers.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Bezwaar
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Bezwaar;
+
+use OCA\Procest\Service\SettingsService;
+use OCA\Procest\Service\StatusTransitionService;
+use OCA\Procest\Service\Transitions\GuardFailedException;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * BAC service: committee assignment + advice request lifecycle.
+ *
+ * @spec openspec/changes/bezwaar-advisory-committee/specs/bezwaar-advisory-committee/spec.md
+ */
+class AdvisoryCommitteeService
+{
+    /**
+     * Allowed advice-request lifecycle states.
+     */
+    private const VALID_STATUSES = [
+        'assigned',
+        'in-deliberation',
+        'advice-issued',
+        'niet-ontvankelijk',
+    ];
+
+    /**
+     * Allowed one-way forward transitions (source => [allowed targets]).
+     * niet-ontvankelijk is a terminal advice the committee MAY issue from
+     * in-deliberation per Awb Art. 7:13(7).
+     */
+    private const ALLOWED_TRANSITIONS = [
+        'assigned'        => ['in-deliberation'],
+        'in-deliberation' => ['advice-issued', 'niet-ontvankelijk'],
+        'advice-issued'   => [],
+        'niet-ontvankelijk' => [],
+    ];
+
+    /**
+     * Required structured-advice fields when transitioning to advice-issued.
+     */
+    private const REQUIRED_ADVICE_FIELDS = [
+        'conclusion',
+        'recommendation',
+    ];
+
+    /**
+     * Default deadline in days for advice delivery (12 weeks per Awb 7:24(1)).
+     */
+    private const DEFAULT_DEADLINE_DAYS = 84;
+
+    /**
+     * Constructor.
+     *
+     * @param SettingsService         $settingsService Schema/register bridge
+     * @param IUserSession            $userSession     Acting identity source
+     * @param StatusTransitionService $transitions     Optional integration with
+     *                                                 the case-level status FSM
+     *                                                 (used when the lifecycle
+     *                                                 advances the parent case)
+     * @param LoggerInterface         $logger          Logger
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+        private readonly IUserSession $userSession,
+        private readonly StatusTransitionService $transitions,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Assign a bezwaar case to a committee, creating a bacAdviceRequest in
+     * state `assigned`. The independence check (Awb Art. 7:13(3)) is
+     * deferred until the advance-to-in-deliberation transition because a
+     * committee MAY be valid for one bezwaar and invalid for another.
+     *
+     * @param string               $bezwaarCaseId UUID of the bezwaar case
+     * @param string               $commissieId   UUID of the committee
+     * @param array<string, mixed> $payload       Optional extra fields
+     *                                            (panel, deadline, etc.)
+     *
+     * @return array<string, mixed> The created bacAdviceRequest record
+     *
+     * @throws RuntimeException When OpenRegister unavailable or refs invalid
+     */
+    public function assignToCommittee(
+        string $bezwaarCaseId,
+        string $commissieId,
+        array $payload = []
+    ): array {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            throw new RuntimeException('OpenRegister is not available');
+        }
+
+        $register   = $this->settingsService->getConfigValue(key: 'register');
+        $requestSchema = $this->settingsService->getConfigValue(
+            key: 'bac_advice_request_schema'
+        );
+        $committeeSchema = $this->settingsService->getConfigValue(
+            key: 'bezwaaradviescommissie_schema'
+        );
+
+        if ($register === '' || $requestSchema === '' || $committeeSchema === '') {
+            throw new RuntimeException(
+                'BAC schemas are not configured'
+            );
+        }
+
+        // Validate committee exists and is active.
+        $committee = $objectService->findObject(
+            $register,
+            $committeeSchema,
+            $commissieId
+        );
+        if (is_array($committee) === false) {
+            throw new RuntimeException('Committee not found');
+        }
+
+        $active = $committee['active'] ?? true;
+        if ($active === false) {
+            throw new RuntimeException(
+                'Committee is archived and cannot accept new bezwaaren'
+            );
+        }
+
+        $now      = (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM);
+        $deadline = (new \DateTimeImmutable())
+            ->modify('+'.self::DEFAULT_DEADLINE_DAYS.' days')
+            ->format('Y-m-d');
+
+        $record = array_merge(
+            [
+                'panel'    => [],
+                'deadline' => $deadline,
+            ],
+            $payload,
+            [
+                'bezwaar'    => $bezwaarCaseId,
+                'commissie'  => $commissieId,
+                'status'     => 'assigned',
+                'assignedAt' => $now,
+            ]
+        );
+
+        // Append audit entry for panel composition.
+        $record['auditTrail'] = $this->appendAudit(
+            existing: [],
+            event: 'panel-member-added',
+            payload: [
+                'panel'        => $record['panel'],
+                'commissieId'  => $commissieId,
+                'bezwaarCase'  => $bezwaarCaseId,
+            ],
+        );
+
+        try {
+            return $objectService->saveObject($register, $requestSchema, $record);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Procest BAC: failed to create advice request: '.$e->getMessage()
+            );
+            throw new RuntimeException('Could not create advice request');
+        }
+    }//end assignToCommittee()
+
+    /**
+     * Advance the advice request to a new status. Enforces the one-way
+     * lifecycle (REQ-BAC-3), the independence check (REQ-BAC-2) and the
+     * advice content contract (REQ-BAC-4).
+     *
+     * @param string               $requestId Advice request UUID
+     * @param string               $newStatus Target status
+     * @param array<string, mixed> $payload   Optional patch (advice text,
+     *                                        signatureEvidence, conclusion, ...)
+     *
+     * @return array<string, mixed> The updated advice request record
+     *
+     * @throws RuntimeException     When the transition is forbidden
+     * @throws GuardFailedException When the independence check fails
+     */
+    public function transitionAdviceStatus(
+        string $requestId,
+        string $newStatus,
+        array $payload = []
+    ): array {
+        if (in_array($newStatus, self::VALID_STATUSES, true) === false) {
+            throw new RuntimeException('Invalid BAC advice status');
+        }
+
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            throw new RuntimeException('OpenRegister is not available');
+        }
+
+        $register      = $this->settingsService->getConfigValue(key: 'register');
+        $requestSchema = $this->settingsService->getConfigValue(
+            key: 'bac_advice_request_schema'
+        );
+
+        $current = $objectService->findObject(
+            $register,
+            $requestSchema,
+            $requestId
+        );
+        if (is_array($current) === false) {
+            throw new RuntimeException('Advice request not found');
+        }
+
+        $from = (string) ($current['status'] ?? 'assigned');
+        $allowed = self::ALLOWED_TRANSITIONS[$from] ?? [];
+
+        if (in_array($newStatus, $allowed, true) === false) {
+            throw new RuntimeException(
+                'Transition from '.$from.' to '.$newStatus.' is not permitted'
+            );
+        }
+
+        // Guard: assigned → in-deliberation requires panel and
+        // independence (REQ-BAC-2).
+        if ($from === 'assigned' && $newStatus === 'in-deliberation') {
+            $panel = (array) ($current['panel'] ?? []);
+            if ($panel === []) {
+                throw new RuntimeException(
+                    'Panel must be set before deliberation can start'
+                );
+            }
+
+            $independence = $this->checkPanelIndependence(
+                bezwaarCaseId: (string) ($current['bezwaar'] ?? ''),
+                panel: $panel,
+            );
+
+            if ($independence['ok'] === false) {
+                // Persist the failure to the audit trail before raising.
+                $audit = $this->appendAudit(
+                    existing: (array) ($current['auditTrail'] ?? []),
+                    event: 'independence-check-failed',
+                    payload: [
+                        'conflictingMember' => $independence['member'],
+                        'reason'            => $independence['reason'],
+                    ],
+                );
+                try {
+                    $objectService->saveObject(
+                        $register,
+                        $requestSchema,
+                        ['auditTrail' => $audit],
+                        $requestId
+                    );
+                } catch (\Throwable $auditError) {
+                    $this->logger->error(
+                        'Procest BAC: failed to write audit on '
+                        .'independence failure: '
+                        .$auditError->getMessage()
+                    );
+                }
+
+                throw new GuardFailedException(
+                    'Panel member conflict (Awb Art. 7:13 lid 3): '
+                    .$independence['reason']
+                );
+            }
+        }
+
+        // Guard: in-deliberation → advice-issued requires the structured
+        // advice content (REQ-BAC-4).
+        if ($from === 'in-deliberation' && $newStatus === 'advice-issued') {
+            $merged = array_merge($current, $payload);
+            foreach (self::REQUIRED_ADVICE_FIELDS as $field) {
+                $value = $merged[$field] ?? null;
+                if ($value === null || $value === '' || $value === []) {
+                    throw new RuntimeException(
+                        'Advice cannot be issued: missing required field '
+                        .$field
+                    );
+                }
+            }
+        }
+
+        $userId = $this->resolveUserId();
+
+        // Compose the update.
+        $update = $payload;
+        $update['status'] = $newStatus;
+
+        if ($newStatus === 'advice-issued' || $newStatus === 'niet-ontvankelijk') {
+            $update['adviceIssuedAt'] = (new \DateTimeImmutable())
+                ->format(\DateTimeInterface::ATOM);
+            $auditEvent = 'advice-signed-by-chair';
+            $auditPayload = [
+                'chair'             => $userId,
+                'signatureEvidence' => $update['signatureEvidence']
+                    ?? ($current['signatureEvidence'] ?? null),
+                'conclusion'        => $update['conclusion']
+                    ?? ($current['conclusion'] ?? null),
+            ];
+            $update['auditTrail'] = $this->appendAudit(
+                existing: (array) ($current['auditTrail'] ?? []),
+                event: $auditEvent,
+                payload: $auditPayload,
+            );
+        }
+
+        try {
+            return $objectService->saveObject(
+                $register,
+                $requestSchema,
+                $update,
+                $requestId
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Procest BAC: failed to transition advice request '
+                .$requestId.': '.$e->getMessage()
+            );
+            throw new RuntimeException('Could not transition advice request');
+        }
+    }//end transitionAdviceStatus()
+
+    /**
+     * Listener entry-point: when a bezwaar case enters status
+     * "Advies aangevraagd", auto-assign the default committee for the
+     * case's jurisdiction.
+     *
+     * @param string $bezwaarCaseId The bezwaar case UUID
+     *
+     * @return array<string, mixed>|null The created advice request, or
+     *                                    null when no default committee
+     *                                    is configured.
+     */
+    public function autoAssignDefaultCommittee(string $bezwaarCaseId): ?array
+    {
+        $defaultId = $this->settingsService->getConfigValue(
+            key: 'bac_default_committee'
+        );
+        if ($defaultId === '') {
+            $this->logger->info(
+                'Procest BAC: no default committee configured; '
+                .'skipping auto-assignment for case '.$bezwaarCaseId
+            );
+            return null;
+        }
+
+        try {
+            return $this->assignToCommittee(
+                bezwaarCaseId: $bezwaarCaseId,
+                commissieId: $defaultId,
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Procest BAC: auto-assignment failed for case '
+                .$bezwaarCaseId.': '.$e->getMessage()
+            );
+            return null;
+        }
+    }//end autoAssignDefaultCommittee()
+
+    /**
+     * Record a council-deviation event on the linked advice request after
+     * the parent bezwaar-lifecycle finalises a besluit op bezwaar with
+     * `motivatieAfwijkingAdvies` set (REQ-BAC-5).
+     *
+     * @param string $requestId    Advice request UUID
+     * @param string $besluitId    Besluit op bezwaar UUID
+     * @param string $motivatieRef Reference / hash of the motivation
+     *
+     * @return void
+     */
+    public function recordCouncilDeviation(
+        string $requestId,
+        string $besluitId,
+        string $motivatieRef
+    ): void {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return;
+        }
+
+        $register      = $this->settingsService->getConfigValue(key: 'register');
+        $requestSchema = $this->settingsService->getConfigValue(
+            key: 'bac_advice_request_schema'
+        );
+
+        try {
+            $current = $objectService->findObject(
+                $register,
+                $requestSchema,
+                $requestId
+            );
+            if (is_array($current) === false) {
+                return;
+            }
+
+            $audit = $this->appendAudit(
+                existing: (array) ($current['auditTrail'] ?? []),
+                event: 'council-deviation-recorded',
+                payload: [
+                    'besluit'     => $besluitId,
+                    'motivatie'   => $motivatieRef,
+                ],
+            );
+
+            $objectService->saveObject(
+                $register,
+                $requestSchema,
+                ['auditTrail' => $audit],
+                $requestId
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Procest BAC: failed to record council deviation: '
+                .$e->getMessage()
+            );
+        }
+    }//end recordCouncilDeviation()
+
+    /**
+     * Member-independence check per Awb Art. 7:13(3).
+     *
+     * Compares each panel member UID against the `createdBy` (steller) of
+     * the bezwaar case's contested decision (resolved via the linked
+     * objection.contestedDecision pointer). A direct match blocks the
+     * transition.
+     *
+     * @param string        $bezwaarCaseId The bezwaar case UUID
+     * @param array<string> $panel         Panel member UIDs
+     *
+     * @return array{ok: bool, member: ?string, reason: ?string}
+     */
+    private function checkPanelIndependence(
+        string $bezwaarCaseId,
+        array $panel
+    ): array {
+        if ($bezwaarCaseId === '' || $panel === []) {
+            return ['ok' => true, 'member' => null, 'reason' => null];
+        }
+
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return ['ok' => true, 'member' => null, 'reason' => null];
+        }
+
+        $register        = $this->settingsService->getConfigValue(key: 'register');
+        $objectionSchema = $this->settingsService->getConfigValue(
+            key: 'objection_schema'
+        );
+        $decisionSchema  = $this->settingsService->getConfigValue(
+            key: 'decision_schema'
+        );
+
+        if ($objectionSchema === '' || $decisionSchema === '') {
+            // Unable to resolve; do not block the transition, but log.
+            $this->logger->info(
+                'Procest BAC: objection/decision schemas not configured; '
+                .'skipping independence check'
+            );
+            return ['ok' => true, 'member' => null, 'reason' => null];
+        }
+
+        try {
+            $objections = $objectService->findObjects(
+                $register,
+                $objectionSchema,
+                ['case' => $bezwaarCaseId]
+            );
+            $objection = (is_array($objections) && $objections !== [])
+                ? $objections[0]
+                : null;
+            if (is_array($objection) === false) {
+                return ['ok' => true, 'member' => null, 'reason' => null];
+            }
+
+            $contestedId = (string) ($objection['contestedDecision'] ?? '');
+            if ($contestedId === '') {
+                return ['ok' => true, 'member' => null, 'reason' => null];
+            }
+
+            $decision = $objectService->findObject(
+                $register,
+                $decisionSchema,
+                $contestedId
+            );
+            if (is_array($decision) === false) {
+                return ['ok' => true, 'member' => null, 'reason' => null];
+            }
+
+            $steller = (string) (
+                $decision['@self']['owner']
+                ?? ($decision['createdBy']
+                    ?? ($decision['steller'] ?? ''))
+            );
+            if ($steller === '') {
+                return ['ok' => true, 'member' => null, 'reason' => null];
+            }
+
+            foreach ($panel as $memberUid) {
+                if ((string) $memberUid === $steller) {
+                    return [
+                        'ok'     => false,
+                        'member' => (string) $memberUid,
+                        'reason' => 'Lid was betrokken bij het bestreden '
+                                    .'besluit (Awb Art. 7:13 lid 3)',
+                    ];
+                }
+            }
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Procest BAC: independence check error: '.$e->getMessage()
+            );
+            // Fail-open here is intentional: do not block on infra issues.
+        }
+
+        return ['ok' => true, 'member' => null, 'reason' => null];
+    }//end checkPanelIndependence()
+
+    /**
+     * Append an entry to the bac_audit_trail array.
+     *
+     * @param array<int, array<string, mixed>> $existing Current audit entries
+     * @param string                           $event    Event slug
+     * @param array<string, mixed>             $payload  Structured payload
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function appendAudit(
+        array $existing,
+        string $event,
+        array $payload
+    ): array {
+        $entry = [
+            'event'   => $event,
+            'actor'   => $this->resolveUserId(),
+            'at'      => (new \DateTimeImmutable())
+                ->format(\DateTimeInterface::ATOM),
+            'payload' => $payload,
+        ];
+
+        $existing[] = $entry;
+        return $existing;
+    }//end appendAudit()
+
+    /**
+     * Resolve the acting user UID from IUserSession.
+     *
+     * @return string
+     */
+    private function resolveUserId(): string
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return 'system';
+        }
+
+        return $user->getUID();
+    }//end resolveUserId()
+}//end class

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -93,6 +93,10 @@ class SettingsService
         'share_permission_level_schema',
         'case_transfer_schema',
         'automatic_action_schema',
+        // Bezwaar advisory committee (BAC) — Awb Art. 7:13.
+        'bezwaaradviescommissie_schema',
+        'bac_advice_request_schema',
+        'bac_default_committee',
         'lhsMatrix',
         // AI-Assisted Processing settings.
         'ai_audit_entry_schema',
@@ -182,6 +186,8 @@ class SettingsService
         'sharePermissionLevel'         => 'share_permission_level_schema',
         'casetransfer'                 => 'case_transfer_schema',
         'automaticAction'              => 'automatic_action_schema',
+        'bezwaaradviescommissie'       => 'bezwaaradviescommissie_schema',
+        'bacAdviceRequest'             => 'bac_advice_request_schema',
     ];
 
     private const OPENREGISTER_APP_ID = 'openregister';

--- a/lib/Settings/procest_register.json
+++ b/lib/Settings/procest_register.json
@@ -962,9 +962,15 @@
             "items": {
               "type": "object",
               "properties": {
-                "type": { "type": "string" },
-                "passed": { "type": "boolean" },
-                "details": { "type": "object" }
+                "type": {
+                  "type": "string"
+                },
+                "passed": {
+                  "type": "boolean"
+                },
+                "details": {
+                  "type": "object"
+                }
               }
             }
           },
@@ -974,9 +980,15 @@
             "items": {
               "type": "object",
               "properties": {
-                "type": { "type": "string" },
-                "ok": { "type": "boolean" },
-                "error": { "type": "string" }
+                "type": {
+                  "type": "string"
+                },
+                "ok": {
+                  "type": "boolean"
+                },
+                "error": {
+                  "type": "string"
+                }
               }
             }
           },
@@ -3457,6 +3469,259 @@
             "type": "string",
             "format": "date-time",
             "description": "When the transfer was completed (ISO 8601)"
+          }
+        }
+      },
+      "bezwaaradviescommissie": {
+        "slug": "bezwaaradviescommissie",
+        "icon": "AccountGroupOutline",
+        "version": "1.0.0",
+        "x-schema-org-type": "schema:GovernmentOrganization",
+        "title": "Bezwaaradviescommissie",
+        "description": "Independent advisory committee (BAC, VKK or VTH) that reviews objections under Awb Art. 7:13 and issues a written advice to the council. Long-lived configuration entity owned by the council; member independence is enforced per case at advice-request assignment.",
+        "type": "object",
+        "required": [
+          "name",
+          "type",
+          "members"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 255,
+            "description": "Display name (e.g. 'Bezwaarcommissie sociaal domein')"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "BAC",
+              "VKK",
+              "VTH"
+            ],
+            "default": "BAC",
+            "description": "Committee type: BAC (Bezwaar Advies), VKK (Vaste Kamer/Klachten), VTH (Vergunning Toezicht Handhaving)"
+          },
+          "domain": {
+            "type": "string",
+            "enum": [
+              "algemeen",
+              "sociaal_domein",
+              "wabo",
+              "belasting",
+              "personeel"
+            ],
+            "description": "Optional jurisdiction filter for auto-assignment by case type / domain"
+          },
+          "jurisdiction": {
+            "type": "string",
+            "description": "Free-text jurisdiction descriptor (e.g. municipal area, region, or 'all')"
+          },
+          "chair": {
+            "type": "string",
+            "description": "Nextcloud UID of the committee chair (voorzitter, Awb Art. 7:13(1))"
+          },
+          "members": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "uid": {
+                  "type": "string",
+                  "description": "Nextcloud UID or external party reference"
+                },
+                "displayName": {
+                  "type": "string",
+                  "description": "Human-readable member name"
+                },
+                "role": {
+                  "type": "string",
+                  "enum": [
+                    "chair",
+                    "member",
+                    "deputy"
+                  ],
+                  "default": "member",
+                  "description": "Member role on the committee"
+                },
+                "external": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Whether this member is external to the council (not a civil servant)"
+                }
+              }
+            },
+            "description": "Committee members; chair + at least two members required (Awb Art. 7:13(1))"
+          },
+          "secretary": {
+            "type": "string",
+            "description": "Nextcloud UID of the secretary (civil servant per Awb Art. 7:13(2))"
+          },
+          "quorum": {
+            "type": "integer",
+            "minimum": 2,
+            "default": 3,
+            "description": "Minimum members needed to issue advice"
+          },
+          "termStartsOn": {
+            "type": "string",
+            "format": "date",
+            "description": "Validity window start"
+          },
+          "termEndsOn": {
+            "type": "string",
+            "format": "date",
+            "description": "Validity window end"
+          },
+          "active": {
+            "type": "boolean",
+            "default": true,
+            "description": "Whether the committee is active and can be assigned new cases"
+          },
+          "created": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Server timestamp at creation"
+          }
+        }
+      },
+      "bacAdviceRequest": {
+        "slug": "bacAdviceRequest",
+        "icon": "CommentTextOutline",
+        "version": "1.0.0",
+        "x-schema-org-type": "schema:AskAction",
+        "x-zgw-equivalent": "Adviesdocument",
+        "title": "BAC Advice Request",
+        "description": "Per-bezwaar referral of an objection case to a bezwaaradviescommissie. Tracks the advice deliverable through the assigned -> in-deliberation -> advice-issued lifecycle (Awb Art. 7:13). One-way transitions; withdrawn bezwaaren leave the request in its last state for audit.",
+        "type": "object",
+        "required": [
+          "bezwaar",
+          "commissie",
+          "status"
+        ],
+        "properties": {
+          "bezwaar": {
+            "type": "string",
+            "format": "uuid",
+            "$ref": "case",
+            "onDelete": "CASCADE",
+            "description": "The bezwaar case being reviewed (reference to case)"
+          },
+          "commissie": {
+            "type": "string",
+            "format": "uuid",
+            "$ref": "bezwaaradviescommissie",
+            "description": "The assigned bezwaaradviescommissie"
+          },
+          "panel": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Subset of commissie.members.uid actually sitting on this case (used for independence check per Awb Art. 7:13(3))"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "assigned",
+              "in-deliberation",
+              "advice-issued",
+              "niet-ontvankelijk"
+            ],
+            "default": "assigned",
+            "description": "Lifecycle state. niet-ontvankelijk represents the terminal advice that the bezwaar is inadmissible (Awb Art. 7:13(7))"
+          },
+          "assignedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Server timestamp when the council referred the bezwaar to the committee"
+          },
+          "deadline": {
+            "type": "string",
+            "format": "date",
+            "description": "Target advice date — defaults to assignedAt + 12 weeks (Awb Art. 7:24(1))"
+          },
+          "advice": {
+            "type": "string",
+            "description": "Advice text (findings + legal_assessment + recommendation). Free-text fallback when no structured document is uploaded"
+          },
+          "adviceDocuments": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "References (Nextcloud file IDs or OpenRegister doc refs) of the signed advice and supporting documents"
+          },
+          "adviceIssuedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp the chair signed and issued the advice"
+          },
+          "signatureEvidence": {
+            "type": "string",
+            "description": "Reference (NC file ID or signing-app evidence ref) to the chair's signature evidence"
+          },
+          "hearingReportRef": {
+            "type": "string",
+            "description": "Link to the hoorzittingverslag owned by the bezwaar-lifecycle / hearing-session"
+          },
+          "conclusion": {
+            "type": "string",
+            "enum": [
+              "gegrond",
+              "ongegrond",
+              "gedeeltelijk_gegrond",
+              "niet_ontvankelijk"
+            ],
+            "description": "Committee's conclusion per Awb Art. 7:13(7)"
+          },
+          "recommendation": {
+            "type": "string",
+            "description": "Free-text recommendation to the council"
+          },
+          "dissentingOpinions": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "memberUid": {
+                  "type": "string"
+                },
+                "opinion": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Optional dissenting opinions when panel disagreement exists"
+          },
+          "auditTrail": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "event": {
+                  "type": "string",
+                  "enum": [
+                    "panel-member-added",
+                    "panel-member-removed",
+                    "independence-check-failed",
+                    "advice-signed-by-chair",
+                    "council-deviation-recorded"
+                  ]
+                },
+                "actor": {
+                  "type": "string"
+                },
+                "at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "payload": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            },
+            "description": "Append-only audit trail for BAC-specific events (Archiefwet 1995). Complements the OpenRegister automatic per-save log."
           }
         }
       }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -11,6 +11,7 @@
 		{ "id": "CaseMap", "label": "Map", "icon": "icon-address", "route": "CaseMap", "order": 60 },
 		{ "id": "Voorstellen", "label": "Voorstellen", "icon": "icon-comment", "route": "Voorstellen", "order": 70 },
 		{ "id": "Advice", "label": "Advice", "icon": "icon-comment", "route": "Advice", "order": 75 },
+		{ "id": "BezwaarAdviceRequests", "label": "BAC-adviezen", "icon": "icon-comment", "route": "BezwaarAdviceRequests", "order": 76 },
 		{ "id": "Transfers", "label": "Transfers", "icon": "icon-shared", "route": "Transfers", "order": 80 },
 		{ "id": "Documentation", "label": "Documentation", "icon": "icon-info", "href": "https://conduction.gitbook.io/procest-nextcloud", "section": "settings", "order": 90 },
 		{ "id": "CaseTypesMenu", "label": "Case Types", "icon": "icon-category-customization", "route": "CaseTypes", "section": "settings", "order": 95 },
@@ -22,6 +23,7 @@
 		{ "id": "WorkflowDefinitionsMenu", "label": "Workflow definitions", "icon": "icon-category-workflow", "route": "WorkflowDefinitions", "section": "settings", "order": 97 },
 		{ "id": "AutomaticActionsMenu", "label": "Automatische acties", "icon": "icon-category-workflow", "route": "AutomaticActions", "section": "settings", "order": 96 },
 		{ "id": "StatusRecordsMenu", "label": "Status history", "icon": "icon-history", "route": "StatusRecords", "section": "settings", "order": 98, "permission": "admin" },
+		{ "id": "BezwaarCommitteesMenu", "label": "Bezwaaradviescommissies", "icon": "icon-group", "route": "BezwaarCommittees", "section": "settings", "order": 99 },
 		{ "id": "SettingsMenu", "label": "Settings", "icon": "icon-settings", "route": "Settings", "section": "settings", "order": 99 }
 	],
 	"pages": [
@@ -587,6 +589,65 @@
 					{ "id": "guards",       "label": "Evaluated guards", "icon": "icon-checkmark", "widgets": [{ "type": "data", "config": { "fields": ["evaluatedGuards"] } }], "order": 20 },
 					{ "id": "actions",      "label": "Dispatched actions", "icon": "icon-toggle", "widgets": [{ "type": "data", "config": { "fields": ["dispatchedActions"] } }], "order": 30 },
 					{ "id": "audit",        "label": "Audit trail",      "icon": "icon-history", "widgets": [{ "type": "audit-trail" }],                   "order": 90 }
+				]
+			}
+		},
+		{
+			"id": "BezwaarCommittees",
+			"route": "/settings/bezwaar-committees",
+			"type": "index",
+			"title": "Bezwaaradviescommissies",
+			"config": {
+				"register": "procest",
+				"schema": "bezwaaradviescommissie",
+				"columns": ["name", "type", "domain", "quorum", "active", "termEndsOn"],
+				"actions": [
+					{ "id": "view", "label": "View", "icon": "icon-info", "handler": "navigate", "route": "BezwaarCommitteeDetail" }
+				],
+				"sidebar": { "enabled": true, "showMetadata": true }
+			}
+		},
+		{
+			"id": "BezwaarCommitteeDetail",
+			"route": "/settings/bezwaar-committees/:id",
+			"type": "detail",
+			"title": "Bezwaaradviescommissie",
+			"config": {
+				"register": "procest",
+				"schema": "bezwaaradviescommissie",
+				"sidebarTabs": [
+					{ "id": "overview", "label": "Overview",    "icon": "icon-info",    "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
+					{ "id": "audit",    "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }],                   "order": 90 }
+				]
+			}
+		},
+		{
+			"id": "BezwaarAdviceRequests",
+			"route": "/bezwaar-advice-requests",
+			"type": "index",
+			"title": "BAC-adviezen",
+			"config": {
+				"register": "procest",
+				"schema": "bacAdviceRequest",
+				"columns": ["bezwaar", "commissie", "status", "assignedAt", "deadline", "conclusion"],
+				"actions": [
+					{ "id": "view", "label": "View", "icon": "icon-info", "handler": "navigate", "route": "BezwaarAdviceRequestDetail" }
+				],
+				"sidebar": { "enabled": true, "showMetadata": true }
+			}
+		},
+		{
+			"id": "BezwaarAdviceRequestDetail",
+			"route": "/bezwaar-advice-requests/:id",
+			"type": "detail",
+			"title": "BAC-advies",
+			"config": {
+				"register": "procest",
+				"schema": "bacAdviceRequest",
+				"sidebarTabs": [
+					{ "id": "overview",  "label": "Overview",    "icon": "icon-info",    "widgets": [{ "type": "data" }, { "type": "metadata" }],                            "order": 10 },
+					{ "id": "documents", "label": "Documenten",  "icon": "icon-files",   "widgets": [{ "type": "data", "config": { "fields": ["adviceDocuments"] } }],        "order": 20 },
+					{ "id": "audit",     "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }],                                              "order": 90 }
 				]
 			}
 		}


### PR DESCRIPTION
## Summary

Manifest-first application of the `bezwaar-advisory-committee` capability under **Awb Art. 7:13**. Adds the bezwaaradviescommissie (BAC) as a long-lived configuration entity, a per-bezwaar `bacAdviceRequest` entity with the `assigned -> in-deliberation -> advice-issued` lifecycle, the member-independence guard (Awb 7:13(3)), and the council-deviation audit hook for the sister `bezwaar-lifecycle` capability to call when finalising a besluit op bezwaar.

## What changed

**Schemas** (`lib/Settings/procest_register.json`):
- `bezwaaradviescommissie` - name, type (BAC|VKK|VTH), domain, chair, members[], secretary, quorum (default 3), term window, active.
- `bacAdviceRequest` - bezwaar (`$ref: bezwaar`), commissie, panel[], status, assignedAt, 12-week deadline (Awb 7:24), advice, adviceDocuments[], adviceIssuedAt, signatureEvidence, hearingReportRef, conclusion, recommendation, dissentingOpinions[], auditTrail[].

**Manifest pages** (`src/manifest.json`):
- `BezwaarCommittees` (index, settings) + `BezwaarCommitteeDetail` (detail)
- `BezwaarAdviceRequests` (index, main nav order 76) + `BezwaarAdviceRequestDetail` (detail with Documents and Audit tabs)
- Menu entries register both in the settings section and main nav. CRUD goes through the OpenRegister auto-form - **no bespoke controllers**.

**Service** (`lib/Service/Bezwaar/AdvisoryCommitteeService.php`):
- `assignToCommittee()` - creates the request in `assigned`, applies the 12-week deadline, refuses archived committees, writes `panel-member-added` audit entry.
- `transitionAdviceStatus()` - enforces the one-way FSM, runs the independence check at `assigned -> in-deliberation`, enforces the advice content contract (conclusion + recommendation) at `in-deliberation -> advice-issued`, writes `advice-signed-by-chair` audit entries.
- `autoAssignDefaultCommittee()` - listener entry point; uses `bac_default_committee` app config.
- `recordCouncilDeviation()` - cross-spec hook for `bezwaar-lifecycle`'s besluit finaliser to record deviation from advice.

**Listener** (`lib/Listener/BezwaarAdviceRequestedListener.php`): watches `bezwaar` ObjectUpdatedEvent and, when status transitions into `Hoorzitting gepland`, calls `autoAssignDefaultCommittee`. Failures swallowed; manual fallback via the BAC index page.

## Test plan

- [ ] Provision a `bezwaaradviescommissie` via `/settings/bezwaar-committees` (manifest auto-form); verify quorum default + active flag persist.
- [ ] Set `bac_default_committee` via OCC `config:app:set procest bac_default_committee <committeeUuid>`.
- [ ] Transition a bezwaar lifecycle record to `Hoorzitting gepland`; verify a `bacAdviceRequest` is auto-created in `assigned`.
- [ ] Attempt `assigned -> in-deliberation` with a panel containing the original-decision creator; verify HTTP 409 + `independence-check-failed` audit entry.
- [ ] Set conclusion + recommendation, advance to `advice-issued`; verify `advice-signed-by-chair` audit entry + `adviceIssuedAt` populated.
- [ ] Verify `php -l` clean on all touched files and `jq empty` clean on `procest_register.json`, `src/manifest.json`, `builds/build.json`.