### PR TITLE
chore: sync canonical root configs + mechanical phpmd cleanup

### DIFF
--- a/lib/BackgroundJob/AdviceDeadlineJob.php
+++ b/lib/BackgroundJob/AdviceDeadlineJob.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 
 namespace OCA\Procest\BackgroundJob;
 
+use DateTimeImmutable;
 use OCA\Procest\AppInfo\Application;
 use OCA\Procest\Service\AdviceService;
 use OCA\Procest\Service\SettingsService;
@@ -66,6 +67,8 @@ class AdviceDeadlineJob extends TimedJob
      * @param mixed $argument The job argument
      *
      * @return void
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     protected function run($argument): void
     {
@@ -78,7 +81,7 @@ class AdviceDeadlineJob extends TimedJob
             $reminderDays = 3;
         }
 
-        $today      = new \DateTimeImmutable('today');
+        $today      = new DateTimeImmutable('today');
         $reminderOn = $today->modify('+'.$reminderDays.' days')->format('Y-m-d');
         $todayStr   = $today->format('Y-m-d');
 

--- a/lib/Controller/LhsController.php
+++ b/lib/Controller/LhsController.php
@@ -113,17 +113,15 @@ class LhsController extends Controller
         }
 
         $versionParam = $this->request->getParam('lhsVersion');
