### PR TITLE
retrofit: reverse-spec advice-management (3 REQs / 3 files)

### DIFF
--- a/lib/BackgroundJob/AdviceDeadlineJob.php
+++ b/lib/BackgroundJob/AdviceDeadlineJob.php
@@ -20,6 +20,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md#task-3
  */
 
 declare(strict_types=1);

--- a/lib/Controller/AdviceController.php
+++ b/lib/Controller/AdviceController.php
@@ -21,6 +21,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md#task-1
  */
 
 declare(strict_types=1);

--- a/lib/Service/AdviceService.php
+++ b/lib/Service/AdviceService.php
@@ -26,6 +26,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md#task-2
  */
 
 declare(strict_types=1);

--- a/openspec/changes/retrofit-2026-05-24-advice-management/design.md
+++ b/openspec/changes/retrofit-2026-05-24-advice-management/design.md
@@ -1,0 +1,3 @@
+# Design — retrofit advice-management
+
+Retrofit change. Tasks describe retroactive annotation.

--- a/openspec/changes/retrofit-2026-05-24-advice-management/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-advice-management/proposal.md
@@ -1,0 +1,10 @@
+# Retrofit — advice-management
+
+Describes observed behavior of 3 PHP files (~18 methods) — advice controller, service, deadline background job — as 3 new REQs.
+
+## Affected code units
+- lib/Controller/AdviceController.php (4 methods) — advice transitions + reminders
+- lib/Service/AdviceService.php (12 methods) — advice lifecycle + workflow guard
+- lib/BackgroundJob/AdviceDeadlineJob.php (2 methods) — deadline reminders + auto-expiry
+
+Source: openspec/coverage-report.md generated 2026-05-24. Tracks ConductionNL/procest#565.

--- a/openspec/changes/retrofit-2026-05-24-advice-management/specs/advice-management/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-advice-management/specs/advice-management/spec.md
@@ -1,0 +1,40 @@
+---
+retrofit_extensions:
+  - REQ-001
+  - REQ-002
+  - REQ-003
+---
+
+# Advice Management — controller + service + deadline job (retrofit)
+
+## Requirements
+
+### REQ-001: AdviceController SHALL expose advice transition + reminder endpoints
+
+`OCA\Procest\Controller\AdviceController` SHALL provide `POST /api/advice/{id}/transition` (transition the advice between statuses with optional payload) and `POST /api/advice/{id}/reminder` (manually dispatch a reminder to the assigned adviseur). Each endpoint SHALL delegate to `AdviceService` and SHALL enforce that the calling user has authority on the parent case.
+
+#### Scenario: Manual reminder dispatch
+- **WHEN** a behandelaar calls `POST /api/advice/{id}/reminder`
+- **THEN** the controller SHALL call `AdviceService::dispatchReminder($id)` and respond with the dispatch outcome
+
+### REQ-002: AdviceService SHALL implement the full advice lifecycle + workflow guard
+
+`OCA\Procest\Service\AdviceService` SHALL provide `transitionStatus()`, `dispatchReminder()`, `getAdviceForCase()`, `getOpenAdvice()`, `expireAdvice()`, and `applyWorkflowGuard()`. The workflow guard SHALL block parent-case status transitions while open advice requests are still pending for that case — releasing only when all advice is `received`, `withdrawn`, or `expired`. Status transitions SHALL be append-only audit-trailed.
+
+#### Scenario: Workflow guard blocks case completion while advice pending
+- **GIVEN** a case with one advice request at status `requested`
+- **WHEN** `AdviceService::applyWorkflowGuard($caseId)` is evaluated for a "complete case" transition
+- **THEN** the guard SHALL block the transition with the reason "Open advice request — awaiting reply"
+
+#### Scenario: Expire overdue advice
+- **WHEN** `AdviceService::expireAdvice($adviceId)` is called for an advice whose deadline has passed
+- **THEN** the advice status SHALL transition to `expired` and the parent case workflow guard SHALL release this dependency
+
+### REQ-003: AdviceDeadlineJob SHALL send reminders and auto-expire overdue advice
+
+`OCA\Procest\BackgroundJob\AdviceDeadlineJob` SHALL run on the Nextcloud BackgroundJob schedule and: (a) dispatch reminders to assigned adviseurs at the configured thresholds before the deadline, (b) call `AdviceService::expireAdvice()` on requests whose deadline has passed without response. The job SHALL be idempotent — duplicate runs SHALL NOT send duplicate reminders for the same threshold.
+
+#### Scenario: Reminder is sent once per threshold
+- **GIVEN** an advice with deadline 3 days away and a 3-day reminder configured
+- **WHEN** `AdviceDeadlineJob::run()` runs twice within the same threshold window
+- **THEN** the reminder SHALL be dispatched only once

