### PR TITLE
retrofit: reverse-spec zgw-api-mapping (5 REQs / 13 files)

### DIFF
--- a/lib/Controller/BrcController.php
+++ b/lib/Controller/BrcController.php
@@ -22,6 +22,7 @@
  * @link https://procest.nl
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-1
+ * @spec openspec/changes/retrofit-2026-05-24-zgw-api-mapping/tasks.md#task-2
  */
 
 declare(strict_types=1);

--- a/lib/Controller/DrcController.php
+++ b/lib/Controller/DrcController.php
@@ -22,6 +22,7 @@
  * @link https://procest.nl
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-1
+ * @spec openspec/changes/retrofit-2026-05-24-zgw-api-mapping/tasks.md#task-2
  */
 
 declare(strict_types=1);

--- a/lib/Controller/NrcController.php
+++ b/lib/Controller/NrcController.php
@@ -22,6 +22,7 @@
  * @link https://procest.nl
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-1
+ * @spec openspec/changes/retrofit-2026-05-24-zgw-api-mapping/tasks.md#task-2
  */
 
 declare(strict_types=1);

--- a/lib/Controller/ZgwMappingController.php
+++ b/lib/Controller/ZgwMappingController.php
@@ -20,6 +20,7 @@
  * @link https://procest.nl
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-1
+ * @spec openspec/changes/retrofit-2026-05-24-zgw-api-mapping/tasks.md#task-3
  */
 
 declare(strict_types=1);

--- a/lib/Controller/ZrcController.php
+++ b/lib/Controller/ZrcController.php
@@ -25,6 +25,7 @@
  * @link https://procest.nl
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-1
+ * @spec openspec/changes/retrofit-2026-05-24-zgw-api-mapping/tasks.md#task-1
  */
 
 declare(strict_types=1);

--- a/lib/Controller/ZtcController.php
+++ b/lib/Controller/ZtcController.php
@@ -23,6 +23,7 @@
  * @link https://procest.nl
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-1
+ * @spec openspec/changes/retrofit-2026-05-24-zgw-api-mapping/tasks.md#task-2
  */
 
 declare(strict_types=1);

--- a/lib/Middleware/ZgwAuthMiddleware.php
+++ b/lib/Middleware/ZgwAuthMiddleware.php
@@ -18,6 +18,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-zgw-api-mapping/tasks.md#task-4
  */
 
 declare(strict_types=1);

--- a/lib/Repair/LoadDefaultZgwMappings.php
+++ b/lib/Repair/LoadDefaultZgwMappings.php
@@ -20,6 +20,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-zgw-api-mapping/tasks.md#task-5
  */
 
 declare(strict_types=1);

--- a/lib/Service/NotificatieService.php
+++ b/lib/Service/NotificatieService.php
@@ -16,6 +16,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-zgw-api-mapping/tasks.md#task-3
  */
 
 declare(strict_types=1);

--- a/lib/Service/ZgwDocumentService.php
+++ b/lib/Service/ZgwDocumentService.php
@@ -18,6 +18,8 @@
  * @link https://procest.nl
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-zgw-api-mapping/tasks.md#task-3
  */
 
 declare(strict_types=1);

--- a/lib/Service/ZgwMappingService.php
+++ b/lib/Service/ZgwMappingService.php
@@ -17,6 +17,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-zgw-api-mapping/tasks.md#task-3
  */
 
 declare(strict_types=1);

--- a/lib/Service/ZgwPaginationHelper.php
+++ b/lib/Service/ZgwPaginationHelper.php
@@ -15,6 +15,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-zgw-api-mapping/tasks.md#task-3
  */
 
 declare(strict_types=1);

--- a/lib/Service/ZgwService.php
+++ b/lib/Service/ZgwService.php
@@ -19,6 +19,7 @@
  * @link https://procest.nl
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-1
+ * @spec openspec/changes/retrofit-2026-05-24-zgw-api-mapping/tasks.md#task-3
  */
 
 declare(strict_types=1);