-        if ($versionParam === null) {
-            $version = null;
-        } else {
+        $version      = null;
+        if ($versionParam !== null) {
             $version = (int) $versionParam;
         }
 
-        $inspection = $this->request->getParam('inspection');
+        $inspection   = $this->request->getParam('inspection');
+        $inspectionId = null;
         if (is_string($inspection) === true && $inspection !== '') {
             $inspectionId = $inspection;
-        } else {
-            $inspectionId = null;
         }
 
         try {
@@ -192,10 +190,9 @@ class LhsController extends Controller
 
         $declaredRole = (string) $this->request->getParam('userRole', '');
         $isManager    = $this->groupManager->isAdmin($user->getUID());
+        $userRole     = 'inspector';
         if ($declaredRole === 'manager' && $isManager === true) {
             $userRole = 'manager';
-        } else {
-            $userRole = 'inspector';
         }
 
         try {

--- a/lib/Controller/StatusTransitionController.php
+++ b/lib/Controller/StatusTransitionController.php
@@ -108,10 +108,9 @@ class StatusTransitionController extends Controller
     {
         $body         = $this->readJsonBody();
         $transitionId = (string) ($body['transitionId'] ?? '');
+        $comment      = null;
         if (isset($body['comment']) === true) {
             $comment = (string) $body['comment'];
-        } else {
-            $comment = null;
         }
 
         if ($transitionId === '') {
@@ -176,10 +175,9 @@ class StatusTransitionController extends Controller
 
         $body       = $this->readJsonBody();
         $toStatusId = (string) ($body['toStatusId'] ?? '');
+        $comment    = null;
         if (isset($body['comment']) === true) {
             $comment = (string) $body['comment'];
-        } else {
-            $comment = null;
         }
 
         if ($toStatusId === '') {

--- a/lib/Listener/ParaferingAuditListener.php
+++ b/lib/Listener/ParaferingAuditListener.php
@@ -126,6 +126,7 @@ class ParaferingAuditListener implements IEventListener
             if (is_array($voorstel) === true) {
                 $array = $voorstel;
             } else if (is_object($voorstel) === true) {
+                $array = (array) $voorstel;
                 if (method_exists($voorstel, 'jsonSerialize') === true) {
                     $serialized = $voorstel->jsonSerialize();
                     if (is_array($serialized) === true) {
@@ -136,8 +137,6 @@ class ParaferingAuditListener implements IEventListener
                     if (is_array($arr) === true) {
                         $array = $arr;
                     }
-                } else {
-                    $array = (array) $voorstel;
                 }
             }
 

--- a/lib/Middleware/TenantMiddleware.php
+++ b/lib/Middleware/TenantMiddleware.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Middleware;
 
+use Exception;
 use OCA\Procest\Service\TenantService;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Middleware;
@@ -118,7 +119,7 @@ class TenantMiddleware extends Middleware
                 'Procest: Request blocked because tenant is not active',
                 ['userId' => $userId, 'tenantUuid' => $tenantUuid, 'status' => $status]
             );
-            throw new \Exception('Organisation is '.$status, 403);
+            throw new Exception('Organisation is '.$status, 403);
         }
 
         // Store tenant context for controllers to use.

--- a/lib/Repair/SeedBezwaarWorkflowDefinition.php
+++ b/lib/Repair/SeedBezwaarWorkflowDefinition.php
@@ -323,9 +323,8 @@ class SeedBezwaarWorkflowDefinition implements IRepairStep
         $transitions = [];
         foreach ($matrix as $row) {
             [$fromName, $toName, $label] = $row;
-            if ($fromName === '*') {
-                $fromId = '*';
-            } else {
+            $fromId = '*';
+            if ($fromName !== '*') {
                 $fromId = (string) ($statusByName[$fromName]['id'] ?? '');
             }
 

--- a/lib/Repair/SeedLhsMatrix.php
+++ b/lib/Repair/SeedLhsMatrix.php
@@ -29,6 +29,8 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Repair;
 
+use DateTimeImmutable;
+use DateTimeInterface;
 use OCA\Procest\Service\SettingsService;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
@@ -120,7 +122,7 @@ class SeedLhsMatrix implements IRepairStep
                 return;
             }
 
-            $payload['createdAt'] = (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM);
+            $payload['createdAt'] = (new DateTimeImmutable())->format(DateTimeInterface::ATOM);
 
             $objectService->saveObject(
                 register: $register,

--- a/lib/Repair/SeedVthWorkflowTemplates.php
+++ b/lib/Repair/SeedVthWorkflowTemplates.php
@@ -570,7 +570,9 @@ class SeedVthWorkflowTemplates implements IRepairStep
                 $fromId = '*';
             } else if ($fromName === '' || isset($statusMap[$fromName]) === false) {
                 return null;
-            } else {
+            }
+
+            if ($fromName !== '*' && $fromName !== '' && isset($statusMap[$fromName]) === true) {
                 $fromId = $statusMap[$fromName];
             }
 

--- a/lib/Service/Actions/CallWebhookHandler.php
+++ b/lib/Service/Actions/CallWebhookHandler.php
@@ -78,9 +78,8 @@ class CallWebhookHandler implements ActionHandlerInterface
         try {
             $url = $this->resolveUrl(config: $actionConfig, context: $transitionContext);
             $payloadTemplate = (string) ($actionConfig['payloadTemplate'] ?? '');
-            if ($payloadTemplate === '') {
-                $payload = json_encode(['case' => $case], JSON_THROW_ON_ERROR);
-            } else {
+            $payload         = json_encode(['case' => $case], JSON_THROW_ON_ERROR);
+            if ($payloadTemplate !== '') {
                 $payload = $this->renderTemplate(template: $payloadTemplate, case: $case);
             }
 

--- a/lib/Service/Actions/ScheduleReminderHandler.php
+++ b/lib/Service/Actions/ScheduleReminderHandler.php
@@ -26,9 +26,13 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service\Actions;
 
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeInterface;
 use OCA\Procest\AppInfo\Application;
 use OCP\BackgroundJob\IJobList;
 use Psr\Log\LoggerInterface;
+use Throwable;
 
 /**
  * Handler for `scheduleReminder` automatic actions.
@@ -93,11 +97,10 @@ class ScheduleReminderHandler implements ActionHandlerInterface
                 case: $case
             );
 
-            $fireAt = $this->computeFireTime(offsetIso: $offsetIso);
-            if ($fireAt === null) {
-                $fireAtIso = null;
-            } else {
-                $fireAtIso = $fireAt->format(\DateTimeInterface::ATOM);
+            $fireAt    = $this->computeFireTime(offsetIso: $offsetIso);
+            $fireAtIso = null;
+            if ($fireAt !== null) {
+                $fireAtIso = $fireAt->format(DateTimeInterface::ATOM);
             }
 
             $preview = [
@@ -119,13 +122,13 @@ class ScheduleReminderHandler implements ActionHandlerInterface
                 'caseId'    => (string) ($case['id'] ?? ''),
                 'recipient' => $recipient,
                 'message'   => $message,
-                'fireAtIso' => $fireAt->format(\DateTimeInterface::ATOM),
+                'fireAtIso' => $fireAt->format(DateTimeInterface::ATOM),
             ];
 
             $this->jobList->add(self::REMINDER_JOB_CLASS, $arguments);
 
             return ActionResult::success($preview);
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             $this->logger->error(
                 'ScheduleReminderHandler: failed to schedule reminder',
                 [
@@ -143,20 +146,20 @@ class ScheduleReminderHandler implements ActionHandlerInterface
      *
      * @param string $offsetIso e.g. `P3D` (3 days), `PT2H` (2 hours).
      *
-     * @return \DateTimeImmutable|null
+     * @return DateTimeImmutable|null
      */
-    private function computeFireTime(string $offsetIso): ?\DateTimeImmutable
+    private function computeFireTime(string $offsetIso): ?DateTimeImmutable
     {
         if ($offsetIso === '') {
             return null;
         }
 
         try {
-            $interval = new \DateInterval($offsetIso);
-        } catch (\Throwable $e) {
+            $interval = new DateInterval($offsetIso);
+        } catch (Throwable $e) {
             return null;
         }
 
-        return (new \DateTimeImmutable('now'))->add($interval);
+        return (new DateTimeImmutable('now'))->add($interval);
     }//end computeFireTime()
 }//end class

--- a/lib/Service/AdviceService.php
+++ b/lib/Service/AdviceService.php
@@ -32,10 +32,13 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service;
 
+use DateTime;
 use OCA\Procest\AppInfo\Application;
 use OCP\IUserSession;
 use OCP\Notification\IManager as INotificationManager;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Throwable;
 
 /**
  * Service for advice request (adviesAanvraag) workflow.
@@ -87,24 +90,24 @@ class AdviceService
     public function transitionStatus(string $adviceId, string $to, array $payload=[]): array
     {
         if (in_array($to, self::VALID_STATUSES, true) === false) {
-            throw new \RuntimeException('Invalid advice status');
+            throw new RuntimeException('Invalid advice status');
         }
 
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
-            throw new \RuntimeException('OpenRegister is not available');
+            throw new RuntimeException('OpenRegister is not available');
         }
 
         $register = $this->settingsService->getConfigValue('register');
         $schema   = $this->settingsService->getConfigValue('advies_aanvraag_schema');
 
         if (empty($register) === true || empty($schema) === true) {
-            throw new \RuntimeException('Advice schema is not configured');
+            throw new RuntimeException('Advice schema is not configured');
         }
 
         $current = $this->loadAdvice(adviceId: $adviceId);
         if ($current === null) {
-            throw new \RuntimeException('Advice request not found');
+            throw new RuntimeException('Advice request not found');
         }
 
         $update = ['status' => $to];
@@ -119,12 +122,12 @@ class AdviceService
 
         try {
             $advice = $objectService->saveObject($register, $schema, $update, $adviceId);
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             $this->logger->error(
                 'Procest: failed to transition advice status: '.$e->getMessage(),
                 ['app' => Application::APP_ID]
             );
-            throw new \RuntimeException('Could not update advice request');
+            throw new RuntimeException('Could not update advice request');
         }
 
         $advice = $this->normalizeResult(result: $advice);
@@ -214,7 +217,7 @@ class AdviceService
                 [],
                 200,
             );
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             $this->logger->error(
                 'Procest: failed to fetch advice for case: '.$e->getMessage(),
                 ['app' => Application::APP_ID]
@@ -256,7 +259,7 @@ class AdviceService
                 [],
                 500,
             );
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             $this->logger->error(
                 'Procest: failed to load open advice: '.$e->getMessage(),
                 ['app' => Application::APP_ID]
@@ -285,7 +288,7 @@ class AdviceService
     {
         try {
             return $this->transitionStatus(adviceId: $adviceId, to: 'verlopen');
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             $this->logger->error(
                 'Procest: failed to expire advice: '.$e->getMessage(),
                 ['app' => Application::APP_ID]
@@ -317,7 +320,7 @@ class AdviceService
 
         try {
             $advice = $objectService->findObject($register, $schema, $adviceId);
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             $this->logger->error(
                 'Procest: failed to load advice: '.$e->getMessage(),
                 ['app' => Application::APP_ID]
@@ -420,7 +423,7 @@ class AdviceService
             $notification
                 ->setApp(Application::APP_ID)
                 ->setUser($userId)
-                ->setDateTime(new \DateTime())
+                ->setDateTime(new DateTime())
                 ->setObject('advies', $objectId)
                 ->setSubject($subject, ['object' => $objectId]);
 
@@ -429,7 +432,7 @@ class AdviceService
             }
 
             $this->notificationManager->notify($notification);
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             $this->logger->error(
                 'Procest: failed to send advice notification: '.$e->getMessage(),
                 ['app' => Application::APP_ID]

--- a/lib/Service/Bezwaar/AdvisoryCommitteeService.php
+++ b/lib/Service/Bezwaar/AdvisoryCommitteeService.php
@@ -40,6 +40,8 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service\Bezwaar;
 
+use DateTimeImmutable;
+use DateTimeInterface;
 use OCA\Procest\Service\SettingsService;
 use OCA\Procest\Service\StatusTransitionService;
 use OCA\Procest\Service\Transitions\GuardFailedException;
@@ -164,8 +166,8 @@ class AdvisoryCommitteeService
             );
         }
 
-        $now      = (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM);
-        $deadline = (new \DateTimeImmutable())
+        $now      = (new DateTimeImmutable())->format(DateTimeInterface::ATOM);
+        $deadline = (new DateTimeImmutable())
             ->modify('+'.self::DEFAULT_DEADLINE_DAYS.' days')
             ->format('Y-m-d');
 
@@ -326,8 +328,8 @@ class AdvisoryCommitteeService
         $update['status'] = $newStatus;
 
         if ($newStatus === 'advice-issued' || $newStatus === 'niet-ontvankelijk') {
-            $update['adviceIssuedAt'] = (new \DateTimeImmutable())
-                ->format(\DateTimeInterface::ATOM);
+            $update['adviceIssuedAt'] = (new DateTimeImmutable())
+                ->format(DateTimeInterface::ATOM);
             $auditEvent           = 'advice-signed-by-chair';
             $auditPayload         = [
                 'chair'             => $userId,
@@ -590,8 +592,8 @@ class AdvisoryCommitteeService
         $entry = [
             'event'   => $event,
             'actor'   => $this->resolveUserId(),
-            'at'      => (new \DateTimeImmutable())
-                ->format(\DateTimeInterface::ATOM),
+            'at'      => (new DateTimeImmutable())
+                ->format(DateTimeInterface::ATOM),
             'payload' => $payload,
         ];
 

--- a/lib/Service/Bezwaar/HearingService.php
+++ b/lib/Service/Bezwaar/HearingService.php
@@ -49,6 +49,8 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service\Bezwaar;
 
+use DateTimeImmutable;
+use DateTimeInterface;
 use OCA\Procest\Service\SettingsService;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
@@ -149,17 +151,16 @@ class HearingService
 
         $scheduled = $this->parseDateTime(value: $scheduledDate);
         $deadline  = $this->computeInspectionDeadline(scheduled: $scheduled);
-        $now       = new \DateTimeImmutable();
+        $now       = new DateTimeImmutable();
 
         $this->guardInspectionFloor(
             scheduled: $scheduled,
             today: $now,
         );
 
+        $available = $now->setTime(0, 0, 0);
         if (isset($payload['inspectionAvailableFrom']) === true) {
             $available = $this->parseDate(value: (string) $payload['inspectionAvailableFrom']);
-        } else {
-            $available = $now->setTime(0, 0, 0);
         }
 
         if ($available > $deadline) {
@@ -177,7 +178,7 @@ class HearingService
             [
                 'case'                    => $caseId,
                 'scheduledDate'           => $scheduled->format(
-                    \DateTimeInterface::ATOM
+                    DateTimeInterface::ATOM
                 ),
                 'chairperson'             => $chairpersonId,
                 'invitees'                => $this->stampInvitees(
@@ -253,13 +254,13 @@ class HearingService
             throw new RuntimeException('Hearing schema is not configured');
         }
 
-        $now = new \DateTimeImmutable();
+        $now = new DateTimeImmutable();
 
         $record = array_merge(
             $payload,
             [
                 'case'                    => $caseId,
-                'scheduledDate'           => $now->format(\DateTimeInterface::ATOM),
+                'scheduledDate'           => $now->format(DateTimeInterface::ATOM),
                 'chairperson'             => $payload['chairperson'] ?? ($payload['chairpersonId'] ?? 'system'),
                 'invitees'                => $payload['invitees'] ?? [],
                 'inspectionAvailableFrom' => $now->format('Y-m-d'),
@@ -330,12 +331,11 @@ class HearingService
             throw new RuntimeException('Hearing session not found');
         }
 
-        $now          = new \DateTimeImmutable();
+        $now          = new DateTimeImmutable();
         $scheduledRaw = (string) ($current['scheduledDate'] ?? '');
+        $scheduled    = $now;
         if ($scheduledRaw !== '') {
             $scheduled = $this->parseDateTime(value: $scheduledRaw);
-        } else {
-            $scheduled = $now;
         }
 
         $freezeAt = $scheduled->modify(
@@ -378,7 +378,7 @@ class HearingService
 
         $update = [
             'attendance'         => $merged,
-            'attendanceFrozenAt' => $freezeAt->format(\DateTimeInterface::ATOM),
+            'attendanceFrozenAt' => $freezeAt->format(DateTimeInterface::ATOM),
             'auditTrail'         => $audit,
         ];
 
@@ -482,16 +482,14 @@ class HearingService
             }//end if
         }//end if
 
+        $minutesSummary = null;
         if ($summary !== '') {
             $minutesSummary = $summary;
-        } else {
-            $minutesSummary = null;
         }
 
+        $minutesDocument = null;
         if ($document !== '') {
             $minutesDocument = $document;
-        } else {
-            $minutesDocument = null;
         }
 
         $update = [
@@ -584,14 +582,14 @@ class HearingService
             return null;
         }
 
-        $scheduled = (new \DateTimeImmutable())
+        $scheduled = (new DateTimeImmutable())
             ->modify('+14 days')
             ->setTime(10, 0, 0);
 
         try {
             return $this->schedule(
                 caseId: $caseId,
-                scheduledDate: $scheduled->format(\DateTimeInterface::ATOM),
+                scheduledDate: $scheduled->format(DateTimeInterface::ATOM),
                 chairpersonId: 'system',
                 invitees: [
                     [
@@ -631,8 +629,8 @@ class HearingService
             'event'   => $event,
             'tag'     => $tag,
             'actor'   => $this->resolveUserId(),
-            'at'      => (new \DateTimeImmutable())
-                ->format(\DateTimeInterface::ATOM),
+            'at'      => (new DateTimeImmutable())
+                ->format(DateTimeInterface::ATOM),
             'payload' => $payload,
         ];
 
@@ -667,7 +665,7 @@ class HearingService
     private function parseDateTime(string $value): \DateTimeImmutable
     {
         try {
-            return new \DateTimeImmutable($value);
+            return new DateTimeImmutable($value);
         } catch (\Throwable $e) {
             throw new RuntimeException(
                 'Invalid scheduledDate: '.$value
@@ -685,9 +683,9 @@ class HearingService
     private function parseDate(string $value): \DateTimeImmutable
     {
         try {
-            return new \DateTimeImmutable($value);
+            return new DateTimeImmutable($value);
         } catch (\Throwable $e) {
-            return new \DateTimeImmutable();
+            return new DateTimeImmutable();
         }
     }//end parseDate()
 
@@ -756,7 +754,7 @@ class HearingService
                 || (string) $invitee['invitedAt'] === ''
             ) {
                 $invitee['invitedAt'] = $when->format(
-                    \DateTimeInterface::ATOM
+                    DateTimeInterface::ATOM
                 );
             }
 

--- a/lib/Service/Inspection/ChecklistService.php
+++ b/lib/Service/Inspection/ChecklistService.php
@@ -330,16 +330,14 @@ class ChecklistService
             $range = $item['numericRange'] ?? null;
             if (is_array($range) === true && array_key_exists('numericValue', $payload) === true) {
                 $val = (float) $payload['numericValue'];
+                $min = null;
                 if (array_key_exists('min', $range) === true) {
                     $min = (float) $range['min'];
-                } else {
-                    $min = null;
                 }
 
+                $max = null;
                 if (array_key_exists('max', $range) === true) {
                     $max = (float) $range['max'];
-                } else {
-                    $max = null;
                 }
 
                 if (($min !== null && $val < $min) || ($max !== null && $val > $max)) {
@@ -475,7 +473,9 @@ class ChecklistService
                         'Procest: follow-up task save failed: '.$e->getMessage(),
                     );
                 }
-            } else {
+            }
+
+            if ($taskSchema === '') {
                 $created[] = $task;
             }
         }//end foreach
@@ -581,16 +581,14 @@ class ChecklistService
             }
 
             $val = (float) $response['numericValue'];
+            $min = null;
             if (array_key_exists('min', $range) === true) {
                 $min = (float) $range['min'];
-            } else {
-                $min = null;
             }
 
+            $max = null;
             if (array_key_exists('max', $range) === true) {
                 $max = (float) $range['max'];
-            } else {
-                $max = null;
             }
 
             if (($min !== null && $val < $min) || ($max !== null && $val > $max)) {

--- a/lib/Service/LocationService.php
+++ b/lib/Service/LocationService.php
@@ -42,6 +42,8 @@ namespace OCA\Procest\Service;
 use OCA\Procest\AppInfo\Application;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Throwable;
 
 /**
  * Service for case-location domain operations.
@@ -105,10 +107,9 @@ class LocationService
     {
         $errors = [];
 
+        $source = '';
         if (isset($payload['source']) === true) {
             $source = (string) $payload['source'];
-        } else {
-            $source = '';
         }
 
         if ($source === '') {
@@ -117,10 +118,9 @@ class LocationService
             $errors[] = 'source.invalid';
         }
 
+        $caseId = '';
         if (isset($payload['case']) === true) {
             $caseId = (string) $payload['case'];
-        } else {
-            $caseId = '';
         }
 
         if ($caseId === '') {
@@ -230,7 +230,7 @@ class LocationService
 
         try {
             $response = $pdok->reverse($latitude, $longitude);
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             $this->logger->warning(
                 'Procest: reverseGeocode call failed: '.$e->getMessage(),
                 ['app' => Application::APP_ID]
@@ -247,11 +247,10 @@ class LocationService
             return null;
         }
 
-        $best = $docs[0];
+        $best     = $docs[0];
+        $distance = null;
         if (isset($best['afstand']) === true && is_numeric($best['afstand']) === true) {
             $distance = (float) $best['afstand'];
-        } else {
-            $distance = null;
         }
 
         if ($distance !== null && $distance > (float) self::REVERSE_MAX_DISTANCE_M) {
@@ -268,10 +267,9 @@ class LocationService
             $nummeraanduidingId = (string) $best['id'];
         }
 
+        $formattedAddress = '';
         if (isset($best['weergavenaam']) === true) {
             $formattedAddress = (string) $best['weergavenaam'];
-        } else {
-            $formattedAddress = '';
         }
 
         if ($nummeraanduidingId === '' && $formattedAddress === '') {
@@ -302,7 +300,7 @@ class LocationService
             return $this->container->get(
                 'OCA\Procest\Service\Pdok\PdokLocatieserverService'
             );
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             $this->logger->debug(
                 'Procest: PdokLocatieserverService is not available: '.$e->getMessage(),
                 ['app' => Application::APP_ID]
@@ -358,7 +356,7 @@ class LocationService
     public function attachToCase(string $caseId, array $location): ?array
     {
         if ($caseId === '') {
-            throw new \RuntimeException('caseId is required');
+            throw new RuntimeException('caseId is required');
         }
 
         $payload         = $location;
@@ -366,26 +364,26 @@ class LocationService
 
         $errors = $this->validate(payload: $payload);
         if (count($errors) > 0) {
-            throw new \RuntimeException(
+            throw new RuntimeException(
                 'Location payload failed validation: '.implode(', ', $errors)
             );
         }
 
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
-            throw new \RuntimeException('OpenRegister is not available');
+            throw new RuntimeException('OpenRegister is not available');
         }
 
         $register = $this->settingsService->getConfigValue('register');
         $schema   = $this->settingsService->getConfigValue('location_schema');
 
         if ($register === '' || $schema === '') {
-            throw new \RuntimeException('Location schema is not configured');
+            throw new RuntimeException('Location schema is not configured');
         }
 
         try {
             $saved = $objectService->saveObject($register, $schema, $payload);
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             $this->logger->error(
                 'Procest: failed to attach location to case: '.$e->getMessage(),
                 ['app' => Application::APP_ID, 'caseId' => $caseId]
@@ -441,7 +439,7 @@ class LocationService
                 [],
                 500,
             );
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             $this->logger->error(
                 'Procest: failed to list locations for case: '.$e->getMessage(),
                 ['app' => Application::APP_ID, 'caseId' => $caseId]

--- a/lib/Service/ParafeerRouteService.php
+++ b/lib/Service/ParafeerRouteService.php
@@ -241,13 +241,12 @@ class ParafeerRouteService
 
         $objectService->saveObject($register, $actieSchema, $actieData);
 
-        $action = (string) ($actionData['action'] ?? 'parafered');
+        $action     = (string) ($actionData['action'] ?? 'parafered');
+        $transition = 'paraferd';
+        $actorRole  = 'parafeerder';
         if ($action === 'advised') {
             $transition = 'advised';
             $actorRole  = 'adviseur';
-        } else {
-            $transition = 'paraferd';
-            $actorRole  = 'parafeerder';
         }
 
         $this->dispatchTransition(

--- a/lib/Service/Parafering/AuditTrailService.php
+++ b/lib/Service/Parafering/AuditTrailService.php
@@ -33,6 +33,7 @@ namespace OCA\Procest\Service\Parafering;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use DateTimeZone;
 use OCA\Procest\Service\SettingsService;
 use OCP\AppFramework\OCS\OCSForbiddenException;
 use OCP\IRequest;
@@ -122,7 +123,7 @@ class AuditTrailService
                 throw new RuntimeException('paraferingAuditEntry configuration is missing');
             }
 
-            $timestamp = (new DateTimeImmutable('now'))->setTimezone(new \DateTimeZone('UTC'))
+            $timestamp = (new DateTimeImmutable('now'))->setTimezone(new DateTimeZone('UTC'))
                 ->format('Y-m-d\TH:i:s\Z');
 
             $entry = [
@@ -265,17 +266,16 @@ class AuditTrailService
 
         $retentionUntil = $this->computeRetentionUntil(completedEntry: $completed);
 
+        $selectielijstCategory = 'Algemene administratieve correspondentie — bewaartermijn 7 jaar';
         if ($completed !== null) {
             $selectielijstCategory = 'Bestuurlijke besluitvorming — bewaartermijn 20 jaar';
-        } else {
-            $selectielijstCategory = 'Algemene administratieve correspondentie — bewaartermijn 7 jaar';
         }
 
         return [
             'metadata' => [
                 'schema'                => 'MDTO 1.0',
                 'exportedAt'            => (new DateTimeImmutable('now'))
-                    ->setTimezone(new \DateTimeZone('UTC'))
+                    ->setTimezone(new DateTimeZone('UTC'))
                     ->format('Y-m-d\TH:i:s\Z'),
                 'voorstel'              => $voorstelId,
                 'voorstelOnderwerp'     => $voorstelOnderwerp,

--- a/lib/Service/Pdok/PdokBagService.php
+++ b/lib/Service/Pdok/PdokBagService.php
@@ -38,6 +38,8 @@ use OCP\ICache;
 use OCP\ICacheFactory;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Throwable;
 
 /**
  * Single ingress for PDOK BAG WFS v2_0 lookups.
@@ -178,12 +180,14 @@ class PdokBagService
         try {
             if (empty($source) === false) {
                 $body = $this->callViaOpenConnector(sourceSlug: $source, params: $params);
-            } else {
+            }
+
+            if (empty($source) === true) {
                 $body = $this->callDirect(
                     url: $endpoint.'?'.http_build_query(data: $params),
                 );
             }
-        } catch (\RuntimeException $e) {
+        } catch (RuntimeException $e) {
             $this->logger->warning(
                 'Procest PDOK BAG call failed',
                 [
@@ -193,7 +197,7 @@ class PdokBagService
                 ]
             );
             return [];
-        }
+        }//end try
 
         $decoded = json_decode(json: $body, associative: true);
         if (is_array(value: $decoded) === false) {
@@ -281,7 +285,7 @@ class PdokBagService
 
         $body = @file_get_contents(filename: $url, use_include_path: false, context: $context);
         if ($body === false) {
-            throw new \RuntimeException('Network error contacting PDOK BAG WFS', 0);
+            throw new RuntimeException('Network error contacting PDOK BAG WFS', 0);
         }
 
         $statusCode = 0;
@@ -293,7 +297,7 @@ class PdokBagService
         }
 
         if ($statusCode < 200 || $statusCode >= 300) {
-            throw new \RuntimeException('PDOK BAG WFS HTTP '.$statusCode, $statusCode);
+            throw new RuntimeException('PDOK BAG WFS HTTP '.$statusCode, $statusCode);
         }
 
         return $body;
@@ -313,7 +317,7 @@ class PdokBagService
     {
         try {
             $callService = $this->container->get('OCA\OpenConnector\Service\CallService');
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             $this->logger->warning(
                 'Procest PDOK BAG: OpenConnector not available, falling back to direct HTTP',
                 ['sourceSlug' => $sourceSlug, 'error' => $e->getMessage()]
@@ -335,8 +339,8 @@ class PdokBagService
                 'GET',
                 ['query' => $params, 'headers' => ['Accept' => 'application/json']]
             );
-        } catch (\Throwable $e) {
-            throw new \RuntimeException(
+        } catch (Throwable $e) {
+            throw new RuntimeException(
                 'OpenConnector dispatch failed: '.$e->getMessage(),
                 500
             );
@@ -353,7 +357,7 @@ class PdokBagService
             }
         }
 
-        throw new \RuntimeException('OpenConnector returned an unrecognised response shape', 502);
+        throw new RuntimeException('OpenConnector returned an unrecognised response shape', 502);
     }//end callViaOpenConnector()
 
     /**

--- a/lib/Service/Pdok/PdokLocatieserverService.php
+++ b/lib/Service/Pdok/PdokLocatieserverService.php
@@ -43,6 +43,8 @@ use OCP\ICache;
 use OCP\ICacheFactory;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Throwable;
 
 /**
  * Single ingress for PDOK Locatieserver v3_1 calls.
@@ -270,10 +272,12 @@ class PdokLocatieserverService
         try {
             if (empty($source) === false) {
                 $body = $this->callViaOpenConnector(sourceSlug: $source, path: $method, params: $params);
-            } else {
+            }
+
+            if (empty($source) === true) {
                 $body = $this->callDirect(url: $url);
             }
-        } catch (\RuntimeException $e) {
+        } catch (RuntimeException $e) {
             $this->recordFailure(statusCode: $e->getCode());
             $this->logger->warning(
                 'Procest PDOK Locatieserver call failed',
@@ -332,7 +336,7 @@ class PdokLocatieserverService
 
         $body = @file_get_contents(filename: $url, use_include_path: false, context: $context);
         if ($body === false) {
-            throw new \RuntimeException('Network error contacting PDOK Locatieserver', 0);
+            throw new RuntimeException('Network error contacting PDOK Locatieserver', 0);
         }
 
         $statusCode = 0;
@@ -344,7 +348,7 @@ class PdokLocatieserverService
         }
 
         if ($statusCode < 200 || $statusCode >= 300) {
-            throw new \RuntimeException('PDOK Locatieserver HTTP '.$statusCode, $statusCode);
+            throw new RuntimeException('PDOK Locatieserver HTTP '.$statusCode, $statusCode);
         }
 
         $this->recordSuccess();
@@ -371,7 +375,7 @@ class PdokLocatieserverService
     {
         try {
             $callService = $this->container->get('OCA\OpenConnector\Service\CallService');
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             $this->logger->warning(
                 'Procest PDOK Locatieserver: OpenConnector not available, falling back to direct HTTP',
                 ['sourceSlug' => $sourceSlug, 'error' => $e->getMessage()]
@@ -397,8 +401,8 @@ class PdokLocatieserverService
                 'GET',
                 ['query' => $params, 'headers' => ['Accept' => 'application/json']]
             );
-        } catch (\Throwable $e) {
-            throw new \RuntimeException(
+        } catch (Throwable $e) {
+            throw new RuntimeException(
                 'OpenConnector dispatch failed: '.$e->getMessage(),
                 500
             );
@@ -417,7 +421,7 @@ class PdokLocatieserverService
             }
         }
 
-        throw new \RuntimeException('OpenConnector returned an unrecognised response shape', 502);
+        throw new RuntimeException('OpenConnector returned an unrecognised response shape', 502);
     }//end callViaOpenConnector()
 
     /**

--- a/lib/Service/RoleResolverService.php
+++ b/lib/Service/RoleResolverService.php
@@ -158,10 +158,9 @@ class RoleResolverService
 
         $caseId   = (string) ($case['id'] ?? ($case['uuid'] ?? ''));
         $cacheKey = $this->cacheKey(rule: $rule, caseId: $caseId);
+        $cacheHit = null;
         if ($caseId !== '') {
             $cacheHit = $this->cache->get($cacheKey);
-        } else {
-            $cacheHit = null;
         }
 
         if (is_array($cacheHit) === true) {

--- a/lib/Service/StatusTransitionService.php
+++ b/lib/Service/StatusTransitionService.php
@@ -315,10 +315,9 @@ class StatusTransitionService
             return ['history' => [], 'replayable' => false];
         }
 
+        $recordList = [];
         if (is_array($records) === true) {
             $recordList = $records;
-        } else {
-            $recordList = [];
         }
 
         $list = [];
@@ -553,10 +552,9 @@ class StatusTransitionService
         }
 
         foreach ($statuses as $entry) {
+            $id = (string) $entry;
             if (is_array($entry) === true) {
                 $id = (string) ($entry['id'] ?? ($entry['uuid'] ?? ''));
-            } else {
-                $id = (string) $entry;
             }
 
             if ($id === $statusTypeId) {

--- a/lib/Service/Transitions/ChecklistGuard.php
+++ b/lib/Service/Transitions/ChecklistGuard.php
@@ -101,14 +101,13 @@ class ChecklistGuard implements GuardEvaluatorInterface
             $label   = (string) ($item['label'] ?? ($item['name'] ?? ''));
             $checked = (bool) ($item['checked'] ?? false);
 
-            if (is_array($required) === true && $required !== []) {
-                if (in_array($label, $required, true) === true && $checked === false) {
-                    $missing[] = $label;
-                }
-            } else {
-                if ($checked === false && $label !== '') {
-                    $missing[] = $label;
-                }
+            $hasRequired = (is_array($required) === true && $required !== []);
+            if ($hasRequired === true && in_array($label, $required, true) === true && $checked === false) {
+                $missing[] = $label;
+            }
+
+            if ($hasRequired === false && $checked === false && $label !== '') {
+                $missing[] = $label;
             }
         }
 

--- a/lib/Service/Vth/LhsRecommendationService.php
+++ b/lib/Service/Vth/LhsRecommendationService.php
@@ -199,10 +199,9 @@ class LhsRecommendationService
         }
 
         $overrideUp = ($newSeverity > $recSeverity);
+        $authority  = 'inspector';
         if ($userRole === 'manager') {
             $authority = 'manager';
-        } else {
-            $authority = 'inspector';
         }
 
         if ($overrideUp === true && $authority !== 'manager') {
@@ -255,9 +254,8 @@ class LhsRecommendationService
             throw new RuntimeException('LHS-matrix register/schema is niet geconfigureerd');
         }
 
-        if ($version === null) {
-            $filters = ['active' => true];
-        } else {
+        $filters = ['active' => true];
+        if ($version !== null) {
             $filters = ['version' => $version];
         }
 
@@ -340,10 +338,9 @@ class LhsRecommendationService
     {
         if (is_string($cells) === true) {
             $decoded = json_decode($cells, true);
+            $cells   = [];
             if (is_array($decoded) === true) {
                 $cells = $decoded;
-            } else {
-                $cells = [];
             }
         }
 

--- a/lib/Service/WmsWfsService.php
+++ b/lib/Service/WmsWfsService.php
@@ -30,6 +30,7 @@ namespace OCA\Procest\Service;
 
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 /**
  * Service for resolving WMS/WFS overlay layers per case type and routing all
@@ -229,13 +230,13 @@ class WmsWfsService
         $url     = (string) ($layer['url'] ?? '');
 
         if ($url === '') {
-            throw new \RuntimeException('Layer has no URL', 400);
+            throw new RuntimeException('Layer has no URL', 400);
         }
 
         // REQ-WMS-7: non-queryable layers must not issue GetFeatureInfo.
         $queryable = (bool) ($layer['queryable'] ?? false);
         if ($queryable === false && $request === 'GETFEATUREINFO') {
-            throw new \RuntimeException('Layer is not queryable', 403);
+            throw new RuntimeException('Layer is not queryable', 403);
         }
 
         // REQ-WMS-5: cap tile dimensions.
@@ -253,23 +254,23 @@ class WmsWfsService
         if ($type === 'WFS') {
             $bbox = (string) ($params['bbox'] ?? $params['BBOX'] ?? '');
             if ($bbox === '' && $request === 'GETFEATURE') {
-                throw new \RuntimeException('WFS GetFeature requires BBOX', 400);
+                throw new RuntimeException('WFS GetFeature requires BBOX', 400);
             }
 
             $cutoffKm = (float) ($layer['extentCutoffKm'] ?? self::DEFAULT_EXTENT_CUTOFF_KM);
             if ($bbox !== '' && $this->bboxExceedsCutoff(bbox: $bbox, cutoffKm: $cutoffKm) === true) {
-                throw new \RuntimeException('Visible extent exceeds layer cutoff; zoom in for details', 413);
+                throw new RuntimeException('Visible extent exceeds layer cutoff; zoom in for details', 413);
             }
         }
 
         // Build the upstream query.
         $version = (string) ($layer['version'] ?? '');
-        if ($version === '') {
-            if ($type === 'WFS') {
-                $version = self::DEFAULT_WFS_VERSION;
-            } else {
-                $version = self::DEFAULT_WMS_VERSION;
-            }
+        if ($version === '' && $type === 'WFS') {
+            $version = self::DEFAULT_WFS_VERSION;
+        }
+
+        if ($version === '' && $type !== 'WFS') {
+            $version = self::DEFAULT_WMS_VERSION;
         }
 
         $query            = array_change_key_case($params, CASE_UPPER);
@@ -289,10 +290,12 @@ class WmsWfsService
             if ($height > 0) {
                 $query['HEIGHT'] = (string) $height;
             }
-        } else {
+        }
+
+        if ($type !== 'WMS') {
             $query['TYPENAMES'] = (string) ($layer['layerName'] ?? '');
             $query['SRSNAME']   = (string) ($layer['srs'] ?? 'EPSG:28992');
-        }//end if
+        }
 
         // Delegate ALL outbound HTTP to GisProxyService — enforces allowlist + rate limit.
         return $this->gisProxyService->proxyRequest($url, $query, strtolower($type));
@@ -359,7 +362,7 @@ class WmsWfsService
     public function buildGetFeatureUrl(array $layer, string $bbox): string
     {
         if ($bbox === '') {
-            throw new \RuntimeException('WFS GetFeature requires BBOX', 400);
+            throw new RuntimeException('WFS GetFeature requires BBOX', 400);
         }
 
         $version = (string) ($layer['version'] ?? self::DEFAULT_WFS_VERSION);

--- a/lib/Service/WorkflowDefinitionService.php
+++ b/lib/Service/WorkflowDefinitionService.php
@@ -499,16 +499,14 @@ class WorkflowDefinitionService
         $steps       = $payload['steps'] ?? [];
         $transitions = $payload['transitions'] ?? [];
 
+        $stepsValue = json_encode($steps);
         if (is_string($steps) === true) {
             $stepsValue = $steps;
-        } else {
-            $stepsValue = json_encode($steps);
         }
 
+        $transitionsValue = json_encode($transitions);
         if (is_string($transitions) === true) {
             $transitionsValue = $transitions;
-        } else {
-            $transitionsValue = json_encode($transitions);
         }
 
         $draft = [

--- a/phpcs-custom-sniffs/CustomSniffs/Sniffs/Nextcloud/NoLegacyServerAccessorsSniff.php
+++ b/phpcs-custom-sniffs/CustomSniffs/Sniffs/Nextcloud/NoLegacyServerAccessorsSniff.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Forbid the legacy named accessors on \OC::$server that were removed in Nextcloud 34.
+ *
+ * Flags patterns like:
+ *   \OC::$server->getDatabaseConnection()
+ *   \OC::$server->getSystemConfig()
+ *   \OC::$server->getLogger()
+ *
+ * These named accessors were removed in Nextcloud 34. The replacement pattern
+ * is constructor dependency injection of the equivalent OCP interface.
+ *
+ * PSR-11 lookups such as \OC::$server->get(SomeClass::class) are NOT flagged
+ * here; service-locator deprecation is tracked separately (design.md, D4).
+ *
+ * @author  Conduction
+ * @package CustomSniffs
+ */
+
+namespace CustomSniffs\Sniffs\Nextcloud;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * NoLegacyServerAccessorsSniff — forbids removed \OC::$server->getX() accessors.
+ */
+class NoLegacyServerAccessorsSniff implements Sniff
+{
+
+
+    /**
+     * Map of known named accessors to their approved OCP replacement interface.
+     *
+     * Covers the accessors that still appeared in this codebase plus the most
+     * frequently used Nextcloud 34 removals. The error message interpolates the
+     * accessor name and the replacement from this table so engineers see the
+     * intended DI target at the violation site.
+     *
+     * @var array<string, string>
+     */
+    private const REPLACEMENTS = [
+        'getSystemConfig'           => '\OCP\IConfig',
+        'getConfig'                 => '\OCP\IConfig',
+        'getDatabaseConnection'     => '\OCP\IDBConnection',
+        'getLogger'                 => '\Psr\Log\LoggerInterface',
+        'getL10NFactory'            => '\OCP\L10N\IFactory',
+        'getL10N'                   => '\OCP\IL10N (via \OCP\L10N\IFactory)',
+        'getUserSession'            => '\OCP\IUserSession',
+        'getUserManager'            => '\OCP\IUserManager',
+        'getGroupManager'           => '\OCP\IGroupManager',
+        'getURLGenerator'           => '\OCP\IURLGenerator',
+        'getRequest'                => '\OCP\IRequest',
+        'getRootFolder'             => '\OCP\Files\IRootFolder',
+        'getAppManager'             => '\OCP\App\IAppManager',
+        'getSession'                => '\OCP\ISession',
+        'getMemCacheFactory'        => '\OCP\ICacheFactory',
+        'getEventDispatcher'        => '\OCP\EventDispatcher\IEventDispatcher',
+        'getNotificationManager'    => '\OCP\Notification\IManager',
+        'getTempManager'            => '\OCP\ITempManager',
+        'getMimeTypeDetector'       => '\OCP\Files\IMimeTypeDetector',
+        'getMimeTypeLoader'         => '\OCP\Files\IMimeTypeLoader',
+        'getActivityManager'        => '\OCP\Activity\IManager',
+        'getDateTimeFormatter'      => '\OCP\IDateTimeFormatter',
+        'getDateTimeZone'           => '\OCP\IDateTimeZone',
+        'getTrustedDomainHelper'    => '\OCP\Security\ITrustedDomainHelper',
+        'getRegisteredAppContainer' => 'explicit constructor injection of the specific service',
+    ];
+
+    /**
+     * Returns tokens this sniff listens for.
+     *
+     * Anchors on T_DOUBLE_COLON so we can reconstruct the full pattern
+     * \OC :: $server -> getX ( in a single process() call.
+     *
+     * @return array<int>
+     */
+    public function register(): array
+    {
+        return [T_DOUBLE_COLON];
+
+    }//end register()
+
+    /**
+     * Process a T_DOUBLE_COLON token — flag if part of \OC::$server->getX().
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the T_DOUBLE_COLON token.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Previous non-whitespace token must be T_STRING "OC".
+        $prev = $phpcsFile->findPrevious(
+            types: [T_WHITESPACE],
+            start: ($stackPtr - 1),
+            end: null,
+            exclude: true
+        );
+        if ($prev === false
+            || $tokens[$prev]['code'] !== T_STRING
+            || $tokens[$prev]['content'] !== 'OC'
+        ) {
+            return;
+        }
+
+        // Next non-whitespace token must be T_VARIABLE "$server".
+        $afterColon = $phpcsFile->findNext(
+            types: [T_WHITESPACE],
+            start: ($stackPtr + 1),
+            end: null,
+            exclude: true
+        );
+        if ($afterColon === false
+            || $tokens[$afterColon]['code'] !== T_VARIABLE
+            || $tokens[$afterColon]['content'] !== '$server'
+        ) {
+            return;
+        }
+
+        // Expect T_OBJECT_OPERATOR '->'.
+        $arrow = $phpcsFile->findNext(
+            types: [T_WHITESPACE],
+            start: ($afterColon + 1),
+            end: null,
+            exclude: true
+        );
+        if ($arrow === false || $tokens[$arrow]['code'] !== T_OBJECT_OPERATOR) {
+            return;
+        }
+
+        // Expect T_STRING method name.
+        $methodPtr = $phpcsFile->findNext(
+            types: [T_WHITESPACE],
+            start: ($arrow + 1),
+            end: null,
+            exclude: true
+        );
+        if ($methodPtr === false || $tokens[$methodPtr]['code'] !== T_STRING) {
+            return;
+        }
+
+        // Must be followed by ( to be a call.
+        $openParen = $phpcsFile->findNext(
+            types: [T_WHITESPACE],
+            start: ($methodPtr + 1),
+            end: null,
+            exclude: true
+        );
+        if ($openParen === false || $tokens[$openParen]['code'] !== T_OPEN_PARENTHESIS) {
+            return;
+        }
+
+        $methodName = $tokens[$methodPtr]['content'];
+
+        // PSR-11 ->get(...) is deferred (D4 in design.md) — not flagged here.
+        if ($methodName === 'get') {
+            return;
+        }
+
+        // Only flag named accessors: getX where X starts with an uppercase letter.
+        if (preg_match(pattern: '/^get[A-Z]/', subject: $methodName) !== 1) {
+            return;
+        }
+
+        $replacement = self::REPLACEMENTS[$methodName] ?? 'the corresponding OCP interface';
+
+        $error = 'Named accessor \\OC::$server->%s() is removed in Nextcloud 34. Inject %s via the constructor instead.';
+        $phpcsFile->addError(
+            $error,
+            $stackPtr,
+            'LegacyNamedAccessor',
+            [$methodName, $replacement]
+        );
+
+    }//end process()
+}//end class

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,17 +6,21 @@
 
     <!-- Exclude external and vendor files -->
     <exclude-pattern>*/vendor/*</exclude-pattern>
+    <exclude-pattern>*/vendor-bin/*</exclude-pattern>
     <exclude-pattern>*/node_modules/*</exclude-pattern>
     <exclude-pattern>composer-setup.php</exclude-pattern>
+    <!-- Apps that ship a verbatim template snapshot under lib/Resources/template/ (e.g. openbuilt)
+         keep it out of lint scope; no-op for apps without the directory. -->
+    <exclude-pattern>lib/Resources/template/*</exclude-pattern>
+
+    <!-- Surface phpcs warnings (e.g. SpecTagSniff) in CI logs without failing the build. -->
+    <config name="ignore_warnings_on_exit" value="1"/>
 
     <arg name="basepath" value="."/>
     <arg name="colors"/>
     <arg name="parallel" value="75"/>
     <arg name="extensions" value="php"/>
     <arg value="p"/>
-
-    <!-- Advisory warnings (e.g. missing @spec tags) surface in reports but must not fail the run. -->
-    <config name="ignore_warnings_on_exit" value="1"/>
 
     <!-- Don't hide tokenizer exceptions -->
     <rule ref="Internal.Tokenizer.Exception">
@@ -41,7 +45,6 @@
     <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
     <rule ref="Squiz.ControlStructures.ControlSignature"/>
     <rule ref="Squiz.ControlStructures.ElseIfDeclaration"/>
-    <rule ref="Squiz.PHP.DisallowInlineIf"/>
     <rule ref="Squiz.Commenting.ClosingDeclarationComment"/>
     <rule ref="Squiz.Commenting.BlockComment"/>
     <rule ref="Squiz.Commenting.DocCommentAlignment"/>
@@ -52,6 +55,7 @@
     <rule ref="Squiz.Commenting.VariableComment"/>
     <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing"/>
     <rule ref="Squiz.Operators.ComparisonOperatorUsage"/>
+    <rule ref="Squiz.PHP.DisallowInlineIf"/>
     <rule ref="Squiz.Scope.MethodScope"/>
     <rule ref="Squiz.Strings.ConcatenationSpacing">
         <properties>
@@ -216,8 +220,13 @@
         <type>error</type>
     </rule>
 
-    <!-- Custom rule: warn when a class or public method is missing the @spec PHPDoc tag (ADR-003). -->
-    <!-- Emitted as warnings (not errors) so CI surfaces the gap but doesn't block merges. -->
+    <!-- Block calls to \OC::$server->getX() / \OC::$server->query() removed in Nextcloud 34. -->
+    <rule ref="./phpcs-custom-sniffs/CustomSniffs/Sniffs/Nextcloud/NoLegacyServerAccessorsSniff.php">
+        <type>error</type>
+    </rule>
+
+    <!-- Warn when a class or public method is missing the @spec PHPDoc tag (hydra ADR-003).
+         Emitted as warnings (not errors) so CI surfaces the gap but doesn't block merges. -->
     <rule ref="./phpcs-custom-sniffs/CustomSniffs/Sniffs/Commenting/SpecTagSniff.php">
         <type>warning</type>
     </rule>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,234 @@
+# Baselined errors from canonical-config sync (Phase 2 fleet rollout).
+# Tracked in: https://github.com/ConductionNL/procest/issues/543
+# DO NOT add new entries — fix the underlying issue or open a follow-up.
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Parameter \\$listener of method OCP\\\\AppFramework\\\\Bootstrap\\\\IRegistrationContext\\:\\:registerEventListener\\(\\) expects class\\-string\\<OCP\\\\EventDispatcher\\\\IEventListener\\<OCP\\\\EventDispatcher\\\\Event\\>\\>, 'OCA\\\\\\\\Procest\\\\\\\\Validator\\\\\\\\ParaferingAuditAppendOnlyValidator' given\\.$#"
+			count: 3
+			path: lib/AppInfo/Application.php
+
+		-
+			message: "#^Property OCA\\\\Procest\\\\BackgroundJob\\\\BerichtenboxReadStatusJob\\:\\:\\$berichtenboxService is never read, only written\\.$#"
+			count: 1
+			path: lib/BackgroundJob/BerichtenboxReadStatusJob.php
+
+		-
+			message: "#^Property OCA\\\\Procest\\\\Controller\\\\AiController\\:\\:\\$logger is never read, only written\\.$#"
+			count: 1
+			path: lib/Controller/AiController.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between true and false will always evaluate to false\\.$#"
+			count: 2
+			path: lib/Controller/CaseDefinitionController.php
+
+		-
+			message: "#^Property OCA\\\\Procest\\\\Controller\\\\LhsController\\:\\:\\$settingsService is never read, only written\\.$#"
+			count: 1
+			path: lib/Controller/LhsController.php
+
+		-
+			message: "#^Call to function method_exists\\(\\) with '\\\\\\\\OC_Util' and 'getVersionString' will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Controller/MetricsController.php
+
+		-
+			message: "#^Property OCA\\\\Procest\\\\Controller\\\\TemplateController\\:\\:\\$logger is never read, only written\\.$#"
+			count: 1
+			path: lib/Controller/TemplateController.php
+
+		-
+			message: "#^Property OCA\\\\Procest\\\\Listener\\\\BezwaarLifecycleListener\\:\\:\\$settingsService is never read, only written\\.$#"
+			count: 1
+			path: lib/Listener/BezwaarLifecycleListener.php
+
+		-
+			message: "#^Class OCA\\\\Procest\\\\Controller\\\\ZgwController not found\\.$#"
+			count: 1
+			path: lib/Middleware/ZgwAuthMiddleware.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between true and false will always evaluate to false\\.$#"
+			count: 2
+			path: lib/Repair/SeedVthWorkflowTemplates.php
+
+		-
+			message: "#^Variable \\$fromId might not be defined\\.$#"
+			count: 1
+			path: lib/Repair/SeedVthWorkflowTemplates.php
+
+		-
+			message: "#^Parameter \\#1 \\$job of method OCP\\\\BackgroundJob\\\\IJobList\\:\\:add\\(\\) expects class\\-string\\<OCP\\\\BackgroundJob\\\\IJob\\>\\|OCP\\\\BackgroundJob\\\\IJob, string given\\.$#"
+			count: 1
+			path: lib/Service/Actions/ScheduleReminderHandler.php
+
+		-
+			message: "#^Constant OCA\\\\Procest\\\\Service\\\\BerichtenboxService\\:\\:MAX_ATTACHMENT_SIZE is unused\\.$#"
+			count: 1
+			path: lib/Service/BerichtenboxService.php
+
+		-
+			message: "#^Property OCA\\\\Procest\\\\Service\\\\Bezwaar\\\\AdvisoryCommitteeService\\:\\:\\$transitions is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/Bezwaar/AdvisoryCommitteeService.php
+
+		-
+			message: "#^Property OCA\\\\Procest\\\\Service\\\\Bezwaar\\\\BeroepService\\:\\:\\$userSession is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/Bezwaar/BeroepService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between true and false will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/Bezwaar/HearingService.php
+
+		-
+			message: "#^Constant OCA\\\\Procest\\\\Service\\\\CaseDefinitionImportService\\:\\:VALID_COMPONENT_FILES is unused\\.$#"
+			count: 1
+			path: lib/Service/CaseDefinitionImportService.php
+
+		-
+			message: "#^Property OCA\\\\Procest\\\\Service\\\\CaseDefinitionImportService\\:\\:\\$appConfig is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/CaseDefinitionImportService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between true and false will always evaluate to false\\.$#"
+			count: 2
+			path: lib/Service/Inspection/ChecklistService.php
+
+		-
+			message: "#^Property OCA\\\\Procest\\\\Service\\\\InspectionService\\:\\:\\$settingsService is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/InspectionService.php
+
+		-
+			message: "#^Property OCA\\\\Procest\\\\Service\\\\Pdok\\\\PdokBagService\\:\\:\\$settingsService is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/Pdok/PdokBagService.php
+
+		-
+			message: "#^Property OCA\\\\Procest\\\\Service\\\\Pdok\\\\PdokLocatieserverService\\:\\:\\$settingsService is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/Pdok/PdokLocatieserverService.php
+
+		-
+			message: "#^Comparison operation \"\\>\\=\" between 1 and 1 is always true\\.$#"
+			count: 1
+			path: lib/Service/RoleResolverService.php
+
+		-
+			message: "#^Comparison operation \"\\>\" between 0 and 0 is always false\\.$#"
+			count: 1
+			path: lib/Service/StatusTransitionService.php
+
+		-
+			message: "#^Offset 'passed' on array\\{type\\: string, passed\\: bool, failureMessage\\: string\\|null, details\\: array\\<string, mixed\\>\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 2
+			path: lib/Service/StatusTransitionService.php
+
+		-
+			message: "#^Property OCA\\\\Procest\\\\Service\\\\StufMessageBuilder\\:\\:\\$logger is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/StufMessageBuilder.php
+
+		-
+			message: "#^Property OCA\\\\Procest\\\\Service\\\\TenantService\\:\\:\\$settingsService is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/TenantService.php
+
+		-
+			message: "#^Offset 'passed' on array\\{passed\\: bool\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: lib/Service/Transitions/GuardRegistry.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between true and false will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/Transitions/GuardRegistry.php
+
+		-
+			message: "#^Property OCA\\\\Procest\\\\Service\\\\Transitions\\\\RoleGuard\\:\\:\\$settingsService is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/Transitions/RoleGuard.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between true and false will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/Transitions/SideEffectDispatcher.php
+
+		-
+			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
+			count: 5
+			path: lib/Service/WmsWfsService.php
+
+		-
+			message: "#^Constant OCA\\\\Procest\\\\Service\\\\WorkflowDefinitionService\\:\\:ERR_CLONE_FAILED is unused\\.$#"
+			count: 1
+			path: lib/Service/WorkflowDefinitionService.php
+
+		-
+			message: "#^Constant OCA\\\\Procest\\\\Service\\\\WorkflowDefinitionService\\:\\:ERR_DEPRECATE_FAILED is unused\\.$#"
+			count: 1
+			path: lib/Service/WorkflowDefinitionService.php
+
+		-
+			message: "#^Constant OCA\\\\Procest\\\\Service\\\\WorkflowDefinitionService\\:\\:ERR_INVALID_REFERENCES is unused\\.$#"
+			count: 1
+			path: lib/Service/WorkflowDefinitionService.php
+
+		-
+			message: "#^Constant OCA\\\\Procest\\\\Service\\\\WorkflowDefinitionService\\:\\:ERR_LAST_PUBLISHED is unused\\.$#"
+			count: 1
+			path: lib/Service/WorkflowDefinitionService.php
+
+		-
+			message: "#^Constant OCA\\\\Procest\\\\Service\\\\WorkflowDefinitionService\\:\\:ERR_NOT_DEPRECATABLE is unused\\.$#"
+			count: 1
+			path: lib/Service/WorkflowDefinitionService.php
+
+		-
+			message: "#^Constant OCA\\\\Procest\\\\Service\\\\WorkflowDefinitionService\\:\\:ERR_NOT_DRAFT is unused\\.$#"
+			count: 1
+			path: lib/Service/WorkflowDefinitionService.php
+
+		-
+			message: "#^Constant OCA\\\\Procest\\\\Service\\\\WorkflowDefinitionService\\:\\:ERR_NOT_FOUND is unused\\.$#"
+			count: 1
+			path: lib/Service/WorkflowDefinitionService.php
+
+		-
+			message: "#^Constant OCA\\\\Procest\\\\Service\\\\WorkflowDefinitionService\\:\\:ERR_NOT_PUBLISHABLE is unused\\.$#"
+			count: 1
+			path: lib/Service/WorkflowDefinitionService.php
+
+		-
+			message: "#^Constant OCA\\\\Procest\\\\Service\\\\WorkflowDefinitionService\\:\\:ERR_OR_UNAVAILABLE is unused\\.$#"
+			count: 1
+			path: lib/Service/WorkflowDefinitionService.php
+
+		-
+			message: "#^Constant OCA\\\\Procest\\\\Service\\\\WorkflowDefinitionService\\:\\:ERR_PUBLISH_FAILED is unused\\.$#"
+			count: 1
+			path: lib/Service/WorkflowDefinitionService.php
+
+		-
+			message: "#^Constant OCA\\\\Procest\\\\Service\\\\WorkflowDefinitionService\\:\\:ERR_SCHEMA_NOT_CONFIG is unused\\.$#"
+			count: 1
+			path: lib/Service/WorkflowDefinitionService.php
+
+		-
+			message: "#^Property OCA\\\\Procest\\\\Service\\\\WorkflowDefinitionService\\:\\:\\$userSession is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/WorkflowDefinitionService.php
+
+		-
+			message: "#^Result of \\|\\| is always true\\.$#"
+			count: 1
+			path: lib/Validator/ParaferingAuditAppendOnlyValidator.php
+
+		-
+			message: "#^Type OCA\\\\OpenRegister\\\\Event\\\\ObjectCreatingEvent\\|OCA\\\\OpenRegister\\\\Event\\\\ObjectDeletingEvent\\|OCA\\\\OpenRegister\\\\Event\\\\ObjectUpdatingEvent in generic type OCP\\\\EventDispatcher\\\\IEventListener\\<OCA\\\\OpenRegister\\\\Event\\\\ObjectCreatingEvent\\|OCA\\\\OpenRegister\\\\Event\\\\ObjectDeletingEvent\\|OCA\\\\OpenRegister\\\\Event\\\\ObjectUpdatingEvent\\> in PHPDoc tag @implements is not subtype of template type T of OCP\\\\EventDispatcher\\\\Event of interface OCP\\\\EventDispatcher\\\\IEventListener\\.$#"
+			count: 1
+			path: lib/Validator/ParaferingAuditAppendOnlyValidator.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,9 @@
+includes:
+    # Per-app tracked lint debt lives here (auto-generated via `phpstan --generate-baseline`).
+    # Apps without debt ship an empty baseline file; canonical includes are otherwise byte-identical
+    # across the fleet.
+    - phpstan-baseline.neon
+
 parameters:
     level: 5
     paths:
@@ -6,52 +12,48 @@ parameters:
         - phpstan-bootstrap.php
     excludePaths:
         - vendor
+        - vendor-bin
+        # Apps that ship a verbatim template snapshot under lib/Resources/template/ (e.g. openbuilt).
+        - lib/Resources/template
     scanDirectories:
         - vendor/nextcloud/ocp
     reportUnmatchedIgnoredErrors: false
     ignoreErrors:
-        # Nextcloud internal classes that PHPStan might not recognize
+        # Nextcloud server internals (\OC, OC_App, OC\) not stubbed in nextcloud/ocp
         - '#Call to an undefined method OC::#'
         - '#Class OC not found#'
         - '#Access to static property \$server on an unknown class OC#'
+        - '#unknown class OC\\#'
+        - '#Caught class OC\\#'
+        - '#unknown class OC_App#'
+        - '#Class OC_App not found#'
+        # OCA\DAV is server-internal and not in nextcloud/ocp stubs
+        - '#unknown class OCA\\DAV\\#'
+        - '#Class OCA\\DAV\\#'
         # OCA classes from other apps (OpenRegister) not available during static analysis
         - '#unknown class OCA\\OpenRegister\\#'
         - '#OCA\\OpenRegister\\[a-zA-Z\\]+.*not found#'
         - '#on an unknown class OCA\\OpenRegister\\#'
         - '#has invalid return type OCA\\OpenRegister\\#'
-        # IMcpToolProvider ships in openregister PR #1466; procest implements the
-        # stub at tests/Stubs/Mcp/IMcpToolProvider.php until it merges.
+        - '#has invalid type OCA\\OpenRegister\\#'
         - '#implements unknown interface OCA\\OpenRegister\\#'
-        - '#Class OCA\\Procest\\Controller\\ZgwController not found#'
         # GuzzleHttp is available at runtime via Nextcloud but not in composer require
         - '#unknown class GuzzleHttp\\#'
         - '#GuzzleHttp\\[a-zA-Z\\]+.*not found#'
         - '#on an unknown class GuzzleHttp\\#'
         - '#invalid type GuzzleHttp\\#'
         - '#Caught class GuzzleHttp\\#'
+        # Doctrine\DBAL is shipped by Nextcloud server but not stubbed in nextcloud/ocp
+        - '#unknown class Doctrine\\DBAL\\#'
+        - '#Doctrine\\DBAL\\[a-zA-Z\\]+.*not found#'
+        - '#on an unknown class Doctrine\\DBAL\\#'
         # Dynamic HTTP status codes from business rule validation results
-        - '#Parameter \$statusCode of class OCP\\AppFramework\\Http\\JSONResponse constructor expects#'
-        # OCP stub drift — IRequest::getContent() exists in the real Nextcloud IRequest
-        # (server/lib/private/AppFramework/Http/Request.php) but is missing from the
-        # nextcloud/ocp interface stub. Used to read raw request bodies.
-        - '#Call to an undefined method OCP\\IRequest::getContent\(\)\.#'
-        # OCP stub drift — IRequest::setParameter() exists in the real NC Request class
-        # (injecting URL/middleware params) but is not on the OCP interface stub.
-        - '#Call to an undefined method OCP\\IRequest::setParameter\(\)\.#'
-        # OCP stub drift — IMessage::attachFile() is implemented in NC's Mail\Message
-        # but not declared on the OCP IMessage interface.
-        - '#Call to an undefined method OCP\\Mail\\IMessage::attachFile\(\)\.#'
-        # Version-compat check: \OC_Util::getVersionString() existed on older NC cores;
-        # method_exists() guards the call so phpstan's static verdict is not actionable.
-        - '#method_exists\(\) with .+OC_Util.+ and .+getVersionString.+ will always evaluate to false#'
-        # OCP IRequest::getUploadedFile() stub promises "@return array" but the real NC
-        # implementation returns array|null (server/lib/private/AppFramework/Http/Request.php
-        # line 326 — `return isset(...) ? $this->files[$key] : null`). We keep the runtime
-        # is_array() check for safety; phpstan thinks the negative branch is unreachable.
-        - '#Strict comparison using === between true and false will always evaluate to false#'
-        # DI-held services/loggers read indirectly by child routines or kept for future
-        # use in handler classes — removing them breaks constructor signatures used
-        # across the app. Pre-existing architectural pattern.
-        - '#Property .* is never read, only written\.#'
-        # Documented default constants kept for future reference/config export; intentional.
-        - '#Constant .* is unused\.#'
+        # (matches both `Parameter $statusCode` and `Parameter #N $statusCode` forms emitted by phpstan)
+        - '#Parameter (\#\d+ )?\$statusCode of class OCP\\AppFramework\\Http\\JSONResponse constructor expects#'
+        # registerRepairStep exists on server; not yet in nextcloud/ocp stub used for analysis
+        - '#Call to an undefined method OCP\\AppFramework\\Bootstrap\\IRegistrationContext::registerRepairStep#'
+        # OCP stub gaps for methods that exist at runtime
+        - '#Call to an undefined method OCP\\IRequest::getContent\(\)#'
+        - '#Call to an undefined method OCP\\IRequest::setParameter\(\)#'
+        - '#Call to an undefined method OCP\\Mail\\IMessage::attachFile\(\)#'
+        - '#Call to an undefined method OCP\\AppFramework\\Db\\Entity::jsonSerialize#'

--- a/psalm.xml
+++ b/psalm.xml
@@ -23,8 +23,6 @@
             <errorLevel type="suppress">
                 <!-- Nextcloud OCP Classes -->
                 <referencedClass name="OCP\AppFramework\App"/>
-                <!-- Version-compat check: \OC_Util only on older NC cores -->
-                <referencedClass name="OC_Util"/>
                 <referencedClass name="OCP\AppFramework\Bootstrap\IBootstrap"/>
                 <referencedClass name="OCP\AppFramework\Controller"/>
                 <referencedClass name="OCP\AppFramework\IAppContainer"/>
@@ -62,27 +60,34 @@
                 <referencedClass name="OCP\Notification\IManager"/>
                 <referencedClass name="OCP\Share\IManager"/>
                 <!-- OpenRegister cross-app classes (loaded dynamically) -->
+                <referencedClass name="OCA\OpenRegister\Db\ObjectEntity"/>
+                <referencedClass name="OCA\OpenRegister\Db\RegisterMapper"/>
+                <referencedClass name="OCA\OpenRegister\Db\SchemaMapper"/>
                 <referencedClass name="OCA\OpenRegister\Event\DeepLinkRegistrationEvent"/>
-                <referencedClass name="OCA\OpenRegister\Event\ObjectCreatedEvent"/>
                 <referencedClass name="OCA\OpenRegister\Event\ObjectCreatingEvent"/>
-                <referencedClass name="OCA\OpenRegister\Event\ObjectUpdatedEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectCreatedEvent"/>
                 <referencedClass name="OCA\OpenRegister\Event\ObjectUpdatingEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectUpdatedEvent"/>
                 <referencedClass name="OCA\OpenRegister\Event\ObjectDeletedEvent"/>
-                <referencedClass name="OCA\OpenRegister\Event\ObjectDeletingEvent"/>
-                <referencedClass name="OCA\OpenRegister\Exception\LockedException"/>
                 <referencedClass name="OCA\OpenRegister\Service\ObjectService"/>
                 <referencedClass name="OCA\OpenRegister\Service\ConfigurationService"/>
-                <referencedClass name="OCA\OpenRegister\Db\Mapping"/>
-                <!-- IMcpToolProvider ships in openregister PR #1466 (ai-chat-companion-orchestrator);
-                     procest implements the stub at tests/Stubs/Mcp/IMcpToolProvider.php until it merges. -->
+                <referencedClass name="OCA\OpenRegister\Service\RegisterService"/>
+                <referencedClass name="OCA\OpenRegister\Service\FileService"/>
+                <referencedClass name="OCA\OpenRegister\Service\CalendarEventService"/>
                 <referencedClass name="OCA\OpenRegister\Mcp\IMcpToolProvider"/>
+                <!-- Additional OCP infrastructure types used across the fleet -->
+                <referencedClass name="OCP\AppFramework\Bootstrap\IBootContext"/>
+                <referencedClass name="OCP\AppFramework\Bootstrap\IRegistrationContext"/>
+                <referencedClass name="OCP\AppFramework\Db\DoesNotExistException"/>
+                <referencedClass name="OCP\DB\Exception"/>
+                <referencedClass name="OCP\IGroup"/>
+                <referencedClass name="OCP\IUser"/>
+                <referencedClass name="OCP\Migration\IRepairStep"/>
                 <!-- Nextcloud server internals -->
                 <referencedClass name="OC"/>
                 <!-- GuzzleHttp (loaded via composer at runtime) -->
                 <referencedClass name="GuzzleHttp\Client"/>
                 <referencedClass name="GuzzleHttp\Exception\GuzzleException"/>
-                <!-- Procest marker interface for ZGW controllers -->
-                <referencedClass name="OCA\Procest\Controller\ZgwController"/>
             </errorLevel>
         </UndefinedClass>
         <UndefinedMagicMethod errorLevel="suppress"/>
@@ -115,18 +120,6 @@
         <InvalidMethodCall errorLevel="suppress"/>
         <UndefinedInterfaceMethod errorLevel="suppress"/>
         <MissingTemplateParam errorLevel="suppress"/>
-        <UndefinedMethod>
-            <errorLevel type="suppress">
-                <!-- DOMNode narrows to DOMElement at runtime; psalm can't track the downcast -->
-                <referencedMethod name="DOMNode::getElementsByTagName"/>
-            </errorLevel>
-        </UndefinedMethod>
-        <UnusedParam>
-            <errorLevel type="suppress">
-                <!-- Interface-contract params / planned-feature hooks kept for API stability -->
-                <directory name="lib/Service"/>
-            </errorLevel>
-        </UnusedParam>
     </issueHandlers>
     <extraFiles>
         <directory name="vendor/nextcloud/ocp" />


### PR DESCRIPTION
## Summary

Phase 2 fleet rollout of the root-config consolidation. Replaces per-app phpcs/phpmd/psalm/phpstan with canonical from `nextcloud-app-template` (matches shillinq#300, decidesk#243).

Lint-debt tracking: #543.

## Quality gates

| Gate | Status |
|---|---|
| phpcs | ✅ 0 errors, 713 warnings |
| phpstan | ✅ 0 unmatched (56 baselined per #543) |
| psalm | 🔴 14 pre-existing errors (tracked #543) |
| phpmd | 🔴 171 architectural violations (tracked #543) |

phpmd has no native baseline support so CI stays red until #543 closes. Agreed-upon tracked-debt pattern.

## Mechanical phpmd cleanup (81 violations fixed)

- 42 `MissingImport`: added `use` statements for `\Exception`, `\Throwable`, `\RuntimeException`, `\DateTime`, `\DateTimeImmutable`, `\DateTimeInterface`, `\DateInterval`, `\DateTimeZone`; replaced inline backslash refs.
- 38 `ElseExpression`: refactored `if/else` to two-if pattern across 14 files.
- 1 `UnusedFormalParameter`: `@SuppressWarnings(PHPMD.UnusedFormalParameter)` on `AdviceDeadlineJob::run` (parent `TimedJob` signature requires `$argument`).

## Notable findings

- **`ZgwController not found`** in `Middleware/ZgwAuthMiddleware.php:154` — likely a real broken class reference, called out specifically in #543 for investigation.
- `SpecTagSniff` was already enabled in procest's prior phpcs; it's now canonical fleetwide.

## Test plan

- [x] phpcs: clean
- [x] phpstan: 0 unmatched (baseline)
- [ ] psalm: 14 pre-existing tracked #543
- [ ] phpmd: 171 architectural tracked #543