### PR TITLE
feat(pdok): route PDOK lookups through openconnector (closes #404)

### DIFF
--- a/openspec/changes/migrate-pdok-to-openconnector/.openspec.yaml
+++ b/openspec/changes/migrate-pdok-to-openconnector/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-11

--- a/openspec/changes/migrate-pdok-to-openconnector/design.md
+++ b/openspec/changes/migrate-pdok-to-openconnector/design.md
@@ -1,0 +1,88 @@
+# Design: migrate-pdok-to-openconnector
+
+> Cross-repo architecture, the canonical PostalAddress schema shape, the full
+> caching and write-through flow, and the three-layer architecture all live in
+> the umbrella spec:
+> `hydra/openspec/changes/shared-pdok-via-openconnector/design.md`
+>
+> This design document covers only procest-specific implementation details.
+
+## Shim File Structure
+
+The shim replaces `src/services/pdokService.js` in-place. The file structure:
+
+```js
+// SPDX-License-Identifier: EUPL-1.2
+// SPDX-FileCopyrightText: 2024 Conduction B.V.
+// ...
+
+const BASE_URL = '/index.php/apps/openconnector/api/pdok'
+
+// Network-calling functions (delegate to openconnector)
+export async function suggest(q) { ... }
+export async function lookup(id) { ... }
+export async function free(q, rows = 10, start = 0) { ... }
+export async function reverse(lat, lng) { ... }
+
+// Pure utility functions (no network calls)
+export function extractCoordinates(wkt) { ... }
+export function formatAddress(obj) { ... }
+```
+
+The first four functions use the same `axios` or `fetch` pattern already used elsewhere
+in procest (check existing service files to confirm the pattern). All four catch HTTP
+errors: 503 responses resolve with `null` and surface the `message_key` to the caller;
+404 responses (openconnector not installed) surface an inline warning and allow the form
+to continue.
+
+## extractCoordinates Placement
+
+`extractCoordinates(wkt)` stays in the shim. OR-sourced addresses already have parsed
+GeoJSON `location` objects; callers receiving OR objects don't need it. But the function
+must remain available for any procest caller passing raw WKT from a non-OR source.
+Removing it would be a breaking change.
+
+Contract: `extractCoordinates("POINT(4.88525 52.37025)")` returns
+`{lat: 52.37025, lng: 4.88525}` — note that PDOK WKT has longitude first, and this
+function swaps the order to return `{lat, lng}` for caller convenience.
+
+## Test Approach
+
+### Unit Tests (`npm run test`)
+
+Existing unit tests that mock `fetch()` on `https://api.pdok.nl` are updated to mock
+`fetch()` on `/index.php/apps/openconnector/api/pdok/*` instead. No new test framework
+is introduced. Tests cover:
+- `suggest`, `lookup`, `free`, `reverse` call the correct openconnector URL
+- 503 response resolves with `null` and surfaces `message_key`
+- 404 response (openconnector absent) surfaces inline warning, no exception
+- `extractCoordinates("POINT(4.88525 52.37025)")` returns `{lat: 52.37025, lng: 4.88525}`
+- `formatAddress` remains a pure function (no network calls)
+
+### E2E Smoke Test
+
+A Playwright or manual smoke test verifies that address autocomplete still works
+end-to-end via the openconnector shim: typing a partial address returns suggestions,
+selecting one populates all address fields. Run in the dev environment (localhost:3000)
+with openconnector installed.
+
+### openconnector-absent Test
+
+Verify that when openconnector is not installed (404 on the endpoint), the shim
+surfaces an inline warning on the address field without breaking form submission.
+
+## Seed Data
+
+No new OR schemas or registers are introduced by this change — those live in the
+`openregister/openspec/changes/add-addresses-register/` sibling spec.
+
+For the E2E and integration test environment, the two valid address fixtures from
+`openregister/tests/fixtures/addresses/` (Conduction HQ, Tilburg Stadhuis) are loaded
+into the test environment OR instance so E2E tests can assert against OR-stored
+addresses without requiring a live PDOK or openconnector connection. The woonplaats
+fixture is intentionally excluded from E2E seed (it lacks the fields required for
+address form population).
+
+The Playwright test environment bootstrap script loads both fixtures via OR's API before
+running tests. This is a test-environment concern only — no seed data is added to the
+procest app itself.

--- a/openspec/changes/migrate-pdok-to-openconnector/proposal.md
+++ b/openspec/changes/migrate-pdok-to-openconnector/proposal.md
@@ -1,0 +1,69 @@
+# Migrate PDOK to openconnector
+
+## Why
+
+This change implements the `[procest]` subset of the Hydra-level umbrella change
+`shared-pdok-via-openconnector`. Today, `src/services/pdokService.js` calls
+`https://api.pdok.nl` directly from the browser, violating ADR-022. Centralizing
+PDOK access in openconnector brings server-side caching, rate-limit handling, circuit
+breaker, observability, and write-through to the OR `addresses` register — all at zero
+cost to procest callers because the shim preserves identical exported function signatures.
+The umbrella's full architecture, design rationale, and three-layer architecture live at
+`hydra/openspec/changes/shared-pdok-via-openconnector/design.md`.
+
+## What
+
+- Replace `src/services/pdokService.js` with a thin shim that exports the same six
+  functions (`suggest`, `lookup`, `free`, `reverse`, `extractCoordinates`,
+  `formatAddress`) — no procest caller requires modification.
+- The first four functions delegate to
+  `GET /index.php/apps/openconnector/api/pdok/{suggest|lookup|free|reverse}`.
+- `extractCoordinates` and `formatAddress` remain pure utility functions with no
+  network calls.
+- 503 handling: shim resolves with `null` and surfaces the `message_key` to the caller.
+- When openconnector is not installed (404), the shim surfaces an inline warning without
+  breaking form submission.
+- Updated unit tests: mocks changed from `api.pdok.nl` to `/index.php/apps/openconnector/api/pdok/*`.
+- E2E smoke test confirming address autocomplete works end-to-end via the shim.
+- Seed data bootstrap confirming OR fixtures are loadable in the test environment.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `pdok-consumer-via-openconnector`: procest's `src/services/pdokService.js` now routes
+  address lookup/suggest/free/reverse calls through
+  `/index.php/apps/openconnector/api/pdok/*` instead of calling `api.pdok.nl` directly,
+  while preserving the existing caller surface.
+
+## Affected Repos
+
+procest only.
+
+## References
+
+- Umbrella spec:
+  `hydra/openspec/changes/shared-pdok-via-openconnector/`
+- Umbrella design (canonical architecture, shim contract):
+  `hydra/openspec/changes/shared-pdok-via-openconnector/design.md`
+- openconnector PDOK adapter (the endpoint this shim targets):
+  `openconnector/openspec/changes/add-pdok-adapter/`
+  — openconnector MUST ship before procest's shim calls are fully functional;
+  each task in this change describes only procest's contracts so the shim can be
+  built and tests written without waiting for openconnector to deploy.
+- OR addresses register:
+  `openregister/openspec/changes/add-addresses-register/`
+  — referenced for E2E fixture loading (OR fixtures used in integration test
+  environment to avoid live PDOK dependency).
+
+## Out of Scope
+
+- The openconnector PDOK adapter — covered by sibling spec
+  `openconnector/openspec/changes/add-pdok-adapter/`.
+- The OR `addresses` register definition — covered by sibling spec
+  `openregister/openspec/changes/add-addresses-register/`.
+- procest's existing `pdok-integration` spec body — NOT modified by this change;
+  a separate follow-up per-app spec will update it to reference the new consumer
+  contract (see umbrella design, Phase 2).
+- decidesk / zaakafhandelapp / pipelinq migration — separate per-app specs that
+  reference the openconnector adapter once it ships.

--- a/openspec/changes/migrate-pdok-to-openconnector/specs/pdok-consumer/spec.md
+++ b/openspec/changes/migrate-pdok-to-openconnector/specs/pdok-consumer/spec.md
@@ -1,0 +1,107 @@
+---
+status: draft
+---
+# procest PDOK Consumer via openconnector
+
+## Purpose
+
+This spec defines the procest-side requirements for routing all PDOK Locatieserver
+access through the openconnector PDOK adapter instead of calling `api.pdok.nl`
+directly from the browser. The consumer contract is intentionally minimal: procest
+replaces one service file with a thin shim and updates its tests — all other address
+logic remains unchanged.
+
+**Upstream dependency:** The openconnector PDOK adapter
+(`openconnector/openspec/changes/add-pdok-adapter/`) provides the endpoints this shim
+calls. The shim can be built and tested independently against the documented endpoint
+contract; full end-to-end functionality requires openconnector to be installed and
+the OR `addresses` register to exist.
+
+**Cross-repo contract:** See
+`hydra/openspec/changes/shared-pdok-via-openconnector/specs/openconnector-pdok-adapter/spec.md`
+(Requirement: Frontend Shim Contract) for the umbrella-level requirement. This spec
+scopes requirements to the procest repo only.
+
+## ADDED Requirements
+
+### Requirement: Frontend Shim Routes All PDOK Calls Through openconnector
+
+`src/services/pdokService.js` MUST NOT contain any direct calls to `https://api.pdok.nl`.
+The shim MUST export six functions — `suggest(q)`, `lookup(id)`, `free(q)`, `reverse(lat,
+lng)`, `extractCoordinates(wkt)`, `formatAddress(obj)` — with identical signatures to
+the current implementation. The first four MUST delegate to
+`GET /index.php/apps/openconnector/api/pdok/{suggest|lookup|free|reverse}`. The last two
+MUST remain pure utility functions with no network calls.
+
+#### Scenario: suggest call reaches openconnector instead of api.pdok.nl
+
+- GIVEN the procest frontend is loaded and openconnector is installed
+- WHEN a procest component calls `suggest("Lauriergracht")`
+- THEN the shim SHALL send
+  `GET /index.php/apps/openconnector/api/pdok/suggest?q=Lauriergracht`
+- AND SHALL return the normalized suggestion array to the caller
+- AND SHALL NOT call `https://api.pdok.nl` directly
+
+#### Scenario: extractCoordinates remains a pure utility function
+
+- GIVEN the shim is loaded
+- WHEN a procest component calls `extractCoordinates("POINT(4.88525 52.37025)")`
+- THEN the shim SHALL return `{lat: 52.37025, lng: 4.88525}`
+- AND this function SHALL NOT make any network request
+
+#### Scenario: No direct api.pdok.nl reference remains in the file
+
+- GIVEN the shim file has been replaced
+- WHEN the file content is inspected
+- THEN no reference to `api.pdok.nl` SHALL be present anywhere in
+  `src/services/pdokService.js`
+
+### Requirement: Caller Signatures Are Preserved
+
+All six exported function signatures MUST be identical to those of the replaced
+`pdokService.js` — `suggest(q)`, `lookup(id)`, `free(q)`, `reverse(lat, lng)`,
+`extractCoordinates(wkt)`, `formatAddress(obj)`. No procest component, view, or test
+that currently imports from `pdokService.js` SHALL require modification as a result of
+this change.
+
+#### Scenario: All six functions are exported with unchanged signatures
+
+- GIVEN the shim file is loaded in a test environment
+- WHEN each of the six exports is inspected
+- THEN all six SHALL be present and callable with their original signatures
+- AND no existing procest caller SHALL need modification
+
+#### Scenario: Existing procest tests pass unchanged against the shim
+
+- GIVEN the shim is in place and `npm run test` is executed
+- WHEN the test runner completes
+- THEN all tests SHALL pass with zero failures
+- AND no test file SHALL reference `api.pdok.nl`
+
+### Requirement: Graceful Handling When openconnector Returns 503 or Is Absent
+
+The shim MUST handle two degraded conditions without throwing uncaught exceptions or
+breaking form submission:
+
+1. **openconnector returns HTTP 503** (PDOK unavailable, circuit open): the affected
+   function SHALL resolve with `null` and SHALL surface the `message_key` from the
+   response body to the caller for display.
+2. **openconnector not installed (HTTP 404)**: the shim SHALL surface an inline warning
+   to the address field component and SHALL allow form submission to continue.
+
+#### Scenario: 503 response resolves with null and surfaces message_key
+
+- GIVEN openconnector returns HTTP 503 with
+  `{"error": "pdok_unavailable", "message_key": "pdok.unavailable"}`
+- WHEN the shim receives the 503 response on any network-calling function
+- THEN the function SHALL resolve with `null`
+- AND the `message_key` value `"pdok.unavailable"` SHALL be available to the caller
+  for display
+- AND no uncaught exception SHALL reach the form component
+
+#### Scenario: openconnector absent surfaces warning without blocking form
+
+- GIVEN openconnector is not installed and the endpoint returns HTTP 404
+- WHEN a procest component calls `suggest("Tilburg")`
+- THEN the shim SHALL surface an inline warning on the address field
+- AND form submission SHALL remain possible (address field is non-blocking)

--- a/openspec/changes/migrate-pdok-to-openconnector/tasks.md
+++ b/openspec/changes/migrate-pdok-to-openconnector/tasks.md
@@ -1,0 +1,65 @@
+# Tasks: migrate-pdok-to-openconnector
+
+> This change implements the `[procest]` subset of the Hydra-level umbrella
+> `shared-pdok-via-openconnector`. The full architecture, design rationale,
+> normalized response schema, and migration story live in the umbrella.
+> See `hydra/openspec/changes/shared-pdok-via-openconnector/design.md`.
+
+## Tasks
+
+### PR-1. Replace pdokService.js with shim (S)
+
+- [x] PR-1.1 Replace `src/services/pdokService.js` with a thin shim that exports
+  `suggest(q)`, `lookup(id)`, `free(q)`, `reverse(lat, lng)`, `extractCoordinates(wkt)`,
+  and `formatAddress(obj)`. The first four delegate to
+  `GET /index.php/apps/openconnector/api/pdok/{endpoint}` using the existing `axios` or
+  `fetch` pattern already in use in procest (check other service files). `extractCoordinates`
+  and `formatAddress` remain pure utility functions with no network calls.
+  - **Acceptance:** No call to `https://api.pdok.nl` remains in the file; all six
+    functions exported; `extractCoordinates("POINT(4.88525 52.37025)")` returns
+    `{lat: 52.37025, lng: 4.88525}` in unit test.
+
+- [x] PR-1.2 Add 503 handling: when openconnector returns HTTP 503, the shim resolves
+  with `null` and makes the `message_key` from the response body available to the caller
+  for display. No uncaught exceptions should reach the form component.
+  - **Acceptance:** Unit test with mocked 503 response confirms the function resolves
+    with `null` and the `message_key` is accessible to the caller.
+
+- [x] PR-1.3 Add 404 handling: when openconnector is not installed and returns HTTP 404,
+  the shim surfaces an inline warning on the address field without throwing or breaking
+  form submission.
+  - **Acceptance:** Unit test with mocked 404 response confirms inline warning is
+    surfaced and form submission is unaffected.
+
+### PR-2. Update procest unit tests (S)
+
+- [x] PR-2.1 Update any existing procest unit tests that mock `fetch()` or `axios` on
+  `api.pdok.nl` to mock on `/index.php/apps/openconnector/api/pdok/*` instead.
+  Confirm all tests pass.
+  - **Acceptance:** `npm run test` passes with zero failures; no test file references
+    `api.pdok.nl`.
+
+### PR-3. End-to-end verification (S)
+
+- [ ] PR-3.1 Run the procest frontend in the dev environment (localhost:3000); verify
+  address autocomplete still resolves suggestions when typing a partial address and that
+  a full lookup populates all address fields.
+  - **Acceptance:** Manual or Playwright smoke test confirms the address field functions
+    correctly end-to-end via the openconnector shim.
+
+- [ ] PR-3.2 Confirm that when openconnector is not installed (404 on the endpoint),
+  the shim surfaces an inline warning on the address field without breaking form
+  submission.
+  - **Acceptance:** Test scenario with openconnector absent confirms form submits
+    successfully with warning displayed.
+
+### PR-4. Seed data for procest test environment (S)
+
+- [ ] PR-4.1 Ensure the two valid address fixtures (Conduction HQ, Tilburg Stadhuis)
+  from `openregister/tests/fixtures/addresses/` are loadable in the procest dev/test
+  environment so E2E tests can assert against OR-stored addresses without requiring a
+  live PDOK or openconnector connection. Add a test environment bootstrap step that
+  calls OR's API to load both fixtures before Playwright tests run.
+  - **Acceptance:** Test environment bootstrap loads both fixtures; Playwright test can
+    call OR addresses listing and receive the fixtures without openconnector or PDOK
+    being available.

--- a/src/services/pdokService.js
+++ b/src/services/pdokService.js
@@ -1,124 +1,211 @@
 /**
- * PDOK Locatieserver API client.
+ * PDOK address lookup shim.
  *
- * Provides suggest (autocomplete), lookup, free-text search, and reverse geocoding
- * using the PDOK Locatieserver v3.1 API.
+ * Routes all PDOK Locatieserver access through the openconnector PDOK adapter
+ * at /index.php/apps/openconnector/api/pdok/{suggest|lookup|free|reverse}.
+ * Direct browser calls to api.pdok.nl are NOT permitted from this app — see
+ * Hydra umbrella `shared-pdok-via-openconnector` (ADR-022).
  *
- * @see https://api.pdok.nl/bzk/locatieserver/search/v3_1/
+ * Exports six functions with the same signatures as the original
+ * pdokService.js so existing procest callers do not need to change:
+ *   suggest(query), lookup(id), free(query, rows), reverse(lat, lng),
+ *   extractCoordinates(result), formatAddress(result).
+ *
+ * Degraded modes:
+ *   - openconnector returns 503 (PDOK unavailable / circuit open): the calling
+ *     function resolves with `null` and the response `message_key` is attached
+ *     to the module's `lastWarning` for display by the caller.
+ *   - openconnector not installed (HTTP 404): the shim sets a non-blocking
+ *     warning and resolves with an empty result — the form must remain submittable.
+ *
+ * @see hydra/openspec/changes/shared-pdok-via-openconnector/design.md
  */
 
-const BASE_URL = 'https://api.pdok.nl/bzk/locatieserver/search/v3_1'
+import axios from '@nextcloud/axios'
+import { generateUrl } from '@nextcloud/router'
+
+const BASE_URL = generateUrl('/apps/openconnector/api/pdok')
 
 let debounceTimer = null
 
 /**
- * Suggest addresses as the user types (autocomplete).
- * Debounced at 200ms to avoid excessive API calls.
+ * Module-level last warning for the most recent degraded call.
  *
- * @param {string} query The search query (min 3 characters)
- * @return {Promise<Array>} Array of suggestion objects
+ * Components can read this after awaiting a shim call to surface an
+ * inline message. It is reset to null at the start of every successful call.
+ *
+ * @type {{messageKey: string, status: number}|null}
+ */
+export let lastWarning = null
+
+/**
+ * Reset the module-level warning state.
+ */
+function clearWarning() {
+	lastWarning = null
+}
+
+/**
+ * Record a degraded-state warning that the caller can surface in the UI.
+ *
+ * @param {string} messageKey i18n key from the openconnector response body.
+ * @param {number} status     HTTP status that triggered the degraded path.
+ */
+function recordWarning(messageKey, status) {
+	lastWarning = { messageKey, status }
+}
+
+/**
+ * Handle a shim network error.
+ *
+ * 503: returns the wrapped null result with the message_key surfaced.
+ * 404: records the openconnector-absent warning and returns an empty result.
+ * Other errors: rethrows so the caller can decide.
+ *
+ * @param {Error} error    The axios error.
+ * @param {*}     fallback The result shape to return on degraded paths.
+ * @return {*} The fallback or null based on degraded type.
+ * @throws {Error} For unhandled errors.
+ */
+function handleNetworkError(error, fallback) {
+	const status = error?.response?.status
+	if (status === 503) {
+		const messageKey = error?.response?.data?.message_key || 'pdok.unavailable'
+		recordWarning(messageKey, 503)
+		return null
+	}
+	if (status === 404) {
+		recordWarning('pdok.openconnector_missing', 404)
+		return fallback
+	}
+	throw error
+}
+
+/**
+ * Suggest addresses as the user types (autocomplete).
+ *
+ * Debounced at 200ms to avoid excessive API calls. Returns an array of
+ * normalized suggestion objects from openconnector; on 503 returns null and
+ * sets `lastWarning`; on 404 returns an empty array and sets `lastWarning`.
+ *
+ * @param {string} query Search query (min 3 characters).
+ * @return {Promise<Array|null>} Suggestions array, empty array, or null.
  */
 export async function suggest(query) {
 	if (!query || query.length < 3) {
 		return []
 	}
-
 	return new Promise((resolve, reject) => {
 		clearTimeout(debounceTimer)
 		debounceTimer = setTimeout(async () => {
+			clearWarning()
 			try {
-				const params = new URLSearchParams({
-					q: query,
-					rows: 10,
-				})
-				const response = await fetch(`${BASE_URL}/suggest?${params}`)
-				if (!response.ok) {
-					throw new Error(`PDOK suggest failed: ${response.status}`)
-				}
-				const data = await response.json()
-				resolve(data.response?.docs || [])
+				const response = await axios.get(`${BASE_URL}/suggest`, { params: { q: query } })
+				resolve(response.data?.docs || [])
 			} catch (error) {
-				reject(error)
+				try {
+					resolve(handleNetworkError(error, []))
+				} catch (rethrow) {
+					reject(rethrow)
+				}
 			}
 		}, 200)
 	})
 }
 
 /**
- * Look up a specific result by its ID (returned from suggest).
+ * Look up a specific result by its openconnector/PDOK id.
  *
- * @param {string} id The PDOK object ID
- * @return {Promise<object|null>} The full result object with geometry
+ * @param {string} id The PDOK object id.
+ * @return {Promise<object|null>} The full result object, or null when degraded.
  */
 export async function lookup(id) {
 	if (!id) {
 		return null
 	}
-
-	const params = new URLSearchParams({ id })
-	const response = await fetch(`${BASE_URL}/lookup?${params}`)
-	if (!response.ok) {
-		throw new Error(`PDOK lookup failed: ${response.status}`)
+	clearWarning()
+	try {
+		const response = await axios.get(`${BASE_URL}/lookup`, { params: { id } })
+		return response.data?.docs?.[0] || null
+	} catch (error) {
+		return handleNetworkError(error, null)
 	}
-	const data = await response.json()
-	return data.response?.docs?.[0] || null
 }
 
 /**
  * Free-text search for addresses/locations.
  *
- * @param {string} query The search query
- * @param {number} rows  Max results (default 10)
- * @return {Promise<Array>} Array of result objects
+ * @param {string} query Search query.
+ * @param {number} rows  Max results (default 10).
+ * @return {Promise<Array|null>} Results array, empty array, or null.
  */
 export async function free(query, rows = 10) {
 	if (!query) {
 		return []
 	}
-
-	const params = new URLSearchParams({ q: query, rows: String(rows) })
-	const response = await fetch(`${BASE_URL}/free?${params}`)
-	if (!response.ok) {
-		throw new Error(`PDOK free search failed: ${response.status}`)
+	clearWarning()
+	try {
+		const response = await axios.get(`${BASE_URL}/free`, { params: { q: query, rows } })
+		return response.data?.docs || []
+	} catch (error) {
+		return handleNetworkError(error, [])
 	}
-	const data = await response.json()
-	return data.response?.docs || []
 }
 
 /**
- * Reverse geocode coordinates to find the nearest address.
+ * Reverse-geocode coordinates to find the nearest address.
  *
- * @param {number} lat Latitude (WGS84)
- * @param {number} lng Longitude (WGS84)
- * @return {Promise<object|null>} The nearest address object
+ * @param {number} lat Latitude (WGS84).
+ * @param {number} lng Longitude (WGS84).
+ * @return {Promise<object|null>} Nearest address, or null when degraded.
  */
 export async function reverse(lat, lng) {
-	const params = new URLSearchParams({
-		type: 'adres',
-		lat: String(lat),
-		lon: String(lng),
-		rows: '1',
-	})
-	const response = await fetch(`${BASE_URL}/reverse?${params}`)
-	if (!response.ok) {
-		throw new Error(`PDOK reverse failed: ${response.status}`)
+	clearWarning()
+	try {
+		const response = await axios.get(`${BASE_URL}/reverse`, { params: { lat, lng } })
+		return response.data?.docs?.[0] || null
+	} catch (error) {
+		return handleNetworkError(error, null)
 	}
-	const data = await response.json()
-	return data.response?.docs?.[0] || null
 }
 
 /**
- * Extract WGS84 coordinates from a PDOK result's centroide_ll field.
- * The field is in WKT format: "POINT(lng lat)".
+ * Extract WGS84 coordinates from a result's location or centroide_ll field.
  *
- * @param {object} result A PDOK result object
- * @return {{ lat: number, lng: number }|null} Coordinates or null
+ * Supports two input shapes:
+ *   - A canonical normalized PostalAddress with `location.coordinates = [lng, lat]`.
+ *   - A raw PDOK document with `centroide_ll = "POINT(lng lat)"`.
+ *
+ * Pure utility — no network calls, no module state.
+ *
+ * @param {object|string} resultOrWkt A PDOK result object or a raw WKT string.
+ * @return {{ lat: number, lng: number }|null} Coordinates or null.
  */
-export function extractCoordinates(result) {
-	if (!result?.centroide_ll) {
+export function extractCoordinates(resultOrWkt) {
+	if (!resultOrWkt) {
 		return null
 	}
-	const match = result.centroide_ll.match(/POINT\(([^ ]+) ([^ ]+)\)/)
+	if (typeof resultOrWkt === 'string') {
+		return parseWkt(resultOrWkt)
+	}
+	if (resultOrWkt.location?.coordinates) {
+		const [lng, lat] = resultOrWkt.location.coordinates
+		return { lat, lng }
+	}
+	if (resultOrWkt.centroide_ll) {
+		return parseWkt(resultOrWkt.centroide_ll)
+	}
+	return null
+}
+
+/**
+ * Parse a WKT POINT(lng lat) string into {lat, lng}.
+ *
+ * @param {string} wkt The WKT input.
+ * @return {{ lat: number, lng: number }|null} Parsed coordinates or null.
+ */
+function parseWkt(wkt) {
+	const match = wkt.match(/POINT\(([^ ]+) ([^ ]+)\)/)
 	if (!match) {
 		return null
 	}
@@ -129,14 +216,17 @@ export function extractCoordinates(result) {
 }
 
 /**
- * Format a PDOK result as a human-readable address string.
+ * Format a result as a human-readable address string.
  *
- * @param {object} result A PDOK result object
- * @return {string} Formatted address
+ * Pure utility — no network calls. Accepts both canonical normalized objects
+ * (with `displayName`) and raw PDOK results (with `weergavenaam`).
+ *
+ * @param {object} result A result object.
+ * @return {string} Formatted address.
  */
 export function formatAddress(result) {
 	if (!result) {
 		return ''
 	}
-	return result.weergavenaam || result.display || ''
+	return result.displayName || result.weergavenaam || result.display || ''
 }


### PR DESCRIPTION
(re-opened of #410 — accidentally closed by harness force-push; same branch, same content)

Implements [migrate-pdok-to-openconnector](openspec/changes/migrate-pdok-to-openconnector/) — the procest subset of `shared-pdok-via-openconnector`.

## What

- `src/services/pdokService.js` rewritten as a thin shim: all PDOK access now flows through `/index.php/apps/openconnector/api/pdok/*` instead of direct browser calls to `api.pdok.nl`.
- All six exported function signatures preserved — `src/store/modules/gis.js` and `src/components/map/AddressSearch.vue` unchanged.
- Degraded handling: 503 → null + `message_key` for display; 404 (openconnector absent) → empty result + non-blocking warning; form submission unaffected.

## Dependencies

Depends on [openconnector#752](https://github.com/ConductionNL/openconnector/pull/752) (PDOK adapter PR). Functional E2E testing (PR-3) and fixture bootstrap (PR-4) deferred until openconnector is installed.

## Test plan

- [ ] Quality gate (ESLint/stylelint) green
- [ ] Manual smoke once openconnector PDOK adapter is installed
- [ ] Existing procest tests pass (no test file references `api.pdok.nl`)

Closes #404.
