### PR TITLE
retrofit: reverse-spec stuf-integration (5 REQs / 3 files)

### DIFF
--- a/lib/Controller/StufController.php
+++ b/lib/Controller/StufController.php
@@ -20,6 +20,10 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-stuf-integration/tasks.md#task-1
+ * @spec openspec/changes/retrofit-2026-05-24-stuf-integration/tasks.md#task-2
+ * @spec openspec/changes/retrofit-2026-05-24-stuf-integration/tasks.md#task-3
  */
 
 declare(strict_types=1);

--- a/lib/Service/StufFieldMappingService.php
+++ b/lib/Service/StufFieldMappingService.php
@@ -17,6 +17,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-stuf-integration/tasks.md#task-4
  */
 
 declare(strict_types=1);

--- a/lib/Service/StufMessageBuilder.php
+++ b/lib/Service/StufMessageBuilder.php
@@ -16,6 +16,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-stuf-integration/tasks.md#task-5
  */
 
 declare(strict_types=1);

--- a/openspec/changes/retrofit-2026-05-24-stuf-integration/design.md
+++ b/openspec/changes/retrofit-2026-05-24-stuf-integration/design.md
@@ -1,0 +1,3 @@
+# Design — retrofit stuf-integration
+
+Retrofit change. Tasks describe retroactive annotation of existing code, not new implementation work.

--- a/openspec/changes/retrofit-2026-05-24-stuf-integration/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-stuf-integration/proposal.md
@@ -1,0 +1,17 @@
+# Retrofit — stuf-integration
+
+Describes observed behavior of 3 PHP files (~32 methods) — StUF SOAP controller, ZKN/BG field mapping service, and SOAP/StUF message builder — as 5 new REQs.
+
+## Affected code units
+
+- lib/Controller/StufController.php (11 methods) — `/api/stuf/{service}` raw-XML SOAP endpoint with per-message-type dispatch
+- lib/Service/StufFieldMappingService.php (14 methods) — bidirectional StUF↔OpenRegister field mapping, date/enum transforms, custom-mapping override
+- lib/Service/StufMessageBuilder.php (7 methods) — SOAP envelope construction with proper namespaces, stuurgegevens, noValue attribute handling
+
+## Approach
+
+- For each method: describe observed inputs, outputs, pre/postconditions, failure modes
+- Draft REQs that match behavior (not aspirational)
+- Notes flag observed stubs ("In a full implementation, create/update OpenRegister objects here" — handlers return Bv01 confirmations without persisting)
+
+Source: openspec/coverage-report.md generated 2026-05-24. Tracks ConductionNL/procest#565.

