### PR TITLE
spec(procest): bring all changes under ADR-032 20-task cap (Wave 2)

### DIFF
--- a/openspec/changes/case-email-integration/tasks.md
+++ b/openspec/changes/case-email-integration/tasks.md
@@ -2,51 +2,32 @@
 
 ## Implementation Tasks
 
-### Schema & Configuration
+### Schema, Configuration, Settings
 
-- [ ] **T01**: Add `emailTemplate`, `emailMessage`, `emailThread` schemas to `lib/Settings/procest_register.json` with all fields from design (name/subject/body/caseType/variables/version/isActive for template; messageId/inReplyTo/direction/from/to/cc/bcc/subject/body/case/thread/pdfPath/pdfStatus/sentAt/templateId/templateVersion for message; subject/case/messageCount/firstMessageAt/lastMessageAt for thread). Include schema.org annotations (`schema:DigitalDocument`, `schema:EmailMessage`, `schema:Conversation`). Add config keys `email_template_schema`, `email_message_schema`, `email_thread_schema`, plus SMTP/IMAP keys (`email_smtp_host`, `email_smtp_port`, `email_smtp_encryption`, `email_smtp_username`, `email_smtp_password`, `email_from_address`, `email_imap_host`, `email_imap_port`, `email_imap_folder`, `email_transport`, `email_poll_interval`, `email_poll_batch_size`, `email_max_attachment_size`) to `SettingsService.php` CONFIG_KEYS and SLUG_TO_CONFIG_KEY arrays.
+- [ ] **T01**: Add `emailTemplate`, `emailMessage`, `emailThread` schemas to `lib/Settings/procest_register.json` (schema.org annotations `schema:DigitalDocument`, `schema:EmailMessage`, `schema:Conversation`; fields per design). Add config keys (`email_template_schema`, `email_message_schema`, `email_thread_schema`, full SMTP/IMAP/transport/polling/attachment-size set) to `SettingsService.php` `CONFIG_KEYS` and `SLUG_TO_CONFIG_KEY`.
+- [ ] **T02**: Create `lib/Settings/EmailSettings.php` + `src/views/settings/EmailSettings.vue` — Admin form with SMTP fields, IMAP fields, transport selector (Nextcloud Mail account picker or standalone SMTP), and a "Send test email" button hitting `POST /api/settings/email/test-smtp`. Passwords masked, stored as sensitive `IAppConfig` keys. Register settings section in `appinfo/info.xml`.
 
 ### Backend Services
 
-- [ ] **T02**: Create `lib/Service/CaseEmailService.php` — Methods: `sendEmail(caseId, templateId, subject, body, recipients, cc, bcc, attachmentIds)` resolves template variables, generates `Message-ID`, dispatches via configured transport, stores `emailMessage`, triggers PDF conversion, appends `email_sent` activity entry; `processInboundEmail(rawMessage)` parses headers, auto-links by subject regex `\[([A-Z]+-\d{4}-\d{6})\]` or by `In-Reply-To`, stores `emailMessage` and updates/creates `emailThread`, queues unlinked messages; `resolveTemplateVariables(template, case)` returns rendered subject+body with unresolved names listed; `linkUnlinkedEmail(emailId, caseId)` moves an email from queue to case; `discardUnlinkedEmail(emailId, reason)` marks as discarded. Uses ObjectService from OpenRegister, Docudesk for PDF.
+- [ ] **T03**: Create `lib/Service/CaseEmailService.php` — `sendEmail()` resolves template variables, generates `Message-ID`, dispatches via configured transport, stores `emailMessage`, triggers PDF conversion, appends `email_sent` activity entry. `processInboundEmail()` parses headers, auto-links by `\[([A-Z]+-\d{4}-\d{6})\]` subject regex or `In-Reply-To`, stores `emailMessage` + updates/creates `emailThread`, queues unlinked. Plus `resolveTemplateVariables()`, `linkUnlinkedEmail()`, `discardUnlinkedEmail()`. Uses OpenRegister ObjectService + Docudesk for PDF.
+- [ ] **T04**: Create `lib/Service/EmailTemplateService.php` — `createTemplate()` saves with `version: 1`; `updateTemplate()` creates a new version object (no overwrite); `listTemplates()`, `getAvailableVariables()` grouped by source (case/contact/caseType), `seedDefaultTemplates()` creates `Ontvangstbevestiging`, `Informatieverzoek`, `Besluit`.
 
