### PR TITLE
fix: route procest API calls through generateUrl() (work without mod_rewrite)

### DIFF
--- a/src/store/modules/settings.js
+++ b/src/store/modules/settings.js
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia'
+import { generateUrl } from '@nextcloud/router'
 
 export const useSettingsStore = defineStore('settings', {
 	state: () => ({
@@ -23,7 +24,7 @@ export const useSettingsStore = defineStore('settings', {
 			this.error = null
 
 			try {
-				const response = await fetch('/apps/procest/api/settings', {
+				const response = await fetch(generateUrl('/apps/procest/api/settings'), {
 					method: 'GET',
 					headers: {
 						'Content-Type': 'application/json',
@@ -57,7 +58,7 @@ export const useSettingsStore = defineStore('settings', {
 			this.error = null
 
 			try {
-				const response = await fetch('/apps/procest/api/settings', {
+				const response = await fetch(generateUrl('/apps/procest/api/settings'), {
 					method: 'POST',
 					headers: {
 						'Content-Type': 'application/json',

--- a/src/store/modules/zgwMapping.js
+++ b/src/store/modules/zgwMapping.js
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia'
+import { generateUrl } from '@nextcloud/router'
 
 export const useZgwMappingStore = defineStore('zgwMapping', {
 	state: () => ({
@@ -17,7 +18,7 @@ export const useZgwMappingStore = defineStore('zgwMapping', {
 			this.error = null
 
 			try {
-				const response = await fetch('/apps/procest/api/zgw-mappings', {
+				const response = await fetch(generateUrl('/apps/procest/api/zgw-mappings'), {
 					method: 'GET',
 					headers: {
 						'Content-Type': 'application/json',
@@ -47,7 +48,7 @@ export const useZgwMappingStore = defineStore('zgwMapping', {
 			this.error = null
 
 			try {
-				const response = await fetch(`/apps/procest/api/zgw-mappings/${resourceKey}`, {
+				const response = await fetch(generateUrl(`/apps/procest/api/zgw-mappings/${resourceKey}`), {
 					method: 'PUT',
 					headers: {
 						'Content-Type': 'application/json',
@@ -78,7 +79,7 @@ export const useZgwMappingStore = defineStore('zgwMapping', {
 			this.error = null
 
 			try {
-				const response = await fetch(`/apps/procest/api/zgw-mappings/${resourceKey}/reset`, {
+				const response = await fetch(generateUrl(`/apps/procest/api/zgw-mappings/${resourceKey}/reset`), {
 					method: 'POST',
 					headers: {
 						'Content-Type': 'application/json',

--- a/src/views/settings/AdminRoot.vue
+++ b/src/views/settings/AdminRoot.vue
@@ -76,6 +76,7 @@ import CaseTypeAdmin from './CaseTypeAdmin.vue'
 import ZgwMappingSettings from './ZgwMappingSettings.vue'
 import MapLayerSettings from './MapLayerSettings.vue'
 import AiSettingsTab from './tabs/AiSettingsTab.vue'
+import { generateUrl } from '@nextcloud/router'
 import { initializeStores } from '../../store/store.js'
 
 export default {
@@ -112,7 +113,7 @@ export default {
 			this.message = ''
 
 			try {
-				const response = await fetch('/apps/procest/api/settings/load', {
+				const response = await fetch(generateUrl('/apps/procest/api/settings/load'), {
 					method: 'POST',
 					headers: {
 						'Content-Type': 'application/json',

--- a/src/views/voorstellen/VoorstelList.vue
+++ b/src/views/voorstellen/VoorstelList.vue
@@ -106,6 +106,7 @@ import { NcButton, NcEmptyContent, NcLoadingIcon } from '@nextcloud/vue'
 import FileDocumentEditOutline from 'vue-material-design-icons/FileDocumentEditOutline.vue'
 import BellRing from 'vue-material-design-icons/BellRing.vue'
 import VoorstelCreateDialog from './components/VoorstelCreateDialog.vue'
+import { generateUrl } from '@nextcloud/router'
 import { useObjectStore } from '../../store/modules/object.js'
 
 const STATUS_LABELS = {
@@ -255,7 +256,7 @@ export default {
 		async sendReminder(voorstel) {
 			const actor = this.getWaitingActor(voorstel)
 			try {
-				await fetch('/apps/procest/api/notifications/parafering-reminder', {
+				await fetch(generateUrl('/apps/procest/api/notifications/parafering-reminder'), {
 					method: 'POST',
 					headers: {
 						'Content-Type': 'application/json',


### PR DESCRIPTION
Several frontend `fetch()` calls hardcode `/apps/procest/api/...`. That works behind Apache + `mod_rewrite`, but in a bare `php -S` environment (including the CI E2E job) those paths aren't routable and 404.

Most visibly: the settings store's `/api/settings` fetch 404s in CI, so the dashboard widgets never get configured (all 11 render "Widget not available", and the dashboard header `<h2>` + action buttons don't render), and `CnFormDialog` opens with an empty form on the Cases page. Confirmed from the Playwright trace (`404 GET http://localhost:8080/apps/procest/api/settings`).

Fix: wrap the URLs in `generateUrl()`, matching the other API services (`aiApi.js`, `parafeerRouteApi.js`, etc.):
- `store/modules/settings.js` — `/api/settings`
- `store/modules/zgwMapping.js` — `/api/zgw-mappings[...]`
- `views/settings/AdminRoot.vue` — `/api/settings/load`
- `views/voorstellen/VoorstelList.vue` — `/api/notifications/parafering-reminder`

Should fix the 2 remaining E2E failures (`Dashboard › shows heading and action buttons`, `Cases page › new case modal has correct fields`).