### PR TITLE
retrofit: reverse-spec inspection-checklists execution surface (3 REQs / 3 files)

### DIFF
--- a/lib/Controller/InspectionController.php
+++ b/lib/Controller/InspectionController.php
@@ -19,6 +19,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md#task-1
  */
 
 declare(strict_types=1);

--- a/lib/Service/ChecklistService.php
+++ b/lib/Service/ChecklistService.php
@@ -19,6 +19,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md#task-3
  */
 
 declare(strict_types=1);

--- a/lib/Service/InspectionService.php
+++ b/lib/Service/InspectionService.php
@@ -16,6 +16,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md#task-2
  */
 
 declare(strict_types=1);

--- a/openspec/changes/retrofit-2026-05-24-inspection-checklists/design.md
+++ b/openspec/changes/retrofit-2026-05-24-inspection-checklists/design.md
@@ -1,0 +1,6 @@
+# Design — retrofit inspection-checklists
+
+Retrofit change. Tasks describe retroactive annotation.
+
+## Out of scope
+- Consolidating ChecklistService (top-level) + Service/Inspection/ChecklistService.php (namespaced) — deferred to a future refactor change

--- a/openspec/changes/retrofit-2026-05-24-inspection-checklists/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-inspection-checklists/proposal.md
@@ -1,0 +1,14 @@
+# Retrofit — inspection-checklists
+
+Describes observed behavior of 3 PHP files (~18 methods) as 3 new REQs covering the inspection-execution surface (controller + inspection service + checklist progress service).
+
+## Affected code units
+- lib/Controller/InspectionController.php (7 methods) — inspection lifecycle endpoints
+- lib/Service/InspectionService.php (6 methods) — location capture, photo add, completion
+- lib/Service/ChecklistService.php (5 methods) — item completion + progress + conformity summary (top-level — duplicate of lib/Service/Inspection/ChecklistService.php which is annotated under Bucket 1; this top-level service appears to focus on per-item completion progress while the Inspection/-namespaced one focuses on template lifecycle. Both are kept for now; consolidation deferred.)
+
+## Approach
+- File-level survey
+- 3 REQs: controller HTTP surface, inspection service, checklist progress service
+
+Source: openspec/coverage-report.md generated 2026-05-24. Tracks ConductionNL/procest#565.

--- a/openspec/changes/retrofit-2026-05-24-inspection-checklists/specs/inspection-checklists/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-inspection-checklists/specs/inspection-checklists/spec.md
@@ -1,0 +1,39 @@
+---
+retrofit_extensions:
+  - REQ-001
+  - REQ-002
+  - REQ-003
+---
+
+# Inspection Checklists — execution surface (retrofit)
+
+## Requirements
+
+### REQ-001: InspectionController SHALL expose the in-field inspection lifecycle endpoints
+
+`OCA\Procest\Controller\InspectionController` SHALL provide endpoints for the field inspector: `index()` (list assigned inspections), `captureLocation($id)` (record GPS), `completeChecklistItem($id, $itemId)` (mark one item with conformity + comment + mandatory photos), `addPhoto($id)` (attach photo with EXIF metadata), and `complete($id)` (finalise the inspection with overall conclusion). Each endpoint SHALL delegate to `InspectionService` or `ChecklistService` and SHALL enforce that the calling user is the assigned inspector for the record.
+
+#### Scenario: Inspector completes an item with mandatory photo
+- **GIVEN** a checklist item flagged `photoRequired: true`
+- **WHEN** the inspector calls `completeChecklistItem` without attaching at least one photo
+- **THEN** the controller SHALL respond `400 Bad Request` and the item SHALL remain incomplete
+
+### REQ-002: InspectionService SHALL implement field-side state mutations
+
+`OCA\Procest\Service\InspectionService` SHALL implement `getInspections()` (filter by user/case/status), `captureLocation()` (persist GPS + accuracy + timestamp), `addPhoto()` (attach a photo with EXIF metadata + GPS extracted from the file), and `completeInspection()` (mark all items final, persist conclusion, transition the parent case if configured). Location and photo timestamps SHALL be persisted as `DateTime` and tagged with the capturing user — never overwritten by a later edit.
+
+#### Scenario: Complete an inspection with non-conformities
+- **GIVEN** an inspection with at least one item flagged non-conforming
+- **WHEN** `completeInspection($inspection, 'Niet conform; correctie vereist')` is called
+- **THEN** the inspection SHALL be marked completed and a corrective-action workflow SHALL be triggered on the parent case if one is configured for non-conform outcomes
+
+### REQ-003: ChecklistService SHALL compute item completion + progress + conformity summary
+
+`OCA\Procest\Service\ChecklistService` (top-level, separate from `lib/Service/Inspection/ChecklistService.php` which handles template lifecycle) SHALL provide `completeItem()`, `getProgress()` (returns `{completed, total, percent}`), `validateCompletion()` (enforces mandatory items + photo-required rules), and `getConformitySummary()` (returns `{conforming, nonConforming, na, pending}` counts). All four methods SHALL be pure with respect to the checklist payload — no I/O — so they are reusable for both server-side validation and dry-run preview.
+
+#### Scenario: Pure progress calculation
+- **WHEN** `ChecklistService::getProgress($checklist)` is called
+- **THEN** the result SHALL be derivable from the checklist payload alone (no database lookups) so the same calculation can run in unit tests
+
+Notes
+- The duplicate-file callout (Service/ChecklistService.php vs Service/Inspection/ChecklistService.php) is preserved: the top-level service handles per-run progress, the namespaced one handles templates. Consolidation deferred to a future refactor change.

