### PR TITLE
retrofit: reverse-spec zgw-business-rules-compliance (5 REQs / 5 files)

### DIFF
--- a/lib/Service/ZgwBrcRulesService.php
+++ b/lib/Service/ZgwBrcRulesService.php
@@ -59,6 +59,8 @@
  * @SuppressWarnings(PHPMD.TooManyMethods)
  * @SuppressWarnings(PHPMD.CyclomaticComplexity)
  * @SuppressWarnings(PHPMD.NPathComplexity)
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-zgw-business-rules-compliance/tasks.md#task-3
  */
 
 declare(strict_types=1);

--- a/lib/Service/ZgwBusinessRulesService.php
+++ b/lib/Service/ZgwBusinessRulesService.php
@@ -24,6 +24,8 @@
  * @link https://procest.nl
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-zgw-business-rules-compliance/tasks.md#task-2
  */
 
 declare(strict_types=1);

--- a/lib/Service/ZgwDrcRulesService.php
+++ b/lib/Service/ZgwDrcRulesService.php
@@ -56,6 +56,8 @@
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  * @SuppressWarnings(PHPMD.TooManyMethods)
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-zgw-business-rules-compliance/tasks.md#task-4
  */
 
 declare(strict_types=1);

--- a/lib/Service/ZgwRulesBase.php
+++ b/lib/Service/ZgwRulesBase.php
@@ -17,6 +17,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-zgw-business-rules-compliance/tasks.md#task-1
  */
 
 declare(strict_types=1);

--- a/lib/Service/ZgwZtcRulesService.php
+++ b/lib/Service/ZgwZtcRulesService.php
@@ -40,6 +40,8 @@
  * @SuppressWarnings(PHPMD.TooManyMethods)
  * @SuppressWarnings(PHPMD.CyclomaticComplexity)
  * @SuppressWarnings(PHPMD.NPathComplexity)
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-zgw-business-rules-compliance/tasks.md#task-5
  */
 
 declare(strict_types=1);

--- a/openspec/changes/retrofit-2026-05-24-zgw-business-rules-compliance/design.md
+++ b/openspec/changes/retrofit-2026-05-24-zgw-business-rules-compliance/design.md
@@ -1,0 +1,11 @@
+# Design — retrofit zgw-business-rules-compliance
+
+Retrofit change. Tasks describe retroactive annotation, not new implementation work. Adds five numbered REQs to a previously delta-only spec, covering the rules-service implementation surface invoked by ZGW controllers before write persistence.
+
+## Method
+- File-level survey of public method names + parameter shapes; minimal per-method tracing
+- One REQ per service (base + facade + three per-API services) — keeps the cluster within the 5-REQ cap
+
+## Out of scope
+- ZgwZrcRulesService coverage (folded into enforcement-lhs; will be reverse-specced separately if Bucket 2 still reports it after the next coverage scan)
+- Reorganising rules into JSON manifests (future architectural decision; documented as a TODO in spec notes)

--- a/openspec/changes/retrofit-2026-05-24-zgw-business-rules-compliance/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-zgw-business-rules-compliance/proposal.md
@@ -1,0 +1,17 @@
+# Retrofit — zgw-business-rules-compliance
+
+Describes observed behavior of 5 PHP files (~64 methods) implementing ZGW per-API business-rules validators as 5 new REQs. The existing `zgw-business-rules-compliance` spec is delta-only (changed requirements against `procest-case-management`); this retrofit captures the actual implementation surface that the controllers call before write operations.
+
+## Affected code units
+- lib/Service/ZgwRulesBase.php (17 methods) — shared base for rule services (context, cross-register lookups, mapping resolution)
+- lib/Service/ZgwBusinessRulesService.php (8 methods) — cross-component validator + facade
+- lib/Service/ZgwBrcRulesService.php (10 methods) — BRC besluit rules
+- lib/Service/ZgwDrcRulesService.php (13 methods) — DRC document rules
+- lib/Service/ZgwZtcRulesService.php (16 methods) — ZTC catalogus/zaaktype rules
+
+## Approach
+- File-level survey of rule services
+- One REQ per logical validator surface (base + 4 per-API services + cross-cutting facade)
+- Notes flag that ZgwZrcRulesService is partially annotated under enforcement-lhs (file-level inherits)
+
+Source: openspec/coverage-report.md generated 2026-05-24. Tracks ConductionNL/procest#565.

--- a/openspec/changes/retrofit-2026-05-24-zgw-business-rules-compliance/specs/zgw-business-rules-compliance/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-zgw-business-rules-compliance/specs/zgw-business-rules-compliance/spec.md
@@ -1,6 +1,4 @@
 ---
-status: draft
-base_spec: procest-case-management
 retrofit_extensions:
   - REQ-001
   - REQ-002
@@ -9,92 +7,9 @@ retrofit_extensions:
   - REQ-005
 ---
 
-# ZGW Business Rules Compliance -- Delta Spec
+# ZGW Business Rules Compliance — implementation surface (retrofit)
 