-- [ ] **T03**: Create `lib/Service/EmailTemplateService.php` — Methods: `createTemplate(caseTypeId, data)` saves new template with `version: 1`; `updateTemplate(templateId, data)` creates a new version object rather than overwriting; `listTemplates(caseTypeId)` returns active templates for case type; `getAvailableVariables(caseTypeId)` returns the variable catalog grouped by source (case, contact, caseType); `seedDefaultTemplates(caseTypeId)` creates `Ontvangstbevestiging`, `Informatieverzoek`, `Besluit`.
+### Controllers, Routes, Background Jobs
 
-### Controllers & Routes
-
-- [ ] **T04**: Create `lib/Controller/CaseEmailController.php` — Authenticated controller with endpoints: `sendEmail(caseId)`, `listEmails(caseId)`, `listUnlinked()`, `linkEmail(emailId)`, `discardEmail(emailId)`, `listTemplates(caseTypeId)`, `createTemplate(caseTypeId)`, `updateTemplate(templateId)`. All methods `@NoAdminRequired`, returns `JSONResponse`.
-
-- [ ] **T05**: Add routes to `appinfo/routes.php` — `POST /api/cases/{caseId}/emails`, `GET /api/cases/{caseId}/emails`, `GET /api/emails/unlinked`, `POST /api/emails/unlinked/{id}/link`, `POST /api/emails/unlinked/{id}/discard`, template CRUD under `/api/casetypes/{caseTypeId}/email-templates` and `/api/email-templates/{templateId}`, settings under `/api/settings/email`. All before SPA catch-all.
-
-### Background Jobs
-
-- [ ] **T06**: Create `lib/BackgroundJob/InboundEmailJob.php` — `TimedJob` with default interval from `email_poll_interval` (default 300 s). Connects to IMAP via `imap_open()` or Nextcloud Mail's account API, fetches unread messages from configured folder (default INBOX), processes up to `email_poll_batch_size` per run (default 50), skips messages whose `Message-ID` already exists, moves processed messages to a "Processed" folder. Catches and logs exceptions without rethrowing.
-
-- [ ] **T07**: Create `lib/BackgroundJob/EmailPdfRetryJob.php` — `TimedJob` (every 15 min) that scans `emailMessage` objects with `pdfStatus: failed` and retries Docudesk conversion up to 3× with exponential backoff (15 min, 1 h, 4 h). Registers both jobs via `IJobList` in `appinfo/info.xml` background-jobs section or `Application::register()`.
+- [ ] **T05**: Create `lib/Controller/CaseEmailController.php` (sendEmail/listEmails/listUnlinked/linkEmail/discardEmail/listTemplates/createTemplate/updateTemplate, all `@NoAdminRequired`) and add routes to `appinfo/routes.php` (`/api/cases/{caseId}/emails`, `/api/emails/unlinked[/{id}/{link,discard}]`, template CRUD under `/api/casetypes/{caseTypeId}/email-templates` + `/api/email-templates/{templateId}`, `/api/settings/email`). All before SPA catch-all.
+- [ ] **T06**: Create `lib/BackgroundJob/InboundEmailJob.php` (`TimedJob`, interval from `email_poll_interval` default 300s; connects via IMAP or Nextcloud Mail account API, processes up to `email_poll_batch_size` unread messages, dedupes by `Message-ID`, moves processed to "Processed" folder, swallows + logs exceptions) and `lib/BackgroundJob/EmailPdfRetryJob.php` (every 15min, retries `pdfStatus: failed` up to 3× with 15m/1h/4h backoff). Register both via `IJobList` in `Application::register()` or `appinfo/info.xml`.
 
 ### Frontend Components
 
