### PR TITLE
retrofit: reverse-spec automatic-actions (5 REQs / 10 files)

### DIFF
--- a/lib/Service/Actions/ActionHandlerInterface.php
+++ b/lib/Service/Actions/ActionHandlerInterface.php
@@ -21,6 +21,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-automatic-actions/tasks.md#task-1
  */
 
 declare(strict_types=1);

--- a/lib/Service/Actions/ActionRegistry.php
+++ b/lib/Service/Actions/ActionRegistry.php
@@ -22,6 +22,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-automatic-actions/tasks.md#task-2
  */
 
 declare(strict_types=1);

--- a/lib/Service/Actions/ActionResult.php
+++ b/lib/Service/Actions/ActionResult.php
@@ -21,6 +21,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-automatic-actions/tasks.md#task-1
  */
 
 declare(strict_types=1);

--- a/lib/Service/Actions/CallWebhookHandler.php
+++ b/lib/Service/Actions/CallWebhookHandler.php
@@ -21,6 +21,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-automatic-actions/tasks.md#task-3
  */
 
 declare(strict_types=1);

--- a/lib/Service/Actions/CreateDocumentHandler.php
+++ b/lib/Service/Actions/CreateDocumentHandler.php
@@ -20,6 +20,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-automatic-actions/tasks.md#task-4
  */
 
 declare(strict_types=1);

--- a/lib/Service/Actions/HandlesTemplates.php
+++ b/lib/Service/Actions/HandlesTemplates.php
@@ -22,6 +22,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-automatic-actions/tasks.md#task-4
  */
 
 declare(strict_types=1);

--- a/lib/Service/Actions/MergeTemplateHandler.php
+++ b/lib/Service/Actions/MergeTemplateHandler.php
@@ -20,6 +20,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-automatic-actions/tasks.md#task-4
  */
 
 declare(strict_types=1);

--- a/lib/Service/Actions/NotifyRoleHandler.php
+++ b/lib/Service/Actions/NotifyRoleHandler.php
@@ -20,6 +20,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-automatic-actions/tasks.md#task-3
  */
 
 declare(strict_types=1);

--- a/lib/Service/Actions/ScheduleReminderHandler.php
+++ b/lib/Service/Actions/ScheduleReminderHandler.php
@@ -20,6 +20,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-automatic-actions/tasks.md#task-5
  */
 
 declare(strict_types=1);

--- a/lib/Service/Actions/SendEmailHandler.php
+++ b/lib/Service/Actions/SendEmailHandler.php
@@ -20,6 +20,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-automatic-actions/tasks.md#task-3
  */
 
 declare(strict_types=1);

--- a/openspec/changes/retrofit-2026-05-24-automatic-actions/design.md
+++ b/openspec/changes/retrofit-2026-05-24-automatic-actions/design.md
@@ -1,0 +1,11 @@
+# Design — retrofit automatic-actions
+
+Retrofit change. Tasks describe retroactive annotation, not new implementation work.
+
+## Method
+- File-level survey by class signature + public method shape
+- Group 10 files into 5 logical REQs (contract types + registry + 3 handler families)
+
+## Out of scope
+- Resolving the SendEmailHandler duplicate (Transitions/SendEmailHandler is owned by status-transition-engine)
+- Adding new handler types (covered by the existing automatic-actions framework REQs)

--- a/openspec/changes/retrofit-2026-05-24-automatic-actions/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-automatic-actions/proposal.md
@@ -1,0 +1,22 @@
+# Retrofit — automatic-actions
+
+Describes observed behavior of 10 PHP files (~33 methods) implementing the per-handler action framework as 5 new REQs. The existing `automatic-actions` spec defines the abstract framework + per-handler behavior but is not pinned to the implementation classes.
+
+## Affected code units
+- lib/Service/Actions/ActionHandlerInterface.php — handler contract (type + handle)
+- lib/Service/Actions/ActionResult.php — handler result value object
+- lib/Service/Actions/HandlesTemplates.php — shared template-rendering trait
+- lib/Service/Actions/ActionRegistry.php (7 methods) — handler lookup + listing
+- lib/Service/Actions/CallWebhookHandler.php (5 methods) — webhook delivery
+- lib/Service/Actions/CreateDocumentHandler.php (4 methods) — case-attached document creation
+- lib/Service/Actions/MergeTemplateHandler.php (4 methods) — template rendering action
+- lib/Service/Actions/NotifyRoleHandler.php (5 methods) — role-based notification
+- lib/Service/Actions/ScheduleReminderHandler.php (4 methods) — deferred reminder via BackgroundJob
+- lib/Service/Actions/SendEmailHandler.php (4 methods) — email via NotificatieService (canonical; the `Transitions/SendEmailHandler.php` duplicate is a separate transitions-engine concern)
+
+## Approach
+- File-level survey by class name + public method shape
+- Group handlers by family: notification surface (webhook/email/notify), content surface (document/template), schedule surface (reminder); plus the contract types and the registry
+- Note: `lib/Service/Actions/SendEmailHandler.php` is the canonical sendEmail handler for the automatic-actions framework; `lib/Service/Transitions/SendEmailHandler.php` is a parallel transitions-engine action and belongs to the status-transition-engine spec, not here.
+
+Source: openspec/coverage-report.md generated 2026-05-24. Tracks ConductionNL/procest#565.

