### PR TITLE
feat(mcp-tools): ProcestToolProvider — AI companion MCP tools

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,11 @@
 			"OCA\\Procest\\": "lib/"
 		}
 	},
+	"autoload-dev": {
+		"psr-4": {
+			"OCA\\OpenRegister\\": "tests/Stubs/"
+		}
+	},
 	"require": {
 		"php": "^8.1"
 	},

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -47,6 +47,7 @@ use OCA\Procest\Listener\DeepLinkRegistrationListener;
 use OCA\Procest\Listener\KpiCacheInvalidationListener;
 use OCA\Procest\Listener\ParaferingAuditListener;
 use OCA\Procest\Listener\RoleMutationListener;
+use OCA\Procest\Mcp\ProcestToolProvider;
 use OCA\Procest\Middleware\TenantMiddleware;
 use OCA\Procest\Middleware\ZgwAuthMiddleware;
 use OCA\Procest\Validator\ParaferingAuditAppendOnlyValidator;
@@ -115,6 +116,23 @@ class Application extends App implements IBootstrap
             listener: RoleMutationListener::class
         );
 
+        $this->registerBezwaarListeners(context: $context);
+
+        $context->registerMiddleware(class: ZgwAuthMiddleware::class);
+        $context->registerMiddleware(class: TenantMiddleware::class);
+
+        $this->registerWidgetsAndProviders(context: $context);
+    }//end register()
+
+    /**
+     * Register bezwaar-lifecycle and parafering-audit event listeners.
+     *
+     * @param IRegistrationContext $context The registration context
+     *
+     * @return void
+     */
+    private function registerBezwaarListeners(IRegistrationContext $context): void
+    {
         // Bezwaar-lifecycle observer — routes bezwaar/hearing/advice/decision
         // events onto the status-transition-engine without duplicating
         // transition logic. See ADR-022 + REQ-BL-8.
@@ -173,10 +191,17 @@ class Application extends App implements IBootstrap
             event: ObjectUpdatedEvent::class,
             listener: BezwaarDecisionListener::class
         );
+    }//end registerBezwaarListeners()
 