-- [ ] **T08**: Create `src/views/cases/components/EmailComposer.vue` — Modal dialog with recipient (pre-filled from case contact), CC, BCC, subject (pre-filled with `[{{identifier}}]` prefix), rich text body editor, template selector dropdown, attachment picker (case documents), running attachment size, send confirmation step. Validates attachment size against `email_max_attachment_size`. Disabled when case status `isFinal`.
-
-- [ ] **T09**: Create `src/views/cases/components/EmailThread.vue` and `src/views/cases/components/EmailTab.vue` — Tab lists threads grouped collapsible (most recent first) with count badge in tab header; thread renders messages chronologically with direction-distinguished styling (inbound left, outbound right), inline body expand, PDF download link, and per-message Reply action that opens EmailComposer pre-populated.
-
-- [ ] **T10**: Create `src/views/casetypes/components/EmailTemplateAdmin.vue` and `src/views/emails/UnlinkedQueue.vue` — Template admin lists templates per case type with create/edit form, variable sidebar grouped by source (case/contact/caseType), live preview with red-highlighted unresolved variables. UnlinkedQueue lists sender/subject/date/body preview with search-and-link UI plus discard action.
-
-### Settings & Integration
-
-- [ ] **T11**: Create `src/views/settings/EmailSettings.vue` and `lib/Settings/EmailSettings.php` — Admin settings form with SMTP fields (host/port/encryption/username/password/from-address), IMAP fields (host/port/encryption/username/password/folder), transport selector (Nextcloud Mail account picker or standalone SMTP), and "Send test email" button calling `POST /api/settings/email/test-smtp`. Passwords masked and stored via sensitive `IAppConfig` keys. Register settings section in `appinfo/info.xml`.
-
-- [ ] **T12**: Update `src/views/cases/CaseDetail.vue` — Add `EmailTab` to the sidebar tabs in `sidebarProps`. Add "Verstuur email" header action that opens `EmailComposer` (disabled when status `isFinal`). Subscribe to email events to refresh `ActivityTimeline` after send.
+- [ ] **T07**: Create `src/views/cases/components/EmailComposer.vue` — Modal with recipient prefilled from case contact, CC/BCC, subject prefilled with `[{{identifier}}]`, rich-text body, template dropdown, case-document attachment picker with running size + `email_max_attachment_size` validation, send confirmation. Disabled when case status `isFinal`.
+- [ ] **T08**: Create `src/views/cases/components/EmailThread.vue` and `EmailTab.vue` — Tab lists threads grouped collapsible (most recent first) with count badge, messages chronological with inbound/outbound styling, inline body expand, PDF download link, per-message Reply opens prefilled EmailComposer.
+- [ ] **T09**: Create `src/views/casetypes/components/EmailTemplateAdmin.vue` (per-case-type CRUD form, variable sidebar grouped by source, live preview with red-highlighted unresolved variables) and `src/views/emails/UnlinkedQueue.vue` (sender/subject/date/body preview with search-and-link + discard).
+- [ ] **T10**: Update `src/views/cases/CaseDetail.vue` — Add `EmailTab` to sidebar tabs in `sidebarProps`. Add "Verstuur email" header action that opens `EmailComposer` (disabled when status `isFinal`). Subscribe to email events to refresh `ActivityTimeline`.
 
 ## Verification Tasks
 
-- [ ] **V01**: All new schemas valid JSON in `procest_register.json`; load via `openregister:load-register` succeeds
-- [ ] **V02**: Routes registered before SPA catch-all and resolve under `/index.php/apps/procest/api/`
-- [ ] **V03**: Outbound email is sent, `emailMessage` stored, PDF generated, `email_sent` appears in activity timeline
-- [ ] **V04**: Inbound email with `[ZAAK-2026-001234]` subject auto-links to the matching case
-- [ ] **V05**: Inbound reply with `In-Reply-To` header is appended to the existing thread
-- [ ] **V06**: Unlinked email appears in `/emails/unlinked` and can be manually linked
-- [ ] **V07**: Template variables resolve from case data; unresolved variables highlighted red in preview
-- [ ] **V08**: Template edit creates a new version; previously sent messages retain `templateVersion`
-- [ ] **V09**: Docudesk failure marks `pdfStatus: failed` and retry job re-attempts up to 3×
-- [ ] **V10**: SMTP/IMAP passwords stored sensitive; test-email button returns success/failure with specific error
+- [ ] **V01**: Schemas + routes load: `procest_register.json` valid, `openregister:load-register` succeeds, all routes resolve under `/index.php/apps/procest/api/` before SPA catch-all.
+- [ ] **V02**: Outbound flow end-to-end: send produces stored `emailMessage`, PDF generated, `email_sent` shown in activity timeline; Docudesk failure marks `pdfStatus: failed` + retry job re-attempts up to 3×.
+- [ ] **V03**: Inbound + threading: subject-tagged inbound auto-links; `In-Reply-To` appends to existing thread; unrecognised mail surfaces in `/emails/unlinked` and can be manually linked.
+- [ ] **V04**: Template variables resolve from case data with red-highlighted unresolved in preview; template edit creates a new version while previously sent messages retain their original `templateVersion`.
+- [ ] **V05**: SMTP/IMAP credentials stored sensitive; "Send test email" returns success/failure with specific error message.

--- a/openspec/changes/docs-product-pages-conformance/tasks.md
+++ b/openspec/changes/docs-product-pages-conformance/tasks.md
@@ -1,85 +1,35 @@
-## 1. Folder renames (git mv — preserves history)
+## 1. Folder renames + Technical folder (git mv preserves history)
 
