### PR TITLE
retrofit: reverse-spec berichtenbox-integration (5 REQs / 5 files)

### DIFF
--- a/lib/BackgroundJob/BerichtenboxReadStatusJob.php
+++ b/lib/BackgroundJob/BerichtenboxReadStatusJob.php
@@ -16,6 +16,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-berichtenbox-integration/tasks.md#task-5
  */
 
 declare(strict_types=1);

--- a/lib/Controller/BerichtenboxController.php
+++ b/lib/Controller/BerichtenboxController.php
@@ -16,6 +16,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-berichtenbox-integration/tasks.md#task-1
  */
 
 declare(strict_types=1);

--- a/lib/Service/BerichtenboxAdapter/BerichtenboxAdapterInterface.php
+++ b/lib/Service/BerichtenboxAdapter/BerichtenboxAdapterInterface.php
@@ -15,6 +15,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-berichtenbox-integration/tasks.md#task-3
  */
 
 declare(strict_types=1);

--- a/lib/Service/BerichtenboxAdapter/MockAdapter.php
+++ b/lib/Service/BerichtenboxAdapter/MockAdapter.php
@@ -16,6 +16,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-berichtenbox-integration/tasks.md#task-3
  */
 
 declare(strict_types=1);

--- a/lib/Service/BerichtenboxService.php
+++ b/lib/Service/BerichtenboxService.php
@@ -16,6 +16,9 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-berichtenbox-integration/tasks.md#task-2
+ * @spec openspec/changes/retrofit-2026-05-24-berichtenbox-integration/tasks.md#task-4
  */
 
 declare(strict_types=1);

--- a/openspec/changes/retrofit-2026-05-24-berichtenbox-integration/design.md
+++ b/openspec/changes/retrofit-2026-05-24-berichtenbox-integration/design.md
@@ -1,0 +1,3 @@
+# Design — retrofit berichtenbox-integration
+
+Retrofit change. Tasks describe retroactive annotation of existing code, not new implementation work.

--- a/openspec/changes/retrofit-2026-05-24-berichtenbox-integration/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-berichtenbox-integration/proposal.md
@@ -1,0 +1,19 @@
+# Retrofit — berichtenbox-integration
+
+Describes observed behavior of 5 PHP files (~17 methods) — Berichtenbox HTTP controller, service, pluggable adapter interface + mock, and daily polling background job — as 5 new REQs.
+
+## Affected code units
+
+- lib/Controller/BerichtenboxController.php (4 methods) — REST endpoints send / messages / poll
+- lib/Service/BerichtenboxService.php (8 methods) — send orchestration, BSN 11-proef validation, message storage in OpenRegister, read-status polling, adapter resolution
+- lib/Service/BerichtenboxAdapter/BerichtenboxAdapterInterface.php — adapter contract (sendMessage, getReadStatus)
+- lib/Service/BerichtenboxAdapter/MockAdapter.php (3 methods) — MVP mock adapter
+- lib/BackgroundJob/BerichtenboxReadStatusJob.php (2 methods) — daily TimedJob (86400s) scaffold
+
+## Approach
+
+- For each method: describe observed inputs, outputs, pre/postconditions, failure modes
+- Draft REQs that match behavior (not aspirational)
+- Notes section surfaces observed-but-suspicious behavior (e.g. MVP-hardcoded MockAdapter, placeholder attachment read, scaffold-only background job body)
+
+Source: openspec/coverage-report.md generated 2026-05-24. Tracks ConductionNL/procest#565.