--- a/openspec/changes/retrofit-2026-05-24-zgw-api-mapping/design.md
+++ b/openspec/changes/retrofit-2026-05-24-zgw-api-mapping/design.md
@@ -1,0 +1,13 @@
+# Design — retrofit zgw-api-mapping
+
+Retrofit change. Tasks describe retroactive annotation, not new implementation work. The 5 REQs in this delta describe the procest-side ZGW surface (controllers, service, middleware, default-seed repair step) — the existing `zgw-api-mapping` spec focuses on the OpenRegister-side mapping engine.
+
+## Method
+- Survey each cluster file by public-method shape (file-level read, no per-method tracing)
+- Group methods by observable behavior (REST resource handling, shared service surface, auth middleware, install seed)
+- File-level `@spec` tag added to every cluster file (or appended where a Bucket 1 `@spec` already exists)
+
+## Out of scope
+- Per-method confidence scoring (deferred; will surface in coverage v2 once Vue sources are bucketed)
+- Splitting the 32-method DrcController into per-resource controllers (future work)
+- Resolving SendEmailHandler duplicates — handled under automatic-actions retrofit

--- a/openspec/changes/retrofit-2026-05-24-zgw-api-mapping/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-zgw-api-mapping/proposal.md
@@ -1,0 +1,25 @@
+# Retrofit — zgw-api-mapping
+
+Describes observed behavior of 13 PHP files (~234 methods) implementing the in-procest ZGW API surface as 5 new REQs. The current `zgw-api-mapping` spec focuses on the OpenRegister-side mapping engine and Endpoint wiring; this retrofit adds REQs for the procest-side controllers, service, middleware, and repair seeder that actually serve the ZGW APIs from the procest app.
+
+## Affected code units
+- lib/Controller/ZrcController.php (16 methods) — Zaakregistratiecomponent endpoints
+- lib/Controller/ZtcController.php (21 methods) — Zaaktypecatalogus endpoints
+- lib/Controller/DrcController.php (32 methods) — Documentregistratiecomponent endpoints
+- lib/Controller/BrcController.php (18 methods) — Besluitregistratiecomponent endpoints
+- lib/Controller/NrcController.php (10 methods) — Notificatieroutingcomponent endpoints
+- lib/Controller/ZgwMappingController.php (6 methods) — Mapping CRUD endpoints
+- lib/Service/ZgwService.php (37 methods) — Mapping execution + response shaping
+- lib/Service/ZgwMappingService.php (8 methods) — Mapping wiring helpers
+- lib/Service/ZgwDocumentService.php (12 methods) — Document operations
+- lib/Service/ZgwPaginationHelper.php (1 method) — Pagination helper
+- lib/Service/NotificatieService.php (5 methods) — NRC notificatie dispatch
+- lib/Middleware/ZgwAuthMiddleware.php (9 methods) — Bearer-token + vertrouwelijkheid auth
+- lib/Repair/LoadDefaultZgwMappings.php (36 methods) — Seeds default ZGW mappings on install
+
+## Approach
+- File-level survey of each controller's public method surface
+- One REQ per logical capability cluster (ZRC, the other four APIs collectively, shared service surface, auth middleware, default-seed repair step)
+- Notes flag the two duplicate handlers callout from the coverage report (SendEmailHandler) — out of scope for this cluster, addressed under automatic-actions
+
+Source: openspec/coverage-report.md generated 2026-05-24. Tracks ConductionNL/procest#565.

