### PR TITLE
retrofit: reverse-spec parafering-actions general controller (3 REQs / 3 files)

### DIFF
--- a/lib/Controller/ParaferingController.php
+++ b/lib/Controller/ParaferingController.php
@@ -19,6 +19,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-parafering-actions-impl/tasks.md#task-1
  */
 
 declare(strict_types=1);

--- a/lib/Service/ParaferingNotificationService.php
+++ b/lib/Service/ParaferingNotificationService.php
@@ -15,6 +15,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-parafering-actions-impl/tasks.md#task-3
  */
 
 declare(strict_types=1);

--- a/lib/Service/ParaferingService.php
+++ b/lib/Service/ParaferingService.php
@@ -17,6 +17,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-parafering-actions-impl/tasks.md#task-2
  */
 
 declare(strict_types=1);

--- a/openspec/changes/retrofit-2026-05-24-parafering-actions-impl/design.md
+++ b/openspec/changes/retrofit-2026-05-24-parafering-actions-impl/design.md
@@ -1,0 +1,6 @@
+# Design — retrofit parafering-actions (general-controller surface)
+
+Retrofit change. Tasks describe retroactive annotation. The parafering-actions spec is marked retired (canonical home is case-management); the REQs in this delta narrowly describe the general ParaferingController + service surface, not the per-action ParafeerActieController already annotated under parafering-actions Bucket 1.
+
+## Out of scope
+- Reorganising parafering REQs into case-management (architectural decision; would require a separate spec move)

--- a/openspec/changes/retrofit-2026-05-24-parafering-actions-impl/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-parafering-actions-impl/proposal.md
@@ -1,0 +1,12 @@
+# Retrofit — parafering-actions (general-controller surface)
+
+Describes observed behavior of 3 PHP files (~23 methods) — the general `ParaferingController`, `ParaferingService`, and `ParaferingNotificationService` — as 3 new REQs extending the parafering-actions capability. The spec is marked retired with `canonical_home: case-management/spec.md`; the REQs here narrowly document the general-controller surface (not the per-action `ParafeerActieController` surface which is already annotated).
+
+## Affected code units
+- lib/Controller/ParaferingController.php (9 methods) — voorstel CRUD + start + per-action endpoints + audit trail
+- lib/Service/ParaferingService.php (10 methods) — voorstel lifecycle + action execution + step resolution
+- lib/Service/ParaferingNotificationService.php (4 methods) — step-activated / returned / reminder / completed
+
+Note: the retired status reflects that parafering is folded into case-management at the capability level. The implementation files still need annotation; this delta captures their per-method REQs on the original spec rather than re-opening the canonical case-management spec.
+
+Source: openspec/coverage-report.md generated 2026-05-24. Tracks ConductionNL/procest#565.

--- a/openspec/changes/retrofit-2026-05-24-parafering-actions-impl/specs/parafering-actions/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-parafering-actions-impl/specs/parafering-actions/spec.md
@@ -1,0 +1,42 @@
+---
+retrofit_extensions:
+  - REQ-101
+  - REQ-102
+  - REQ-103
+---
+
+# Parafering Actions — general-controller surface (retrofit)
+
+## Requirements
+
+### REQ-101: ParaferingController SHALL expose voorstel CRUD + per-action endpoints + audit trail
+
+`OCA\Procest\Controller\ParaferingController` SHALL provide HTTP endpoints for: `createVoorstel()`, `startParafering($id)`, `paraferen($id)`, `terugsturen($id)`, `adviseren($id)`, and `auditTrail($id)`. The controller SHALL delegate all state mutation to `ParaferingService` and SHALL enforce that the calling user holds the role required by the current parafering step before executing an action.
+
+#### Scenario: Adviseren by a user lacking the adviseur role
+- **GIVEN** a voorstel in step `advies-juridisch` requiring role `adviseur`
+- **WHEN** a user without that role calls `POST /api/paraferingen/{id}/adviseren`
+- **THEN** the controller SHALL respond `403 Forbidden`
+
+### REQ-102: ParaferingService SHALL implement voorstel lifecycle + action execution + step resolution
+
+`OCA\Procest\Service\ParaferingService` SHALL provide the canonical lifecycle: `createVoorstel(...)`, `startParafering(...)`, `executeAction(...)`, `getCurrentStep(...)`, `getAuditTrail(...)`, and `overrideRoute(...)`. The service SHALL persist every action as an audit-trail entry attached to the voorstel and SHALL advance the parafering route after each successful action — except `terugsturen`, which SHALL rewind to the previous handler.
+
+#### Scenario: Successful paraferen advances to next step
+- **GIVEN** a voorstel at step S1 with successor S2
+- **WHEN** `ParaferingService::executeAction($voorstel, 'paraferen', $user, $context)` succeeds
+- **THEN** the voorstel's current step SHALL be S2 and an audit-trail entry SHALL record the paraferen action with user + timestamp
+
+#### Scenario: Terugsturen rewinds to previous handler
+- **GIVEN** a voorstel at step S2 returned from S1
+- **WHEN** `terugsturen` is invoked with a comment
+- **THEN** the voorstel SHALL move back to S1 and the comment SHALL be attached to both the rewind audit entry and the original S1 handler's notification
+
+### REQ-103: ParaferingNotificationService SHALL emit step + reminder + completion notifications
+
+`OCA\Procest\Service\ParaferingNotificationService` SHALL emit Nextcloud notifications: `notifyStepActivated()` when a new step's assigned handlers become responsible, `notifyVoorstelReturned()` when an upstream handler returns the voorstel for rework, and `notifyParaferingReminder()` on the BackgroundJob cadence for steps approaching their deadline. Notifications SHALL be deduplicated per (voorstel, step, type) so handlers do not see repeat noise within the same step.
+
+#### Scenario: Reminder is sent once per step
+- **GIVEN** a step approaching its deadline with no prior reminder
+- **WHEN** `notifyParaferingReminder(...)` runs
+- **THEN** the assigned handlers SHALL receive a notification once and subsequent runs within the same step SHALL be no-ops

