### PR TITLE
retrofit: reverse-spec case-types export/import (2 REQs / 3 files)

### DIFF
--- a/lib/Controller/CaseDefinitionController.php
+++ b/lib/Controller/CaseDefinitionController.php
@@ -21,6 +21,8 @@
  * @link https://procest.nl
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-3
+ * @spec openspec/changes/retrofit-2026-05-24-case-types/tasks.md#task-1
+ * @spec openspec/changes/retrofit-2026-05-24-case-types/tasks.md#task-2
  */
 
 declare(strict_types=1);

--- a/lib/Service/CaseDefinitionExportService.php
+++ b/lib/Service/CaseDefinitionExportService.php
@@ -21,6 +21,7 @@
  * @link https://procest.nl
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-3
+ * @spec openspec/changes/retrofit-2026-05-24-case-types/tasks.md#task-1
  */
 
 declare(strict_types=1);

--- a/lib/Service/CaseDefinitionImportService.php
+++ b/lib/Service/CaseDefinitionImportService.php
@@ -21,6 +21,7 @@
  * @link https://procest.nl
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-3
+ * @spec openspec/changes/retrofit-2026-05-24-case-types/tasks.md#task-2
  */
 
 declare(strict_types=1);

--- a/openspec/changes/retrofit-2026-05-24-case-types/design.md
+++ b/openspec/changes/retrofit-2026-05-24-case-types/design.md
@@ -1,0 +1,7 @@
+# Design — retrofit case-types
+
+Retrofit change. Tasks describe retroactive annotation. The case-types spec already has REQ-CT-01..REQ-CT-16 covering the CRUD/lifecycle surface; this delta adds the export/import portability surface as REQ-CT-17 + REQ-CT-18.
+
+## Out of scope
+- Cross-instance versioning / sync (separate concern; would need a new capability)
+- Frontend import UI (covered by case-types REQ-CT-15 admin tab work)

--- a/openspec/changes/retrofit-2026-05-24-case-types/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-case-types/proposal.md
@@ -1,0 +1,14 @@
+# Retrofit — case-types
+
+Describes observed behavior of the case-type export/import surface (3 files / 14 methods) as 2 new REQs (REQ-CT-17, REQ-CT-18) extending the case-types capability.
+
+## Affected code units
+- lib/Controller/CaseDefinitionController.php (4 methods) — export/validate/import endpoints
+- lib/Service/CaseDefinitionExportService.php (5 methods) — ZIP package builder
+- lib/Service/CaseDefinitionImportService.php (5 methods) — ZIP package validator + importer
+
+## Approach
+- File-level survey
+- Two REQs: (1) HTTP surface + ZIP export, (2) ZIP validation + import
+
+Source: openspec/coverage-report.md generated 2026-05-24. Tracks ConductionNL/procest#565.

--- a/openspec/changes/retrofit-2026-05-24-case-types/specs/case-types/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-case-types/specs/case-types/spec.md
@@ -1,0 +1,30 @@
+---
+retrofit_extensions:
+  - REQ-CT-17
+  - REQ-CT-18
+---
+
+# Case Types — export/import surface (retrofit)
+
+## Requirements
+
+### REQ-CT-17: Procest SHALL expose case-definition export endpoints + ZIP package format
+
+`OCA\Procest\Controller\CaseDefinitionController` SHALL provide `GET /api/case-definitions/{id}/export` that returns a ZIP package (via `DataDownloadResponse`) containing the case type and all linked dependencies (workflow templates, role/group mappings, document templates) needed for round-trip portability to another procest instance. The ZIP SHALL be produced by `CaseDefinitionExportService::exportCaseDefinition()` and SHALL embed a `manifest.json` describing the package schema version, source instance, and contained object refs.
+
+#### Scenario: Export a published case type
+- **GIVEN** a published case type with workflow templates + roles
+- **WHEN** a behandelaar calls `GET /api/case-definitions/{id}/export`
+- **THEN** the response SHALL be a ZIP download containing `case-type.json`, all linked `workflow-template-*.json` files, role/group mapping definitions, and a top-level `manifest.json`
+
+### REQ-CT-18: Procest SHALL validate + import case-definition packages with explicit conflict reporting
+
+`CaseDefinitionImportService::validatePackage()` SHALL inspect a ZIP package, parse `manifest.json`, and return a structured report of: (a) missing required files, (b) schema-version compatibility, (c) name/slug collisions against existing case types and templates, and (d) cross-reference integrity. Validation SHALL be a pure read — no side effects on the procest instance.
+
+`CaseDefinitionImportService::importCaseDefinition()` SHALL run validation first, then create the case type and all linked objects atomically. On collision, the importer SHALL accept a caller-provided `conflictResolution` mode (`reject`, `rename`, `replace`) and SHALL surface its decisions in the response so the admin can audit what was created versus replaced.
+
+`CaseDefinitionController::validate()` SHALL expose validation-only HTTP access (`POST /api/case-definitions/import?dryRun=true`) so admins can review a package before committing.
+
+#### Scenario: Dry-run validates without persisting
+- **WHEN** an admin calls `POST /api/case-definitions/import?dryRun=true` with a ZIP body
+- **THEN** the response SHALL include the structured validation report and no objects SHALL be created

