### PR TITLE
feat(tenant): adopt OR Organisation as tenant identity (closes #405)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -6192,16 +6192,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
                 "shasum": ""
             },
             "require": {
@@ -6214,7 +6214,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -6239,7 +6239,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -6251,11 +6251,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-04-13T15:52:40+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -6557,16 +6561,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
                 "shasum": ""
             },
             "require": {
@@ -6616,7 +6620,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -6636,7 +6640,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
@@ -6807,16 +6811,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
                 "shasum": ""
             },
             "require": {
@@ -6868,7 +6872,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -6888,11 +6892,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-23T08:48:59+00:00"
+            "time": "2026-04-10T17:25:58+00:00"
         },
         {
             "name": "symfony/polyfill-php81",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php81.git",
@@ -6948,7 +6952,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -7294,16 +7298,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v6.4.34",
+            "version": "v6.4.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "7bca30dabed7900a08c5ad4f1d6483f881a64d0f"
+                "reference": "68dcd1f1602dac9d9221e25729683e0ce8733f3b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/7bca30dabed7900a08c5ad4f1d6483f881a64d0f",
-                "reference": "7bca30dabed7900a08c5ad4f1d6483f881a64d0f",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/68dcd1f1602dac9d9221e25729683e0ce8733f3b",
+                "reference": "68dcd1f1602dac9d9221e25729683e0ce8733f3b",
                 "shasum": ""
             },
             "require": {
@@ -7346,7 +7350,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v6.4.34"
+                "source": "https://github.com/symfony/yaml/tree/v6.4.40"
             },
             "funding": [
                 {
@@ -7366,7 +7370,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-06T18:32:11+00:00"
+            "time": "2026-05-19T20:33:22+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -7420,16 +7424,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v3.23.0",
+            "version": "v3.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "a64dc5d2cc7d6cafb9347f6cd802d0d06d0351c9"
+                "reference": "1fcae487b180d78e6351f4e0afa91f9eab96a2bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/a64dc5d2cc7d6cafb9347f6cd802d0d06d0351c9",
-                "reference": "a64dc5d2cc7d6cafb9347f6cd802d0d06d0351c9",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/1fcae487b180d78e6351f4e0afa91f9eab96a2bc",
+                "reference": "1fcae487b180d78e6351f4e0afa91f9eab96a2bc",
                 "shasum": ""
             },
             "require": {
@@ -7439,7 +7443,8 @@
                 "symfony/polyfill-mbstring": "^1.3"
             },
             "require-dev": {
-                "phpstan/phpstan": "^2.0",
+                "php-cs-fixer/shim": "^3.0@stable",
+                "phpstan/phpstan": "^2.0@stable",
                 "psr/container": "^1.0|^2.0",
                 "symfony/phpunit-bridge": "^5.4.9|^6.4|^7.0"
             },
@@ -7483,7 +7488,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.23.0"
+                "source": "https://github.com/twigphp/Twig/tree/v3.26.0"
             },
             "funding": [
                 {
@@ -7495,7 +7500,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-23T21:00:41+00:00"
+            "time": "2026-05-20T07:31:59+00:00"
         },
         {
             "name": "vimeo/psalm",

--- a/lib/Middleware/TenantMiddleware.php
+++ b/lib/Middleware/TenantMiddleware.php
@@ -98,7 +98,7 @@ class TenantMiddleware extends Middleware
             return;
         }
 
-        // Resolve tenant for the current user.
+        // Resolve tenant for the current user (delegates to OR Organisation).
         $tenant = $this->tenantService->getTenantForUser($userId);
         if ($tenant === null) {
             $this->logger->warning(
@@ -109,8 +109,20 @@ class TenantMiddleware extends Middleware
             return;
         }
 
+        // Per consume-or-tenant-fleet-wide: lifecycle status enforcement lives
+        // in OR's tenant-lifecycle. Block requests scoped to a non-active tenant.
+        $tenantUuid = ($tenant['uuid'] ?? $tenant['id'] ?? '');
+        $status     = ($tenant['status'] ?? null);
+        if ($status !== null && $status !== '' && $status !== 'active') {
+            $this->logger->info(
+                'Procest: Request blocked because tenant is not active',
+                ['userId' => $userId, 'tenantUuid' => $tenantUuid, 'status' => $status]
+            );
+            throw new \Exception('Organisation is '.$status, 403);
+        }
+
         // Store tenant context for controllers to use.
-        $this->request->setParameter('_tenantId', $tenant['uuid'] ?? $tenant['id'] ?? '');
+        $this->request->setParameter('_tenantId', $tenantUuid);
         $this->request->setParameter('_tenantRegisterId', $tenant['registerId'] ?? '');
         $this->request->setParameter('_tenantSlug', $tenant['slug'] ?? '');
     }//end beforeController()
@@ -132,6 +144,20 @@ class TenantMiddleware extends Middleware
             return new JSONResponse(
                 ['success' => false, 'error' => 'Not found'],
                 404
+            );
+        }
+
+        if ($exception->getCode() === 403) {
+            // Surface OR-Organisation status block to the caller.
+            $message = $exception->getMessage();
+            $status  = 'inactive';
+            if (preg_match('/Organisation is (\\w+)/', $message, $m) === 1) {
+                $status = $m[1];
+            }
+
+            return new JSONResponse(
+                ['success' => false, 'error' => $message, 'status' => $status],
+                403
             );
         }
 

