### PR TITLE
feat(bezwaar-decision): apply spec

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -39,6 +39,7 @@ use OCA\Procest\Dashboard\StalledCasesWidget;
 use OCA\Procest\Dashboard\TaskRemindersWidget;
 use OCA\Procest\Dashboard\StartCaseWidget;
 use OCA\Procest\Listener\BezwaarAdviceRequestedListener;
+use OCA\Procest\Listener\BezwaarDecisionListener;
 use OCA\Procest\Listener\BezwaarHearingScheduledListener;
 use OCA\Procest\Listener\BezwaarLifecycleListener;
 use OCA\Procest\Event\ParafeerTransitionEvent;
@@ -162,6 +163,15 @@ class Application extends App implements IBootstrap
         $context->registerEventListener(
             event: ObjectUpdatedEvent::class,
             listener: BezwaarHearingScheduledListener::class
+        );
+
+        // Bezwaar-decision guard: a bezwaar may only enter status
+        // "Beslissing op bezwaar" when a published bezwaarDecision
+        // exists for it. The listener reverts illegal transitions
+        // without bypassing the status-transition-engine.
+        $context->registerEventListener(
+            event: ObjectUpdatedEvent::class,
+            listener: BezwaarDecisionListener::class
         );
 
         $context->registerMiddleware(class: ZgwAuthMiddleware::class);