--- a/openspec/changes/retrofit-2026-05-24-zgw-api-mapping/specs/zgw-api-mapping/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-zgw-api-mapping/specs/zgw-api-mapping/spec.md
@@ -1,0 +1,81 @@
+---
+retrofit_extensions:
+  - REQ-001
+  - REQ-002
+  - REQ-003
+  - REQ-004
+  - REQ-005
+---
+
+# ZGW API Mapping — Procest-side surface (retrofit)
+
+## Requirements
+
+### REQ-001: Procest SHALL expose ZGW Zaakregistratiecomponent (ZRC) endpoints via ZrcController
+
+`OCA\Procest\Controller\ZrcController` SHALL serve the ZGW Zaken API resources (zaken, statussen, resultaten, rollen, zaakeigenschappen, zaakinformatieobjecten, zaakobjecten, klantcontacten) using the shared `ZgwService` for inbound/outbound translation against English-language OpenRegister schemas. The controller SHALL handle list/show/create/update/patch/destroy plus the nested `zaakeigenschappen*` and `zaakbesluiten` sub-resources, expose `/zoek` search, and serve audit-trail lookup endpoints.
+
+#### Scenario: List zaken with outbound mapping
+- **WHEN** a client calls `GET /api/zgw/zaken/v1/zaken/`
+- **THEN** `ZrcController::index('zaken')` SHALL load the outbound Mapping for `zaken`, query the configured register/schema, and return ZGW-compliant JSON with Dutch property names
+- **AND** the response SHALL be wrapped in the HAL-style pagination envelope from `ZgwPaginationHelper`
+
+#### Scenario: Zaak with eindstatus side-effect
+- **GIVEN** a zaak status transition resolves to a status type marked as eindstatus
+- **WHEN** `ZrcController::create('statussen')` (or patch/update on statussen) is invoked
+- **THEN** the corresponding zaak object SHALL be flagged closed and any eindstatus side effects SHALL be applied as a single atomic operation
+
+Notes
+- ZRC currently delegates shared CRUD to `ZgwService`; ZRC-specific logic (closed-zaak resolution, vertrouwelijkheid filtering, OIO sync) lives inline in this controller and is partially exercised by `zrc-005`/`zrc-006` integration-test fixtures.
+
+### REQ-002: Procest SHALL expose ZTC, DRC, BRC and NRC endpoints via dedicated controllers
+
+`OCA\Procest\Controller\ZtcController` (Catalogi API), `DrcController` (Documenten API), `BrcController` (Besluiten API) and `NrcController` (Notificaties API) SHALL each serve the canonical ZGW resources for their API per the VNG ZGW standard versions tracked in this spec (ZTC v1.3.1, DRC v1.4.3, BRC v1.1.0, NRC v1.0.0). Each controller SHALL reuse `ZgwService` for shared mapping execution, pagination, and ZGW response shaping while implementing API-specific resource paths.
+
+#### Scenario: List catalogi via ZTC
+- **WHEN** a client calls `GET /api/zgw/catalogi/v1/catalogussen/`
+- **THEN** `ZtcController::index('catalogussen')` SHALL return ZGW-compliant catalog objects via the catalogi outbound Mapping
+
+#### Scenario: Send notificatie via NRC
+- **WHEN** an event triggers a notificatie dispatch through `NotificatieService`
+- **THEN** the configured NRC subscriber URLs SHALL be POSTed the ZGW-shaped notification payload
+
+Notes
+- DRC has 32 methods (largest controller); a future refinement may split per-resource controllers.
+
+### REQ-003: ZgwService SHALL provide a shared ZGW mapping/runtime surface to all five controllers
+
+`OCA\Procest\Service\ZgwService` SHALL centralise the cross-controller ZGW pipeline: mapping configuration loading, outbound and inbound mapping construction, query-parameter translation, pagination, ZGW error shape construction, and access to the helper services (`ZgwMappingService`, `ZgwDocumentService`, `ZgwPaginationHelper`, `NotificatieService`, `ZgwBusinessRulesService`). Controllers SHALL NOT inline mapping engine calls — every translation SHALL go through `ZgwService::loadMappingConfig()`, `createOutboundMapping()`, `createInboundMapping()`, or one of the wrapper helpers.
+
+#### Scenario: Translate ZGW query parameter names to schema property names
+- **GIVEN** an incoming request with query parameter `zaaktype=https://example.com/api/zgw/catalogi/v1/zaaktypen/abc-def`
+- **WHEN** `ZgwService::translateQueryParams()` is called with the loaded mapping configuration
+- **THEN** the parameter SHALL be renamed to the English schema property and the UUID SHALL be extracted from the URL
+
+#### Scenario: Build an outbound mapping object
+- **WHEN** `ZgwService::createOutboundMapping(array $mappingConfig)` is called
+- **THEN** the returned mapping object SHALL be ready for `MappingService::executeMapping()` consumption against an OpenRegister `case` (or sibling) object
+
+### REQ-004: ZGW endpoints SHALL be gated by bearer-token authentication with vertrouwelijkheid filtering
+
+`OCA\Procest\Middleware\ZgwAuthMiddleware` SHALL run before every ZGW controller method, validate the inbound `Authorization: Bearer …` JWT, resolve the client's autorisaties (scope + max-vertrouwelijkheidaanduiding), and reject the request with the ZGW `403` error shape when the client's authorizations do not cover the requested resource. Confidentiality filtering SHALL use the ordered `VERTROUWELIJKHEID_LEVELS` table (openbaar=1 … zeer_geheim=8) such that a client whose maximum is `intern` (level 3) cannot read records flagged `zaakvertrouwelijk` (level 4) or higher.
+
+#### Scenario: Bearer token missing or invalid
+- **WHEN** a request reaches a ZGW controller without a valid `Authorization: Bearer` JWT
+- **THEN** `ZgwAuthMiddleware::beforeController()` SHALL throw a `ZgwAuthException` and `afterException()` SHALL render the ZGW-shaped 401 JSON response
+
+#### Scenario: Client requests vertrouwelijker resource than allowed
+- **WHEN** `ZgwAuthMiddleware::isConfidentialityAllowed('vertrouwelijk', 'intern')` is evaluated
+- **THEN** it SHALL return `false` and the surrounding filter SHALL exclude the record from the response
+
+### REQ-005: Procest SHALL ship default ZGW mappings via a repair step on app install
+
+`OCA\Procest\Repair\LoadDefaultZgwMappings` SHALL run as a Nextcloud repair step on app install/upgrade and create one default Mapping record per ZGW resource (ZRC zaak, status, resultaat, rol, zaakeigenschap, zaakinformatieobject, zaakobject, klantcontact; ZTC catalogus, zaaktype, statustype, resultaattype, roltype, eigenschap, besluittype, informatieobjecttype; DRC enkelvoudiginformatieobject, gebruiksrechten, objectinformatieobject; BRC besluit, besluitinformatieobject; NRC kanaal, abonnement) using `LoadDefaultZgwMappings::create…Mapping()` private methods. Existing mappings (matched by slug/reference) SHALL be left untouched — the repair step SHALL be idempotent.
+
+#### Scenario: Fresh install seeds the default mapping set
+- **WHEN** procest is installed for the first time and `LoadDefaultZgwMappings::run()` executes
+- **THEN** the ZGW Mapping entities for every default resource SHALL exist in the configured register
+- **AND** the seeder SHALL be safe to re-run after upgrade — pre-existing custom mappings with the same slug SHALL NOT be overwritten
+
+Notes
+- The seeder defines 36 private `create…Mapping()` methods, one per resource. Adding a new default mapping is a code-level operation; future work may move this to a JSON manifest under `openspec/`.

