### PR TITLE
sync: development to documentation (meta descriptions #81)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,7 @@
 id: intro
 title: Introduction
 sidebar_position: 1
+description: Get started with Procest, case management and BPMN workflows on Nextcloud. VTH-grade compliance with typed registers and a full audit trail.
 ---
 
 # Procest Documentation


### PR DESCRIPTION
Sync development to documentation so the meta-description deploy fires.