### PR TITLE
docs(openspec): IA alignment refactor (1 drift: task-management)

### DIFF
--- a/openspec/changes/refactor-procest-ia-alignment/design.md
+++ b/openspec/changes/refactor-procest-ia-alignment/design.md
@@ -1,0 +1,91 @@
+# Design: Procest IA Topology
+
+## Goal
+
+Lock in the left-nav topology that the implemented specs are expected to map
+into, then identify the single drift (`task-management`) that needs relocation.
+
+## Target left-nav (post-change)
+
+```
+Procest
++-- Dashboard                       (TOP_MENU; route /)
+|     widgets:
+|       count-open-cases, count-overdue, count-completed,
+|       count-my-tasks, count-sla,
+|       cases-by-status, cases-by-type, my-work, case-map,
+|       deadline-alerts, task-due-reminders, stalled-cases
+|
++-- Mijn werk                       (TOP_MENU; route /my-work)
+|     children:
+|       +- Taken                    (SUB_PAGE; route /tasks)   <-- moved here
+|
++-- Werkvoorraad                    (TOP_MENU; route /werkvoorraad)
+|
++-- Zaken                           (TOP_MENU group; route /cases is "Alle zaken")
+|     children:
+|       +- Alle zaken               (SUB_PAGE; route /cases)
+|       +- Bezwaren                 (SUB_PAGE; route /bezwaren)
+|       +- Beslissingen op bezwaar  (SUB_PAGE; route /bezwaar-decisions)
+|       +- Beroepen                 (SUB_PAGE; route /beroepen)
+|
++-- Kaart                           (TOP_MENU; route /map)
++-- Voorstellen                     (TOP_MENU; route /voorstellen)
++-- Advice                          (TOP_MENU; route /advice)
++-- BAC-adviezen                    (TOP_MENU; route /bezwaar-advice-requests)
++-- Transfers                       (TOP_MENU; route /transfers)
+|
++-- (settings drawer; "Configuratie")
+      +-- Documentation              (href)
+      +-- Zaaktypes                  (CaseTypesMenu, /case-types)
+      +-- Legesverordeningen
+      +-- Legesberekeningen
+      +-- Partner organisations
+      +-- Tenants                    (admin)
+      +-- Parafeerroutes
+      +-- Kaartlagen                 (admin)
+      +-- Workflow definitions
+      +-- Automatische acties
+      +-- Status history             (admin)
+      +-- Handhavingsstrategie       (admin)
+      +-- LHS Recommendations
+      +-- Case locations             (admin)
+      +-- Bezwaaradviescommissies
+      +-- Settings                   (AdminRootView)
+      +-- Features & roadmap
+```
+
+Note: the proposed IA only requires the `task-management` move. The Zaken-group
+nesting and other tidy-ups (Bezwaren/Beroepen folded under a Zaken group) are
+out of scope for this change — none of the 14 audited specs requires it. They
+will be addressed when those specs (`bezwaar-lifecycle`, `beroep-escalation`,
+etc.) come up for IA review.
+
+## Rationale for the one move
+
+Per the IA heuristics: **IA says SUB_PAGE under parent X, but spec lives as a
+sibling route to X → DRIFT.** `task-management` IA places it under "Mijn werk
+› Taken" but it's currently at top-level `Tasks` (manifest menu order 50),
+sibling to `MyWork` (order 20). Moving it makes the only journey that lands on
+the global task list ("what's on my plate") consistent with the My Work
+framing.
+
+## Constraints
+
+- The procest manifest's `menu[]` is flat (each entry has `id`, `label`,
+  `route`, optional `section`, `permission`, `order`). It does not natively
+  support nested children. Two implementation options:
+  1. **Remove** the `Tasks` menu entry; surface the global task list from
+     inside `MyWork.vue` as a tab / explicit link to `/tasks`. The route stays
+     for deep-link compatibility.
+  2. **Group visually** via a manifest-level convention (sub-menu on hover,
+     prefixed labels). Not currently supported by `@conduction/nextcloud-vue`.
+- This change adopts option (1): demote in `menu[]`, keep the page entry.
+
+## Out of scope
+
+- Bezwaren / Beroepen / BezwaarDecisions consolidation under a Zaken group.
+- Settings drawer reorganisation (the IA shows `Configuratie › Admin ›
+  Observability/Storage` sub-grouping that the current flat drawer doesn't
+  express).
+- Backend / API / schema work.