--- a/openspec/changes/retrofit-2026-05-24-case-types/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-case-types/tasks.md
@@ -1,0 +1,4 @@
+# Tasks
+
+- [x] task-1: case-types#REQ-CT-17 — Export endpoint + ZIP package format (retroactive annotation)
+- [x] task-2: case-types#REQ-CT-18 — Validate + import with conflict resolution (retroactive annotation)

--- a/openspec/specs/case-types/spec.md
+++ b/openspec/specs/case-types/spec.md
@@ -1,5 +1,8 @@
 ---
 status: implemented
+retrofit_extensions:
+  - REQ-CT-17
+  - REQ-CT-18
 ---
 
 # Case Type System Specification
@@ -964,3 +967,28 @@ Each case type SHALL include its associated:
 1. Should editing a published case type require unpublishing first, or can it be edited in-place with a warning?
 2. How should the system handle changes to a case type that affect existing cases (e.g., removing a status type that cases are currently at)?
 3. Should the `subCaseTypes` field enforce a tree structure (no cycles) and how is this validated?
+
+<!-- BEGIN retrofit-2026-05-24-case-types -->
+
+### REQ-CT-17: Procest SHALL expose case-definition export endpoints + ZIP package format
+
+`OCA\Procest\Controller\CaseDefinitionController` SHALL provide `GET /api/case-definitions/{id}/export` that returns a ZIP package (via `DataDownloadResponse`) containing the case type and all linked dependencies (workflow templates, role/group mappings, document templates) needed for round-trip portability to another procest instance. The ZIP SHALL be produced by `CaseDefinitionExportService::exportCaseDefinition()` and SHALL embed a `manifest.json` describing the package schema version, source instance, and contained object refs.
+
+#### Scenario: Export a published case type
+- **GIVEN** a published case type with workflow templates + roles
+- **WHEN** a behandelaar calls `GET /api/case-definitions/{id}/export`
+- **THEN** the response SHALL be a ZIP download containing `case-type.json`, all linked `workflow-template-*.json` files, role/group mapping definitions, and a top-level `manifest.json`
+
+### REQ-CT-18: Procest SHALL validate + import case-definition packages with explicit conflict reporting
+
+`CaseDefinitionImportService::validatePackage()` SHALL inspect a ZIP package, parse `manifest.json`, and return a structured report of: (a) missing required files, (b) schema-version compatibility, (c) name/slug collisions against existing case types and templates, and (d) cross-reference integrity. Validation SHALL be a pure read — no side effects on the procest instance.
+
+`CaseDefinitionImportService::importCaseDefinition()` SHALL run validation first, then create the case type and all linked objects atomically. On collision, the importer SHALL accept a caller-provided `conflictResolution` mode (`reject`, `rename`, `replace`) and SHALL surface its decisions in the response so the admin can audit what was created versus replaced.
+
+`CaseDefinitionController::validate()` SHALL expose validation-only HTTP access (`POST /api/case-definitions/import?dryRun=true`) so admins can review a package before committing.
+
+#### Scenario: Dry-run validates without persisting
+- **WHEN** an admin calls `POST /api/case-definitions/import?dryRun=true` with a ZIP body
+- **THEN** the response SHALL include the structured validation report and no objects SHALL be created
+
+<!-- END retrofit-2026-05-24-case-types -->


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Drafts 2 numbered REQs (REQ-CT-17, REQ-CT-18) describing the case-definition export/import surface.

Ghost change: retrofit-2026-05-24-case-types (delta merged).

Source: openspec/coverage-report.md generated 2026-05-24 | Cluster: case-types

Refs #565