### PR TITLE
fix(#323): clear 6 mechanical ESLint source errors

### DIFF
--- a/src/views/cases/components/EmailComposer.vue
+++ b/src/views/cases/components/EmailComposer.vue
@@ -46,7 +46,7 @@
 			<div v-if="unresolvedVars.length > 0" class="email-composer__warning">
 				{{ t('procest', 'Unresolved variables:') }}
 				<span v-for="v in unresolvedVars" :key="v" class="email-composer__unresolved">
-					{{ '{' + '{' + v + '}' + '}' }}
+					{{ formatVariable(v) }}
 				</span>
 			</div>
 
@@ -56,7 +56,7 @@
 					<summary>{{ t('procest', 'Available variables') }}</summary>
 					<div class="email-composer__variable-list">
 						<code v-for="v in availableVariables" :key="v" @click="insertVariable(v)">
-							{{ '{' + '{' + v + '}' + '}' }}
+							{{ formatVariable(v) }}
 						</code>
 					</div>
 				</details>
@@ -163,6 +163,9 @@ export default {
 		},
 	},
 	methods: {
+		formatVariable(varName) {
+			return '{{' + varName + '}}'
+		},
 		onTemplateSelected(template) {
 			if (!template) return
 			this.form.subject = template.subjectPattern || ''


### PR DESCRIPTION
(re-opened of #327 — accidentally closed by harness force-push; same branch, same content)

Pure no-op cleanup; no semantic change to any view. Six errors fixed: bezwaar.js no-unused-vars (settingsStore), CaseTransferDialog.vue + CreateShareDialog.vue vue/valid-v-slot (move template #actions to direct child of NcDialog), EmailComposer.vue vue/no-parsing-error x2 (literal '{{' inside interpolation -> formatVariable() method), DurationPicker.vue no-unused-vars (formatDuration). 7th error (vue/no-dupe-v-else-if in MyWork.vue) split into separate PR #326 (behaviour change, needs smoke-test). Refs #323.
