### PR TITLE
chore(deps): bump @conduction/nextcloud-vue to ^1.0.0-beta.40

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.0",
 			"license": "EUPL-1.2",
 			"dependencies": {
-				"@conduction/nextcloud-vue": "^1.0.0-beta.29",
+				"@conduction/nextcloud-vue": "^1.0.0-beta.40",
 				"@nextcloud/auth": "^2.6.0",
 				"@nextcloud/axios": "~2.5.2",
 				"@nextcloud/dialogs": "^3.2.0",
@@ -505,9 +505,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "1.0.0-beta.29",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.29.tgz",
-			"integrity": "sha512-gFnC9I9z2v76HutB7klBvZ52k7ep7VvCsYlM0iyK4R8yIOIb7bKTBV4OBMG51Epfg5hkVoKwayDxUnju+lUerg==",
+			"version": "1.0.0-beta.40",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.40.tgz",
+			"integrity": "sha512-tiC0MZT3mPupFRgB9F5p0FY6o50PDwc2seGcAKENO8aFpgCQOgudJs+s1FiprtEJ19RX6tMDByXeeD2Cxd9eyw==",
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.0.0",
@@ -520,13 +520,14 @@
 				"@codemirror/search": "^6.0.0",
 				"@codemirror/state": "^6.0.0",
 				"@codemirror/view": "^6.0.0",
-				"@nextcloud/capabilities": "^1.2.1",
+				"@microsoft/fetch-event-source": "^2.0.1",
 				"@nextcloud/dialogs": "^7.3.0",
 				"@nextcloud/notify_push": "^1.0.0",
 				"@uiw/codemirror-theme-github": "^4.25.8",
 				"@vueuse/core": "^10.0.0",
 				"apexcharts": "^4.7.0",
 				"codemirror": "^6.0.0",
+				"dompurify": "^3.0.0",
 				"gridstack": "^10.3.1",
 				"leaflet": "^1.9.0",
 				"lodash": "^4.17.21",
@@ -538,7 +539,9 @@
 				"vue-template-compiler": "^2.7.16"
 			},
 			"peerDependencies": {
+				"@nextcloud/auth": "^2.0.0 || ^3.0.0",
 				"@nextcloud/axios": "^2.0.0",
+				"@nextcloud/capabilities": "^1.2.1",
 				"@nextcloud/l10n": "^2.0.0 || ^3.0.0",
 				"@nextcloud/router": "^2.0.0 || ^3.0.0",
 				"@nextcloud/vue": "^8.0.0",
@@ -2032,6 +2035,12 @@
 			"resolved": "https://registry.npmjs.org/@mdi/js/-/js-7.4.47.tgz",
 			"integrity": "sha512-KPnNOtm5i2pMabqZxpUz7iQf+mfrYZyKCZ8QNz85czgEt7cuHcGorWfdzUMWYA0SD+a6Hn4FmJ+YhzzzjkTZrQ==",
 			"license": "Apache-2.0"
+		},
+		"node_modules/@microsoft/fetch-event-source": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz",
+			"integrity": "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==",
+			"license": "MIT"
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
 			"version": "0.2.12",
@@ -16282,9 +16291,9 @@
 			}
 		},
 		"@conduction/nextcloud-vue": {
-			"version": "1.0.0-beta.29",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.29.tgz",
-			"integrity": "sha512-gFnC9I9z2v76HutB7klBvZ52k7ep7VvCsYlM0iyK4R8yIOIb7bKTBV4OBMG51Epfg5hkVoKwayDxUnju+lUerg==",
+			"version": "1.0.0-beta.40",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.40.tgz",
+			"integrity": "sha512-tiC0MZT3mPupFRgB9F5p0FY6o50PDwc2seGcAKENO8aFpgCQOgudJs+s1FiprtEJ19RX6tMDByXeeD2Cxd9eyw==",
 			"requires": {
 				"@codemirror/autocomplete": "^6.0.0",
 				"@codemirror/commands": "^6.0.0",
@@ -16296,13 +16305,14 @@
 				"@codemirror/search": "^6.0.0",
 				"@codemirror/state": "^6.0.0",
 				"@codemirror/view": "^6.0.0",
-				"@nextcloud/capabilities": "^1.2.1",
+				"@microsoft/fetch-event-source": "^2.0.1",
 				"@nextcloud/dialogs": "^7.3.0",
 				"@nextcloud/notify_push": "^1.0.0",
 				"@uiw/codemirror-theme-github": "^4.25.8",
 				"@vueuse/core": "^10.0.0",
 				"apexcharts": "^4.7.0",
 				"codemirror": "^6.0.0",
+				"dompurify": "^3.0.0",
 				"gridstack": "^10.3.1",
 				"leaflet": "^1.9.0",
 				"lodash": "^4.17.21",
@@ -17305,6 +17315,11 @@
 			"version": "7.4.47",
 			"resolved": "https://registry.npmjs.org/@mdi/js/-/js-7.4.47.tgz",
 			"integrity": "sha512-KPnNOtm5i2pMabqZxpUz7iQf+mfrYZyKCZ8QNz85czgEt7cuHcGorWfdzUMWYA0SD+a6Hn4FmJ+YhzzzjkTZrQ=="
+		},
+		"@microsoft/fetch-event-source": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz",
+			"integrity": "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA=="
 		},
 		"@napi-rs/wasm-runtime": {
 			"version": "0.2.12",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"extends @nextcloud/browserslist-config"
 	],
 	"dependencies": {
-		"@conduction/nextcloud-vue": "^1.0.0-beta.29",
+		"@conduction/nextcloud-vue": "^1.0.0-beta.40",
 		"@nextcloud/auth": "^2.6.0",
 		"@nextcloud/axios": "~2.5.2",
 		"@nextcloud/dialogs": "^3.2.0",


### PR DESCRIPTION
Bumps `@conduction/nextcloud-vue` `^1.0.0-beta.29` → `^1.0.0-beta.40` — picks up the `CnIndexPage` store-backed self-fetch (nc-vue #223; manifest `type:"index"` pages now render rows) plus `columns[].formatter`/`.widget`/`.aggregate` and `pages[].config.filter` (#219/#221/#222). Pure dep bump; CI runs the build. (Supersedes the `beta.38` bump in the in-flight Voorstellen-conversion PR #429 — that branch can drop its package.json hunk once this lands.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)