### PR TITLE
retrofit: reverse-spec signalering-widgets (3 REQs / 4 files)

### DIFF
--- a/lib/Dashboard/DeadlineAlertsWidget.php
+++ b/lib/Dashboard/DeadlineAlertsWidget.php
@@ -21,6 +21,9 @@
  * @link https://procest.nl
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-4
+ * @spec openspec/changes/retrofit-2026-05-24-signalering-widgets/tasks.md#task-1
+ * @spec openspec/changes/retrofit-2026-05-24-signalering-widgets/tasks.md#task-2
+ * @spec openspec/changes/retrofit-2026-05-24-signalering-widgets/tasks.md#task-3
  */
 
 declare(strict_types=1);

--- a/lib/Dashboard/OverdueCasesWidget.php
+++ b/lib/Dashboard/OverdueCasesWidget.php
@@ -20,6 +20,9 @@
  * @link https://procest.nl
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-4
+ * @spec openspec/changes/retrofit-2026-05-24-signalering-widgets/tasks.md#task-1
+ * @spec openspec/changes/retrofit-2026-05-24-signalering-widgets/tasks.md#task-2
+ * @spec openspec/changes/retrofit-2026-05-24-signalering-widgets/tasks.md#task-3
  */
 
 declare(strict_types=1);

--- a/lib/Dashboard/StalledCasesWidget.php
+++ b/lib/Dashboard/StalledCasesWidget.php
@@ -21,6 +21,9 @@
  * @link https://procest.nl
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-4
+ * @spec openspec/changes/retrofit-2026-05-24-signalering-widgets/tasks.md#task-1
+ * @spec openspec/changes/retrofit-2026-05-24-signalering-widgets/tasks.md#task-2
+ * @spec openspec/changes/retrofit-2026-05-24-signalering-widgets/tasks.md#task-3
  */
 
 declare(strict_types=1);

--- a/lib/Dashboard/TaskRemindersWidget.php
+++ b/lib/Dashboard/TaskRemindersWidget.php
@@ -21,6 +21,9 @@
  * @link https://procest.nl
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-4
+ * @spec openspec/changes/retrofit-2026-05-24-signalering-widgets/tasks.md#task-1
+ * @spec openspec/changes/retrofit-2026-05-24-signalering-widgets/tasks.md#task-2
+ * @spec openspec/changes/retrofit-2026-05-24-signalering-widgets/tasks.md#task-3
  */
 
 declare(strict_types=1);

--- a/openspec/changes/retrofit-2026-05-24-signalering-widgets/design.md
+++ b/openspec/changes/retrofit-2026-05-24-signalering-widgets/design.md
@@ -1,0 +1,6 @@
+# Design — retrofit signalering-widgets
+
+Retrofit change. Tasks describe retroactive annotation. Four IWidget implementations share an identical method shape, so a single REQ per concern (contract, load, registration) covers all 4 files.
+
+## Out of scope
+- Adding the Vue components to the spec — they live in src/views/widgets and are covered by the existing Bucket 3 frontend assumption.

--- a/openspec/changes/retrofit-2026-05-24-signalering-widgets/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-signalering-widgets/proposal.md
@@ -1,0 +1,16 @@
+# Retrofit — signalering-widgets
+
+Describes observed behavior of 4 Nextcloud `IWidget` implementations (DeadlineAlerts, OverdueCases, StalledCases, TaskReminders) as 3 new REQs covering the widget class contract, data-loading lifecycle, and dashboard wiring.
+
+## Affected code units
+- lib/Dashboard/DeadlineAlertsWidget.php (7 methods)
+- lib/Dashboard/OverdueCasesWidget.php (7 methods)
+- lib/Dashboard/StalledCasesWidget.php (7 methods)
+- lib/Dashboard/TaskRemindersWidget.php (7 methods)
+
+## Approach
+- All 4 widgets implement `OCP\Dashboard\IWidget` with the same method shape
+- One REQ per cross-cutting concern (class contract, load lifecycle, dashboard wiring)
+- Bucket-1 file-level `@spec` already in place; this retrofit adds the per-task pointers
+
+Source: openspec/coverage-report.md generated 2026-05-24. Tracks ConductionNL/procest#565.

