### PR TITLE
ci(dependabot): target development branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "development"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10


### PR DESCRIPTION
Adds `target-branch: development` to .github/dependabot.yml so dependency PRs are opened against `development` (matches ADR-013 branching strategy). Closes #305's misdirected base, which has been retargeted manually.