### PR TITLE
feat(schemas): x-openregister-lifecycle on 7 schemas (re-do of #306)

### DIFF
--- a/lib/Settings/procest_register.json
+++ b/lib/Settings/procest_register.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Procest Case Management Register",
     "description": "Register containing all schemas for the Procest case management application. Defines case types, status types, role types, result types, decision types, document types, property definitions, voorstel, parafeerroute, parafeeractie, automaticAction, and their instance counterparts.",
-    "version": "0.7.0"
+    "version": "0.8.0"
   },
   "x-openregister": {
     "type": "application",
@@ -749,7 +749,7 @@
       "task": {
         "slug": "task",
         "icon": "CheckboxMarkedOutline",
-        "version": "1.0.0",
+        "version": "1.1.0",
         "x-schema-org-type": "schema:Action",
         "x-zgw-equivalent": "Taak",
         "title": "Task",
@@ -830,6 +830,49 @@
             "type": "string",
             "description": "JSON-encoded array of checklist items ({id, label, checked})",
             "visible": false
+          }
+        },
+        "configuration": {
+          "x-openregister-lifecycle": {
+            "field": "status",
+            "initial": "available",
+            "final": [
+              "completed",
+              "terminated",
+              "disabled"
+            ],
+            "transitions": {
+              "activate": {
+                "from": [
+                  "available"
+                ],
+                "to": "active",
+                "description": "Pick up the task."
+              },
+              "complete": {
+                "from": [
+                  "active"
+                ],
+                "to": "completed",
+                "description": "Mark task as completed."
+              },
+              "terminate": {
+                "from": [
+                  "available",
+                  "active"
+                ],
+                "to": "terminated",
+                "description": "Terminate the task."
+              },
+              "disable": {
+                "from": [
+                  "available",
+                  "active"
+                ],
+                "to": "disabled",
+                "description": "Disable the task."
+              }
+            }
           }
         }
       },
@@ -1083,7 +1126,7 @@
       "document": {
         "slug": "document",
         "icon": "FileDocumentOutline",
-        "version": "1.0.0",
+        "version": "1.1.0",
         "x-schema-org-type": "schema:DigitalDocument",
         "x-zgw-equivalent": "EnkelvoudigInformatieObject",
         "title": "Document",
@@ -1192,6 +1235,45 @@
             "nullable": true,
             "default": null,
             "description": "Indicates whether usage rights have been set for this document"
+          }
+        },
+        "configuration": {
+          "x-openregister-lifecycle": {
+            "field": "status",
+            "initial": "in_bewerking",
+            "final": [
+              "gearchiveerd"
+            ],
+            "transitions": {
+              "submit": {
+                "from": [
+                  "in_bewerking"
+                ],
+                "to": "ter_vaststelling",
+                "description": "Submit the document for adoption."
+              },
+              "adopt": {
+                "from": [
+                  "ter_vaststelling"
+                ],
+                "to": "definitief",
+                "description": "Adopt the document as final."
+              },
+              "archive": {
+                "from": [
+                  "definitief"
+                ],
+                "to": "gearchiveerd",
+                "description": "Archive the final document."
+              },
+              "sendBack": {
+                "from": [
+                  "ter_vaststelling"
+                ],
+                "to": "in_bewerking",
+                "description": "Send back for revisions."
+              }
+            }
           }
         }
       },
@@ -1640,7 +1722,7 @@
       "voorstel": {
         "slug": "voorstel",
         "icon": "FileDocumentEditOutline",
-        "version": "1.0.0",
+        "version": "1.1.0",
         "x-schema-org-type": "schema:CreativeWork",
         "title": "Voorstel",
         "description": "A B&W voorstel (proposal) for decision-making in a case",
@@ -1751,6 +1833,77 @@
             "format": "uuid",
             "description": "Reference to the linked decision (set when besluit is registered)",
             "visible": false
+          }
+        },
+        "configuration": {
+          "x-openregister-lifecycle": {
+            "field": "status",
+            "initial": "concept",
+            "final": [
+              "besloten",
+              "gearchiveerd"
+            ],
+            "transitions": {
+              "startParafering": {
+                "from": [
+                  "concept"
+                ],
+                "to": "in_parafering",
+                "description": "Start initialing route."
+              },
+              "paraferingDone": {
+                "from": [
+                  "in_parafering"
+                ],
+                "to": "ter_accordering",
+                "description": "Initialing complete; ready for accordance."
+              },
+              "accord": {
+                "from": [
+                  "ter_accordering"
+                ],
+                "to": "geaccordeerd",
+                "description": "Accord the proposal."
+              },
+              "submit": {
+                "from": [
+                  "geaccordeerd"
+                ],
+                "to": "aangeboden",
+                "description": "Submit the proposal for decision."
+              },
+              "decide": {
+                "from": [
+                  "aangeboden"
+                ],
+                "to": "besloten",
+                "description": "Decision made on the proposal."
+              },
+              "archive": {
+                "from": [
+                  "besloten"
+                ],
+                "to": "gearchiveerd",
+                "description": "Archive the proposal."
+              },
+              "sendBack": {
+                "from": [
+                  "in_parafering",
+                  "ter_accordering",
+                  "geaccordeerd",
+                  "aangeboden"
+                ],
+                "to": "teruggestuurd",
+                "description": "Send the proposal back for revisions."
+              },
+              "revise": {
+                "from": [
+                  "teruggestuurd"
+                ],
+                "to": "concept",
+                "description": "Take a returned proposal back into draft."
+              }
+            }
           }
         }
       },
