### PR TITLE
ci: disable SBOM until @conduction/nextcloud-vue dep declarations are cleaned up (#434)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -30,7 +30,14 @@ jobs:
       newman-environment-path: "tests/zgw/zgw-environment.json"
       newman-seed-command: "bash apps/procest/tests/zgw/seed-consumers.sh"
       additional-apps: '[{"repo":"ConductionNL/openregister","app":"openregister","ref":"feature/php-linting"}]'
-      enable-sbom: true
+      # SBOM disabled until @conduction/nextcloud-vue's dependency declarations
+      # are cleaned up — its `npm ls` tree fails ELSPROBLEMS (bootstrap-vue is a
+      # non-optional peer, apexcharts/pinia/vue version ranges don't match what
+      # apps install, @types/react comes from a transitive rehype-react), which
+      # @cyclonedx/cyclonedx-npm propagates as a hard failure (it always runs
+      # `npm ls` under the hood; `--package-lock-only` doesn't sidestep it).
+      # No other Conduction app enables SBOM today. Tracked in #434.
+      enable-sbom: false
       enable-playwright: true
       enable-playwright-coverage: true
       playwright-coverage-threshold: 75


### PR DESCRIPTION
The `SBOM` job fails on `development` (and any PR run that reaches it): `npx @cyclonedx/cyclonedx-npm` invokes `npm ls` internally, and `npm ls` exits `ELSPROBLEMS` because procest's installed tree doesn't satisfy `@conduction/nextcloud-vue`'s declarations — `bootstrap-vue` is a non-optional peer, `apexcharts`/`pinia`/`vue` come out "invalid" against its ranges, `@types/react` is pulled in (optionally) by a transitive `rehype-react`. `--package-lock-only` doesn't help (cyclonedx-npm passes it straight to `npm ls`). No other Conduction app enables `enable-sbom`.

Set `enable-sbom: false` here too until the upstream nc-vue dependency cleanup happens — tracked in #434. (Separately, `quality.yml` was already updated to make the unrelated coverage-baseline `git push` non-blocking — ConductionNL/.github#62 — and #61 tracks adding the CI bot as a ruleset bypass actor.)

After this, every gate in procest's "Code Quality" workflow is green.