### PR TITLE
feat(manifest): re-add Voorstellen filter-tabs via config.quickFilters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.0",
 			"license": "EUPL-1.2",
 			"dependencies": {
-				"@conduction/nextcloud-vue": "^1.0.0-beta.40",
+				"@conduction/nextcloud-vue": "^1.0.0-beta.42",
 				"@nextcloud/auth": "^2.6.0",
 				"@nextcloud/axios": "~2.5.2",
 				"@nextcloud/dialogs": "^3.2.0",
@@ -506,9 +506,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "1.0.0-beta.40",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.40.tgz",
-			"integrity": "sha512-tiC0MZT3mPupFRgB9F5p0FY6o50PDwc2seGcAKENO8aFpgCQOgudJs+s1FiprtEJ19RX6tMDByXeeD2Cxd9eyw==",
+			"version": "1.0.0-beta.42",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.42.tgz",
+			"integrity": "sha512-6ITMUXPNdfmaitFIeDMk4VjffrNKfAM5kjFUFl/XtORz4A6nD0DpEIrxdtZF1ltODlQoI+d4ADijP8pEr02U6g==",
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.0.0",
@@ -531,6 +531,7 @@
 				"dompurify": "^3.0.0",
 				"gridstack": "^10.3.1",
 				"leaflet": "^1.9.0",
+				"leaflet.markercluster": "^1.5.3",
 				"lodash": "^4.17.21",
 				"marked": "^15.0.0",
 				"style-mod": "^4.0.0",
@@ -16355,9 +16356,9 @@
 			}
 		},
 		"@conduction/nextcloud-vue": {
-			"version": "1.0.0-beta.40",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.40.tgz",
-			"integrity": "sha512-tiC0MZT3mPupFRgB9F5p0FY6o50PDwc2seGcAKENO8aFpgCQOgudJs+s1FiprtEJ19RX6tMDByXeeD2Cxd9eyw==",
+			"version": "1.0.0-beta.42",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.42.tgz",
+			"integrity": "sha512-6ITMUXPNdfmaitFIeDMk4VjffrNKfAM5kjFUFl/XtORz4A6nD0DpEIrxdtZF1ltODlQoI+d4ADijP8pEr02U6g==",
 			"requires": {
 				"@codemirror/autocomplete": "^6.0.0",
 				"@codemirror/commands": "^6.0.0",
@@ -16379,6 +16380,7 @@
 				"dompurify": "^3.0.0",
 				"gridstack": "^10.3.1",
 				"leaflet": "^1.9.0",
+				"leaflet.markercluster": "^1.5.3",
 				"lodash": "^4.17.21",
 				"marked": "^15.0.0",
 				"style-mod": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"extends @nextcloud/browserslist-config"
 	],
 	"dependencies": {
-		"@conduction/nextcloud-vue": "^1.0.0-beta.40",
+		"@conduction/nextcloud-vue": "^1.0.0-beta.42",
 		"@nextcloud/auth": "^2.6.0",
 		"@nextcloud/axios": "~2.5.2",
 		"@nextcloud/dialogs": "^3.2.0",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -263,6 +263,12 @@
 			"config": {
 				"register": "procest",
 				"schema": "voorstel",
+				"quickFilters": [
+					{ "label": "Alle", "filter": {}, "default": true },
+					{ "label": "Concept", "filter": { "status": "concept" } },
+					{ "label": "In behandeling", "filter": { "status": ["in_parafering", "ter_accordering", "geaccordeerd", "aangeboden", "teruggestuurd"] } },
+					{ "label": "Afgerond", "filter": { "status": ["besloten", "gearchiveerd"] } }
+				],
 				"columns": [
 					{ "key": "onderwerp", "label": "Onderwerp" },
 					{ "key": "type", "label": "Type", "formatter": "voorstelType" },


### PR DESCRIPTION
Restores the Concept / In behandeling / Afgerond filter-tabs the Voorstellen conversion (#429) had to drop — `config.filter` is fixed, not a clickable toggle. nc-vue beta.42 (#226) added `config.quickFilters` (tab strip above the table whose `filter` is merged into the fetch when active).

**Tabs** (Alle is default — initial view shows everything):
- Alle — no filter
- Concept — `status:"concept"`
- In behandeling — `status: ["in_parafering","ter_accordering","geaccordeerd","aangeboden","teruggestuurd"]`
- Afgerond — `status: ["besloten","gearchiveerd"]`

Status enum values verified against `voorstel` schema in `lib/Settings/procest_register.json`.

Also bumps `@conduction/nextcloud-vue` `^1.0.0-beta.40` → `^1.0.0-beta.42` (the version that ships `quickFilters` + built-in `date`/`link` cell rendering).

Verified: `node tests/validate-manifest.js` — same pre-existing error set on unrelated pages; Voorstellen (page 13) has no errors. `npm run build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)