--- a/openspec/changes/retrofit-2026-05-24-signalering-widgets/specs/signalering-widgets/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-signalering-widgets/specs/signalering-widgets/spec.md
@@ -1,0 +1,36 @@
+---
+retrofit_extensions:
+  - REQ-001
+  - REQ-002
+  - REQ-003
+---
+
+# Signalering Widgets — IWidget implementation shape (retrofit)
+
+## Requirements
+
+### REQ-001: Each signalering widget SHALL implement Nextcloud IWidget with id/title/order/icon/url metadata
+
+Each of `DeadlineAlertsWidget`, `OverdueCasesWidget`, `StalledCasesWidget`, and `TaskRemindersWidget` SHALL implement `OCP\Dashboard\IWidget` and expose the canonical metadata via `getId()`, `getTitle()`, `getOrder()`, `getIconClass()`, and `getUrl()`. The widget id SHALL be a stable kebab-case identifier (`procest-deadline-alerts`, `procest-overdue-cases`, `procest-stalled-cases`, `procest-task-reminders`) used by both the Nextcloud dashboard registry and the in-app `widgetDefs` map. The title SHALL be returned through `IL10N::t()` so it follows the user locale.
+
+#### Scenario: Widget id is stable for layout persistence
+- **WHEN** `DeadlineAlertsWidget::getId()` is called
+- **THEN** it SHALL return `'procest-deadline-alerts'` (verbatim, not derived from class name)
+- **AND** the same id SHALL be used in `DEFAULT_LAYOUT` row 3 so saved user layouts stay valid across deployments
+
+### REQ-002: Each signalering widget SHALL register its frontend bundle via load()
+
+`IWidget::load()` SHALL call `Util::addScript('procest', '<widget>-main')` and `Util::addStyle('procest', '<widget>-main')` for the widget's compiled Vue bundle. The widget SHALL NOT compute its data payload server-side in PHP — the Vue component fetches data via the Procest API after mounting. The PHP class exists solely to register the widget with Nextcloud's dashboard system and load the frontend bundle.
+
+#### Scenario: Widget bundle is loaded when dashboard is opened
+- **WHEN** a user opens the Nextcloud Dashboard with the Deadline Alerts widget in their layout
+- **THEN** `DeadlineAlertsWidget::load()` SHALL run and the `deadlineAlertsWidget-main.js` + `.css` bundles SHALL be added to the page
+
+### REQ-003: All four signalering widgets SHALL be registered at app boot via Application
+
+`OCA\Procest\AppInfo\Application::register()` SHALL register all four signalering widgets with the Nextcloud dashboard container so they appear in the dashboard widget picker. Registration order in `Application` SHALL match the canonical `getOrder()` return values to avoid layout drift between dashboard picker and saved user layouts.
+
+#### Scenario: Widgets appear in the dashboard picker
+- **WHEN** an authenticated user opens the dashboard widget picker
+- **THEN** all four signalering widgets SHALL be listed and clickable
+- **AND** each widget's icon + title SHALL match its `getIconClass()` + `getTitle()` return values

--- a/openspec/changes/retrofit-2026-05-24-signalering-widgets/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-signalering-widgets/tasks.md
@@ -1,0 +1,5 @@
+# Tasks
+
+- [x] task-1: signalering-widgets#REQ-001 — IWidget metadata contract (retroactive annotation)
+- [x] task-2: signalering-widgets#REQ-002 — load() registers frontend bundle (retroactive annotation)
+- [x] task-3: signalering-widgets#REQ-003 — Application.register() boot-time registration (retroactive annotation)

