### PR TITLE
fix(manifest): scope CaseShares to its route param via config.filter

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -576,7 +576,8 @@
 			"config": {
 				"register": "procest",
 				"schema": "caseShare",
-				"columns": ["sharedWith", "permission", "createdAt", "revokedAt"],
+				"filter": { "caseId": "@route.caseId" },
+				"columns": ["label", "shareType", "partnerId", "permissionLevel", "expiresAt", "revokedAt"],
 				"sidebar": { "enabled": true, "showMetadata": true }
 			}
 		},


### PR DESCRIPTION
Adds `config.filter: { caseId: "@route.caseId" }` to the `CaseShares` page (`/cases/:caseId/shares`, `type:index` on `caseShare`) — it was rendering ALL case-shares instead of the ones for the case in the URL. `CnIndexPage` honours `pages[].config.filter` since nc-vue beta.40. Also fixes the column list (`sharedWith`/`permission`/`createdAt` aren't `caseShare` fields → `label, shareType, partnerId, permissionLevel, expiresAt, revokedAt`). Pre-existing `validate-manifest.js` failures on unrelated pages are untouched. Verified: `npm run build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)