--- a/openspec/changes/retrofit-2026-05-24-zgw-api-mapping/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-zgw-api-mapping/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] task-1: zgw-api-mapping#REQ-001 — Procest SHALL expose ZRC endpoints via ZrcController (retroactive annotation)
+- [x] task-2: zgw-api-mapping#REQ-002 — Procest SHALL expose ZTC/DRC/BRC/NRC endpoints via dedicated controllers (retroactive annotation)
+- [x] task-3: zgw-api-mapping#REQ-003 — ZgwService SHALL provide shared ZGW mapping/runtime surface (retroactive annotation)
+- [x] task-4: zgw-api-mapping#REQ-004 — ZGW endpoints SHALL be gated by ZgwAuthMiddleware (retroactive annotation)
+- [x] task-5: zgw-api-mapping#REQ-005 — Procest SHALL ship default ZGW mappings via LoadDefaultZgwMappings repair step (retroactive annotation)

--- a/openspec/specs/zgw-api-mapping/spec.md
+++ b/openspec/specs/zgw-api-mapping/spec.md
@@ -1,5 +1,11 @@
 ---
 status: implemented
+retrofit_extensions:
+  - REQ-001
+  - REQ-002
+  - REQ-003
+  - REQ-004
+  - REQ-005
 ---
 
 # ZGW API Mapping
@@ -613,6 +619,79 @@ The ZGW mapping layer MUST be built on OpenRegister's generic Mapping + Endpoint
 - **WHEN** listing all configured API profiles
 - **THEN** ZGW endpoints MUST be identifiable by their `/api/zgw/` path prefix
 - **AND** other profiles MUST use different prefixes (e.g., `/api/fhir/`, `/api/stuf/`)
