### PR TITLE
feat(manifest-v2): flip 5 custom pages to typed primitives (refs #514)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.0",
 			"license": "EUPL-1.2",
 			"dependencies": {
-				"@conduction/nextcloud-vue": "1.0.0-beta.57",
+				"@conduction/nextcloud-vue": "^1.0.0-beta.60",
 				"@nextcloud/auth": "^2.6.0",
 				"@nextcloud/axios": "~2.5.2",
 				"@nextcloud/dialogs": "^3.2.0",
@@ -507,9 +507,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "1.0.0-beta.57",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.57.tgz",
-			"integrity": "sha512-RQmqpvSGvD3PbU46sG6dneqP+9UQRvHumtZQzEI8An1NitHtIIVXUcaiN3Z3mQs/m68SLIyrXoBQIbNQZftxmA==",
+			"version": "1.0.0-beta.60",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.60.tgz",
+			"integrity": "sha512-VZ6tyH349Oa/k+zobzA86DC7OqP6x8OkuGsXVN22wWZ0DE0584CM05te2M+3oIC9BPELFi2lt84tq0FOKf8ehw==",
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"extends @nextcloud/browserslist-config"
 	],
 	"dependencies": {
-		"@conduction/nextcloud-vue": "1.0.0-beta.57",
+		"@conduction/nextcloud-vue": "^1.0.0-beta.60",
 		"@nextcloud/auth": "^2.6.0",
 		"@nextcloud/axios": "~2.5.2",
 		"@nextcloud/dialogs": "^3.2.0",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest-v2.schema.json",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"dependencies": [
 		"openregister"
 	],
@@ -108,7 +108,7 @@
 			"id": "CaseTypesMenu",
 			"label": "Case Types",
 			"icon": "icon-category-customization",
-			"route": "CaseTypes",
+			"route": "Settings",
 			"section": "settings",
 			"order": 95
 		},
@@ -395,18 +395,36 @@
 		{
 			"id": "MyWork",
 			"route": "/my-work",
-			"type": "custom",
+			"type": "dashboard",
 			"title": "My Work",
-			"component": "MyWorkView",
-			"_note": "Bespoke 4-tab filter UI mixing case + task entities; resolved via registry entry MyWorkView."
+			"config": {
+				"widgets": [
+					{ "id": "myWorkBoard", "title": "My Work", "type": "custom" }
+				],
+				"layout": [
+					{ "id": 1, "widgetId": "myWorkBoard", "gridX": 0, "gridY": 0, "gridWidth": 12, "gridHeight": 12 }
+				]
+			},
+			"slots": {
+				"widget-myWorkBoard": "MyWorkView"
+			}
 		},
 		{
 			"id": "Werkvoorraad",
 			"route": "/werkvoorraad",
-			"type": "custom",
+			"type": "dashboard",
 			"title": "Work Queue",
-			"component": "WerkvoorraadView",
-			"_note": "KPI-strip-driven work queue; resolved via registry entry WerkvoorraadView."
+			"config": {
+				"widgets": [
+					{ "id": "werkvoorraad", "title": "Work Queue", "type": "custom" }
+				],
+				"layout": [
+					{ "id": 1, "widgetId": "werkvoorraad", "gridX": 0, "gridY": 0, "gridWidth": 12, "gridHeight": 12 }
+				]
+			},
+			"slots": {
+				"widget-werkvoorraad": "WerkvoorraadView"
+			}
 		},
 		{
 			"id": "Cases",
@@ -975,10 +993,16 @@
 		{
 			"id": "VoorstelDetail",
 			"route": "/voorstellen/:id",
-			"type": "custom",
+			"type": "detail",
 			"title": "Voorstel",
-			"component": "VoorstelDetailView",
-			"_note": "Parafeerroute multi-step approver flow; resolved via registry entry VoorstelDetailView. Migration to typed page deferred."
+			"config": {
+				"register": "procest",
+				"schema": "voorstel",
+				"sidebar": { "enabled": true, "showMetadata": true }
+			},
+			"slots": {
+				"default": "VoorstelDetailView"
+			}
 		},
 		{
 			"id": "Advice",
@@ -1044,26 +1068,33 @@
 		{
 			"id": "Doorlooptijd",
 			"route": "/doorlooptijd",
-			"type": "custom",
+			"type": "dashboard",
 			"title": "Doorlooptijd",
-			"component": "DoorlooptijdView",
-			"_note": "KPI dashboard with apexcharts; resolved via registry entry DoorlooptijdView. Pending lib chart-widget support."
+			"config": {
+				"widgets": [
+					{ "id": "doorlooptijd", "title": "Doorlooptijd", "type": "custom" }
+				],
+				"layout": [
+					{ "id": 1, "widgetId": "doorlooptijd", "gridX": 0, "gridY": 0, "gridWidth": 12, "gridHeight": 12 }
+				]
+			},
+			"slots": {
+				"widget-doorlooptijd": "DoorlooptijdView"
+			}
 		},
 		{
 			"id": "Settings",
 			"route": "/settings",
-			"type": "custom",
+			"type": "settings",
 			"title": "Settings",
-			"component": "AdminRootView",
-			"_note": "Multi-tab admin root; resolved via registry entry AdminRootView. Pending lib settings-custom-slot support."
-		},
-		{
-			"id": "CaseTypes",
-			"route": "/case-types",
-			"type": "custom",
-			"title": "Case types",
-			"component": "AdminRootView",
-			"_note": "Multi-tab admin root; resolved via registry entry AdminRootView. Pending lib settings-custom-slot support."
+			"config": {
+				"sections": [
+					{ "id": "admin", "title": "Settings" }
+				]
+			},
+			"slots": {
+				"section-admin": "AdminRootView"
+			}
 		},
 		{
 			"id": "Legesverordeningen",


### PR DESCRIPTION
Drops customs from 10/57 (18%) → 5/57 (9%).

- MyWork, Werkvoorraad, Doorlooptijd → `type:"dashboard"` (single-widget wrap)
- Settings → `type:"settings"` (single-section wrap)
- VoorstelDetail → `type:"detail"` + slots.default → VoorstelDetailView

5 residual customs with genuine reasons: WorkflowTemplateEditor (graph editor), Public[Case|Appointment|Status] (anonymous routes), FeaturesRoadmap (move to nc-vue).

Bumps nc-vue to ^1.0.0-beta.60.