### PR TITLE
retrofit: reverse-spec dashboard (3 REQs / 4 files)

### DIFF
--- a/lib/Controller/DashboardController.php
+++ b/lib/Controller/DashboardController.php
@@ -20,6 +20,7 @@
  * @link https://procest.nl
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-5
+ * @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md#task-2
  */
 
 declare(strict_types=1);

--- a/lib/Dashboard/CasesOverviewWidget.php
+++ b/lib/Dashboard/CasesOverviewWidget.php
@@ -20,6 +20,8 @@
  * @link https://procest.nl
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-5
+ * @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md#task-1
+ * @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md#task-3
  */
 
 declare(strict_types=1);

--- a/lib/Dashboard/MyTasksWidget.php
+++ b/lib/Dashboard/MyTasksWidget.php
@@ -20,6 +20,8 @@
  * @link https://procest.nl
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-5
+ * @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md#task-1
+ * @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md#task-3
  */
 
 declare(strict_types=1);

--- a/lib/Dashboard/StartCaseWidget.php
+++ b/lib/Dashboard/StartCaseWidget.php
@@ -20,6 +20,8 @@
  * @link https://procest.nl
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-5
+ * @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md#task-1
+ * @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md#task-3
  */
 
 declare(strict_types=1);

--- a/openspec/changes/retrofit-2026-05-24-dashboard/design.md
+++ b/openspec/changes/retrofit-2026-05-24-dashboard/design.md
@@ -1,0 +1,7 @@
+# Design — retrofit dashboard
+
+Retrofit change. Tasks describe retroactive annotation. Three IWidget files share the same shape covered by signalering-widgets REQ-001; this delta focuses on the workflow-widget set + DashboardController.
+
+## Out of scope
+- KPI computation (covered by add-server-side-kpi-aggregation, already linked via openspec_changes)
+- Vue dashboard composition (frontend; not in this PHP scan)

--- a/openspec/changes/retrofit-2026-05-24-dashboard/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-dashboard/proposal.md
@@ -1,0 +1,15 @@
+# Retrofit — dashboard
+
+Describes observed behavior of 4 PHP files (~23 methods) — the three remaining Nextcloud dashboard widgets (CasesOverview, MyTasks, StartCase) plus the in-app `DashboardController` — as 3 new REQs (REQ-DASH-016..018) extending the dashboard capability.
+
+## Affected code units
+- lib/Dashboard/CasesOverviewWidget.php (7 methods)
+- lib/Dashboard/MyTasksWidget.php (7 methods)
+- lib/Dashboard/StartCaseWidget.php (7 methods)
+- lib/Controller/DashboardController.php (2 methods)
+
+## Approach
+- File-level survey; all 3 widgets share the IWidget shape covered by signalering-widgets REQ-001
+- One REQ for the widget set, one for the controller API surface, one for boot-time registration
+
+Source: openspec/coverage-report.md generated 2026-05-24. Tracks ConductionNL/procest#565.

--- a/openspec/changes/retrofit-2026-05-24-dashboard/specs/dashboard/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-dashboard/specs/dashboard/spec.md
@@ -1,0 +1,34 @@
+---
+retrofit_extensions:
+  - REQ-DASH-016
+  - REQ-DASH-017
+  - REQ-DASH-018
+---
+
+# Dashboard — widget + controller surface (retrofit)
+
+## Requirements
+
+### REQ-DASH-016: The Nextcloud dashboard SHALL provide CasesOverview, MyTasks and StartCase widgets
+
+`CasesOverviewWidget`, `MyTasksWidget` and `StartCaseWidget` SHALL each implement `OCP\Dashboard\IWidget` with stable kebab-case ids (`procest-cases-overview`, `procest-my-tasks`, `procest-start-case`), localised titles via `IL10N::t()`, deterministic `getOrder()` return values, MDI-style `getIconClass()`, and an in-app `getUrl()` deep link. Each widget's `load()` SHALL register the corresponding webpack-built Vue bundle via `Util::addScript()` + `Util::addStyle()` — no server-side data computation in PHP.
+
+#### Scenario: StartCase widget exposes deep-link to the case-creation flow
+- **WHEN** a user clicks the Start Case widget tile
+- **THEN** the dashboard SHALL navigate to the URL returned by `StartCaseWidget::getUrl()` (which deep-links to `/cases/new`)
+
+### REQ-DASH-017: DashboardController SHALL expose the in-app dashboard data endpoints
+
+`OCA\Procest\Controller\DashboardController` SHALL serve the in-app dashboard surface (not the Nextcloud dashboard system, which is widget-driven and loads client-side). The controller SHALL provide endpoints for the dashboard landing-page Vue to fetch its initial state (KPIs, layout, widget data) so the SPA can render without spinning up multiple per-widget HTTP requests.
+
+#### Scenario: Initial dashboard payload
+- **WHEN** an authenticated user opens the in-app dashboard (`/dashboard`)
+- **THEN** `DashboardController` SHALL respond with a single payload containing the user's saved layout plus the data each widget needs to render its first frame
+
+### REQ-DASH-018: All three workflow widgets SHALL be registered at app boot via Application
+
+`OCA\Procest\AppInfo\Application::register()` SHALL register `CasesOverviewWidget`, `MyTasksWidget`, and `StartCaseWidget` with the Nextcloud dashboard container so they appear in the dashboard widget picker. Registration order SHALL match the canonical `getOrder()` return values.
+
+#### Scenario: Widgets appear in the dashboard picker
+- **WHEN** an authenticated user opens the dashboard widget picker
+- **THEN** all three workflow widgets SHALL be listed alongside the signalering widgets