--- a/lib/Listener/BezwaarDecisionListener.php
+++ b/lib/Listener/BezwaarDecisionListener.php
@@ -1,0 +1,326 @@
+<?php
+
+/**
+ * Procest Bezwaar Decision Listener.
+ *
+ * Observes OpenRegister object events on the `bezwaar` schema and
+ * blocks a transition into status "Beslissing op bezwaar" when no
+ * published bezwaarDecision exists for the case. The listener is a
+ * pure guard: when the precondition is satisfied it is a no-op; when
+ * the precondition fails it reverts the status to the previous value
+ * via OpenRegister (no bespoke status-machine logic — the
+ * status-transition-engine remains the single owner of transition
+ * mechanics, this guard just enforces the published-decision
+ * requirement).
+ *
+ * Failures of the guard derivation itself are swallowed (logged) so
+ * that bezwaar persistence is never blocked by a defective lookup.
+ *
+ * @category Listener
+ * @package  OCA\Procest\Listener
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Listener;
+
+use OCA\OpenRegister\Event\ObjectUpdatedEvent;
+use OCA\Procest\Service\SettingsService;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Guards bezwaar transitions into "Beslissing op bezwaar" by requiring
+ * a published bezwaarDecision to exist for the bezwaar.
+ *
+ * @template-implements IEventListener<Event>
+ *
+ * @spec openspec/changes/bezwaar-decision/specs/bezwaar-decision/spec.md
+ */
+class BezwaarDecisionListener implements IEventListener
+{
+    /**
+     * Target status the guard protects.
+     */
+    private const PROTECTED_STATUS = 'Beslissing op bezwaar';
+
+    /**
+     * Constructor.
+     *
+     * @param SettingsService $settingsService Schema slug bridge.
+     * @param LoggerInterface $logger          Logger.
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Handle a bezwaar update event.
+     *
+     * @param Event $event Event instance.
+     *
+     * @return void
+     */
+    public function handle(Event $event): void
+    {
+        if ($event instanceof ObjectUpdatedEvent === false) {
+            return;
+        }
+
+        try {
+            $object = $this->extractObject($event);
+            if ($object === null) {
+                return;
+            }
+
+            if ($this->isBezwaarSchema(object: $object) === false) {
+                return;
+            }
+
+            $status = (string) ($object['status'] ?? '');
+            if ($status !== self::PROTECTED_STATUS) {
+                return;
+            }
+
+            if ($this->hasPublishedDecision(bezwaar: $object) === true) {
+                return;
+            }
+
+            // Guard violated — revert.
+            $this->revertStatus(bezwaar: $object, event: $event);
+        } catch (Throwable $e) {
+            $this->logger->debug(
+                'Procest bezwaar-decision: guard derivation swallowed '
+                .'exception: '.$e->getMessage()
+            );
+        }
+    }//end handle()
+
+    /**
+     * Decide whether the bezwaar has at least one published
+     * bezwaarDecision.
+     *
+     * @param array<string, mixed> $bezwaar The bezwaar payload.
+     *
+     * @return bool
+     */
+    private function hasPublishedDecision(array $bezwaar): bool
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return true;
+        }
+
+        $register       = $this->settingsService->getConfigValue(
+            key: 'register'
+        );
+        $decisionSchema = $this->settingsService->getConfigValue(
+            key: 'bezwaar_decision_schema'
+        );
+        if ($register === '' || $decisionSchema === '') {
+            return true;
+        }
+
+        $bezwaarId = (string) ($bezwaar['id'] ?? ($bezwaar['uuid'] ?? ''));
+        if ($bezwaarId === '') {
+            return true;
+        }
+
+        try {
+            $matches = $objectService->findAll(
+                $register,
+                $decisionSchema,
+                ['bezwaar' => $bezwaarId, 'status' => 'published']
+            );
+        } catch (Throwable $e) {
+            $this->logger->debug(
+                'Procest bezwaar-decision: lookup failed — allowing '
+                .'transition by default: '.$e->getMessage()
+            );
+            return true;
+        }
+
+        if (is_array($matches) === false) {
+            return false;
+        }
+
+        return count($matches) > 0;
+    }//end hasPublishedDecision()
+
+    /**
+     * Revert the bezwaar's status by reading the previous status from
+     * the event and writing it back via OpenRegister. The
+     * status-transition-engine remains the sole owner of forward
+     * transitions; this listener only reverts disallowed jumps.
+     *
+     * @param array<string, mixed> $bezwaar Current bezwaar payload.
+     * @param Event                $event   Event instance.
+     *
+     * @return void
+     */
+    private function revertStatus(array $bezwaar, Event $event): void
+    {
+        $previous = $this->extractPreviousStatus(event: $event);
+        if ($previous === '') {
+            return;
+        }
+
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return;
+        }
+
+        $register      = $this->settingsService->getConfigValue(
+            key: 'register'
+        );
+        $bezwaarSchema = $this->settingsService->getConfigValue(
+            key: 'bezwaar_schema'
+        );
+        if ($register === '' || $bezwaarSchema === '') {
+            return;
+        }
+
+        $bezwaarId = (string) ($bezwaar['id'] ?? ($bezwaar['uuid'] ?? ''));
+        if ($bezwaarId === '') {
+            return;
+        }
+
+        try {
+            $objectService->saveObject(
+                $register,
+                $bezwaarSchema,
+                ['status' => $previous],
+                $bezwaarId
+            );
+            $this->logger->warning(
+                'Procest bezwaar-decision: blocked transition into "'
+                .self::PROTECTED_STATUS.'" — no published bezwaarDecision; '
+                .'reverted to "'.$previous.'"',
+                ['bezwaarId' => $bezwaarId]
+            );
+        } catch (Throwable $e) {
+            $this->logger->error(
+                'Procest bezwaar-decision: revert failed: '.$e->getMessage()
+            );
+        }
+    }//end revertStatus()
+
+    /**
+     * Extract the previous status from an ObjectUpdatedEvent.
+     *
+     * @param Event $event Event instance.
+     *
+     * @return string
+     */
+    private function extractPreviousStatus(Event $event): string
+    {
+        if (method_exists($event, 'getOldObject') === true) {
+            $old = $event->getOldObject();
+            $arr = $this->normalise(value: $old);
+            if ($arr !== null) {
+                return (string) ($arr['status'] ?? '');
+            }
+        }
+
+        return '';
+    }//end extractPreviousStatus()
+
+    /**
+     * Whether the object belongs to the `bezwaar` schema.
+     *
+     * @param array<string, mixed> $object The object payload.
+     *
+     * @return bool
+     */
+    private function isBezwaarSchema(array $object): bool
+    {
+        $schemaSlug = $this->settingsService->getConfigValue(
+            key: 'bezwaar_schema'
+        );
+        if ($schemaSlug === '') {
+            return false;
+        }
+
+        $candidate = (string) (
+            $object['@self']['schema']
+            ?? ($object['@self']['schemaSlug']
+                ?? ($object['schema'] ?? ($object['_schemaSlug'] ?? '')))
+        );
+
+        return $candidate !== '' && (
+            $candidate === $schemaSlug
+            || str_ends_with($candidate, '/'.$schemaSlug)
+        );
+    }//end isBezwaarSchema()
+
+    /**
+     * Extract the new object payload from an event.
+     *
+     * @param Event $event Event instance.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function extractObject(Event $event): ?array
+    {
+        foreach (['getNewObject', 'getObject'] as $method) {
+            if (method_exists($event, $method) === false) {
+                continue;
+            }
+
+            $value = $event->{$method}();
+            $array = $this->normalise(value: $value);
+            if ($array !== null) {
+                return $array;
+            }
+        }
+
+        return null;
+    }//end extractObject()
+
+    /**
+     * Normalise a getter return value to an associative array.
+     *
+     * @param mixed $value The raw value.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function normalise(mixed $value): ?array
+    {
+        if (is_array($value) === true) {
+            return $value;
+        }
+
+        if (is_object($value) === true) {
+            if (method_exists($value, 'jsonSerialize') === true) {
+                $serialised = $value->jsonSerialize();
+                if (is_array($serialised) === true) {
+                    return $serialised;
+                }
+            }
+
+            if (method_exists($value, 'toArray') === true) {
+                $arr = $value->toArray();
+                if (is_array($arr) === true) {
+                    return $arr;
+                }
+            }
+        }
+
+        return null;
+    }//end normalise()
+}//end class

--- a/lib/Service/Bezwaar/DecisionService.php
+++ b/lib/Service/Bezwaar/DecisionService.php
@@ -1,0 +1,580 @@
+<?php
+
+/**
+ * Procest Bezwaar Decision Service.
+ *
+ * Domain service for the bezwaar-decision capability — the formal
+ * beslissing op bezwaar under Awb art. 7:11/7:12. Procest owns the
+ * decision record, the structured rechtsmiddelenclausule, the
+ * proceskostenvergoeding bookkeeping, and the publication + notification
+ * flow. This service composes those operations and delegates every
+ * persistence call to OpenRegister via SettingsService::getObjectService();
+ * it never owns bespoke CRUD or a custom controller.
+ *
+ *  - draft()             — create a bezwaarDecision in status "draft" with
+ *                          the canonical Awb 7:11 disposition enum and
+ *                          link it to its bezwaar; required fields are
+ *                          surface-validated.
+ *  - publish()           — promote a draft to published after the
+ *                          per-dispositionType mandatory-field guard
+ *                          passes (replacementDecision for
+ *                          gegrond_wijzigen; appealNotice completeness;
+ *                          deviationRationale when advisoryOpinion is set
+ *                          and the decision deviates; proceskosten rules
+ *                          when herroepen/wijzigen). Sets publishedAt,
+ *                          stamps notifiedRecipients, calls
+ *                          applyToBezwaar() so the case transitions to
+ *                          "Beslissing op bezwaar" via the
+ *                          status-transition-engine.
+ *  - applyToBezwaar()    — write the decision back onto the linked
+ *                          bezwaar by invoking the
+ *                          StatusTransitionService — no bespoke
+ *                          transition logic lives here.
+ *
+ * Identity for the publication actor is ALWAYS derived from
+ * IUserSession. Static error messages only — exception details never
+ * bubble to controllers.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Bezwaar
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Bezwaar;
+
+use DateTimeImmutable;
+use OCA\Procest\Service\SettingsService;
+use OCA\Procest\Service\StatusTransitionService;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Bezwaar decision service: draft, publish, and apply to the linked
+ * bezwaar via the status-transition-engine.
+ *
+ * @spec openspec/changes/bezwaar-decision/specs/bezwaar-decision/spec.md
+ */
+class DecisionService
+{
+    /**
+     * Canonical Awb art. 7:11 disposition values (REQ-BD-2).
+     */
+    public const VALID_DISPOSITIONS = [
+        'niet_ontvankelijk',
+        'ongegrond',
+        'gegrond_handhaven',
+        'gegrond_herroepen',
+        'gegrond_wijzigen',
+    ];
+
+    /**
+     * Dispositions for which a replacementDecision is allowed/required.
+     */
+    private const REPLACEMENT_ALLOWED = [
+        'gegrond_herroepen',
+        'gegrond_wijzigen',
+    ];
+
+    /**
+     * Dispositions for which proceskostenvergoeding may be awarded
+     * (Awb art. 7:15 lid 2).
+     */
+    private const PROCESKOSTEN_ELIGIBLE = [
+        'gegrond_herroepen',
+        'gegrond_wijzigen',
+    ];
+
+    /**
+     * Bezwaar status target on publication (handed off to the
+     * status-transition-engine).
+     */
+    private const TARGET_BEZWAAR_STATUS = 'Beslissing op bezwaar';
+
+    /**
+     * Transition id wired on the bezwaar workflowTemplate to move into
+     * "Beslissing op bezwaar".
+     */
+    private const TRANSITION_ID = 'beslissing-op-bezwaar';
+
+    /**
+     * Required appealNotice sub-fields (REQ-BD-6) regardless of
+     * filingMethod. filingUrl/filingAddress requirements are
+     * conditional on filingMethod and handled separately.
+     *
+     * @var array<int, string>
+     */
+    private const APPEAL_NOTICE_BASE_REQUIRED = [
+        'competentCourt',
+        'beroepTerm',
+        'effectiveDate',
+        'filingMethod',
+    ];
+
+    /**
+     * Constructor.
+     *
+     * @param SettingsService         $settingsService Schema/register bridge.
+     * @param IUserSession            $userSession     Acting identity source.
+     * @param StatusTransitionService $transitions     Engine used by
+     *                                                 applyToBezwaar() to
+     *                                                 transition the
+     *                                                 linked bezwaar
+     *                                                 without bespoke
+     *                                                 transition logic.
+     * @param LoggerInterface         $logger          Logger.
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+        private readonly IUserSession $userSession,
+        private readonly StatusTransitionService $transitions,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Create a bezwaarDecision in status "draft".
+     *
+     * Surface-validates the disposition enum and the per-disposition
+     * mandatory-field rules that apply at draft time (canonical enum,
+     * replacementDecision compatibility, reasoning + legalBasis
+     * presence). Hard guards that only apply at publication time
+     * (appealNotice completeness, proceskosten resolution) are
+     * deferred to publish().
+     *
+     * @param string               $bezwaarId UUID of the bezwaar.
+     * @param array<string, mixed> $payload   Decision properties.
+     *
+     * @return array<string, mixed> The created decision record.
+     *
+     * @throws RuntimeException When OpenRegister is unavailable, schemas
+     *                          are unconfigured, or the payload is
+     *                          invalid at draft time.
+     */
+    public function draft(string $bezwaarId, array $payload): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            throw new RuntimeException('OpenRegister is not available');
+        }
+
+        $register       = $this->settingsService->getConfigValue(key: 'register');
+        $decisionSchema = $this->settingsService->getConfigValue(
+            key: 'bezwaar_decision_schema'
+        );
+        if ($register === '' || $decisionSchema === '') {
+            throw new RuntimeException(
+                'BezwaarDecision schema is not configured'
+            );
+        }
+
+        $disposition = (string) ($payload['dispositionType'] ?? '');
+        if (in_array($disposition, self::VALID_DISPOSITIONS, true) === false) {
+            throw new RuntimeException(
+                'Invalid disposition — must be one of the five canonical Awb '
+                .'7:11 values'
+            );
+        }
+
+        $reasoning  = (string) ($payload['reasoning'] ?? '');
+        $legalBasis = (string) ($payload['legalBasis'] ?? '');
+        if ($reasoning === '' || $legalBasis === '') {
+            throw new RuntimeException(
+                'reasoning and legalBasis are required (Awb art. 7:12)'
+            );
+        }
+
+        $replacement = (string) ($payload['replacementDecision'] ?? '');
+        if ($replacement !== ''
+            && in_array($disposition, self::REPLACEMENT_ALLOWED, true) === false
+        ) {
+            throw new RuntimeException(
+                'replacementDecision MUST NOT be set when disposition is not '
+                .'gegrond_herroepen or gegrond_wijzigen'
+            );
+        }
+
+        $record = array_merge(
+            $payload,
+            [
+                'bezwaar' => $bezwaarId,
+                'status'  => 'draft',
+            ]
+        );
+        // publishedAt and notifiedRecipients are owned by publish().
+        unset($record['publishedAt'], $record['notifiedRecipients']);
+
+        try {
+            return $objectService->saveObject(
+                $register,
+                $decisionSchema,
+                $record
+            );
+        } catch (Throwable $e) {
+            $this->logger->error(
+                'Procest bezwaar-decision: failed to draft: '.$e->getMessage()
+            );
+            throw new RuntimeException('Could not draft bezwaarDecision');
+        }
+    }//end draft()
+
+    /**
+     * Publish a draft bezwaarDecision.
+     *
+     * Runs the full validity matrix (REQ-BD-3, REQ-BD-5, REQ-BD-6,
+     * REQ-BD-7), sets publishedAt + notifiedRecipients, computes the
+     * proceskosten total when applicable, and hands the case off to
+     * the status-transition-engine via applyToBezwaar().
+     *
+     * @param string $decisionId UUID of the bezwaarDecision.
+     *
+     * @return array<string, mixed> The published decision record.
+     *
+     * @throws RuntimeException When validation fails or persistence
+     *                          errors occur.
+     */
+    public function publish(string $decisionId): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            throw new RuntimeException('OpenRegister is not available');
+        }
+
+        $register       = $this->settingsService->getConfigValue(key: 'register');
+        $decisionSchema = $this->settingsService->getConfigValue(
+            key: 'bezwaar_decision_schema'
+        );
+        if ($register === '' || $decisionSchema === '') {
+            throw new RuntimeException(
+                'BezwaarDecision schema is not configured'
+            );
+        }
+
+        $current = $objectService->findObject(
+            $register,
+            $decisionSchema,
+            $decisionId
+        );
+        if (is_array($current) === false) {
+            throw new RuntimeException('BezwaarDecision not found');
+        }
+
+        $this->assertPublishable(decision: $current);
+
+        $patch = [
+            'status'             => 'published',
+            'publishedAt'        => (new DateTimeImmutable())->format(
+                DateTimeImmutable::ATOM
+            ),
+            'notifiedRecipients' => $this->collectRecipients(
+                decision: $current
+            ),
+        ];
+
+        $totalAmount = $this->computeProceskostenTotal(decision: $current);
+        if ($totalAmount !== null) {
+            $proceskosten = (array) ($current['proceskostenvergoeding'] ?? []);
+            $proceskosten['totalAmount']    = $totalAmount;
+            $patch['proceskostenvergoeding'] = $proceskosten;
+        }
+
+        try {
+            $saved = $objectService->saveObject(
+                $register,
+                $decisionSchema,
+                $patch,
+                $decisionId
+            );
+        } catch (Throwable $e) {
+            $this->logger->error(
+                'Procest bezwaar-decision: failed to publish: '
+                .$e->getMessage()
+            );
+            throw new RuntimeException('Could not publish bezwaarDecision');
+        }
+
+        $bezwaarId = (string) ($current['bezwaar'] ?? '');
+        if ($bezwaarId !== '') {
+            $this->applyToBezwaar(
+                bezwaarId: $bezwaarId,
+                decisionId: $decisionId
+            );
+        }
+
+        return $saved;
+    }//end publish()
+
+    /**
+     * Apply a published decision back to its bezwaar by triggering the
+     * configured status transition. Never carries out a bespoke
+     * transition itself — the engine owns guards + side effects.
+     *
+     * @param string $bezwaarId  UUID of the source bezwaar.
+     * @param string $decisionId UUID of the bezwaarDecision triggering
+     *                           the transition.
+     *
+     * @return void
+     */
+    public function applyToBezwaar(string $bezwaarId, string $decisionId): void
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return;
+        }
+
+        $register      = $this->settingsService->getConfigValue(
+            key: 'register'
+        );
+        $bezwaarSchema = $this->settingsService->getConfigValue(
+            key: 'bezwaar_schema'
+        );
+        if ($register === '' || $bezwaarSchema === '') {
+            return;
+        }
+
+        $bezwaar = $objectService->findObject(
+            $register,
+            $bezwaarSchema,
+            $bezwaarId
+        );
+        if (is_array($bezwaar) === false) {
+            return;
+        }
+
+        $caseId = (string) ($bezwaar['case'] ?? '');
+        if ($caseId === '') {
+            return;
+        }
+
+        try {
+            $this->transitions->execute(
+                caseId: $caseId,
+                transitionId: self::TRANSITION_ID,
+                comment: 'Applied beslissing op bezwaar '.$decisionId,
+            );
+        } catch (Throwable $e) {
+            $this->logger->warning(
+                'Procest bezwaar-decision: transition to '
+                .self::TARGET_BEZWAAR_STATUS.' failed: '.$e->getMessage()
+            );
+        }
+    }//end applyToBezwaar()
+
+    /**
+     * Run every publication-time guard against a draft decision.
+     *
+     * @param array<string, mixed> $decision The decision payload.
+     *
+     * @return void
+     *
+     * @throws RuntimeException When any guard rejects.
+     */
+    private function assertPublishable(array $decision): void
+    {
+        $disposition = (string) ($decision['dispositionType'] ?? '');
+        if (in_array($disposition, self::VALID_DISPOSITIONS, true) === false) {
+            throw new RuntimeException(
+                'dispositionType is invalid — refusing to publish'
+            );
+        }
+
+        // REQ-BD-3: gegrond_wijzigen requires replacementDecision.
+        $replacement = (string) ($decision['replacementDecision'] ?? '');
+        if ($disposition === 'gegrond_wijzigen' && $replacement === '') {
+            throw new RuntimeException(
+                'replacementDecision is required when disposition is '
+                .'gegrond_wijzigen'
+            );
+        }
+
+        // REQ-BD-3: ongegrond and gegrond_handhaven MUST NOT carry one.
+        if ($replacement !== ''
+            && in_array($disposition, self::REPLACEMENT_ALLOWED, true) === false
+        ) {
+            throw new RuntimeException(
+                'replacementDecision MUST NOT be set when disposition is '
+                .$disposition
+            );
+        }
+
+        // REQ-BD-5: deviationRationale required when advisoryOpinion is
+        // set and the decision deviates.
+        $advisory = (string) ($decision['advisoryOpinion'] ?? '');
+        if ($advisory !== '') {
+            $follows  = (bool) ($decision['followsAdvice'] ?? true);
+            $reason   = (string) ($decision['deviationRationale'] ?? '');
+            if ($follows === false && $reason === '') {
+                throw new RuntimeException(
+                    'deviationRationale is required when followsAdvice is '
+                    .'false (Awb art. 7:13 lid 7)'
+                );
+            }
+        }
+
+        // REQ-BD-6: appealNotice completeness.
+        $this->assertAppealNoticeComplete(decision: $decision);
+
+        // REQ-BD-7: proceskostenvergoeding rules.
+        $this->assertProceskostenRules(decision: $decision);
+    }//end assertPublishable()
+
+    /**
+     * Validate the rechtsmiddelenclausule (REQ-BD-6).
+     *
+     * @param array<string, mixed> $decision Decision payload.
+     *
+     * @return void
+     *
+     * @throws RuntimeException When the appealNotice is incomplete.
+     */
+    private function assertAppealNoticeComplete(array $decision): void
+    {
+        $appealNotice = (array) ($decision['appealNotice'] ?? []);
+        foreach (self::APPEAL_NOTICE_BASE_REQUIRED as $field) {
+            $value = (string) ($appealNotice[$field] ?? '');
+            if ($value === '') {
+                throw new RuntimeException(
+                    'Rechtsmiddelenclausule onvolledig: '.$field.' ontbreekt'
+                );
+            }
+        }
+
+        $method = (string) $appealNotice['filingMethod'];
+        if (in_array($method, ['digitaal', 'beide'], true) === true) {
+            $url = (string) ($appealNotice['filingUrl'] ?? '');
+            if ($url === '') {
+                throw new RuntimeException(
+                    'filingUrl is required when filingMethod is '.$method
+                );
+            }
+        }
+
+        if (in_array($method, ['schriftelijk', 'beide'], true) === true) {
+            $address = (string) ($appealNotice['filingAddress'] ?? '');
+            if ($address === '') {
+                throw new RuntimeException(
+                    'filingAddress is required when filingMethod is '.$method
+                );
+            }
+        }
+    }//end assertAppealNoticeComplete()
+
+    /**
+     * Validate the proceskostenvergoeding decision (REQ-BD-7).
+     *
+     * @param array<string, mixed> $decision Decision payload.
+     *
+     * @return void
+     *
+     * @throws RuntimeException When proceskosten rules are violated.
+     */
+    private function assertProceskostenRules(array $decision): void
+    {
+        $disposition  = (string) ($decision['dispositionType'] ?? '');
+        $proceskosten = (array) ($decision['proceskostenvergoeding'] ?? []);
+        $requested    = (bool) ($proceskosten['requested'] ?? false);
+        $awardedSet   = array_key_exists('awarded', $proceskosten);
+        $awarded      = (bool) ($proceskosten['awarded'] ?? false);
+
+        $eligible = in_array(
+            $disposition,
+            self::PROCESKOSTEN_ELIGIBLE,
+            true
+        );
+
+        if ($awarded === true && $eligible === false) {
+            throw new RuntimeException(
+                'Proceskostenvergoeding niet mogelijk: primair besluit niet '
+                .'herroepen (Awb art. 7:15 lid 2)'
+            );
+        }
+
+        if ($requested === true && $eligible === true && $awardedSet === false) {
+            throw new RuntimeException(
+                'proceskosten.awarded MUST be explicitly set (true or false '
+                .'with reasoning) when the bezwaarmaker requested '
+                .'proceskostenvergoeding'
+            );
+        }
+    }//end assertProceskostenRules()
+
+    /**
+     * Compute proceskosten.totalAmount = awardedPoints * pointValue.
+     *
+     * @param array<string, mixed> $decision Decision payload.
+     *
+     * @return float|null Null when no recalculation is needed.
+     */
+    private function computeProceskostenTotal(array $decision): ?float
+    {
+        $proceskosten = (array) ($decision['proceskostenvergoeding'] ?? []);
+        if (($proceskosten['awarded'] ?? false) !== true) {
+            return null;
+        }
+
+        $points = (float) ($proceskosten['awardedPoints'] ?? 0);
+        $value  = (float) ($proceskosten['pointValue'] ?? 0);
+        if ($points <= 0.0 || $value <= 0.0) {
+            return null;
+        }
+
+        return ($points * $value);
+    }//end computeProceskostenTotal()
+
+    /**
+     * Build the recipient audit list for the publication notification
+     * flow (REQ-BD-10). Bezwaarmaker, gemachtigde, primair beslisser,
+     * and the BAC secretaris (when advisoryOpinion is set) are
+     * surfaced from the decision payload where available. The actual
+     * notification fan-out is owned by NotificatieService /
+     * BerichtenboxAdapter; this method records who SHOULD be reached.
+     *
+     * @param array<string, mixed> $decision Decision payload.
+     *
+     * @return array<int, string>
+     */
+    private function collectRecipients(array $decision): array
+    {
+        $recipients = [];
+
+        $acting = $this->userSession->getUser();
+        if ($acting !== null) {
+            $recipients[] = 'actor:'.$acting->getUID();
+        }
+
+        $bezwaarmaker = (string) ($decision['bezwaarmaker'] ?? '');
+        if ($bezwaarmaker !== '') {
+            $recipients[] = 'bezwaarmaker:'.$bezwaarmaker;
+        }
+
+        $gemachtigde = (string) ($decision['gemachtigde'] ?? '');
+        if ($gemachtigde !== '') {
+            $recipients[] = 'gemachtigde:'.$gemachtigde;
+        }
+
+        $primairBeslisser = (string) ($decision['primairBeslisser'] ?? '');
+        if ($primairBeslisser !== '') {
+            $recipients[] = 'primair-beslisser:'.$primairBeslisser;
+        }
+
+        $advisory = (string) ($decision['advisoryOpinion'] ?? '');
+        if ($advisory !== '') {
+            $recipients[] = 'bac-secretaris:'.$advisory;
+        }
+
+        return array_values(array_unique($recipients));
+    }//end collectRecipients()
+}//end class

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -103,6 +103,8 @@ class SettingsService
         'bac_default_committee',
         // Beroep escalation (beroep-escalation spec) — Awb hoofdstuk 8.
         'beroep_schema',
