### PR TITLE
retrofit: reverse-spec workflow-definition-model (3 REQs / 3 files)

### DIFF
--- a/lib/Controller/WorkflowDefinitionController.php
+++ b/lib/Controller/WorkflowDefinitionController.php
@@ -22,6 +22,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-workflow-definition-model/tasks.md#task-1
  */
 
 declare(strict_types=1);

--- a/lib/Repair/MigrateWorkflowDefinitions.php
+++ b/lib/Repair/MigrateWorkflowDefinitions.php
@@ -21,6 +21,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-workflow-definition-model/tasks.md#task-3
  */
 
 declare(strict_types=1);

--- a/lib/Service/WorkflowDefinitionService.php
+++ b/lib/Service/WorkflowDefinitionService.php
@@ -45,6 +45,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-workflow-definition-model/tasks.md#task-2
  */
 
 declare(strict_types=1);

--- a/openspec/changes/retrofit-2026-05-24-workflow-definition-model/design.md
+++ b/openspec/changes/retrofit-2026-05-24-workflow-definition-model/design.md
@@ -1,0 +1,6 @@
+# Design — retrofit workflow-definition-model
+
+Retrofit change. Tasks describe retroactive annotation.
+
+## Out of scope
+- Removing MigrateWorkflowDefinitions (deferred until all deployments confirmed past the migration window)

--- a/openspec/changes/retrofit-2026-05-24-workflow-definition-model/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-workflow-definition-model/proposal.md
@@ -1,0 +1,10 @@
+# Retrofit — workflow-definition-model
+
+Describes observed behavior of 3 PHP files (~33 methods) — controller, service, migration repair — as 3 new REQs covering the workflow definition lifecycle implementation.
+
+## Affected code units
+- lib/Controller/WorkflowDefinitionController.php (6 methods) — publish/deprecate/clone + lookups
+- lib/Service/WorkflowDefinitionService.php (20 methods) — full lifecycle service
+- lib/Repair/MigrateWorkflowDefinitions.php (7 methods) — data-migration helper
+
+Source: openspec/coverage-report.md generated 2026-05-24. Tracks ConductionNL/procest#565.

--- a/openspec/changes/retrofit-2026-05-24-workflow-definition-model/specs/workflow-definition-model/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-workflow-definition-model/specs/workflow-definition-model/spec.md
@@ -1,0 +1,39 @@
+---
+retrofit_extensions:
+  - REQ-001
+  - REQ-002
+  - REQ-003
+---
+
+# Workflow Definition Model — implementation surface (retrofit)
+
+## Requirements
+
+### REQ-001: WorkflowDefinitionController SHALL expose lifecycle + lookup endpoints
+
+`OCA\Procest\Controller\WorkflowDefinitionController` SHALL provide HTTP endpoints for: `publish($id)` (move draft → active), `deprecate($id)` (active → deprecated), `cloneDefinition($id)` (create new draft from existing), `active($caseTypeId)` (lookup currently-active version for a case type), and `forCase($caseId)` (lookup version bound to a specific case). Each endpoint SHALL delegate to `WorkflowDefinitionService` and SHALL reject lifecycle transitions that violate the draft → active → deprecated state machine.
+
+#### Scenario: Publish a draft
+- **WHEN** `POST /api/workflow-definitions/{id}/publish` is called on a draft definition
+- **THEN** the definition's status SHALL flip to active and any previously-active version for the same case type SHALL be auto-deprecated
+
+### REQ-002: WorkflowDefinitionService SHALL implement the full lifecycle + version selection
+
+`OCA\Procest\Service\WorkflowDefinitionService` SHALL provide the canonical version-selection logic (`getActiveDefinitionFor($caseTypeId)`, `getDefinitionForCase($caseId)`, `listVersions($caseTypeId)`) and the full lifecycle (`createDraft`, `publish`, `deprecate`, `cloneDefinition`, `getDefinition`). Version selection SHALL be deterministic: at most one active version per case type at any time; a case bound to a specific version SHALL continue to use that version even after a newer one is published (versions, not branches).
+
+#### Scenario: Existing case keeps its bound version after a new one is published
+- **GIVEN** case C bound to workflow version v1
+- **WHEN** v2 is published for the same case type
+- **THEN** `getDefinitionForCase(C.id)` SHALL still return v1 and only newly-created cases SHALL be bound to v2
+
+### REQ-003: MigrateWorkflowDefinitions SHALL be a one-shot repair step for legacy data
+
+`OCA\Procest\Repair\MigrateWorkflowDefinitions` SHALL run as a Nextcloud repair step that detects legacy inline workflow definitions on case-type records and lifts them into stand-alone workflow definition entities. The repair step SHALL be idempotent: on a fully-migrated dataset it SHALL be a no-op, and re-running it SHALL NOT duplicate definitions.
+
+#### Scenario: Idempotent re-run
+- **GIVEN** a procest instance where MigrateWorkflowDefinitions has already run
+- **WHEN** `MigrateWorkflowDefinitions::run($output)` runs again
+- **THEN** no new workflow definitions SHALL be created and the output SHALL log the no-op
+
+Notes
+- Once every active deployment is past the migration window, this repair step is a candidate for removal in a future cleanup spec.

