### PR TITLE
retrofit: reverse-spec wms-wfs-layers (2 REQs / 2 files)

### DIFF
--- a/lib/Controller/WmsWfsController.php
+++ b/lib/Controller/WmsWfsController.php
@@ -22,6 +22,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-wms-wfs-layers/tasks.md#task-1
  */
 
 declare(strict_types=1);

--- a/lib/Service/WmsWfsService.php
+++ b/lib/Service/WmsWfsService.php
@@ -22,6 +22,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-wms-wfs-layers/tasks.md#task-2
  */
 
 declare(strict_types=1);

--- a/openspec/changes/retrofit-2026-05-24-wms-wfs-layers/design.md
+++ b/openspec/changes/retrofit-2026-05-24-wms-wfs-layers/design.md
@@ -1,0 +1,3 @@
+# Design — retrofit wms-wfs-layers
+
+Retrofit change. Tasks describe retroactive annotation.

--- a/openspec/changes/retrofit-2026-05-24-wms-wfs-layers/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-wms-wfs-layers/proposal.md
@@ -1,0 +1,9 @@
+# Retrofit — wms-wfs-layers
+
+Describes observed behavior of 2 PHP files (~8 methods) — WMS/WFS proxy controller + layer resolution service — as 2 new REQs.
+
+## Affected code units
+- lib/Controller/WmsWfsController.php (1 method) — per-layer WMS/WFS proxy action endpoint
+- lib/Service/WmsWfsService.php (7 methods) — layer resolution per case type, layer validation, GetMap/GetFeature URL construction, allowlisted proxy delegation
+
+Source: openspec/coverage-report.md generated 2026-05-24. Tracks ConductionNL/procest#565.

--- a/openspec/changes/retrofit-2026-05-24-wms-wfs-layers/specs/wms-wfs-layers/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-wms-wfs-layers/specs/wms-wfs-layers/spec.md
@@ -1,0 +1,45 @@
+---
+retrofit_extensions:
+  - REQ-001
+  - REQ-002
+---
+
+# WMS/WFS Layers — proxy controller + layer service (retrofit)
+
+## Requirements
+
+### REQ-001: WmsWfsController SHALL expose a per-layer WMS/WFS proxy action endpoint
+
+`OCA\Procest\Controller\WmsWfsController::proxy()` SHALL accept a `layerId` query parameter, resolve the corresponding `wmsLayer` object via `WmsWfsService::getLayerById()`, and forward all other request parameters to `WmsWfsService::proxyRequest()`. The endpoint SHALL be authenticated (`#[NoAdminRequired]`) and SHALL return JSON error envelopes for missing parameters (HTTP 400), unknown layers (HTTP 404), and upstream failures (HTTP 4xx/5xx, defaulting to 502 when the upstream exception code is out of range).
+
+#### Scenario: Missing layerId returns 400
+- **WHEN** a caller invokes the proxy action without a `layerId` parameter
+- **THEN** the controller SHALL return a JSON response with status 400 and body `{"error": "Missing required parameter: layerId"}`
+
+#### Scenario: Unknown layer returns 404
+- **GIVEN** a `layerId` that does not match any configured `wmsLayer` object
+- **WHEN** the proxy action is invoked
+- **THEN** the controller SHALL return a JSON response with status 404 and body `{"error": "Layer not found"}`
+
+#### Scenario: Upstream RuntimeException maps to HTTP status
+- **GIVEN** a valid `layerId` whose proxied request raises `\RuntimeException` with code 503
+- **WHEN** the proxy action is invoked
+- **THEN** the controller SHALL return a JSON response with the exception's code (or 502 if the code is outside 400-599) and body `{"error": "<message>"}`
+
+### REQ-002: WmsWfsService SHALL resolve, validate, and proxy layers without direct outbound HTTP
+
+`OCA\Procest\Service\WmsWfsService` SHALL provide `getLayersForCaseType()`, `validateLayer()`, `proxyRequest()`, `buildGetMapUrl()`, `buildGetFeatureUrl()`, and `getLayerById()`. The service SHALL NEVER issue direct outbound HTTP — every external request SHALL be delegated to `GisProxyService::proxyRequest()` so the GIS proxy allowlist (REQ-LAYER-03c) and rate limiting (REQ-LAYER-03d) remain authoritative. Layer resolution per case type SHALL include all `wmsLayer` UUIDs listed in `caseType.layerIds` plus all layers with `isDefault: true`, with `active: false` layers filtered out. GetMap tile dimensions SHALL be capped at 512 pixels.
+
+#### Scenario: Layer resolution merges subscribed + default layers
+- **GIVEN** a case type with `layerIds: ["uuid-a"]` and three configured layers — uuid-a (active), uuid-b (active, isDefault=true), uuid-c (inactive, isDefault=true)
+- **WHEN** `WmsWfsService::getLayersForCaseType($caseType)` is called
+- **THEN** the result SHALL contain layers uuid-a and uuid-b only
+
+#### Scenario: All outbound traffic flows through GisProxyService
+- **WHEN** `WmsWfsService::proxyRequest($layer, $params)` is invoked for any layer
+- **THEN** the call SHALL delegate to `GisProxyService::proxyRequest()` and SHALL NOT open a direct HTTP connection from `WmsWfsService` itself
+
+#### Scenario: Tile dimensions are capped at 512px
+- **GIVEN** a caller requests `width=1024 height=1024` against `buildGetMapUrl()`
+- **WHEN** the URL is constructed
+- **THEN** the WIDTH and HEIGHT parameters SHALL be clamped to 512