+        // Bezwaar decision (bezwaar-decision spec) — Awb art. 7:11/7:12.
+        'bezwaar_decision_schema',
         'lhsMatrix',
         'lhs_matrix_schema',
         'lhs_recommendation_schema',
@@ -204,6 +206,7 @@ class SettingsService
         'bezwaaradviescommissie'       => 'bezwaaradviescommissie_schema',
         'bacAdviceRequest'             => 'bac_advice_request_schema',
         'beroep'                       => 'beroep_schema',
+        'bezwaarDecision'              => 'bezwaar_decision_schema',
     ];
 
     private const OPENREGISTER_APP_ID = 'openregister';

--- a/lib/Settings/procest_register.json
+++ b/lib/Settings/procest_register.json
@@ -2650,6 +2650,186 @@
           }
         }
       },
+      "bezwaarDecision": {
+        "slug": "bezwaarDecision",
+        "icon": "GavelOutline",
+        "version": "1.0.0",
+        "x-schema-org-type": "schema:Action",
+        "x-zgw-equivalent": "BeslissingOpBezwaar",
+        "title": "Bezwaar Decision",
+        "description": "Beslissing op bezwaar — canonical decision entity per Awb art. 7:11/7:12 with the 5-value disposition enum, structured rechtsmiddelenclausule, proceskostenvergoeding, and publication flow",
+        "type": "object",
+        "required": [
+          "bezwaar",
+          "dispositionType",
+          "reasoning",
+          "legalBasis"
+        ],
+        "properties": {
+          "bezwaar": {
+            "type": "string",
+            "format": "uuid",
+            "$ref": "bezwaar",
+            "onDelete": "CASCADE",
+            "description": "The bezwaar case this decision belongs to"
+          },
+          "dispositionType": {
+            "type": "string",
+            "enum": [
+              "niet_ontvankelijk",
+              "ongegrond",
+              "gegrond_handhaven",
+              "gegrond_herroepen",
+              "gegrond_wijzigen"
+            ],
+            "description": "Awb art. 7:11 canonical outcome — drives mandatory fields, replacement besluit, and proceskosten eligibility"
+          },
+          "reasoning": {
+            "type": "string",
+            "description": "Substantive motivation (motiveringsplicht Awb art. 7:12); for niet_ontvankelijk MUST cite Awb 6:5/6:6/6:7"
+          },
+          "legalBasis": {
+            "type": "string",
+            "description": "Awb article(s) and/or sectoral wettelijke grondslag the decision rests on"
+          },
+          "advisoryOpinion": {
+            "type": "string",
+            "format": "uuid",
+            "$ref": "bacAdviceRequest",
+            "description": "Linked BAC advisory request (Awb 7:13); when set, followsAdvice and deviationRationale apply"
+          },
+          "followsAdvice": {
+            "type": "boolean",
+            "description": "Whether this decision follows the BAC advisory opinion"
+          },
+          "deviationRationale": {
+            "type": "string",
+            "description": "Required when advisoryOpinion is set and the decision deviates from the committee advice (Awb art. 7:13 lid 7)"
+          },
+          "replacementDecision": {
+            "type": "string",
+            "format": "uuid",
+            "$ref": "decision",
+            "description": "New besluit replacing the primair besluit — required when dispositionType is gegrond_wijzigen, optional for gegrond_herroepen, MUST NOT be set otherwise"
+          },
+          "appealNotice": {
+            "type": "object",
+            "description": "Structured rechtsmiddelenclausule — replaces free-form prose; every required sub-field MUST be filled before publication",
+            "properties": {
+              "competentCourt": {
+                "type": "string",
+                "description": "Bevoegde rechter (e.g. 'Rechtbank Midden-Nederland, sector bestuursrecht')"
+              },
+              "beroepTerm": {
+                "type": "string",
+                "description": "ISO 8601 duration of the beroep filing window; default P6W (Awb 6:7)",
+                "default": "P6W"
+              },
+              "effectiveDate": {
+                "type": "string",
+                "format": "date",
+                "description": "Date from which beroepTerm runs"
+              },
+              "filingMethod": {
+                "type": "string",
+                "enum": ["digitaal", "schriftelijk", "beide"],
+                "description": "How beroep may be filed; drives whether filingUrl and/or filingAddress are required"
+              },
+              "filingUrl": {
+                "type": "string",
+                "description": "Digital filing URL (required when filingMethod is digitaal or beide)"
+              },
+              "filingAddress": {
+                "type": "string",
+                "description": "Postal filing address (required when filingMethod is schriftelijk or beide)"
+              },
+              "griffierecht": {
+                "type": "string",
+                "description": "Griffierecht copy (amount + payment instructions)"
+              },
+              "voorlopigeVoorziening": {
+                "type": "boolean",
+                "description": "Mentions option to request voorlopige voorziening at the court"
+              }
+            }
+          },
+          "proceskostenvergoeding": {
+            "type": "object",
+            "description": "Awb art. 7:15 cost award — awardable only when dispositionType is gegrond_herroepen or gegrond_wijzigen, the bezwaarmaker requested it, and the herroeping is attributable to onrechtmatigheid van het primair besluit; totalAmount is calculated as awardedPoints * pointValue",
+            "properties": {
+              "requested": {
+                "type": "boolean",
+                "description": "Whether the bezwaarmaker requested proceskostenvergoeding before the beslissing"
+              },
+              "awarded": {
+                "type": "boolean",
+                "description": "Explicit awarded/declined decision; MUST be set with reasoning when requested is true and disposition is gegrond_herroepen or gegrond_wijzigen"
+              },
+              "pointBasis": {
+                "type": "string",
+                "description": "BPB-puntensysteem reference (Besluit proceskosten bestuursrecht)"
+              },
+              "awardedPoints": {
+                "type": "number",
+                "description": "Number of points awarded (BPB-puntensysteem)"
+              },
+              "pointValue": {
+                "type": "number",
+                "description": "EUR per point at the time of beslissing"
+              },
+              "totalAmount": {
+                "type": "number",
+                "description": "Calculated total = awardedPoints * pointValue"
+              },
+              "reasoning": {
+                "type": "string",
+                "description": "Motivation for awarding or refusing proceskostenvergoeding"
+              },
+              "paymentDate": {
+                "type": "string",
+                "format": "date",
+                "description": "Date the proceskosten were paid out"
+              }
+            }
+          },
+          "decisionDate": {
+            "type": "string",
+            "format": "date",
+            "description": "Date the decision was made; validated against bezwaar.afhandelDeadline (Awb 7:10)"
+          },
+          "effectiveDate": {
+            "type": "string",
+            "format": "date",
+            "description": "Date the decision takes legal effect; beroep-clock runs from here"
+          },
+          "decisionMaker": {
+            "type": "string",
+            "format": "uuid",
+            "$ref": "role",
+            "description": "Bestuursorgaan or mandated official; derived from mandate config, never from request body"
+          },
+          "decisionDocument": {
+            "type": "string",
+            "description": "Nextcloud file ID of the generated PDF beslissing op bezwaar"
+          },
+          "publishedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Set on transition to published; once set the bezwaarDecision is immutable"
+          },
+          "notifiedRecipients": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Audit of UIDs/email addresses notified on publication; berichtenbox deliveries are prefixed 'berichtenbox:'"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["draft", "published"],
+            "default": "draft",
+            "description": "Draft until publish() validates required fields and sets publishedAt"
+          }
+        }
+      },
       "beroep": {
         "slug": "beroep",
         "icon": "ScaleBalance",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -8,6 +8,7 @@
 		{ "id": "Werkvoorraad", "label": "Work Queue", "icon": "icon-group", "route": "Werkvoorraad", "order": 30 },
 		{ "id": "Cases", "label": "Cases", "icon": "icon-folder", "route": "Cases", "order": 40 },
 		{ "id": "Bezwaren", "label": "Bezwaren", "icon": "icon-toggle-filelist", "route": "Bezwaren", "order": 45 },
+		{ "id": "BezwaarDecisions", "label": "Beslissingen op bezwaar", "icon": "icon-toggle", "route": "BezwaarDecisions", "order": 47 },
 		{ "id": "Beroepen", "label": "Beroepen", "icon": "icon-toggle-filelist", "route": "Beroepen", "order": 46 },
 		{ "id": "Tasks", "label": "Tasks", "icon": "icon-checkmark", "route": "Tasks", "order": 50 },
 		{ "id": "CaseMap", "label": "Map", "icon": "icon-address", "route": "CaseMap", "order": 60 },
@@ -156,6 +157,37 @@
 					{ "id": "hearing",  "label": "Hearing",  "icon": "icon-group",    "component": "CaseTasksTab",                             "order": 30 },
 					{ "id": "decision", "label": "Decision", "icon": "icon-toggle",   "component": "CaseDecisionsTab",                         "order": 40 },
 					{ "id": "audit",    "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }],                "order": 90 }
+				]
+			}
+		},
+		{
+			"id": "BezwaarDecisions",
+			"route": "/bezwaar-decisions",
+			"type": "index",
+			"title": "Beslissingen op bezwaar",
+			"config": {
+				"register": "procest",
+				"schema": "bezwaarDecision",
+				"columns": ["bezwaar", "dispositionType", "decisionDate", "effectiveDate", "status", "publishedAt"],
+				"actions": [
+					{ "id": "view", "label": "View", "icon": "icon-info", "handler": "navigate", "route": "BezwaarDecisionDetail" }
+				],
+				"sidebar": { "enabled": true, "showMetadata": true }
+			}
+		},
+		{
+			"id": "BezwaarDecisionDetail",
+			"route": "/bezwaar-decisions/:id",
+			"type": "detail",
+			"title": "Beslissing op bezwaar",
+			"config": {
+				"register": "procest",
+				"schema": "bezwaarDecision",
+				"sidebarTabs": [
+					{ "id": "overview",      "label": "Overview",      "icon": "icon-info",    "widgets": [{ "type": "data" }, { "type": "metadata" }],                                                                                                                                "order": 10 },
+					{ "id": "appeal-notice", "label": "Appeal notice", "icon": "icon-toggle",  "widgets": [{ "type": "data", "config": { "fields": ["appealNotice"] } }],                                                                                                                "order": 20 },
+					{ "id": "documents",     "label": "Documents",     "icon": "icon-files",   "widgets": [{ "type": "data", "config": { "fields": ["decisionDocument", "replacementDecision"] } }],                                                                                    "order": 30 },
+					{ "id": "audit",         "label": "Audit",         "icon": "icon-history", "widgets": [{ "type": "audit-trail" }, { "type": "data", "config": { "fields": ["publishedAt", "notifiedRecipients"] } }],                                                               "order": 90 }
 				]
 			}
 		},