--- a/openspec/changes/retrofit-2026-05-24-workflow-definition-model/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-workflow-definition-model/tasks.md
@@ -1,0 +1,5 @@
+# Tasks
+
+- [x] task-1: workflow-definition-model#REQ-001 — WorkflowDefinitionController lifecycle + lookups (retroactive annotation)
+- [x] task-2: workflow-definition-model#REQ-002 — WorkflowDefinitionService canonical version selection (retroactive annotation)
+- [x] task-3: workflow-definition-model#REQ-003 — MigrateWorkflowDefinitions one-shot legacy migration (retroactive annotation)

--- a/openspec/specs/workflow-definition-model/spec.md
+++ b/openspec/specs/workflow-definition-model/spec.md
@@ -1,3 +1,10 @@
+---
+retrofit_extensions:
+  - REQ-001
+  - REQ-002
+  - REQ-003
+---
+
 ## Requirements
 
 ### Requirement: Workflow Template Data Model
@@ -167,3 +174,36 @@ The system SHALL provide a pre-seeded workflow template for the Beroep case type
 - **THEN** a workflow template SHALL exist for the Beroep case type
 - **AND** the template SHALL contain all defined transitions
 - **AND** the template SHALL be published (isDraft: false, isActive: true)
+
+<!-- BEGIN retrofit-2026-05-24-workflow-definition-model -->
+
+### REQ-001: WorkflowDefinitionController SHALL expose lifecycle + lookup endpoints
+
+`OCA\Procest\Controller\WorkflowDefinitionController` SHALL provide HTTP endpoints for: `publish($id)` (move draft → active), `deprecate($id)` (active → deprecated), `cloneDefinition($id)` (create new draft from existing), `active($caseTypeId)` (lookup currently-active version for a case type), and `forCase($caseId)` (lookup version bound to a specific case). Each endpoint SHALL delegate to `WorkflowDefinitionService` and SHALL reject lifecycle transitions that violate the draft → active → deprecated state machine.
+
+#### Scenario: Publish a draft
+- **WHEN** `POST /api/workflow-definitions/{id}/publish` is called on a draft definition
+- **THEN** the definition's status SHALL flip to active and any previously-active version for the same case type SHALL be auto-deprecated
+
+### REQ-002: WorkflowDefinitionService SHALL implement the full lifecycle + version selection
+
+`OCA\Procest\Service\WorkflowDefinitionService` SHALL provide the canonical version-selection logic (`getActiveDefinitionFor($caseTypeId)`, `getDefinitionForCase($caseId)`, `listVersions($caseTypeId)`) and the full lifecycle (`createDraft`, `publish`, `deprecate`, `cloneDefinition`, `getDefinition`). Version selection SHALL be deterministic: at most one active version per case type at any time; a case bound to a specific version SHALL continue to use that version even after a newer one is published (versions, not branches).
+
+#### Scenario: Existing case keeps its bound version after a new one is published
+- **GIVEN** case C bound to workflow version v1
+- **WHEN** v2 is published for the same case type
+- **THEN** `getDefinitionForCase(C.id)` SHALL still return v1 and only newly-created cases SHALL be bound to v2
+
+### REQ-003: MigrateWorkflowDefinitions SHALL be a one-shot repair step for legacy data
+
+`OCA\Procest\Repair\MigrateWorkflowDefinitions` SHALL run as a Nextcloud repair step that detects legacy inline workflow definitions on case-type records and lifts them into stand-alone workflow definition entities. The repair step SHALL be idempotent: on a fully-migrated dataset it SHALL be a no-op, and re-running it SHALL NOT duplicate definitions.
+
+#### Scenario: Idempotent re-run
+- **GIVEN** a procest instance where MigrateWorkflowDefinitions has already run
+- **WHEN** `MigrateWorkflowDefinitions::run($output)` runs again
+- **THEN** no new workflow definitions SHALL be created and the output SHALL log the no-op
+
+Notes
+- Once every active deployment is past the migration window, this repair step is a candidate for removal in a future cleanup spec.
+
+<!-- END retrofit-2026-05-24-workflow-definition-model -->


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Drafts 3 numbered REQs covering controller / service / migration of the workflow-definition lifecycle.

Ghost change: retrofit-2026-05-24-workflow-definition-model (delta merged).

Source: openspec/coverage-report.md generated 2026-05-24 | Cluster: workflow-definition-model

Refs #565