### PR TITLE
retrofit: reverse-spec milestone-tracking (5 REQs / 2 files)

### DIFF
--- a/lib/Controller/MilestoneController.php
+++ b/lib/Controller/MilestoneController.php
@@ -18,6 +18,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-milestone-tracking/tasks.md#task-1
  */
 
 declare(strict_types=1);

--- a/lib/Service/MilestoneService.php
+++ b/lib/Service/MilestoneService.php
@@ -16,6 +16,11 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-milestone-tracking/tasks.md#task-2
+ * @spec openspec/changes/retrofit-2026-05-24-milestone-tracking/tasks.md#task-3
+ * @spec openspec/changes/retrofit-2026-05-24-milestone-tracking/tasks.md#task-4
+ * @spec openspec/changes/retrofit-2026-05-24-milestone-tracking/tasks.md#task-5
  */
 
 declare(strict_types=1);

--- a/openspec/changes/retrofit-2026-05-24-milestone-tracking/design.md
+++ b/openspec/changes/retrofit-2026-05-24-milestone-tracking/design.md
@@ -1,0 +1,3 @@
+# Design — retrofit milestone-tracking
+
+Retrofit change. Tasks describe retroactive annotation of existing code, not new implementation work.

--- a/openspec/changes/retrofit-2026-05-24-milestone-tracking/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-milestone-tracking/proposal.md
@@ -1,0 +1,16 @@
+# Retrofit — milestone-tracking
+
+Describes observed behavior of 2 PHP files (~11 methods) — milestone controller and service — as 5 new REQs.
+
+## Affected code units
+
+- lib/Controller/MilestoneController.php (4 methods) — REST endpoints progress / mark / reverse
+- lib/Service/MilestoneService.php (7 methods) — milestone definitions per case type, progress calculation, mark, reverse (with audit reason), duration analytics
+
+## Approach
+
+- For each method: describe observed inputs, outputs, pre/postconditions, failure modes
+- Draft REQs that match observed behavior
+- Note: an unarchived design change exists at `openspec/changes/milestone-tracking/`; this retrofit specs the **already-implemented slice**.
+
+Source: openspec/coverage-report.md generated 2026-05-24. Tracks ConductionNL/procest#565.

