### PR TITLE
retrofit: annotate procest Bucket 1 (19 files / 5 capabilities)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Retrofit annotation commit (opsx-annotate, 2026-05-24)
+2ca28029190dc145dca72d2cebbc0ab9c9a6aeb4

--- a/lib/Controller/BrcController.php
+++ b/lib/Controller/BrcController.php
@@ -20,6 +20,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-1
  */
 
 declare(strict_types=1);

--- a/lib/Controller/CaseDefinitionController.php
+++ b/lib/Controller/CaseDefinitionController.php
@@ -19,6 +19,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-3
  */
 
 declare(strict_types=1);

--- a/lib/Controller/DashboardController.php
+++ b/lib/Controller/DashboardController.php
@@ -18,6 +18,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-5
  */
 
 declare(strict_types=1);

--- a/lib/Controller/DrcController.php
+++ b/lib/Controller/DrcController.php
@@ -20,6 +20,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-1
  */
 
 declare(strict_types=1);

--- a/lib/Controller/MetricsController.php
+++ b/lib/Controller/MetricsController.php
@@ -18,6 +18,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-2
  */
 
 declare(strict_types=1);

--- a/lib/Controller/NrcController.php
+++ b/lib/Controller/NrcController.php
@@ -20,6 +20,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-1
  */
 
 declare(strict_types=1);

--- a/lib/Controller/ZgwMappingController.php
+++ b/lib/Controller/ZgwMappingController.php
@@ -18,6 +18,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-1
  */
 
 declare(strict_types=1);

--- a/lib/Controller/ZrcController.php
+++ b/lib/Controller/ZrcController.php
@@ -23,6 +23,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-1
  */
 
 declare(strict_types=1);

--- a/lib/Controller/ZtcController.php
+++ b/lib/Controller/ZtcController.php
@@ -21,6 +21,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-1
  */
 
 declare(strict_types=1);

--- a/lib/Dashboard/CasesOverviewWidget.php
+++ b/lib/Dashboard/CasesOverviewWidget.php
@@ -18,6 +18,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-5
  */
 
 declare(strict_types=1);

--- a/lib/Dashboard/DeadlineAlertsWidget.php
+++ b/lib/Dashboard/DeadlineAlertsWidget.php
@@ -19,6 +19,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-4
  */
 
 declare(strict_types=1);

--- a/lib/Dashboard/MyTasksWidget.php
+++ b/lib/Dashboard/MyTasksWidget.php
@@ -18,6 +18,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-5
  */
 
 declare(strict_types=1);

--- a/lib/Dashboard/OverdueCasesWidget.php
+++ b/lib/Dashboard/OverdueCasesWidget.php
@@ -18,6 +18,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-4
  */
 
 declare(strict_types=1);

--- a/lib/Dashboard/StalledCasesWidget.php
+++ b/lib/Dashboard/StalledCasesWidget.php
@@ -19,6 +19,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-4
  */
 
 declare(strict_types=1);

--- a/lib/Dashboard/StartCaseWidget.php
+++ b/lib/Dashboard/StartCaseWidget.php
@@ -18,6 +18,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-5
  */
 
 declare(strict_types=1);

--- a/lib/Dashboard/TaskRemindersWidget.php
+++ b/lib/Dashboard/TaskRemindersWidget.php
@@ -19,6 +19,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-4
  */
 
 declare(strict_types=1);

--- a/lib/Service/CaseDefinitionExportService.php
+++ b/lib/Service/CaseDefinitionExportService.php
@@ -19,6 +19,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-3
  */
 
 declare(strict_types=1);

--- a/lib/Service/CaseDefinitionImportService.php
+++ b/lib/Service/CaseDefinitionImportService.php
@@ -19,6 +19,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-3
  */
 
 declare(strict_types=1);

--- a/lib/Service/ZgwService.php
+++ b/lib/Service/ZgwService.php
@@ -17,6 +17,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-1
  */
 
 declare(strict_types=1);

--- a/openspec/changes/archive/retrofit-2026-05-24-annotate-procest/proposal.md
+++ b/openspec/changes/archive/retrofit-2026-05-24-annotate-procest/proposal.md
@@ -1,0 +1,25 @@
+# Retrofit — annotate procest against existing specs
+
+Retroactive annotation of 19 files across 5 capabilities against 60 REQs.
+No code logic changes. No spec deltas (all REQs already exist in `openspec/specs/`).
+
+Source: `openspec/coverage-report.md` generated 2026-05-24 (Bucket 1).
+
+Files in scope:
+
+- **zgw-api-mapping** (21 REQs) — 7 files: ZRC/DRC/ZTC/BRC/NRC controllers + ZgwMappingController + ZgwService (~163 methods)
+- **prometheus-metrics** (10 REQs) — MetricsController (13 methods)
+- **case-types** (17 REQs) — CaseDefinitionController + CaseDefinitionExportService + CaseDefinitionImportService (~14 methods)
+- **signalering-widgets** (6 REQs) — DeadlineAlertsWidget + TaskRemindersWidget + StalledCasesWidget + OverdueCasesWidget (~28 methods)
+- **dashboard** (16 REQs) — CasesOverviewWidget + MyTasksWidget + StartCaseWidget + DashboardController (~21 methods)
+
+The coverage scan deferred per-method confidence scoring (v1 limitation; see notes
+in `coverage-report.json`). This annotation pass therefore applies file-level
+`@spec` tags only — methods inherit the file-level tag per the existing
+procest convention (see `lib/Service/KpiAggregationService.php` as reference,
+where T01 lives on the file docblock plus the first method).
+
+Voorstel-management Bucket 1 entries are excluded — the spec is being moved to
+`parafering-actions` in pending PR #566.
+
+See [retrofit playbook](../../../.github/docs/claude/retrofit.md).

--- a/openspec/changes/archive/retrofit-2026-05-24-annotate-procest/tasks.md
+++ b/openspec/changes/archive/retrofit-2026-05-24-annotate-procest/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] task-1: zgw-api-mapping — ZGW API surface (ZRC/ZTC/DRC/BRC/NRC controllers, ZgwMappingController, ZgwService) implements 21 REQs (retroactive annotation)
+- [x] task-2: prometheus-metrics — MetricsController implements REQ-PROM-001..010 (retroactive annotation)
+- [x] task-3: case-types — CaseDefinition controller + Export/Import services implement 17 REQs REQ-CT-01..16 + Case Type Pre-Seeded Data (retroactive annotation)
+- [x] task-4: signalering-widgets — Deadline / Task-due / Stalled-cases / Overdue widgets implement 6 REQs (retroactive annotation)
+- [x] task-5: dashboard — CasesOverview / MyTasks / StartCase widgets + DashboardController implement 16 REQs REQ-DASH-001..015 (retroactive annotation)

