### PR TITLE
retrofit: reverse-spec bezwaar-lifecycle (3 REQs / 3 files)

### DIFF
--- a/lib/Listener/BezwaarLifecycleListener.php
+++ b/lib/Listener/BezwaarLifecycleListener.php
@@ -28,6 +28,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md#task-1
  */
 
 declare(strict_types=1);

--- a/lib/Repair/SeedBezwaarBeroepData.php
+++ b/lib/Repair/SeedBezwaarBeroepData.php
@@ -19,6 +19,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md#task-2
  */
 
 declare(strict_types=1);

--- a/lib/Repair/SeedBezwaarWorkflowDefinition.php
+++ b/lib/Repair/SeedBezwaarWorkflowDefinition.php
@@ -24,6 +24,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md#task-3
  */
 
 declare(strict_types=1);

--- a/openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/design.md
+++ b/openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/design.md
@@ -1,0 +1,3 @@
+# Design — retrofit bezwaar-lifecycle
+
+Retrofit change. Tasks describe retroactive annotation.

--- a/openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/proposal.md
@@ -1,0 +1,10 @@
+# Retrofit — bezwaar-lifecycle
+
+Describes observed behavior of 3 PHP files (~14 methods) — lifecycle event listener + two seed repair steps — as 3 new REQs.
+
+## Affected code units
+- lib/Listener/BezwaarLifecycleListener.php (4 methods) — handles bezwaar-lifecycle events
+- lib/Repair/SeedBezwaarBeroepData.php (3 methods) — seeds reference data
+- lib/Repair/SeedBezwaarWorkflowDefinition.php (7 methods) — seeds bezwaar workflow definition
+
+Source: openspec/coverage-report.md generated 2026-05-24. Tracks ConductionNL/procest#565.

--- a/openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/specs/bezwaar-lifecycle/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/specs/bezwaar-lifecycle/spec.md
@@ -1,0 +1,36 @@
+---
+retrofit_extensions:
+  - REQ-001
+  - REQ-002
+  - REQ-003
+---
+
+# Bezwaar Lifecycle — listener + seed surface (retrofit)
+
+## Requirements
+
+### REQ-001: BezwaarLifecycleListener SHALL react to lifecycle events and update bezwaar state
+
+`OCA\Procest\Listener\BezwaarLifecycleListener` SHALL implement `OCP\EventDispatcher\IEventListener::handle($event)` and react to: bezwaar created (set initial status + assigned reviewer), bezwaar hearing scheduled (block status changes until hearing concludes), bezwaar decision made (compute decision deadline + propagate to case timeline), and bezwaar withdrawn (terminate the lifecycle). The listener SHALL be idempotent on repeated event delivery — handler effects SHALL be guarded by the bezwaar's current state so a re-played event is a no-op when the transition already occurred.
+
+#### Scenario: Replayed creation event is a no-op
+- **GIVEN** a bezwaar already at status `in-behandeling` from a prior creation event
+- **WHEN** the same `BezwaarCreatedEvent` is dispatched again
+- **THEN** the listener SHALL detect the existing state and SHALL NOT re-trigger status / assignment side effects
+
+### REQ-002: SeedBezwaarBeroepData SHALL seed shared reference data for bezwaar + beroep
+
+`OCA\Procest\Repair\SeedBezwaarBeroepData` SHALL run on app install/upgrade and create the shared reference data for bezwaar + beroep workflows: status types, role types, decision-type enumerations, and any standing notification templates. The seeder SHALL be idempotent — pre-existing records (matched by slug/code) SHALL be left untouched, and re-running the repair SHALL be safe.
+
+#### Scenario: Repair re-runs on upgrade
+- **WHEN** a procest upgrade triggers repair steps
+- **THEN** `SeedBezwaarBeroepData::run($output)` SHALL skip rows already in the database and only add net-new reference data introduced in this release
+
+### REQ-003: SeedBezwaarWorkflowDefinition SHALL seed the canonical bezwaar workflow definition
+
+`OCA\Procest\Repair\SeedBezwaarWorkflowDefinition` SHALL create the canonical bezwaar workflow definition (status nodes, transitions, role guards, deadline rules) as a published version 1 record. The seeder SHALL be idempotent — if a published bezwaar workflow already exists, the repair SHALL be a no-op rather than creating a competing version. If the existing record is on an older schema version, the seeder SHALL migrate it forward in-place rather than seeding a parallel record.
+
+#### Scenario: Existing v1 workflow is preserved
+- **GIVEN** a bezwaar workflow already published as v1
+- **WHEN** `SeedBezwaarWorkflowDefinition::run($output)` runs
+- **THEN** no new workflow record SHALL be created and the output SHALL log the no-op

