### PR TITLE
chore(openspec): mark voorstel-management as moved into case-management

### DIFF
--- a/openspec/specs/case-management/spec.md
+++ b/openspec/specs/case-management/spec.md
@@ -16,7 +16,8 @@ Case management is the core capability of Procest. A case represents a coherent 
 Procest case lifecycle is expressed as an OR `x-openregister-lifecycle`
 annotation on the case schema. **This spec is the canonical home;
 previously sibling specs (`parafering-actions`, `parafering-audit-trail`,
-`parafeerroute-engine`) are retired and their requirements live here.**
+`parafeerroute-engine`, `voorstel-management`) are retired and their
+requirements live here.**
 
 ### OR Capabilities Consumed
 
@@ -61,6 +62,7 @@ consumes:
 | `parafering-actions/spec.md` | Lifecycle transitions with `roles` array (advies, parafering, accordering). |
 | `parafering-audit-trail/spec.md` | OR `audit-trail-immutable` capability; delegation captured as audit context. |
 | `parafeerroute-engine/spec.md` | Lifecycle transitions with `requires` guards (skip-step / ad-hoc-step semantics). |
+| `voorstel-management/spec.md` | Voorstel entity is the case itself across the `concept`..`besloten` lifecycle; create-flow → REQ-CM-01, status lifecycle → REQ-CM-14, detail view → REQ-CM-06, multi-voorstel-per-case → REQ-CM-18 (deelzaak). |
 
 ### ZGW Notificaties API boundary preserved
 

--- a/openspec/specs/voorstel-management/spec.md
+++ b/openspec/specs/voorstel-management/spec.md
@@ -1,3 +1,33 @@
+---
+status: retired
+retired_in: procest-adopt-or-abstractions
+canonical_home: case-management/spec.md
+---
+
+> **RETIRED — voorstel folded into the consolidated case lifecycle.**
+>
+> In the OR-abstractions consolidation the `voorstel` entity was
+> absorbed into the case schema: a case in `concept` → `in_parafering`
+> → `teruggestuurd` → `geparafeerd` → `aangeboden` → `besloten`
+> **is** the voorstel. The schema, status lifecycle, detail view,
+> create-from-case flow, and per-case multiplicity (deelzaak) all
+> live on the case entity now, with role-based transition
+> authorization expressed in the `x-openregister-lifecycle`
+> annotation. See ADR-022 and `case-management/spec.md`.
+>
+> This file is preserved as a historical appendix. Refer to
+> `case-management/spec.md` for canonical voorstel semantics.
+
+## REQ migration map
+
+| Retired REQ here | New home in `case-management/spec.md` |
+|------------------|----------------------------------------|
+| Voorstel Schema Registration | Case Entity data model + lifecycle states (`concept`..`besloten`) on the case schema. |
+| Create Voorstel from Case | REQ-CM-01 Case Creation (with case-type-driven defaults). |
+| Voorstel Status Lifecycle | REQ-CM-14 Status Change + consolidated `x-openregister-lifecycle` annotation; `terugsturen` / `paraferen` / `aanbieden` are guarded transitions. |
+| Multiple Voorstellen per Case | REQ-CM-18 Sub-Cases (deelzaak) — each B&W-voorstel that needs an independent route is modeled as a deelzaak under its parent case. |
+| Voorstel Detail View | REQ-CM-06 Case Detail View — including parafering progress timeline (REQ-CM-07) and audit trail (REQ-CM-22). |
+
 ## ADDED Requirements
 
 ### Requirement: Voorstel Schema Registration


### PR DESCRIPTION
## Summary

Marks `openspec/specs/voorstel-management/spec.md` as **retired** with `canonical_home: case-management/spec.md`, matching the existing pattern of the three sibling specs (`parafering-actions`, `parafering-audit-trail`, `parafeerroute-engine`) that were retired in `procest-adopt-or-abstractions` (2026-05-11).

During that consolidation the voorstel entity was folded into the case schema: a case across the `concept` → `in_parafering` → `teruggestuurd` → `geparafeerd` → `aangeboden` → `besloten` lifecycle **is** the voorstel. The three parafering-* sibling specs got the retired-frontmatter treatment, but voorstel-management itself was missed — which is what the coverage scan picked up (389 voorstel-hits in removed-lines, zero in current code).

## What changed

- `openspec/specs/voorstel-management/spec.md` — added retired frontmatter, header banner, and a REQ migration map mapping all 5 retired REQs onto existing REQ-CM-* in case-management. Body REQs preserved verbatim as historical appendix (matches sibling pattern).
- `openspec/specs/case-management/spec.md` — added `voorstel-management` to the four-spec retirement note in the Consolidated Lifecycle section, and added a row to the Migration Map table.

## REQ migration (no unique REQs needed merging)

| Retired REQ | New home |
|---|---|
| Voorstel Schema Registration | Case Entity + lifecycle states (`concept`..`besloten`) on the case schema |
| Create Voorstel from Case | REQ-CM-01 Case Creation |
| Voorstel Status Lifecycle | REQ-CM-14 Status Change + consolidated `x-openregister-lifecycle` annotation |
| Multiple Voorstellen per Case | REQ-CM-18 Sub-Cases (deelzaak) |
| Voorstel Detail View | REQ-CM-06 Case Detail View |

## Coverage scan impact

Resolves the Bucket 3b false-positive for `voorstel-management` in `openspec/coverage-report.md` (389 hits in removed-lines, 0 in current code — the domain was consolidated, not abandoned).

## Validate

`openspec validate voorstel-management --type spec --strict` fails on the same "missing Purpose section" rule that the three sibling retired specs also fail on — this is the canonical pattern in this repo, not a regression. `case-management` strict validation has one pre-existing REQ-21 SHALL-keyword warning that was failing on `origin/development` before this PR.

Refs #565

## Test plan

- [ ] Coverage scan re-run no longer surfaces voorstel-management as Bucket 3b
- [ ] Retired-frontmatter + canonical_home pointer matches the three sibling parafering-* specs