--- a/openspec/changes/retrofit-2026-05-24-stuf-integration/specs/stuf-integration/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-stuf-integration/specs/stuf-integration/spec.md
@@ -1,0 +1,133 @@
+---
+retrofit: true
+---
+
+# StUF Integration Specification
+
+## Purpose
+
+Accept inbound StUF (Standaard Uitwisselings Formaat) 3.01 SOAP messages from legacy Dutch government back-office systems, dispatch them by message type to dedicated handlers, map ZKN/BG fields to OpenRegister object properties (and back), and respond with well-formed StUF SOAP envelopes — so that Procest can interoperate with legacy zaaksystemen, BRP-clients and document systems without the producing system having to migrate to REST.
+
+## Requirements
+
+### REQ-001: Inbound StUF SOAP routing + message-type dispatch
+
+The system SHALL expose `/api/stuf/{service}` endpoints (`zaken`, `personen`) on `StufController` that accept raw XML POST, parse the SOAP envelope, extract the first StUF message child of `soap:Body`, log it, and dispatch by `localName` to the matching private handler (`zakLk01` / `zakLv01` / `npsLv01` / `edcLk01`) or return a SOAP `Fo01` fault for unknown types.
+
+#### Scenario: Empty or malformed body
+
+- WHEN the controller receives an empty body or fails to parse XML (libxml errors)
+- THEN it SHALL return a SOAP fault envelope with HTTP 400 (`'Leeg bericht ontvangen'` / `'Ongeldig XML bericht'`)
+
+#### Scenario: Missing SOAP envelope structure
+
+- WHEN the request body parses but lacks a `soap:Body` element, has an empty body, or has no child element under body
+- THEN the controller SHALL return a `buildSoapFault` envelope with HTTP 400 and a descriptive message in Dutch
+
+#### Scenario: Dispatch by message type
+
+- WHEN the body contains a valid StUF message
+- THEN the controller SHALL log `'Received StUF message: {type} at {service}'` and dispatch via PHP `match` to the handler for that `localName`
+
+#### Notes
+
+- Both endpoints (`zaken`, `personen`) share the same dispatcher — the `{service}` segment is logged but does not constrain which message types are accepted.
+- Unknown message types route to `handleUnknownMessage` which returns `Fo01` with code `StUF001` and HTTP 400.
+
+### REQ-002: StUF-ZKN case handlers (zakLk01, zakLv01, edcLk01)
+
+The system SHALL handle StUF-ZKN case-lifecycle messages: `zakLk01` (create/update) extracts standard case fields, maps them to internal properties, captures `mutatiesoort` + `referentienummer`, and returns a `Bv01` confirmation; `zakLv01` (query) extracts criteria from the `gelijk` element and returns an empty `zakLa01` answer envelope; `edcLk01` (document message) returns a `Bv01` confirmation with the inbound `referentienummer`.
+
+#### Scenario: zakLk01 create/update
+
+- WHEN a `zakLk01` arrives
+- THEN the controller SHALL extract `identificatie`, `omschrijving`, `toelichting`, `startdatum`, `einddatum`, `einddatumGepland`, `uiterlijkeEinddatumAfdoening`, `vertrouwelijkAanduiding` from the first `object` element
+- AND call `StufFieldMappingService::mapZknToInternal` to convert to OpenRegister property names
+- AND respond with `buildBv01(zender, [], crossRef)` where `crossRef` is the inbound `stuurgegevens/referentienummer`
+- AND if no `object` element is present, respond with `buildFo01('StUF055', 'Geen object element in zakLk01', 'server', zender, [])`
+
+#### Scenario: zakLv01 query
+
+- WHEN a `zakLv01` arrives
+- THEN the controller SHALL extract `identificatie`, `omschrijving`, `startdatum` from the first `gelijk` element
+- AND respond with a SOAP envelope wrapping `<zkn:zakLa01>` containing `stuurgegevens` and an empty `<zkn:antwoord/>`
+
+#### Scenario: edcLk01 document
+
+- WHEN an `edcLk01` arrives
+- THEN the controller SHALL respond with `buildBv01(zender, [], crossRef)` using the inbound `referentienummer`
+
+#### Notes
+
+- Persistence to OpenRegister is observed-but-stubbed (`// In a full implementation, create/update OpenRegister objects here`). The handler logs the mapped data and returns success without writing.
+- `zakLv01` always returns an empty `<antwoord/>` — OpenRegister query is observed-but-stubbed.
+
+### REQ-003: StUF-BG person query handler (npsLv01)
+
+The system SHALL handle `npsLv01` (person-by-BSN query) by extracting the BSN from `gelijk/bsn`, logging the first 3 digits with the rest masked (`BSN abc***`), and returning an empty `<bg:npsLa01>` envelope.
+
+#### Scenario: BSN extraction and PII-safe logging
+
+- WHEN an `npsLv01` arrives
+- THEN the controller SHALL extract the BSN from the first `gelijk` element's `bsn` child
+- AND log `'Processed npsLv01 person query for BSN {bsn}'` with `substr($bsn, 0, 3) . '***'` to redact the rest
+
+#### Scenario: Response envelope
+
+- WHEN the handler completes
+- THEN it SHALL respond with a SOAP envelope wrapping `<bg:npsLa01>` containing `stuurgegevens` and an empty `<bg:antwoord/>`
+
+#### Notes
+
+- OpenRegister person lookup is observed-but-stubbed; the handler always returns the empty `<antwoord/>` placeholder.
+
+### REQ-004: Bidirectional StUF↔OpenRegister field mapping with date and enum transforms
+
+The system SHALL provide a `StufFieldMappingService` that maps StUF-ZKN field names (`identificatie`, `omschrijving`, `startdatum`, ...) and StUF-BG field names (`inp.bsn`, `geslachtsnaam`, `geboortedatum`, ...) to OpenRegister property names, applying transforms for StUF `Ymd`/`YmdHis` dates (↔ ISO 8601) and the `vertrouwelijkAanduiding` enum (OPENBAAR → public, GEHEIM → secret, etc.), with support for runtime custom-mapping override.
+
+#### Scenario: Default ZKN mapping
+
+- WHEN `mapZknToInternal` is called with `{identificatie, omschrijving, startdatum: '20240315'}`
+- THEN it SHALL return `{identifier, title, startDate: '2024-03-15...'}` applying `stufDateToIso` to date-typed fields
+
+#### Scenario: Default BG mapping
+
+- WHEN `mapBgToInternal` is called with `{'inp.bsn', geslachtsnaam, voornamen, geboortedatum}`
+- THEN it SHALL return `{bsn, lastName, firstName, dateOfBirth (ISO 8601)}`
+
+#### Scenario: Confidentiality enum
+
+- WHEN a StUF field maps with the `confidentialityToInternal` transform
+- THEN values map per the table OPENBAAR→public, `BEPERKT OPENBAAR`→restricted, INTERN→internal, ZAAKVERTROUWELIJK→case_sensitive, VERTROUWELIJK→confidential, CONFIDENTIEEL→highly_confidential, GEHEIM→secret, `ZEER GEHEIM`→top_secret
+
+#### Scenario: Custom mapping override
+
+- WHEN custom mappings have been loaded for a sector
+- THEN they SHALL take precedence over the corresponding default mapping for that sector
+
+#### Notes
+
+- Date format constants are `Ymd` (date) and `YmdHis` (datetime); mapping is bidirectional via paired `*ToStuf`/`*ToInternal` methods.
+
+### REQ-005: StUF SOAP envelope construction with namespaces, stuurgegevens, noValue
+
+The system SHALL provide a `StufMessageBuilder` that constructs StUF SOAP envelopes with the four canonical namespaces (`NS_STUF`, `NS_ZKN`, `NS_BG`, `NS_SOAP`, `NS_XSI`), builds `stuurgegevens` blocks from zender/ontvanger arrays, builds `Bv01` confirmation and `Fo01` fault payloads, and produces `noValue`-attribute markers for the four StUF "absence" types.
+
+#### Scenario: SOAP envelope wrapping
+
+- WHEN `buildSoapEnvelope(bodyXml)` is called
+- THEN the result SHALL be a UTF-8 XML document with `soap:Envelope` declaring `stuf`, `zkn`, `bg`, `xsi` namespaces, an empty `soap:Header`, and a `soap:Body` containing the imported body element
+
+#### Scenario: Fo01 fault payload
+
+- WHEN `buildFo01(code, omschrijving, plek, zender, ontvanger)` is called
+- THEN the result SHALL be a SOAP envelope wrapping a StUF `Fo01` payload carrying the fault `code`, human-readable `omschrijving`, fault `plek` (server/client), and stuurgegevens
+
+#### Scenario: noValue attribute set
+
+- WHEN the builder is asked to emit a noValue marker
+- THEN it SHALL pick from `NO_VALUE_TYPES` exactly one of `geenWaarde`, `waardeOnbekend`, `nietOndersteund`, `vastgesteldOnbekend`
+
+#### Notes
+
+- All namespace constants are public (`StufController` reads `StufMessageBuilder::NS_SOAP` directly to find `soap:Body`); callers depend on them as part of the public API.