--- a/openspec/changes/refactor-procest-ia-alignment/proposal.md
+++ b/openspec/changes/refactor-procest-ia-alignment/proposal.md
@@ -1,0 +1,61 @@
+# Refactor Procest IA Alignment
+
+## Why
+
+A fresh Information Architecture (IA) proposal was drafted for procest based on
+user-journey analysis and competitive-IA review. This change reconciles the
+fleet-wide IA proposal against what is actually implemented in
+`apps-extra/procest/src/manifest.json` and the Vue view tree.
+
+The audit covered 14 implemented specs. **13 are already aligned**; **1
+drifts** and is moved by this change. No new specs are introduced — only
+re-placements.
+
+## What Changes
+
+### Drifted spec
+
+- **`task-management`** — currently a TOP_MENU entry (`/tasks`, manifest
+  menu order 50). Proposed IA placement is `Mijn werk › Taken`. The Tasks
+  list belongs nested under My Work, not as a sibling top-level item, because
+  the only journey that lands on the global task list IS "what's on my plate"
+  — which is My Work's job. A separate top-level Tasks page duplicates the
+  framing and pushes case-scoped task views (already correctly modelled as a
+  `CaseTasksTab` sidebar tab on `CaseDetail`) into a less-discoverable second
+  surface.
+
+  **Move:** demote the top-level `Tasks` menu entry to a sub-route under My
+  Work. The `/tasks` route stays (deep links + `CaseTasksTab` navigation), but
+  the left-nav exposes it as a child of `MyWork` rather than as a sibling.
+
+### Verified aligned (no change)
+
+| spec                          | IA placement                                       | current placement                          |
+|-------------------------------|----------------------------------------------------|--------------------------------------------|
+| `admin-settings`              | Configuratie › Admin                               | `section: settings` drawer (multiple entries) |
+| `case-dashboard-view`         | WIDGET on Dashboard                                | `count-open-cases`, `cases-by-status`, `cases-by-type`, `count-overdue`, `count-completed` widgets in Dashboard manifest |
+| `case-management`             | Zaken › Alle zaken                                 | top-level `Cases` (`/cases`) — IS the "Alle zaken" surface |
+| `case-types`                  | Configuratie › Zaaktypes (CONFIG, geen menu)       | `CaseTypesMenu` in settings drawer         |
+| `dashboard`                   | TOP_MENU                                            | top-level `Dashboard` (`/`)                |
+| `my-work`                     | TOP_MENU                                            | top-level `MyWork` (`/my-work`)            |
+| `openregister-integration`    | SETTING › Configuratie › Integraties               | foundational infra; no UI route to misplace |
+| `procest-app-scaffold`        | meta / —                                            | scaffold-only; no UI                       |
+| `procest-case-management`     | Zaken › Alle zaken                                 | implementation spec for case-management; same placement |
+| `procest-object-store`        | SETTING › Configuratie › Admin › Storage           | runtime Pinia store; no UI                 |
+| `prometheus-metrics`          | SETTING › Configuratie › Admin › Observability     | backend `/api/metrics` endpoint; no UI     |
+| `roles-decisions`             | SETTING › Configuratie › Rollen & rechten          | role/decision data via `CaseDecisionsTab` sidebar tab; TYPE config lives under Case Types admin. No separate top-level routes. |
+| `zgw-api-mapping`             | SETTING › Configuratie › Integraties               | backend ZGW endpoints; no UI route         |
+
+## Impact
+
+- **Affected specs**: `task-management` (placement change only — data model and
+  REQ-TASK-* requirements unchanged).
+- **Affected code**:
+  - `src/manifest.json` — `Tasks` menu entry demoted (parent/group under
+    MyWork, or removed from top-level and surfaced from within MyWork).
+  - `src/views/MyWork.vue` — adds explicit "Taken" tab/link to `/tasks` (the
+    existing My Work view already aggregates personal cases + tasks; this
+    surfaces the global task list explicitly).
+  - No backend changes. No schema changes. Routes preserved for deep-link
+    backwards compatibility.
+- **Risk**: low — purely menu structure; route paths unchanged.

