### PR TITLE
chore(brand): align app-store hex to canonical cobalt #21468B

### DIFF
--- a/img/app-store.svg
+++ b/img/app-store.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-  <polygon points="256,26 455.19,141 455.19,371 256,486 56.81,371 56.81,141" fill="#4376FC"/>
+  <polygon points="256,26 455.19,141 455.19,371 256,486 56.81,371 56.81,141" fill="#21468B"/>
   <g transform="translate(136, 136) scale(10)" fill="#ffffff">
     <path d="M5,3H19A2,2,0,0,1,21,5V19A2,2,0,0,1,19,21H5A2,2,0,0,1,3,19V5A2,2,0,0,1,5,3M5,5V9H19V5H5M5,11V19H9V11H5M11,11V19H19V11H11"/>
     <circle cx="7" cy="14" r="1.5"/>


### PR DESCRIPTION
(re-opened of #446 — accidentally closed by harness force-push; same branch, same content)

Single-file change to `img/app-store.svg`: hex polygon fill updated from legacy `#4376FC` to canonical `#21468B` (`--c-blue-cobalt`). Part of the fleet sweep aligning the app icon to the brand cobalt — see [design-system colors.html](https://identity.conduction.nl/preview/colors.html) for the rationale. No code or behavior changes.