@@ -2340,7 +2493,7 @@
       "hearingSession": {
         "slug": "hearingSession",
         "icon": "AccountGroupOutline",
-        "version": "1.1.0",
+        "version": "1.2.0",
         "x-schema-org-type": "schema:Event",
         "x-zgw-equivalent": "Hoorzitting",
         "title": "Hearing Session",
@@ -2478,6 +2631,52 @@
               "type": "object"
             },
             "description": "Append-only audit entries tagged with applicable Awb article (awb-art-7:2|7:3|7:4|7:6|7:7|7:13 or avg-art-6)"
+          }
+        },
+        "configuration": {
+          "x-openregister-lifecycle": {
+            "field": "status",
+            "initial": "gepland",
+            "final": [
+              "uitgevoerd",
+              "geannuleerd",
+              "afgezien"
+            ],
+            "transitions": {
+              "invite": {
+                "from": [
+                  "gepland"
+                ],
+                "to": "uitgenodigd",
+                "description": "Send hearing invitations."
+              },
+              "execute": {
+                "from": [
+                  "uitgenodigd",
+                  "dossier_beschikbaar"
+                ],
+                "to": "uitgevoerd",
+                "description": "Mark the hearing as carried out."
+              },
+              "cancel": {
+                "from": [
+                  "gepland",
+                  "uitgenodigd",
+                  "dossier_beschikbaar"
+                ],
+                "to": "geannuleerd",
+                "description": "Cancel the hearing."
+              },
+              "waive": {
+                "from": [
+                  "gepland",
+                  "uitgenodigd",
+                  "dossier_beschikbaar"
+                ],
+                "to": "afgezien",
+                "description": "Waive the hearing."
+              }
+            }
           }
         }
       },
@@ -3234,7 +3433,7 @@
       "adviesAanvraag": {
         "slug": "adviesAanvraag",
         "icon": "CommentQuestionOutline",
-        "version": "1.0.0",
+        "version": "1.1.0",
         "x-schema-org-type": "schema:AskAction",
         "title": "Advice Request",
         "description": "A request for internal or external advice on a case, with deadline tracking",
@@ -3298,6 +3497,32 @@
           "questions": {
             "type": "string",
             "description": "Specific questions for the adviseur"
+          }
+        },
+        "configuration": {
+          "x-openregister-lifecycle": {
+            "field": "status",
+            "initial": "aangevraagd",
+            "final": [
+              "ontvangen",
+              "verlopen"
+            ],
+            "transitions": {
+              "receive": {
+                "from": [
+                  "aangevraagd"
+                ],
+                "to": "ontvangen",
+                "description": "Mark the advice as received."
+              },
+              "expire": {
+                "from": [
+                  "aangevraagd"
+                ],
+                "to": "verlopen",
+                "description": "Mark the advice request as expired."
+              }
+            }
           }
         }
       },