### PR DESCRIPTION
## Summary

Manifest-first apply of the `bezwaar-decision` capability per `openspec/changes/bezwaar-decision`.

- `bezwaarDecision` schema in `lib/Settings/procest_register.json` with the canonical 5-value Awb 7:11 `dispositionType` enum (`niet_ontvankelijk | ongegrond | gegrond_handhaven | gegrond_herroepen | gegrond_wijzigen`), structured `appealNotice`, `proceskostenvergoeding` sub-object, `draft`/`published` status, `publishedAt`, `notifiedRecipients`.
- Manifest pages `BezwaarDecisions` (index) + `BezwaarDecisionDetail` with sidebar tabs Overview, Appeal notice, Documents, Audit; menu entry "Beslissingen op bezwaar".
- `Service\Bezwaar\DecisionService::draft()` / `publish()` validates per-disposition mandatory fields (replacement-besluit rules, appealNotice completeness, deviationRationale on BAC deviation, proceskosten Awb 7:15 eligibility) and computes `totalAmount`. `applyToBezwaar()` delegates the case status flip to `StatusTransitionService` — NO bespoke transition logic.
- `Listener\BezwaarDecisionListener` guards transitions into status "Beslissing op bezwaar" and reverts the update when no published bezwaarDecision exists for the bezwaar.
- `SettingsService` config key `bezwaar_decision_schema` + `bezwaarDecision` -> `bezwaar_decision_schema` slug mapping.
- NO bespoke CRUD controller — every mutation routes through OpenRegister via `SettingsService::getObjectService()`.

## Spec

`openspec/changes/bezwaar-decision/specs/bezwaar-decision/spec.md` — 10 requirements (REQ-BD-1..10).

## Validation

- `php -l` clean on all four touched/added PHP files.
- `jq '.'` clean on `procest_register.json` and `src/manifest.json`.
- Per the strict watchdog: no `composer check`, no i18n; 25-min budget respected.

## Test plan

- [ ] Schema visible after install via repair step
- [ ] BezwaarDecisions index page lists draft + published decisions
- [ ] `draft()` rejects unknown disposition and missing reasoning/legalBasis
- [ ] `publish()` blocks when `gegrond_wijzigen` has no `replacementDecision`
- [ ] `publish()` blocks when `appealNotice` is incomplete
- [ ] `publish()` rejects proceskosten on `ongegrond`
- [ ] Listener reverts bezwaar status when set to "Beslissing op bezwaar" with no published decision