### PR TITLE
retrofit: reverse-spec case-management sharing/transfer/email (5 REQs / 7 files)

### DIFF
--- a/lib/BackgroundJob/ShareMaintenanceJob.php
+++ b/lib/BackgroundJob/ShareMaintenanceJob.php
@@ -18,6 +18,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md#task-5
  */
 
 declare(strict_types=1);

--- a/lib/Controller/CaseSharingController.php
+++ b/lib/Controller/CaseSharingController.php
@@ -23,6 +23,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md#task-1
  */
 
 declare(strict_types=1);

--- a/lib/Controller/EmailController.php
+++ b/lib/Controller/EmailController.php
@@ -18,6 +18,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md#task-3
  */
 
 declare(strict_types=1);

--- a/lib/Controller/PublicShareController.php
+++ b/lib/Controller/PublicShareController.php
@@ -18,6 +18,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md#task-4
  */
 
 declare(strict_types=1);

--- a/lib/Service/CaseEmailService.php
+++ b/lib/Service/CaseEmailService.php
@@ -20,6 +20,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md#task-3
  */
 
 declare(strict_types=1);

--- a/lib/Service/CaseSharingService.php
+++ b/lib/Service/CaseSharingService.php
@@ -18,6 +18,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md#task-1
  */
 
 declare(strict_types=1);

--- a/lib/Service/CaseTransferService.php
+++ b/lib/Service/CaseTransferService.php
@@ -18,6 +18,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md#task-2
  */
 
 declare(strict_types=1);

--- a/openspec/changes/retrofit-2026-05-24-case-management/design.md
+++ b/openspec/changes/retrofit-2026-05-24-case-management/design.md
@@ -1,0 +1,11 @@
+# Design — retrofit case-management (sharing + transfer + email + public access)
+
+Retrofit change. Tasks describe retroactive annotation, not new implementation work. REQ numbers start at 101 to avoid collision with existing case-management REQs (the spec has 62 unnumbered named requirements; numbering this delta from 101 leaves room for future renumbering).
+
+## Method
+- File-level survey of public method names
+- Group 7 files into 5 cohesive REQs by domain action
+
+## Out of scope
+- Renumbering the existing 62 named requirements (separate cleanup)
+- Refactoring CaseEmailService to use the OpenRegister attachment API (planned in deelzaak-support follow-up)

--- a/openspec/changes/retrofit-2026-05-24-case-management/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-case-management/proposal.md
@@ -1,0 +1,18 @@
+# Retrofit — case-management (sharing + transfer + email surface)
+
+Describes observed behavior of 7 PHP files (~48 methods) implementing case-sharing, case-transfer, case-email, and public-share access as 5 new REQs in the case-management capability.
+
+## Affected code units
+- lib/Controller/CaseSharingController.php (5 methods) — share + transfer endpoints
+- lib/Service/CaseSharingService.php (12 methods) — token + partner share creation/revocation
+- lib/Service/CaseTransferService.php (5 methods) — case transfer/reassign
+- lib/Service/CaseEmailService.php (13 methods) — case-email rendering + dispatch
+- lib/Controller/EmailController.php (5 methods) — case-email API
+- lib/Controller/PublicShareController.php (6 methods) — public-token case access
+- lib/BackgroundJob/ShareMaintenanceJob.php (2 methods) — expire/cleanup of stale shares
+
+## Approach
+- File-level survey by class signature + public method shape
+- Group 7 files into 5 logical REQs (sharing controller + service, transfer service, email surface, public-token access, share-lifecycle maintenance)
+
+Source: openspec/coverage-report.md generated 2026-05-24. Tracks ConductionNL/procest#565.

