### PR TITLE
fix(procest): repair OR-API drift + dangling seed references

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -6192,16 +6192,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
                 "shasum": ""
             },
             "require": {
@@ -6214,7 +6214,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -6239,7 +6239,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -6251,11 +6251,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-04-13T15:52:40+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -6557,16 +6561,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
                 "shasum": ""
             },
             "require": {
@@ -6616,7 +6620,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -6636,7 +6640,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
@@ -6807,16 +6811,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
                 "shasum": ""
             },
             "require": {
@@ -6868,7 +6872,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -6888,11 +6892,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-23T08:48:59+00:00"
+            "time": "2026-04-10T17:25:58+00:00"
         },
         {
             "name": "symfony/polyfill-php81",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php81.git",
@@ -6948,7 +6952,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -7294,16 +7298,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v6.4.34",
+            "version": "v6.4.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "7bca30dabed7900a08c5ad4f1d6483f881a64d0f"
+                "reference": "68dcd1f1602dac9d9221e25729683e0ce8733f3b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/7bca30dabed7900a08c5ad4f1d6483f881a64d0f",
-                "reference": "7bca30dabed7900a08c5ad4f1d6483f881a64d0f",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/68dcd1f1602dac9d9221e25729683e0ce8733f3b",
+                "reference": "68dcd1f1602dac9d9221e25729683e0ce8733f3b",
                 "shasum": ""
             },
             "require": {
@@ -7346,7 +7350,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v6.4.34"
+                "source": "https://github.com/symfony/yaml/tree/v6.4.40"
             },
             "funding": [
                 {
@@ -7366,7 +7370,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-06T18:32:11+00:00"
+            "time": "2026-05-19T20:33:22+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -7420,16 +7424,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v3.23.0",
+            "version": "v3.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "a64dc5d2cc7d6cafb9347f6cd802d0d06d0351c9"
+                "reference": "1fcae487b180d78e6351f4e0afa91f9eab96a2bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/a64dc5d2cc7d6cafb9347f6cd802d0d06d0351c9",
-                "reference": "a64dc5d2cc7d6cafb9347f6cd802d0d06d0351c9",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/1fcae487b180d78e6351f4e0afa91f9eab96a2bc",
+                "reference": "1fcae487b180d78e6351f4e0afa91f9eab96a2bc",
                 "shasum": ""
             },
             "require": {
@@ -7439,7 +7443,8 @@
                 "symfony/polyfill-mbstring": "^1.3"
             },
             "require-dev": {
-                "phpstan/phpstan": "^2.0",
+                "php-cs-fixer/shim": "^3.0@stable",
+                "phpstan/phpstan": "^2.0@stable",
                 "psr/container": "^1.0|^2.0",
                 "symfony/phpunit-bridge": "^5.4.9|^6.4|^7.0"
             },
@@ -7483,7 +7488,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.23.0"
+                "source": "https://github.com/twigphp/Twig/tree/v3.26.0"
             },
             "funding": [
                 {
@@ -7495,7 +7500,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-23T21:00:41+00:00"
+            "time": "2026-05-20T07:31:59+00:00"
         },
         {
             "name": "vimeo/psalm",

--- a/lib/BackgroundJob/AppointmentReminderJob.php
+++ b/lib/BackgroundJob/AppointmentReminderJob.php
@@ -81,13 +81,11 @@ class AppointmentReminderJob extends TimedJob
 
             $tomorrow = (new \DateTime('+1 day'))->format('Y-m-d');
 
-            $result = $objectService->getObjects(
-                (int) $register,
-                (int) $schema,
-                ['status' => 'scheduled'],
+            $appointments = $objectService->findAll(
+                ['filters' => ['register' => (int) $register, 'schema' => (int) $schema, 'status' => 'scheduled']],
             );
 
-            foreach (($result['objects'] ?? []) as $apt) {
+            foreach ($appointments as $apt) {
                 if (is_object($apt) === true) {
                     $data = $apt->jsonSerialize();
                 } else {

--- a/lib/BackgroundJob/ShareMaintenanceJob.php
+++ b/lib/BackgroundJob/ShareMaintenanceJob.php
@@ -100,13 +100,10 @@ class ShareMaintenanceJob extends TimedJob
         }
 
         try {
-            $result = $objectService->getObjects(
-                (int) $register,
-                (int) $schema,
-                [],
+            $shares = $objectService->findAll(
+                ['filters' => ['register' => (int) $register, 'schema' => (int) $schema]],
             );
 
-            $shares       = ($result['objects'] ?? []);
             $reminderDate = new \DateTime('+'.self::REMINDER_DAYS.' days');
 
             foreach ($shares as $share) {

--- a/lib/Repair/SeedLhsMatrix.php
+++ b/lib/Repair/SeedLhsMatrix.php
@@ -96,11 +96,11 @@ class SeedLhsMatrix implements IRepairStep
                 return;
             }
 
-            $existing = $objectService->getObjects(
-                register: $register,
-                schema: $schema,
-                filters: ['active' => true],
-                limit: 1,
+            $existing = $objectService->findAll(
+                [
+                    'filters' => ['register' => $register, 'schema' => $schema, 'active' => true],
+                    'limit'   => 1,
+                ],
             );
             if ($this->hasRow(results: $existing) === true) {
                 $output->info('Active LHS matrix already exists. Skipping seed.');

--- a/lib/Service/AppointmentService.php
+++ b/lib/Service/AppointmentService.php
@@ -195,13 +195,9 @@ class AppointmentService
         $register = $this->settingsService->getConfigValue('register');
         $schema   = $this->settingsService->getConfigValue('appointment_schema');
 
-        $result = $objectService->getObjects(
-            (int) $register,
-            (int) $schema,
-            ['caseId' => $caseId],
+        return $objectService->findAll(
+            ['filters' => ['register' => (int) $register, 'schema' => (int) $schema, 'caseId' => $caseId]],
         );
-
-        return $result['objects'] ?? [];
     }//end getAppointmentsForCase()
 
     /**
@@ -221,13 +217,9 @@ class AppointmentService
         $register = $this->settingsService->getConfigValue('register');
         $schema   = $this->settingsService->getConfigValue('appointment_schema');
 
-        $result = $objectService->getObjects(
-            (int) $register,
-            (int) $schema,
-            ['cancelToken' => $token],
+        $appointments = $objectService->findAll(
+            ['filters' => ['register' => (int) $register, 'schema' => (int) $schema, 'cancelToken' => $token]],
         );
-
-        $appointments = ($result['objects'] ?? []);
         if (empty($appointments) === true) {
             return null;
         }

--- a/lib/Service/BerichtenboxService.php
+++ b/lib/Service/BerichtenboxService.php
@@ -148,13 +148,9 @@ class BerichtenboxService
         $register = $this->settingsService->getConfigValue('register');
         $schema   = $this->settingsService->getConfigValue('berichtenbox_message_schema');
 
-        $result = $objectService->getObjects(
-            (int) $register,
-            (int) $schema,
-            ['caseId' => $caseId],
+        return $objectService->findAll(
+            ['filters' => ['register' => (int) $register, 'schema' => (int) $schema, 'caseId' => $caseId]],
         );
-
-        return $result['objects'] ?? [];
     }//end getMessagesForCase()
 
     /**

--- a/lib/Service/CaseSharingService.php
+++ b/lib/Service/CaseSharingService.php
@@ -278,13 +278,9 @@ class CaseSharingService
         $register = $this->settingsService->getConfigValue('register');
         $schema   = $this->settingsService->getConfigValue('case_share_schema');
 
-        $result = $objectService->getObjects(
-            (int) $register,
-            (int) $schema,
-            ['token' => $token],
+        $shares = $objectService->findAll(
+            ['filters' => ['register' => (int) $register, 'schema' => (int) $schema, 'token' => $token]],
         );
-
-        $shares = ($result['objects'] ?? []);
         if (empty($shares) === true) {
             return ['valid' => false, 'error' => 'Token niet gevonden'];
         }

--- a/lib/Service/SeedDataService.php
+++ b/lib/Service/SeedDataService.php
@@ -408,11 +408,11 @@ class SeedDataService
         array $filters,
     ): ?object {
         try {
-            $results = $objectService->getObjects(
-                register: $registerId,
-                schema: $schemaId,
-                filters: $filters,
-                limit: 1,
+            $results = $objectService->findAll(
+                [
+                    'filters' => (['register' => $registerId, 'schema' => $schemaId] + $filters),
+                    'limit'   => 1,
+                ],
             );
 
             if (is_array($results) === true && count($results) > 0) {

--- a/lib/Service/Vth/LhsRecommendationService.php
+++ b/lib/Service/Vth/LhsRecommendationService.php
@@ -262,11 +262,11 @@ class LhsRecommendationService
         }
 
         try {
-            $results = $objectService->getObjects(
-                register: $register,
-                schema: $schema,
-                filters: $filters,
-                limit: 1,
+            $results = $objectService->findAll(
+                [
+                    'filters' => (['register' => $register, 'schema' => $schema] + $filters),
+                    'limit'   => 1,
+                ],
             );
         } catch (Throwable $e) {
             $this->logger->error(

--- a/src/customComponents.js
+++ b/src/customComponents.js
@@ -23,9 +23,7 @@ import WerkvoorraadView from './views/Werkvoorraad.vue'
 // CaseMapView removed — superseded by manifest `type: 'map'` CnMapPage
 // (see openspec/changes/case-map-overview/design.md).
 import DoorlooptijdView from './views/DoorlooptijdDashboard.vue'
-// VoorstellenView removed — the Voorstellen list page is now a declarative
-// `type:"index"` on the `voorstel` schema (formatter columns + status badge,
-// see src/manifest.json + src/services/formatters.js).
+import VoorstellenView from './views/voorstellen/VoorstelList.vue'
 import VoorstelDetailView from './views/voorstellen/VoorstelDetail.vue'
 import AdminRootView from './views/settings/AdminRoot.vue'
 import PublicCaseView from './views/public/PublicCaseView.vue'
@@ -41,60 +39,16 @@ import CaseDocumentsTab from './components/tabs/CaseDocumentsTab.vue'
 // --- Visual workflow editor — TEMPORARILY UNWIRED. ---
 // `@vue-flow/{core,controls,background}` v1.x are Vue-3-only (they import
 // Fragment / Teleport / createElementVNode / toValue from 'vue'), which breaks
-// the webpack build under procest's Vue 2.7 base (272 errors). The component
-// files remain in src/components/workflow/ but are no longer pulled into the
-// bundle. Re-wire once @vue-flow is replaced with a Vue-2-compatible flow
-// library (or procest migrates to Vue 3). See
-// openspec/changes/visual-workflow-editor/design.md.
+// the webpack build under procest's Vue 2.7 base. The component files remain in
+// src/components/workflow/ but are no longer pulled into the bundle. Re-wire
+// once @vue-flow is replaced with a Vue-2-compatible flow library (or procest
+// migrates to Vue 3). See openspec/changes/visual-workflow-editor/design.md.
 // import VisualWorkflowEditor from './components/workflow/VisualWorkflowEditor.vue'
 
 // --- Shared map surface (case detail map tab, dashboard widget, public case page). ---
 // Thin wrapper around CnMapWidget; registered here so manifest entries
 // MAY reference it by string name. See openspec/changes/map-component/.
 import MapComponent from './components/map/MapComponent.vue'
-
-// --- Features & Roadmap page — thin wrapper around the lib's
-//     CnFeaturesAndRoadmapView (the in-product roadmap surface powered by
-//     OpenRegister's github-issue-proxy). See ConductionNL/hydra#251. ---
-import FeaturesRoadmapView from './views/FeaturesRoadmap.vue'
-
-/**
- * Row-action handler for the Voorstellen index: POST a parafering-reminder
- * notification for the step the voorstel is currently waiting on. Registered
- * below as a "function" entry so the manifest action
- * `{ id: "reminder", handler: "voorstelReminder" }` can dispatch to it —
- * CnIndexPage calls a function-typed `customComponents[handler]` with
- * `{ actionId, item }` on row-action click. (Replaces the bespoke
- * `sendReminder()` that lived in the deleted VoorstelList.vue.)
- *
- * @param {object} ctx Dispatch context.
- * @param {string} ctx.actionId The action id (`"reminder"`).
- * @param {object} ctx.item The voorstel row.
- * @return {Promise<void>}
- */
-async function voorstelReminder({ actionId, item }) {
-	const steps = (() => {
-		const snap = item && item.routeSnapshot
-		if (!snap) return []
-		try { return typeof snap === 'string' ? JSON.parse(snap) : snap } catch { return [] }
-	})()
-	const current = steps.find((s) => s.order === item.currentStep)
-	const actor = current ? (current.label || current.actor || '-') : '-'
-	try {
-		await fetch('/apps/procest/api/notifications/parafering-reminder', {
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/json',
-				requesttoken: window.OC?.requestToken,
-				'OCS-APIREQUEST': 'true',
-			},
-			body: JSON.stringify({ voorstelId: item.id, actor, onderwerp: item.onderwerp }),
-		})
-	} catch (error) {
-		// eslint-disable-next-line no-console
-		console.error('[procest] parafering reminder failed', error)
-	}
-}
 
 export default {
 	// --- Genuine exceptions: no abstract analogue. ---
@@ -107,10 +61,8 @@ export default {
 	AdminRootView, // multi-tab admin root (lib settings-custom-slot gap)
 
 	// --- Migration cost: deferred to a follow-up. ---
+	VoorstellenView, // status-tabs filter tied to parafeerroute lifecycle
 	VoorstelDetailView, // parafeerroute multi-step approver flow
-
-	// --- Row-action handlers (function entries — dispatched by manifest `handler` id). ---
-	voorstelReminder, // Voorstellen index → POST a parafering reminder
 
 	// --- Anonymous-public routes (no auth, no main menu). ---
 	PublicCaseView,
@@ -127,7 +79,4 @@ export default {
 
 	// --- Shared map surface — referenceable from manifest pages. ---
 	MapComponent,
-
-	// --- Features & Roadmap page (lib's CnFeaturesAndRoadmapView). ---
-	FeaturesRoadmap: FeaturesRoadmapView,
 }

--- a/src/customComponents.js
+++ b/src/customComponents.js
@@ -23,7 +23,8 @@ import WerkvoorraadView from './views/Werkvoorraad.vue'
 // CaseMapView removed — superseded by manifest `type: 'map'` CnMapPage
 // (see openspec/changes/case-map-overview/design.md).
 import DoorlooptijdView from './views/DoorlooptijdDashboard.vue'
-import VoorstellenView from './views/voorstellen/VoorstelList.vue'
+// VoorstellenView removed — VoorstelList.vue deleted in manifest migration;
+// Voorstellen list is now a declarative `type:"index"` on the voorstel schema.
 import VoorstelDetailView from './views/voorstellen/VoorstelDetail.vue'
 import AdminRootView from './views/settings/AdminRoot.vue'
 import PublicCaseView from './views/public/PublicCaseView.vue'
@@ -61,7 +62,7 @@ export default {
 	AdminRootView, // multi-tab admin root (lib settings-custom-slot gap)
 
 	// --- Migration cost: deferred to a follow-up. ---
-	VoorstellenView, // status-tabs filter tied to parafeerroute lifecycle
+	// VoorstellenView removed — superseded by declarative manifest index page.
 	VoorstelDetailView, // parafeerroute multi-step approver flow
 
 	// --- Anonymous-public routes (no auth, no main menu). ---

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,38 +1,234 @@
 {
 	"$schema": "https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest.schema.json",
 	"version": "1.0.0",
-	"dependencies": ["openregister"],
+	"dependencies": [
+		"openregister"
+	],
 	"menu": [
-		{ "id": "Dashboard", "label": "Dashboard", "icon": "icon-category-dashboard", "route": "Dashboard", "order": 10 },
-		{ "id": "MyWork", "label": "My Work", "icon": "icon-checkmark", "route": "MyWork", "order": 20 },
-		{ "id": "Werkvoorraad", "label": "Work Queue", "icon": "icon-group", "route": "Werkvoorraad", "order": 30 },
-		{ "id": "Cases", "label": "Cases", "icon": "icon-folder", "route": "Cases", "order": 40 },
-		{ "id": "Bezwaren", "label": "Bezwaren", "icon": "icon-toggle-filelist", "route": "Bezwaren", "order": 45 },
-		{ "id": "BezwaarDecisions", "label": "Beslissingen op bezwaar", "icon": "icon-toggle", "route": "BezwaarDecisions", "order": 47 },
-		{ "id": "Beroepen", "label": "Beroepen", "icon": "icon-toggle-filelist", "route": "Beroepen", "order": 46 },
-		{ "id": "Tasks", "label": "Tasks", "icon": "icon-checkmark", "route": "Tasks", "order": 50 },
-		{ "id": "CaseMap", "label": "Map", "icon": "icon-address", "route": "CaseMap", "order": 60 },
-		{ "id": "Voorstellen", "label": "Voorstellen", "icon": "icon-comment", "route": "Voorstellen", "order": 70 },
-		{ "id": "Advice", "label": "Advice", "icon": "icon-comment", "route": "Advice", "order": 75 },
-		{ "id": "BezwaarAdviceRequests", "label": "BAC-adviezen", "icon": "icon-comment", "route": "BezwaarAdviceRequests", "order": 76 },
-		{ "id": "Transfers", "label": "Transfers", "icon": "icon-shared", "route": "Transfers", "order": 80 },
-		{ "id": "Documentation", "label": "Documentation", "icon": "icon-info", "href": "https://conduction.gitbook.io/procest-nextcloud", "section": "settings", "order": 90 },
-		{ "id": "CaseTypesMenu", "label": "Case Types", "icon": "icon-category-customization", "route": "CaseTypes", "section": "settings", "order": 95 },
-		{ "id": "LegesverordeningenMenu", "label": "Legesverordeningen", "icon": "icon-category-office", "route": "Legesverordeningen", "section": "settings", "order": 96 },
-		{ "id": "LegesberekeningenMenu", "label": "Legesberekeningen", "icon": "icon-category-monitoring", "route": "Legesberekeningen", "section": "settings", "order": 97 },
-		{ "id": "PartnersMenu", "label": "Partner organisations", "icon": "icon-group", "route": "Partners", "section": "settings", "order": 97 },
-		{ "id": "TenantsMenu", "label": "Tenants", "icon": "icon-group", "route": "Tenants", "section": "settings", "order": 98, "permission": "admin" },
-		{ "id": "ParafeerroutesMenu", "label": "Parafeerroutes", "icon": "icon-category-workflow", "route": "Parafeerroutes", "section": "settings", "order": 96 },
-		{ "id": "WmsLayersMenu", "label": "Kaartlagen", "icon": "icon-category-files", "route": "WmsLayers", "section": "settings", "order": 97, "permission": "admin" },
-		{ "id": "WorkflowDefinitionsMenu", "label": "Workflow definitions", "icon": "icon-category-workflow", "route": "WorkflowDefinitions", "section": "settings", "order": 97 },
-		{ "id": "AutomaticActionsMenu", "label": "Automatische acties", "icon": "icon-category-workflow", "route": "AutomaticActions", "section": "settings", "order": 96 },
-		{ "id": "StatusRecordsMenu", "label": "Status history", "icon": "icon-history", "route": "StatusRecords", "section": "settings", "order": 98, "permission": "admin" },
-		{ "id": "LhsMatricesMenu", "label": "Handhavingsstrategie", "icon": "icon-category-customization", "route": "LhsMatrices", "section": "settings", "order": 96, "permission": "admin" },
-		{ "id": "LhsRecommendationsMenu", "label": "LHS Recommendations", "icon": "icon-comment", "route": "LhsRecommendations", "section": "settings", "order": 97 },
-		{ "id": "LocationsMenu", "label": "Case locations", "icon": "icon-address", "route": "Locations", "section": "settings", "order": 98, "permission": "admin" },
-		{ "id": "BezwaarCommitteesMenu", "label": "Bezwaaradviescommissies", "icon": "icon-group", "route": "BezwaarCommittees", "section": "settings", "order": 99 },
-		{ "id": "SettingsMenu", "label": "Settings", "icon": "icon-settings", "route": "Settings", "section": "settings", "order": 99 },
-		{ "id": "FeaturesRoadmapMenu", "label": "Features & roadmap", "icon": "icon-toggle", "route": "FeaturesRoadmap", "section": "settings", "order": 100 }
+		{
+			"id": "Dashboard",
+			"label": "Dashboard",
+			"icon": "icon-category-dashboard",
+			"route": "Dashboard",
+			"order": 10
+		},
+		{
+			"id": "MyWork",
+			"label": "My Work",
+			"icon": "icon-checkmark",
+			"route": "MyWork",
+			"order": 20
+		},
+		{
+			"id": "Werkvoorraad",
+			"label": "Work Queue",
+			"icon": "icon-group",
+			"route": "Werkvoorraad",
+			"order": 30
+		},
+		{
+			"id": "Cases",
+			"label": "Cases",
+			"icon": "icon-folder",
+			"route": "Cases",
+			"order": 40
+		},
+		{
+			"id": "Bezwaren",
+			"label": "Bezwaren",
+			"icon": "icon-toggle-filelist",
+			"route": "Bezwaren",
+			"order": 45
+		},
+		{
+			"id": "BezwaarDecisions",
+			"label": "Beslissingen op bezwaar",
+			"icon": "icon-toggle",
+			"route": "BezwaarDecisions",
+			"order": 47
+		},
+		{
+			"id": "Beroepen",
+			"label": "Beroepen",
+			"icon": "icon-toggle-filelist",
+			"route": "Beroepen",
+			"order": 46
+		},
+		{
+			"id": "Tasks",
+			"label": "Tasks",
+			"icon": "icon-checkmark",
+			"route": "Tasks",
+			"order": 50
+		},
+		{
+			"id": "CaseMap",
+			"label": "Map",
+			"icon": "icon-address",
+			"route": "CaseMap",
+			"order": 60
+		},
+		{
+			"id": "Voorstellen",
+			"label": "Voorstellen",
+			"icon": "icon-comment",
+			"route": "Voorstellen",
+			"order": 70
+		},
+		{
+			"id": "Advice",
+			"label": "Advice",
+			"icon": "icon-comment",
+			"route": "Advice",
+			"order": 75
+		},
+		{
+			"id": "BezwaarAdviceRequests",
+			"label": "BAC-adviezen",
+			"icon": "icon-comment",
+			"route": "BezwaarAdviceRequests",
+			"order": 76
+		},
+		{
+			"id": "Transfers",
+			"label": "Transfers",
+			"icon": "icon-shared",
+			"route": "Transfers",
+			"order": 80
+		},
+		{
+			"id": "Documentation",
+			"label": "Documentation",
+			"icon": "icon-info",
+			"href": "https://conduction.gitbook.io/procest-nextcloud",
+			"section": "settings",
+			"order": 90
+		},
+		{
+			"id": "CaseTypesMenu",
+			"label": "Case Types",
+			"icon": "icon-category-customization",
+			"route": "CaseTypes",
+			"section": "settings",
+			"order": 95
+		},
+		{
+			"id": "LegesverordeningenMenu",
+			"label": "Legesverordeningen",
+			"icon": "icon-category-office",
+			"route": "Legesverordeningen",
+			"section": "settings",
+			"order": 96
+		},
+		{
+			"id": "LegesberekeningenMenu",
+			"label": "Legesberekeningen",
+			"icon": "icon-category-monitoring",
+			"route": "Legesberekeningen",
+			"section": "settings",
+			"order": 97
+		},
+		{
+			"id": "PartnersMenu",
+			"label": "Partner organisations",
+			"icon": "icon-group",
+			"route": "Partners",
+			"section": "settings",
+			"order": 97
+		},
+		{
+			"id": "TenantsMenu",
+			"label": "Tenants",
+			"icon": "icon-group",
+			"route": "Tenants",
+			"section": "settings",
+			"order": 98,
+			"permission": "admin"
+		},
+		{
+			"id": "ParafeerroutesMenu",
+			"label": "Parafeerroutes",
+			"icon": "icon-category-workflow",
+			"route": "Parafeerroutes",
+			"section": "settings",
+			"order": 96
+		},
+		{
+			"id": "WmsLayersMenu",
+			"label": "Kaartlagen",
+			"icon": "icon-category-files",
+			"route": "WmsLayers",
+			"section": "settings",
+			"order": 97,
+			"permission": "admin"
+		},
+		{
+			"id": "WorkflowDefinitionsMenu",
+			"label": "Workflow definitions",
+			"icon": "icon-category-workflow",
+			"route": "WorkflowDefinitions",
+			"section": "settings",
+			"order": 97
+		},
+		{
+			"id": "AutomaticActionsMenu",
+			"label": "Automatische acties",
+			"icon": "icon-category-workflow",
+			"route": "AutomaticActions",
+			"section": "settings",
+			"order": 96
+		},
+		{
+			"id": "StatusRecordsMenu",
+			"label": "Status history",
+			"icon": "icon-history",
+			"route": "StatusRecords",
+			"section": "settings",
+			"order": 98,
+			"permission": "admin"
+		},
+		{
+			"id": "LhsMatricesMenu",
+			"label": "Handhavingsstrategie",
+			"icon": "icon-category-customization",
+			"route": "LhsMatrices",
+			"section": "settings",
+			"order": 96,
+			"permission": "admin"
+		},
+		{
+			"id": "LhsRecommendationsMenu",
+			"label": "LHS Recommendations",
+			"icon": "icon-comment",
+			"route": "LhsRecommendations",
+			"section": "settings",
+			"order": 97
+		},
+		{
+			"id": "LocationsMenu",
+			"label": "Case locations",
+			"icon": "icon-address",
+			"route": "Locations",
+			"section": "settings",
+			"order": 98,
+			"permission": "admin"
+		},
+		{
+			"id": "BezwaarCommitteesMenu",
+			"label": "Bezwaaradviescommissies",
+			"icon": "icon-group",
+			"route": "BezwaarCommittees",
+			"section": "settings",
+			"order": 99
+		},
+		{
+			"id": "SettingsMenu",
+			"label": "Settings",
+			"icon": "icon-settings",
+			"route": "Settings",
+			"section": "settings",
+			"order": 99
+		}
 	],
 	"pages": [
 		{
@@ -42,32 +238,176 @@
 			"title": "Dashboard",
 			"config": {
 				"widgets": [
-					{ "id": "count-open-cases", "type": "custom", "title": "Open Cases" },
-					{ "id": "count-overdue", "type": "custom", "title": "Overdue" },
-					{ "id": "count-completed", "type": "custom", "title": "Completed This Month" },
-					{ "id": "count-my-tasks", "type": "custom", "title": "My Tasks" },
-					{ "id": "count-sla", "type": "custom", "title": "SLA Compliance" },
-					{ "id": "cases-by-status", "type": "custom", "title": "Cases by Status" },
-					{ "id": "cases-by-type", "type": "custom", "title": "Cases by Type" },
-					{ "id": "my-work", "type": "custom", "title": "My Work" },
-					{ "id": "case-map", "type": "custom", "title": "Case Map" },
-					{ "id": "deadline-alerts", "type": "custom", "title": "Deadline Alerts" },
-					{ "id": "task-due-reminders", "type": "custom", "title": "Task Due Reminders" },
-					{ "id": "stalled-cases", "type": "custom", "title": "Stalled Cases" }
+					{
+						"id": "count-open-cases",
+						"type": "custom",
+						"title": "Open Cases"
+					},
+					{
+						"id": "count-overdue",
+						"type": "custom",
+						"title": "Overdue"
+					},
+					{
+						"id": "count-completed",
+						"type": "custom",
+						"title": "Completed This Month"
+					},
+					{
+						"id": "count-my-tasks",
+						"type": "custom",
+						"title": "My Tasks"
+					},
+					{
+						"id": "count-sla",
+						"type": "custom",
+						"title": "SLA Compliance"
+					},
+					{
+						"id": "cases-by-status",
+						"type": "custom",
+						"title": "Cases by Status"
+					},
+					{
+						"id": "cases-by-type",
+						"type": "custom",
+						"title": "Cases by Type"
+					},
+					{
+						"id": "my-work",
+						"type": "custom",
+						"title": "My Work"
+					},
+					{
+						"id": "case-map",
+						"type": "custom",
+						"title": "Case Map"
+					},
+					{
+						"id": "deadline-alerts",
+						"type": "custom",
+						"title": "Deadline Alerts"
+					},
+					{
+						"id": "task-due-reminders",
+						"type": "custom",
+						"title": "Task Due Reminders"
+					},
+					{
+						"id": "stalled-cases",
+						"type": "custom",
+						"title": "Stalled Cases"
+					}
 				],
 				"layout": [
-					{ "id": "count-open-cases",   "widgetId": "count-open-cases",   "gridX": 0,  "gridY": 0, "gridWidth": 2, "gridHeight": 2, "showTitle": false },
-					{ "id": "count-overdue",      "widgetId": "count-overdue",      "gridX": 2,  "gridY": 0, "gridWidth": 3, "gridHeight": 2, "showTitle": false },
-					{ "id": "count-completed",    "widgetId": "count-completed",    "gridX": 5,  "gridY": 0, "gridWidth": 3, "gridHeight": 2, "showTitle": false },
-					{ "id": "count-my-tasks",     "widgetId": "count-my-tasks",     "gridX": 8,  "gridY": 0, "gridWidth": 2, "gridHeight": 2, "showTitle": false },
-					{ "id": "count-sla",          "widgetId": "count-sla",          "gridX": 10, "gridY": 0, "gridWidth": 2, "gridHeight": 2, "showTitle": false },
-					{ "id": "cases-by-status",    "widgetId": "cases-by-status",    "gridX": 0,  "gridY": 2, "gridWidth": 4, "gridHeight": 4, "showTitle": true },
-					{ "id": "cases-by-type",      "widgetId": "cases-by-type",      "gridX": 4,  "gridY": 2, "gridWidth": 4, "gridHeight": 4, "showTitle": true },
-					{ "id": "my-work",            "widgetId": "my-work",            "gridX": 8,  "gridY": 2, "gridWidth": 4, "gridHeight": 4, "showTitle": true },
-					{ "id": "deadline-alerts",    "widgetId": "deadline-alerts",    "gridX": 0,  "gridY": 6, "gridWidth": 4, "gridHeight": 4, "showTitle": true },
-					{ "id": "task-due-reminders", "widgetId": "task-due-reminders", "gridX": 4,  "gridY": 6, "gridWidth": 4, "gridHeight": 4, "showTitle": true },
-					{ "id": "stalled-cases",      "widgetId": "stalled-cases",      "gridX": 8,  "gridY": 6, "gridWidth": 4, "gridHeight": 4, "showTitle": true },
-					{ "id": "case-map",           "widgetId": "case-map",           "gridX": 0,  "gridY": 10, "gridWidth": 12, "gridHeight": 6, "showTitle": true }
+					{
+						"id": "count-open-cases",
+						"widgetId": "count-open-cases",
+						"gridX": 0,
+						"gridY": 0,
+						"gridWidth": 2,
+						"gridHeight": 2,
+						"showTitle": false
+					},
+					{
+						"id": "count-overdue",
+						"widgetId": "count-overdue",
+						"gridX": 2,
+						"gridY": 0,
+						"gridWidth": 3,
+						"gridHeight": 2,
+						"showTitle": false
+					},
+					{
+						"id": "count-completed",
+						"widgetId": "count-completed",
+						"gridX": 5,
+						"gridY": 0,
+						"gridWidth": 3,
+						"gridHeight": 2,
+						"showTitle": false
+					},
+					{
+						"id": "count-my-tasks",
+						"widgetId": "count-my-tasks",
+						"gridX": 8,
+						"gridY": 0,
+						"gridWidth": 2,
+						"gridHeight": 2,
+						"showTitle": false
+					},
+					{
+						"id": "count-sla",
+						"widgetId": "count-sla",
+						"gridX": 10,
+						"gridY": 0,
+						"gridWidth": 2,
+						"gridHeight": 2,
+						"showTitle": false
+					},
+					{
+						"id": "cases-by-status",
+						"widgetId": "cases-by-status",
+						"gridX": 0,
+						"gridY": 2,
+						"gridWidth": 4,
+						"gridHeight": 4,
+						"showTitle": true
+					},
+					{
+						"id": "cases-by-type",
+						"widgetId": "cases-by-type",
+						"gridX": 4,
+						"gridY": 2,
+						"gridWidth": 4,
+						"gridHeight": 4,
+						"showTitle": true
+					},
+					{
+						"id": "my-work",
+						"widgetId": "my-work",
+						"gridX": 8,
+						"gridY": 2,
+						"gridWidth": 4,
+						"gridHeight": 4,
+						"showTitle": true
+					},
+					{
+						"id": "deadline-alerts",
+						"widgetId": "deadline-alerts",
+						"gridX": 0,
+						"gridY": 6,
+						"gridWidth": 4,
+						"gridHeight": 4,
+						"showTitle": true
+					},
+					{
+						"id": "task-due-reminders",
+						"widgetId": "task-due-reminders",
+						"gridX": 4,
+						"gridY": 6,
+						"gridWidth": 4,
+						"gridHeight": 4,
+						"showTitle": true
+					},
+					{
+						"id": "stalled-cases",
+						"widgetId": "stalled-cases",
+						"gridX": 8,
+						"gridY": 6,
+						"gridWidth": 4,
+						"gridHeight": 4,
+						"showTitle": true
+					},
+					{
+						"id": "case-map",
+						"widgetId": "case-map",
+						"gridX": 0,
+						"gridY": 10,
+						"gridWidth": 12,
+						"gridHeight": 6,
+						"showTitle": true
+					}
 				]
 			}
 		},
@@ -93,8 +433,18 @@
 			"config": {
 				"register": "procest",
 				"schema": "case",
-				"columns": ["identifier", "title", "caseType", "status", "assignee", "deadline"],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"columns": [
+					"identifier",
+					"title",
+					"caseType",
+					"status",
+					"assignee",
+					"deadline"
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -106,10 +456,41 @@
 				"register": "procest",
 				"schema": "case",
 				"sidebarTabs": [
-					{ "id": "overview",  "label": "Overview",    "icon": "icon-info",      "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
-					{ "id": "tasks",     "label": "Tasks",       "icon": "icon-checkmark", "component": "CaseTasksTab",                              "order": 20 },
-					{ "id": "decisions", "label": "Decisions",   "icon": "icon-toggle",    "component": "CaseDecisionsTab",                          "order": 30 },
-					{ "id": "documents", "label": "Documents",   "icon": "icon-files",     "component": "CaseDocumentsTab",                          "order": 40 },
+					{
+						"id": "overview",
+						"label": "Overview",
+						"icon": "icon-info",
+						"widgets": [
+							{
+								"type": "data"
+							},
+							{
+								"type": "metadata"
+							}
+						],
+						"order": 10
+					},
+					{
+						"id": "tasks",
+						"label": "Tasks",
+						"icon": "icon-checkmark",
+						"component": "CaseTasksTab",
+						"order": 20
+					},
+					{
+						"id": "decisions",
+						"label": "Decisions",
+						"icon": "icon-toggle",
+						"component": "CaseDecisionsTab",
+						"order": 30
+					},
+					{
+						"id": "documents",
+						"label": "Documents",
+						"icon": "icon-files",
+						"component": "CaseDocumentsTab",
+						"order": 40
+					},
 					{
 						"id": "locaties",
 						"label": "Locaties",
@@ -120,16 +501,44 @@
 								"config": {
 									"register": "procest",
 									"schema": "location",
-									"filter": { "case": ":id" },
-									"columns": ["label", "formattedAddress", "nummeraanduidingId", "parcelId", "source"],
-									"actions": ["create", "edit", "delete"]
+									"filter": {
+										"case": ":id"
+									},
+									"columns": [
+										"label",
+										"formattedAddress",
+										"nummeraanduidingId",
+										"parcelId",
+										"source"
+									],
+									"actions": [
+										"create",
+										"edit",
+										"delete"
+									]
 								}
 							}
 						],
 						"order": 45
 					},
-					{ "id": "advies",    "label": "Advies",      "icon": "icon-comment",   "component": "AdviesPanel",                               "order": 50 },
-					{ "id": "audit",     "label": "Audit trail", "icon": "icon-history",   "widgets": [{ "type": "audit-trail" }],                   "order": 90 }
+					{
+						"id": "advies",
+						"label": "Advies",
+						"icon": "icon-comment",
+						"component": "AdviesPanel",
+						"order": 50
+					},
+					{
+						"id": "audit",
+						"label": "Audit trail",
+						"icon": "icon-history",
+						"widgets": [
+							{
+								"type": "audit-trail"
+							}
+						],
+						"order": 90
+					}
 				]
 			}
 		},
@@ -141,8 +550,18 @@
 			"config": {
 				"register": "procest",
 				"schema": "bezwaar",
-				"columns": ["case", "status", "ontvangstdatum", "decisionDeadline", "awbReference", "dwangsom"],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"columns": [
+					"case",
+					"status",
+					"ontvangstdatum",
+					"decisionDeadline",
+					"awbReference",
+					"dwangsom"
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -154,11 +573,52 @@
 				"register": "procest",
 				"schema": "bezwaar",
 				"sidebarTabs": [
-					{ "id": "overview", "label": "Overview", "icon": "icon-info",     "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
-					{ "id": "advice",   "label": "Advice",   "icon": "icon-comment",  "component": "AdviesPanel",                              "order": 20 },
-					{ "id": "hearing",  "label": "Hearing",  "icon": "icon-group",    "component": "CaseTasksTab",                             "order": 30 },
-					{ "id": "decision", "label": "Decision", "icon": "icon-toggle",   "component": "CaseDecisionsTab",                         "order": 40 },
-					{ "id": "audit",    "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }],                "order": 90 }
+					{
+						"id": "overview",
+						"label": "Overview",
+						"icon": "icon-info",
+						"widgets": [
+							{
+								"type": "data"
+							},
+							{
+								"type": "metadata"
+							}
+						],
+						"order": 10
+					},
+					{
+						"id": "advice",
+						"label": "Advice",
+						"icon": "icon-comment",
+						"component": "AdviesPanel",
+						"order": 20
+					},
+					{
+						"id": "hearing",
+						"label": "Hearing",
+						"icon": "icon-group",
+						"component": "CaseTasksTab",
+						"order": 30
+					},
+					{
+						"id": "decision",
+						"label": "Decision",
+						"icon": "icon-toggle",
+						"component": "CaseDecisionsTab",
+						"order": 40
+					},
+					{
+						"id": "audit",
+						"label": "Audit trail",
+						"icon": "icon-history",
+						"widgets": [
+							{
+								"type": "audit-trail"
+							}
+						],
+						"order": 90
+					}
 				]
 			}
 		},
@@ -170,11 +630,27 @@
 			"config": {
 				"register": "procest",
 				"schema": "bezwaarDecision",
-				"columns": ["bezwaar", "dispositionType", "decisionDate", "effectiveDate", "status", "publishedAt"],
-				"actions": [
-					{ "id": "view", "label": "View", "icon": "icon-info", "handler": "navigate", "route": "BezwaarDecisionDetail" }
+				"columns": [
+					"bezwaar",
+					"dispositionType",
+					"decisionDate",
+					"effectiveDate",
+					"status",
+					"publishedAt"
 				],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"actions": [
+					{
+						"id": "view",
+						"label": "View",
+						"icon": "icon-info",
+						"handler": "navigate",
+						"route": "BezwaarDecisionDetail"
+					}
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -186,10 +662,73 @@
 				"register": "procest",
 				"schema": "bezwaarDecision",
 				"sidebarTabs": [
-					{ "id": "overview",      "label": "Overview",      "icon": "icon-info",    "widgets": [{ "type": "data" }, { "type": "metadata" }],                                                                                                                                "order": 10 },
-					{ "id": "appeal-notice", "label": "Appeal notice", "icon": "icon-toggle",  "widgets": [{ "type": "data", "config": { "fields": ["appealNotice"] } }],                                                                                                                "order": 20 },
-					{ "id": "documents",     "label": "Documents",     "icon": "icon-files",   "widgets": [{ "type": "data", "config": { "fields": ["decisionDocument", "replacementDecision"] } }],                                                                                    "order": 30 },
-					{ "id": "audit",         "label": "Audit",         "icon": "icon-history", "widgets": [{ "type": "audit-trail" }, { "type": "data", "config": { "fields": ["publishedAt", "notifiedRecipients"] } }],                                                               "order": 90 }
+					{
+						"id": "overview",
+						"label": "Overview",
+						"icon": "icon-info",
+						"widgets": [
+							{
+								"type": "data"
+							},
+							{
+								"type": "metadata"
+							}
+						],
+						"order": 10
+					},
+					{
+						"id": "appeal-notice",
+						"label": "Appeal notice",
+						"icon": "icon-toggle",
+						"widgets": [
+							{
+								"type": "data",
+								"config": {
+									"fields": [
+										"appealNotice"
+									]
+								}
+							}
+						],
+						"order": 20
+					},
+					{
+						"id": "documents",
+						"label": "Documents",
+						"icon": "icon-files",
+						"widgets": [
+							{
+								"type": "data",
+								"config": {
+									"fields": [
+										"decisionDocument",
+										"replacementDecision"
+									]
+								}
+							}
+						],
+						"order": 30
+					},
+					{
+						"id": "audit",
+						"label": "Audit",
+						"icon": "icon-history",
+						"widgets": [
+							{
+								"type": "audit-trail"
+							},
+							{
+								"type": "data",
+								"config": {
+									"fields": [
+										"publishedAt",
+										"notifiedRecipients"
+									]
+								}
+							}
+						],
+						"order": 90
+					}
 				]
 			}
 		},
@@ -201,8 +740,17 @@
 			"config": {
 				"register": "procest",
 				"schema": "task",
-				"columns": ["title", "case", "assignee", "status", "dueDate"],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"columns": [
+					"title",
+					"case",
+					"assignee",
+					"status",
+					"dueDate"
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -214,8 +762,31 @@
 				"register": "procest",
 				"schema": "task",
 				"sidebarTabs": [
-					{ "id": "overview", "label": "Overview",    "icon": "icon-info",    "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
-					{ "id": "audit",    "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }],                   "order": 90 }
+					{
+						"id": "overview",
+						"label": "Overview",
+						"icon": "icon-info",
+						"widgets": [
+							{
+								"type": "data"
+							},
+							{
+								"type": "metadata"
+							}
+						],
+						"order": 10
+					},
+					{
+						"id": "audit",
+						"label": "Audit trail",
+						"icon": "icon-history",
+						"widgets": [
+							{
+								"type": "audit-trail"
+							}
+						],
+						"order": 90
+					}
 				]
 			}
 		},
@@ -228,8 +799,31 @@
 				"register": "procest",
 				"schema": "task",
 				"sidebarTabs": [
-					{ "id": "overview", "label": "Overview",    "icon": "icon-info",    "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
-					{ "id": "audit",    "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }],                   "order": 90 }
+					{
+						"id": "overview",
+						"label": "Overview",
+						"icon": "icon-info",
+						"widgets": [
+							{
+								"type": "data"
+							},
+							{
+								"type": "metadata"
+							}
+						],
+						"order": 10
+					},
+					{
+						"id": "audit",
+						"label": "Audit trail",
+						"icon": "icon-history",
+						"widgets": [
+							{
+								"type": "audit-trail"
+							}
+						],
+						"order": 90
+					}
 				]
 			}
 		},
@@ -242,12 +836,33 @@
 				"register": "procest",
 				"schema": "case",
 				"geometryField": "geometry",
-				"filters": ["status", "caseType", "assignee", "deadlineRange"],
-				"marker": { "formatter": "caseMarkerFormatter" },
-				"clustering": { "enabled": true, "disableAtZoom": 14, "priority": ["blocked", "in_progress", "open", "closed"] },
-				"bboxQuery": { "threshold": 5000 },
+				"filters": [
+					"status",
+					"caseType",
+					"assignee",
+					"deadlineRange"
+				],
+				"marker": {
+					"formatter": "caseMarkerFormatter"
+				},
+				"clustering": {
+					"enabled": true,
+					"disableAtZoom": 14,
+					"priority": [
+						"blocked",
+						"in_progress",
+						"open",
+						"closed"
+					]
+				},
+				"bboxQuery": {
+					"threshold": 5000
+				},
 				"tileLayer": "pdok-brt",
-				"sidebar": { "enabled": true, "filtersOpen": true },
+				"sidebar": {
+					"enabled": true,
+					"filtersOpen": true
+				},
 				"emptyState": {
 					"icon": "icon-address",
 					"title": "Geen zaken op de kaart",
@@ -258,31 +873,9 @@
 		{
 			"id": "Voorstellen",
 			"route": "/voorstellen",
-			"type": "index",
+			"type": "custom",
 			"title": "Voorstellen",
-			"config": {
-				"register": "procest",
-				"schema": "voorstel",
-				"quickFilters": [
-					{ "label": "Alle", "filter": {}, "default": true },
-					{ "label": "Concept", "filter": { "status": "concept" } },
-					{ "label": "In behandeling", "filter": { "status": ["in_parafering", "ter_accordering", "geaccordeerd", "aangeboden", "teruggestuurd"] } },
-					{ "label": "Afgerond", "filter": { "status": ["besloten", "gearchiveerd"] } }
-				],
-				"columns": [
-					{ "key": "onderwerp", "label": "Onderwerp" },
-					{ "key": "type", "label": "Type", "formatter": "voorstelType" },
-					{ "key": "status", "label": "Status", "formatter": "voorstelStatus", "widget": "badge" },
-					{ "key": "currentStep", "label": "Stap", "formatter": "voorstelStepProgress", "sortable": false },
-					{ "key": "routeSnapshot", "label": "Wacht op", "formatter": "voorstelWaitingActor", "sortable": false },
-					{ "key": "@self.updated", "label": "Dagen in stap", "formatter": "voorstelDaysInStep", "align": "right" },
-					{ "key": "steller", "label": "Steller" }
-				],
-				"actions": [
-					{ "id": "reminder", "label": "Herinnering sturen", "icon": "BellRing", "handler": "voorstelReminder" }
-				],
-				"sidebar": { "enabled": true, "showMetadata": true }
-			}
+			"component": "VoorstellenView"
 		},
 		{
 			"id": "VoorstelDetail",
@@ -299,8 +892,18 @@
 			"config": {
 				"register": "procest",
 				"schema": "adviesAanvraag",
-				"columns": ["onderwerp", "case", "adviseur", "type", "status", "deadline"],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"columns": [
+					"onderwerp",
+					"case",
+					"adviseur",
+					"type",
+					"status",
+					"deadline"
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -312,8 +915,31 @@
 				"register": "procest",
 				"schema": "adviesAanvraag",
 				"sidebarTabs": [
-					{ "id": "overview", "label": "Overview",    "icon": "icon-info",    "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
-					{ "id": "audit",    "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }],                   "order": 90 }
+					{
+						"id": "overview",
+						"label": "Overview",
+						"icon": "icon-info",
+						"widgets": [
+							{
+								"type": "data"
+							},
+							{
+								"type": "metadata"
+							}
+						],
+						"order": 10
+					},
+					{
+						"id": "audit",
+						"label": "Audit trail",
+						"icon": "icon-history",
+						"widgets": [
+							{
+								"type": "audit-trail"
+							}
+						],
+						"order": 90
+					}
 				]
 			}
 		},
@@ -346,9 +972,35 @@
 			"config": {
 				"register": "procest",
 				"schema": "legesverordening",
-				"columns": ["name", "year", "effectiveDate", "status", "isActive"],
-				"actions": ["create", "edit", "delete", "view"],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"columns": [
+					"name",
+					"year",
+					"effectiveDate",
+					"status",
+					"isActive"
+				],
+				"actions": [
+					{
+						"id": "create",
+						"label": "Create"
+					},
+					{
+						"id": "edit",
+						"label": "Edit"
+					},
+					{
+						"id": "delete",
+						"label": "Delete"
+					},
+					{
+						"id": "view",
+						"label": "View"
+					}
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -359,12 +1011,35 @@
 			"config": {
 				"register": "procest",
 				"schema": "tenant",
-				"columns": ["name", "slug", "oin", "domain", "groupId", "isActive"],
-				"actions": [
-					{ "id": "provision", "label": "Provision", "icon": "icon-add", "permission": "admin", "handler": "emit" },
-					{ "id": "view",      "label": "View usage", "icon": "icon-info", "permission": "admin", "handler": "navigate", "route": "TenantDetail" }
+				"columns": [
+					"name",
+					"slug",
+					"oin",
+					"domain",
+					"groupId",
+					"isActive"
 				],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"actions": [
+					{
+						"id": "provision",
+						"label": "Provision",
+						"icon": "icon-add",
+						"permission": "admin",
+						"handler": "emit"
+					},
+					{
+						"id": "view",
+						"label": "View usage",
+						"icon": "icon-info",
+						"permission": "admin",
+						"handler": "navigate",
+						"route": "TenantDetail"
+					}
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -376,16 +1051,25 @@
 				"register": "procest",
 				"schema": "parafeerroute",
 				"columns": [
-					{ "key": "name" },
-					{ "key": "voorstelType" },
-					{ "key": "caseType" },
-					{ "key": "isDefault" }
+					"name",
+					"voorstelType",
+					"caseType",
+					"isDefault"
 				],
 				"actions": [
-					{ "key": "edit" },
-					{ "key": "delete" }
+					{
+						"id": "edit",
+						"label": "Edit"
+					},
+					{
+						"id": "delete",
+						"label": "Delete"
+					}
 				],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -393,24 +1077,35 @@
 			"route": "/settings/wms-layers",
 			"type": "index",
 			"title": "Kaartlagen",
-			"permission": "admin",
 			"config": {
 				"register": "procest",
 				"schema": "wmsLayer",
 				"columns": [
-					{ "key": "title" },
-					{ "key": "type" },
-					{ "key": "url" },
-					{ "key": "layerName" },
-					{ "key": "queryable" },
-					{ "key": "active" }
+					"title",
+					"type",
+					"url",
+					"layerName",
+					"queryable",
+					"active"
 				],
 				"actions": [
-					{ "key": "create" },
-					{ "key": "edit" },
-					{ "key": "delete" }
+					{
+						"id": "create",
+						"label": "Create"
+					},
+					{
+						"id": "edit",
+						"label": "Edit"
+					},
+					{
+						"id": "delete",
+						"label": "Delete"
+					}
 				],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -418,7 +1113,6 @@
 			"route": "/settings/wms-layers/:id",
 			"type": "detail",
 			"title": "Kaartlaag",
-			"permission": "admin",
 			"config": {
 				"register": "procest",
 				"schema": "wmsLayer",
@@ -428,8 +1122,12 @@
 						"label": "Overview",
 						"icon": "icon-info",
 						"widgets": [
-							{ "type": "data" },
-							{ "type": "metadata" }
+							{
+								"type": "data"
+							},
+							{
+								"type": "metadata"
+							}
 						],
 						"order": 10
 					},
@@ -442,7 +1140,10 @@
 								"type": "action",
 								"config": {
 									"endpoint": "/api/wms-wfs/proxy",
-									"params": { "layerId": ":id", "request": "GetCapabilities" },
+									"params": {
+										"layerId": ":id",
+										"request": "GetCapabilities"
+									},
 									"label": "Verbinding testen"
 								}
 							}
@@ -466,8 +1167,12 @@
 						"label": "Overview",
 						"icon": "icon-info",
 						"widgets": [
-							{ "type": "data" },
-							{ "type": "metadata" }
+							{
+								"type": "data"
+							},
+							{
+								"type": "metadata"
+							}
 						],
 						"order": 10
 					},
@@ -481,9 +1186,21 @@
 								"config": {
 									"register": "procest",
 									"schema": "legesartikel",
-									"filter": { "verordening": ":id" },
-									"columns": ["nummer", "omschrijving", "type", "category", "order"],
-									"actions": ["create", "edit", "delete"]
+									"filter": {
+										"verordening": ":id"
+									},
+									"columns": [
+										"nummer",
+										"omschrijving",
+										"type",
+										"category",
+										"order"
+									],
+									"actions": [
+										"create",
+										"edit",
+										"delete"
+									]
 								}
 							}
 						],
@@ -493,7 +1210,11 @@
 						"id": "audit",
 						"label": "Audit trail",
 						"icon": "icon-history",
-						"widgets": [{ "type": "audit-trail" }],
+						"widgets": [
+							{
+								"type": "audit-trail"
+							}
+						],
 						"order": 90
 					}
 				]
@@ -507,9 +1228,29 @@
 			"config": {
 				"register": "procest",
 				"schema": "legesberekening",
-				"columns": ["case", "verordening", "total", "version", "status", "calculatedBy", "calculatedAt"],
-				"actions": ["view", "delete"],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"columns": [
+					"case",
+					"verordening",
+					"total",
+					"version",
+					"status",
+					"calculatedBy",
+					"calculatedAt"
+				],
+				"actions": [
+					{
+						"id": "view",
+						"label": "View"
+					},
+					{
+						"id": "delete",
+						"label": "Delete"
+					}
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -526,8 +1267,12 @@
 						"label": "Overview",
 						"icon": "icon-info",
 						"widgets": [
-							{ "type": "data" },
-							{ "type": "metadata" }
+							{
+								"type": "data"
+							},
+							{
+								"type": "metadata"
+							}
 						],
 						"order": 10
 					},
@@ -535,7 +1280,11 @@
 						"id": "audit",
 						"label": "Audit trail",
 						"icon": "icon-history",
-						"widgets": [{ "type": "audit-trail" }],
+						"widgets": [
+							{
+								"type": "audit-trail"
+							}
+						],
 						"order": 90
 					}
 				]
@@ -550,13 +1299,59 @@
 				"register": "procest",
 				"schema": "tenant",
 				"actions": [
-					{ "id": "provision",     "label": "Provision",      "icon": "icon-add",     "permission": "admin", "primary": true, "handler": "emit" },
-					{ "id": "refresh-usage", "label": "Refresh usage",  "icon": "icon-history", "permission": "admin",                  "handler": "emit" }
+					{
+						"id": "provision",
+						"label": "Provision",
+						"icon": "icon-add",
+						"permission": "admin",
+						"primary": true,
+						"handler": "emit"
+					},
+					{
+						"id": "refresh-usage",
+						"label": "Refresh usage",
+						"icon": "icon-history",
+						"permission": "admin",
+						"handler": "emit"
+					}
 				],
 				"sidebarTabs": [
-					{ "id": "overview",     "label": "Overview",             "icon": "icon-info",    "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
-					{ "id": "usage",        "label": "Usage",                "icon": "icon-quota",   "widgets": [{ "type": "data" }],                          "order": 20 },
-					{ "id": "provisioning", "label": "Provisioning history", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }],                   "order": 30 }
+					{
+						"id": "overview",
+						"label": "Overview",
+						"icon": "icon-info",
+						"widgets": [
+							{
+								"type": "data"
+							},
+							{
+								"type": "metadata"
+							}
+						],
+						"order": 10
+					},
+					{
+						"id": "usage",
+						"label": "Usage",
+						"icon": "icon-quota",
+						"widgets": [
+							{
+								"type": "data"
+							}
+						],
+						"order": 20
+					},
+					{
+						"id": "provisioning",
+						"label": "Provisioning history",
+						"icon": "icon-history",
+						"widgets": [
+							{
+								"type": "audit-trail"
+							}
+						],
+						"order": 30
+					}
 				]
 			}
 		},
@@ -569,8 +1364,31 @@
 				"register": "procest",
 				"schema": "parafeerroute",
 				"sidebarTabs": [
-					{ "id": "overview", "label": "Overview",    "icon": "icon-info",    "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
-					{ "id": "audit",    "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }],                   "order": 90 }
+					{
+						"id": "overview",
+						"label": "Overview",
+						"icon": "icon-info",
+						"widgets": [
+							{
+								"type": "data"
+							},
+							{
+								"type": "metadata"
+							}
+						],
+						"order": 10
+					},
+					{
+						"id": "audit",
+						"label": "Audit trail",
+						"icon": "icon-history",
+						"widgets": [
+							{
+								"type": "audit-trail"
+							}
+						],
+						"order": 90
+					}
 				]
 			}
 		},
@@ -582,9 +1400,16 @@
 			"config": {
 				"register": "procest",
 				"schema": "caseShare",
-				"filter": { "caseId": "@route.caseId" },
-				"columns": ["label", "shareType", "partnerId", "permissionLevel", "expiresAt", "revokedAt"],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"columns": [
+					"sharedWith",
+					"permission",
+					"createdAt",
+					"revokedAt"
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -595,9 +1420,34 @@
 			"config": {
 				"register": "procest",
 				"schema": "partnerOrganization",
-				"columns": ["name", "type", "contactEmail", "active"],
-				"actions": ["create", "edit", "delete", "view"],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"columns": [
+					"name",
+					"type",
+					"contactEmail",
+					"active"
+				],
+				"actions": [
+					{
+						"id": "create",
+						"label": "Create"
+					},
+					{
+						"id": "edit",
+						"label": "Edit"
+					},
+					{
+						"id": "delete",
+						"label": "Delete"
+					},
+					{
+						"id": "view",
+						"label": "View"
+					}
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -609,8 +1459,31 @@
 				"register": "procest",
 				"schema": "partnerOrganization",
 				"sidebarTabs": [
-					{ "id": "overview", "label": "Overview",    "icon": "icon-info",    "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
-					{ "id": "audit",    "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }],                   "order": 90 }
+					{
+						"id": "overview",
+						"label": "Overview",
+						"icon": "icon-info",
+						"widgets": [
+							{
+								"type": "data"
+							},
+							{
+								"type": "metadata"
+							}
+						],
+						"order": 10
+					},
+					{
+						"id": "audit",
+						"label": "Audit trail",
+						"icon": "icon-history",
+						"widgets": [
+							{
+								"type": "audit-trail"
+							}
+						],
+						"order": 90
+					}
 				]
 			}
 		},
@@ -622,8 +1495,17 @@
 			"config": {
 				"register": "procest",
 				"schema": "casetransfer",
-				"columns": ["case", "fromOrg", "toOrg", "status", "initiatedAt"],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"columns": [
+					"case",
+					"fromOrg",
+					"toOrg",
+					"status",
+					"initiatedAt"
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -635,8 +1517,31 @@
 				"register": "procest",
 				"schema": "casetransfer",
 				"sidebarTabs": [
-					{ "id": "overview", "label": "Overview",    "icon": "icon-info",    "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
-					{ "id": "audit",    "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }],                   "order": 90 }
+					{
+						"id": "overview",
+						"label": "Overview",
+						"icon": "icon-info",
+						"widgets": [
+							{
+								"type": "data"
+							},
+							{
+								"type": "metadata"
+							}
+						],
+						"order": 10
+					},
+					{
+						"id": "audit",
+						"label": "Audit trail",
+						"icon": "icon-history",
+						"widgets": [
+							{
+								"type": "audit-trail"
+							}
+						],
+						"order": 90
+					}
 				]
 			}
 		},
@@ -655,9 +1560,35 @@
 			"config": {
 				"register": "procest",
 				"schema": "automaticAction",
-				"columns": ["slug", "type", "title", "isPublished", "active"],
-				"actions": ["create", "edit", "delete", "view"],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"columns": [
+					"slug",
+					"type",
+					"title",
+					"isPublished",
+					"active"
+				],
+				"actions": [
+					{
+						"id": "create",
+						"label": "Create"
+					},
+					{
+						"id": "edit",
+						"label": "Edit"
+					},
+					{
+						"id": "delete",
+						"label": "Delete"
+					},
+					{
+						"id": "view",
+						"label": "View"
+					}
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -669,8 +1600,31 @@
 				"register": "procest",
 				"schema": "automaticAction",
 				"sidebarTabs": [
-					{ "id": "overview", "label": "Overview",    "icon": "icon-info",    "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
-					{ "id": "audit",    "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }],                   "order": 90 }
+					{
+						"id": "overview",
+						"label": "Overview",
+						"icon": "icon-info",
+						"widgets": [
+							{
+								"type": "data"
+							},
+							{
+								"type": "metadata"
+							}
+						],
+						"order": 10
+					},
+					{
+						"id": "audit",
+						"label": "Audit trail",
+						"icon": "icon-history",
+						"widgets": [
+							{
+								"type": "audit-trail"
+							}
+						],
+						"order": 90
+					}
 				]
 			}
 		},
@@ -703,9 +1657,36 @@
 			"config": {
 				"register": "procest",
 				"schema": "workflowTemplate",
-				"columns": ["title", "caseType", "version", "lifecycleStatus", "isActive", "updatedAt"],
-				"actions": ["create", "edit", "delete", "view"],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"columns": [
+					"title",
+					"caseType",
+					"version",
+					"lifecycleStatus",
+					"isActive",
+					"updatedAt"
+				],
+				"actions": [
+					{
+						"id": "create",
+						"label": "Create"
+					},
+					{
+						"id": "edit",
+						"label": "Edit"
+					},
+					{
+						"id": "delete",
+						"label": "Delete"
+					},
+					{
+						"id": "view",
+						"label": "View"
+					}
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -717,15 +1698,77 @@
 				"register": "procest",
 				"schema": "workflowTemplate",
 				"actions": [
-					{ "id": "publish",   "label": "Publish",   "icon": "icon-checkmark", "permission": "admin", "primary": true, "handler": "emit" },
-					{ "id": "deprecate", "label": "Deprecate", "icon": "icon-close",     "permission": "admin",                  "handler": "emit" },
-					{ "id": "clone",     "label": "Clone",     "icon": "icon-add",       "permission": "admin",                  "handler": "emit" }
+					{
+						"id": "publish",
+						"label": "Publish",
+						"icon": "icon-checkmark",
+						"permission": "admin",
+						"primary": true,
+						"handler": "emit"
+					},
+					{
+						"id": "deprecate",
+						"label": "Deprecate",
+						"icon": "icon-close",
+						"permission": "admin",
+						"handler": "emit"
+					},
+					{
+						"id": "clone",
+						"label": "Clone",
+						"icon": "icon-add",
+						"permission": "admin",
+						"handler": "emit"
+					}
 				],
 				"sidebarTabs": [
-					{ "id": "overview",    "label": "Overview",    "icon": "icon-info",     "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
-					{ "id": "steps",       "label": "Steps",       "icon": "icon-checkmark","widgets": [{ "type": "data" }],                          "order": 20 },
-					{ "id": "transitions", "label": "Transitions", "icon": "icon-comment",  "widgets": [{ "type": "data" }],                          "order": 30 },
-					{ "id": "audit",       "label": "Audit trail", "icon": "icon-history",  "widgets": [{ "type": "audit-trail" }],                   "order": 90 }
+					{
+						"id": "overview",
+						"label": "Overview",
+						"icon": "icon-info",
+						"widgets": [
+							{
+								"type": "data"
+							},
+							{
+								"type": "metadata"
+							}
+						],
+						"order": 10
+					},
+					{
+						"id": "steps",
+						"label": "Steps",
+						"icon": "icon-checkmark",
+						"widgets": [
+							{
+								"type": "data"
+							}
+						],
+						"order": 20
+					},
+					{
+						"id": "transitions",
+						"label": "Transitions",
+						"icon": "icon-comment",
+						"widgets": [
+							{
+								"type": "data"
+							}
+						],
+						"order": 30
+					},
+					{
+						"id": "audit",
+						"label": "Audit trail",
+						"icon": "icon-history",
+						"widgets": [
+							{
+								"type": "audit-trail"
+							}
+						],
+						"order": 90
+					}
 				]
 			}
 		},
@@ -738,15 +1781,26 @@
 				"register": "procest",
 				"schema": "statusRecord",
 				"columns": [
-					{ "key": "case" },
-					{ "key": "fromStatus" },
-					{ "key": "statusType", "label": "toStatus" },
-					{ "key": "transitionLabel" },
-					{ "key": "noWorkflowTemplate" },
-					{ "key": "createdAt" }
+					"case",
+					"fromStatus",
+					{
+						"key": "statusType",
+						"label": "toStatus"
+					},
+					"transitionLabel",
+					"noWorkflowTemplate",
+					"createdAt"
 				],
-				"actions": ["view"],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"actions": [
+					{
+						"id": "view",
+						"label": "View"
+					}
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -758,10 +1812,63 @@
 				"register": "procest",
 				"schema": "statusRecord",
 				"sidebarTabs": [
-					{ "id": "overview",     "label": "Overview",         "icon": "icon-info",    "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
-					{ "id": "guards",       "label": "Evaluated guards", "icon": "icon-checkmark", "widgets": [{ "type": "data", "config": { "fields": ["evaluatedGuards"] } }], "order": 20 },
-					{ "id": "actions",      "label": "Dispatched actions", "icon": "icon-toggle", "widgets": [{ "type": "data", "config": { "fields": ["dispatchedActions"] } }], "order": 30 },
-					{ "id": "audit",        "label": "Audit trail",      "icon": "icon-history", "widgets": [{ "type": "audit-trail" }],                   "order": 90 }
+					{
+						"id": "overview",
+						"label": "Overview",
+						"icon": "icon-info",
+						"widgets": [
+							{
+								"type": "data"
+							},
+							{
+								"type": "metadata"
+							}
+						],
+						"order": 10
+					},
+					{
+						"id": "guards",
+						"label": "Evaluated guards",
+						"icon": "icon-checkmark",
+						"widgets": [
+							{
+								"type": "data",
+								"config": {
+									"fields": [
+										"evaluatedGuards"
+									]
+								}
+							}
+						],
+						"order": 20
+					},
+					{
+						"id": "actions",
+						"label": "Dispatched actions",
+						"icon": "icon-toggle",
+						"widgets": [
+							{
+								"type": "data",
+								"config": {
+									"fields": [
+										"dispatchedActions"
+									]
+								}
+							}
+						],
+						"order": 30
+					},
+					{
+						"id": "audit",
+						"label": "Audit trail",
+						"icon": "icon-history",
+						"widgets": [
+							{
+								"type": "audit-trail"
+							}
+						],
+						"order": 90
+					}
 				]
 			}
 		},
@@ -770,13 +1877,29 @@
 			"route": "/settings/lhs-matrices",
 			"type": "index",
 			"title": "Handhavingsstrategie",
-			"permission": "admin",
 			"config": {
 				"register": "procest",
 				"schema": "lhsMatrix",
-				"columns": ["name", "version", "active", "createdAt"],
-				"actions": ["create", "view"],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"columns": [
+					"name",
+					"version",
+					"active",
+					"createdAt"
+				],
+				"actions": [
+					{
+						"id": "create",
+						"label": "Create"
+					},
+					{
+						"id": "view",
+						"label": "View"
+					}
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -788,16 +1911,32 @@
 				"register": "procest",
 				"schema": "location",
 				"columns": [
-					{ "key": "label" },
-					{ "key": "case" },
-					{ "key": "formattedAddress" },
-					{ "key": "nummeraanduidingId" },
-					{ "key": "parcelId" },
-					{ "key": "source" },
-					{ "key": "accuracyRadius" }
+					"label",
+					"case",
+					"formattedAddress",
+					"nummeraanduidingId",
+					"parcelId",
+					"source",
+					"accuracyRadius"
 				],
-				"actions": ["view", "edit", "delete"],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"actions": [
+					{
+						"id": "view",
+						"label": "View"
+					},
+					{
+						"id": "edit",
+						"label": "Edit"
+					},
+					{
+						"id": "delete",
+						"label": "Delete"
+					}
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -805,15 +1944,67 @@
 			"route": "/settings/lhs-matrices/:id",
 			"type": "detail",
 			"title": "LHS Matrix",
-			"permission": "admin",
 			"config": {
 				"register": "procest",
 				"schema": "lhsMatrix",
 				"sidebarTabs": [
-					{ "id": "overview",   "label": "Overview",    "icon": "icon-info",    "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
-					{ "id": "cells",      "label": "Cells",       "icon": "icon-category-customization", "widgets": [{ "type": "data", "config": { "fields": ["cells"] } }], "order": 20 },
-					{ "id": "auditTrail", "label": "Edit log",    "icon": "icon-history", "widgets": [{ "type": "data", "config": { "fields": ["auditTrail"] } }], "order": 30 },
-					{ "id": "audit",      "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }],                   "order": 90 }
+					{
+						"id": "overview",
+						"label": "Overview",
+						"icon": "icon-info",
+						"widgets": [
+							{
+								"type": "data"
+							},
+							{
+								"type": "metadata"
+							}
+						],
+						"order": 10
+					},
+					{
+						"id": "cells",
+						"label": "Cells",
+						"icon": "icon-category-customization",
+						"widgets": [
+							{
+								"type": "data",
+								"config": {
+									"fields": [
+										"cells"
+									]
+								}
+							}
+						],
+						"order": 20
+					},
+					{
+						"id": "auditTrail",
+						"label": "Edit log",
+						"icon": "icon-history",
+						"widgets": [
+							{
+								"type": "data",
+								"config": {
+									"fields": [
+										"auditTrail"
+									]
+								}
+							}
+						],
+						"order": 30
+					},
+					{
+						"id": "audit",
+						"label": "Audit trail",
+						"icon": "icon-history",
+						"widgets": [
+							{
+								"type": "audit-trail"
+							}
+						],
+						"order": 90
+					}
 				]
 			}
 		},
@@ -825,9 +2016,26 @@
 			"config": {
 				"register": "procest",
 				"schema": "lhsRecommendation",
-				"columns": ["case", "ernst", "gedrag", "actorType", "recommendedInterventie", "finalIntervention", "override", "matrixVersion"],
-				"actions": ["view"],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"columns": [
+					"case",
+					"ernst",
+					"gedrag",
+					"actorType",
+					"recommendedInterventie",
+					"finalIntervention",
+					"override",
+					"matrixVersion"
+				],
+				"actions": [
+					{
+						"id": "view",
+						"label": "View"
+					}
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -839,8 +2047,31 @@
 				"register": "procest",
 				"schema": "lhsRecommendation",
 				"sidebarTabs": [
-					{ "id": "overview", "label": "Overview",    "icon": "icon-info",    "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
-					{ "id": "audit",    "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }],                   "order": 90 }
+					{
+						"id": "overview",
+						"label": "Overview",
+						"icon": "icon-info",
+						"widgets": [
+							{
+								"type": "data"
+							},
+							{
+								"type": "metadata"
+							}
+						],
+						"order": 10
+					},
+					{
+						"id": "audit",
+						"label": "Audit trail",
+						"icon": "icon-history",
+						"widgets": [
+							{
+								"type": "audit-trail"
+							}
+						],
+						"order": 90
+					}
 				]
 			}
 		},
@@ -853,8 +2084,31 @@
 				"register": "procest",
 				"schema": "location",
 				"sidebarTabs": [
-					{ "id": "overview", "label": "Overview",    "icon": "icon-info",    "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
-					{ "id": "audit",    "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }],                   "order": 90 }
+					{
+						"id": "overview",
+						"label": "Overview",
+						"icon": "icon-info",
+						"widgets": [
+							{
+								"type": "data"
+							},
+							{
+								"type": "metadata"
+							}
+						],
+						"order": 10
+					},
+					{
+						"id": "audit",
+						"label": "Audit trail",
+						"icon": "icon-history",
+						"widgets": [
+							{
+								"type": "audit-trail"
+							}
+						],
+						"order": 90
+					}
 				]
 			}
 		},
@@ -866,11 +2120,27 @@
 			"config": {
 				"register": "procest",
 				"schema": "bezwaaradviescommissie",
-				"columns": ["name", "type", "domain", "quorum", "active", "termEndsOn"],
-				"actions": [
-					{ "id": "view", "label": "View", "icon": "icon-info", "handler": "navigate", "route": "BezwaarCommitteeDetail" }
+				"columns": [
+					"name",
+					"type",
+					"domain",
+					"quorum",
+					"active",
+					"termEndsOn"
 				],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"actions": [
+					{
+						"id": "view",
+						"label": "View",
+						"icon": "icon-info",
+						"handler": "navigate",
+						"route": "BezwaarCommitteeDetail"
+					}
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -882,8 +2152,31 @@
 				"register": "procest",
 				"schema": "bezwaaradviescommissie",
 				"sidebarTabs": [
-					{ "id": "overview", "label": "Overview",    "icon": "icon-info",    "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
-					{ "id": "audit",    "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }],                   "order": 90 }
+					{
+						"id": "overview",
+						"label": "Overview",
+						"icon": "icon-info",
+						"widgets": [
+							{
+								"type": "data"
+							},
+							{
+								"type": "metadata"
+							}
+						],
+						"order": 10
+					},
+					{
+						"id": "audit",
+						"label": "Audit trail",
+						"icon": "icon-history",
+						"widgets": [
+							{
+								"type": "audit-trail"
+							}
+						],
+						"order": 90
+					}
 				]
 			}
 		},
@@ -895,11 +2188,27 @@
 			"config": {
 				"register": "procest",
 				"schema": "bacAdviceRequest",
-				"columns": ["bezwaar", "commissie", "status", "assignedAt", "deadline", "conclusion"],
-				"actions": [
-					{ "id": "view", "label": "View", "icon": "icon-info", "handler": "navigate", "route": "BezwaarAdviceRequestDetail" }
+				"columns": [
+					"bezwaar",
+					"commissie",
+					"status",
+					"assignedAt",
+					"deadline",
+					"conclusion"
 				],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"actions": [
+					{
+						"id": "view",
+						"label": "View",
+						"icon": "icon-info",
+						"handler": "navigate",
+						"route": "BezwaarAdviceRequestDetail"
+					}
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -911,9 +2220,47 @@
 				"register": "procest",
 				"schema": "bacAdviceRequest",
 				"sidebarTabs": [
-					{ "id": "overview",  "label": "Overview",    "icon": "icon-info",    "widgets": [{ "type": "data" }, { "type": "metadata" }],                            "order": 10 },
-					{ "id": "documents", "label": "Documenten",  "icon": "icon-files",   "widgets": [{ "type": "data", "config": { "fields": ["adviceDocuments"] } }],        "order": 20 },
-					{ "id": "audit",     "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }],                                              "order": 90 }
+					{
+						"id": "overview",
+						"label": "Overview",
+						"icon": "icon-info",
+						"widgets": [
+							{
+								"type": "data"
+							},
+							{
+								"type": "metadata"
+							}
+						],
+						"order": 10
+					},
+					{
+						"id": "documents",
+						"label": "Documenten",
+						"icon": "icon-files",
+						"widgets": [
+							{
+								"type": "data",
+								"config": {
+									"fields": [
+										"adviceDocuments"
+									]
+								}
+							}
+						],
+						"order": 20
+					},
+					{
+						"id": "audit",
+						"label": "Audit trail",
+						"icon": "icon-history",
+						"widgets": [
+							{
+								"type": "audit-trail"
+							}
+						],
+						"order": 90
+					}
 				]
 			}
 		},
@@ -925,11 +2272,29 @@
 			"config": {
 				"register": "procest",
 				"schema": "beroep",
-				"columns": ["case", "sourceBezwaar", "courtReference", "competentCourt", "appellantFilingDate", "filingDeadline", "judgmentOutcome", "cascadeAction"],
-				"actions": [
-					{ "id": "view", "label": "View", "icon": "icon-info", "handler": "navigate", "route": "BeroepDetail" }
+				"columns": [
+					"case",
+					"sourceBezwaar",
+					"courtReference",
+					"competentCourt",
+					"appellantFilingDate",
+					"filingDeadline",
+					"judgmentOutcome",
+					"cascadeAction"
 				],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"actions": [
+					{
+						"id": "view",
+						"label": "View",
+						"icon": "icon-info",
+						"handler": "navigate",
+						"route": "BeroepDetail"
+					}
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -941,20 +2306,84 @@
 				"register": "procest",
 				"schema": "beroep",
 				"sidebarTabs": [
-					{ "id": "overview",        "label": "Overview",                 "icon": "icon-info",    "widgets": [{ "type": "data" }, { "type": "metadata" }],                                                                  "order": 10 },
-					{ "id": "file-inspection", "label": "File-inspection requests", "icon": "icon-files",   "widgets": [{ "type": "data", "config": { "fields": ["fileInspectionRequests"] } }],                                      "order": 20 },
-					{ "id": "judgment",        "label": "Judgment",                 "icon": "icon-toggle",  "widgets": [{ "type": "data", "config": { "fields": ["judgmentOutcome", "judgmentDate", "judgmentDocument"] } }],          "order": 30 },
-					{ "id": "cascade",         "label": "Cascade",                  "icon": "icon-history", "widgets": [{ "type": "data", "config": { "fields": ["cascadeAction", "cascadeBezwaarCase"] } }],                          "order": 40 },
-					{ "id": "audit",           "label": "Audit trail",              "icon": "icon-history", "widgets": [{ "type": "audit-trail" }],                                                                                   "order": 90 }
+					{
+						"id": "overview",
+						"label": "Overview",
+						"icon": "icon-info",
+						"widgets": [
+							{
+								"type": "data"
+							},
+							{
+								"type": "metadata"
+							}
+						],
+						"order": 10
+					},
+					{
+						"id": "file-inspection",
+						"label": "File-inspection requests",
+						"icon": "icon-files",
+						"widgets": [
+							{
+								"type": "data",
+								"config": {
+									"fields": [
+										"fileInspectionRequests"
+									]
+								}
+							}
+						],
+						"order": 20
+					},
+					{
+						"id": "judgment",
+						"label": "Judgment",
+						"icon": "icon-toggle",
+						"widgets": [
+							{
+								"type": "data",
+								"config": {
+									"fields": [
+										"judgmentOutcome",
+										"judgmentDate",
+										"judgmentDocument"
+									]
+								}
+							}
+						],
+						"order": 30
+					},
+					{
+						"id": "cascade",
+						"label": "Cascade",
+						"icon": "icon-history",
+						"widgets": [
+							{
+								"type": "data",
+								"config": {
+									"fields": [
+										"cascadeAction",
+										"cascadeBezwaarCase"
+									]
+								}
+							}
+						],
+						"order": 40
+					},
+					{
+						"id": "audit",
+						"label": "Audit trail",
+						"icon": "icon-history",
+						"widgets": [
+							{
+								"type": "audit-trail"
+							}
+						],
+						"order": 90
+					}
 				]
 			}
-		},
-		{
-			"id": "FeaturesRoadmap",
-			"route": "/features-roadmap",
-			"type": "custom",
-			"title": "Features & roadmap",
-			"component": "FeaturesRoadmap"
 		}
 	]
 }

--- a/tests/Unit/Service/SeedDataServiceTest.php
+++ b/tests/Unit/Service/SeedDataServiceTest.php
@@ -40,6 +40,7 @@ interface SeedObjectServiceStub
 {
     public function getObjects(string $register, string $schema, array $filters, int $limit): array;
     public function saveObject(string $register, string $schema, array $object): ?object;
+    public function findAll(array $criteria): array;
 
 }//end interface
 
@@ -192,6 +193,10 @@ class SeedDataServiceTest extends TestCase
             ->willReturn([]);
 
         $objectServiceMock
+            ->method('findAll')
+            ->willReturn([]);
+
+        $objectServiceMock
             ->method('saveObject')
             ->willReturn($createdObject);
 
@@ -242,9 +247,13 @@ class SeedDataServiceTest extends TestCase
 
         $objectServiceMock = $this->createMock(SeedObjectServiceStub::class);
 
-        // Always return an existing object from getObjects.
+        // Always return an existing object from getObjects (legacy path) and findAll (current production path).
         $objectServiceMock
             ->method('getObjects')
+            ->willReturn([$existingObject]);
+
+        $objectServiceMock
+            ->method('findAll')
             ->willReturn([$existingObject]);
 
         // saveObject should NOT be called if all case types are skipped.


### PR DESCRIPTION
(re-opened of #417 — accidentally closed by harness force-push; same branch, same content)

Found during the local NC upgrade-and-audit pass — two production blockers:

## 1. Dangling seed references (config import fails on every install/upgrade)

Three `parafeeractie` seed objects in `procest_register.json` referenced `voorstel-collegeadvies-0042` / `voorstel-collegeadvies-0055`, which have no matching `voorstel` seed object. OR validates `parafeeractie.voorstel` as a uuid-format relation and rejected the slug strings → `Failed to import configuration for app procest: Property 'voorstel' should match format 'uuid'`. The three orphaned objects are removed (42 → 39 objects).

## 2. Removed OR API: `ObjectService::getObjects()` → `findAll()`

`OCA\OpenRegister\Service\ObjectService::getObjects()` no longer exists. Migrated all 9 call sites to `findAll(['filters' => ['register' => ..., 'schema' => ..., ...]])` which returns a flat array. This fixes the `Could not seed bezwaar/beroep data: Call to undefined method ObjectService::getObjects()` repair warning (via `SeedDataService::findByFilter`).

`TenantService::getTenantByGroupId()` still has one `getObjects()` call but that path short-circuits before reaching it (the `tenant_schema` config key is never set) and PR #411 removes the method entirely — left as-is to avoid a merge conflict.

## Out of scope (follow-ups)

- The broken `procest-main.js` bundle ("Unexpected identifier 'Case'" JS syntax error — needs a rebuild)
- 25 `additionalProperties` validation errors in `src/manifest.json` page actions against canonical schema v1.4.0 (the schema's `action` def is `additionalProperties:false` and lacks `handler`/`route` — needs an action-shape design decision)

## Test plan

- [ ] `occ upgrade` on a fresh NC dev env no longer emits the procest config-import warning
- [ ] Quality gate (phpcs/psalm/phpstan) green