-        $context->registerMiddleware(class: ZgwAuthMiddleware::class);
-        $context->registerMiddleware(class: TenantMiddleware::class);
-
+    /**
+     * Register dashboard widgets and the MCP tool provider.
+     *
+     * @param IRegistrationContext $context The registration context
+     *
+     * @return void
+     */
+    private function registerWidgetsAndProviders(IRegistrationContext $context): void
+    {
         // Dashboard widgets.
         $context->registerDashboardWidget(CasesOverviewWidget::class);
         $context->registerDashboardWidget(MyTasksWidget::class);
@@ -185,7 +210,18 @@ class Application extends App implements IBootstrap
         $context->registerDashboardWidget(TaskRemindersWidget::class);
         $context->registerDashboardWidget(StalledCasesWidget::class);
         $context->registerDashboardWidget(StartCaseWidget::class);
-    }//end register()
+
+        // Register ProcestToolProvider as the MCP tool provider for the AI Chat
+        // Companion. The alias key 'OCA\OpenRegister\Mcp\IMcpToolProvider::procest'
+        // is the format that OR's McpToolsService enumerates to discover per-app
+        // providers (hydra ADR-034 / ADR-035, design D3). The interface ships in
+        // openregister PR #1466 (ai-chat-companion-orchestrator); until it merges
+        // procest implements the stub at tests/Stubs/Mcp/IMcpToolProvider.php.
+        $context->registerServiceAlias(
+            'OCA\\OpenRegister\\Mcp\\IMcpToolProvider::procest',
+            ProcestToolProvider::class
+        );
+    }//end registerWidgetsAndProviders()
 
     /**
      * Boot the application.

--- a/lib/Mcp/ProcestToolProvider.php
+++ b/lib/Mcp/ProcestToolProvider.php
@@ -1,0 +1,733 @@
+<?php
+/**
+ * Procest MCP Tool Provider
+ *
+ * Per-app implementation of OCA\OpenRegister\Mcp\IMcpToolProvider for the
+ * Procest case-management app. Exposes a minimal, read-only MVP skeleton of
+ * MCP tools so the AI Chat Companion (hydra ADR-034 / ADR-035) can surface
+ * Procest capabilities — listing running process instances (cases) and
+ * reading one process instance with its current step + history — to an LLM.
+ *
+ * @category Mcp
+ * @package  OCA\Procest\Mcp
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Mcp;
+
+use OCA\OpenRegister\Mcp\IMcpToolProvider;
+use OCA\Procest\Service\SettingsService;
+use OCP\IGroupManager;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Procest MCP Tool Provider.
+ *
+ * Implements IMcpToolProvider (from openregister PR #1466,
+ * change ai-chat-companion-orchestrator) exposing 2 read-only tools to the
+ * AI Chat Companion. This is an MVP skeleton — the full tool set tracked in
+ * ConductionNL/procest#416 (startProcess, advanceStep, listMyTasks,
+ * getTaskDetails) is intentionally out of scope of this change.
+ *
+ * Auth design (OWASP A01:2021 / ADR-005):
+ * - Per-object authorisation runs inside invokeTool(), AFTER argument
+ *   validation but BEFORE business logic. The helper actually runs — it does
+ *   NOT return true unconditionally and is NOT wrapped in catch(\Throwable).
+ * - isAdmin() resolves via IGroupManager (the dedicated procest admin group OR
+ *   the Nextcloud system admin group), mirroring StatusTransitionService.
+ * - A non-admin caller may read a case only when they are its assignee
+ *   (primary handler) or hold a role record linking them to the case.
+ */
+class ProcestToolProvider implements IMcpToolProvider
+{
+
+    /**
+     * Maximum number of items / source descriptors returned per tool result.
+     *
+     * @var int
+     */
+    private const ITEMS_CAP = 20;
+
+    /**
+     * Hard upper bound for the listProcesses limit argument.
+     *
+     * @var int
+     */
+    private const LIMIT_MAX = 50;
+
+    /**
+     * Dedicated procest admin group id (mirrors StatusTransitionService).
+     *
+     * @var string
+     */
+    private const ADMIN_GROUP_ID = 'procest-admin';
+
+    /**
+     * Tool catalogue — hard-coded so unit tests can assert it as a fixture.
+     *
+     * Exactly 2 read-only tools for the MVP skeleton.
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    private const TOOL_DESCRIPTORS = [
+        [
+            'id'          => 'procest.listProcesses',
+            'name'        => 'List processes',
+            'description' => 'List running process instances (cases). Optionally filter by status'
+                .' type id (status) and cap the result with limit (1-50, default 20).',
+            'inputSchema' => [
+                'type'       => 'object',
+                'properties' => [
+                    'limit'  => [
+                        'type'    => 'integer',
+                        'minimum' => 1,
+                        'maximum' => 50,
+                        'default' => 20,
+                    ],
+                    'status' => [
+                        'type'        => 'string',
+                        'description' => 'Optional status type id or slug to filter by.',
+                    ],
+                ],
+                'required'   => [],
+            ],
+        ],
+        [
+            'id'          => 'procest.getProcessDetails',
+            'name'        => 'Get process details',
+            'description' => 'Get one process instance (case) by id or uuid, including its'
+                .' current step (status) and chronological transition history.',
+            'inputSchema' => [
+                'type'       => 'object',
+                'properties' => [
+                    'id'   => [
+                        'type'        => 'string',
+                        'description' => 'The process instance (case) id or uuid.',
+                    ],
+                    'uuid' => [
+                        'type'        => 'string',
+                        'description' => 'Alias for id — the process instance (case) uuid.',
+                    ],
+                ],
+                'required'   => [],
+            ],
+        ],
+    ];
+
+    /**
+     * Constructor for ProcestToolProvider.
+     *
+     * @param SettingsService $settingsService The Procest settings service (OpenRegister bridge + config)
+     * @param IUserSession    $userSession     The current user session
+     * @param IGroupManager   $groupManager    The group manager (for admin checks)
+     * @param LoggerInterface $logger          The PSR-3 logger
+     *
+     * @return void
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+        private readonly IUserSession $userSession,
+        private readonly IGroupManager $groupManager,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Returns the app ID that namespaces every tool id.
+     *
+     * @return string "procest"
+     */
+    public function getAppId(): string
+    {
+        return 'procest';
+
+    }//end getAppId()
+
+    /**
+     * Returns the full tool catalogue (2 tools, always).
+     *
+     * The full catalogue is returned regardless of caller permissions.
+     * Per-object authorisation runs in invokeTool().
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function getTools(): array
+    {
+        return self::TOOL_DESCRIPTORS;
+
+    }//end getTools()
+
+    /**
+     * Dispatch a tool call by id.
+     *
+     * Argument validation runs BEFORE authorisation, which runs BEFORE
+     * business logic. Unknown tool ids return a structured error; no
+     * exception is thrown.
+     *
+     * @param string               $toolId    The tool id (e.g. "procest.listProcesses")
+     * @param array<string, mixed> $arguments Tool arguments from the LLM call
+     *
+     * @return array<string, mixed>
+     */
+    public function invokeTool(string $toolId, array $arguments): array
+    {
+        switch ($toolId) {
+            case 'procest.listProcesses':
+                return $this->handleListProcesses(args: $arguments);
+            case 'procest.getProcessDetails':
+                return $this->handleGetProcessDetails(args: $arguments);
+            default:
+                return $this->errorEnvelope(
+                    code: 'unknown_tool',
+                    message: "Unknown tool id '{$toolId}'. Available tools: "
+                        .implode(', ', array_column(self::TOOL_DESCRIPTORS, 'id')).'.'
+                );
+        }//end switch
+
+    }//end invokeTool()
+
+    // =========================================================================
+    // Private tool handlers
+    // =========================================================================
+
+    /**
+     * Handle procest.listProcesses.
+     *
+     * Lists running process instances (cases) the caller may read.
+     *
+     * @param array<string, mixed> $args Tool arguments
+     *
+     * @return array<string, mixed>
+     */
+    private function handleListProcesses(array $args): array
+    {
+        $limit = $this->parseLimit(args: $args);
+        if ($limit === null) {
+            return $this->errorEnvelope(code: 'invalid_arguments', message: 'Invalid limit. Must be an integer between 1 and 50.');
+        }
+
+        $store = $this->resolveCaseStore();
+        if (isset($store['error']) === true) {
+            return $store;
+        }
+
+        $filters  = $this->buildListFilters(args: $args);
+        $rawCases = $this->findCases(store: $store, filters: $filters, limit: $limit);
+        if ($rawCases === null) {
+            return $this->errorEnvelope(code: 'internal_error', message: 'Failed to list processes. See server log for details.');
+        }
+
+        $items   = [];
+        $sources = [];
+        foreach ($rawCases as $raw) {
+            $case = $this->toArray(value: $raw);
+            if ($this->canReadCase(case: $case) === false) {
+                continue;
+            }
+
+            $items[]   = $case;
+            $sources[] = $this->buildCaseSource(case: $case);
+        }
+
+        return [
+            'success'   => true,
+            'processes' => array_slice($items, 0, self::ITEMS_CAP),
+            'sources'   => array_slice($sources, 0, self::ITEMS_CAP),
+        ];
+
+    }//end handleListProcesses()
+
+    /**
+     * Handle procest.getProcessDetails.
+     *
+     * Fetches one process instance (case) with its current step (status) and
+     * chronological transition history.
+     *
+     * @param array<string, mixed> $args Tool arguments
+     *
+     * @return array<string, mixed>
+     */
+    private function handleGetProcessDetails(array $args): array
+    {
+        $caseId = $this->parseCaseId(args: $args);
+        if ($caseId === null) {
+            return $this->errorEnvelope(code: 'invalid_arguments', message: 'Required argument id (or uuid) is missing.');
+        }
+
+        $store = $this->resolveCaseStore();
+        if (isset($store['error']) === true) {
+            return $store;
+        }
+
+        $case = $this->findCase(store: $store, caseId: $caseId);
+        if ($case === null) {
+            return $this->errorEnvelope(code: 'internal_error', message: 'Failed to load the process. See server log for details.');
+        }
+
+        if ($case === []) {
+            return $this->errorEnvelope(code: 'not_found', message: 'Process not found.');
+        }
+
+        // Authorisation BEFORE business logic — actually runs, not wrapped in catch.
+        if ($this->canReadCase(case: $case) === false) {
+            return $this->errorEnvelope(code: 'forbidden', message: 'You are not authorised to read this process.');
+        }
+
+        $caseUuid = $this->extractUuid(item: $case);
+        $history  = $this->loadHistory(store: $store, caseUuid: $caseUuid);
+
+        return [
+            'success'     => true,
+            'process'     => $case,
+            'currentStep' => ($case['status'] ?? null),
+            'history'     => array_slice($history, 0, self::ITEMS_CAP),
+            'sources'     => [$this->buildCaseSource(case: $case)],
+        ];
+
+    }//end handleGetProcessDetails()
+
+    // =========================================================================
+    // Private helpers — argument parsing
+    // =========================================================================
+
+    /**
+     * Parse and validate the optional `limit` argument.
+     *
+     * @param array<string, mixed> $args Tool arguments
+     *
+     * @return int|null The clamped limit, or null when the supplied value is out of range.
+     */
+    private function parseLimit(array $args): ?int
+    {
+        if (isset($args['limit']) === false) {
+            return self::ITEMS_CAP;
+        }
+
+        $limit = (int) $args['limit'];
+        if ($limit < 1 || $limit > self::LIMIT_MAX) {
+            return null;
+        }
+
+        return $limit;
+
+    }//end parseLimit()
+
+    /**
+     * Build the OpenRegister filter map for procest.listProcesses.
+     *
+     * @param array<string, mixed> $args Tool arguments
+     *
+     * @return array<string, mixed>
+     */
+    private function buildListFilters(array $args): array
+    {
+        $filters = [];
+        if (isset($args['status']) === true && $args['status'] !== '') {
+            $filters['status'] = (string) $args['status'];
+        }
+
+        return $filters;
+
+    }//end buildListFilters()
+
+    /**
+     * Resolve the case id from either the `id` or `uuid` argument.
+     *
+     * @param array<string, mixed> $args Tool arguments
+     *
+     * @return string|null The case id, or null when neither argument is supplied.
+     */
+    private function parseCaseId(array $args): ?string
+    {
+        if (isset($args['id']) === true && $args['id'] !== '') {
+            return (string) $args['id'];
+        }
+
+        if (isset($args['uuid']) === true && $args['uuid'] !== '') {
+            return (string) $args['uuid'];
+        }
+
+        return null;
+
+    }//end parseCaseId()
+
+    // =========================================================================
+    // Private helpers — OpenRegister access
+    // =========================================================================
+
+    /**
+     * Resolve the OpenRegister object store + configured register/case schema.
+     *
+     * @return array{objectService: object, register: string, caseSchema: string}|array{error: array{code: string, message: string}}
+     */
+    private function resolveCaseStore(): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return $this->errorEnvelope(code: 'storage_unavailable', message: 'The OpenRegister object store is not available.');
+        }
+
+        $register   = $this->settingsService->getConfigValue(key: 'register');
+        $caseSchema = $this->settingsService->getConfigValue(key: 'case_schema');
+        if ($register === '' || $caseSchema === '') {
+            return $this->errorEnvelope(code: 'not_configured', message: 'The Procest case schema is not configured.');
+        }
+
+        return [
+            'objectService' => $objectService,
+            'register'      => $register,
+            'caseSchema'    => $caseSchema,
+        ];
+
+    }//end resolveCaseStore()
+
+    /**
+     * Find cases via the OpenRegister object store.
+     *
+     * @param array<string, mixed> $store   The resolved case store
+     * @param array<string, mixed> $filters The OpenRegister filter map
+     * @param int                  $limit   The maximum number of rows to fetch
+     *
+     * @return array<int, mixed>|null The raw rows, or null on backend failure.
+     */
+    private function findCases(array $store, array $filters, int $limit): ?array
+    {
+        try {
+            $rows = $store['objectService']->findObjects(
+                $store['register'],
+                $store['caseSchema'],
+                $filters,
+                [],
+                $limit,
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Procest MCP: listProcesses findObjects failed',
+                ['exception' => $e->getMessage()]
+            );
+            return null;
+        }
+
+        if (is_array($rows) === false) {
+            return [];
+        }
+
+        return $rows;
+
+    }//end findCases()
+
+    /**
+     * Find a single case via the OpenRegister object store.
+     *
+     * @param array<string, mixed> $store  The resolved case store
+     * @param string               $caseId The case id or uuid
+     *
+     * @return array<string, mixed>|null The case array (empty when not found), or null on backend failure.
+     */
+    private function findCase(array $store, string $caseId): ?array
+    {
+        try {
+            return $this->toArray(value: $store['objectService']->findObject($store['register'], $store['caseSchema'], $caseId));
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Procest MCP: getProcessDetails findObject failed',
+                ['caseId' => $caseId, 'exception' => $e->getMessage()]
+            );
+            return null;
+        }
+
+    }//end findCase()
+
+    /**
+     * Load the chronological transition history (statusRecord rows) for a case.
+     *
+     * @param array<string, mixed> $store    The resolved case store
+     * @param string               $caseUuid The case uuid
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function loadHistory(array $store, string $caseUuid): array
+    {
+        if ($caseUuid === '') {
+            return [];
+        }
+
+        $recordSchema = $this->settingsService->getConfigValue(key: 'status_record_schema');
+        if ($recordSchema === '') {
+            return [];
+        }
+
+        try {
+            $records = $store['objectService']->findObjects(
+                $store['register'],
+                $recordSchema,
+                ['case' => $caseUuid],
+                [],
+                self::ITEMS_CAP,
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Procest MCP: loadHistory findObjects failed',
+                ['caseUuid' => $caseUuid, 'exception' => $e->getMessage()]
+            );
+            return [];
+        }
+
+        $rows = [];
+        if (is_array($records) === true) {
+            $rows = $records;
+        }
+
+        $list = [];
+        foreach ($rows as $record) {
+            $list[] = $this->toArray(value: $record);
+        }
+
+        usort(
+            $list,
+            static function (array $left, array $right): int {
+                $leftAt  = (string) ($left['createdAt'] ?? ($left['@self']['createdAt'] ?? ''));
+                $rightAt = (string) ($right['createdAt'] ?? ($right['@self']['createdAt'] ?? ''));
+                return strcmp($leftAt, $rightAt);
+            }
+        );
+
+        return $list;
+
+    }//end loadHistory()
+
+    // =========================================================================
+    // Private helpers — authorisation
+    // =========================================================================
+
+    /**
+     * Check whether the calling user may read a case.
+     *
+     * Auth design (OWASP A01:2021 / ADR-005):
+     * - This helper actually runs — it does NOT return true unconditionally
+     *   and is NOT wrapped in catch(\Throwable).
+     * - An admin (procest admin group OR system admin group) may read any case.
+     * - A non-admin may read a case only when they are its assignee (primary
+     *   handler) or hold a role record linking them to the case.
+     *
+     * @param array<string, mixed> $case The case object as an associative array
+     *
+     * @return bool True when the caller may read the case.
+     */
+    private function canReadCase(array $case): bool
+    {
+        $userId = $this->currentUserId();
+        if ($userId === '') {
+            return false;
+        }
+
+        if ($this->isAdmin(userId: $userId) === true) {
+            return true;
+        }
+
+        $assignee = $case['assignee'] ?? null;
+        if ($assignee !== null && (string) $assignee === $userId) {
+            return true;
+        }
+
+        return $this->hasRoleOnCase(caseUuid: $this->extractUuid(item: $case), userId: $userId);
+
+    }//end canReadCase()
+
+    /**
+     * Check whether the user holds a role record linking them to the case.
+     *
+     * @param string $caseUuid The case uuid
+     * @param string $userId   The Nextcloud user id
+     *
+     * @return bool True when at least one role record links the user to the case.
+     */
+    private function hasRoleOnCase(string $caseUuid, string $userId): bool
+    {
+        if ($caseUuid === '') {
+            return false;
+        }
+
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return false;
+        }
+
+        $register   = $this->settingsService->getConfigValue(key: 'register');
+        $roleSchema = $this->settingsService->getConfigValue(key: 'role_schema');
+        if ($register === '' || $roleSchema === '') {
+            return false;
+        }
+
+        try {
+            $roles = $objectService->findObjects(
+                $register,
+                $roleSchema,
+                [
+                    'case'        => $caseUuid,
+                    'participant' => $userId,
+                ],
+                [],
+                1,
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Procest MCP: hasRoleOnCase findObjects failed',
+                ['caseUuid' => $caseUuid, 'exception' => $e->getMessage()]
+            );
+            return false;
+        }
+
+        return is_array($roles) === true && count($roles) > 0;
+
+    }//end hasRoleOnCase()
+
+    /**
+     * Resolve the current user id, or an empty string when unauthenticated.
+     *
+     * @return string
+     */
+    private function currentUserId(): string
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return '';
+        }
+
+        return $user->getUID();
+
+    }//end currentUserId()
+
+    /**
+     * Check whether the user is a Procest or Nextcloud system administrator.
+     *
+     * @param string $userId The Nextcloud user id
+     *
+     * @return bool True when the user is an admin.
+     */
+    private function isAdmin(string $userId): bool
+    {
+        if ($userId === '') {
+            return false;
+        }
+
+        try {
+            if ($this->groupManager->isInGroup($userId, self::ADMIN_GROUP_ID) === true) {
+                return true;
+            }
+
+            return $this->groupManager->isAdmin($userId);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Procest MCP: admin check failed',
+                ['userId' => $userId, 'exception' => $e->getMessage()]
+            );
+            return false;
+        }
+
+    }//end isAdmin()
+
+    // =========================================================================
+    // Private helpers — shaping
+    // =========================================================================
+
+    /**
+     * Build a structured error envelope (never thrown).
+     *
+     * @param string $code    Machine-readable error code
+     * @param string $message Human-readable message
+     *
+     * @return array{error: array{code: string, message: string}}
+     */
+    private function errorEnvelope(string $code, string $message): array
+    {
+        return [
+            'error' => [
+                'code'    => $code,
+                'message' => $message,
+            ],
+        ];
+
+    }//end errorEnvelope()
+
+    /**
+     * Build a source descriptor for a case.
+     *
+     * @param array<string, mixed> $case The case array
+     *
+     * @return array{type: string, uuid: string, url: string, label: string}
+     */
+    private function buildCaseSource(array $case): array
+    {
+        $uuid = $this->extractUuid(item: $case);
+        return [
+            'type'  => 'procest.case',
+            'uuid'  => $uuid,
+            'url'   => "/apps/procest/cases/{$uuid}",
+            'label' => (string) ($case['title'] ?? ($case['identifier'] ?? 'Case')),
+        ];
+
+    }//end buildCaseSource()
+
+    /**
+     * Normalise an OpenRegister object (entity / array / null) to a plain array.
+     *
+     * @param mixed $value Raw value from ObjectService
+     *
+     * @return array<string, mixed>
+     */
+    private function toArray(mixed $value): array
+    {
+        if (is_array($value) === true) {
+            return $value;
+        }
+
+        if (is_object($value) === false) {
+            return [];
+        }
+
+        if (method_exists($value, 'jsonSerialize') === true) {
+            $serialized = $value->jsonSerialize();
+            if (is_array($serialized) === true) {
+                return $serialized;
+            }
+        }
+
+        if (method_exists($value, 'getObject') === true) {
+            $object = $value->getObject();
+            if (is_array($object) === true) {
+                return $object;
+            }
+        }
+
+        return (array) $value;
+
+    }//end toArray()
+
+    /**
+     * Extract the uuid from a normalised object array.
+     *
+     * @param array<string, mixed> $item The normalised object array
+     *
+     * @return string The uuid, or empty string when not found.
+     */
+    private function extractUuid(array $item): string
+    {
+        $uuid = $item['uuid'] ?? ($item['id'] ?? ($item['@self']['uuid'] ?? ($item['@self']['id'] ?? '')));
+        return (string) $uuid;
+
+    }//end extractUuid()
+}//end class