--- a/openspec/changes/retrofit-2026-05-24-case-management/specs/case-management/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-case-management/specs/case-management/spec.md
@@ -1,0 +1,67 @@
+---
+retrofit_extensions:
+  - REQ-101
+  - REQ-102
+  - REQ-103
+  - REQ-104
+  - REQ-105
+---
+
+# Case Management — sharing + transfer + email + public access (retrofit)
+
+## Requirements
+
+### REQ-101: Procest SHALL expose case-sharing endpoints via CaseSharingController
+
+`OCA\Procest\Controller\CaseSharingController` SHALL provide REST endpoints to create, revoke, list and inspect case shares — both token-based (anonymous URL with secret) and partner-based (named Nextcloud user/group). Endpoints SHALL delegate state changes to `CaseSharingService` and SHALL enforce that the calling user has write authority on the case being shared.
+
+#### Scenario: Create token-based share
+- **WHEN** a behandelaar POSTs `/api/case-shares` with `{caseId, type: 'token', permissions: ['read', 'comment'], expiresAt}`
+- **THEN** the controller SHALL call `CaseSharingService::createTokenShare(...)`, which SHALL generate a cryptographically-random token via `generateToken()` and persist a Share record
+- **AND** the response SHALL include the share URL with the token embedded
+
+### REQ-102: CaseTransferService SHALL implement the case-transfer workflow
+
+`OCA\Procest\Service\CaseTransferService` SHALL manage the explicit case-handover workflow: a behandelaar initiates a transfer to another user, the target user accepts or rejects, and on accept the case ownership is reassigned. Rejected transfers SHALL preserve the original owner and SHALL be recorded in the case audit trail with the rejection reason.
+
+#### Scenario: Target user accepts a transfer
+- **GIVEN** behandelaar A has called `initiateTransfer($caseId, userB, 'Going on leave')` creating transfer T
+- **WHEN** user B calls `acceptTransfer(T.id)`
+- **THEN** the case behandelaar SHALL be set to userB, the transfer record SHALL be marked accepted, and an audit-trail entry SHALL record both timestamps and the reason
+
+#### Scenario: Target user rejects a transfer
+- **WHEN** user B calls `rejectTransfer(T.id, 'Out of scope')`
+- **THEN** the case behandelaar SHALL remain userA and the transfer record SHALL store the rejection reason
+
+### REQ-103: Procest SHALL render and dispatch case emails via CaseEmailService
+
+`OCA\Procest\Service\CaseEmailService` SHALL be the single entry point for sending case-context emails. It SHALL accept either a raw subject+body pair or a template id (resolving via the templates register), substitute case-payload variables via `resolveVariables()`, render the result, and dispatch via the underlying mail subsystem. Sent emails SHALL be persisted as an email record attached to the case so they appear in the case timeline.
+
+The `OCA\Procest\Controller\EmailController` SHALL expose the HTTP surface: `POST /api/cases/{id}/email/send`, `POST /api/cases/{id}/email/sendFromTemplate`, and `GET /api/cases/{id}/email/preview` (which renders without sending so the user can review).
+
+#### Scenario: Preview before send
+- **WHEN** a behandelaar calls `EmailController::preview($caseId)` with `{templateId, recipient}`
+- **THEN** the response SHALL contain the fully-rendered subject + body without any side effects
+
+### REQ-104: PublicShareController SHALL enforce token-scoped access to case data
+
+`OCA\Procest\Controller\PublicShareController` SHALL serve unauthenticated callers identifying themselves by share-token only. Each endpoint SHALL: (a) resolve the token via `CaseSharingService`, (b) reject if the share is expired or revoked, (c) restrict the operation to the permissions encoded on the share record (`read`, `comment`, `viewStatus`), and (d) NOT expose any case data outside the configured permissions.
+
+#### Scenario: Read-only share cannot add a comment
+- **GIVEN** an active share with permissions `['read']`
+- **WHEN** the holder calls `addComment(token)`
+- **THEN** the controller SHALL respond `403 Forbidden`
+
+#### Scenario: Expired share is rejected
+- **GIVEN** a share whose `expiresAt` is in the past
+- **WHEN** any `PublicShareController` endpoint is called with its token
+- **THEN** the controller SHALL respond `410 Gone` and the share SHALL NOT be auto-renewed
+
+### REQ-105: ShareMaintenanceJob SHALL expire and prune stale shares
+
+`OCA\Procest\BackgroundJob\ShareMaintenanceJob` SHALL run on the Nextcloud BackgroundJob schedule and: (a) mark token shares whose `expiresAt` is past as expired, (b) hard-delete shares older than the configured retention window, (c) close transfer records that have been pending past the configured timeout, returning the case ownership to the original behandelaar. The job SHALL be idempotent — re-running over a clean dataset SHALL be a no-op.
+
+#### Scenario: Expire a token share
+- **GIVEN** a Share with `expiresAt = now() - 1 hour` and status `active`
+- **WHEN** `ShareMaintenanceJob::run()` executes
+- **THEN** the Share SHALL be updated to status `expired`

--- a/openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-case-management/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] task-1: case-management#REQ-101 — CaseSharingController endpoints (retroactive annotation)
+- [x] task-2: case-management#REQ-102 — CaseTransferService transfer workflow (retroactive annotation)
+- [x] task-3: case-management#REQ-103 — CaseEmailService + EmailController (retroactive annotation)
+- [x] task-4: case-management#REQ-104 — PublicShareController token-scoped access (retroactive annotation)
+- [x] task-5: case-management#REQ-105 — ShareMaintenanceJob expiry + pruning (retroactive annotation)

--- a/openspec/specs/case-management/spec.md
+++ b/openspec/specs/case-management/spec.md
@@ -1,5 +1,11 @@
 ---
 status: implemented
+retrofit_extensions:
+  - REQ-101
+  - REQ-102
+  - REQ-103
+  - REQ-104
+  - REQ-105
 ---
 
 # Case Management Specification
@@ -955,6 +961,69 @@ The system MUST maintain a complete audit trail for all case modifications. The 
 - GIVEN a user creating a new case
 - WHEN the case is successfully created
 - THEN the audit trail MUST record: event type "case_created", user, timestamp, case type, initial status, calculated deadline