+
+<!-- BEGIN retrofit-2026-05-24-zgw-api-mapping -->
+
+### REQ-001: Procest SHALL expose ZGW Zaakregistratiecomponent (ZRC) endpoints via ZrcController
+
+`OCA\Procest\Controller\ZrcController` SHALL serve the ZGW Zaken API resources (zaken, statussen, resultaten, rollen, zaakeigenschappen, zaakinformatieobjecten, zaakobjecten, klantcontacten) using the shared `ZgwService` for inbound/outbound translation against English-language OpenRegister schemas. The controller SHALL handle list/show/create/update/patch/destroy plus the nested `zaakeigenschappen*` and `zaakbesluiten` sub-resources, expose `/zoek` search, and serve audit-trail lookup endpoints.
+
+#### Scenario: List zaken with outbound mapping
+- **WHEN** a client calls `GET /api/zgw/zaken/v1/zaken/`
+- **THEN** `ZrcController::index('zaken')` SHALL load the outbound Mapping for `zaken`, query the configured register/schema, and return ZGW-compliant JSON with Dutch property names
+- **AND** the response SHALL be wrapped in the HAL-style pagination envelope from `ZgwPaginationHelper`
+
+#### Scenario: Zaak with eindstatus side-effect
+- **GIVEN** a zaak status transition resolves to a status type marked as eindstatus
+- **WHEN** `ZrcController::create('statussen')` (or patch/update on statussen) is invoked
+- **THEN** the corresponding zaak object SHALL be flagged closed and any eindstatus side effects SHALL be applied as a single atomic operation
+
+Notes
+- ZRC currently delegates shared CRUD to `ZgwService`; ZRC-specific logic (closed-zaak resolution, vertrouwelijkheid filtering, OIO sync) lives inline in this controller and is partially exercised by `zrc-005`/`zrc-006` integration-test fixtures.
+
+### REQ-002: Procest SHALL expose ZTC, DRC, BRC and NRC endpoints via dedicated controllers
+
+`OCA\Procest\Controller\ZtcController` (Catalogi API), `DrcController` (Documenten API), `BrcController` (Besluiten API) and `NrcController` (Notificaties API) SHALL each serve the canonical ZGW resources for their API per the VNG ZGW standard versions tracked in this spec (ZTC v1.3.1, DRC v1.4.3, BRC v1.1.0, NRC v1.0.0). Each controller SHALL reuse `ZgwService` for shared mapping execution, pagination, and ZGW response shaping while implementing API-specific resource paths.
+
+#### Scenario: List catalogi via ZTC
+- **WHEN** a client calls `GET /api/zgw/catalogi/v1/catalogussen/`
+- **THEN** `ZtcController::index('catalogussen')` SHALL return ZGW-compliant catalog objects via the catalogi outbound Mapping
+
+#### Scenario: Send notificatie via NRC
+- **WHEN** an event triggers a notificatie dispatch through `NotificatieService`
+- **THEN** the configured NRC subscriber URLs SHALL be POSTed the ZGW-shaped notification payload
+
+Notes
+- DRC has 32 methods (largest controller); a future refinement may split per-resource controllers.
+
+### REQ-003: ZgwService SHALL provide a shared ZGW mapping/runtime surface to all five controllers
+
+`OCA\Procest\Service\ZgwService` SHALL centralise the cross-controller ZGW pipeline: mapping configuration loading, outbound and inbound mapping construction, query-parameter translation, pagination, ZGW error shape construction, and access to the helper services (`ZgwMappingService`, `ZgwDocumentService`, `ZgwPaginationHelper`, `NotificatieService`, `ZgwBusinessRulesService`). Controllers SHALL NOT inline mapping engine calls — every translation SHALL go through `ZgwService::loadMappingConfig()`, `createOutboundMapping()`, `createInboundMapping()`, or one of the wrapper helpers.
+
+#### Scenario: Translate ZGW query parameter names to schema property names
+- **GIVEN** an incoming request with query parameter `zaaktype=https://example.com/api/zgw/catalogi/v1/zaaktypen/abc-def`
+- **WHEN** `ZgwService::translateQueryParams()` is called with the loaded mapping configuration
+- **THEN** the parameter SHALL be renamed to the English schema property and the UUID SHALL be extracted from the URL
+
+#### Scenario: Build an outbound mapping object
+- **WHEN** `ZgwService::createOutboundMapping(array $mappingConfig)` is called
+- **THEN** the returned mapping object SHALL be ready for `MappingService::executeMapping()` consumption against an OpenRegister `case` (or sibling) object
+
+### REQ-004: ZGW endpoints SHALL be gated by bearer-token authentication with vertrouwelijkheid filtering
+
+`OCA\Procest\Middleware\ZgwAuthMiddleware` SHALL run before every ZGW controller method, validate the inbound `Authorization: Bearer …` JWT, resolve the client's autorisaties (scope + max-vertrouwelijkheidaanduiding), and reject the request with the ZGW `403` error shape when the client's authorizations do not cover the requested resource. Confidentiality filtering SHALL use the ordered `VERTROUWELIJKHEID_LEVELS` table (openbaar=1 … zeer_geheim=8) such that a client whose maximum is `intern` (level 3) cannot read records flagged `zaakvertrouwelijk` (level 4) or higher.
+
+#### Scenario: Bearer token missing or invalid
+- **WHEN** a request reaches a ZGW controller without a valid `Authorization: Bearer` JWT
+- **THEN** `ZgwAuthMiddleware::beforeController()` SHALL throw a `ZgwAuthException` and `afterException()` SHALL render the ZGW-shaped 401 JSON response
+
+#### Scenario: Client requests vertrouwelijker resource than allowed
+- **WHEN** `ZgwAuthMiddleware::isConfidentialityAllowed('vertrouwelijk', 'intern')` is evaluated
+- **THEN** it SHALL return `false` and the surrounding filter SHALL exclude the record from the response
+
+### REQ-005: Procest SHALL ship default ZGW mappings via a repair step on app install
+
+`OCA\Procest\Repair\LoadDefaultZgwMappings` SHALL run as a Nextcloud repair step on app install/upgrade and create one default Mapping record per ZGW resource (ZRC zaak, status, resultaat, rol, zaakeigenschap, zaakinformatieobject, zaakobject, klantcontact; ZTC catalogus, zaaktype, statustype, resultaattype, roltype, eigenschap, besluittype, informatieobjecttype; DRC enkelvoudiginformatieobject, gebruiksrechten, objectinformatieobject; BRC besluit, besluitinformatieobject; NRC kanaal, abonnement) using `LoadDefaultZgwMappings::create…Mapping()` private methods. Existing mappings (matched by slug/reference) SHALL be left untouched — the repair step SHALL be idempotent.
+
+#### Scenario: Fresh install seeds the default mapping set
+- **WHEN** procest is installed for the first time and `LoadDefaultZgwMappings::run()` executes
+- **THEN** the ZGW Mapping entities for every default resource SHALL exist in the configured register
+- **AND** the seeder SHALL be safe to re-run after upgrade — pre-existing custom mappings with the same slug SHALL NOT be overwritten
+
+Notes
+- The seeder defines 36 private `create…Mapping()` methods, one per resource. Adding a new default mapping is a code-level operation; future work may move this to a JSON manifest under `openspec/`.
+
+<!-- END retrofit-2026-05-24-zgw-api-mapping -->
 
 ## Non-Requirements
 - Full ZGW compliance certification -- this is a compatibility layer, not a VNG reference implementation


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Drafts 5 numbered REQs describing the procest-side ZGW API surface (controllers, ZgwService + helpers, auth middleware, default-mapping seeder).

Ghost change: retrofit-2026-05-24-zgw-api-mapping (delta merged into openspec/specs/zgw-api-mapping/spec.md).

### What this PR does
- Adds retrofit_extensions: [REQ-001..REQ-005] to the main spec frontmatter
- Appends REQ-001..REQ-005 to the main spec inside a marked block
- Annotates 13 files with file-level @spec pointers (one per task)
- Scaffold under openspec/changes/retrofit-2026-05-24-zgw-api-mapping/

### What this PR does NOT do
- No code logic changes — annotations + spec only
- Does not resolve the SendEmailHandler duplicate flagged in the coverage report (handled under automatic-actions cluster)
- Does not split the 32-method DrcController (future work)

### REQ summary
1. REQ-001 — ZRC endpoints via ZrcController
2. REQ-002 — ZTC/DRC/BRC/NRC endpoints via dedicated controllers
3. REQ-003 — ZgwService shared mapping/runtime surface
4. REQ-004 — Bearer-token + vertrouwelijkheid filtering in ZgwAuthMiddleware
5. REQ-005 — Default ZGW mapping seed via LoadDefaultZgwMappings repair step

Source: openspec/coverage-report.md generated 2026-05-24 | Cluster: zgw-api-mapping

Refs #565