--- a/openspec/changes/retrofit-2026-05-24-dashboard/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-dashboard/tasks.md
@@ -1,0 +1,5 @@
+# Tasks
+
+- [x] task-1: dashboard#REQ-DASH-016 — CasesOverview/MyTasks/StartCase IWidget implementations (retroactive annotation)
+- [x] task-2: dashboard#REQ-DASH-017 — DashboardController in-app dashboard data endpoints (retroactive annotation)
+- [x] task-3: dashboard#REQ-DASH-018 — Application boot-time widget registration (retroactive annotation)

--- a/openspec/specs/dashboard/spec.md
+++ b/openspec/specs/dashboard/spec.md
@@ -2,6 +2,10 @@
 status: implemented
 openspec_changes:
   - add-server-side-kpi-aggregation
+retrofit_extensions:
+  - REQ-DASH-016
+  - REQ-DASH-017
+  - REQ-DASH-018
 ---
 
 # Dashboard Specification
@@ -528,3 +532,33 @@ The system MUST register three Nextcloud-native dashboard widgets for display on
 - **Nextcloud Activity API (`OCP\Activity\IManager`)**: Activity feed data source (mentioned in spec, `ActivityFeed.vue` component exists).
 - **GEMMA**: Dashboard follows zaakgericht werken management information patterns.
 - **Competitor reference**: Dimpact ZAC provides a dashboard with case counts, overdue warnings, and team workload views. Flowable Platform includes case KPI dashboards with SLA compliance metrics and workload distribution.
+
+<!-- BEGIN retrofit-2026-05-24-dashboard -->
+
+## Widget Implementation Surface (retrofit)
+
+### REQ-DASH-016: The Nextcloud dashboard SHALL provide CasesOverview, MyTasks and StartCase widgets
+
+`CasesOverviewWidget`, `MyTasksWidget` and `StartCaseWidget` SHALL each implement `OCP\Dashboard\IWidget` with stable kebab-case ids (`procest-cases-overview`, `procest-my-tasks`, `procest-start-case`), localised titles via `IL10N::t()`, deterministic `getOrder()` return values, MDI-style `getIconClass()`, and an in-app `getUrl()` deep link. Each widget's `load()` SHALL register the corresponding webpack-built Vue bundle via `Util::addScript()` + `Util::addStyle()` — no server-side data computation in PHP.
+
+#### Scenario: StartCase widget exposes deep-link to the case-creation flow
+- **WHEN** a user clicks the Start Case widget tile
+- **THEN** the dashboard SHALL navigate to the URL returned by `StartCaseWidget::getUrl()` (which deep-links to `/cases/new`)
+
+### REQ-DASH-017: DashboardController SHALL expose the in-app dashboard data endpoints
+
+`OCA\Procest\Controller\DashboardController` SHALL serve the in-app dashboard surface (not the Nextcloud dashboard system, which is widget-driven and loads client-side). The controller SHALL provide endpoints for the dashboard landing-page Vue to fetch its initial state (KPIs, layout, widget data) so the SPA can render without spinning up multiple per-widget HTTP requests.
+
+#### Scenario: Initial dashboard payload
+- **WHEN** an authenticated user opens the in-app dashboard (`/dashboard`)
+- **THEN** `DashboardController` SHALL respond with a single payload containing the user's saved layout plus the data each widget needs to render its first frame
+
+### REQ-DASH-018: All three workflow widgets SHALL be registered at app boot via Application
+
+`OCA\Procest\AppInfo\Application::register()` SHALL register `CasesOverviewWidget`, `MyTasksWidget`, and `StartCaseWidget` with the Nextcloud dashboard container so they appear in the dashboard widget picker. Registration order SHALL match the canonical `getOrder()` return values.
+
+#### Scenario: Widgets appear in the dashboard picker
+- **WHEN** an authenticated user opens the dashboard widget picker
+- **THEN** all three workflow widgets SHALL be listed alongside the signalering widgets
+
+<!-- END retrofit-2026-05-24-dashboard -->


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Drafts 3 numbered REQs (REQ-DASH-016..018) describing the CasesOverview/MyTasks/StartCase widgets + DashboardController.

Ghost change: retrofit-2026-05-24-dashboard (delta merged).

Source: openspec/coverage-report.md generated 2026-05-24 | Cluster: dashboard

Refs #565