### PR TITLE
fix(procest): repair OR-API drift in 8 service/job call sites

### DIFF
--- a/lib/BackgroundJob/AppointmentReminderJob.php
+++ b/lib/BackgroundJob/AppointmentReminderJob.php
@@ -81,13 +81,11 @@ class AppointmentReminderJob extends TimedJob
 
             $tomorrow = (new \DateTime('+1 day'))->format('Y-m-d');
 
-            $result = $objectService->getObjects(
-                (int) $register,
-                (int) $schema,
-                ['status' => 'scheduled'],
+            $appointments = $objectService->findAll(
+                ['filters' => ['register' => (int) $register, 'schema' => (int) $schema, 'status' => 'scheduled']],
             );
 
-            foreach (($result['objects'] ?? []) as $apt) {
+            foreach ($appointments as $apt) {
                 if (is_object($apt) === true) {
                     $data = $apt->jsonSerialize();
                 } else {

--- a/lib/BackgroundJob/ShareMaintenanceJob.php
+++ b/lib/BackgroundJob/ShareMaintenanceJob.php
@@ -100,13 +100,10 @@ class ShareMaintenanceJob extends TimedJob
         }
 
         try {
-            $result = $objectService->getObjects(
-                (int) $register,
-                (int) $schema,
-                [],
+            $shares = $objectService->findAll(
+                ['filters' => ['register' => (int) $register, 'schema' => (int) $schema]],
             );
 
-            $shares       = ($result['objects'] ?? []);
             $reminderDate = new \DateTime('+'.self::REMINDER_DAYS.' days');
 
             foreach ($shares as $share) {

--- a/lib/Repair/SeedLhsMatrix.php
+++ b/lib/Repair/SeedLhsMatrix.php
@@ -96,11 +96,11 @@ class SeedLhsMatrix implements IRepairStep
                 return;
             }
 
-            $existing = $objectService->getObjects(
-                register: $register,
-                schema: $schema,
-                filters: ['active' => true],
-                limit: 1,
+            $existing = $objectService->findAll(
+                [
+                    'filters' => ['register' => $register, 'schema' => $schema, 'active' => true],
+                    'limit'   => 1,
+                ],
             );
             if ($this->hasRow(results: $existing) === true) {
                 $output->info('Active LHS matrix already exists. Skipping seed.');

--- a/lib/Service/AppointmentService.php
+++ b/lib/Service/AppointmentService.php
@@ -195,13 +195,9 @@ class AppointmentService
         $register = $this->settingsService->getConfigValue('register');
         $schema   = $this->settingsService->getConfigValue('appointment_schema');
 
-        $result = $objectService->getObjects(
-            (int) $register,
-            (int) $schema,
-            ['caseId' => $caseId],
+        return $objectService->findAll(
+            ['filters' => ['register' => (int) $register, 'schema' => (int) $schema, 'caseId' => $caseId]],
         );
-
-        return $result['objects'] ?? [];
     }//end getAppointmentsForCase()
 
     /**
@@ -221,13 +217,9 @@ class AppointmentService
         $register = $this->settingsService->getConfigValue('register');
         $schema   = $this->settingsService->getConfigValue('appointment_schema');
 
-        $result = $objectService->getObjects(
-            (int) $register,
-            (int) $schema,
-            ['cancelToken' => $token],
+        $appointments = $objectService->findAll(
+            ['filters' => ['register' => (int) $register, 'schema' => (int) $schema, 'cancelToken' => $token]],
         );
-
-        $appointments = ($result['objects'] ?? []);
         if (empty($appointments) === true) {
             return null;
         }

--- a/lib/Service/BerichtenboxService.php
+++ b/lib/Service/BerichtenboxService.php
@@ -148,13 +148,9 @@ class BerichtenboxService
         $register = $this->settingsService->getConfigValue('register');
         $schema   = $this->settingsService->getConfigValue('berichtenbox_message_schema');
 
-        $result = $objectService->getObjects(
-            (int) $register,
-            (int) $schema,
-            ['caseId' => $caseId],
+        return $objectService->findAll(
+            ['filters' => ['register' => (int) $register, 'schema' => (int) $schema, 'caseId' => $caseId]],
         );
-
-        return $result['objects'] ?? [];
     }//end getMessagesForCase()
 
     /**

--- a/lib/Service/CaseSharingService.php
+++ b/lib/Service/CaseSharingService.php
@@ -278,13 +278,9 @@ class CaseSharingService
         $register = $this->settingsService->getConfigValue('register');
         $schema   = $this->settingsService->getConfigValue('case_share_schema');
 
-        $result = $objectService->getObjects(
-            (int) $register,
-            (int) $schema,
-            ['token' => $token],
+        $shares = $objectService->findAll(
+            ['filters' => ['register' => (int) $register, 'schema' => (int) $schema, 'token' => $token]],
         );
-
-        $shares = ($result['objects'] ?? []);
         if (empty($shares) === true) {
             return ['valid' => false, 'error' => 'Token niet gevonden'];
         }

--- a/lib/Service/SeedDataService.php
+++ b/lib/Service/SeedDataService.php
@@ -408,11 +408,11 @@ class SeedDataService
         array $filters,
     ): ?object {
         try {
-            $results = $objectService->getObjects(
-                register: $registerId,
-                schema: $schemaId,
-                filters: $filters,
-                limit: 1,
+            $results = $objectService->findAll(
+                [
+                    'filters' => (['register' => $registerId, 'schema' => $schemaId] + $filters),
+                    'limit'   => 1,
+                ],
             );
 
             if (is_array($results) === true && count($results) > 0) {

--- a/lib/Service/Vth/LhsRecommendationService.php
+++ b/lib/Service/Vth/LhsRecommendationService.php
@@ -262,11 +262,11 @@ class LhsRecommendationService
         }
 
         try {
-            $results = $objectService->getObjects(
-                register: $register,
-                schema: $schema,
-                filters: $filters,
-                limit: 1,
+            $results = $objectService->findAll(
+                [
+                    'filters' => (['register' => $register, 'schema' => $schema] + $filters),
+                    'limit'   => 1,
+                ],
             );
         } catch (Throwable $e) {
             $this->logger->error(


### PR DESCRIPTION
## Summary

Surgical cherry-pick of [`a02abf2`](https://github.com/ConductionNL/procest/pull/491/commits/a02abf2df738c5027b48252cfd740c8a0a26bfcf) from the divergent #491 branch onto a fresh branch from `development`. Closes the OR-API-drift half of #491 (re-opened from #417).

## What this fixes

`OCA\OpenRegister\Service\ObjectService::getObjects()` no longer exists; the current API is `findAll(array $config)` which returns a flat array of rendered objects and reads `register`/`schema` from `$config['filters']`. `development` had 9 broken call sites across 8 files — this migrates them all.

Files migrated:

- `lib/BackgroundJob/AppointmentReminderJob.php`
- `lib/BackgroundJob/ShareMaintenanceJob.php`
- `lib/Repair/SeedLhsMatrix.php`
- `lib/Service/AppointmentService.php` (×2)
- `lib/Service/BerichtenboxService.php`
- `lib/Service/CaseSharingService.php`
- `lib/Service/SeedDataService.php` (fixes the `Could not seed bezwaar/beroep data` repair warning)
- `lib/Service/Vth/LhsRecommendationService.php`

`lib/Service/TenantService.php` still has one `getObjects()` call as a known follow-up (also called out in the original commit).

## Why not the full #491

The other commits on that branch are either already on `development` via separate PRs (e.g. yaml/twig security bumps — composer.lock now at v6.4.40 + v3.26.0 already), unrelated (`@vue-flow` unwire), or supersededby the manifest-v2 migration (`fix(procest): conform src/manifest.json to canonical app-manifest schema`).

Seed-data orphans (the second half of the original fix) — verified gone: `lib/Settings/procest_register.json` no longer contains `voorstel-collegeadvies-0042/0055` refs.

#491 was blocked on divergent root history. This PR replaces it as the merge path for the OR-API drift fix.

## Test plan

- [x] `composer lint` green (PHP syntax)
- [ ] CI to confirm full check:strict on the migrated files