### PR TITLE
feat: adopt the Features & Roadmap menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.0",
 			"license": "EUPL-1.2",
 			"dependencies": {
-				"@conduction/nextcloud-vue": "^1.0.0-beta.29",
+				"@conduction/nextcloud-vue": "^1.0.0-beta.35",
 				"@nextcloud/auth": "^2.6.0",
 				"@nextcloud/axios": "~2.5.2",
 				"@nextcloud/dialogs": "^3.2.0",
@@ -502,9 +502,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "1.0.0-beta.29",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.29.tgz",
-			"integrity": "sha512-gFnC9I9z2v76HutB7klBvZ52k7ep7VvCsYlM0iyK4R8yIOIb7bKTBV4OBMG51Epfg5hkVoKwayDxUnju+lUerg==",
+			"version": "1.0.0-beta.35",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.35.tgz",
+			"integrity": "sha512-T80Y6z+m/ni2z1yCNVrXAjzacv2WdXFNQcfZYfXHHmtCbJOjdFWLwALZ/WCrGO1FQIQMnjq01G0gBdMXXKQimg==",
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.0.0",
@@ -517,13 +517,14 @@
 				"@codemirror/search": "^6.0.0",
 				"@codemirror/state": "^6.0.0",
 				"@codemirror/view": "^6.0.0",
-				"@nextcloud/capabilities": "^1.2.1",
+				"@microsoft/fetch-event-source": "^2.0.1",
 				"@nextcloud/dialogs": "^7.3.0",
 				"@nextcloud/notify_push": "^1.0.0",
 				"@uiw/codemirror-theme-github": "^4.25.8",
 				"@vueuse/core": "^10.0.0",
 				"apexcharts": "^4.7.0",
 				"codemirror": "^6.0.0",
+				"dompurify": "^3.0.0",
 				"gridstack": "^10.3.1",
 				"leaflet": "^1.9.0",
 				"lodash": "^4.17.21",
@@ -535,7 +536,9 @@
 				"vue-template-compiler": "^2.7.16"
 			},
 			"peerDependencies": {
+				"@nextcloud/auth": "^2.0.0 || ^3.0.0",
 				"@nextcloud/axios": "^2.0.0",
+				"@nextcloud/capabilities": "^1.2.1",
 				"@nextcloud/l10n": "^2.0.0 || ^3.0.0",
 				"@nextcloud/router": "^2.0.0 || ^3.0.0",
 				"@nextcloud/vue": "^8.0.0",
@@ -2030,6 +2033,12 @@
 			"integrity": "sha512-KPnNOtm5i2pMabqZxpUz7iQf+mfrYZyKCZ8QNz85czgEt7cuHcGorWfdzUMWYA0SD+a6Hn4FmJ+YhzzzjkTZrQ==",
 			"license": "Apache-2.0"
 		},