@@ -3602,7 +3827,7 @@
       "handhavingsactie": {
         "slug": "handhavingsactie",
         "icon": "Gavel",
-        "version": "1.0.0",
+        "version": "1.1.0",
         "x-schema-org-type": "schema:LegalForceStatus",
         "title": "Enforcement Action",
         "description": "An enforcement action (handhavingsactie) on a case, classified per the Landelijke Handhavingsstrategie (LHS)",
@@ -3684,6 +3909,40 @@
           "overrideReason": {
             "type": "string",
             "description": "Documented reasoning if the LHS suggestion was overridden"
+          }
+        },
+        "configuration": {
+          "x-openregister-lifecycle": {
+            "field": "status",
+            "initial": "opgelegd",
+            "final": [
+              "geeffectueerd",
+              "ingetrokken"
+            ],
+            "transitions": {
+              "forfeit": {
+                "from": [
+                  "opgelegd"
+                ],
+                "to": "verbeurd",
+                "description": "Mark the enforcement action as forfeited."
+              },
+              "execute": {
+                "from": [
+                  "verbeurd"
+                ],
+                "to": "geeffectueerd",
+                "description": "Mark the enforcement action as executed."
+              },
+              "withdraw": {
+                "from": [
+                  "opgelegd",
+                  "verbeurd"
+                ],
+                "to": "ingetrokken",
+                "description": "Withdraw the enforcement action."
+              }
+            }
           }
         }
       },
@@ -3880,7 +4139,7 @@
       "inspectieChecklist": {
         "slug": "inspectieChecklist",
         "icon": "ClipboardCheckOutline",
-        "version": "1.0.0",
+        "version": "1.1.0",
         "x-schema-org-type": "schema:HowTo",
         "title": "Inspection Checklist",
         "description": "Configurable inspection checklist template linked to a case type, with versioning support",
@@ -3961,6 +4220,31 @@
                   "type": "string",
                   "description": "Guidance text for the inspector"
                 }
+              }
+            }
+          }
+        },
+        "configuration": {
+          "x-openregister-lifecycle": {
+            "field": "status",
+            "initial": "draft",
+            "final": [
+              "archived"
+            ],
+            "transitions": {
+              "activate": {
+                "from": [
+                  "draft"
+                ],
+                "to": "active",
+                "description": "Activate the checklist."
+              },
+              "archive": {
+                "from": [
+                  "active"
+                ],
+                "to": "archived",
+                "description": "Archive the checklist."
               }
             }
           }


### PR DESCRIPTION
(re-opened of #419 — accidentally closed by harness force-push; same branch, same content)

## Summary

Re-applies the ADR-031 declarative-state-machine annotations from PR #306 onto the current post-manifest-migration `lib/Settings/procest_register.json`. PR #306's branch (`feature/declarative-annotation-pilot`) accumulated 40+ conflicts with `development` (which has since landed the json-manifest migration that deleted/restructured files the branch modified) and could not be rebased — this is a clean re-do off current `development`.

Adds `configuration.x-openregister-lifecycle` blocks (state machine: `field`, `initial`, `final`, `transitions`) to 7 schemas, with version bumps:

| Schema | Version | Transitions |
|---|---|---|
| `task` | 1.0.0 → 1.1.0 | activate, complete, terminate, disable |
| `document` | 1.0.0 → 1.1.0 | submit, adopt, archive, sendBack |
| `voorstel` | 1.0.0 → 1.1.0 | startParafering, paraferingDone, accord, submit, decide, archive, sendBack, revise |
| `hearingSession` | 1.1.0 → 1.2.0 | invite, execute, cancel, waive (incl. the `dossier_beschikbaar` status that development added) |
| `adviesAanvraag` | 1.0.0 → 1.1.0 | receive, expire |
| `handhavingsactie` | 1.0.0 → 1.1.0 | forfeit, execute, withdraw |
| `inspectieChecklist` | 1.0.0 → 1.1.0 | activate, archive |

Register version bumped 0.7.0 → 0.8.0.

## Notes / scope

- PR #306 itself contained **no** guard classes (`lib/Lifecycle/`), no `x-openregister-calculations`/`-aggregations`/`-notifications`, and no `STATUS_*` constant removal — those were never part of that PR — so this re-do mirrors it: register-JSON-only. No PHP changes.
- The unrelated noise in #306's diff (`docs/development.md`, `l10n/*`, `src/utils/taskLifecycle.js`) was branch drift, not part of the lifecycle deliverable, and is intentionally not carried over.
- Companion OpenRegister tracking issue: ConductionNL/openregister#1357.
- `python3 -m json.tool lib/Settings/procest_register.json` validates.

**Supersedes #306**, which is on an un-rebaseable branch.

## Test plan
- [ ] `python3 -m json.tool lib/Settings/procest_register.json` is valid (done)
- [ ] OpenRegister picks up the lifecycle blocks; `POST /api/objects/{id}/transition` honours the new transition tables
- [ ] Register re-import / upgrade applies the version bumps without errors