--- a/openspec/changes/refactor-procest-ia-alignment/specs/task-management/spec.md
+++ b/openspec/changes/refactor-procest-ia-alignment/specs/task-management/spec.md
@@ -1,0 +1,61 @@
+---
+name: task-management
+status: draft
+version: draft
+---
+
+# Task Management — IA Placement Delta
+
+This delta only modifies the navigation placement requirements of the
+`task-management` spec. All data-model, lifecycle, RBAC, and API requirements
+(REQ-TASK-001..REQ-TASK-N) are unchanged and remain canonical in
+`openspec/specs/task-management/spec.md`.
+
+## ADDED Requirements
+
+### Requirement: Task list MUST be reached via Mijn werk, not a sibling top-level menu
+
+The global task list view (`/tasks`) MUST be discoverable through the "Mijn
+werk" top-level menu rather than as a sibling top-level menu entry. This
+matches the proposed IA placement `Mijn werk › Taken` and removes the
+duplicate framing where Tasks and My Work compete as separate "what's on my
+plate" entries.
+
+#### Scenario: Tasks does not appear as a top-level menu item
+
+- GIVEN a behandelaar opens the Procest app
+- WHEN the left navigation renders
+- THEN the top-level menu MUST NOT include an entry labelled "Tasks" /
+  "Taken" with a top-level icon
+- AND the manifest `menu[]` array MUST NOT contain an entry with
+  `id: "Tasks"` outside of the `section: "settings"` group
+
+#### Scenario: Task list is reachable from Mijn werk
+
+- GIVEN a behandelaar is on `/my-work`
+- WHEN they look for the global task list
+- THEN the `MyWork` view MUST surface an explicit affordance (tab, link, or
+  button) labelled "Taken" / "Tasks" that navigates to `/tasks`
+- AND the affordance MUST be discoverable above the fold
+
+#### Scenario: Existing /tasks deep links continue to resolve
+
+- GIVEN a stored bookmark or external link points to `/tasks`
+- WHEN a user opens that URL
+- THEN the route MUST still resolve to the existing `Tasks` index page (the
+  manifest `pages[]` entry with `id: "Tasks"` is preserved)
+- AND no 404 or redirect MUST occur
+
+## REMOVED Requirements
+
+### Requirement: Tasks MUST appear as a top-level navigation entry
+
+**Reason:** Replaced by the new requirement above. The proposed IA places
+Tasks under Mijn werk, not as a sibling. The implicit assumption (in the
+original spec's `src/views/tasks/TaskList.vue` placement and manifest menu
+order 50) that Tasks deserves a top-level slot duplicates the My Work framing
+and is no longer aligned with the IA.
+
+**Migration:** The `pages[]` entry for `Tasks` is preserved (route `/tasks`
+still works for deep links and for `CaseTasksTab` navigation). Only the
+`menu[]` entry is removed.