--- a/openspec/coverage-report.json
+++ b/openspec/coverage-report.json
@@ -1,0 +1,336 @@
+{
+  "generated_at": "2026-05-24T08:36:00Z",
+  "app": "procest",
+  "branch": "development",
+  "scanner_version": "1",
+  "scan_scope": "lib/**/*.php (172 files, 1235 methods). src/**/*.{vue,js,ts} not bucketed in v1 — see notes.",
+  "spec_counts": {
+    "specs_total": 47,
+    "reqs_extracted": 359,
+    "req_id_styles": ["REQ-XX-NN", "Requirement: <title>", "Requirement N: <title>", "ZRC-NNN"]
+  },
+  "buckets": {
+    "annotated": [
+      {"file": "lib/Service/KpiAggregationService.php", "methods_annotated": 11, "methods_total": 11, "spec_tag": "openspec/changes/add-server-side-kpi-aggregation/tasks.md (T01-T12)"},
+      {"file": "lib/Controller/KpiController.php", "methods_annotated": 2, "methods_total": 2, "spec_tag": "openspec/changes/add-server-side-kpi-aggregation/tasks.md"},
+      {"file": "lib/Listener/KpiCacheInvalidationListener.php", "methods_annotated": 2, "methods_total": 2, "spec_tag": "openspec/changes/add-server-side-kpi-aggregation/tasks.md"},
+      {"file": "lib/Controller/ParafeerActieController.php", "methods_annotated": 4, "methods_total": 4, "spec_tag": "openspec/changes/parafering-actions/tasks.md"},
+      {"file": "lib/Controller/ParafeerRouteController.php", "methods_annotated": 5, "methods_total": 8, "spec_tag": "openspec/changes/parafeerroute-engine/tasks.md"},
+      {"file": "lib/Service/ParafeerActieService.php", "methods_annotated": 5, "methods_total": 15, "spec_tag": "openspec/changes/parafering-actions/tasks.md + file-level"},
+      {"file": "lib/Service/ParafeerRouteService.php", "methods_annotated": 6, "methods_total": 16, "spec_tag": "openspec/changes/parafeerroute-engine/tasks.md + file-level"},
+      {"file": "lib/Service/Parafering/AuditTrailService.php", "spec_tag": "openspec/changes/parafering-audit-trail/tasks.md"},
+      {"file": "lib/Listener/ParaferingAuditListener.php", "spec_tag": "openspec/changes/parafering-audit-trail/tasks.md"},
+      {"file": "lib/Controller/ParaferingAuditExportController.php", "spec_tag": "openspec/changes/parafering-audit-trail/tasks.md"},
+      {"file": "lib/Validator/ParaferingAuditAppendOnlyValidator.php", "spec_tag": "openspec/changes/parafering-audit-trail/tasks.md"},
+      {"file": "lib/Event/ParafeerTransitionEvent.php", "spec_tag": "openspec/changes/parafering-actions/specs/parafering-actions/spec.md"},
+      {"file": "lib/Controller/RoutingController.php", "methods_annotated": 2, "methods_total": 4, "spec_tag": "openspec/changes/role-based-step-routing/tasks.md"},
+      {"file": "lib/Service/RoleResolverService.php", "methods_annotated": 1, "methods_total": 10, "spec_tag": "openspec/changes/role-based-step-routing/tasks.md (file-level inherits)"},
+      {"file": "lib/Service/Routing/RoutingStrategyInterface.php", "spec_tag": "openspec/changes/role-based-step-routing/tasks.md"},
+      {"file": "lib/Service/Routing/RoutingStrategyMissingException.php", "spec_tag": "openspec/changes/role-based-step-routing/tasks.md"},
+      {"file": "lib/Service/Routing/StrategyRegistry.php", "spec_tag": "openspec/changes/role-based-step-routing/tasks.md"},
+      {"file": "lib/Service/Routing/Strategy/HierarchicalStrategy.php", "spec_tag": "openspec/changes/role-based-step-routing/tasks.md"},
+      {"file": "lib/Service/Routing/Strategy/LeastLoadedStrategy.php", "spec_tag": "openspec/changes/role-based-step-routing/tasks.md"},
+      {"file": "lib/Service/Routing/Strategy/OrSetStrategy.php", "spec_tag": "openspec/changes/role-based-step-routing/tasks.md"},
+      {"file": "lib/Service/Routing/Strategy/RoundRobinStrategy.php", "spec_tag": "openspec/changes/role-based-step-routing/tasks.md"},
+      {"file": "lib/Service/Routing/Strategy/SingleRoleStrategy.php", "spec_tag": "openspec/changes/role-based-step-routing/tasks.md"},
+      {"file": "lib/Listener/RoleMutationListener.php", "spec_tag": "openspec/changes/role-based-step-routing/tasks.md"},
+      {"file": "lib/Controller/StatusTransitionController.php", "spec_tag": "openspec/changes/status-transition-engine/tasks.md"},
+      {"file": "lib/Service/StatusTransitionService.php", "methods_annotated": 1, "methods_total": 17, "spec_tag": "openspec/changes/status-transition-engine/tasks.md (file-level inherits)"},
+      {"file": "lib/Service/Transitions/ActionHandlerInterface.php", "spec_tag": "openspec/changes/status-transition-engine/tasks.md"},
+      {"file": "lib/Service/Transitions/ActionHandlerRegistry.php", "spec_tag": "openspec/changes/status-transition-engine/tasks.md"},
+      {"file": "lib/Service/Transitions/ActionResult.php", "spec_tag": "openspec/changes/status-transition-engine/tasks.md"},
+      {"file": "lib/Service/Transitions/ChecklistGuard.php", "spec_tag": "openspec/changes/status-transition-engine/tasks.md"},
+      {"file": "lib/Service/Transitions/CreateSubCaseHandler.php", "spec_tag": "openspec/changes/status-transition-engine/tasks.md#T08"},
+      {"file": "lib/Service/Transitions/CreateTaskHandler.php", "spec_tag": "openspec/changes/status-transition-engine/tasks.md"},
+      {"file": "lib/Service/Transitions/GuardEvaluatorInterface.php", "spec_tag": "openspec/changes/status-transition-engine/tasks.md"},
+      {"file": "lib/Service/Transitions/GuardFailedException.php", "spec_tag": "openspec/changes/status-transition-engine/tasks.md"},
+      {"file": "lib/Service/Transitions/GuardRegistry.php", "spec_tag": "openspec/changes/status-transition-engine/tasks.md"},
+      {"file": "lib/Service/Transitions/GuardResult.php", "spec_tag": "openspec/changes/status-transition-engine/tasks.md"},
+      {"file": "lib/Service/Transitions/NotifyHandler.php", "spec_tag": "openspec/changes/status-transition-engine/tasks.md"},
+      {"file": "lib/Service/Transitions/RequiredDocumentGuard.php", "spec_tag": "openspec/changes/status-transition-engine/tasks.md"},
+      {"file": "lib/Service/Transitions/RequiredFieldGuard.php", "spec_tag": "openspec/changes/status-transition-engine/tasks.md"},
+      {"file": "lib/Service/Transitions/RoleGuard.php", "spec_tag": "openspec/changes/status-transition-engine/tasks.md"},
+      {"file": "lib/Service/Transitions/SendEmailHandler.php", "spec_tag": "openspec/changes/status-transition-engine/tasks.md"},
+      {"file": "lib/Service/Transitions/SetFieldHandler.php", "spec_tag": "openspec/changes/status-transition-engine/tasks.md"},
+      {"file": "lib/Service/Transitions/SideEffectDispatcher.php", "spec_tag": "openspec/changes/status-transition-engine/tasks.md"},
+      {"file": "lib/Service/Transitions/WebhookHandler.php", "spec_tag": "openspec/changes/status-transition-engine/tasks.md"},
+      {"file": "lib/Service/Bezwaar/AdvisoryCommitteeService.php", "spec_tag": "openspec/changes/bezwaar-advisory-committee/specs/.../spec.md"},
+      {"file": "lib/Service/Bezwaar/BeroepService.php", "spec_tag": "openspec/changes/beroep-escalation/specs/.../spec.md"},
+      {"file": "lib/Service/Bezwaar/DecisionService.php", "spec_tag": "openspec/changes/bezwaar-decision/specs/.../spec.md"},
+      {"file": "lib/Service/Bezwaar/HearingService.php", "spec_tag": "openspec/changes/bezwaar-hearing/specs/.../spec.md"},
+      {"file": "lib/Listener/BezwaarAdviceRequestedListener.php", "spec_tag": "openspec/changes/bezwaar-advisory-committee/specs/.../spec.md"},
+      {"file": "lib/Listener/BezwaarDecisionListener.php", "spec_tag": "openspec/changes/bezwaar-decision/specs/.../spec.md"},
+      {"file": "lib/Listener/BezwaarHearingScheduledListener.php", "spec_tag": "openspec/changes/bezwaar-hearing/specs/.../spec.md"},
+      {"file": "lib/Listener/BeroepEscalationListener.php", "spec_tag": "openspec/changes/beroep-escalation/specs/.../spec.md"},
+      {"file": "lib/Service/Inspection/ChecklistService.php", "spec_tag": "openspec/changes/inspection-checklists/tasks.md"},
+      {"file": "lib/Listener/ChecklistRunImmutabilityListener.php", "spec_tag": "openspec/changes/inspection-checklists/tasks.md"},
+      {"file": "lib/Repair/SeedLhsMatrix.php", "spec_tag": "openspec/changes/enforcement-lhs/tasks.md"},
+      {"file": "lib/Controller/LhsController.php", "methods_annotated": 3, "methods_total": 3, "spec_tag": "openspec/changes/enforcement-lhs/tasks.md"},
+      {"file": "lib/Service/Vth/LhsRecommendationService.php", "spec_tag": "openspec/changes/enforcement-lhs/tasks.md"},
+      {"file": "lib/Service/ZgwZrcRulesService.php", "methods_annotated": 1, "methods_total": 19, "spec_tag": "openspec/changes/zgw-business-rules-compliance/.../spec.md (only 1/19 methods)"},
+      {"file": "lib/Service/WorkflowTemplateLoader.php", "methods_annotated": 1, "methods_total": 6, "spec_tag": "1 method tagged"}
+    ],
+    "plumbing": [
+      {"file": "lib/AppInfo/Application.php", "reason": "app-bootstrap (register listeners, services, dashboard widgets)"},
+      {"file": "lib/Sections/SettingsSection.php", "reason": "settings section registration"},
+      {"file": "lib/Settings/AdminSettings.php", "reason": "admin settings page registration"},
+      {"file": "lib/Middleware/TenantMiddleware.php", "reason": "generic tenant middleware"},
+      {"file": "lib/Middleware/ZgwAuthException.php", "reason": "exception value object"},
+      {"file": "lib/Listener/DeepLinkRegistrationListener.php", "reason": "single handle() registers deep links"},
+      {"reason_aggregate": "151 __construct methods across all files counted as plumbing"}
+    ],
+    "bucket_1": "[deferred — only 30 method-level annotations exist; the other 277 methods in 'annotated' files inherit file-level @spec but no per-method confidence scoring done. Treat the entire 'annotated' bucket as Bucket-1-equivalent for /opsx-annotate's purposes.]",
+    "bucket_2a": {
+      "zgw-api-mapping": [
+        {"file": "lib/Controller/ZrcController.php", "methods": 39, "observed_behavior": "ZGW Zaakregistratiecomponent (ZRC) API endpoints — case CRUD, status, role, attachment relations under /api/zrc/..."},
+        {"file": "lib/Controller/ZtcController.php", "methods": 21, "observed_behavior": "ZGW Zaaktypecatalogus (ZTC) API endpoints — case-type catalog"},
+        {"file": "lib/Controller/DrcController.php", "methods": 32, "observed_behavior": "ZGW Documentregistratiecomponent (DRC) API endpoints"},
+        {"file": "lib/Controller/BrcController.php", "methods": 18, "observed_behavior": "ZGW Besluitregistratiecomponent (BRC) API endpoints"},
+        {"file": "lib/Controller/NrcController.php", "methods": 10, "observed_behavior": "ZGW Notificatieroutingcomponent (NRC) endpoints"},
+        {"file": "lib/Controller/ZgwMappingController.php", "methods": 6, "observed_behavior": "Mapping CRUD endpoints"},
+        {"file": "lib/Service/ZgwService.php", "methods": 37, "observed_behavior": "ZGW base service — mapping execution, ZGW response shaping"},
+        {"file": "lib/Service/ZgwMappingService.php", "methods": 8, "observed_behavior": "ZGW mapping wiring"},
+        {"file": "lib/Service/ZgwDocumentService.php", "methods": 12, "observed_behavior": "ZGW document operations"},
+        {"file": "lib/Service/ZgwPaginationHelper.php", "methods": 1, "observed_behavior": "ZGW pagination helper"},
+        {"file": "lib/Service/NotificatieService.php", "methods": 5, "observed_behavior": "ZGW NRC notificatie dispatch"},
+        {"file": "lib/Middleware/ZgwAuthMiddleware.php", "methods": 9, "observed_behavior": "Bearer-token + ZGW auth middleware"},
+        {"file": "lib/Repair/LoadDefaultZgwMappings.php", "methods": 36, "observed_behavior": "Seeds default ZGW mapping records on install (one private method per mapping definition)"}
+      ],
+      "zgw-business-rules-compliance": [
+        {"file": "lib/Service/ZgwBrcRulesService.php", "methods": 10, "observed_behavior": "BRC business rules (Besluit)"},
+        {"file": "lib/Service/ZgwBusinessRulesService.php", "methods": 8, "observed_behavior": "Cross-component ZGW business rules"},
+        {"file": "lib/Service/ZgwDrcRulesService.php", "methods": 13, "observed_behavior": "DRC business rules (Document)"},
+        {"file": "lib/Service/ZgwRulesBase.php", "methods": 17, "observed_behavior": "Shared base for ZGW rule services"},
+        {"file": "lib/Service/ZgwZtcRulesService.php", "methods": 16, "observed_behavior": "ZTC business rules"}
+      ],
+      "automatic-actions": [
+        {"file": "lib/Service/Actions/ActionHandlerInterface.php"},
+        {"file": "lib/Service/Actions/ActionRegistry.php", "methods": 7},
+        {"file": "lib/Service/Actions/ActionResult.php"},
+        {"file": "lib/Service/Actions/CallWebhookHandler.php", "methods": 5},
+        {"file": "lib/Service/Actions/CreateDocumentHandler.php", "methods": 4},
+        {"file": "lib/Service/Actions/HandlesTemplates.php", "observed_behavior": "trait shared by template-touching handlers"},
+        {"file": "lib/Service/Actions/MergeTemplateHandler.php", "methods": 4},
+        {"file": "lib/Service/Actions/NotifyRoleHandler.php", "methods": 5},
+        {"file": "lib/Service/Actions/ScheduleReminderHandler.php", "methods": 4},
+        {"file": "lib/Service/Actions/SendEmailHandler.php", "methods": 4, "observed_behavior": "duplicate of lib/Service/Transitions/SendEmailHandler.php — verify which is canonical"}
+      ],
+      "case-management": [
+        {"file": "lib/Controller/CaseSharingController.php", "methods": 5},
+        {"file": "lib/Service/CaseSharingService.php", "methods": 12, "observed_behavior": "share-case-with-user/role logic"},
+        {"file": "lib/Service/CaseTransferService.php", "methods": 5, "observed_behavior": "case transfer/reassign"},
+        {"file": "lib/Service/CaseEmailService.php", "methods": 13, "observed_behavior": "case-email integration"},
+        {"file": "lib/Controller/EmailController.php", "methods": 5, "observed_behavior": "case-email endpoints"},
+        {"file": "lib/Controller/PublicShareController.php", "methods": 6, "observed_behavior": "public case-share endpoints"},
+        {"file": "lib/BackgroundJob/ShareMaintenanceJob.php", "methods": 2, "observed_behavior": "expire/cleanup case shares"}
+      ],
+      "signalering-widgets": [
+        {"file": "lib/Dashboard/DeadlineAlertsWidget.php", "methods": 7},
+        {"file": "lib/Dashboard/OverdueCasesWidget.php", "methods": 7},
+        {"file": "lib/Dashboard/StalledCasesWidget.php", "methods": 7},
+        {"file": "lib/Dashboard/TaskRemindersWidget.php", "methods": 7}
+      ],
+      "dashboard": [
+        {"file": "lib/Dashboard/CasesOverviewWidget.php", "methods": 7},
+        {"file": "lib/Dashboard/MyTasksWidget.php", "methods": 7},
+        {"file": "lib/Dashboard/StartCaseWidget.php", "methods": 7},
+        {"file": "lib/Controller/DashboardController.php", "methods": 2}
+      ],
+      "case-types": [
+        {"file": "lib/Controller/CaseDefinitionController.php", "methods": 4, "observed_behavior": "case-type export/import endpoints"},
+        {"file": "lib/Service/CaseDefinitionExportService.php", "methods": 5, "observed_behavior": "ZIP export of case definitions"},
+        {"file": "lib/Service/CaseDefinitionImportService.php", "methods": 5, "observed_behavior": "ZIP import of case definitions"}
+      ],
+      "workflow-definition-model": [
+        {"file": "lib/Controller/WorkflowDefinitionController.php", "methods": 6},
+        {"file": "lib/Service/WorkflowDefinitionService.php", "methods": 20},
+        {"file": "lib/Repair/MigrateWorkflowDefinitions.php", "methods": 7, "observed_behavior": "data migration helper"}
+      ],
+      "parafering-actions": [
+        {"file": "lib/Controller/ParaferingController.php", "methods": 9, "observed_behavior": "general parafering endpoints (versus action-specific ParafeerActieController)"},
+        {"file": "lib/Service/ParaferingService.php", "methods": 10},
+        {"file": "lib/Service/ParaferingNotificationService.php", "methods": 4}
+      ],
+      "inspection-checklists": [
+        {"file": "lib/Controller/InspectionController.php", "methods": 7},
+        {"file": "lib/Service/InspectionService.php", "methods": 6},
+        {"file": "lib/Service/ChecklistService.php", "methods": 5, "observed_behavior": "top-level Checklist service alongside Service/Inspection/ChecklistService — verify which is canonical"}
+      ],
+      "bezwaar-lifecycle": [
+        {"file": "lib/Listener/BezwaarLifecycleListener.php", "methods": 4},
+        {"file": "lib/Repair/SeedBezwaarBeroepData.php", "methods": 3, "observed_behavior": "seeds bezwaar + beroep reference data; could split"},
+        {"file": "lib/Repair/SeedBezwaarWorkflowDefinition.php", "methods": 7, "observed_behavior": "seeds bezwaar workflow definition"}
+      ],
+      "advice-management": [
+        {"file": "lib/Controller/AdviceController.php", "methods": 4},
+        {"file": "lib/Service/AdviceService.php", "methods": 12},
+        {"file": "lib/BackgroundJob/AdviceDeadlineJob.php", "methods": 2}
+      ],
+      "bezwaar-advisory-committee": [
+        {"file": "lib/Controller/AcController.php", "methods": 16, "observed_behavior": "Adviescommissie (BAC) CRUD + assignment endpoints; 16 methods unannotated despite sibling AdvisoryCommitteeService having file-level @spec"}
+      ],
+      "wms-wfs-layers": [
+        {"file": "lib/Controller/WmsWfsController.php", "methods": 2},
+        {"file": "lib/Service/WmsWfsService.php", "methods": 10}
+      ],
+      "map-component": [
+        {"file": "lib/Controller/GisProxyController.php", "methods": 3},
+        {"file": "lib/Service/GisProxyService.php", "methods": 7}
+      ],
+      "pdok-integration": [
+        {"file": "lib/Service/Pdok/PdokBagService.php", "methods": 10},
+        {"file": "lib/Service/Pdok/PdokLocatieserverService.php", "methods": 12}
+      ],
+      "admin-settings": [
+        {"file": "lib/Controller/SettingsController.php", "methods": 6},
+        {"file": "lib/Service/SettingsService.php", "methods": 9, "observed_behavior": "register resolver + getObjectService() — central to ADR-022 work"}
+      ],
+      "procest-app-scaffold": [
+        {"file": "lib/Repair/InitializeSettings.php", "methods": 3},
+        {"file": "lib/Service/SeedDataService.php", "methods": 10}
+      ],
+      "case-location": [
+        {"file": "lib/Service/LocationService.php", "methods": 7}
+      ],
+      "prometheus-metrics": [
+        {"file": "lib/Controller/MetricsController.php", "methods": 13, "observed_behavior": "Prometheus text-exposition endpoint — implements REQ-PROM-001..010 but unannotated"}
+      ],
+      "vth-workflow-templates": [
+        {"file": "lib/Repair/SeedVthWorkflowTemplates.php", "methods": 12}
+      ],
+      "process-step-configuration": [
+        {"file": "lib/Service/StepConfigValidator.php", "methods": 6}
+      ]
+    },
+    "bucket_2b": {
+      "appointment-booking": [
+        {"file": "lib/Controller/AppointmentController.php", "methods": 6},
+        {"file": "lib/Controller/PublicAppointmentController.php", "methods": 3},
+        {"file": "lib/Service/AppointmentService.php", "methods": 9},
+        {"file": "lib/Service/AppointmentBackend/AppointmentBackendInterface.php"},
+        {"file": "lib/Service/AppointmentBackend/JccBackend.php", "methods": 5},
+        {"file": "lib/Service/AppointmentBackend/LocalBackend.php", "methods": 5},
+        {"file": "lib/Service/AppointmentBackend/QmaticBackend.php", "methods": 5},
+        {"file": "lib/BackgroundJob/AppointmentReminderJob.php", "methods": 2}
+      ],
+      "berichtenbox-integration": [
+        {"file": "lib/Controller/BerichtenboxController.php", "methods": 4},
+        {"file": "lib/Service/BerichtenboxService.php", "methods": 8},
+        {"file": "lib/Service/BerichtenboxAdapter/BerichtenboxAdapterInterface.php"},
+        {"file": "lib/Service/BerichtenboxAdapter/MockAdapter.php", "methods": 3},
+        {"file": "lib/BackgroundJob/BerichtenboxReadStatusJob.php", "methods": 2}
+      ],
+      "stuf-integration": [
+        {"file": "lib/Controller/StufController.php", "methods": 11},
+        {"file": "lib/Service/StufFieldMappingService.php", "methods": 14},
+        {"file": "lib/Service/StufMessageBuilder.php", "methods": 7}
+      ],
+      "leges-fees": [
+        {"file": "lib/Controller/LegesController.php", "methods": 6},
+        {"file": "lib/Service/LegesCalculationService.php", "methods": 11},
+        {"file": "lib/Service/LegesExportService.php", "methods": 7}
+      ],
+      "consultation-management": [
+        {"file": "lib/Controller/ConsultationController.php", "methods": 6},
+        {"file": "lib/Service/ConsultationService.php", "methods": 6}
+      ],
+      "milestone-tracking": [
+        {"file": "lib/Controller/MilestoneController.php", "methods": 4},
+        {"file": "lib/Service/MilestoneService.php", "methods": 7}
+      ],
+      "template-library": [
+        {"file": "lib/Controller/TemplateController.php", "methods": 4},
+        {"file": "lib/Service/TemplateLibraryService.php", "methods": 4}
+      ],
+      "multi-tenancy": [
+        {"file": "lib/Controller/TenantController.php", "methods": 5},
+        {"file": "lib/Service/TenantService.php", "methods": 8}
+      ],
+      "ai-assistance": [
+        {"file": "lib/Controller/AiController.php", "methods": 13},
+        {"file": "lib/Service/AiService.php", "methods": 22}
+      ],
+      "mcp-integration": [
+        {"file": "lib/Mcp/ProcestToolProvider.php", "methods": 21, "observed_behavior": "Per-app MCP tool provider (IMcpToolProvider) — registered fleet-wide via openregister AI orchestrator"}
+      ],
+      "dso-omgevingsloket": [
+        {"file": "lib/Service/DsoIntakeService.php", "methods": 3, "observed_behavior": "DSO Omgevingsloket intake — there is an unarchived change `dso-omgevingsloket` but no spec lives in openspec/specs/ yet"}
+      ],
+      "ops-observability": [
+        {"file": "lib/Controller/HealthController.php", "methods": 6, "observed_behavior": "health-check endpoints (/health, /health/db, ...)"}
+      ]
+    },
+    "bucket_3a": [
+      {"req": "doorlooptijd-dashboard#multiple", "evidence": "16+18 matches in removed-lines cache for `slaComplian`/`doorlooptijd`. Frontend in src/views/DoorlooptijdDashboard.vue + src/utils/doorlooptijdHelpers.js + KPI backend (KpiAggregationService); spec is frontend-only but worth verifying SLA-breakdown widgets still render."},
+      {"req": "visual-workflow-editor#all", "evidence": "9 hits for `workflowEditor`; current frontend at src/views/settings/WorkflowEditor.vue + src/components/workflow/. Implemented in Vue, no PHP signal."}
+    ],
+    "bucket_3b": [
+      {"req": "zaaktype-versioning#Workflow-Template-Versioning", "note": "0 hits in removed-lines; not visible in current PHP. Verify if frontend-only or deferred."},
+      {"req": "zaaktype-versioning#Case-to-Workflow-Version-Binding", "note": "0 hits; appears deferred."},
+      {"req": "workflow-import-export#Export-Workflow-Template", "note": "0 hits for `exportWorkflow`; CaseDefinitionExportService exists but exports case definitions, not workflow templates specifically. Verify scope."},
+      {"req": "workflow-import-export#Import-Workflow-Template", "note": "2 hits for `importWorkflow` — likely related to MigrateWorkflowDefinitions but partial."},
+      {"req": "parafering-dashboard#all", "note": "0 hits for `secretariaat`, `Inbox`; appears to be a Vue-only dashboard view not yet implemented."},
+      {"req": "process-step-configuration#both", "note": "Spec has only 2 requirements; StepConfigValidator (6 methods) covers part. Verify against REQ scenarios."},
+      {"req": "voorstel-management#all", "note": "Voorstel domain is implemented as part of parafering (a voorstel is the object being paraffed). 389 voorstel hits in removed-lines indicates active code. Likely Bucket 2a misclassified — folded into parafering-actions during refactor."}
+    ],
+    "bucket_4": {
+      "missing-spec-in-file-docblock": "114 files lack any @spec tag (66% of lib/). See bucket_2a + bucket_2b for the breakdown.",
+      "missing-SPDX-FileCopyrightText": [
+        "lib/Service/ZgwZtcRulesService.php",
+        "lib/Service/SeedDataService.php",
+        "lib/Service/ZgwDrcRulesService.php",
+        "lib/Service/StufFieldMappingService.php",
+        "lib/Service/StufMessageBuilder.php",
+        "lib/Service/ZgwBusinessRulesService.php",
+        "lib/Service/NotificatieService.php",
+        "lib/Service/ZgwMappingService.php",
+        "lib/Service/GisProxyService.php",
+        "lib/Service/ZgwService.php",
+        "lib/Service/ZgwRulesBase.php",
+        "lib/Service/ZgwZrcRulesService.php",
+        "lib/Service/TemplateLibraryService.php",
+        "lib/Service/SettingsService.php",
+        "lib/Service/LegesExportService.php",
+        "lib/Service/MilestoneService.php",
+        "lib/Service/ParaferingNotificationService.php",
+        "lib/Service/ParaferingService.php",
+        "lib/Service/AppointmentService.php",
+        "lib/Service/ZgwPaginationHelper.php",
+        "lib/Service/LegesCalculationService.php",
+        "lib/Service/BerichtenboxService.php",
+        "lib/Service/TenantService.php",
+        "lib/Service/InspectionService.php",
+        "lib/Service/ZgwBrcRulesService.php",
+        "lib/Service/DsoIntakeService.php",
+        "lib/Service/ZgwDocumentService.php",
+        "lib/BackgroundJob/AppointmentReminderJob.php",
+        "lib/BackgroundJob/BerichtenboxReadStatusJob.php",
+        "lib/Controller/BerichtenboxController.php",
+        "lib/Controller/AppointmentController.php",
+        "lib/Controller/PublicAppointmentController.php",
+        "lib/Service/Pdok/PdokLocatieserverService.php",
+        "lib/Service/Pdok/PdokBagService.php",
+        "lib/Service/BerichtenboxAdapter/BerichtenboxAdapterInterface.php",
+        "lib/Service/BerichtenboxAdapter/MockAdapter.php",
+        "lib/Service/AppointmentBackend/LocalBackend.php",
+        "lib/Service/AppointmentBackend/JccBackend.php",
+        "lib/Service/AppointmentBackend/QmaticBackend.php",
+        "lib/Service/AppointmentBackend/AppointmentBackendInterface.php"
+      ],
+      "forbidden-patterns": "0 hits (clean)",
+      "direct-SQL": "0 hits ($this->db->query/prepare not used)",
+      "missing-@license": "0 hits (all files carry @license)",
+      "missing-@copyright": "0 hits (all files carry @copyright)"
+    }
+  },
+  "ignored": 0,
+  "notes": [
+    "Vue/JS/TS sources under src/ (~135 files including views, components, stores) were NOT bucketed in this scan — many specs (visual-workflow-editor, doorlooptijd-dashboard, my-work, parafering-dashboard, task-management, signalering-widgets, procest-object-store, procest-store-migration) are frontend-only or frontend-primary; their PHP shadow is sometimes nil. A v2 pass should enumerate src/ and re-bucket.",
+    "Bucket-1 vs annotated: this scan does NOT generate per-method confidence-scored Bucket-1 entries beyond what is already annotated. The 58 'annotated' files include 30 method-level + 59 file-level @spec tags; the file-level tags imply every method in that file inherits the tag. /opsx-annotate should treat the unannotated methods in already-tagged files as candidates for explicit per-method annotation.",
+    "Strongest blind spots: (1) the 5 ZGW *Controllers (ZRC/ZTC/DRC/BRC/NRC, 120 methods total) and 4 ZGW Rules services have zero @spec despite mapping directly to zgw-api-mapping (21 reqs) and zgw-business-rules-compliance (13 reqs). High ROI for /opsx-annotate. (2) MetricsController implements REQ-PROM-001..010 (prometheus-metrics has 10 explicit REQs) — straight Bucket 1.",
+    "Watch for duplicates: lib/Service/Actions/SendEmailHandler.php and lib/Service/Transitions/SendEmailHandler.php look like two parallel implementations of the same action. Same for lib/Service/ChecklistService.php (top-level) vs lib/Service/Inspection/ChecklistService.php (subdir, annotated to inspection-checklists). Verify which is canonical before annotating.",
+    "Spec 'voorstel-management' has 5 REQs and zero matching files in lib/Service or lib/Controller, but 389 hits in removed-lines (voorstel == subject of parafering). Almost certainly folded into the parafering-* services during refactor. Either reverse-spec a `voorstel` cluster or mark voorstel-management as moved into parafering-actions.",
+    "Spec parser supports four REQ patterns: REQ-XX-NN (15 specs), `Requirement: <title>` (24 specs), `Requirement N: <title>` (procest-case-management), and ZRC-NNN (zgw-business-rules-compliance). Final REQ count = 359 across 46 specs (1 spec, advice-management is delta-only and was counted).",
+    "Removed-lines cache built in 2.6s (46749 lines), under the 30s budget — Bucket 3 reverse-pass is reliable."
+  ]
+}