--- a/openspec/changes/retrofit-2026-05-24-berichtenbox-integration/specs/berichtenbox-integration/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-berichtenbox-integration/specs/berichtenbox-integration/spec.md
@@ -1,0 +1,122 @@
+---
+retrofit: true
+---
+
+# Berichtenbox Integration Specification
+
+## Purpose
+
+Provide Procest with the ability to send citizen-facing messages to a citizen's Mijn Overheid Berichtenbox, list messages linked to a case, and poll for read status — abstracted behind a pluggable adapter so the production Berichtenbox API can be swapped in for the development mock.
+
+## Requirements
+
+### REQ-001: Berichtenbox send / list / poll REST endpoints
+
+The system SHALL expose three `@NoAdminRequired` JSON endpoints on `BerichtenboxController` — `send`, `messages`, and `poll` — that route to `BerichtenboxService` for message dispatch, case-scoped message listing, and per-message read-status polling respectively.
+
+#### Scenario: Send a message
+
+- WHEN a user POSTs to `send` with `caseId`, `bsn`, `subject`, `body`, `berichtTypeCode`, and optional `attachmentFileId`
+- THEN the controller SHALL return HTTP 400 `{success: false, error: 'caseId is required'}` when `caseId` is empty
+- AND it SHALL otherwise delegate to `BerichtenboxService::sendMessage` and return `{success: true, message: <result>}` on success or `{success: false, error: <validation message>}` on validation failure
+
+#### Scenario: List messages for a case
+
+- WHEN a user calls `messages` with `caseId`
+- THEN the controller SHALL return `{success: true, messages: [...]}` containing every Berichtenbox message stored in OpenRegister for that case
+
+#### Scenario: Poll read status
+
+- WHEN a user calls `poll/{messageId}`
+- THEN the controller SHALL return `{success: true, message: <updated record>}` reflecting the current read status
+
+#### Notes
+
+- All three endpoints are `@NoAdminRequired` — they rely on case-level access checks performed downstream.
+
+### REQ-002: BSN 11-proef + plain-text message validation
+
+The system SHALL validate every outbound Berichtenbox message before dispatch: BSN MUST be a 9-digit string passing the Dutch 11-proef checksum; subject and body MUST be non-empty; body MUST contain no HTML markup.
+
+#### Scenario: Reject invalid BSN
+
+- WHEN `sendMessage` is called with a `bsn` that is empty, non-numeric, not 9 digits, or fails the 11-proef
+- THEN the service SHALL return `{error: 'BSN is verplicht voor berichten via Mijn Overheid'}` (empty) or `{error: 'Ongeldig BSN-nummer'}` (invalid checksum) without invoking the adapter
+
+#### Scenario: Reject missing subject or body
+
+- WHEN `sendMessage` is called with an empty `subject` or `body`
+- THEN the service SHALL return a validation-error payload (`'Onderwerp is verplicht'` / `'Berichttekst is verplicht'`) without invoking the adapter
+
+#### Scenario: Reject HTML in body
+
+- WHEN `sendMessage` is called with a `body` that differs from `strip_tags($body)`
+- THEN the service SHALL return `{error: 'Berichttekst mag alleen platte tekst bevatten'}` without invoking the adapter
+
+#### Notes
+
+- The 11-proef weights digits 1-8 by `(9 - i)` and subtracts digit 9, accepting only `sum % 11 === 0` AND `sum !== 0`.
+- Multiple errors are accumulated and joined with `'; '` in the returned `error` field.
+
+### REQ-003: Pluggable Berichtenbox adapter contract
+
+The system SHALL define a `BerichtenboxAdapterInterface` with two methods — `sendMessage(bsn, subject, body, typeCode, ?attachment): array` returning at minimum `{messageId, status}`, and `getReadStatus(messageId): array` returning at minimum `{read: bool, readAt: ?datetime}` — so that production Berichtenbox API adapters can be swapped in without touching `BerichtenboxService`.
+
+#### Scenario: Service resolves adapter via factory
+
+- WHEN `BerichtenboxService::sendMessage` or `pollReadStatus` needs to talk to Berichtenbox
+- THEN it SHALL call the private `getAdapter()` factory which returns an implementation of `BerichtenboxAdapterInterface`
+
+#### Scenario: MVP ships with mock adapter
+
+- WHEN no production adapter is configured (current state)
+- THEN `getAdapter()` SHALL return `MockAdapter` which generates a `mock-<hex>` message id, logs a redacted BSN, and reports messages as read 1h after send
+
+#### Notes
+
+- The current factory unconditionally instantiates `MockAdapter` — settings-based adapter selection is observed-but-stubbed and remains a TODO.
+- `MockAdapter::sendMessage` logs only the first 4 BSN digits, masking the rest with `*****` — PII handling pattern future production adapters should preserve.
+
+### REQ-004: Read-status polling with 7-day unread-flagging
+
+When `pollReadStatus(messageId)` is called, the system SHALL look up the stored Berichtenbox message in OpenRegister, call the adapter's `getReadStatus` with the stored `externalMessageId`, update local status to `read` (with `readAt`) when the adapter reports read, and otherwise stamp `readPolledAt` and re-flag status as `unread_flagged` when the message has been unread for 7 or more days.
+
+#### Scenario: Mark message as read
+
+- GIVEN a stored message with a non-empty `externalMessageId`
+- WHEN `pollReadStatus` runs and the adapter returns `{read: true, readAt: <iso8601>}`
+- THEN the service SHALL update the stored object with `status='read'`, `readAt=<adapter value>`, and `readPolledAt=<now>` and persist via `saveObject`
+
+#### Scenario: Flag long-unread message
+
+- GIVEN a stored message with `sentAt` 7+ days ago and adapter `read=false`
+- WHEN `pollReadStatus` runs
+- THEN the service SHALL set `status='unread_flagged'`, stamp `readPolledAt`, and persist; for `< 7` days the status SHALL be left untouched while `readPolledAt` is stamped
+
+#### Scenario: Skip when not yet dispatched
+
+- WHEN the stored message has an empty `externalMessageId`
+- THEN the service SHALL return the record unchanged without contacting the adapter
+
+#### Notes
+
+- The 7-day threshold is hardcoded; making it configurable is a known follow-up.
+- When OpenRegister is unavailable the service SHORT-CIRCUITS with `{error: 'OpenRegister not available'}` — Berichtenbox messages are not persisted anywhere else.
+
+### REQ-005: Daily background polling job
+
+The system SHALL register a `BerichtenboxReadStatusJob` extending `TimedJob` with an interval of `86400` seconds (daily) that the Nextcloud cron picks up and runs server-side.
+
+#### Scenario: Job interval
+
+- WHEN `BerichtenboxReadStatusJob` is constructed
+- THEN its parent `TimedJob` interval SHALL be set to `86400` seconds (24h)
+
+#### Scenario: Run iterates unread messages
+
+- WHEN the cron triggers `run($argument)`
+- THEN the job SHALL log `'Procest: Running Berichtenbox read status poll'` and (future) iterate unread messages calling `BerichtenboxService::pollReadStatus` on each
+
+#### Notes
+
+- The current `run()` body is a logging-only scaffold — the per-message iteration is observed-but-stubbed. A real production rollout must implement the iteration or risk silently failing to update read status.