--- a/openspec/changes/retrofit-2026-05-24-stuf-integration/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-stuf-integration/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] task-1: stuf-integration#REQ-001 — Inbound StUF SOAP routing + message-type dispatch (retroactive annotation)
+- [x] task-2: stuf-integration#REQ-002 — StUF-ZKN case handlers (zakLk01, zakLv01, edcLk01) (retroactive annotation)
+- [x] task-3: stuf-integration#REQ-003 — StUF-BG person query handler (npsLv01) (retroactive annotation)
+- [x] task-4: stuf-integration#REQ-004 — Bidirectional StUF↔OpenRegister field mapping with date and enum transforms (retroactive annotation)
+- [x] task-5: stuf-integration#REQ-005 — StUF SOAP envelope construction with namespaces, stuurgegevens, noValue (retroactive annotation)

--- a/openspec/specs/stuf-integration/spec.md
+++ b/openspec/specs/stuf-integration/spec.md
@@ -1,0 +1,133 @@
+---
+retrofit: true
+---
+
+# StUF Integration Specification
+
+## Purpose
+
+Accept inbound StUF (Standaard Uitwisselings Formaat) 3.01 SOAP messages from legacy Dutch government back-office systems, dispatch them by message type to dedicated handlers, map ZKN/BG fields to OpenRegister object properties (and back), and respond with well-formed StUF SOAP envelopes — so that Procest can interoperate with legacy zaaksystemen, BRP-clients and document systems without the producing system having to migrate to REST.
+
+## Requirements
+
+### REQ-001: Inbound StUF SOAP routing + message-type dispatch
+
+The system SHALL expose `/api/stuf/{service}` endpoints (`zaken`, `personen`) on `StufController` that accept raw XML POST, parse the SOAP envelope, extract the first StUF message child of `soap:Body`, log it, and dispatch by `localName` to the matching private handler (`zakLk01` / `zakLv01` / `npsLv01` / `edcLk01`) or return a SOAP `Fo01` fault for unknown types.
+
+#### Scenario: Empty or malformed body
+
+- WHEN the controller receives an empty body or fails to parse XML (libxml errors)
+- THEN it SHALL return a SOAP fault envelope with HTTP 400 (`'Leeg bericht ontvangen'` / `'Ongeldig XML bericht'`)
+
+#### Scenario: Missing SOAP envelope structure
+
+- WHEN the request body parses but lacks a `soap:Body` element, has an empty body, or has no child element under body
+- THEN the controller SHALL return a `buildSoapFault` envelope with HTTP 400 and a descriptive message in Dutch
+
+#### Scenario: Dispatch by message type
+
+- WHEN the body contains a valid StUF message
+- THEN the controller SHALL log `'Received StUF message: {type} at {service}'` and dispatch via PHP `match` to the handler for that `localName`
+
+#### Notes
+
+- Both endpoints (`zaken`, `personen`) share the same dispatcher — the `{service}` segment is logged but does not constrain which message types are accepted.
+- Unknown message types route to `handleUnknownMessage` which returns `Fo01` with code `StUF001` and HTTP 400.
+
+### REQ-002: StUF-ZKN case handlers (zakLk01, zakLv01, edcLk01)
+
+The system SHALL handle StUF-ZKN case-lifecycle messages: `zakLk01` (create/update) extracts standard case fields, maps them to internal properties, captures `mutatiesoort` + `referentienummer`, and returns a `Bv01` confirmation; `zakLv01` (query) extracts criteria from the `gelijk` element and returns an empty `zakLa01` answer envelope; `edcLk01` (document message) returns a `Bv01` confirmation with the inbound `referentienummer`.
+
+#### Scenario: zakLk01 create/update
+
+- WHEN a `zakLk01` arrives
+- THEN the controller SHALL extract `identificatie`, `omschrijving`, `toelichting`, `startdatum`, `einddatum`, `einddatumGepland`, `uiterlijkeEinddatumAfdoening`, `vertrouwelijkAanduiding` from the first `object` element
+- AND call `StufFieldMappingService::mapZknToInternal` to convert to OpenRegister property names
+- AND respond with `buildBv01(zender, [], crossRef)` where `crossRef` is the inbound `stuurgegevens/referentienummer`
+- AND if no `object` element is present, respond with `buildFo01('StUF055', 'Geen object element in zakLk01', 'server', zender, [])`
+
+#### Scenario: zakLv01 query
+
+- WHEN a `zakLv01` arrives
+- THEN the controller SHALL extract `identificatie`, `omschrijving`, `startdatum` from the first `gelijk` element
+- AND respond with a SOAP envelope wrapping `<zkn:zakLa01>` containing `stuurgegevens` and an empty `<zkn:antwoord/>`
+
+#### Scenario: edcLk01 document
+
+- WHEN an `edcLk01` arrives
+- THEN the controller SHALL respond with `buildBv01(zender, [], crossRef)` using the inbound `referentienummer`
+
+#### Notes
+
+- Persistence to OpenRegister is observed-but-stubbed (`// In a full implementation, create/update OpenRegister objects here`). The handler logs the mapped data and returns success without writing.
+- `zakLv01` always returns an empty `<antwoord/>` — OpenRegister query is observed-but-stubbed.
+
+### REQ-003: StUF-BG person query handler (npsLv01)
+
+The system SHALL handle `npsLv01` (person-by-BSN query) by extracting the BSN from `gelijk/bsn`, logging the first 3 digits with the rest masked (`BSN abc***`), and returning an empty `<bg:npsLa01>` envelope.
+
+#### Scenario: BSN extraction and PII-safe logging
+
+- WHEN an `npsLv01` arrives
+- THEN the controller SHALL extract the BSN from the first `gelijk` element's `bsn` child
+- AND log `'Processed npsLv01 person query for BSN {bsn}'` with `substr($bsn, 0, 3) . '***'` to redact the rest
+
+#### Scenario: Response envelope
+
+- WHEN the handler completes
+- THEN it SHALL respond with a SOAP envelope wrapping `<bg:npsLa01>` containing `stuurgegevens` and an empty `<bg:antwoord/>`
+
+#### Notes
+
+- OpenRegister person lookup is observed-but-stubbed; the handler always returns the empty `<antwoord/>` placeholder.
+
+### REQ-004: Bidirectional StUF↔OpenRegister field mapping with date and enum transforms
+
+The system SHALL provide a `StufFieldMappingService` that maps StUF-ZKN field names (`identificatie`, `omschrijving`, `startdatum`, ...) and StUF-BG field names (`inp.bsn`, `geslachtsnaam`, `geboortedatum`, ...) to OpenRegister property names, applying transforms for StUF `Ymd`/`YmdHis` dates (↔ ISO 8601) and the `vertrouwelijkAanduiding` enum (OPENBAAR → public, GEHEIM → secret, etc.), with support for runtime custom-mapping override.
+
+#### Scenario: Default ZKN mapping
+
+- WHEN `mapZknToInternal` is called with `{identificatie, omschrijving, startdatum: '20240315'}`
+- THEN it SHALL return `{identifier, title, startDate: '2024-03-15...'}` applying `stufDateToIso` to date-typed fields
+
+#### Scenario: Default BG mapping
+
+- WHEN `mapBgToInternal` is called with `{'inp.bsn', geslachtsnaam, voornamen, geboortedatum}`
+- THEN it SHALL return `{bsn, lastName, firstName, dateOfBirth (ISO 8601)}`
+
+#### Scenario: Confidentiality enum
+
+- WHEN a StUF field maps with the `confidentialityToInternal` transform
+- THEN values map per the table OPENBAAR→public, `BEPERKT OPENBAAR`→restricted, INTERN→internal, ZAAKVERTROUWELIJK→case_sensitive, VERTROUWELIJK→confidential, CONFIDENTIEEL→highly_confidential, GEHEIM→secret, `ZEER GEHEIM`→top_secret
+
+#### Scenario: Custom mapping override
+
+- WHEN custom mappings have been loaded for a sector
+- THEN they SHALL take precedence over the corresponding default mapping for that sector
+
+#### Notes
+
+- Date format constants are `Ymd` (date) and `YmdHis` (datetime); mapping is bidirectional via paired `*ToStuf`/`*ToInternal` methods.
+
+### REQ-005: StUF SOAP envelope construction with namespaces, stuurgegevens, noValue
+
+The system SHALL provide a `StufMessageBuilder` that constructs StUF SOAP envelopes with the four canonical namespaces (`NS_STUF`, `NS_ZKN`, `NS_BG`, `NS_SOAP`, `NS_XSI`), builds `stuurgegevens` blocks from zender/ontvanger arrays, builds `Bv01` confirmation and `Fo01` fault payloads, and produces `noValue`-attribute markers for the four StUF "absence" types.
+
+#### Scenario: SOAP envelope wrapping
+
+- WHEN `buildSoapEnvelope(bodyXml)` is called
+- THEN the result SHALL be a UTF-8 XML document with `soap:Envelope` declaring `stuf`, `zkn`, `bg`, `xsi` namespaces, an empty `soap:Header`, and a `soap:Body` containing the imported body element
+
+#### Scenario: Fo01 fault payload
+
+- WHEN `buildFo01(code, omschrijving, plek, zender, ontvanger)` is called
+- THEN the result SHALL be a SOAP envelope wrapping a StUF `Fo01` payload carrying the fault `code`, human-readable `omschrijving`, fault `plek` (server/client), and stuurgegevens
+
+#### Scenario: noValue attribute set
+
+- WHEN the builder is asked to emit a noValue marker
+- THEN it SHALL pick from `NO_VALUE_TYPES` exactly one of `geenWaarde`, `waardeOnbekend`, `nietOndersteund`, `vastgesteldOnbekend`
+
+#### Notes
+
+- All namespace constants are public (`StufController` reads `StufMessageBuilder::NS_SOAP` directly to find `soap:Body`); callers depend on them as part of the public API.


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Describes observed behavior of 3 files (~32 methods) under `stuf-integration` as 5 new REQs.

Ghost change: `retrofit-2026-05-24-stuf-integration` (archived inline).

### What this PR does

- Drafts 5 REQs in `openspec/specs/stuf-integration/spec.md` with `retrofit: true`
- Creates ghost change scaffold (proposal/design/tasks/specs delta)
- Annotates 3 files with `@spec ...tasks.md#task-N`
- Archives the change inline (spec delta copied into main specs/)

### What this PR does NOT do

- No code behavior changes
- Notes surface observed stubs: zakLk01/zakLv01/npsLv01 handlers do not actually persist or query OpenRegister; they log + return Bv01/empty-antwoord placeholders

### Review focus

- REQ-002 stub note is accurate ("In a full implementation, create/update OpenRegister objects here")
- Confidentiality enum table matches code
- PII-safe BSN logging behaviour captured

Source: `openspec/coverage-report.md` generated 2026-05-24 | Cluster: `stuf-integration`

Refs #565.