--- a/openspec/coverage-report.md
+++ b/openspec/coverage-report.md
@@ -1,0 +1,242 @@
+# Coverage Report — procest
+
+Generated: 2026-05-24 08:36 UTC
+Branch: development
+Scanner: opsx-coverage-scan v1
+
+## Scan scope
+
+- **PHP**: `lib/**/*.php` — 172 files, 1235 methods enumerated (no `lib/Migration/` or `lib/Db/` in this app).
+- **Vue/JS/TS**: `src/**/*.{vue,js,ts}` — **NOT** bucketed in this pass. Many procest specs are frontend-only or frontend-primary (visual-workflow-editor, doorlooptijd-dashboard, my-work, parafering-dashboard, task-management, signalering-widgets, procest-object-store/store-migration). A v2 should enumerate `src/`.
+- **Specs**: 47 directories under `openspec/specs/`, **359 REQs** extracted across 4 heading conventions (`REQ-XX-NN`, `Requirement: <title>`, `Requirement N: <title>`, `ZRC-NNN`).
+- **Removed-lines cache**: `/tmp/removed-lines-procest.txt` (46749 lines, built in 2.6s — well under the 30s budget).
+- **No `.opsx-ignore`** in repo; nothing suppressed.
+
+## Summary
+
+| Bucket | Count | Next action |
+|---|---|---|
+| annotated | 58 files / ~30 methods explicitly tagged + ~278 inherited via file-level @spec | — (already tagged) |
+| plumbing | 6 files + 151 `__construct` methods | — (never tagged) |
+| 1 — REQ matched | (folded into 'annotated' — see notes) | — (confidence-scored per-method Bucket 1 deferred) |
+| 2a — existing capability, no REQ | 76 files / 684 methods / **22 clusters** | `/opsx-reverse-spec procest --extend <cap>` |
+| 2b — no capability owner | 32 files / 223 methods / **12 clusters** | `/opsx-reverse-spec procest --cluster <name>` |
+| 3a — REQ broken (code removed) | 2 spec-clusters | Verify Vue impl still ships |
+| 3b — REQ never implemented (or moved) | 7 spec-clusters | Mark deferred, moved, or build |
+| 4 — ADR conformance | 40 files missing SPDX-FileCopyrightText; 114 files missing file-level @spec | Follow-up issue |
+
+**Coverage headline**: 308/1235 = **~25%** of lib methods are in @spec-tagged files. The remaining 75% are real domain code with no spec linkage yet — the lift here is large but tractable because file→capability mapping is high-confidence (the codebase has strong naming conventions).
+
+## Bucket 1 — Ready to annotate
+
+> **Note**: this scan did not run a per-method confidence-scored Bucket 1 pass. The 58 already-annotated files cover ~308 methods (30 method-level + 278 inheriting from file-level `@spec`). The high-ROI Bucket 1 targets that are NOT yet annotated are flagged here as ready for `/opsx-annotate procest`:
+
+### capability: zgw-api-mapping (5 controllers, ~120 methods)
+
+`zgw-api-mapping` has 21 REQs and ZERO annotations across 5 large controllers — biggest single annotation opportunity.
+
+| File | Methods | Notes |
+|---|---|---|
+| lib/Controller/ZrcController.php | 39 | ZRC endpoints — case/role/status/attachment |
+| lib/Controller/DrcController.php | 32 | DRC endpoints — documents |
+| lib/Controller/ZtcController.php | 21 | ZTC endpoints — case-type catalog |
+| lib/Controller/BrcController.php | 18 | BRC endpoints — besluit |
+| lib/Controller/NrcController.php | 10 | NRC endpoints — notificaties |
+| lib/Controller/ZgwMappingController.php | 6 | Mapping CRUD |
+| lib/Service/ZgwService.php | 37 | Base service |
+
+### capability: prometheus-metrics
+
+| File | Methods | Notes |
+|---|---|---|
+| lib/Controller/MetricsController.php | 13 | Implements REQ-PROM-001..010 — file docblock literally says "Prometheus text exposition format" yet has no @spec |
+
+### capability: case-types
+
+| File | Methods | Notes |
+|---|---|---|
+| lib/Controller/CaseDefinitionController.php | 4 | case-type export/import |
+| lib/Service/CaseDefinitionExportService.php | 5 | |
+| lib/Service/CaseDefinitionImportService.php | 5 | |
+
+### capability: dashboard / signalering-widgets
+
+7 Dashboard widget files (~49 methods) cleanly map to either `dashboard` (16 REQs) or `signalering-widgets` (6 REQs). One annotation per file plus the existing KpiAggregationService annotations would close the loop.
+
+### Already annotated (no further work needed)
+
+58 files cover:
+
+- **status-transition-engine** (20 files, fully annotated)
+- **role-based-step-routing** (11 files, fully annotated)
+- **add-server-side-kpi-aggregation** (3 files, every method annotated)
+- **parafering-actions / parafeerroute-engine / parafering-audit-trail** (12 files, file-level + selective method tags)
+- **bezwaar-{advisory-committee,decision,hearing,lifecycle}** + **beroep-escalation** (8 files via file-level @spec)
+- **enforcement-lhs / inspection-checklists** (5 files)
+- **zgw-business-rules-compliance** (1/19 methods on ZgwZrcRulesService.php — others unannotated, see 2a)
+
+## Bucket 2a — Existing capability, no REQ (reverse-spec --extend)
+
+22 clusters. Top 5 by volume:
+
+### cluster: zgw-api-mapping (13 files / ~213 methods)
+
+The entire ZGW API surface (ZRC/ZTC/DRC/BRC/NRC controllers + ZGW services + middleware + mapping seeder). zgw-api-mapping has 21 REQs but no methods linked to them. Highest-ROI `--extend` target — clean per-controller mapping per ZGW component.
+
+### cluster: zgw-business-rules-compliance (5 files / 64 methods)
+
+- lib/Service/ZgwBrcRulesService.php (10) — BRC business rules
+- lib/Service/ZgwBusinessRulesService.php (8) — cross-component
+- lib/Service/ZgwDrcRulesService.php (13) — DRC rules
+- lib/Service/ZgwRulesBase.php (17) — shared base
+- lib/Service/ZgwZtcRulesService.php (16) — ZTC rules
+- (ZgwZrcRulesService is partly annotated, see Bucket 1)
+
+The spec has 13 REQs (ZRC-007, ZRC-007b, ZRC-007q, ZRC-008c, ZRC-010, ZRC-013a, ZRC-015, ZRC-016/018, ZRC-021, ZRC-002, ZRC-005b/023h, ZRC-009, ZRC-006, plus a performance REQ). Most rule files are about ZRC, but the spec also touches DRC/BRC — extend to cover all five components.
+
+### cluster: automatic-actions (10 files / ~45 methods)
+
+`lib/Service/Actions/*` — generic action-handler registry + 7 concrete handlers (Webhook, CreateDocument, MergeTemplate, NotifyRole, ScheduleReminder, SendEmail). The `automatic-actions` spec has 2 REQs which seems light vs the 7 handlers; reverse-spec should probably mint ~8 REQs (one per handler + the registry contract).
+
+### cluster: case-management (7 files / 48 methods)
+
+CaseSharing, CaseTransfer, CaseEmail, EmailController, PublicShareController, ShareMaintenanceJob. The case-management spec has 45 REQs (REQ-CM-01..45) but none cover sharing/transfer/email integration. Either extend case-management or split into new sister capability (`case-sharing` already exists as a controller name).
+
+### cluster: signalering-widgets (4 files / 28 methods)
+
+Dashboard/{DeadlineAlerts,OverdueCases,StalledCases,TaskReminders}Widget.php. The spec has 6 REQs ("Deadline Alerts Widget", "Task Due Reminders Widget", etc.) that cleanly map 1:1 to these files. **Looks more like Bucket 1 candidates than 2a** — pulled here only because no @spec tag exists yet.
+
+### Smaller 2a clusters (sketched)
+
+| Cluster | Files | Methods | Notes |
+|---|---|---|---|
+| dashboard | 4 | 23 | CasesOverview/MyTasks/StartCase widgets + DashboardController |
+| workflow-definition-model | 3 | 33 | WorkflowDefinitionController + Service + MigrateWorkflowDefinitions repair |
+| parafering-actions | 3 | 23 | ParaferingController/Service + Notification service (sibling to annotated ParafeerActieController) |
+| inspection-checklists | 3 | 18 | InspectionController + InspectionService + top-level ChecklistService (verify vs annotated Inspection/ChecklistService) |
+| case-types | 3 | 14 | CaseDefinition controller + export + import (Bucket 1 candidate, see above) |
+| bezwaar-lifecycle | 3 | 14 | BezwaarLifecycleListener + 2 SeedBezwaar*Repair steps |
+| advice-management | 3 | 18 | AdviceController/Service + AdviceDeadlineJob |
+| bezwaar-advisory-committee | 1 | 16 | AcController (Adviescommissie — note the BAC abbreviation) |
+| wms-wfs-layers | 2 | 12 | WmsWfsController + Service |
+| pdok-integration | 2 | 22 | PdokBag + PdokLocatieserver services |
+| map-component | 2 | 10 | GisProxyController + Service |
+| admin-settings | 2 | 15 | SettingsController + SettingsService (also touches register-resolver, central to ADR-022) |
+| procest-app-scaffold | 2 | 13 | InitializeSettings + SeedDataService |
+| case-location | 1 | 7 | LocationService |
+| prometheus-metrics | 1 | 13 | MetricsController (Bucket 1 candidate) |
+| vth-workflow-templates | 1 | 12 | SeedVthWorkflowTemplates |
+| process-step-configuration | 1 | 6 | StepConfigValidator |
+
+## Bucket 2b — No capability owner (reverse-spec --cluster)
+
+12 clusters. None of these labels are namespace-words — all are behavioral domain names (no warnings to flag).
+
+### cluster: appointment-booking (8 files / ~40 methods)
+
+`lib/Controller/Appointment*Controller.php` + `lib/Service/AppointmentService.php` + 4 backend adapters (Interface, Jcc, Local, Qmatic) + `AppointmentReminderJob`. No spec exists for the appointment-booking feature. Likely a Specter / market gap — this is a substantial slot-booking subsystem that should have its own spec.
+
+### cluster: berichtenbox-integration (5 files / ~17 methods)
+
+MijnOverheid Berichtenbox adapter + sync job + controller. No spec.
+
+### cluster: stuf-integration (3 files / 32 methods)
+
+StUF (Standaard Uitwisseling Formaat) integration — StufController, StufFieldMappingService, StufMessageBuilder. No spec; common Dutch government data interchange standard, separate from ZGW.
+
+### cluster: leges-fees (3 files / 24 methods)
+
+Fee calculation + export for leges (Dutch municipal fees). No spec.
+
+### Smaller 2b clusters
+
+| Cluster | Files | Methods | Notes |
+|---|---|---|---|
+| consultation-management | 2 | 12 | A change `consultation-management` is in flight; no archived spec |
+| milestone-tracking | 2 | 11 | A change `milestone-tracking` is in flight |
+| template-library | 2 | 8 | TemplateController + Service |
+| multi-tenancy | 2 | 13 | TenantController + Service |
+| ai-assistance | 2 | 35 | AiController (13) + AiService (22) — substantial AI surface |
+| mcp-integration | 1 | 21 | ProcestToolProvider — fleet-wide MCP provider pattern (per Hydra ADR-019 / OpenRegister AI orchestrator) |
+| dso-omgevingsloket | 1 | 3 | DsoIntakeService — `dso-omgevingsloket` change is open but no archived spec |
+| ops-observability | 1 | 6 | HealthController |
+
+## Bucket 3 — Surfaced for human triage
+
+### 3a — possibly broken (code-removed evidence)
+
+- **doorlooptijd-dashboard** — 9 REQs, 16+18 hits in removed-lines for `slaComplian`/`doorlooptijd`. Frontend lives at `src/views/DoorlooptijdDashboard.vue` + `src/utils/doorlooptijdHelpers.js`; backend KPI feed via `KpiAggregationService`. Likely Bucket 1 in the frontend half — verify SLA-breakdown still renders.
+- **visual-workflow-editor** — 3 REQs, 9 hits for `workflowEditor` in removed-lines. Current Vue editor at `src/views/settings/WorkflowEditor.vue` + `src/components/workflow/`. PHP layer absent (frontend-only spec); v2 scan should claim it.
+
+### 3b — never implemented (or moved)
+
+- **zaaktype-versioning** (2 REQs) — 0 hits anywhere. Either deferred or part of `case-types` REQ-CT-* coverage.
+- **workflow-import-export** (2 REQs) — 2 hits only; `CaseDefinitionExportService` exports case defs not workflow templates. Scope mismatch.
+- **parafering-dashboard** (4 REQs) — 0 hits for `secretariaat`, `Inbox`. Frontend-only dashboard, not implemented in PHP. Confirm in `src/`.
+- **process-step-configuration** (2 REQs) — `StepConfigValidator` exists (6 methods); scenarios may already be covered. Re-bucket from 2a to 1 after manual review.
+- **voorstel-management** (5 REQs) — `voorstel` has 389 hits in removed-lines; the domain folded into the parafering-* services (a voorstel IS the object being paraffed). Mark spec moved into `parafering-actions` or reverse-spec a `voorstel` extension.
+
+### Specs that look implemented but are entirely frontend (v2 scan needed)
+
+`my-work` (11 REQs → `src/views/MyWork.vue`), `task-management` (13 REQs → `src/views/tasks/`), `case-dashboard-view` (12 REQs → Vue views), `case-map-overview` (4 REQs), `procest-object-store` (10 REQs → `src/store/`), `procest-store-migration` (3 REQs → `src/store/`), `procest-case-management` (13 REQs → mix), `case-types` REQ-CT-* (Vue settings tab partly).
+
+## Bucket 4 — ADR conformance findings
+
+### missing-spec-in-file-docblock (114 files)
+
+66% of `lib/` has no `@spec openspec/changes/...` tag in file or method docblocks. Top affected groups:
+
+- All 5 ZGW component controllers (ZRC/ZTC/DRC/BRC/NRC) and 7 ZGW services
+- All 7 Dashboard widget files
+- All 10 lib/Service/Actions/ handlers
+- All 8 appointment-booking files
+- All 5 berichtenbox-integration files
+- AiController + AiService + ProcestToolProvider (MCP)
+
+(See `bucket_2a` + `bucket_2b` in the JSON for the full per-file breakdown.)
+
+### missing-SPDX-FileCopyrightText (40 files)
+
+Each carries `@copyright` and `@license` in the docblock but is missing the dedicated `SPDX-FileCopyrightText:` line. ADR-014 + hydra-gate-spdx require both. Pattern is regression-prone — these were likely scaffolded before the SPDX rule landed.
+
+Affected files include: every Zgw* service in lib/Service/ (12), every appointment-booking file (7), every berichtenbox file (4), every pdok service (2), several misc services. Full list in JSON.
+
+### forbidden-patterns: 0 hits (clean — no var_dump/die/print_r/dd/error_log/dump)
+
+### Direct SQL: 0 hits (clean — no `$this->db->query(`/`prepare(` outside Db boilerplate)
+
+### Missing `@license` / `@copyright`: 0 hits
+
+## Notes for the human reviewer
+
+1. **Vue/JS/TS not scanned.** Procest is roughly half frontend; many specs are Vue-only and look "unimplemented" only because the PHP scan missed them. Schedule a v2 to enumerate `src/`. Specs primarily landing in Bucket 3 because of this: `visual-workflow-editor`, `doorlooptijd-dashboard`, `my-work`, `task-management`, `parafering-dashboard`, `procest-object-store`, `procest-store-migration`, parts of `case-map-overview`, `case-dashboard-view`.
+
+2. **Coverage is bimodal.** The codebase has TWO well-annotated subsystems (status-transition-engine + role-based-step-routing + parafering family + KPI aggregation, ~58 files at 100% file-level @spec) and one COMPLETELY un-annotated subsystem (ZGW API + ZGW rules + dashboards + actions + AI + 2b clusters). The annotated half was clearly built spec-first with `/opsx-apply`; the unannotated half predates that workflow. `/opsx-annotate procest` should be cheap because the file→capability mapping is unambiguous.
+
+3. **Duplicate-handler watch.** `lib/Service/Actions/SendEmailHandler.php` and `lib/Service/Transitions/SendEmailHandler.php` are likely parallel implementations of the same action (one for the older Actions registry, one for the new transitions engine). Same pattern for `lib/Service/ChecklistService.php` (top-level, unannotated) vs `lib/Service/Inspection/ChecklistService.php` (16 methods, file-level @spec to inspection-checklists). Verify which is canonical before annotating — annotating both will pollute the bucket.
+
+4. **AcController is the obvious bezwaar gap.** `AcController` (16 unannotated methods) is the controller for the bezwaaradviescommissie (BAC); its sibling `AdvisoryCommitteeService` is fully annotated to bezwaar-advisory-committee. Add file-level @spec to AcController.
+
+5. **Reverse-spec priority order** (highest impact first):
+   1. `--extend zgw-api-mapping` — 13 files, 21 REQs, biggest single capability
+   2. `--extend zgw-business-rules-compliance` — 5 files, 13 REQs, completes the ZGW story
+   3. `--extend automatic-actions` — 10 files, only 2 REQs (under-specified)
+   4. `--cluster appointment-booking` — 8 files, no spec at all
+   5. `--cluster berichtenbox-integration` — 5 files, no spec
+   6. `--cluster stuf-integration` — 3 files, no spec
+   7. `--extend case-management` — 7 files in the share/transfer/email subsystem need REQ coverage (or split into `case-sharing` sister capability)
+
+6. **REQ-style heterogeneity.** 4 different REQ-heading conventions in use across the 47 specs. Final REQ count = 359 (not the 47-spec average of ~8). Specs added post-ADR-008 use `REQ-XX-NN`; older specs use `Requirement: <title>`; the zgw-business-rules-compliance delta uses raw `ZRC-NNN`. Consider a normalisation pass before `/opsx-annotate`.
+
+7. **Plumbing is light** — only 6 files + 151 constructors. No empty BackgroundJob `run()` bodies, no dispatch-only listener handles (all 10 listeners have real domain logic).
+
+## Coverage Scan Complete — procest
+
+Buckets: annotated=58 | plumbing=6 | 1=N (folded into annotated; see notes) | 2a=76/22 clusters | 2b=32/12 clusters | 3a=2 | 3b=7 | 4=2 rules (114 missing-spec files + 40 missing-SPDX files)
+
+Next:
+1. Read this report — confirm Bucket 1 / cluster assignments before annotating
+2. `/opsx-annotate procest` — minimum: tag the 5 ZGW controllers + MetricsController + 7 Dashboard widgets + AcController = ~25 file-level tags closing ~70% of the visible gap
+3. `/opsx-reverse-spec procest --extend zgw-api-mapping` — highest-ROI Bucket 2a target
+4. `/opsx-reverse-spec procest --cluster appointment-booking` — pilot the cluster path
+5. Schedule a v2 scan that covers `src/` for the frontend-only specs in Bucket 3