+
+---
+
+<!-- BEGIN retrofit-2026-05-24-case-management -->
+
+## Sharing, Transfer, Email & Public Access (retrofit)
+
+### REQ-101: Procest SHALL expose case-sharing endpoints via CaseSharingController
+
+`OCA\Procest\Controller\CaseSharingController` SHALL provide REST endpoints to create, revoke, list and inspect case shares — both token-based (anonymous URL with secret) and partner-based (named Nextcloud user/group). Endpoints SHALL delegate state changes to `CaseSharingService` and SHALL enforce that the calling user has write authority on the case being shared.
+
+#### Scenario: Create token-based share
+- **WHEN** a behandelaar POSTs `/api/case-shares` with `{caseId, type: 'token', permissions: ['read', 'comment'], expiresAt}`
+- **THEN** the controller SHALL call `CaseSharingService::createTokenShare(...)`, which SHALL generate a cryptographically-random token via `generateToken()` and persist a Share record
+- **AND** the response SHALL include the share URL with the token embedded
+
+### REQ-102: CaseTransferService SHALL implement the case-transfer workflow
+
+`OCA\Procest\Service\CaseTransferService` SHALL manage the explicit case-handover workflow: a behandelaar initiates a transfer to another user, the target user accepts or rejects, and on accept the case ownership is reassigned. Rejected transfers SHALL preserve the original owner and SHALL be recorded in the case audit trail with the rejection reason.
+
+#### Scenario: Target user accepts a transfer
+- **GIVEN** behandelaar A has called `initiateTransfer($caseId, userB, 'Going on leave')` creating transfer T
+- **WHEN** user B calls `acceptTransfer(T.id)`
+- **THEN** the case behandelaar SHALL be set to userB, the transfer record SHALL be marked accepted, and an audit-trail entry SHALL record both timestamps and the reason
+
+#### Scenario: Target user rejects a transfer
+- **WHEN** user B calls `rejectTransfer(T.id, 'Out of scope')`
+- **THEN** the case behandelaar SHALL remain userA and the transfer record SHALL store the rejection reason
+
+### REQ-103: Procest SHALL render and dispatch case emails via CaseEmailService
+
+`OCA\Procest\Service\CaseEmailService` SHALL be the single entry point for sending case-context emails. It SHALL accept either a raw subject+body pair or a template id (resolving via the templates register), substitute case-payload variables via `resolveVariables()`, render the result, and dispatch via the underlying mail subsystem. Sent emails SHALL be persisted as an email record attached to the case so they appear in the case timeline.
+
+The `OCA\Procest\Controller\EmailController` SHALL expose the HTTP surface: `POST /api/cases/{id}/email/send`, `POST /api/cases/{id}/email/sendFromTemplate`, and `GET /api/cases/{id}/email/preview` (which renders without sending so the user can review).
+
+#### Scenario: Preview before send
+- **WHEN** a behandelaar calls `EmailController::preview($caseId)` with `{templateId, recipient}`
+- **THEN** the response SHALL contain the fully-rendered subject + body without any side effects
+
+### REQ-104: PublicShareController SHALL enforce token-scoped access to case data
+
+`OCA\Procest\Controller\PublicShareController` SHALL serve unauthenticated callers identifying themselves by share-token only. Each endpoint SHALL: (a) resolve the token via `CaseSharingService`, (b) reject if the share is expired or revoked, (c) restrict the operation to the permissions encoded on the share record (`read`, `comment`, `viewStatus`), and (d) NOT expose any case data outside the configured permissions.
+
+#### Scenario: Read-only share cannot add a comment
+- **GIVEN** an active share with permissions `['read']`
+- **WHEN** the holder calls `addComment(token)`
+- **THEN** the controller SHALL respond `403 Forbidden`
+
+#### Scenario: Expired share is rejected
+- **GIVEN** a share whose `expiresAt` is in the past
+- **WHEN** any `PublicShareController` endpoint is called with its token
+- **THEN** the controller SHALL respond `410 Gone` and the share SHALL NOT be auto-renewed
+
+### REQ-105: ShareMaintenanceJob SHALL expire and prune stale shares
+
+`OCA\Procest\BackgroundJob\ShareMaintenanceJob` SHALL run on the Nextcloud BackgroundJob schedule and: (a) mark token shares whose `expiresAt` is past as expired, (b) hard-delete shares older than the configured retention window, (c) close transfer records that have been pending past the configured timeout, returning the case ownership to the original behandelaar. The job SHALL be idempotent — re-running over a clean dataset SHALL be a no-op.
+
+#### Scenario: Expire a token share
+- **GIVEN** a Share with `expiresAt = now() - 1 hour` and status `active`
+- **WHEN** `ShareMaintenanceJob::run()` executes
+- **THEN** the Share SHALL be updated to status `expired`
+
+<!-- END retrofit-2026-05-24-case-management -->
 
 ---
 


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Drafts 5 numbered REQs (REQ-101..REQ-105) describing the case-sharing, transfer, email and public-share surface within the case-management capability.

Ghost change: retrofit-2026-05-24-case-management (delta merged into openspec/specs/case-management/spec.md).

### REQ summary
- REQ-101 — CaseSharingController share endpoints
- REQ-102 — CaseTransferService transfer workflow
- REQ-103 — CaseEmailService + EmailController email surface
- REQ-104 — PublicShareController token-scoped access
- REQ-105 — ShareMaintenanceJob expiry + pruning

Source: openspec/coverage-report.md generated 2026-05-24 | Cluster: case-management

Refs #565