--- a/openspec/changes/retrofit-2026-05-24-automatic-actions/specs/automatic-actions/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-automatic-actions/specs/automatic-actions/spec.md
@@ -7,67 +7,9 @@ retrofit_extensions:
   - REQ-005
 ---
 
+# Automatic Actions — handler framework (retrofit)
+
 ## Requirements
-
-### Requirement: Automatic Action Framework
-
-The system SHALL support configurable automatic actions that execute when a status transition occurs or a step is completed. Actions are defined as part of the workflow template and executed by the frontend or delegated to n8n webhooks.
-
-**Feature tier**: V1
-
-Action types:
-- `sendEmail`: Send a templated email to a case participant
-- `createTask`: Create a new task for a specified role
-- `createSubCase`: Create a deelzaak of a specified type
-- `webhook`: Call an n8n webhook URL with case data
-- `setField`: Set a case property to a computed value
-- `notify`: Create a Nextcloud notification for a user or role
-
-#### Scenario: Configure email action on transition
-
-- **WHEN** an administrator configures transition "Afhandelen" with action `sendEmail`
-- **THEN** the configuration panel SHALL allow setting: recipient (role or specific field), email template, subject template
-- **AND** templates SHALL support variable substitution: `{{case.title}}`, `{{case.handler}}`, `{{transition.label}}`
-
-#### Scenario: Email action executes on transition
-
-- **WHEN** transition "Afhandelen" is executed on case "ZK-2024-001"
-- **AND** the transition has a `sendEmail` action configured for the "zaakklant" role
-- **THEN** the system SHALL send the templated email to the email address of the user with role "zaakklant" on the case
-
-#### Scenario: Task creation action on step completion
-
-- **WHEN** step "Toets ontvankelijkheid" is completed
-- **AND** the step has a `createTask` action configured for role "Vakspecialist"
-- **THEN** the system SHALL create a new task with the configured title and description, assigned to role "Vakspecialist"
-
-#### Scenario: Webhook action delegates to n8n
-
-- **WHEN** a transition has a `webhook` action configured with URL `https://n8n.example.com/webhook/abc123`
-- **AND** the transition is executed
-- **THEN** the system SHALL POST the case data (id, title, status, transition details) to the webhook URL
-- **AND** the webhook response SHALL be logged but SHALL NOT block the transition
-
-### Requirement: Action Execution Error Handling
-
-The system SHALL handle action execution failures gracefully without rolling back the transition.
-
-**Feature tier**: V1
-
-#### Scenario: Email action fails
-
-- **WHEN** a `sendEmail` action fails (SMTP error, invalid recipient)
-- **THEN** the status transition SHALL still complete successfully
-- **AND** the error SHALL be logged in the case audit trail
-- **AND** a warning notification SHALL be created for the case handler: "Automatische e-mail kon niet worden verzonden"
-
-#### Scenario: Webhook action times out
-
-- **WHEN** a `webhook` action does not respond within 10 seconds
-- **THEN** the action SHALL be marked as failed in the audit trail
-- **AND** the transition SHALL still complete successfully
-
-<!-- BEGIN retrofit-2026-05-24-automatic-actions -->
 
 ### REQ-001: Action handlers SHALL implement a common contract
 
@@ -120,5 +62,3 @@ Every automatic-action handler SHALL implement `OCA\Procest\Service\Actions\Acti
 
 Notes
 - `lib/Service/Transitions/SendEmailHandler.php` (separate file) is a parallel implementation for the status-transition-engine framework and is NOT part of this cluster.
-
-<!-- END retrofit-2026-05-24-automatic-actions -->

--- a/openspec/changes/retrofit-2026-05-24-automatic-actions/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-automatic-actions/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] task-1: automatic-actions#REQ-001 — ActionHandlerInterface + ActionResult common contract (retroactive annotation)
+- [x] task-2: automatic-actions#REQ-002 — ActionRegistry lookup + listing (retroactive annotation)
+- [x] task-3: automatic-actions#REQ-003 — Notification-family handlers (SendEmail/CallWebhook/NotifyRole) (retroactive annotation)
+- [x] task-4: automatic-actions#REQ-004 — Content-family handlers (CreateDocument/MergeTemplate) (retroactive annotation)
+- [x] task-5: automatic-actions#REQ-005 — ScheduleReminderHandler deferred execution (retroactive annotation)


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Drafts 5 numbered REQs describing the procest automatic-action handler framework.

Ghost change: retrofit-2026-05-24-automatic-actions (delta merged into openspec/specs/automatic-actions/spec.md).

### REQ summary
1. REQ-001 — ActionHandlerInterface + ActionResult common contract
2. REQ-002 — ActionRegistry lookup + listing
3. REQ-003 — Notification-family handlers (SendEmail/CallWebhook/NotifyRole)
4. REQ-004 — Content-family handlers (CreateDocument/MergeTemplate)
5. REQ-005 — ScheduleReminderHandler deferred execution

### What this PR does NOT do
- No code logic changes
- Does not resolve the SendEmailHandler duplicate (Transitions/SendEmailHandler belongs to status-transition-engine)

Source: openspec/coverage-report.md generated 2026-05-24 | Cluster: automatic-actions

Refs #565