--- a/openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
@@ -1,0 +1,5 @@
+# Tasks
+
+- [x] task-1: advice-management#REQ-001 — AdviceController transition + reminder endpoints (retroactive annotation)
+- [x] task-2: advice-management#REQ-002 — AdviceService lifecycle + workflow guard (retroactive annotation)
+- [x] task-3: advice-management#REQ-003 — AdviceDeadlineJob reminders + auto-expiry (retroactive annotation)

--- a/openspec/specs/advice-management/spec.md
+++ b/openspec/specs/advice-management/spec.md
@@ -1,3 +1,10 @@
+---
+retrofit_extensions:
+  - REQ-001
+  - REQ-002
+  - REQ-003
+---
+
 ## ADDED Requirements
 
 ### Requirement: Advice request schema
@@ -69,3 +76,39 @@ The system SHALL provide a form for creating advice requests from the case dashb
 - **WHEN** a workflow transition has a guard requiring "all advice received"
 - **THEN** the transition SHALL be blocked if any adviesAanvraag has status "aangevraagd"
 - **THEN** the guard violation message SHALL list the pending advice requests: "[adviseur]: advies verwacht voor [deadline]"
+
+<!-- BEGIN retrofit-2026-05-24-advice-management -->
+
+## Controller + Service + Deadline Job (retrofit)
+
+### REQ-001: AdviceController SHALL expose advice transition + reminder endpoints
+
+`OCA\Procest\Controller\AdviceController` SHALL provide `POST /api/advice/{id}/transition` (transition the advice between statuses with optional payload) and `POST /api/advice/{id}/reminder` (manually dispatch a reminder to the assigned adviseur). Each endpoint SHALL delegate to `AdviceService` and SHALL enforce that the calling user has authority on the parent case.
+
+#### Scenario: Manual reminder dispatch
+- **WHEN** a behandelaar calls `POST /api/advice/{id}/reminder`
+- **THEN** the controller SHALL call `AdviceService::dispatchReminder($id)` and respond with the dispatch outcome
+
+### REQ-002: AdviceService SHALL implement the full advice lifecycle + workflow guard
+
+`OCA\Procest\Service\AdviceService` SHALL provide `transitionStatus()`, `dispatchReminder()`, `getAdviceForCase()`, `getOpenAdvice()`, `expireAdvice()`, and `applyWorkflowGuard()`. The workflow guard SHALL block parent-case status transitions while open advice requests are still pending for that case — releasing only when all advice is `received`, `withdrawn`, or `expired`. Status transitions SHALL be append-only audit-trailed.
+
+#### Scenario: Workflow guard blocks case completion while advice pending
+- **GIVEN** a case with one advice request at status `requested`
+- **WHEN** `AdviceService::applyWorkflowGuard($caseId)` is evaluated for a "complete case" transition
+- **THEN** the guard SHALL block the transition with the reason "Open advice request — awaiting reply"
+
+#### Scenario: Expire overdue advice
+- **WHEN** `AdviceService::expireAdvice($adviceId)` is called for an advice whose deadline has passed
+- **THEN** the advice status SHALL transition to `expired` and the parent case workflow guard SHALL release this dependency
+
+### REQ-003: AdviceDeadlineJob SHALL send reminders and auto-expire overdue advice
+
+`OCA\Procest\BackgroundJob\AdviceDeadlineJob` SHALL run on the Nextcloud BackgroundJob schedule and: (a) dispatch reminders to assigned adviseurs at the configured thresholds before the deadline, (b) call `AdviceService::expireAdvice()` on requests whose deadline has passed without response. The job SHALL be idempotent — duplicate runs SHALL NOT send duplicate reminders for the same threshold.
+
+#### Scenario: Reminder is sent once per threshold
+- **GIVEN** an advice with deadline 3 days away and a 3-day reminder configured
+- **WHEN** `AdviceDeadlineJob::run()` runs twice within the same threshold window
+- **THEN** the reminder SHALL be dispatched only once
+
+<!-- END retrofit-2026-05-24-advice-management -->


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Drafts 3 numbered REQs covering AdviceController + AdviceService + AdviceDeadlineJob.

Ghost change: retrofit-2026-05-24-advice-management (delta merged).

Source: openspec/coverage-report.md generated 2026-05-24 | Cluster: advice-management

Refs #565