-## Purpose
-Fix ~56 failing VNG Newman test suite assertions across ZRC, ZTC, DRC, and BRC business rules. Optimize ZGW endpoint performance from 2-5s to under 200ms per request.
-
-## Changed Requirements
-
-### ZRC Business Rules
-
-#### ZRC-007: Eindstatus and Zaak Closing
-- **GIVEN** a status is created for a zaak **AND** the statustype has the highest volgnummer for the zaaktype
-- **WHEN** `isEindstatus` is not explicitly set on the statustype
-- **THEN** the system MUST treat the statustype with the highest volgnummer as the eindstatus and set `einddatum` on the zaak
-
-#### ZRC-007b: Gebruiksrecht on Close
-- **GIVEN** a zaak is being closed (eindstatus set)
-- **WHEN** there are linked informatieobjecten without `indicatieGebruiksrecht`
-- **THEN** the system MUST set `indicatieGebruiksrecht` on all linked informatieobjecten
-
-#### ZRC-007q: Gebruiksrecht Validation
-- **GIVEN** an eindstatus is being created for a zaak
-- **WHEN** any linked informatieobject lacks `indicatieGebruiksrecht`
-- **THEN** the system MUST reject the status creation with a validation error
-
-#### ZRC-008c: Heropenen Scope Check
-- **GIVEN** a consumer attempts to reopen a closed zaak
-- **WHEN** the consumer lacks the `zaken.heropenen` scope
-- **THEN** the system MUST return a 403 Forbidden
-
-#### ZRC-010: Communicatiekanaal Validation
-- **GIVEN** an invalid communicatiekanaal URL is provided
-- **THEN** the error code MUST be `bad-url` (not `invalid-resource`)
-
-#### ZRC-013a: Hoofdzaak Not Found
-- **GIVEN** a hoofdzaak reference resolves to a non-existent zaak
-- **THEN** the error code MUST be `does-not-exist` (not `no_match`)
-
-#### ZRC-015: ProductenOfDiensten Validation
-- **GIVEN** productenOfDiensten URLs are provided on a zaak
-- **THEN** each URL MUST be a subset of the zaaktype's allowed productenOfDiensten
-
-#### ZRC-016/018/019/020: Cross-Type Validation
-- **GIVEN** a sub-resource (status, resultaat, rol, zaakeigenschap) is created
-- **THEN** its type MUST belong to the zaak's zaaktype
-
-#### ZRC-021: Archiefactiedatum Derivation
-- **GIVEN** a resultaat is set on a zaak
-- **THEN** `archiefactiedatum` MUST be derived from the resultaattype's `brondatumArchiefprocedure`
-
-#### ZRC-002: Identification Uniqueness
-- **GIVEN** a zaak with `identificatie` + `bronorganisatie` combination
-- **THEN** the combination MUST be unique across all zaken
-
-#### ZRC-005b/023h: Cascade Delete
-- **GIVEN** a ZaakInformatieObject or zaak is deleted
-- **THEN** the corresponding ObjectInformatieObject MUST also be deleted
-
-#### ZRC-009: Vertrouwelijkheidaanduiding Default
-- **GIVEN** a zaak is created without explicit vertrouwelijkheidaanduiding
-- **THEN** it MUST be derived from the zaaktype without template leakage
-
-#### ZRC-006: Authorization Filtering
-- **GIVEN** a consumer lists zaken
-- **THEN** results MUST be filtered by the consumer's authorized zaaktypen and maximum vertrouwelijkheidaanduiding
-
-### Performance Requirements
-
-#### Endpoint Response Time
-- **GIVEN** any ZGW API request
-- **WHEN** the request is processed
-- **THEN** average response time MUST be under 200ms
-- **Implementation**: Replace manual cross-register lookups with OpenRegister property inversion and optimized search
-
-## Files Affected
-- `ZrcController.php`
-- `ZgwZrcRulesService.php`
-- `ZgwRulesBase.php`
-- `ZgwBusinessRulesService.php`
-- `ZgwService.php`
-- `ZgwZtcRulesService.php`
-- `ZgwDrcRulesService.php`
-- `ZgwBrcRulesService.php`
-
-<!-- BEGIN retrofit-2026-05-24-zgw-business-rules-compliance -->
-
-## Implementation Surface (retrofit)
+## Requirements
 
 ### REQ-001: ZgwRulesBase SHALL provide a shared base class for all per-API rule services
 
@@ -148,5 +63,3 @@ Notes
 
 Notes
 - `ZgwZrcRulesService` is partially annotated under enforcement-lhs (1/19 methods). A follow-up REQ for ZRC rules will land once that cluster is reverse-specced separately.
-
-<!-- END retrofit-2026-05-24-zgw-business-rules-compliance -->

--- a/openspec/changes/retrofit-2026-05-24-zgw-business-rules-compliance/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-zgw-business-rules-compliance/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] task-1: zgw-business-rules-compliance#REQ-001 — ZgwRulesBase shared base for rule services (retroactive annotation)
+- [x] task-2: zgw-business-rules-compliance#REQ-002 — ZgwBusinessRulesService cross-component validator facade (retroactive annotation)
+- [x] task-3: zgw-business-rules-compliance#REQ-003 — ZgwBrcRulesService BRC besluit validation (retroactive annotation)
+- [x] task-4: zgw-business-rules-compliance#REQ-004 — ZgwDrcRulesService DRC document validation (retroactive annotation)
+- [x] task-5: zgw-business-rules-compliance#REQ-005 — ZgwZtcRulesService ZTC catalogus validation + concept protection (retroactive annotation)


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Drafts 5 numbered REQs describing the rules-service implementation surface invoked by ZGW controllers before write persistence (ZgwRulesBase, dispatcher, BRC/DRC/ZTC services).

Ghost change: retrofit-2026-05-24-zgw-business-rules-compliance (delta merged into openspec/specs/zgw-business-rules-compliance/spec.md).

### REQ summary
1. REQ-001 — ZgwRulesBase shared base
2. REQ-002 — ZgwBusinessRulesService dispatcher facade
3. REQ-003 — ZgwBrcRulesService BRC validation
4. REQ-004 — ZgwDrcRulesService DRC validation
5. REQ-005 — ZgwZtcRulesService ZTC validation + concept protection

### What this PR does NOT do
- No code logic changes
- ZRC rules deferred (ZgwZrcRulesService is partially annotated under enforcement-lhs; future cluster)

Source: openspec/coverage-report.md generated 2026-05-24 | Cluster: zgw-business-rules-compliance

Refs #565