--- a/openspec/changes/retrofit-2026-05-24-parafering-actions-impl/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-parafering-actions-impl/tasks.md
@@ -1,0 +1,5 @@
+# Tasks
+
+- [x] task-1: parafering-actions#REQ-101 — ParaferingController CRUD + per-action endpoints + audit trail (retroactive annotation)
+- [x] task-2: parafering-actions#REQ-102 — ParaferingService lifecycle + action execution + step resolution (retroactive annotation)
+- [x] task-3: parafering-actions#REQ-103 — ParaferingNotificationService step + reminder + completion notifications (retroactive annotation)

--- a/openspec/specs/parafering-actions/spec.md
+++ b/openspec/specs/parafering-actions/spec.md
@@ -2,6 +2,10 @@
 status: retired
 retired_in: procest-adopt-or-abstractions
 canonical_home: case-management/spec.md
+retrofit_extensions:
+  - REQ-101
+  - REQ-102
+  - REQ-103
 ---
 
 > **RETIRED — see `case-management/spec.md`.**
@@ -133,3 +137,41 @@ The system SHALL support registering a formal besluit (decision) when the colleg
 - **WHEN** no RIS connector is configured in the system
 - **THEN** the "Aanbieden aan RIS" button SHALL NOT be displayed
 - **AND** a "Markeer als besloten" button SHALL allow manual besluit registration
+
+<!-- BEGIN retrofit-2026-05-24-parafering-actions-impl -->
+
+## Implementation Surface (retrofit — general controller)
+
+### REQ-101: ParaferingController SHALL expose voorstel CRUD + per-action endpoints + audit trail
+
+`OCA\Procest\Controller\ParaferingController` SHALL provide HTTP endpoints for: `createVoorstel()`, `startParafering($id)`, `paraferen($id)`, `terugsturen($id)`, `adviseren($id)`, and `auditTrail($id)`. The controller SHALL delegate all state mutation to `ParaferingService` and SHALL enforce that the calling user holds the role required by the current parafering step before executing an action.
+
+#### Scenario: Adviseren by a user lacking the adviseur role
+- **GIVEN** a voorstel in step `advies-juridisch` requiring role `adviseur`
+- **WHEN** a user without that role calls `POST /api/paraferingen/{id}/adviseren`
+- **THEN** the controller SHALL respond `403 Forbidden`
+
+### REQ-102: ParaferingService SHALL implement voorstel lifecycle + action execution + step resolution
+
+`OCA\Procest\Service\ParaferingService` SHALL provide the canonical lifecycle: `createVoorstel(...)`, `startParafering(...)`, `executeAction(...)`, `getCurrentStep(...)`, `getAuditTrail(...)`, and `overrideRoute(...)`. The service SHALL persist every action as an audit-trail entry attached to the voorstel and SHALL advance the parafering route after each successful action — except `terugsturen`, which SHALL rewind to the previous handler.
+
+#### Scenario: Successful paraferen advances to next step
+- **GIVEN** a voorstel at step S1 with successor S2
+- **WHEN** `ParaferingService::executeAction($voorstel, 'paraferen', $user, $context)` succeeds
+- **THEN** the voorstel's current step SHALL be S2 and an audit-trail entry SHALL record the paraferen action with user + timestamp
+
+#### Scenario: Terugsturen rewinds to previous handler
+- **GIVEN** a voorstel at step S2 returned from S1
+- **WHEN** `terugsturen` is invoked with a comment
+- **THEN** the voorstel SHALL move back to S1 and the comment SHALL be attached to both the rewind audit entry and the original S1 handler's notification
+
+### REQ-103: ParaferingNotificationService SHALL emit step + reminder + completion notifications
+
+`OCA\Procest\Service\ParaferingNotificationService` SHALL emit Nextcloud notifications: `notifyStepActivated()` when a new step's assigned handlers become responsible, `notifyVoorstelReturned()` when an upstream handler returns the voorstel for rework, and `notifyParaferingReminder()` on the BackgroundJob cadence for steps approaching their deadline. Notifications SHALL be deduplicated per (voorstel, step, type) so handlers do not see repeat noise within the same step.
+
+#### Scenario: Reminder is sent once per step
+- **GIVEN** a step approaching its deadline with no prior reminder
+- **WHEN** `notifyParaferingReminder(...)` runs
+- **THEN** the assigned handlers SHALL receive a notification once and subsequent runs within the same step SHALL be no-ops
+
+<!-- END retrofit-2026-05-24-parafering-actions-impl -->


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Drafts 3 numbered REQs (REQ-101..103) covering the general ParaferingController surface (the per-action ParafeerActieController is already annotated under parafering-actions Bucket 1).

Ghost change: retrofit-2026-05-24-parafering-actions-impl (delta merged into the retired parafering-actions spec).

Note: parafering-actions is marked retired (canonical home: case-management); this delta documents the implementation surface so the code files still carry valid @spec tags after retirement.

Source: openspec/coverage-report.md generated 2026-05-24 | Cluster: parafering-actions

Refs #565