-- [ ] 1.1 `git mv docs/features docs/Features` — rename features folder to canonical casing (44 feature files + README.md)
-- [ ] 1.2 `git mv docs/tutorials docs/user-guide` — rename tutorials folder to canonical name (11 MD files in admin/ + user/ subdirs, plus all screenshots)
-- [ ] 1.3 Verify screenshot count in `docs/user-guide/` matches original `docs/tutorials/` (PNG files must all be present after mv)
+- [ ] 1.1 `git mv docs/features docs/Features` (44 feature files + README.md) and `git mv docs/tutorials docs/user-guide` (admin/ + user/ subdirs + all screenshots); verify PNG counts match post-mv.
+- [ ] 1.2 Create `docs/Technical/` with `_category_.json` (label "Technical", position 6), then `git mv` legacy root MDs in: `ARCHITECTURE.md` → `Technical/architecture.md`, `DESIGN-REFERENCES.md` → `Technical/design-decisions.md`, `development.md` → `Technical/development-guide.md`, `zgw-implementation.md` → `Technical/zgw-spec.md`, `GOVERNMENT-FEATURES.md` → `Technical/government-compliance.md`, `FEATURES.md` → `Technical/market-analysis.md`.
 
-## 2. Create Technical/ folder and move legacy root MDs
+## 2. Root index + installation + UseCases/Integrations stubs
 
