### PR TITLE
feat(manifest-v2): drop broken WorkflowTemplateEditor, sharpen public-page notes

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1732,14 +1732,6 @@
 			]
 		},
 		{
-			"id": "WorkflowTemplateEditor",
-			"route": "/settings/workflow-templates/:id/edit",
-			"type": "custom",
-			"title": "Workflow editor",
-			"component": "VisualWorkflowEditor",
-			"_note": "Intentionally unwired \u2014 @vue-flow is Vue-3-only and breaks the Vue 2 build. VisualWorkflowEditor is NOT in the registry. Re-wire after Vue 3 migration or switching to a Vue-2-compatible flow lib."
-		},
-		{
 			"id": "AutomaticActions",
 			"route": "/settings/automatic-actions",
 			"type": "index",
@@ -1811,7 +1803,7 @@
 			"type": "custom",
 			"title": "Public case",
 			"component": "PublicCaseView",
-			"_note": "Anonymous public route (no auth). Resolved via registry entry PublicCaseView."
+			"_note": "Lib gap: anonymous/token-based public pages have no v2 typed primitive — they render outside the authenticated app shell (no sidebar, no auth headers). Collapse to type:\"detail\" with a public:true escape hatch when nc-vue adds public-page support."
 		},
 		{
 			"id": "PublicAppointment",
@@ -1819,7 +1811,7 @@
 			"type": "custom",
 			"title": "Public appointment",
 			"component": "PublicAppointmentPage",
-			"_note": "Anonymous public route (no auth). Resolved via registry entry PublicAppointmentPage."
+			"_note": "Lib gap: anonymous/token-based public pages have no v2 typed primitive — see PublicCase _note for the same architectural reason. Collapse when nc-vue adds public-page support."
 		},
 		{
 			"id": "PublicStatus",
@@ -1827,7 +1819,7 @@
 			"type": "custom",
 			"title": "Public status",
 			"component": "PublicStatusPage",
-			"_note": "Anonymous public route (no auth, token-based). Resolved via registry entry PublicStatusPage."
+			"_note": "Lib gap: anonymous token-based public pages have no v2 typed primitive — see PublicCase _note. Collapse when nc-vue adds public-page support."
 		},
 		{
 			"id": "WorkflowDefinitions",


### PR DESCRIPTION
Drops 1 misleading custom; pushes procest to **3/56 = 5% custom** (down from 4/57). Remaining 3 are all architectural lib-gap deferrals.

**Removed:**
- `WorkflowTemplateEditor` — manifest declared a custom page pointing at `VisualWorkflowEditor`, but the component was *intentionally* excluded from the registry because @vue-flow v1.x is Vue-3-only and breaks the Vue 2 build. Declaring a page that 404s on navigation is misleading. Re-add when @vue-flow is replaced with a Vue-2-compatible flow lib or after Vue 3 migration.

**Kept with sharper notes (lib gap — won't move until nc-vue ships):**
- `PublicCase`, `PublicAppointment`, `PublicStatus` — anonymous token-based public routes. Lib gap: the v2 page-type enum (`index detail dashboard logs settings chat files form wiki map custom`) all render *inside* the authenticated app shell. No public-page primitive exists. Will collapse to `type:"detail"` with a `public:true` escape hatch when nc-vue gains public-page support.

Same architectural category as openconnector (awaiting OR adoption) and docudesk (awaiting PvE completion).