--- a/openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md
@@ -1,0 +1,5 @@
+# Tasks
+
+- [x] task-1: inspection-checklists#REQ-001 — InspectionController endpoints (retroactive annotation)
+- [x] task-2: inspection-checklists#REQ-002 — InspectionService field-side state mutations (retroactive annotation)
+- [x] task-3: inspection-checklists#REQ-003 — ChecklistService progress + conformity (retroactive annotation)

--- a/openspec/specs/inspection-checklists/spec.md
+++ b/openspec/specs/inspection-checklists/spec.md
@@ -1,3 +1,10 @@
+---
+retrofit_extensions:
+  - REQ-001
+  - REQ-002
+  - REQ-003
+---
+
 ## ADDED Requirements
 
 ### Requirement: Inspection checklist schema
@@ -92,3 +99,38 @@ The system SHALL display an inspection panel on the case dashboard for Toezicht 
 - **WHEN** a case has multiple inspectieRapporten for the same phase (re-inspection after non-conformity)
 - **THEN** the panel SHALL show all rapporten for that phase in chronological order
 - **THEN** the most recent rapport SHALL determine the current phase status
+
+<!-- BEGIN retrofit-2026-05-24-inspection-checklists -->
+
+## Execution Surface (retrofit)
+
+### REQ-001: InspectionController SHALL expose the in-field inspection lifecycle endpoints
+
+`OCA\Procest\Controller\InspectionController` SHALL provide endpoints for the field inspector: `index()` (list assigned inspections), `captureLocation($id)` (record GPS), `completeChecklistItem($id, $itemId)` (mark one item with conformity + comment + mandatory photos), `addPhoto($id)` (attach photo with EXIF metadata), and `complete($id)` (finalise the inspection with overall conclusion). Each endpoint SHALL delegate to `InspectionService` or `ChecklistService` and SHALL enforce that the calling user is the assigned inspector for the record.
+
+#### Scenario: Inspector completes an item with mandatory photo
+- **GIVEN** a checklist item flagged `photoRequired: true`
+- **WHEN** the inspector calls `completeChecklistItem` without attaching at least one photo
+- **THEN** the controller SHALL respond `400 Bad Request` and the item SHALL remain incomplete
+
+### REQ-002: InspectionService SHALL implement field-side state mutations
+
+`OCA\Procest\Service\InspectionService` SHALL implement `getInspections()` (filter by user/case/status), `captureLocation()` (persist GPS + accuracy + timestamp), `addPhoto()` (attach a photo with EXIF metadata + GPS extracted from the file), and `completeInspection()` (mark all items final, persist conclusion, transition the parent case if configured). Location and photo timestamps SHALL be persisted as `DateTime` and tagged with the capturing user — never overwritten by a later edit.
+
+#### Scenario: Complete an inspection with non-conformities
+- **GIVEN** an inspection with at least one item flagged non-conforming
+- **WHEN** `completeInspection($inspection, 'Niet conform; correctie vereist')` is called
+- **THEN** the inspection SHALL be marked completed and a corrective-action workflow SHALL be triggered on the parent case if one is configured for non-conform outcomes
+
+### REQ-003: ChecklistService SHALL compute item completion + progress + conformity summary
+
+`OCA\Procest\Service\ChecklistService` (top-level, separate from `lib/Service/Inspection/ChecklistService.php` which handles template lifecycle) SHALL provide `completeItem()`, `getProgress()` (returns `{completed, total, percent}`), `validateCompletion()` (enforces mandatory items + photo-required rules), and `getConformitySummary()` (returns `{conforming, nonConforming, na, pending}` counts). All four methods SHALL be pure with respect to the checklist payload — no I/O — so they are reusable for both server-side validation and dry-run preview.
+
+#### Scenario: Pure progress calculation
+- **WHEN** `ChecklistService::getProgress($checklist)` is called
+- **THEN** the result SHALL be derivable from the checklist payload alone (no database lookups) so the same calculation can run in unit tests
+
+Notes
+- The duplicate-file callout (Service/ChecklistService.php vs Service/Inspection/ChecklistService.php) is preserved: the top-level service handles per-run progress, the namespaced one handles templates. Consolidation deferred to a future refactor change.
+
+<!-- END retrofit-2026-05-24-inspection-checklists -->


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Drafts 3 numbered REQs covering the inspection-execution surface.

Notes the ChecklistService duplicate (top-level vs Service/Inspection/); consolidation deferred.

Ghost change: retrofit-2026-05-24-inspection-checklists (delta merged).

Source: openspec/coverage-report.md generated 2026-05-24 | Cluster: inspection-checklists

Refs #565