--- a/openspec/changes/retrofit-2026-05-24-milestone-tracking/specs/milestone-tracking/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-milestone-tracking/specs/milestone-tracking/spec.md
@@ -1,0 +1,95 @@
+---
+retrofit: true
+---
+
+# Milestone Tracking Specification
+
+## Purpose
+
+Translate technical workflow state into business-friendly milestone markers per case: configurable milestone definitions per case type, per-case progress aggregation (reached/total/percentage), explicit marking (with origin), reversal (with audit reason), and a placeholder hook for cross-case duration analytics.
+
+## Requirements
+
+### REQ-001: Milestone REST endpoints (progress / mark / reverse)
+
+The system SHALL expose three `@NoAdminRequired` JSON endpoints on `MilestoneController`: `progress(caseId, caseTypeId)`, `mark(caseId, milestoneId)`, and `reverse(caseId, milestoneId)`. All three SHALL wrap service `\RuntimeException` as JSON envelopes; `progress` returns HTTP 500 on failure; `mark` and `reverse` return HTTP 400.
+
+#### Scenario: Progress endpoint
+
+- WHEN `progress(caseId, caseTypeId)` is called
+- THEN it SHALL return the service's progress payload as JSON, or HTTP 500 `{error: <message>}` on `\RuntimeException`
+
+#### Scenario: Reverse requires reason
+
+- WHEN `reverse` is called with empty or whitespace-only `reason`
+- THEN the controller SHALL return HTTP 400 `{error: 'Reason is required for milestone reversal'}` BEFORE calling the service
+
+#### Scenario: User attribution
+
+- WHEN `mark` or `reverse` is called
+- THEN the controller SHALL resolve the user via `IUserSession::getUser()?->getUID()`, falling back to `'system'` for anonymous calls
+
+### REQ-002: Milestone-progress aggregation by case type
+
+The system SHALL fetch ordered milestone definitions for the case type, fetch all milestone records for the case, and return a payload of `{milestones: [...], reached: <int>, total: <int>, percentage: <int 0-100>}` where each milestone item carries `{identifier, label, order, description, reached: bool, reachedAt: ?datetime, reachedBy: ?userId}`.
+
+#### Scenario: Empty milestone set
+
+- WHEN the case type has no milestone definitions
+- THEN the service SHALL return `{milestones: [], reached: 0, total: 0, percentage: 0}` and NOT attempt to fetch records
+
+#### Scenario: Percentage rounding
+
+- WHEN `total > 0`
+- THEN `percentage` SHALL be `(int) round((reached / total) * 100)`
+
+#### Scenario: Definition fields fallback
+
+- WHEN a definition lacks `label`
+- THEN the payload SHALL fall back to `name`, then empty string
+
+### REQ-003: Mark milestone with trigger origin (manual/workflow/auto)
+
+The system SHALL persist a milestone-record object with `{case, milestoneDefinition, reachedAt, reachedBy, trigger}` where `trigger` defaults to `'manual'` and accepts arbitrary origin strings (the controller currently always passes `'manual'`; service callers can pass `'workflow'` or `'auto'`).
+
+#### Scenario: Persistence shape
+
+- WHEN `markMilestone(caseId, milestoneDefinitionId, userId, trigger)` is called
+- THEN the service SHALL persist `{case, milestoneDefinition, reachedAt: now, reachedBy: userId, trigger}` via OpenRegister and return `{id: <uuid>, reachedAt, reachedBy}`
+
+#### Scenario: Schema-unconfigured guard
+
+- WHEN OpenRegister is unavailable
+- THEN the service SHALL throw `\RuntimeException('OpenRegister is not available')`
+- AND when the milestone-record schema is unconfigured it SHALL throw `\RuntimeException('Milestone record schema not configured')`
+
+### REQ-004: Reverse milestone with mandatory reason
+
+The system SHALL allow reversing a previously-marked milestone by deleting every matching milestone-record (`case` + `milestoneDefinition`) and logging the reversal with the user id and reason. The controller layer SHALL guarantee `reason` is non-empty (REQ-001); the service SHALL accept it as a parameter for the audit log.
+
+#### Scenario: No matching record
+
+- WHEN no milestone records match `(case, milestoneDefinition)`
+- THEN `reverseMilestone` SHALL return `false` without touching OpenRegister or logging a reversal
+
+#### Scenario: Successful reversal
+
+- WHEN one or more matching records exist
+- THEN the service SHALL delete each, log `'Milestone reversed: <defId> on case <caseId> by <userId> reason: <reason>'`, and return `true`
+
+#### Notes
+
+- The audit reason is captured only in the log line; there is no per-reversal audit object persisted. Future hardening could persist a `MilestoneReversal` record alongside deletion.
+
+### REQ-005: Duration analytics placeholder for case-type aggregations
+
+The system SHALL expose a `getDurationAnalytics(caseTypeId)` method that, in the current implementation, returns a placeholder shape `{caseTypeId, phases: [], message: 'Duration analytics requires sufficient historical data'}` and emits a `debug`-level log entry.
+
+#### Scenario: Placeholder shape
+
+- WHEN `getDurationAnalytics(caseTypeId)` is called
+- THEN the service SHALL log at debug and return the placeholder payload above
+
+#### Notes
+
+- The real aggregation is observed-but-stubbed (`// Placeholder: in production, this would aggregate milestone records across all cases of this type and calculate averages`). The signature is locked so future implementations don't break callers.

--- a/openspec/changes/retrofit-2026-05-24-milestone-tracking/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-milestone-tracking/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] task-1: milestone-tracking#REQ-001 — Milestone REST endpoints (progress / mark / reverse) (retroactive annotation)
+- [x] task-2: milestone-tracking#REQ-002 — Milestone-progress aggregation by case type (retroactive annotation)
+- [x] task-3: milestone-tracking#REQ-003 — Mark milestone with trigger origin (manual/workflow/auto) (retroactive annotation)
+- [x] task-4: milestone-tracking#REQ-004 — Reverse milestone with mandatory reason (retroactive annotation)
+- [x] task-5: milestone-tracking#REQ-005 — Duration analytics placeholder for case-type aggregations (retroactive annotation)

