### PR TITLE
chore(brand): preset 2.10 + auto-derived hero + smaller app-icon glyph

### DIFF
--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -273,8 +273,7 @@ export default function Home() {
         <DetailHero
           background="cobalt"
           appId="procest"
-          status={{ label: 'Stable', color: 'var(--c-mint-500)' }}
-          version="v1.6"
+          /* status + version dropped — preset 2.10+ auto-derives from appinfo/info.xml */
           locales="NL · EN"
           title="Procest"
           tagline={TAGLINE}

--- a/docs/static/img/logo.svg
+++ b/docs/static/img/logo.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
   <polygon points="256,26 455.19,141 455.19,371 256,486 56.81,371 56.81,141" fill="#4376FC"/>
-  <g transform="translate(136, 136) scale(10)" fill="#ffffff">
+  <g transform="translate(164, 164) scale(7.67)" fill="#ffffff">
     <path d="M5,3H19A2,2,0,0,1,21,5V19A2,2,0,0,1,19,21H5A2,2,0,0,1,3,19V5A2,2,0,0,1,5,3M5,5V9H19V5H5M5,11V19H9V11H5M11,11V19H19V11H11"/>
     <circle cx="7" cy="14" r="1.5"/>
     <circle cx="7" cy="18" r="1.5"/>

--- a/img/app-store.svg
+++ b/img/app-store.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
   <polygon points="256,26 455.19,141 455.19,371 256,486 56.81,371 56.81,141" fill="#4376FC"/>
-  <g transform="translate(136, 136) scale(10)" fill="#ffffff">
+  <g transform="translate(164, 164) scale(7.67)" fill="#ffffff">
     <path d="M5,3H19A2,2,0,0,1,21,5V19A2,2,0,0,1,19,21H5A2,2,0,0,1,3,19V5A2,2,0,0,1,5,3M5,5V9H19V5H5M5,11V19H9V11H5M11,11V19H19V11H11"/>
     <circle cx="7" cy="14" r="1.5"/>
     <circle cx="7" cy="18" r="1.5"/>


### PR DESCRIPTION
(re-opened of #447 — accidentally closed by harness force-push; same branch, same content)

Aligns this app with the design-system 2.10.0 release: preset bumped, hard-coded `<DetailHero/>` `status`/`version` props dropped (the new preset auto-derives from `appinfo/info.xml` + SemVer), inner glyph in `img/app-store.svg` shrunk to ~40% of the hex height. No code or behaviour changes beyond the brand chrome.