--- a/openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md
@@ -1,0 +1,5 @@
+# Tasks
+
+- [x] task-1: bezwaar-lifecycle#REQ-001 — BezwaarLifecycleListener event handling (retroactive annotation)
+- [x] task-2: bezwaar-lifecycle#REQ-002 — SeedBezwaarBeroepData reference data seeder (retroactive annotation)
+- [x] task-3: bezwaar-lifecycle#REQ-003 — SeedBezwaarWorkflowDefinition canonical workflow seeder (retroactive annotation)

--- a/openspec/specs/bezwaar-lifecycle/spec.md
+++ b/openspec/specs/bezwaar-lifecycle/spec.md
@@ -1,3 +1,10 @@
+---
+retrofit_extensions:
+  - REQ-001
+  - REQ-002
+  - REQ-003
+---
+
 ## ADDED Requirements
 
 ### Requirement: Bezwaar Case Type Pre-Seeded Configuration
@@ -161,3 +168,35 @@ The system SHALL store bezwaarschrift (objection letter) details as an OpenRegis
 - **THEN** the `isTimely` field SHALL default to `false`
 - **AND** the system SHALL display a warning: "Bezwaartermijn mogelijk overschreden"
 - **AND** the behandelaar SHALL be able to override with a `timelinessAssessment` explanation (e.g., verschoonbare termijnoverschrijding)
+
+<!-- BEGIN retrofit-2026-05-24-bezwaar-lifecycle -->
+
+## Listener + Seed Surface (retrofit)
+
+### REQ-001: BezwaarLifecycleListener SHALL react to lifecycle events and update bezwaar state
+
+`OCA\Procest\Listener\BezwaarLifecycleListener` SHALL implement `OCP\EventDispatcher\IEventListener::handle($event)` and react to: bezwaar created (set initial status + assigned reviewer), bezwaar hearing scheduled (block status changes until hearing concludes), bezwaar decision made (compute decision deadline + propagate to case timeline), and bezwaar withdrawn (terminate the lifecycle). The listener SHALL be idempotent on repeated event delivery — handler effects SHALL be guarded by the bezwaar's current state so a re-played event is a no-op when the transition already occurred.
+
+#### Scenario: Replayed creation event is a no-op
+- **GIVEN** a bezwaar already at status `in-behandeling` from a prior creation event
+- **WHEN** the same `BezwaarCreatedEvent` is dispatched again
+- **THEN** the listener SHALL detect the existing state and SHALL NOT re-trigger status / assignment side effects
+
+### REQ-002: SeedBezwaarBeroepData SHALL seed shared reference data for bezwaar + beroep
+
+`OCA\Procest\Repair\SeedBezwaarBeroepData` SHALL run on app install/upgrade and create the shared reference data for bezwaar + beroep workflows: status types, role types, decision-type enumerations, and any standing notification templates. The seeder SHALL be idempotent — pre-existing records (matched by slug/code) SHALL be left untouched, and re-running the repair SHALL be safe.
+
+#### Scenario: Repair re-runs on upgrade
+- **WHEN** a procest upgrade triggers repair steps
+- **THEN** `SeedBezwaarBeroepData::run($output)` SHALL skip rows already in the database and only add net-new reference data introduced in this release
+
+### REQ-003: SeedBezwaarWorkflowDefinition SHALL seed the canonical bezwaar workflow definition
+
+`OCA\Procest\Repair\SeedBezwaarWorkflowDefinition` SHALL create the canonical bezwaar workflow definition (status nodes, transitions, role guards, deadline rules) as a published version 1 record. The seeder SHALL be idempotent — if a published bezwaar workflow already exists, the repair SHALL be a no-op rather than creating a competing version. If the existing record is on an older schema version, the seeder SHALL migrate it forward in-place rather than seeding a parallel record.
+
+#### Scenario: Existing v1 workflow is preserved
+- **GIVEN** a bezwaar workflow already published as v1
+- **WHEN** `SeedBezwaarWorkflowDefinition::run($output)` runs
+- **THEN** no new workflow record SHALL be created and the output SHALL log the no-op
+
+<!-- END retrofit-2026-05-24-bezwaar-lifecycle -->


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Drafts 3 numbered REQs covering the bezwaar lifecycle listener + 2 seed repair steps.

Ghost change: retrofit-2026-05-24-bezwaar-lifecycle (delta merged).

Source: openspec/coverage-report.md generated 2026-05-24 | Cluster: bezwaar-lifecycle

Refs #565