+		"node_modules/@microsoft/fetch-event-source": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz",
+			"integrity": "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==",
+			"license": "MIT"
+		},
 		"node_modules/@napi-rs/wasm-runtime": {
 			"version": "0.2.12",
 			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -3285,9 +3294,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3302,9 +3308,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3319,9 +3322,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3336,9 +3336,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3353,9 +3350,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3370,9 +3364,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3387,9 +3378,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3404,9 +3392,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -16038,9 +16023,9 @@
 			}
 		},
 		"@conduction/nextcloud-vue": {
-			"version": "1.0.0-beta.29",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.29.tgz",
-			"integrity": "sha512-gFnC9I9z2v76HutB7klBvZ52k7ep7VvCsYlM0iyK4R8yIOIb7bKTBV4OBMG51Epfg5hkVoKwayDxUnju+lUerg==",
+			"version": "1.0.0-beta.35",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.35.tgz",
+			"integrity": "sha512-T80Y6z+m/ni2z1yCNVrXAjzacv2WdXFNQcfZYfXHHmtCbJOjdFWLwALZ/WCrGO1FQIQMnjq01G0gBdMXXKQimg==",
 			"requires": {
 				"@codemirror/autocomplete": "^6.0.0",
 				"@codemirror/commands": "^6.0.0",
@@ -16052,13 +16037,14 @@
 				"@codemirror/search": "^6.0.0",
 				"@codemirror/state": "^6.0.0",
 				"@codemirror/view": "^6.0.0",
-				"@nextcloud/capabilities": "^1.2.1",
+				"@microsoft/fetch-event-source": "^2.0.1",
 				"@nextcloud/dialogs": "^7.3.0",
 				"@nextcloud/notify_push": "^1.0.0",
 				"@uiw/codemirror-theme-github": "^4.25.8",
 				"@vueuse/core": "^10.0.0",
 				"apexcharts": "^4.7.0",
 				"codemirror": "^6.0.0",
+				"dompurify": "^3.0.0",
 				"gridstack": "^10.3.1",
 				"leaflet": "^1.9.0",
 				"lodash": "^4.17.21",
@@ -17061,6 +17047,11 @@
 			"version": "7.4.47",
 			"resolved": "https://registry.npmjs.org/@mdi/js/-/js-7.4.47.tgz",
 			"integrity": "sha512-KPnNOtm5i2pMabqZxpUz7iQf+mfrYZyKCZ8QNz85czgEt7cuHcGorWfdzUMWYA0SD+a6Hn4FmJ+YhzzzjkTZrQ=="
+		},
+		"@microsoft/fetch-event-source": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz",
+			"integrity": "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA=="
 		},
 		"@napi-rs/wasm-runtime": {
 			"version": "0.2.12",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"extends @nextcloud/browserslist-config"
 	],
 	"dependencies": {
-		"@conduction/nextcloud-vue": "^1.0.0-beta.29",
+		"@conduction/nextcloud-vue": "^1.0.0-beta.35",
 		"@nextcloud/auth": "^2.6.0",
 		"@nextcloud/axios": "~2.5.2",
 		"@nextcloud/dialogs": "^3.2.0",

--- a/src/customComponents.js
+++ b/src/customComponents.js
@@ -47,6 +47,11 @@ import VisualWorkflowEditor from './components/workflow/VisualWorkflowEditor.vue
 // MAY reference it by string name. See openspec/changes/map-component/.
 import MapComponent from './components/map/MapComponent.vue'
 
+// --- Features & Roadmap page — thin wrapper around the lib's
+//     CnFeaturesAndRoadmapView (the in-product roadmap surface powered by
+//     OpenRegister's github-issue-proxy). See ConductionNL/hydra#251. ---
+import FeaturesRoadmapView from './views/FeaturesRoadmap.vue'
+
 export default {
 	// --- Genuine exceptions: no abstract analogue. ---
 	MyWorkView, // bespoke 4-tab filter UI mixing case + task entities
@@ -76,4 +81,7 @@ export default {
 
 	// --- Shared map surface — referenceable from manifest pages. ---
 	MapComponent,
+
+	// --- Features & Roadmap page (lib's CnFeaturesAndRoadmapView). ---
+	FeaturesRoadmap: FeaturesRoadmapView,
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -31,7 +31,8 @@
 		{ "id": "LhsRecommendationsMenu", "label": "LHS Recommendations", "icon": "icon-comment", "route": "LhsRecommendations", "section": "settings", "order": 97 },
 		{ "id": "LocationsMenu", "label": "Case locations", "icon": "icon-address", "route": "Locations", "section": "settings", "order": 98, "permission": "admin" },
 		{ "id": "BezwaarCommitteesMenu", "label": "Bezwaaradviescommissies", "icon": "icon-group", "route": "BezwaarCommittees", "section": "settings", "order": 99 },
-		{ "id": "SettingsMenu", "label": "Settings", "icon": "icon-settings", "route": "Settings", "section": "settings", "order": 99 }
+		{ "id": "SettingsMenu", "label": "Settings", "icon": "icon-settings", "route": "Settings", "section": "settings", "order": 99 },
+		{ "id": "FeaturesRoadmapMenu", "label": "Features & roadmap", "icon": "icon-toggle", "route": "FeaturesRoadmap", "section": "settings", "order": 100 }
 	],
 	"pages": [
 		{
@@ -924,6 +925,13 @@
 					{ "id": "audit",           "label": "Audit trail",              "icon": "icon-history", "widgets": [{ "type": "audit-trail" }],                                                                                   "order": 90 }
 				]
 			}
+		},
+		{
+			"id": "FeaturesRoadmap",
+			"route": "/features-roadmap",
+			"type": "custom",
+			"title": "Features & roadmap",
+			"component": "FeaturesRoadmap"
 		}
 	]
 }