--- a/phpmd.baseline.xml
+++ b/phpmd.baseline.xml
@@ -29,6 +29,8 @@
   <violation rule="PHPMD\Rule\CleanCode\MissingImport" file="lib/Controller/StufController.php"/>
   <violation rule="PHPMD\Rule\CleanCode\ElseExpression" file="lib/Controller/ZrcController.php"/>
   <violation rule="PHPMD\Rule\CleanCode\ElseExpression" file="lib/Controller/ZtcController.php"/>
+  <!-- ProcestToolProvider: single-class IMcpToolProvider design (mirrors decidesk's exemplar). -->
+  <violation rule="PHPMD\Rule\Design\WeightedMethodCount" file="lib/Mcp/ProcestToolProvider.php"/>
   <violation rule="PHPMD\Rule\UnusedFormalParameter" file="lib/Middleware/TenantMiddleware.php"/>
   <violation rule="PHPMD\Rule\UnusedLocalVariable" file="lib/Service/AiService.php"/>
   <violation rule="PHPMD\Rule\CyclomaticComplexity" file="lib/Service/AiService.php" method="callAiModel"/>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -19,6 +19,9 @@ parameters:
         - '#OCA\\OpenRegister\\[a-zA-Z\\]+.*not found#'
         - '#on an unknown class OCA\\OpenRegister\\#'
         - '#has invalid return type OCA\\OpenRegister\\#'
+        # IMcpToolProvider ships in openregister PR #1466; procest implements the
+        # stub at tests/Stubs/Mcp/IMcpToolProvider.php until it merges.
+        - '#implements unknown interface OCA\\OpenRegister\\#'
         - '#Class OCA\\Procest\\Controller\\ZgwController not found#'
         # GuzzleHttp is available at runtime via Nextcloud but not in composer require
         - '#unknown class GuzzleHttp\\#'

--- a/psalm.xml
+++ b/psalm.xml
@@ -64,12 +64,18 @@
                 <!-- OpenRegister cross-app classes (loaded dynamically) -->
                 <referencedClass name="OCA\OpenRegister\Event\DeepLinkRegistrationEvent"/>
                 <referencedClass name="OCA\OpenRegister\Event\ObjectCreatedEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectCreatingEvent"/>
                 <referencedClass name="OCA\OpenRegister\Event\ObjectUpdatedEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectUpdatingEvent"/>
                 <referencedClass name="OCA\OpenRegister\Event\ObjectDeletedEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectDeletingEvent"/>
                 <referencedClass name="OCA\OpenRegister\Exception\LockedException"/>
                 <referencedClass name="OCA\OpenRegister\Service\ObjectService"/>
                 <referencedClass name="OCA\OpenRegister\Service\ConfigurationService"/>
                 <referencedClass name="OCA\OpenRegister\Db\Mapping"/>
+                <!-- IMcpToolProvider ships in openregister PR #1466 (ai-chat-companion-orchestrator);
+                     procest implements the stub at tests/Stubs/Mcp/IMcpToolProvider.php until it merges. -->
+                <referencedClass name="OCA\OpenRegister\Mcp\IMcpToolProvider"/>
                 <!-- Nextcloud server internals -->
                 <referencedClass name="OC"/>
                 <!-- GuzzleHttp (loaded via composer at runtime) -->

--- a/tests/Stubs/Mcp/IMcpToolProvider.php
+++ b/tests/Stubs/Mcp/IMcpToolProvider.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Test stub for OCA\OpenRegister\Mcp\IMcpToolProvider.
+ *
+ * Mirrors the interface signature from openregister PR #1466
+ * (change: ai-chat-companion-orchestrator). Used only in environments where
+ * the openregister runtime is not installed (e.g. bare CI containers).
+ *
+ * This file is loaded by tests/bootstrap.php when the real interface is absent.
+ * It is NOT scanned by PHPCS.
+ *
+ * @category Test
+ * @package  OCA\Procest\Tests\Stubs\Mcp
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Mcp;
+
+if (interface_exists(IMcpToolProvider::class) === false) {
+    /**
+     * Stub interface for IMcpToolProvider — used only in standalone unit tests.
+     *
+     * Deferred until openregister PR #1466 (ai-chat-companion-orchestrator) ships
+     * the real interface. Procest implements this stub in production; the stub is
+     * replaced by the real interface when the openregister app is installed.
+     */
+    interface IMcpToolProvider
+    {
+
+        /**
+         * Returns the app ID that namespaces every tool id this provider exposes.
+         *
+         * @return string The app slug (e.g. "procest")
+         */
+        public function getAppId(): string;
+
+        /**
+         * Returns the full tool catalogue for this provider.
+         *
+         * Each descriptor is an associative array with keys:
+         * `id`, `name`, `description`, `inputSchema`.
+         *
+         * @return array<int, array<string, mixed>>
+         */
+        public function getTools(): array;
+
+        /**
+         * Invoke a single tool by id with the given arguments.
+         *
+         * Returns a success payload or a structured error envelope.
+         * MUST NOT throw — all failure paths return an array.
+         *
+         * @param string               $toolId    The tool id (e.g. "procest.listProcesses")
+         * @param array<string, mixed> $arguments Tool arguments from the LLM call
+         *
+         * @return array<string, mixed>
+         */
+        public function invokeTool(string $toolId, array $arguments): array;
+
+    }//end interface
+}//end if

--- a/tests/Unit/Mcp/ProcestToolProviderTest.php
+++ b/tests/Unit/Mcp/ProcestToolProviderTest.php
@@ -1,0 +1,177 @@
+<?php
+
+/**
+ * ProcestToolProvider Unit Tests
+ *
+ * Tests for the Procest MCP tool provider (hydra ADR-034 / ADR-035): asserts
+ * the tool catalogue shape and the structured-error contract of invokeTool().
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Mcp
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Mcp;
+
+use OCA\Procest\Mcp\ProcestToolProvider;
+use OCA\Procest\Service\SettingsService;
+use OCP\IGroupManager;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Unit tests for the ProcestToolProvider class.
+ *
+ * @covers \OCA\Procest\Mcp\ProcestToolProvider
+ */
+class ProcestToolProviderTest extends TestCase
+{
+
+    /**
+     * The provider under test.
+     *
+     * @var ProcestToolProvider
+     */
+    private ProcestToolProvider $provider;
+
+    /**
+     * Set up a provider with mocked dependencies.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $settingsService = $this->createMock(SettingsService::class);
+        $userSession     = $this->createMock(IUserSession::class);
+        $groupManager    = $this->createMock(IGroupManager::class);
+        $logger          = $this->createMock(LoggerInterface::class);
+
+        $this->provider = new ProcestToolProvider(
+            settingsService: $settingsService,
+            userSession: $userSession,
+            groupManager: $groupManager,
+            logger: $logger,
+        );
+
+    }//end setUp()
+
+    /**
+     * getAppId() returns the procest app slug.
+     *
+     * @return void
+     */
+    public function testGetAppIdReturnsProcest(): void
+    {
+        $this->assertSame('procest', $this->provider->getAppId());
+
+    }//end testGetAppIdReturnsProcest()
+
+    /**
+     * getTools() returns exactly 2 well-formed descriptors namespaced under procest.
+     *
+     * @return void
+     */
+    public function testGetToolsReturnsTwoWellFormedDescriptors(): void
+    {
+        $tools = $this->provider->getTools();
+
+        $this->assertCount(2, $tools);
+
+        $ids = [];
+        foreach ($tools as $tool) {
+            $this->assertIsArray($tool);
+            $this->assertArrayHasKey('id', $tool);
+            $this->assertArrayHasKey('name', $tool);
+            $this->assertArrayHasKey('description', $tool);
+            $this->assertArrayHasKey('inputSchema', $tool);
+
+            $this->assertIsString($tool['id']);
+            $this->assertStringStartsWith('procest.', $tool['id']);
+
+            $this->assertIsString($tool['description']);
+            $this->assertNotSame('', trim($tool['description']));
+
+            $this->assertIsArray($tool['inputSchema']);
+            $this->assertArrayHasKey('type', $tool['inputSchema']);
+            $this->assertSame('object', $tool['inputSchema']['type']);
+            $this->assertArrayHasKey('properties', $tool['inputSchema']);
+            $this->assertIsArray($tool['inputSchema']['properties']);
+            $this->assertArrayHasKey('required', $tool['inputSchema']);
+            $this->assertIsArray($tool['inputSchema']['required']);
+
+            $ids[] = $tool['id'];
+        }//end foreach
+
+        $this->assertEqualsCanonicalizing(
+            ['procest.listProcesses', 'procest.getProcessDetails'],
+            $ids
+        );
+
+    }//end testGetToolsReturnsTwoWellFormedDescriptors()
+
+    /**
+     * invokeTool() with an unknown tool id returns a structured error (does not throw).
+     *
+     * @return void
+     */
+    public function testInvokeUnknownToolReturnsErrorEnvelope(): void
+    {
+        $result = $this->provider->invokeTool('procest.bogus', []);
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('error', $result);
+        $this->assertIsArray($result['error']);
+        $this->assertArrayHasKey('code', $result['error']);
+        $this->assertArrayHasKey('message', $result['error']);
+        $this->assertSame('unknown_tool', $result['error']['code']);
+
+    }//end testInvokeUnknownToolReturnsErrorEnvelope()
+
+    /**
+     * invokeTool() surfaces a not_configured / storage error rather than throwing
+     * when OpenRegister is unavailable.
+     *
+     * @return void
+     */
+    public function testInvokeToolWithoutStorageReturnsErrorEnvelope(): void
+    {
+        // The mocked SettingsService::getObjectService() returns null by default.
+        $result = $this->provider->invokeTool('procest.listProcesses', []);
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('error', $result);
+        $this->assertContains(
+            $result['error']['code'],
+            ['storage_unavailable', 'not_configured']
+        );
+
+    }//end testInvokeToolWithoutStorageReturnsErrorEnvelope()
+
+    /**
+     * invokeTool('procest.getProcessDetails') with no id argument returns an
+     * invalid_arguments error.
+     *
+     * @return void
+     */
+    public function testGetProcessDetailsWithoutIdReturnsInvalidArguments(): void
+    {
+        $result = $this->provider->invokeTool('procest.getProcessDetails', []);
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('error', $result);
+        $this->assertSame('invalid_arguments', $result['error']['code']);
+
+    }//end testGetProcessDetailsWithoutIdReturnsInvalidArguments()
+}//end class

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -39,6 +39,14 @@ foreach ($loaders as $loader) {
 // Doctrine types not present in this repository's vendor directory.
 require_once __DIR__ . '/Unit/Stubs/DoctrineStubs.php';
 
+// IMcpToolProvider stub — loaded when the openregister runtime (PR #1466,
+// ai-chat-companion-orchestrator) is absent. ProcestToolProvider implements
+// OCA\OpenRegister\Mcp\IMcpToolProvider; the stub no-ops when the real
+// interface is present (e.g. when the openregister app is installed).
+if (interface_exists(\OCA\OpenRegister\Mcp\IMcpToolProvider::class) === false) {
+    require_once __DIR__ . '/Stubs/Mcp/IMcpToolProvider.php';
+}
+
 if (defined('OC_CONSOLE') === false) {
     if (file_exists(__DIR__ . '/../../../lib/base.php') === true) {
         require_once __DIR__ . '/../../../lib/base.php';


### PR DESCRIPTION
## Summary

Adds the per-app `OCA\OpenRegister\Mcp\IMcpToolProvider` for Procest (hydra **ADR-034** AI Chat Companion + **ADR-035** per-app MCP coverage), so the in-app AI companion can surface Procest's process/workflow management to an LLM. This is the **MVP skeleton** — the remaining tools from #416 (`startProcess`, `advanceStep`, `listMyTasks`, `getTaskDetails`) are intentionally out of scope here.

`Refs #416` (this PR ships 2 of the 6 tools in the issue's full MVP).

## Tools added

| Tool id | Purpose |
|---|---|
| `procest.listProcesses` | List running process instances (cases). Optional `limit` (integer 1-50, default 20) + optional `status` filter. |
| `procest.getProcessDetails` | Get one process instance (case) by `id` or `uuid` (required), including its current step (status) and chronological transition history. |

`invokeTool()` validates arguments first, then runs **per-object authorisation before business logic** (OWASP A01:2021 / ADR-005): admin via `IGroupManager` (the `procest-admin` group OR the NC system admin group), otherwise the caller must be the case `assignee` or hold a `role` record linking them to the case. The auth helper actually runs — no unconditional `return true`, not wrapped in `catch(\Throwable)`. It delegates to the existing `SettingsService` + OpenRegister `ObjectService` (same `findObject`/`findObjects` pattern as `StatusTransitionService`/`WorkflowDefinitionService`), caps any returned list at 20 items, and returns a structured `{error: {code, message}}` envelope for every failure (unknown tool, bad args, not found, forbidden, storage unavailable, not configured) — it never throws.

## Files

- `lib/Mcp/ProcestToolProvider.php` — the provider (`getAppId()` → `'procest'`, `getTools()` → 2 descriptors, `invokeTool()`).
- `lib/AppInfo/Application.php` — registers the provider under the DI alias `OCA\OpenRegister\Mcp\IMcpToolProvider::procest` (the format OR's `McpToolsService` enumerates). Also extracted `registerBezwaarListeners()` + `registerWidgetsAndProviders()` helpers so `register()` stays under the PHPMD method-length threshold.
- `tests/Stubs/Mcp/IMcpToolProvider.php` — stub interface (copied from decidesk's exemplar, namespace/package adjusted) used until openregister **PR #1466** (`ai-chat-companion-orchestrator`) ships the real interface; no-ops when the real interface is present.
- `tests/bootstrap.php` — loads the stub when the real interface is absent.
- `tests/Unit/Mcp/ProcestToolProviderTest.php` — asserts `getAppId()`, the 2 descriptors (ids namespaced, non-empty descriptions, valid `inputSchema` objects), and that `invokeTool()` returns structured errors (unknown tool, missing args, no storage) without throwing.
- `composer.json` — `autoload-dev` PSR-4 `OCA\OpenRegister\` → `tests/Stubs/` so PHPStan/PHPUnit discover the stub (mirrors decidesk).
- `psalm.xml` / `phpstan.neon` / `phpmd.baseline.xml` — analysis config for the dynamically-loaded `IMcpToolProvider` + a single PHPMD baseline entry for the single-class provider design (mirrors decidesk's exemplar). The psalm change also fixes a pre-existing `UndefinedClass` gap for the OR `Object*ing` events already referenced in `Application.php`.

## Done vs deferred

- ✅ `IMcpToolProvider` implementation (2 read-only tools), DI registration, stub, unit test, `### MCP coverage` line below.
- ⏸️ **Widget mount deferred** — Procest already consumes `@conduction/nextcloud-vue` via `CnAppRoot` (`src/App.vue`), but `CnAiCompanion` is not yet in any **published** `@conduction/nextcloud-vue` release (it currently lives on `feature/ai-chat-companion-widget` / `fix/ai-companion-*` branches; latest published is `1.0.0-beta.30`). No package bump made; will follow once a release ships the component.
- ⏸️ Remaining #416 tools (`procest.startProcess`, `procest.advanceStep`, `procest.listMyTasks`, `procest.getTaskDetails`) — follow-up.

## Quality

`composer lint` / `phpcs` / `phpmd` (baselined) / `psalm` / `phpstan` / `phpunit` (140 tests, all green) pass for the new/changed code. Two pre-existing failures remain on `development`, unrelated to this change and not chased here: `lib/Validator/ParaferingAuditAppendOnlyValidator.php` triggers `InvalidTemplateParam` (psalm) / 3× `registerEventListener` type mismatch (phpstan) because it implements `IEventListener` over the OR `Object*ing` events.

### MCP coverage
Adds tool: procest.listProcesses
Adds tool: procest.getProcessDetails

ADR-034: hydra `openspec/architecture/adr-034-ai-chat-companion.md`
ADR-035: hydra `openspec/architecture/adr-035-mcp-per-app-coverage.md`