--- a/openspec/changes/retrofit-2026-05-24-wms-wfs-layers/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-wms-wfs-layers/tasks.md
@@ -1,0 +1,4 @@
+# Tasks
+
+- [x] task-1: wms-wfs-layers#REQ-001 — WmsWfsController per-layer proxy action endpoint (retroactive annotation)
+- [x] task-2: wms-wfs-layers#REQ-002 — WmsWfsService layer resolution + validation + proxy delegation (retroactive annotation)

--- a/openspec/specs/wms-wfs-layers/spec.md
+++ b/openspec/specs/wms-wfs-layers/spec.md
@@ -1,3 +1,9 @@
+---
+retrofit_extensions:
+  - REQ-001
+  - REQ-002
+---
+
 # WMS/WFS Layer Support Specification
 
 ## Purpose
@@ -141,3 +147,45 @@ The system MUST parse WMS/WFS GetCapabilities responses to assist administrators
 - WHEN the system fetches the GetCapabilities
 - THEN the admin MUST see available feature types
 - AND the default output format (GeoJSON if available) MUST be auto-selected
+
+<!-- BEGIN retrofit-2026-05-24-wms-wfs-layers -->
+
+## Proxy Controller + Layer Service (retrofit)
+
+### REQ-001: WmsWfsController SHALL expose a per-layer WMS/WFS proxy action endpoint
+
+`OCA\Procest\Controller\WmsWfsController::proxy()` SHALL accept a `layerId` query parameter, resolve the corresponding `wmsLayer` object via `WmsWfsService::getLayerById()`, and forward all other request parameters to `WmsWfsService::proxyRequest()`. The endpoint SHALL be authenticated (`#[NoAdminRequired]`) and SHALL return JSON error envelopes for missing parameters (HTTP 400), unknown layers (HTTP 404), and upstream failures (HTTP 4xx/5xx, defaulting to 502 when the upstream exception code is out of range).
+
+#### Scenario: Missing layerId returns 400
+- **WHEN** a caller invokes the proxy action without a `layerId` parameter
+- **THEN** the controller SHALL return a JSON response with status 400 and body `{"error": "Missing required parameter: layerId"}`
+
+#### Scenario: Unknown layer returns 404
+- **GIVEN** a `layerId` that does not match any configured `wmsLayer` object
+- **WHEN** the proxy action is invoked
+- **THEN** the controller SHALL return a JSON response with status 404 and body `{"error": "Layer not found"}`
+
+#### Scenario: Upstream RuntimeException maps to HTTP status
+- **GIVEN** a valid `layerId` whose proxied request raises `\RuntimeException` with code 503
+- **WHEN** the proxy action is invoked
+- **THEN** the controller SHALL return a JSON response with the exception's code (or 502 if the code is outside 400-599) and body `{"error": "<message>"}`
+
+### REQ-002: WmsWfsService SHALL resolve, validate, and proxy layers without direct outbound HTTP
+
+`OCA\Procest\Service\WmsWfsService` SHALL provide `getLayersForCaseType()`, `validateLayer()`, `proxyRequest()`, `buildGetMapUrl()`, `buildGetFeatureUrl()`, and `getLayerById()`. The service SHALL NEVER issue direct outbound HTTP — every external request SHALL be delegated to `GisProxyService::proxyRequest()` so the GIS proxy allowlist (REQ-LAYER-03c) and rate limiting (REQ-LAYER-03d) remain authoritative. Layer resolution per case type SHALL include all `wmsLayer` UUIDs listed in `caseType.layerIds` plus all layers with `isDefault: true`, with `active: false` layers filtered out. GetMap tile dimensions SHALL be capped at 512 pixels.
+
+#### Scenario: Layer resolution merges subscribed + default layers
+- **GIVEN** a case type with `layerIds: ["uuid-a"]` and three configured layers — uuid-a (active), uuid-b (active, isDefault=true), uuid-c (inactive, isDefault=true)
+- **WHEN** `WmsWfsService::getLayersForCaseType($caseType)` is called
+- **THEN** the result SHALL contain layers uuid-a and uuid-b only
+
+#### Scenario: All outbound traffic flows through GisProxyService
+- **WHEN** `WmsWfsService::proxyRequest($layer, $params)` is invoked for any layer
+- **THEN** the call SHALL delegate to `GisProxyService::proxyRequest()` and SHALL NOT open a direct HTTP connection from `WmsWfsService` itself
+
+#### Scenario: Tile dimensions are capped at 512px
+- **GIVEN** a caller requests `width=1024 height=1024` against `buildGetMapUrl()`
+- **WHEN** the URL is constructed
+- **THEN** the WIDTH and HEIGHT parameters SHALL be clamped to 512
+
+<!-- END retrofit-2026-05-24-wms-wfs-layers -->


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Describes observed behavior of 2 PHP files (~8 methods) under `wms-wfs-layers` as 2 new REQs.

Ghost change: `retrofit-2026-05-24-wms-wfs-layers` (archived).

### What this PR does
- Drafts 2 REQs extending the `wms-wfs-layers` capability (`retrofit_extensions: [REQ-001, REQ-002]`)
- Creates tasks.md with one task per REQ
- Annotates 2 files with `@spec openspec/changes/retrofit-.../tasks.md#task-N`
- Archives the change inline (merges spec delta into main spec)

### What this PR does NOT do
- No code behavior changes — just annotations
- No silent fixes to observed behavior

### Review focus
- REQ language matches observed behavior (not aspirational)
- Scenarios are testable

Source: `openspec/coverage-report.md` generated 2026-05-24 | Cluster: `wms-wfs-layers` | Refs #565