--- a/src/views/FeaturesRoadmap.vue
+++ b/src/views/FeaturesRoadmap.vue
@@ -1,0 +1,38 @@
+<template>
+	<CnFeaturesAndRoadmapView
+		:repo="repo"
+		:features="features"
+		:disabled="disabled" />
+</template>
+
+<script>
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+//
+// Features & Roadmap page — thin wrapper around `CnFeaturesAndRoadmapView`
+// from `@conduction/nextcloud-vue`. Mounted as the manifest `custom` page
+// `FeaturesRoadmap` (route `/features-roadmap`, surfaced from the Settings
+// section of the nav). `repo` / `features` / `disabled` come from
+// server-provided initial state when available, with sensible fallbacks so
+// the page is usable without backend wiring (the roadmap proxy and the
+// `openregister::features_roadmap_enabled` flag live on OpenRegister).
+
+import { CnFeaturesAndRoadmapView } from '@conduction/nextcloud-vue'
+import { loadState } from '@nextcloud/initial-state'
+
+export default {
+	name: 'FeaturesRoadmap',
+
+	components: {
+		CnFeaturesAndRoadmapView,
+	},
+
+	data() {
+		return {
+			repo: loadState('procest', 'features_roadmap_repo', 'ConductionNL/procest'),
+			features: loadState('procest', 'features_roadmap_features', []),
+			disabled: loadState('procest', 'features_roadmap_disabled', false),
+		}
+	},
+}
+</script>


### PR DESCRIPTION
## Summary

Adopts the Features & Roadmap menu in procest — the in-product two-tab page (Features manifest + GitHub roadmap, with the in-context Suggest action) powered by OpenRegister's `github-issue-proxy` and `@conduction/nextcloud-vue`'s `Cn*` roadmap component family. Part of the org-wide rollout — see [ConductionNL/hydra#251](https://github.com/ConductionNL/hydra/issues/251).

procest is manifest-driven (`CnAppRoot` + `manifest.json`, no hand-rolled router/menu), so the adoption is wired through the manifest rather than a custom route:

- **`src/views/FeaturesRoadmap.vue`** — thin wrapper around `CnFeaturesAndRoadmapView`. `repo` (`'ConductionNL/procest'`), `features` (`[]`), and `disabled` (`false`) come from `loadState('procest', 'features_roadmap_*', …)` with those fallbacks, so the page works without backend wiring (the roadmap proxy + the `openregister::features_roadmap_enabled` flag live on OpenRegister).
- **`src/customComponents.js`** — registers it as the `FeaturesRoadmap` custom component.
- **`src/manifest.json`** — adds the `FeaturesRoadmap` `type: "custom"` page (`route: "/features-roadmap"`) and a `FeaturesRoadmapMenu` entry in the `settings` section (`order: 100`).
- **`package.json`** — bumps `@conduction/nextcloud-vue` to `^1.0.0-beta.35` (the release that ships `CnFeaturesAndRoadmapView` / `CnFeaturesAndRoadmapLink` / `CnFeaturesTab` / `CnRoadmapTab` / `CnRoadmapItem` / `CnSuggestFeatureModal`).

## Notes

- procest already pins `@nextcloud/axios` to `~2.5.2` (+ `overrides`), so the `2.6.0`-broke-its-exports issue (ConductionNL/openregister#1489) doesn't bite here.
- Backend dependency: the roadmap tab calls `GET /index.php/apps/openregister/api/github/issues?…` — that proxy is on the OpenRegister side (PR ConductionNL/openregister#1463); until it lands the tab degrades gracefully (`github_pat_not_configured` / empty state).

## Test plan

- [ ] `npm install && npm run build` green (CI resolves `@conduction/nextcloud-vue@^1.0.0-beta.35` from npm)
- [ ] App opens; "Features & roadmap" appears in the Settings section of the left nav, navigates to `/features-roadmap`, renders the Features + Roadmap tabs and the Suggest-feature button
- [ ] Roadmap tab shows the graceful empty state until the OpenRegister proxy is configured

Refs: ConductionNL/hydra#251 · ConductionNL/openregister#1463