-- [ ] 2.1 Create `docs/Technical/` folder with `_category_.json` (label: "Technical", position: 6)
-- [ ] 2.2 `git mv docs/ARCHITECTURE.md docs/Technical/architecture.md`
-- [ ] 2.3 `git mv docs/DESIGN-REFERENCES.md docs/Technical/design-decisions.md`
-- [ ] 2.4 `git mv docs/development.md docs/Technical/development-guide.md`
-- [ ] 2.5 `git mv docs/zgw-implementation.md docs/Technical/zgw-spec.md`
-- [ ] 2.6 `git mv docs/GOVERNMENT-FEATURES.md docs/Technical/government-compliance.md`
-- [ ] 2.7 `git mv docs/FEATURES.md docs/Technical/market-analysis.md`
+- [ ] 2.1 `git mv docs/README.md docs/index.md` and add frontmatter (`id: intro`, `title: Introduction`, `sidebar_position: 1`).
+- [ ] 2.2 Create `docs/installation.md` (`sidebar_position: 2`) with Prerequisites (Nextcloud 28+, OpenRegister), App Store install + enable, post-install configuration (procest register auto-created via repair step, case-type config, ZGW endpoint mapping in Admin Settings), and Troubleshooting (register-not-found → re-run repair step, ZGW 400 → verify endpoint URLs).
+- [ ] 2.3 Create `docs/UseCases/_category_.json` (label "Use Cases", position 4) + `docs/UseCases/index.md` stub (`draft: true`, note tracked in #440), and `docs/Integrations/_category_.json` (label "Integrations", position 5) + `docs/Integrations/index.md` stub (`draft: true`, #440).
 
-## 3. Root README rename and index.md creation
+## 3. _category_.json for canonical folders
 
-- [ ] 3.1 `git mv docs/README.md docs/index.md`
-- [ ] 3.2 Add Docusaurus frontmatter to `docs/index.md`: `id: intro`, `title: Introduction`, `sidebar_position: 1`
+- [ ] 3.1 Create `docs/Features/_category_.json` (label "Features", position 3) and `docs/user-guide/_category_.json` (label "User Guide", position 2) if not already present.
 
-## 4. Create installation.md
+## 4. Redocusaurus + API route
 
-- [ ] 4.1 Create `docs/installation.md` with:
-  - `sidebar_position: 2` frontmatter
-  - Prerequisites section (Nextcloud 28+, OpenRegister app)
-  - App Store installation steps (install from Nextcloud App Store, enable app)
-  - Post-install configuration section: register setup (procest register created automatically via repair step), case-type configuration, ZGW API endpoint mapping in Admin Settings
-  - Troubleshooting section (register not found: re-run repair step; ZGW 400 errors: verify endpoint URLs)
+- [ ] 4.1 Add `"redocusaurus": "^2.0.0"` to `docs/package.json` dependencies, create `docs/static/oas/procest.json` with minimal valid OAS shim (`{"openapi":"3.0.0","info":{"title":"Procest","version":"0.0.0"},"paths":{}}`), wire Redocusaurus plugin (`specs: [{spec: 'static/oas/procest.json', route: '/api/'}]`) and add `{to: '/api/', label: 'API Documentation', position: 'left'}` navbar item in `docs/docusaurus.config.js`.
 
-## 5. Create UseCases/ and Integrations/ stub folders
+## 5. Re-enable nl locale (with escape hatch)
 
-- [ ] 5.1 Create `docs/UseCases/_category_.json` (label: "Use Cases", position: 4)
-- [ ] 5.2 Create `docs/UseCases/index.md` stub (frontmatter: `draft: true`, title: "Use Cases", note: content authoring tracked in issue #440)
-- [ ] 5.3 Create `docs/Integrations/_category_.json` (label: "Integrations", position: 5)
-- [ ] 5.4 Create `docs/Integrations/index.md` stub (frontmatter: `draft: true`, title: "Integrations", note: content authoring tracked in issue #440)
+- [ ] 5.1 In `docs/docusaurus.config.js`, update `i18n.locales` to `['en', 'nl']` and add `nl: { label: 'Nederlands' }` to `localeConfigs`. If `npm run build` fails with SSR error on empty `i18n/nl/`, revert `locales` to `['en']` with comment `/* nl reverted: SSR error with empty i18n/nl/ — re-enable once translation backfill lands (issue #441) */`.
 
-## 6. _category_.json files for canonical folders
+## 6. Em-dash sweep (gate: `git grep -E '—' docs/` returns 0)
 
-- [ ] 6.1 Create `docs/Features/_category_.json` (label: "Features", position: 3)
-- [ ] 6.2 Create `docs/user-guide/_category_.json` (label: "User Guide", position: 2) — only if one does not already exist
-- [ ] 6.3 Create `docs/Technical/_category_.json` if not already done in task 2.1
+- [ ] 6.1 Replace ` — ` with `, ` / `: ` (per context) across the em-dash hot spots in `docs/Technical/market-analysis.md` (11 hits incl. title), `docs/Features/README.md`, and per-feature pages: `administration.md`, `zgw-apis.md`, `bezwaar-beroep-workflow.md`, `workflow-engine-enhancement.md`, `vth-workflow-configuration.md`, `besluitvorming-workflow.md`, `doorlooptijd-dashboard.md`, `deelzaak-support.md`, `app-scaffold.md`, `gis-integration.md`.
+- [ ] 6.2 Replace `—` with `-` inside `docs/user-guide/` HTML `<!-- {{TODO: ... }} -->` comments, then run `git grep -E '—' docs/` (excluding node_modules) and confirm 0 matches.
 
-## 7. Add Redocusaurus and API Documentation route
+## 7. Internal link updates
 
-- [ ] 7.1 Add `"redocusaurus": "^2.0.0"` to `docs/package.json` under `dependencies`
-- [ ] 7.2 Create `docs/static/oas/` directory and write `docs/static/oas/procest.json` with minimal valid OAS shim: `{"openapi":"3.0.0","info":{"title":"Procest","version":"0.0.0"},"paths":{}}`
-- [ ] 7.3 Add Redocusaurus plugin config to `docs/docusaurus.config.js`: plugin `redocusaurus` with `specs: [{spec: 'static/oas/procest.json', route: '/api/'}]`
-- [ ] 7.4 Add "API Documentation" navbar item to `docs/docusaurus.config.js`: `{to: '/api/', label: 'API Documentation', position: 'left'}`
+- [ ] 7.1 Scan files moved into `docs/Technical/` for relative links to sibling root MDs (e.g. `../ARCHITECTURE.md`) and update to new paths. Scan `docs/Features/` for cross-links to root MDs, update. Verify `docs/index.md` references to `features/` are updated to `Features/`.
 
-## 8. Re-enable nl locale
+## 8. Build verification
 
-- [ ] 8.1 In `docs/docusaurus.config.js`, update `i18n.locales` from `['en']` to `['en', 'nl']`
-- [ ] 8.2 Add `nl: { label: 'Nederlands' }` to `i18n.localeConfigs`
-- [ ] 8.3 Run `npm run build` in `docs/`; if SSR fails with nl locale, revert `locales` to `['en']` and add comment: `/* nl reverted: SSR error with empty i18n/nl/ — re-enable once translation backfill lands (issue #441) */`
-
-## 9. Em-dash sweep (gate: git grep -E '—' docs/ returns 0)
-
-- [ ] 9.1 Fix em-dashes in `docs/Technical/market-analysis.md` (11 hits from FEATURES.md): replace ` — ` with `, ` or `: ` per context; title `# Procest — Feature Analysis` → `# Procest: Feature Analysis`
-- [ ] 9.2 Fix em-dashes in `docs/Features/README.md` (table cells and prose): replace ` — ` with `, ` or `: `
-- [ ] 9.3 Fix em-dashes in `docs/Features/administration.md` (bullet list items with ` — `): replace ` — ` with `: `
-- [ ] 9.4 Fix em-dashes in `docs/Features/zgw-apis.md`: replace ` — ` with `: ` in code-reference bullets
-- [ ] 9.5 Fix em-dashes in `docs/Features/bezwaar-beroep-workflow.md`: replace ` — ` with `: `
-- [ ] 9.6 Fix em-dashes in `docs/Features/workflow-engine-enhancement.md`: replace ` — ` with `: `
-- [ ] 9.7 Fix em-dashes in `docs/Features/vth-workflow-configuration.md`: replace ` — ` with `: `
-- [ ] 9.8 Fix em-dashes in `docs/Features/besluitvorming-workflow.md`: replace ` — ` with `: `
-- [ ] 9.9 Fix em-dashes in `docs/Features/doorlooptijd-dashboard.md`: replace ` — ` with `: `
-- [ ] 9.10 Fix em-dashes in `docs/Features/deelzaak-support.md`: replace ` — ` with `: `
-- [ ] 9.11 Fix em-dashes in `docs/Features/app-scaffold.md`: replace ` — ` with `: `
-- [ ] 9.12 Fix em-dashes in `docs/Features/gis-integration.md`: replace ` — ` with `: `
-- [ ] 9.13 Fix em-dashes in `docs/user-guide/` HTML comments (tutorials): in `<!-- {{TODO: ... — see /journeydoc-add-story}} -->`, replace `—` with `-`
-- [ ] 9.14 Verify em-dash gate: run `git grep -E '—' docs/` (excluding node_modules) — must return 0 matches
-
-## 10. Internal link updates in moved files
-
-- [ ] 10.1 Scan all files moved to `docs/Technical/` for relative links pointing to sibling root MDs (e.g., `../ARCHITECTURE.md`) and update to the new paths
-- [ ] 10.2 Scan `docs/Features/` files for any cross-links to root MDs and update accordingly
-- [ ] 10.3 Verify `docs/index.md` links to `features/` are updated to `Features/` (if any)
-
-## 11. Build verification
-
-- [ ] 11.1 Run `cd docs && npm install --legacy-peer-deps`
-- [ ] 11.2 Run `npm run build` (with 10-minute timeout) — must exit 0
-- [ ] 11.3 If build fails due to nl SSR error, execute escape hatch from task 8.3 and re-run build
-- [ ] 11.4 Confirm build output includes `Features/`, `user-guide/`, `Technical/`, `api/` routes
+- [ ] 8.1 `cd docs && npm install --legacy-peer-deps && npm run build` (10-min timeout) must exit 0; apply escape hatch from 5.1 if nl SSR fails, then re-run. Confirm output includes `Features/`, `user-guide/`, `Technical/`, `api/` routes.

--- a/openspec/changes/procest-legacy-quality-cleanup/tasks.md
+++ b/openspec/changes/procest-legacy-quality-cleanup/tasks.md
@@ -2,70 +2,37 @@
 
 ## Phase 1 — Inventory + planning
 
-- [ ] Run `composer phpcs` and capture current baseline error count
-      (target: starting from 3 exclude-patterns in phpcs.xml)
-- [ ] Run `composer phpmd` for the first time as a unified gate
-      and capture violation count + categories
-- [ ] Run `composer phpstan` for the first time as a unified gate
-      and capture error count + categories
-- [ ] Decide per gate: fix-outright (if <50 violations) or capture
-      a fresh baseline (if larger)
-- [ ] Confirm CI runs `composer check:strict` on every PR before
-      starting burn-down work
+- [ ] Run `composer phpcs`, `composer phpmd`, `composer phpstan` for the first time as unified gates; capture baseline counts + violation categories per gate (starting from 3 exclude-patterns in `phpcs.xml`).
+- [ ] Per gate decide: fix-outright (if <50 violations) or capture a fresh baseline. Confirm CI runs `composer check:strict` on every PR before starting burn-down work.
 
 ## Phase 2 — PHPCS burn-down (per excluded file)
 
-For each file: fix errors, remove the phpcs.xml `<exclude-pattern>`
-entry, verify gate stays green.
+For each file: fix errors, remove the `phpcs.xml` `<exclude-pattern>` entry, verify gate stays green.
 
-- [ ] Excluded file 1 — fix sniffs + drop exclude
-- [ ] Excluded file 2 — fix sniffs + drop exclude
-- [ ] Excluded file 3 — fix sniffs + drop exclude
-- [ ] Once all excludes are gone, drop the legacy-debt block from
-      phpcs.xml entirely
+- [ ] Excluded file 1 — fix sniffs + drop exclude.
+- [ ] Excluded file 2 — fix sniffs + drop exclude.
+- [ ] Excluded file 3 — fix sniffs + drop exclude.
+- [ ] Once all excludes are gone, drop the legacy-debt block from `phpcs.xml` entirely.
 
 ## Phase 3 — PHPMD burn-down
 
-Contingent on Phase 1's first-run output. If volume is small, this
-phase collapses to a single fix-outright PR.
+Contingent on Phase 1 output. If volume is small, collapses to a single fix-outright PR.
 
-- [ ] If baseline captured: ElseExpression — re-shape `if/else` to
-      early-return
-- [ ] If baseline captured: CyclomaticComplexity / NPathComplexity —
-      extract methods
-- [ ] If baseline captured: MissingImport — add `use` statements
-- [ ] If baseline captured: StaticAccess — replace with DI
-- [ ] If baseline captured: variable-naming sniffs (Long/Short/
-      Undefined/UnusedFormalParameter)
-- [ ] Once baseline reaches 0 lines: delete phpmd.baseline.xml and
-      drop `--baseline-file` from composer.json's phpmd script
+- [ ] Resolve PHPMD findings by category as baseline dictates: ElseExpression (reshape `if/else` → early-return), CyclomaticComplexity / NPathComplexity (extract methods), MissingImport (`use` statements), StaticAccess (replace with DI), variable-naming (Long/Short/Undefined/UnusedFormalParameter).
+- [ ] Once baseline reaches 0 lines: delete `phpmd.baseline.xml` and drop `--baseline-file` from composer.json's phpmd script.
 
 ## Phase 4 — PHPStan burn-down
 
-Contingent on Phase 1's first-run output. If volume is small, this
-phase collapses to a single fix-outright PR.
+Contingent on Phase 1 output. If volume is small, collapses to a single fix-outright PR.
 
-- [ ] Inventory phpstan errors by file/type
-- [ ] Common patterns to fix:
-  - [ ] Missing return-type / param-type declarations
-  - [ ] Mixed types (specify generic / union)
-  - [ ] Possibly-null dereferences
-- [ ] Once baseline reaches 0 lines (or never created): confirm
-      gate runs clean against current code
+- [ ] Inventory phpstan errors by file/type and fix the common patterns: missing return-type / param-type declarations, mixed types (specify generic / union), possibly-null dereferences.
+- [ ] Once baseline reaches 0 lines (or never created): confirm gate runs clean against current code.
 
 ## Phase 5 — CI integration
 
-- [ ] Verify `composer check:strict` runs in CI on every PR
-- [ ] Once all baselines are empty:
-  - [ ] Delete `phpmd.baseline.xml` (if it was created)
-  - [ ] Delete `phpstan-baseline.neon` (if it was created)
-  - [ ] Drop the legacy-debt section from `phpcs.xml`
-- [ ] Add a smoke-test cron that runs `composer check:strict`
-      weekly on `development`
+- [ ] Verify `composer check:strict` runs in CI on every PR; once all baselines are empty, delete `phpmd.baseline.xml` and `phpstan-baseline.neon` (if either was created) and drop the legacy-debt section from `phpcs.xml`.
+- [ ] Add a smoke-test cron that runs `composer check:strict` weekly on `development`.
 
 ## Phase 6 — Documentation
 
-- [ ] Update README quality-gates section
-- [ ] Note in `app-config.json` that legacy quality cleanup is done
-- [ ] Close the burn-down tracking issue once the last baseline
-      line is removed
+- [ ] Update README quality-gates section, note in `app-config.json` that legacy quality cleanup is done, and close the burn-down tracking issue once the last baseline line is removed.

--- a/openspec/changes/unit-test-coverage-75/tasks.md
+++ b/openspec/changes/unit-test-coverage-75/tasks.md
@@ -1,48 +1,38 @@
 ## 1. Test Infrastructure Setup
 
-- [ ] 1.1 Ensure tests/bootstrap.php supports OC::$server mocking for unit tests that need container access
+- [ ] 1.1 Ensure `tests/bootstrap.php` supports `OC::$server` mocking for unit tests that need container access.
 
-## 2. Service Unit Tests - Simple Services
+## 2. Service Unit Tests — Simple Services
 
-- [ ] 2.1 Create ZgwMappingServiceTest (getMapping, saveMapping, listMappings, deleteMapping)
-- [ ] 2.2 Create ZgwPaginationHelperTest (wrapResults with various page/count combinations)
-- [ ] 2.3 Create ZgwDocumentServiceTest (storeBase64, storeRaw, getContent, fileExists, deleteFiles)
+- [ ] 2.1 `ZgwMappingServiceTest` — `getMapping`, `saveMapping`, `listMappings`, `deleteMapping`.
+- [ ] 2.2 `ZgwPaginationHelperTest` — `wrapResults` with various page/count combinations.
+- [ ] 2.3 `ZgwDocumentServiceTest` — `storeBase64`, `storeRaw`, `getContent`, `fileExists`, `deleteFiles`.
 
-## 3. Service Unit Tests - Business Rules
+## 3. Service Unit Tests — Business Rules
 
-- [ ] 3.1 Create ZgwBrcRulesServiceTest (BRC rules: besluit create validation, uniqueness, immutability)
-- [ ] 3.2 Create ZgwDrcRulesServiceTest (DRC rules: document create validation, lock checks)
-- [ ] 3.3 Create ZgwZtcRulesServiceTest (ZTC rules: concept protection, afleidingswijze validation)
-- [ ] 3.4 Create ZgwBusinessRulesServiceTest (dispatcher: delegates to correct register rules service)
+- [ ] 3.1 Register rules services: `ZgwBrcRulesServiceTest` (besluit create validation, uniqueness, immutability), `ZgwDrcRulesServiceTest` (document create validation, lock checks), `ZgwZtcRulesServiceTest` (concept protection, afleidingswijze validation).
+- [ ] 3.2 `ZgwBusinessRulesServiceTest` — dispatcher delegates to the correct per-register rules service.
 
-## 4. Service Unit Tests - Complex Services
+## 4. Service Unit Tests — Complex Services
 
-- [ ] 4.1 Create NotificatieServiceTest (publish, deliver failure logging)
-- [ ] 4.2 Create ZgwServiceTest (RESOURCE_MAP structure, constructor dependencies)
+- [ ] 4.1 `NotificatieServiceTest` (`publish`, deliver-failure logging) and `ZgwServiceTest` (`RESOURCE_MAP` structure, constructor dependencies).
 
-## 5. Controller Unit Tests - Simple Controllers
+## 5. Controller Unit Tests — Simple Controllers
 
-- [ ] 5.1 Create DashboardControllerTest (page returns TemplateResponse)
-- [ ] 5.2 Create HealthControllerTest (health check returns JSONResponse with status)
-- [ ] 5.3 Create MetricsControllerTest (index returns TextPlainResponse with Prometheus header)
-- [ ] 5.4 Create SettingsControllerTest (getSettings, updateSettings delegation)
-- [ ] 5.5 Create ZgwMappingControllerTest (index, show, update mapping operations)
+- [ ] 5.1 `DashboardControllerTest` (`page` → `TemplateResponse`), `HealthControllerTest` (status JSON), `MetricsControllerTest` (`index` → `TextPlainResponse` with Prometheus header).
+- [ ] 5.2 `SettingsControllerTest` (`getSettings`/`updateSettings` delegation) and `ZgwMappingControllerTest` (`index`, `show`, `update`).
 
-## 6. Controller Unit Tests - ZGW Register Controllers
+## 6. Controller Unit Tests — ZGW Register Controllers
 
-- [ ] 6.1 Create ZrcControllerTest (index, create, show, update, destroy delegation to ZgwService)
-- [ ] 6.2 Create ZtcControllerTest (index, create, show, update, destroy plus publish action)
-- [ ] 6.3 Create DrcControllerTest (index, create, show, update, destroy plus download action)
-- [ ] 6.4 Create BrcControllerTest (index, create, show, update, destroy delegation)
-- [ ] 6.5 Create NrcControllerTest (index, create, show delegation)
-- [ ] 6.6 Create AcControllerTest (index, create, show, update, destroy delegation)
+- [ ] 6.1 `ZrcControllerTest` and `ZtcControllerTest` — index/create/show/update/destroy delegation to `ZgwService`; ZtcControllerTest also covers `publish`.
+- [ ] 6.2 `DrcControllerTest` and `BrcControllerTest` — index/create/show/update/destroy delegation; DrcControllerTest also covers `download`.
+- [ ] 6.3 `NrcControllerTest` (index/create/show delegation) and `AcControllerTest` (index/create/show/update/destroy delegation).
 
 ## 7. Newman API Tests
 
-- [ ] 7.1 Create tests/newman/zgw-workflow.postman_collection.json with ZGW CRUD flow
-- [ ] 7.2 Create tests/newman/procest-environment.json with local dev variables
+- [ ] 7.1 Create `tests/newman/zgw-workflow.postman_collection.json` (ZGW CRUD flow) and `tests/newman/procest-environment.json` (local dev variables).
 
 ## 8. Verification
 
-- [ ] 8.1 Run full PHPUnit suite and verify all tests pass
-- [ ] 8.2 Verify file coverage count is 33+ of 42 (75%+)
+- [ ] 8.1 Run full PHPUnit suite and verify all tests pass.
+- [ ] 8.2 Verify file coverage count is 33+ of 42 (75%+).


### PR DESCRIPTION
Wave 2 fleet rollout of the ADR-032 spec-sizing fix. Brings procest's oversized openspec changes under Hydra's 20-task cap (mix of multi-spec splits + single-spec task-trims). Part of an 8-app fleet sweep following shillinq's #91/#94 precedent. All semantic content preserved.