--- a/openspec/specs/milestone-tracking/spec.md
+++ b/openspec/specs/milestone-tracking/spec.md
@@ -1,0 +1,95 @@
+---
+retrofit: true
+---
+
+# Milestone Tracking Specification
+
+## Purpose
+
+Translate technical workflow state into business-friendly milestone markers per case: configurable milestone definitions per case type, per-case progress aggregation (reached/total/percentage), explicit marking (with origin), reversal (with audit reason), and a placeholder hook for cross-case duration analytics.
+
+## Requirements
+
+### REQ-001: Milestone REST endpoints (progress / mark / reverse)
+
+The system SHALL expose three `@NoAdminRequired` JSON endpoints on `MilestoneController`: `progress(caseId, caseTypeId)`, `mark(caseId, milestoneId)`, and `reverse(caseId, milestoneId)`. All three SHALL wrap service `\RuntimeException` as JSON envelopes; `progress` returns HTTP 500 on failure; `mark` and `reverse` return HTTP 400.
+
+#### Scenario: Progress endpoint
+
+- WHEN `progress(caseId, caseTypeId)` is called
+- THEN it SHALL return the service's progress payload as JSON, or HTTP 500 `{error: <message>}` on `\RuntimeException`
+
+#### Scenario: Reverse requires reason
+
+- WHEN `reverse` is called with empty or whitespace-only `reason`
+- THEN the controller SHALL return HTTP 400 `{error: 'Reason is required for milestone reversal'}` BEFORE calling the service
+
+#### Scenario: User attribution
+
+- WHEN `mark` or `reverse` is called
+- THEN the controller SHALL resolve the user via `IUserSession::getUser()?->getUID()`, falling back to `'system'` for anonymous calls
+
+### REQ-002: Milestone-progress aggregation by case type
+
+The system SHALL fetch ordered milestone definitions for the case type, fetch all milestone records for the case, and return a payload of `{milestones: [...], reached: <int>, total: <int>, percentage: <int 0-100>}` where each milestone item carries `{identifier, label, order, description, reached: bool, reachedAt: ?datetime, reachedBy: ?userId}`.
+
+#### Scenario: Empty milestone set
+
+- WHEN the case type has no milestone definitions
+- THEN the service SHALL return `{milestones: [], reached: 0, total: 0, percentage: 0}` and NOT attempt to fetch records
+
+#### Scenario: Percentage rounding
+
+- WHEN `total > 0`
+- THEN `percentage` SHALL be `(int) round((reached / total) * 100)`
+
+#### Scenario: Definition fields fallback
+
+- WHEN a definition lacks `label`
+- THEN the payload SHALL fall back to `name`, then empty string
+
+### REQ-003: Mark milestone with trigger origin (manual/workflow/auto)
+
+The system SHALL persist a milestone-record object with `{case, milestoneDefinition, reachedAt, reachedBy, trigger}` where `trigger` defaults to `'manual'` and accepts arbitrary origin strings (the controller currently always passes `'manual'`; service callers can pass `'workflow'` or `'auto'`).
+
+#### Scenario: Persistence shape
+
+- WHEN `markMilestone(caseId, milestoneDefinitionId, userId, trigger)` is called
+- THEN the service SHALL persist `{case, milestoneDefinition, reachedAt: now, reachedBy: userId, trigger}` via OpenRegister and return `{id: <uuid>, reachedAt, reachedBy}`
+
+#### Scenario: Schema-unconfigured guard
+
+- WHEN OpenRegister is unavailable
+- THEN the service SHALL throw `\RuntimeException('OpenRegister is not available')`
+- AND when the milestone-record schema is unconfigured it SHALL throw `\RuntimeException('Milestone record schema not configured')`
+
+### REQ-004: Reverse milestone with mandatory reason
+
+The system SHALL allow reversing a previously-marked milestone by deleting every matching milestone-record (`case` + `milestoneDefinition`) and logging the reversal with the user id and reason. The controller layer SHALL guarantee `reason` is non-empty (REQ-001); the service SHALL accept it as a parameter for the audit log.
+
+#### Scenario: No matching record
+
+- WHEN no milestone records match `(case, milestoneDefinition)`
+- THEN `reverseMilestone` SHALL return `false` without touching OpenRegister or logging a reversal
+
+#### Scenario: Successful reversal
+
+- WHEN one or more matching records exist
+- THEN the service SHALL delete each, log `'Milestone reversed: <defId> on case <caseId> by <userId> reason: <reason>'`, and return `true`
+
+#### Notes
+
+- The audit reason is captured only in the log line; there is no per-reversal audit object persisted. Future hardening could persist a `MilestoneReversal` record alongside deletion.
+
+### REQ-005: Duration analytics placeholder for case-type aggregations
+
+The system SHALL expose a `getDurationAnalytics(caseTypeId)` method that, in the current implementation, returns a placeholder shape `{caseTypeId, phases: [], message: 'Duration analytics requires sufficient historical data'}` and emits a `debug`-level log entry.
+
+#### Scenario: Placeholder shape
+
+- WHEN `getDurationAnalytics(caseTypeId)` is called
+- THEN the service SHALL log at debug and return the placeholder payload above
+
+#### Notes
+
+- The real aggregation is observed-but-stubbed (`// Placeholder: in production, this would aggregate milestone records across all cases of this type and calculate averages`). The signature is locked so future implementations don't break callers.


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Describes observed behavior of 2 files (~11 methods) under `milestone-tracking` as 5 new REQs.

Ghost change: `retrofit-2026-05-24-milestone-tracking` (archived inline).

### What this PR does

- Drafts 5 REQs in `openspec/specs/milestone-tracking/spec.md` with `retrofit: true`
- Creates ghost change scaffold (proposal/design/tasks/specs delta)
- Annotates 2 files with `@spec ...tasks.md#task-N`
- Archives the change inline

### Coexists with in-flight design change

`openspec/changes/milestone-tracking/` is a broader design change not yet archived. This retrofit specs the **implemented slice** so the design change can layer additional REQs on top via extension.

### What this PR does NOT do

- No code behavior changes
- Notes call out the duration-analytics placeholder and the "reason captured only in log line" gap

Source: `openspec/coverage-report.md` generated 2026-05-24 | Cluster: `milestone-tracking`

Refs #565.