--- a/openspec/specs/signalering-widgets/spec.md
+++ b/openspec/specs/signalering-widgets/spec.md
@@ -1,3 +1,10 @@
+---
+retrofit_extensions:
+  - REQ-001
+  - REQ-002
+  - REQ-003
+---
+
 # Signalering Widgets Specification
 
 ## Purpose
@@ -159,6 +166,36 @@ The existing dashboard layout SHALL be extended to include the signalering widge
 - **WHEN** signalering widgets are displayed
 - **THEN** they MUST use the CnDashboardPage grid system with proper widgetId and slot names
 - **THEN** users MUST be able to rearrange them like other dashboard widgets
+
+<!-- BEGIN retrofit-2026-05-24-signalering-widgets -->
+
+### REQ-001: Each signalering widget SHALL implement Nextcloud IWidget with id/title/order/icon/url metadata
+
+Each of `DeadlineAlertsWidget`, `OverdueCasesWidget`, `StalledCasesWidget`, and `TaskRemindersWidget` SHALL implement `OCP\Dashboard\IWidget` and expose the canonical metadata via `getId()`, `getTitle()`, `getOrder()`, `getIconClass()`, and `getUrl()`. The widget id SHALL be a stable kebab-case identifier (`procest-deadline-alerts`, `procest-overdue-cases`, `procest-stalled-cases`, `procest-task-reminders`) used by both the Nextcloud dashboard registry and the in-app `widgetDefs` map. The title SHALL be returned through `IL10N::t()` so it follows the user locale.
+
+#### Scenario: Widget id is stable for layout persistence
+- **WHEN** `DeadlineAlertsWidget::getId()` is called
+- **THEN** it SHALL return `'procest-deadline-alerts'` (verbatim, not derived from class name)
+- **AND** the same id SHALL be used in `DEFAULT_LAYOUT` row 3 so saved user layouts stay valid across deployments
+
+### REQ-002: Each signalering widget SHALL register its frontend bundle via load()
+
+`IWidget::load()` SHALL call `Util::addScript('procest', '<widget>-main')` and `Util::addStyle('procest', '<widget>-main')` for the widget's compiled Vue bundle. The widget SHALL NOT compute its data payload server-side in PHP — the Vue component fetches data via the Procest API after mounting. The PHP class exists solely to register the widget with Nextcloud's dashboard system and load the frontend bundle.
+
+#### Scenario: Widget bundle is loaded when dashboard is opened
+- **WHEN** a user opens the Nextcloud Dashboard with the Deadline Alerts widget in their layout
+- **THEN** `DeadlineAlertsWidget::load()` SHALL run and the `deadlineAlertsWidget-main.js` + `.css` bundles SHALL be added to the page
+
+### REQ-003: All four signalering widgets SHALL be registered at app boot via Application
+
+`OCA\Procest\AppInfo\Application::register()` SHALL register all four signalering widgets with the Nextcloud dashboard container so they appear in the dashboard widget picker. Registration order in `Application` SHALL match the canonical `getOrder()` return values to avoid layout drift between dashboard picker and saved user layouts.
+
+#### Scenario: Widgets appear in the dashboard picker
+- **WHEN** an authenticated user opens the dashboard widget picker
+- **THEN** all four signalering widgets SHALL be listed and clickable
+- **AND** each widget's icon + title SHALL match its `getIconClass()` + `getTitle()` return values
+
+<!-- END retrofit-2026-05-24-signalering-widgets -->
 
 ## Non-Functional Requirements
 


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Drafts 3 numbered REQs covering the 4 IWidget implementations under signalering-widgets.

Ghost change: retrofit-2026-05-24-signalering-widgets (delta merged).

### REQ summary
- REQ-001 — IWidget metadata contract (id/title/order/icon/url)
- REQ-002 — load() registers the frontend bundle
- REQ-003 — Application boot-time registration

Source: openspec/coverage-report.md generated 2026-05-24 | Cluster: signalering-widgets

Refs #565