--- a/openspec/changes/refactor-procest-ia-alignment/tasks.md
+++ b/openspec/changes/refactor-procest-ia-alignment/tasks.md
@@ -1,0 +1,60 @@
+# Tasks: Refactor Procest IA Alignment
+
+These tasks are scoped to the single drift (`task-management`). Each task is
+self-contained and should take under 15 minutes.
+
+## 1. Manifest menu edits
+
+- [ ] 1.1 Open `src/manifest.json` and locate the menu entry
+      `{ "id": "Tasks", "label": "Tasks", ..., "route": "Tasks", "order": 50 }`.
+- [ ] 1.2 Delete that entry from the `menu[]` array. Do NOT delete the
+      corresponding `pages[]` entry with `id: "Tasks"` (route `/tasks`) — that
+      page must keep working for deep links and for `CaseTasksTab` navigation.
+- [ ] 1.3 In the same file, find the `MyWork` menu entry (order 20) and
+      verify it remains a top-level entry (no `section`, no `permission`).
+- [ ] 1.4 Save the file and re-run `node validate-manifest.js` (or the
+      project's manifest validator) to confirm the JSON is still valid against
+      `https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest.schema.json`.
+
+## 2. Surface Tasks from inside MyWork
+
+- [ ] 2.1 Open `src/views/MyWork.vue` and locate the `my-work__tabs`
+      block (the filter-tabs row).
+- [ ] 2.2 Immediately after the existing tabs, add a `<router-link>` (or
+      `<NcButton>` with `@click="$router.push({ name: 'Tasks' })"`) labelled
+      `{{ t('procest', 'All tasks') }}` (NL: `Alle taken`). The link MUST be
+      visible without scrolling.
+- [ ] 2.3 Run `npm run lint` and `npm run dev` from the procest repo root;
+      open `http://localhost:3000/apps/procest/my-work` and confirm the new
+      affordance renders and navigates to `/apps/procest/tasks`.
+- [ ] 2.4 Confirm the left-nav no longer shows a "Tasks" top-level entry
+      (only `MyWork`, `Dashboard`, `Werkvoorraad`, etc.).
+
+## 3. Translations
+
+- [ ] 3.1 Add the new string `All tasks` to `l10n/en.json` (and any other
+      English source the build uses).
+- [ ] 3.2 Add the Dutch translation `Alle taken` to `l10n/nl.json`.
+- [ ] 3.3 Rebuild translation bundles if the app uses a build step
+      (`npm run build:l10n` or equivalent — check `package.json`).
+
+## 4. Update the spec
+
+- [ ] 4.1 After this change is approved and the manifest edit is merged,
+      update `openspec/specs/task-management/spec.md` to reflect the new
+      placement: remove any wording asserting that Tasks is a top-level menu
+      entry; replace with "the global task list is reached via Mijn werk".
+- [ ] 4.2 Search the spec for the phrase `top-level` and adjust any
+      paragraph that asserts top-level navigation for Tasks.
+
+## 5. Verify, then archive
+
+- [ ] 5.1 Run `openspec validate refactor-procest-ia-alignment --strict`.
+- [ ] 5.2 Browser-verify: navigate Procest end-to-end (Dashboard → Mijn werk
+      → Tasks via the new affordance → CaseDetail → CaseTasksTab) and
+      screenshot the new nav for the PR.
+- [ ] 5.3 Run `composer check:strict` (no PHP changes are expected, but the
+      gate must stay green).
+- [ ] 5.4 Run `npm run test` to confirm no Vue tests break.
+- [ ] 5.5 Open a PR titled `refactor(procest): align Tasks placement with IA
+      (Mijn werk › Taken)` targeting `development`.


### PR DESCRIPTION
## Information Architecture audit

Generated from the 2026-05-22 IA pass. Compares 14 implemented procest specs against the proposed IA topology.

**Result: 13 aligned · 1 drift · 0 uncertain**

### Drift

- **`task-management`** — currently a TOP_MENU `Tasks` entry at `/tasks` (manifest order 50), sibling to `MyWork`. Proposed IA places it at `Mijn werk › Taken`. Demoting it removes a duplicate framing of "what's on my plate" while preserving the `/tasks` route for deep links + `CaseTasksTab` navigation.

### What's in this change

- `proposal.md` — drift rationale + aligned table
- `design.md` — full left-nav topology
- `specs/task-management/spec.md` — ADDED scenarios for new placement + REMOVED top-level-menu requirement
- `tasks.md` — 5 sections (manifest edit, MyWork.vue affordance, l10n, spec update, verify/validate)

Touches only `src/manifest.json` (delete `Tasks` from `menu[]`, keep in `pages[]`) and `src/views/MyWork.vue` (explicit `/tasks` link). No backend, no schema.

To execute: label with `ready-to-build` + `yolo` once approved.