### PR TITLE
fix(docs): MDX-safe TODO placeholders in journeydoc tutorials

### DIFF
--- a/docs/tutorials/admin/01-configure-case-types.md
+++ b/docs/tutorials/admin/01-configure-case-types.md
@@ -10,26 +10,26 @@ Step-by-step guide to Configure case types and workflows
 
 ## Goal
 
-{{TODO: write the goal}}
+<!-- {{TODO: write the goal}} -->
 
 ## Prerequisites
 
-{{TODO: list prerequisites}}
+<!-- {{TODO: list prerequisites}} -->
 
 ## Steps
 
-{{TODO: numbered steps, each with one inline screenshot — see /journeydoc-add-story}}
+<!-- {{TODO: numbered steps, each with one inline screenshot — see /journeydoc-add-story}} -->
 
 ## Verification
 
-{{TODO: how the user confirms it worked}}
+<!-- {{TODO: how the user confirms it worked}} -->
 
 ## Common issues
 
 | Symptom | Fix |
 |---|---|
-{{TODO: rows}}
+<!-- {{TODO: rows}} -->
 
 ## Reference
 
-{{TODO: cross-link into features/*.md}}
+<!-- {{TODO: cross-link into features/*.md}} -->

--- a/docs/tutorials/admin/02-automatic-actions.md
+++ b/docs/tutorials/admin/02-automatic-actions.md
@@ -10,26 +10,26 @@ Step-by-step guide to Set up automatic actions
 
 ## Goal
 
-{{TODO: write the goal}}
+<!-- {{TODO: write the goal}} -->
 
 ## Prerequisites
 
-{{TODO: list prerequisites}}
+<!-- {{TODO: list prerequisites}} -->
 
 ## Steps
 
-{{TODO: numbered steps, each with one inline screenshot — see /journeydoc-add-story}}
+<!-- {{TODO: numbered steps, each with one inline screenshot — see /journeydoc-add-story}} -->
 
 ## Verification
 
-{{TODO: how the user confirms it worked}}
+<!-- {{TODO: how the user confirms it worked}} -->
 
 ## Common issues
 
 | Symptom | Fix |
 |---|---|
-{{TODO: rows}}
+<!-- {{TODO: rows}} -->
 
 ## Reference
 
-{{TODO: cross-link into features/*.md}}
+<!-- {{TODO: cross-link into features/*.md}} -->

--- a/docs/tutorials/admin/03-admin-settings.md
+++ b/docs/tutorials/admin/03-admin-settings.md
@@ -10,26 +10,26 @@ Step-by-step guide to Manage Procest settings
 
 ## Goal
 
-{{TODO: write the goal}}
+<!-- {{TODO: write the goal}} -->
 
 ## Prerequisites
 
-{{TODO: list prerequisites}}
+<!-- {{TODO: list prerequisites}} -->
 
 ## Steps
 
-{{TODO: numbered steps, each with one inline screenshot — see /journeydoc-add-story}}
+<!-- {{TODO: numbered steps, each with one inline screenshot — see /journeydoc-add-story}} -->
 
 ## Verification
 
-{{TODO: how the user confirms it worked}}
+<!-- {{TODO: how the user confirms it worked}} -->
 
 ## Common issues
 
 | Symptom | Fix |
 |---|---|
-{{TODO: rows}}
+<!-- {{TODO: rows}} -->
 
 ## Reference
 
-{{TODO: cross-link into features/*.md}}
+<!-- {{TODO: cross-link into features/*.md}} -->

--- a/docs/tutorials/user/01-first-launch.md
+++ b/docs/tutorials/user/01-first-launch.md
@@ -10,26 +10,26 @@ Step-by-step guide to Open Procest for the first time
 
 ## Goal
 
-{{TODO: write the goal}}
+<!-- {{TODO: write the goal}} -->
 
 ## Prerequisites
 
-{{TODO: list prerequisites}}
+<!-- {{TODO: list prerequisites}} -->
 
 ## Steps
 
-{{TODO: numbered steps, each with one inline screenshot — see /journeydoc-add-story}}
+<!-- {{TODO: numbered steps, each with one inline screenshot — see /journeydoc-add-story}} -->
 
 ## Verification
 
-{{TODO: how the user confirms it worked}}
+<!-- {{TODO: how the user confirms it worked}} -->
 
 ## Common issues
 
 | Symptom | Fix |
 |---|---|
-{{TODO: rows}}
+<!-- {{TODO: rows}} -->
 
 ## Reference
 
-{{TODO: cross-link into features/*.md}}
+<!-- {{TODO: cross-link into features/*.md}} -->

--- a/docs/tutorials/user/02-my-work.md
+++ b/docs/tutorials/user/02-my-work.md
@@ -10,26 +10,26 @@ Step-by-step guide to Find your work in My Work
 
 ## Goal
 
-{{TODO: write the goal}}
+<!-- {{TODO: write the goal}} -->
 
 ## Prerequisites
 
-{{TODO: list prerequisites}}
+<!-- {{TODO: list prerequisites}} -->
 
 ## Steps
 
-{{TODO: numbered steps, each with one inline screenshot — see /journeydoc-add-story}}
+<!-- {{TODO: numbered steps, each with one inline screenshot — see /journeydoc-add-story}} -->
 
 ## Verification
 
-{{TODO: how the user confirms it worked}}
+<!-- {{TODO: how the user confirms it worked}} -->
 
 ## Common issues
 
 | Symptom | Fix |
 |---|---|
-{{TODO: rows}}
+<!-- {{TODO: rows}} -->
 
 ## Reference
 
-{{TODO: cross-link into features/*.md}}
+<!-- {{TODO: cross-link into features/*.md}} -->

--- a/docs/tutorials/user/03-view-case.md
+++ b/docs/tutorials/user/03-view-case.md
@@ -10,26 +10,26 @@ Step-by-step guide to Open and read a case
 
 ## Goal
 
-{{TODO: write the goal}}
+<!-- {{TODO: write the goal}} -->
 
 ## Prerequisites
 
-{{TODO: list prerequisites}}
+<!-- {{TODO: list prerequisites}} -->
 
 ## Steps
 
-{{TODO: numbered steps, each with one inline screenshot — see /journeydoc-add-story}}
+<!-- {{TODO: numbered steps, each with one inline screenshot — see /journeydoc-add-story}} -->
 
 ## Verification
 
-{{TODO: how the user confirms it worked}}
+<!-- {{TODO: how the user confirms it worked}} -->
 
 ## Common issues
 
 | Symptom | Fix |
 |---|---|
-{{TODO: rows}}
+<!-- {{TODO: rows}} -->
 
 ## Reference
 
-{{TODO: cross-link into features/*.md}}
+<!-- {{TODO: cross-link into features/*.md}} -->

--- a/docs/tutorials/user/04-advance-case.md
+++ b/docs/tutorials/user/04-advance-case.md
@@ -10,26 +10,26 @@ Step-by-step guide to Move a case through its workflow
 
 ## Goal
 
-{{TODO: write the goal}}
+<!-- {{TODO: write the goal}} -->
 
 ## Prerequisites
 
-{{TODO: list prerequisites}}
+<!-- {{TODO: list prerequisites}} -->
 
 ## Steps
 
-{{TODO: numbered steps, each with one inline screenshot — see /journeydoc-add-story}}
+<!-- {{TODO: numbered steps, each with one inline screenshot — see /journeydoc-add-story}} -->
 
 ## Verification
 
-{{TODO: how the user confirms it worked}}
+<!-- {{TODO: how the user confirms it worked}} -->
 
 ## Common issues
 
 | Symptom | Fix |
 |---|---|
-{{TODO: rows}}
+<!-- {{TODO: rows}} -->
 
 ## Reference
 
-{{TODO: cross-link into features/*.md}}
+<!-- {{TODO: cross-link into features/*.md}} -->

--- a/docs/tutorials/user/05-record-decision.md
+++ b/docs/tutorials/user/05-record-decision.md
@@ -10,26 +10,26 @@ Step-by-step guide to Record advice or a decision on a case
 
 ## Goal
 
-{{TODO: write the goal}}
+<!-- {{TODO: write the goal}} -->
 
 ## Prerequisites
 
-{{TODO: list prerequisites}}
+<!-- {{TODO: list prerequisites}} -->
 
 ## Steps
 
-{{TODO: numbered steps, each with one inline screenshot — see /journeydoc-add-story}}
+<!-- {{TODO: numbered steps, each with one inline screenshot — see /journeydoc-add-story}} -->
 
 ## Verification
 
-{{TODO: how the user confirms it worked}}
+<!-- {{TODO: how the user confirms it worked}} -->
 
 ## Common issues
 
 | Symptom | Fix |
 |---|---|
-{{TODO: rows}}
+<!-- {{TODO: rows}} -->
 
 ## Reference
 
-{{TODO: cross-link into features/*.md}}
+<!-- {{TODO: cross-link into features/*.md}} -->

--- a/docs/tutorials/user/06-track-deadlines.md
+++ b/docs/tutorials/user/06-track-deadlines.md
@@ -10,26 +10,26 @@ Step-by-step guide to Track deadlines and lead times on the dashboard
 
 ## Goal
 
-{{TODO: write the goal}}
+<!-- {{TODO: write the goal}} -->
 
 ## Prerequisites
 
-{{TODO: list prerequisites}}
+<!-- {{TODO: list prerequisites}} -->
 
 ## Steps
 
-{{TODO: numbered steps, each with one inline screenshot — see /journeydoc-add-story}}
+<!-- {{TODO: numbered steps, each with one inline screenshot — see /journeydoc-add-story}} -->
 
 ## Verification
 
-{{TODO: how the user confirms it worked}}
+<!-- {{TODO: how the user confirms it worked}} -->
 
 ## Common issues
 
 | Symptom | Fix |
 |---|---|
-{{TODO: rows}}
+<!-- {{TODO: rows}} -->
 
 ## Reference
 
-{{TODO: cross-link into features/*.md}}
+<!-- {{TODO: cross-link into features/*.md}} -->

--- a/docs/tutorials/user/07-handle-objection.md
+++ b/docs/tutorials/user/07-handle-objection.md
@@ -10,26 +10,26 @@ Step-by-step guide to Handle an objection (bezwaar)
 
 ## Goal
 
-{{TODO: write the goal}}
+<!-- {{TODO: write the goal}} -->
 
 ## Prerequisites
 
-{{TODO: list prerequisites}}
+<!-- {{TODO: list prerequisites}} -->
 
 ## Steps
 
-{{TODO: numbered steps, each with one inline screenshot — see /journeydoc-add-story}}
+<!-- {{TODO: numbered steps, each with one inline screenshot — see /journeydoc-add-story}} -->
 
 ## Verification
 
-{{TODO: how the user confirms it worked}}
+<!-- {{TODO: how the user confirms it worked}} -->
 
 ## Common issues
 
 | Symptom | Fix |
 |---|---|
-{{TODO: rows}}
+<!-- {{TODO: rows}} -->
 
 ## Reference
 
-{{TODO: cross-link into features/*.md}}
+<!-- {{TODO: cross-link into features/*.md}} -->

--- a/docs/tutorials/user/08-inspection-checklist.md
+++ b/docs/tutorials/user/08-inspection-checklist.md
@@ -10,26 +10,26 @@ Step-by-step guide to Run an inspection checklist
 
 ## Goal
 
-{{TODO: write the goal}}
+<!-- {{TODO: write the goal}} -->
 
 ## Prerequisites
 
-{{TODO: list prerequisites}}
+<!-- {{TODO: list prerequisites}} -->
 
 ## Steps
 
-{{TODO: numbered steps, each with one inline screenshot — see /journeydoc-add-story}}
+<!-- {{TODO: numbered steps, each with one inline screenshot — see /journeydoc-add-story}} -->
 
 ## Verification
 
-{{TODO: how the user confirms it worked}}
+<!-- {{TODO: how the user confirms it worked}} -->
 
 ## Common issues
 
 | Symptom | Fix |
 |---|---|
-{{TODO: rows}}
+<!-- {{TODO: rows}} -->
 
 ## Reference
 
-{{TODO: cross-link into features/*.md}}
+<!-- {{TODO: cross-link into features/*.md}} -->


### PR DESCRIPTION
The journeydoc bootstrap left bare `{{TODO: ...}}` text in `docs/tutorials/**/*.md`; Docusaurus 3 parses .md as MDX so `{...}` is read as a JS expression and `npm run build` fails. Wrapped them in HTML comments (`<!-- {{TODO: ...}} -->`) so they stay as markers, don't render, and are MDX-safe. Docs build now passes.