--- a/openspec/changes/retrofit-2026-05-24-berichtenbox-integration/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-berichtenbox-integration/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] task-1: berichtenbox-integration#REQ-001 — Berichtenbox send / list / poll REST endpoints (retroactive annotation)
+- [x] task-2: berichtenbox-integration#REQ-002 — BSN 11-proef + plain-text message validation (retroactive annotation)
+- [x] task-3: berichtenbox-integration#REQ-003 — Pluggable Berichtenbox adapter contract (retroactive annotation)
+- [x] task-4: berichtenbox-integration#REQ-004 — Read-status polling with 7-day unread-flagging (retroactive annotation)
+- [x] task-5: berichtenbox-integration#REQ-005 — Daily background polling job (retroactive annotation)

--- a/openspec/specs/berichtenbox-integration/spec.md
+++ b/openspec/specs/berichtenbox-integration/spec.md
@@ -1,0 +1,122 @@
+---
+retrofit: true
+---
+
+# Berichtenbox Integration Specification
+
+## Purpose
+
+Provide Procest with the ability to send citizen-facing messages to a citizen's Mijn Overheid Berichtenbox, list messages linked to a case, and poll for read status — abstracted behind a pluggable adapter so the production Berichtenbox API can be swapped in for the development mock.
+
+## Requirements
+
+### REQ-001: Berichtenbox send / list / poll REST endpoints
+
+The system SHALL expose three `@NoAdminRequired` JSON endpoints on `BerichtenboxController` — `send`, `messages`, and `poll` — that route to `BerichtenboxService` for message dispatch, case-scoped message listing, and per-message read-status polling respectively.
+
+#### Scenario: Send a message
+
+- WHEN a user POSTs to `send` with `caseId`, `bsn`, `subject`, `body`, `berichtTypeCode`, and optional `attachmentFileId`
+- THEN the controller SHALL return HTTP 400 `{success: false, error: 'caseId is required'}` when `caseId` is empty
+- AND it SHALL otherwise delegate to `BerichtenboxService::sendMessage` and return `{success: true, message: <result>}` on success or `{success: false, error: <validation message>}` on validation failure
+
+#### Scenario: List messages for a case
+
+- WHEN a user calls `messages` with `caseId`
+- THEN the controller SHALL return `{success: true, messages: [...]}` containing every Berichtenbox message stored in OpenRegister for that case
+
+#### Scenario: Poll read status
+
+- WHEN a user calls `poll/{messageId}`
+- THEN the controller SHALL return `{success: true, message: <updated record>}` reflecting the current read status
+
+#### Notes
+
+- All three endpoints are `@NoAdminRequired` — they rely on case-level access checks performed downstream.
+
+### REQ-002: BSN 11-proef + plain-text message validation
+
+The system SHALL validate every outbound Berichtenbox message before dispatch: BSN MUST be a 9-digit string passing the Dutch 11-proef checksum; subject and body MUST be non-empty; body MUST contain no HTML markup.
+
+#### Scenario: Reject invalid BSN
+
+- WHEN `sendMessage` is called with a `bsn` that is empty, non-numeric, not 9 digits, or fails the 11-proef
+- THEN the service SHALL return `{error: 'BSN is verplicht voor berichten via Mijn Overheid'}` (empty) or `{error: 'Ongeldig BSN-nummer'}` (invalid checksum) without invoking the adapter
+
+#### Scenario: Reject missing subject or body
+
+- WHEN `sendMessage` is called with an empty `subject` or `body`
+- THEN the service SHALL return a validation-error payload (`'Onderwerp is verplicht'` / `'Berichttekst is verplicht'`) without invoking the adapter
+
+#### Scenario: Reject HTML in body
+
+- WHEN `sendMessage` is called with a `body` that differs from `strip_tags($body)`
+- THEN the service SHALL return `{error: 'Berichttekst mag alleen platte tekst bevatten'}` without invoking the adapter
+
+#### Notes
+
+- The 11-proef weights digits 1-8 by `(9 - i)` and subtracts digit 9, accepting only `sum % 11 === 0` AND `sum !== 0`.
+- Multiple errors are accumulated and joined with `'; '` in the returned `error` field.
+
+### REQ-003: Pluggable Berichtenbox adapter contract
+
+The system SHALL define a `BerichtenboxAdapterInterface` with two methods — `sendMessage(bsn, subject, body, typeCode, ?attachment): array` returning at minimum `{messageId, status}`, and `getReadStatus(messageId): array` returning at minimum `{read: bool, readAt: ?datetime}` — so that production Berichtenbox API adapters can be swapped in without touching `BerichtenboxService`.
+
+#### Scenario: Service resolves adapter via factory
+
+- WHEN `BerichtenboxService::sendMessage` or `pollReadStatus` needs to talk to Berichtenbox
+- THEN it SHALL call the private `getAdapter()` factory which returns an implementation of `BerichtenboxAdapterInterface`
+
+#### Scenario: MVP ships with mock adapter
+
+- WHEN no production adapter is configured (current state)
+- THEN `getAdapter()` SHALL return `MockAdapter` which generates a `mock-<hex>` message id, logs a redacted BSN, and reports messages as read 1h after send
+
+#### Notes
+
+- The current factory unconditionally instantiates `MockAdapter` — settings-based adapter selection is observed-but-stubbed and remains a TODO.
+- `MockAdapter::sendMessage` logs only the first 4 BSN digits, masking the rest with `*****` — PII handling pattern future production adapters should preserve.
+
+### REQ-004: Read-status polling with 7-day unread-flagging
+
+When `pollReadStatus(messageId)` is called, the system SHALL look up the stored Berichtenbox message in OpenRegister, call the adapter's `getReadStatus` with the stored `externalMessageId`, update local status to `read` (with `readAt`) when the adapter reports read, and otherwise stamp `readPolledAt` and re-flag status as `unread_flagged` when the message has been unread for 7 or more days.
+
+#### Scenario: Mark message as read
+
+- GIVEN a stored message with a non-empty `externalMessageId`
+- WHEN `pollReadStatus` runs and the adapter returns `{read: true, readAt: <iso8601>}`
+- THEN the service SHALL update the stored object with `status='read'`, `readAt=<adapter value>`, and `readPolledAt=<now>` and persist via `saveObject`
+
+#### Scenario: Flag long-unread message
+
+- GIVEN a stored message with `sentAt` 7+ days ago and adapter `read=false`
+- WHEN `pollReadStatus` runs
+- THEN the service SHALL set `status='unread_flagged'`, stamp `readPolledAt`, and persist; for `< 7` days the status SHALL be left untouched while `readPolledAt` is stamped
+
+#### Scenario: Skip when not yet dispatched
+
+- WHEN the stored message has an empty `externalMessageId`
+- THEN the service SHALL return the record unchanged without contacting the adapter
+
+#### Notes
+
+- The 7-day threshold is hardcoded; making it configurable is a known follow-up.
+- When OpenRegister is unavailable the service SHORT-CIRCUITS with `{error: 'OpenRegister not available'}` — Berichtenbox messages are not persisted anywhere else.
+
+### REQ-005: Daily background polling job
+
+The system SHALL register a `BerichtenboxReadStatusJob` extending `TimedJob` with an interval of `86400` seconds (daily) that the Nextcloud cron picks up and runs server-side.
+
+#### Scenario: Job interval
+
+- WHEN `BerichtenboxReadStatusJob` is constructed
+- THEN its parent `TimedJob` interval SHALL be set to `86400` seconds (24h)
+
+#### Scenario: Run iterates unread messages
+
+- WHEN the cron triggers `run($argument)`
+- THEN the job SHALL log `'Procest: Running Berichtenbox read status poll'` and (future) iterate unread messages calling `BerichtenboxService::pollReadStatus` on each
+
+#### Notes
+
+- The current `run()` body is a logging-only scaffold — the per-message iteration is observed-but-stubbed. A real production rollout must implement the iteration or risk silently failing to update read status.


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Describes observed behavior of 5 files (~17 methods) under `berichtenbox-integration` as 5 new REQs.

Ghost change: `retrofit-2026-05-24-berichtenbox-integration` (archived inline).

### What this PR does

- Drafts 5 REQs in `openspec/specs/berichtenbox-integration/spec.md` with `retrofit: true`
- Creates ghost change scaffold (proposal/design/tasks/specs delta)
- Annotates 5 files with `@spec openspec/changes/retrofit-2026-05-24-berichtenbox-integration/tasks.md#task-N`
- Archives the change inline (spec delta copied into main specs/)

### What this PR does NOT do

- No code behavior changes — just annotations
- Notes surface observed stubs (MockAdapter hardcoded, scaffold-only BackgroundJob run body, hardcoded 7-day threshold)

### Review focus

- REQ language matches observed behavior
- Scenarios are testable
- Notes flag stub-state honestly

Source: `openspec/coverage-report.md` generated 2026-05-24 | Cluster: `berichtenbox-integration`

Refs #565.