### PR DESCRIPTION
## Retrofit — Annotation Only

Applies `@spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-N` tags per [ADR-003 §Spec traceability](https://github.com/ConductionNL/hydra/blob/main/openspec/architecture/adr-003-backend.md).

Ghost change: `openspec/changes/archive/retrofit-2026-05-24-annotate-procest/` (empty spec delta, 5 tasks).

Umbrella: refs #565.

### What this PR does
- Creates ghost change with 5 tasks (one per Bucket 1 capability with matches)
- Adds file-docblock `@spec` tags to 19 unannotated PHP files spanning 60 REQs:
  - **zgw-api-mapping** (21 REQs) — 7 files: ZRC/DRC/ZTC/BRC/NRC controllers + ZgwMappingController + ZgwService (~163 methods)
  - **prometheus-metrics** (10 REQs) — MetricsController (13 methods)
  - **case-types** (17 REQs) — CaseDefinitionController + Export/Import services (~14 methods)
  - **signalering-widgets** (6 REQs) — Deadline/TaskReminders/Stalled/Overdue widgets (~28 methods)
  - **dashboard** (16 REQs) — CasesOverview/MyTasks/StartCase widgets + DashboardController (~21 methods)
- Adds annotation commit + the blame-revs entry commit to `.git-blame-ignore-revs`
- Commits the coverage report (json + md) that drove the pass

### Why file-level only
The opsx-coverage-scan v1 run for procest **deferred per-method confidence scoring** (see `openspec/coverage-report.json` — `bucket_1` is a deferred-note string, not a per-method list). It identified the 19 files and their capabilities, but didn't bucket individual methods. Per the existing procest convention (see `lib/Service/KpiAggregationService.php`), file-level `@spec` tags propagate to all methods in the file. A future v2 scan + a follow-up annotation pass can refine method-level tagging if needed.

### What this PR does NOT do
- No logic changes
- No formatting / whitespace / reordering / SPDX additions
- No method-level annotations
- No Bucket 2 (see follow-up `/opsx-reverse-spec` PRs for `zgw-api-mapping`, `zgw-business-rules-compliance`, `automatic-actions`, `case-management`, etc.)
- No Bucket 3/4 (separate follow-ups)
- **Voorstel-management Bucket 1 entries SKIPPED** — pending PR #566 moves the spec into `parafering-actions`

### Test plan
- [x] `@spec` tag present on all 19 target files (verified via grep — 19/19)
- [x] All 58 already-annotated files left untouched (skill idempotency)
- [x] Ghost change archived to `openspec/changes/archive/`
- [x] `.git-blame-ignore-revs` includes the annotation commit
- [ ] CI green on `composer phpcs`

### Note for developers
Enable the blame-ignore-revs file once per clone:
```
git config blame.ignoreRevsFile .git-blame-ignore-revs
```

Source: `openspec/coverage-report.md` generated 2026-05-24