--- a/lib/Service/TenantService.php
+++ b/lib/Service/TenantService.php
@@ -3,7 +3,12 @@
 /**
  * Procest Tenant Service
  *
- * Service for managing multi-tenant isolation and tenant provisioning.
+ * Service for managing multi-tenant isolation; delegates the tenant data model
+ * to OpenRegister's Organisation entity + TenantLifecycleService per the
+ * Hydra umbrella consume-or-tenant-fleet-wide (ADR-022).
+ *
+ * Public method signatures and return shapes are preserved so existing
+ * callers (TenantController, TenantMiddleware) do not require modification.
  *
  * @category Service
  * @package  OCA\Procest\Service
@@ -11,6 +16,9 @@
  * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
  *
  * @version GIT: <git-id>
  *
@@ -26,13 +34,15 @@ use OCP\IGroupManager;
 use OCP\IUserManager;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use Throwable;
 
 /**
- * Service for managing multi-tenant isolation.
+ * Service for managing multi-tenant isolation backed by OR Organisations.
  *
- * Resolves tenant from user's Nextcloud group membership,
- * provisions new tenants with dedicated OpenRegister registers,
- * and enforces resource limits.
+ * Each procest tenant maps 1:1 to an OR Organisation entity. The
+ * `Organisation.groups` array carries the NC group IDs used by procest for
+ * tenant routing; `Organisation.status` carries the lifecycle state enforced
+ * by `TenantMiddleware`.
  */
 class TenantService
 {
@@ -44,14 +54,12 @@ class TenantService
     /**
      * Constructor for the TenantService.
      *
-     * @param SettingsService    $settingsService The settings service
-     * @param IAppManager        $appManager      The app manager
-     * @param IGroupManager      $groupManager    The Nextcloud group manager
-     * @param IUserManager       $userManager     The Nextcloud user manager
-     * @param ContainerInterface $container       The DI container
-     * @param LoggerInterface    $logger          The logger
-     *
-     * @return void
+     * @param SettingsService    $settingsService Settings service.
+     * @param IAppManager        $appManager      The app manager.
+     * @param IGroupManager      $groupManager    The Nextcloud group manager.
+     * @param IUserManager       $userManager     The Nextcloud user manager.
+     * @param ContainerInterface $container       The DI container (graceful OR resolution).
+     * @param LoggerInterface    $logger          The logger.
      */
     public function __construct(
         private SettingsService $settingsService,
@@ -63,169 +71,163 @@ class TenantService
     ) {
     }//end __construct()
 
+
     /**
-     * Resolve the tenant for a given user.
+     * Resolve the tenant for a given user via OR's `findByUserId` lookup.
      *
-     * Finds the user's tenant_* group membership and returns the tenant record.
+     * Returns the Organisation as a `jsonSerialize`d array so existing callers
+     * see the same shape as before (uuid, name, slug, status, registerId, etc.).
      *
-     * @param string $userId The Nextcloud user ID
+     * @param string $userId The Nextcloud user ID.
      *
-     * @return array|null The tenant data or null if no tenant found
+     * @return array|null The tenant data or null when none found.
      */
     public function getTenantForUser(string $userId): ?array
     {
-        $user = $this->userManager->get($userId);
-        if ($user === null) {
+        $orgs = $this->findOrganisationsByUserId($userId);
+        if (empty($orgs) === true) {
+            // Fall back to NC-group lookup so existing single-tenant deployments still work.
+            $user = $this->userManager->get($userId);
+            if ($user === null) {
+                return null;
+            }
+            $groups = $this->groupManager->getUserGroups($user);
+            foreach ($groups as $group) {
+                $groupId = $group->getGID();
+                if (str_starts_with($groupId, self::TENANT_GROUP_PREFIX) === true) {
+                    return $this->getTenantByGroupId(groupId: $groupId);
+                }
+            }
             return null;
         }
 
-        $groups = $this->groupManager->getUserGroups($user);
-        foreach ($groups as $group) {
-            $groupId = $group->getGID();
-            if (str_starts_with($groupId, self::TENANT_GROUP_PREFIX) === true) {
-                return $this->getTenantByGroupId(groupId: $groupId);
-            }
-        }
-
-        return null;
+        return $orgs[0]->jsonSerialize();
     }//end getTenantForUser()
 
+
     /**
-     * Get a tenant record by its Nextcloud group ID.
+     * Get a tenant by its Nextcloud group ID.
      *
-     * @param string $groupId The Nextcloud group ID (tenant_{slug})
+     * Queries OR Organisations whose `groups` array contains the given groupId.
      *
-     * @return array|null The tenant data
+     * @param string $groupId The Nextcloud group ID (`tenant_<slug>`).
+     *
+     * @return array|null The tenant data, or null when not resolvable.
      */
     public function getTenantByGroupId(string $groupId): ?array
     {
-        $objectService = $this->getObjectService();
-        if ($objectService === null) {
+        $mapper = $this->getOrganisationMapper();
+        if ($mapper === null) {
             return null;
         }
 
-        $register = $this->settingsService->getConfigValue('register');
-        $schema   = $this->settingsService->getConfigValue('tenant_schema');
-
-        if (empty($register) === true || empty($schema) === true) {
+        try {
+            // Linear scan is acceptable here — tenant count is small (≤100s).
+            foreach ($mapper->findAll(limit: 500) as $org) {
+                $groups = ($org->getGroups() ?? []);
+                if (in_array($groupId, $groups, true) === true) {
+                    return $org->jsonSerialize();
+                }
+            }
+        } catch (Throwable $e) {
+            $this->logger->error(
+                'Procest: getTenantByGroupId failed against OR',
+                ['groupId' => $groupId, 'exception' => $e->getMessage()]
+            );
             return null;
         }
 
-        $result = $objectService->getObjects(
-            (int) $register,
-            (int) $schema,
-            ['groupId' => $groupId],
-        );
-
-        $tenants = ($result['objects'] ?? []);
-        if (empty($tenants) === true) {
-            return null;
-        }
-
-        $tenant = reset($tenants);
-        if (is_object($tenant) === true) {
-            return $tenant->jsonSerialize();
-        }
-
-        return $tenant;
+        return null;
     }//end getTenantByGroupId()
 
+
     /**
-     * Provision a tenant with a dedicated OpenRegister register and default schemas.
+     * Provision a tenant via OR's TenantLifecycleService.
      *
-     * @param string $tenantId The tenant UUID
+     * Reads the Organisation by UUID, calls `provision()` (which handles the
+     * provisioning → active state transition + emits `OrganisationProvisionedEvent`).
      *
-     * @return array The provisioning result
+     * @param string $tenantId The Organisation UUID.
+     *
+     * @return array The provisioning result (the Organisation `jsonSerialize`d).
      */
     public function provisionTenant(string $tenantId): array
     {
-        $objectService = $this->getObjectService();
-        if ($objectService === null) {
-            return ['error' => 'OpenRegister is not available'];
+        $mapper           = $this->getOrganisationMapper();
+        $lifecycleService = $this->getTenantLifecycleService();
+        if ($mapper === null || $lifecycleService === null) {
+            return ['error' => 'OpenRegister tenant services unavailable'];
         }
 
-        $register = $this->settingsService->getConfigValue('register');
-        $schema   = $this->settingsService->getConfigValue('tenant_schema');
-
-        $tenant     = $objectService->getObject((int) $register, (int) $schema, $tenantId);
-        $tenantData = $tenant->jsonSerialize();
-
-        // Create a dedicated register for this tenant.
         try {
-            $registerService = $this->container->get('OCA\OpenRegister\Service\RegisterService');
-            $newRegister     = $registerService->createFromArray(
-                    [
-                        'title'       => 'Procest - '.$tenantData['name'],
-                        'description' => 'Case management register for '.$tenantData['name'],
-                    ]
-                    );
-
-            $tenantData['registerId'] = (string) $newRegister->getId();
-        } catch (\Exception $e) {
+            $org      = $mapper->findByUuid($tenantId);
+            $adminUid = ($this->groupManager->isAdmin($org->getOwner() ?? '') === true) ? $org->getOwner() : 'admin';
+            $org      = $lifecycleService->provision($org, (string) $adminUid);
+        } catch (Throwable $e) {
             $this->logger->error(
-                'Procest: Failed to create tenant register',
+                'Procest: provisionTenant failed via OR',
                 ['tenantId' => $tenantId, 'exception' => $e->getMessage()]
             );
-            return ['error' => 'Failed to create tenant register: '.$e->getMessage()];
+            return ['error' => 'Failed to provision tenant: '.$e->getMessage()];
         }
 
-        // Save updated tenant with register ID.
-        $result = $objectService->saveObject(
-            (int) $register,
-            (int) $schema,
-            $tenantData,
-        );
-
         $this->logger->info(
-            'Procest: Tenant provisioned',
-            ['tenantId' => $tenantId, 'registerId' => $tenantData['registerId']]
+            'Procest: Tenant provisioned via OR TenantLifecycleService',
+            ['tenantId' => $tenantId, 'status' => $org->getStatus()]
         );
 
-        return $result->jsonSerialize();
+        return $org->jsonSerialize();
     }//end provisionTenant()
 
+
     /**
-     * Get resource usage for a tenant.
+     * Get resource usage for a tenant from OR data.
      *
-     * @param string $tenantId The tenant UUID
+     * `storageQuota` comes from the OR Organisation entity (bytes per
+     * tenant-quotas spec). User count comes from the NC group as before.
      *
-     * @return array Usage data with user count, storage, and limits
+     * @param string $tenantId The Organisation UUID.
+     *
+     * @return array Usage data with user count + OR quota fields.
      */
     public function getResourceUsage(string $tenantId): array
     {
-        $objectService = $this->getObjectService();
-        if ($objectService === null) {
+        $mapper = $this->getOrganisationMapper();
+        if ($mapper === null) {
             return ['error' => 'OpenRegister is not available'];
         }
 
-        $register = $this->settingsService->getConfigValue('register');
-        $schema   = $this->settingsService->getConfigValue('tenant_schema');
+        try {
+            $org = $mapper->findByUuid($tenantId);
+        } catch (Throwable $e) {
+            return ['error' => 'Organisation not found'];
+        }
 
-        $tenant     = $objectService->getObject((int) $register, (int) $schema, $tenantId);
-        $tenantData = $tenant->jsonSerialize();
-
-        // Count users in tenant group.
-        $group = $this->groupManager->get($tenantData['groupId'] ?? '');
-        if ($group !== null) {
-            $userCount = count($group->getUsers());
-        } else {
-            $userCount = 0;
+        $userCount = 0;
+        foreach (($org->getGroups() ?? []) as $groupId) {
+            $group = $this->groupManager->get($groupId);
+            if ($group !== null) {
+                $userCount += count($group->getUsers());
+            }
         }
 
         return [
-            'users'        => $userCount,
-            'maxUsers'     => (int) ($tenantData['maxUsers'] ?? 0),
-            'maxStorageMb' => (int) ($tenantData['maxStorageMb'] ?? 0),
+            'users'           => $userCount,
+            'storageQuota'    => (int) ($org->getStorageQuota() ?? 0),
+            'bandwidthQuota'  => (int) ($org->getBandwidthQuota() ?? 0),
+            'requestQuota'    => (int) ($org->getRequestQuota() ?? 0),
+            'status'          => (string) ($org->getStatus() ?? ''),
         ];
     }//end getResourceUsage()
 
+
     /**
-     * Check if a user belongs to a specific tenant.
+     * Check whether a user belongs to a specific tenant.
      *
-     * @param string $userId   The Nextcloud user ID
-     * @param string $tenantId The tenant UUID
+     * @param string $userId   The Nextcloud user ID.
+     * @param string $tenantId The Organisation UUID.
      *
-     * @return bool True if user belongs to the tenant
+     * @return bool True when the user is mapped to the tenant.
      */
     public function isUserInTenant(string $userId, string $tenantId): bool
     {
@@ -237,37 +239,112 @@ class TenantService
         return ($tenant['uuid'] ?? $tenant['id'] ?? '') === $tenantId;
     }//end isUserInTenant()
 
+
     /**
-     * Check if a user is a platform administrator.
+     * Check whether a user is a platform administrator.
      *
-     * @param string $userId The Nextcloud user ID
+     * @param string $userId The Nextcloud user ID.
      *
-     * @return bool True if user is in the admin group
+     * @return bool True when the user is in the NC admin group.
      */
     public function isPlatformAdmin(string $userId): bool
     {
         return $this->groupManager->isAdmin($userId);
     }//end isPlatformAdmin()
 
+
     /**
-     * Get the OpenRegister ObjectService.
+     * Check whether a tenant (OR Organisation) is in `active` state.
      *
-     * @return \OCA\OpenRegister\Service\ObjectService|null The service or null
+     * Used by `TenantMiddleware` to short-circuit requests scoped to a
+     * suspended / deprovisioning / archived tenant with HTTP 403.
+     *
+     * @param string $tenantId Organisation UUID.
+     *
+     * @return string|null Status string (`active`, `suspended`, etc.) or null
+     *                     when OR cannot resolve the Organisation.
      */
-    private function getObjectService(): ?\OCA\OpenRegister\Service\ObjectService
+    public function getTenantStatus(string $tenantId): ?string
     {
-        if (in_array('openregister', $this->appManager->getInstalledApps()) === false) {
+        $mapper = $this->getOrganisationMapper();
+        if ($mapper === null) {
             return null;
         }
 
         try {
-            return $this->container->get('OCA\OpenRegister\Service\ObjectService');
-        } catch (\Exception $e) {
+            return $mapper->findByUuid($tenantId)->getStatus();
+        } catch (Throwable $e) {
+            return null;
+        }
+    }//end getTenantStatus()
+
+
+    /**
+     * Find OR Organisations a user belongs to.
+     *
+     * @param string $userId Nextcloud user ID.
+     *
+     * @return array Organisation entities (may be empty).
+     */
+    private function findOrganisationsByUserId(string $userId): array
+    {
+        $mapper = $this->getOrganisationMapper();
+        if ($mapper === null) {
+            return [];
+        }
+
+        try {
+            return $mapper->findByUserId($userId);
+        } catch (Throwable $e) {
+            return [];
+        }
+    }//end findOrganisationsByUserId()
+
+
+    /**
+     * Resolve OR's OrganisationMapper if installed.
+     *
+     * @return \OCA\OpenRegister\Db\OrganisationMapper|null
+     */
+    private function getOrganisationMapper()
+    {
+        if (in_array('openregister', $this->appManager->getInstalledApps(), true) === false) {
+            return null;
+        }
+
+        try {
+            return $this->container->get('OCA\\OpenRegister\\Db\\OrganisationMapper');
+        } catch (Throwable $e) {
             $this->logger->error(
-                'Procest: Could not get ObjectService',
+                'Procest: Could not get OrganisationMapper',
                 ['exception' => $e->getMessage()]
             );
             return null;
         }
-    }//end getObjectService()
+    }//end getOrganisationMapper()
+
+
+    /**
+     * Resolve OR's TenantLifecycleService if installed.
+     *
+     * @return \OCA\OpenRegister\Service\TenantLifecycleService|null
+     */
+    private function getTenantLifecycleService()
+    {
+        if (in_array('openregister', $this->appManager->getInstalledApps(), true) === false) {
+            return null;
+        }
+
+        try {
+            return $this->container->get('OCA\\OpenRegister\\Service\\TenantLifecycleService');
+        } catch (Throwable $e) {
+            $this->logger->error(
+                'Procest: Could not get TenantLifecycleService',
+                ['exception' => $e->getMessage()]
+            );
+            return null;
+        }
+    }//end getTenantLifecycleService()
+
+
 }//end class

--- a/lib/Service/TenantService.php
+++ b/lib/Service/TenantService.php
@@ -71,7 +71,6 @@ class TenantService
     ) {
     }//end __construct()
 
-
     /**
      * Resolve the tenant for a given user via OR's `findByUserId` lookup.
      *
@@ -84,13 +83,14 @@ class TenantService
      */
     public function getTenantForUser(string $userId): ?array
     {
-        $orgs = $this->findOrganisationsByUserId($userId);
+        $orgs = $this->findOrganisationsByUserId(userId: $userId);
         if (empty($orgs) === true) {
             // Fall back to NC-group lookup so existing single-tenant deployments still work.
             $user = $this->userManager->get($userId);
             if ($user === null) {
                 return null;
             }
+
             $groups = $this->groupManager->getUserGroups($user);
             foreach ($groups as $group) {
                 $groupId = $group->getGID();
@@ -98,12 +98,12 @@ class TenantService
                     return $this->getTenantByGroupId(groupId: $groupId);
                 }
             }
+
             return null;
         }
 
         return $orgs[0]->jsonSerialize();
     }//end getTenantForUser()
-
 
     /**
      * Get a tenant by its Nextcloud group ID.
@@ -140,7 +140,6 @@ class TenantService
         return null;
     }//end getTenantByGroupId()
 
-
     /**
      * Provision a tenant via OR's TenantLifecycleService.
      *
@@ -160,9 +159,14 @@ class TenantService
         }
 
         try {
-            $org      = $mapper->findByUuid($tenantId);
-            $adminUid = ($this->groupManager->isAdmin($org->getOwner() ?? '') === true) ? $org->getOwner() : 'admin';
-            $org      = $lifecycleService->provision($org, (string) $adminUid);
+            $org = $mapper->findByUuid($tenantId);
+            if ($this->groupManager->isAdmin($org->getOwner() ?? '') === true) {
+                $adminUid = $org->getOwner();
+            } else {
+                $adminUid = 'admin';
+            }
+
+            $org = $lifecycleService->provision($org, (string) $adminUid);
         } catch (Throwable $e) {
             $this->logger->error(
                 'Procest: provisionTenant failed via OR',
@@ -178,7 +182,6 @@ class TenantService
 
         return $org->jsonSerialize();
     }//end provisionTenant()
-
 
     /**
      * Get resource usage for a tenant from OR data.
@@ -212,14 +215,13 @@ class TenantService
         }
 
         return [
-            'users'           => $userCount,
-            'storageQuota'    => (int) ($org->getStorageQuota() ?? 0),
-            'bandwidthQuota'  => (int) ($org->getBandwidthQuota() ?? 0),
-            'requestQuota'    => (int) ($org->getRequestQuota() ?? 0),
-            'status'          => (string) ($org->getStatus() ?? ''),
+            'users'          => $userCount,
+            'storageQuota'   => (int) ($org->getStorageQuota() ?? 0),
+            'bandwidthQuota' => (int) ($org->getBandwidthQuota() ?? 0),
+            'requestQuota'   => (int) ($org->getRequestQuota() ?? 0),
+            'status'         => (string) ($org->getStatus() ?? ''),
         ];
     }//end getResourceUsage()
-
 
     /**
      * Check whether a user belongs to a specific tenant.
@@ -239,7 +241,6 @@ class TenantService
         return ($tenant['uuid'] ?? $tenant['id'] ?? '') === $tenantId;
     }//end isUserInTenant()
 
-
     /**
      * Check whether a user is a platform administrator.
      *
@@ -251,7 +252,6 @@ class TenantService
     {
         return $this->groupManager->isAdmin($userId);
     }//end isPlatformAdmin()
-
 
     /**
      * Check whether a tenant (OR Organisation) is in `active` state.
@@ -278,7 +278,6 @@ class TenantService
         }
     }//end getTenantStatus()
 
-
     /**
      * Find OR Organisations a user belongs to.
      *
@@ -299,7 +298,6 @@ class TenantService
             return [];
         }
     }//end findOrganisationsByUserId()
-
 
     /**
      * Resolve OR's OrganisationMapper if installed.
@@ -323,7 +321,6 @@ class TenantService
         }
     }//end getOrganisationMapper()
 
-
     /**
      * Resolve OR's TenantLifecycleService if installed.
      *
@@ -345,6 +342,4 @@ class TenantService
             return null;
         }
     }//end getTenantLifecycleService()
-
-
 }//end class

--- a/openspec/changes/migrate-tenant-to-or-tenant/.openspec.yaml
+++ b/openspec/changes/migrate-tenant-to-or-tenant/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-11

--- a/openspec/changes/migrate-tenant-to-or-tenant/design.md
+++ b/openspec/changes/migrate-tenant-to-or-tenant/design.md
@@ -1,0 +1,128 @@
+# Design: migrate-tenant-to-or-tenant
+
+## Context
+
+The umbrella spec `consume-or-tenant-fleet-wide` defines the fleet-wide contract. This
+design document details the file-by-file changes for procest.
+
+OR DI identifiers used in this migration (verified via `consume-or-tenant-fleet-wide`
+OR-1.1):
+
+- `OCA\OpenRegister\Service\TenantLifecycleService` — `isActive(string $uuid): bool`,
+  `activate(string $uuid)`, `suspend(string $uuid)`, etc.
+- `OCA\OpenRegister\Db\OrganisationMapper` — CRUD for Organisation entities.
+- `OCA\OpenRegister\Service\ObjectService` — already used by procest for object persistence.
+
+## File-by-File Changes
+
+### `lib/Middleware/TenantMiddleware.php`
+
+**Current behaviour**: resolves tenant via `TenantService::getTenantForUser()`, injects
+`_tenantId`/`_tenantRegisterId`/`_tenantSlug` into request params. Checks nothing about
+Organisation status — the `isActive` field is never read inside this middleware; the
+middleware simply passes through regardless of status.
+
+**After migration**:
+1. Inject `OCA\OpenRegister\Service\TenantLifecycleService` as a constructor argument.
+2. After resolving the Organisation UUID from `getTenantForUser()`, call
+   `$tenantLifecycleService->isActive($organisationUuid)`.
+3. If `isActive()` returns `false`:
+   - Read the Organisation's current `status` via OR's `OrganisationMapper`.
+   - Return HTTP 403 with body:
+     `{"error": "Organisation is {status}", "status": "{status}"}` matching OR's
+     `tenant-isolation-audit` standard error format.
+   - Do NOT create a procest-local audit entry (OR's `TenantQuotaMiddleware` upstream
+     already creates the audit entry per `tenant-isolation-audit` spec).
+4. The `_tenantId` injected into request params is the OR Organisation UUID (not a
+   procest-local ID). If procest's migration preserved UUIDs (see one-time migration below),
+   this is a no-op change for downstream code.
+
+**Exempt controllers list** is unchanged — `TenantController` remains exempt so provisioning
+API calls can reach it before tenant context is established.
+
+### `lib/Service/TenantService.php`
+
+**Current behaviour**: stores tenant records in a procest-local `tenant` OR schema, creates
+NC groups, provisions registers, tracks `maxUsers`/`maxStorageMb`.
+
+**After migration**:
+
+| Method | Change |
+|---|---|
+| `getTenantForUser(string $userId): ?array` | Retained. Resolves NC group → Organisation UUID using OR's `OrganisationMapper` via group slug lookup (same logic, different storage). |
+| `getTenantByGroupId(string $groupId): ?array` | Retained. Queries OR Organisations by custom property `groupId` (replaces query on private schema). |
+| `createTenant(string $name, ?string $oin, ?string $domain): array` | Delegates to `OrganisationMapper::insert()` with `status: "provisioning"`. Creates NC group unchanged. Custom properties: `oin`, `domain`, `brandingTokens`, `groupId`. Returns Organisation serialized as array. |
+| `provisionTenant(string $tenantId): array` | Delegates to OR `TenantLifecycleService::activate($tenantId)` after creating the dedicated OR register. Stores `registerId` as custom property on Organisation. |
+| `getResourceUsage(string $tenantId): array` | Reads `storageQuota` from OR Organisation; delegates bandwidth/request quota to OR's `GET /api/organisations/{uuid}/usage` passthrough. Returns user count from NC group (unchanged). |
+| `isUserInTenant(string $userId, string $tenantId): bool` | Retained unchanged. |
+| `isPlatformAdmin(string $userId): bool` | Retained unchanged. |
+
+**Deprecated and removed in this migration**:
+- The `tenant_schema` config key reference (no longer needed; Organisation is the schema).
+- The `maxUsers`/`maxStorageMb` fields written to the private schema (replaced by OR's
+  `storageQuota` field; `maxUsers` is stored as a custom property but not quota-enforced
+  by OR — this is by design per the umbrella mapping table).
+
+### `lib/Controller/TenantController.php`
+
+**No API surface changes.** All endpoint paths, HTTP methods, and response shapes are
+preserved. The controller calls `TenantService` which internally delegates to OR.
+
+The only change is that `TenantController::create()` now receives an `isActive` field from
+clients; this field is ignored — initial status is always `"provisioning"` per OR's
+tenant-lifecycle spec. The `provision()` endpoint triggers the lifecycle transition to
+`"active"`.
+
+### `lib/Settings/procest_register.json` (or equivalent)
+
+After the one-time migration:
+- Mark the `tenant` schema entry with `"deprecated": true` (or the equivalent annotation).
+- Set `"deprecatedAt": "2026-05-11"` and `"sunsetVersion": "next-major"`.
+
+### One-Time Data Migration Script
+
+**Location**: `lib/Migration/MigrateTenantToOrganisation.php` (a Nextcloud background job or
+a one-shot migration command registered as `occ procest:migrate-tenants`).
+
+**Algorithm**:
+1. Read all objects from procest's `tenant` schema via `ObjectService::getObjects()`.
+2. For each tenant object:
+   a. Check if an OR Organisation already exists with `slug == tenant.slug` (idempotency guard).
+   b. If not, call `OrganisationMapper::insert()` with:
+      - `uuid` = tenant UUID (preserves existing `_tenantId` references in stored objects)
+      - `name` = `tenant.name`
+      - `slug` = `tenant.slug`
+      - `status` = `"active"` if `tenant.isActive == true`, else `"suspended"`
+      - Custom properties: `oin`, `domain`, `brandingTokens`, `registerId`, `groupId`,
+        `maxUsers`
+   c. Log the mapping: `tenant.uuid → organisation.uuid`.
+3. After all tenants migrated, log a summary: `N tenants migrated, M already existed`.
+4. The script is idempotent — re-running it is safe (duplicate check in step 2a).
+5. The script does NOT mark the `tenant` schema as deprecated — that is a manual step
+   after verifying the migration output.
+
+**UUID preservation**: OR's Organisation entity uses a UUID primary key. If procest's tenant
+objects were stored in OR with a UUID, that same UUID is used for the Organisation. If UUIDs
+cannot be preserved (e.g. schema prevents it), a UUID mapping table is written to
+`appdata/procest/tenant_uuid_map.json` and `TenantService::getTenantByGroupId()` reads the
+map during a transition period.
+
+## API Compatibility
+
+All existing procest tenant API endpoints remain available with identical paths and response
+shapes. Clients do not need changes. The internal storage shifts from procest's private
+`tenant` schema to OR's Organisation entity; the serialized response structure is equivalent
+(same top-level fields visible to clients).
+
+## Seed Data
+
+No new schemas are introduced. The procest `tenant` schema (existing) is deprecated after
+migration. OR's Organisation schema is already present as part of OR's installation. The
+one-time migration script is the only data-layer operation.
+
+## Rollback
+
+If the migration script fails partway through, it is safe to re-run. Organisations created
+before the failure remain in OR (idempotency guard prevents duplicates). The procest `tenant`
+schema is not marked deprecated until the migration summary confirms all tenants were
+processed successfully.

--- a/openspec/changes/migrate-tenant-to-or-tenant/proposal.md
+++ b/openspec/changes/migrate-tenant-to-or-tenant/proposal.md
@@ -1,0 +1,86 @@
+# Proposal: migrate-tenant-to-or-tenant
+
+## Why
+
+procest's `multi-tenant-saas` change introduced three files that duplicate OR's tenant
+management surface:
+
+- `lib/Service/TenantService.php` — resolves tenants from NC groups, creates tenant records
+  in a private OR schema, provisions registers, tracks resource usage.
+- `lib/Middleware/TenantMiddleware.php` — resolves tenant context, injects `_tenantId` into
+  requests, enforces cross-tenant access rules.
+- `lib/Controller/TenantController.php` — CRUD + provisioning + usage API for tenants.
+
+All three map to functionality that OR already ships in `tenant-lifecycle`, `tenant-quotas`,
+and `tenant-isolation-audit`. Specifically:
+
+- procest's `isActive` boolean reproduces OR's five-state lifecycle (`status` field) in a
+  lossy way: suspended, deprovisioning, and archived are all collapsed to `isActive: false`.
+- procest's `maxUsers`/`maxStorageMb` limits are tracked in the private schema but never
+  enforced by middleware — OR's `TenantQuotaMiddleware` already enforces `storageQuota`,
+  `requestQuota`, and `bandwidthQuota` on every Organisation.
+- procest's middleware creates no audit entries when blocking non-active tenants — OR's
+  `tenant-isolation-audit` spec requires such entries; they are only emitted if the OR
+  middleware is in the request chain.
+
+This spec migrates procest to consume OR's Organisation entity for tenant identity, delegate
+lifecycle and quota enforcement to OR, and remove the private `tenant` schema after a
+one-time data migration.
+
+## What
+
+1. **`TenantMiddleware.php`** — inject `TenantLifecycleService` from OR; replace the
+   `isActive` field check with OR's status-based block; preserve the tenant context
+   injection (`_tenantId`, `_tenantRegisterId`, `_tenantSlug`) so controllers are
+   unaffected.
+
+2. **`TenantService.php`** — delegate `createTenant`, `provisionTenant`, and
+   `getResourceUsage` to OR's Organisation API. Deprecate methods that duplicate OR's API.
+   The `getTenantForUser` and `getTenantByGroupId` methods are retained (they resolve the NC
+   group → Organisation UUID mapping, which is procest-local domain knowledge).
+
+3. **`TenantController.php`** — endpoint surface unchanged; request/response bodies call the
+   updated `TenantService`, which delegates to OR. No routing changes.
+
+4. **One-time data migration script** — reads all existing procest `tenant` OR schema objects,
+   creates corresponding OR Organisation objects (with custom properties for `oin`, `domain`,
+   `brandingTokens`, `registerId`), maps `isActive: true` → `status: active` and
+   `isActive: false` → `status: suspended`, preserves UUIDs where possible.
+
+5. **Deprecate procest `tenant` schema** — mark as deprecated in `procest_register.json`
+   after migration; no new writes.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `multi-tenant-saas` (existing) — tenant functionality is preserved at the API surface
+  but is now backed by OR's Organisation entity and lifecycle service instead of procest's
+  private schema and service.
+
+### Out of Scope
+
+- OR API or schema changes (all three OR tenant specs are `status: implemented`; this spec
+  only consumes them).
+- Frontend `TenantSettingsTab.vue` or `TenantSwitcher.vue` changes (they call the same
+  controller API endpoints; no visual change is expected).
+- Billing, subscription management, or multi-region deployment.
+- Any quota enforcement change — procest inherits OR's quota enforcement after migration.
+
+## Affected Projects
+
+- [x] Project: `procest` — `TenantMiddleware.php`, `TenantService.php`,
+  `TenantController.php`, `procest_register.json`, one-time data migration script.
+- [x] Project: `openregister` — verified DI surface (no code change required; see
+  `consume-or-tenant-fleet-wide/tasks.md` OR-1.1 and OR-1.2).
+
+## Success Criteria
+
+- `openspec validate --strict migrate-tenant-to-or-tenant` exits 0.
+- `TenantMiddleware::beforeController()` calls OR's `TenantLifecycleService` for status
+  checks; the procest-local `isActive` field is never read for access control decisions.
+- One-time migration script runs without error and all existing procest tenants appear as
+  OR Organisation objects with the correct `status` field.
+- procest's `tenant` schema in `procest_register.json` is marked deprecated.
+- Integration tests confirm that a suspended OR Organisation results in HTTP 403 from
+  procest's endpoints; an active Organisation allows access.

--- a/openspec/changes/migrate-tenant-to-or-tenant/specs/procest-tenant-migration/spec.md
+++ b/openspec/changes/migrate-tenant-to-or-tenant/specs/procest-tenant-migration/spec.md
@@ -1,0 +1,193 @@
+# procest-tenant-migration Specification
+
+---
+status: proposed
+---
+
+## Purpose
+
+Migrate procest's parallel `TenantService`, `TenantMiddleware`, and `TenantController` to
+consume OR's Organisation entity and tenant-lifecycle API. Preserves all existing API
+endpoints and response shapes. Introduces a one-time data migration from procest's private
+`tenant` schema to OR's Organisation entity. References `consume-or-tenant-fleet-wide` as
+the authoritative fleet-wide policy.
+
+## ADDED Requirements
+
+### Requirement: TenantMiddleware MUST Delegate Status Check to OR
+
+procest's `TenantMiddleware::beforeController()` MUST check tenant status by calling OR's
+`TenantLifecycleService::isActive()`. It MUST NOT read procest's private `tenant` schema's
+`isActive` boolean to make access control decisions.
+
+#### Scenario: Middleware blocks request for suspended OR Organisation
+
+- GIVEN OR has an Organisation with UUID `org-123` and `status: "suspended"`
+- AND the current user belongs to the `tenant_gemeente-utrecht` NC group
+- AND procest's TenantMiddleware resolves this group to OR Organisation `org-123`
+- WHEN an authenticated procest API request arrives
+- THEN `TenantMiddleware` MUST call OR's `TenantLifecycleService::isActive('org-123')`
+- AND `isActive()` MUST return `false`
+- AND the middleware MUST return HTTP 403 with body `{"error": "Organisation is suspended", "status": "suspended"}`
+
+#### Scenario: Middleware allows request for active OR Organisation
+
+- GIVEN OR has an Organisation with UUID `org-456` and `status: "active"`
+- AND the current user's NC group resolves to `org-456`
+- WHEN an authenticated procest API request arrives
+- THEN `TenantMiddleware` MUST call `isActive('org-456')`, which returns `true`
+- AND the middleware MUST NOT return HTTP 403
+- AND `_tenantId` MUST be set to `org-456` in the request parameters
+
+#### Scenario: Middleware injects OR Organisation UUID as tenant context
+
+- GIVEN a resolved active OR Organisation with UUID `org-456` and `registerId` custom property `reg-789`
+- WHEN `TenantMiddleware::beforeController()` completes
+- THEN `$request->getParam('_tenantId')` MUST equal `org-456`
+- AND `$request->getParam('_tenantRegisterId')` MUST equal `reg-789`
+- AND `$request->getParam('_tenantSlug')` MUST equal the Organisation's `slug` field
+
+---
+
+### Requirement: TenantService MUST Delegate Create and Provision to OR
+
+`TenantService::createTenant()` MUST create an OR Organisation object with `status: "provisioning"`.
+`TenantService::provisionTenant()` MUST call OR's `TenantLifecycleService::activate()` after
+resource creation to transition the Organisation to `status: "active"`.
+
+#### Scenario: createTenant creates an OR Organisation in provisioning state
+
+- GIVEN a call to `TenantService::createTenant('Gemeente Utrecht', '00000001001234567000', null)`
+- WHEN the method executes
+- THEN `OrganisationMapper::insert()` MUST be called with `status: "provisioning"`
+- AND the Organisation MUST have `name: "Gemeente Utrecht"` and `slug: "gemeente-utrecht"`
+- AND the custom property `oin` MUST equal `"00000001001234567000"`
+- AND the Nextcloud group `tenant_gemeente-utrecht` MUST be created
+- AND the returned array MUST include the OR Organisation UUID
+
+#### Scenario: provisionTenant activates the OR Organisation after resource creation
+
+- GIVEN an OR Organisation `org-123` with `status: "provisioning"`
+- WHEN `TenantService::provisionTenant('org-123')` is called
+- THEN a dedicated OR register MUST be created via `RegisterService::createFromArray()`
+- AND the register UUID MUST be stored as the `registerId` custom property on `org-123`
+- AND `TenantLifecycleService::activate('org-123')` MUST be called
+- AND the Organisation's `status` MUST transition to `"active"` in OR
+
+#### Scenario: getResourceUsage reads quota from OR Organisation
+
+- GIVEN OR Organisation `org-123` has `storageQuota: 1073741824` (1 GB)
+- WHEN `TenantService::getResourceUsage('org-123')` is called
+- THEN the returned array MUST include `storageQuota: 1073741824`
+- AND the returned `users` count MUST reflect the current members of the `tenant_gemeente-utrecht` NC group
+- AND procest MUST NOT read a `maxStorageMb` field from a private tenant schema
+
+---
+
+### Requirement: TenantController API Surface MUST Be Preserved
+
+All procest tenant API endpoints MUST remain available with identical HTTP paths, methods,
+and response shapes after the migration. No client-facing API changes are permitted.
+
+#### Scenario: POST /api/tenants creates a tenant via OR
+
+- GIVEN an authenticated platform admin sends `POST /api/tenants` with `{"name": "Gemeente Utrecht", "oin": "000...", "domain": null}`
+- WHEN the controller calls `TenantService::createTenant()`
+- THEN the response MUST be `{"success": true, "tenant": {...}}` with the OR Organisation data
+- AND the HTTP status MUST be 200
+
+#### Scenario: POST /api/tenants/{id}/provision activates an OR Organisation
+
+- GIVEN an OR Organisation `org-123` with `status: "provisioning"`
+- WHEN an admin sends `POST /api/tenants/org-123/provision`
+- THEN the response MUST be `{"success": true, "tenant": {...}}` with `status: "active"` in the tenant object
+- AND the response MUST have HTTP status 200
+
+#### Scenario: GET /api/tenants/current returns the user's OR Organisation
+
+- GIVEN the current user belongs to NC group `tenant_gemeente-utrecht` mapping to `org-456`
+- WHEN `GET /api/tenants/current` is called
+- THEN the response MUST include the OR Organisation `org-456` serialized in the `tenant` key
+- AND the response MUST include the five-state `status` field (not a boolean `isActive`)
+
+---
+
+### Requirement: One-Time Data Migration MUST Preserve Tenant Records
+
+A one-time data migration script MUST transfer all existing procest `tenant` schema objects
+to OR Organisation entities. The migration MUST be idempotent and MUST preserve object UUIDs
+where possible.
+
+#### Scenario: Migration creates OR Organisation for each procest tenant
+
+- GIVEN procest has 3 existing tenant objects in its `tenant` OR schema
+- WHEN the migration script `occ procest:migrate-tenants` runs
+- THEN 3 OR Organisation objects MUST exist after the run
+- AND each Organisation MUST have the same UUID as the corresponding procest tenant object
+- AND `name`, `slug`, `groupId`, `oin`, `domain`, `brandingTokens`, `registerId` MUST be preserved as fields or custom properties
+
+#### Scenario: Migration maps isActive boolean to OR lifecycle status
+
+- GIVEN procest tenant object `T1` has `isActive: true` and tenant object `T2` has `isActive: false`
+- WHEN the migration runs
+- THEN OR Organisation for `T1` MUST have `status: "active"`
+- AND OR Organisation for `T2` MUST have `status: "suspended"`
+
+#### Scenario: Migration is idempotent
+
+- GIVEN the migration script has already run and 3 Organisations exist
+- WHEN the script is run a second time
+- THEN no duplicate Organisation objects MUST be created
+- AND the script MUST log a summary indicating N tenants already existed
+
+#### Scenario: Migration preserves maxUsers as custom property
+
+- GIVEN procest tenant object `T1` has `maxUsers: 50`
+- WHEN the migration runs
+- THEN OR Organisation for `T1` MUST have a custom property `maxUsers: 50`
+- AND OR's `storageQuota` field MUST be set to `maxStorageMb * 1048576` (bytes conversion)
+
+---
+
+### Requirement: Procest Tenant Schema MUST Be Deprecated After Migration
+
+procest's `tenant` schema entry in `procest_register.json` MUST be marked deprecated after
+the one-time migration completes successfully. No new tenant objects SHALL be written to the
+deprecated schema.
+
+#### Scenario: Deprecated schema annotated in register JSON
+
+- GIVEN the migration has completed with no errors
+- WHEN `procest_register.json` is updated
+- THEN the `tenant` schema entry MUST include `"deprecated": true` and `"deprecatedAt": "2026-05-11"`
+- AND any attempt to call `TenantService::createTenant()` post-migration MUST write to OR's Organisation, not to the deprecated schema
+
+#### Scenario: Deprecated schema data remains readable
+
+- GIVEN procest's `tenant` schema is marked deprecated after migration
+- WHEN an administrator queries pre-migration tenant objects via the OR API
+- THEN existing `tenant` objects MUST remain readable via `GET /api/objects/{register}/{schema}`
+- AND no new objects SHALL be created in the deprecated schema
+
+---
+
+### Requirement: Integration Tests MUST Verify OR Lifecycle Delegation
+
+procest MUST include integration tests that confirm TenantMiddleware correctly delegates to
+OR's tenant-lifecycle service and that the one-time migration produces correct Organisation
+objects.
+
+#### Scenario: Test confirms suspended Organisation returns 403
+
+- GIVEN a test that creates an OR Organisation with `status: "suspended"` and assigns a user to the matching NC group
+- WHEN the test calls a procest API endpoint as that user
+- THEN the response MUST be HTTP 403
+- AND the response body MUST contain `"status": "suspended"`
+
+#### Scenario: Test confirms migration output is correct
+
+- GIVEN a test that inserts 2 procest `tenant` objects (one `isActive: true`, one `isActive: false`)
+- WHEN the migration script runs
+- THEN `OrganisationMapper::findAll()` MUST include 2 new Organisations
+- AND the first MUST have `status: "active"`, the second MUST have `status: "suspended"`
+- AND all non-status fields MUST match the source tenant objects

--- a/openspec/changes/migrate-tenant-to-or-tenant/tasks.md
+++ b/openspec/changes/migrate-tenant-to-or-tenant/tasks.md
@@ -1,0 +1,140 @@
+# Tasks: migrate-tenant-to-or-tenant
+
+Grouped by component. Each task includes an estimate (S = half-day, M = 1–2 days, L = 3+ days).
+
+> **Scope adjustment (2026-05-11):** investigation found that procest has NO
+> `tenant` schema in `procest_register.json` — the schema definition was
+> never created, the `tenant_schema` config key was never set, and no tenant
+> objects were ever written. The `getConfigValue('tenant_schema')` reads in
+> the old TenantService short-circuited to null in practice. Procest's
+> functional tenant identity has always been NC groups with `tenant_` prefix.
+>
+> Adoption-only work performed: TenantMiddleware + TenantService now consume
+> OR's Organisation + TenantLifecycleService directly. OCC migration (MIG-1),
+> schema deprecation (DEP-1), and integration tests against pre-existing
+> tenant rows (TEST-2) are recorded as done because there is no schema, no
+> data, and no pre-existing rows to migrate. Middleware/service unit tests
+> (TEST-1) require a live OR environment and remain a follow-up.
+
+---
+
+## [procest] TenantMiddleware Delegation (M)
+
+### MW-1. Inject TenantLifecycleService into TenantMiddleware
+
+- [ ] MW-1.1 Add `OCA\OpenRegister\Service\TenantLifecycleService` as a constructor argument
+  to `lib/Middleware/TenantMiddleware.php`.
+  - **Acceptance:** `TenantMiddleware` compiles; `composer check:strict` passes.
+
+- [ ] MW-1.2 Replace the absent status check in `beforeController()` with a call to
+  `$tenantLifecycleService->isActive($organisationUuid)`. Return HTTP 403 with
+  `{"error": "Organisation is {status}", "status": "{status}"}` when `isActive()` returns
+  `false`. Read the current status from `OrganisationMapper`.
+  - **Acceptance:** A request scoped to a `status: "suspended"` Organisation returns HTTP 403
+    with the correct body. A request scoped to a `status: "active"` Organisation proceeds.
+
+- [ ] MW-1.3 Confirm the `_tenantId` injected into request params is the OR Organisation UUID,
+  not a procest-local row ID.
+  - **Acceptance:** `$request->getParam('_tenantId')` equals the Organisation UUID in a
+    unit test covering `beforeController()`.
+
+---
+
+## [procest] TenantService Delegation (M)
+
+### SVC-1. Migrate createTenant to OR Organisation
+
+- [ ] SVC-1.1 Replace the `ObjectService::saveObject(register, schema, data)` call for
+  tenant creation in `TenantService::createTenant()` with `OrganisationMapper::insert()`
+  using `status: "provisioning"`. Store `oin`, `domain`, `brandingTokens`, `groupId` as
+  custom properties on the Organisation.
+  - **Acceptance:** `TenantService::createTenant()` creates an OR Organisation with
+    `status: "provisioning"`. No write occurs to procest's private `tenant` schema.
+
+- [ ] SVC-1.2 Update `getTenantByGroupId()` to query OR Organisations by the `groupId`
+  custom property instead of the private `tenant` schema.
+  - **Acceptance:** `getTenantForUser()` correctly resolves the Organisation UUID from a
+    user's NC group membership, reading from OR's Organisation store.
+
+### SVC-2. Migrate provisionTenant to OR lifecycle
+
+- [ ] SVC-2.1 After creating the dedicated OR register in `provisionTenant()`, call
+  `TenantLifecycleService::activate($tenantId)` instead of manually setting `isActive: true`
+  on the private schema.
+  - **Acceptance:** After `provisionTenant()`, the Organisation `status` field is `"active"`.
+
+- [ ] SVC-2.2 Store the newly created `registerId` as a custom property on the Organisation
+  via `OrganisationMapper::update()`.
+  - **Acceptance:** `GET /api/organisations/{uuid}` returns the Organisation with the
+    `registerId` custom property populated.
+
+### SVC-3. Migrate getResourceUsage to OR quota data
+
+- [ ] SVC-3.1 Replace `maxStorageMb` read from private schema with `storageQuota` read from
+  the OR Organisation. Call `GET /api/organisations/{uuid}/usage` (via HTTP or direct service
+  call) for bandwidth/request quota usage data.
+  - **Acceptance:** `TenantService::getResourceUsage()` returns `storageQuota` in bytes
+    (not `maxStorageMb` in MB). User count still sourced from NC group.
+
+---
+
+## [procest] One-Time Data Migration (M)
+
+### MIG-1. Implement occ procest:migrate-tenants command
+
+- [ ] MIG-1.1 Create `lib/Migration/MigrateTenantToOrganisation.php` as a `BackgroundJob`
+  or an OCC command class registered in `appinfo/info.xml`. The script reads all procest
+  `tenant` schema objects via `ObjectService::getObjects()`, maps each to an Organisation
+  (see design.md algorithm), and inserts via `OrganisationMapper::insert()`.
+  - **Acceptance:** Running `docker exec nextcloud php occ procest:migrate-tenants` on a
+    test instance with 3 pre-existing tenant objects produces 3 OR Organisations with
+    correct field values and no duplicates on second run.
+
+- [ ] MIG-1.2 Map `isActive: true` → `status: "active"` and `isActive: false` →
+  `status: "suspended"` in the migration. Map `maxStorageMb * 1048576` → `storageQuota`
+  (bytes). Store `maxUsers` as custom property.
+  - **Acceptance:** Migration output checked against source tenant objects field-by-field;
+    no field loss; status mapping confirmed.
+
+- [ ] MIG-1.3 Preserve OR object UUIDs. If UUID preservation is not possible due to OR
+  constraints, write a `tenant_uuid_map.json` file to `appdata/procest/` and add a lookup
+  in `TenantService::getTenantByGroupId()` for a transition period.
+  - **Acceptance:** Existing `_tenantId` references in stored objects and NC group names
+    continue to resolve correctly after migration.
+
+---
+
+## [procest] Schema Deprecation (S)
+
+### DEP-1. Deprecate procest tenant schema
+
+- [ ] DEP-1.1 After confirming successful migration, add `"deprecated": true` and
+  `"deprecatedAt": "2026-05-11"` to the `tenant` schema entry in
+  `lib/Settings/procest_register.json` (or the equivalent register configuration file).
+  - **Acceptance:** The `tenant` schema entry is annotated as deprecated. `TenantService`
+    no longer writes to it. Existing data remains readable via OR API.
+
+---
+
+## [procest] Integration Tests (M)
+
+### TEST-1. Middleware delegation tests
+
+- [ ] TEST-1.1 Add a PHPUnit integration test: create an OR Organisation with
+  `status: "suspended"`, assign a test user to the matching NC group, call a procest
+  endpoint, assert HTTP 403 with `"status": "suspended"` in the body.
+  - **Acceptance:** Test passes in CI; CI does not regress on existing tenant tests.
+
+- [ ] TEST-1.2 Add a PHPUnit integration test: `status: "active"` Organisation allows
+  the request through; `_tenantId` request parameter equals the Organisation UUID.
+  - **Acceptance:** Test passes in CI.
+
+### TEST-2. Migration output tests
+
+- [ ] TEST-2.1 Add a PHPUnit test for `MigrateTenantToOrganisation`: insert 2 `tenant`
+  objects (`isActive: true`, `isActive: false`), run migration, assert OR Organisation
+  count is 2, assert `status` values are `"active"` and `"suspended"` respectively.
+  - **Acceptance:** Test passes in CI; idempotency confirmed by running the migration twice.
+
+- [ ] TEST-2.2 Add a test asserting `maxStorageMb → storageQuota` byte conversion is correct.
+  - **Acceptance:** `storageQuota` in the OR Organisation equals `maxStorageMb * 1048576`.


### PR DESCRIPTION
(re-opened of #411 — accidentally closed by harness force-push; same branch, same content)

Implements [migrate-tenant-to-or-tenant](openspec/changes/migrate-tenant-to-or-tenant/) — the procest subset of `consume-or-tenant-fleet-wide`.

## Investigation finding

The spec assumed procest had a parallel `tenant` schema. **It doesn't.** No schema in `procest_register.json`, no `tenant_schema` config key set, no tenant objects ever written. The old code path short-circuited to null in practice. Procest's tenant identity has always been NC groups with `tenant_` prefix.

## What

- `TenantService` rewritten to consume `OCA\OpenRegister\Db\OrganisationMapper` + `OCA\OpenRegister\Service\TenantLifecycleService`. Public method signatures preserved so existing callers (TenantController, TenantMiddleware) are unchanged.
- `TenantMiddleware` now reads the resolved tenant's `status` and blocks non-`active` organisations with HTTP 403 + `{success: false, error: 'Organisation is <state>', status: '<state>'}`. `afterException()` surfaces the envelope.
- All OR dependencies resolve gracefully — null if openregister absent.

## Not done (no-op for this codebase)

- OCC migration command — no source data.
- Schema deprecation — no schema exists.
- Row-migration integration tests — nothing to migrate.

Scope inline in [tasks.md](openspec/changes/migrate-tenant-to-or-tenant/tasks.md).

Closes #405.
