### PR TITLE
retrofit: reverse-spec template-library (4 REQs / 2 files)

### DIFF
--- a/lib/Controller/TemplateController.php
+++ b/lib/Controller/TemplateController.php
@@ -18,6 +18,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-template-library/tasks.md#task-1
  */
 
 declare(strict_types=1);

--- a/lib/Service/TemplateLibraryService.php
+++ b/lib/Service/TemplateLibraryService.php
@@ -17,6 +17,10 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-template-library/tasks.md#task-2
+ * @spec openspec/changes/retrofit-2026-05-24-template-library/tasks.md#task-3
+ * @spec openspec/changes/retrofit-2026-05-24-template-library/tasks.md#task-4
  */
 
 declare(strict_types=1);

--- a/openspec/changes/retrofit-2026-05-24-template-library/design.md
+++ b/openspec/changes/retrofit-2026-05-24-template-library/design.md
@@ -1,0 +1,3 @@
+# Design — retrofit template-library
+
+Retrofit change. Tasks describe retroactive annotation of existing code, not new implementation work.

--- a/openspec/changes/retrofit-2026-05-24-template-library/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-template-library/proposal.md
@@ -1,0 +1,10 @@
+# Retrofit — template-library
+
+Describes observed behavior of 2 PHP files (~8 methods) — zaaktype-template controller and library service — as 4 new REQs.
+
+## Affected code units
+
+- lib/Controller/TemplateController.php (4 methods) — REST endpoints index / show / activate
+- lib/Service/TemplateLibraryService.php (4 methods) — list / load / activate (filesystem JSON templates → OpenRegister objects)
+
+Source: openspec/coverage-report.md generated 2026-05-24. Tracks ConductionNL/procest#565.

--- a/openspec/changes/retrofit-2026-05-24-template-library/specs/template-library/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-template-library/specs/template-library/spec.md
@@ -1,0 +1,97 @@
+---
+retrofit: true
+---
+
+# Template Library Specification
+
+## Purpose
+
+Ship a library of zaaktype templates (JSON files bundled with the app) and provide a REST surface to discover, inspect, and activate them. Activation expands a template into a fully-linked set of OpenRegister objects (caseType + statusTypes + propertyDefinitions + documentTypes + decisionTypes + roleTypes) so an administrator can stand up a working case type from a single click.
+
+## Requirements
+
+### REQ-001: Template REST endpoints (index / show / activate)
+
+The system SHALL expose three `@NoAdminRequired` JSON endpoints on `TemplateController`: `index()` returns `{results: [...]}` with the template list, `show(id)` returns the full template payload or HTTP 404 `{error: 'Template not found'}`, and `activate(id)` returns the activation result or HTTP 400 `{error: <message>}` on `\RuntimeException`.
+
+#### Scenario: Not found
+
+- WHEN `show(id)` is called with an id that no template advertises
+- THEN the controller SHALL return HTTP 404 `{error: 'Template not found'}`
+
+#### Scenario: Activation failure wrapping
+
+- WHEN `activate(id)` raises `\RuntimeException`
+- THEN the controller SHALL return HTTP 400 `{error: <exception message>}`
+
+### REQ-002: Template discovery from filesystem JSON files
+
+The system SHALL discover templates by scanning `lib/Settings/templates/*.json` (relative to `TemplateLibraryService`), parsing each as JSON, and emitting metadata rows of `{id, title, description, category, version, file}` for every valid file.
+
+#### Scenario: Missing directory
+
+- WHEN `lib/Settings/templates/` does not exist
+- THEN `listTemplates()` SHALL return an empty array (not an error)
+
+#### Scenario: Invalid JSON
+
+- WHEN a `*.json` file fails to parse or is not an object
+- THEN the service SHALL log a warning `'Invalid template file: <basename>'` and skip the file (other files still surface)
+
+#### Scenario: id fallback
+
+- WHEN a template JSON lacks an `id` field
+- THEN the service SHALL fall back to the file's basename (without `.json`)
+
+#### Scenario: Default values
+
+- WHEN a template JSON omits `category` or `version`
+- THEN they SHALL default to `'general'` and `'1.0.0'` respectively
+
+### REQ-003: Template lookup by id with filename-fallback
+
+The system SHALL match `loadTemplate(templateId)` against either the JSON's explicit `id` field or — when absent — the file's basename, returning the full parsed payload on match or `null` on miss.
+
+#### Scenario: Match against explicit id
+
+- WHEN a template file declares `"id": "vth-omgevingsvergunning"`
+- THEN `loadTemplate('vth-omgevingsvergunning')` SHALL return its full parsed payload
+
+#### Scenario: Match against filename fallback
+
+- WHEN a file `omgevingsplan.json` has no explicit `id`
+- THEN `loadTemplate('omgevingsplan')` SHALL return its parsed payload
+
+#### Scenario: No match
+
+- WHEN no file matches by either id or basename
+- THEN the service SHALL return `null`
+
+### REQ-004: Template activation expands JSON into linked OpenRegister objects
+
+The system SHALL activate a template by creating one `caseType` object, then iterating the template's `statusTypes`, `propertyDefinitions`, `documentTypes`, `decisionTypes`, and `roleTypes` collections — each child object SHALL have its `caseType` foreign key set to the newly-created case-type UUID before persistence. The result SHALL be `{templateId, caseType: <uuid>, statuses: [uuid...], properties: [uuid...], documents: [uuid...], decisions: [uuid...], roles: [uuid...]}`.
+
+#### Scenario: Template not found
+
+- WHEN `activateTemplate(<unknown id>)` is called
+- THEN it SHALL throw `\RuntimeException('Template not found: <id>')`
+
+#### Scenario: OpenRegister or register guards
+
+- WHEN OpenRegister is unavailable
+- THEN the service SHALL throw `\RuntimeException('OpenRegister is not available')`
+- AND when `register` config is unset it SHALL throw `\RuntimeException('Procest register not configured')`
+
+#### Scenario: Child objects linked to caseType
+
+- WHEN activation processes any of the five child collections
+- THEN every child payload SHALL be mutated to set `caseType = <new caseTypeId>` before `saveObject`
+
+#### Scenario: Empty collections
+
+- WHEN a template omits one of the child collections (e.g. `decisionTypes`)
+- THEN activation SHALL treat it as `[]` and the corresponding result array SHALL be empty
+
+#### Notes
+
+- Activation is **not transactional** — partial failure leaves the case type and any already-created children persisted with the rest missing. Future hardening should wrap in a transaction or compensating rollback.

--- a/openspec/changes/retrofit-2026-05-24-template-library/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-template-library/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+- [x] task-1: template-library#REQ-001 — Template REST endpoints (index / show / activate) (retroactive annotation)
+- [x] task-2: template-library#REQ-002 — Template discovery from filesystem JSON files (retroactive annotation)
+- [x] task-3: template-library#REQ-003 — Template lookup by id with filename-fallback (retroactive annotation)
+- [x] task-4: template-library#REQ-004 — Template activation expands JSON into linked OpenRegister objects (retroactive annotation)

--- a/openspec/specs/template-library/spec.md
+++ b/openspec/specs/template-library/spec.md
@@ -1,0 +1,97 @@
+---
+retrofit: true
+---
+
+# Template Library Specification
+
+## Purpose
+
+Ship a library of zaaktype templates (JSON files bundled with the app) and provide a REST surface to discover, inspect, and activate them. Activation expands a template into a fully-linked set of OpenRegister objects (caseType + statusTypes + propertyDefinitions + documentTypes + decisionTypes + roleTypes) so an administrator can stand up a working case type from a single click.
+
+## Requirements
+
+### REQ-001: Template REST endpoints (index / show / activate)
+
+The system SHALL expose three `@NoAdminRequired` JSON endpoints on `TemplateController`: `index()` returns `{results: [...]}` with the template list, `show(id)` returns the full template payload or HTTP 404 `{error: 'Template not found'}`, and `activate(id)` returns the activation result or HTTP 400 `{error: <message>}` on `\RuntimeException`.
+
+#### Scenario: Not found
+
+- WHEN `show(id)` is called with an id that no template advertises
+- THEN the controller SHALL return HTTP 404 `{error: 'Template not found'}`
+
+#### Scenario: Activation failure wrapping
+
+- WHEN `activate(id)` raises `\RuntimeException`
+- THEN the controller SHALL return HTTP 400 `{error: <exception message>}`
+
+### REQ-002: Template discovery from filesystem JSON files
+
+The system SHALL discover templates by scanning `lib/Settings/templates/*.json` (relative to `TemplateLibraryService`), parsing each as JSON, and emitting metadata rows of `{id, title, description, category, version, file}` for every valid file.
+
+#### Scenario: Missing directory
+
+- WHEN `lib/Settings/templates/` does not exist
+- THEN `listTemplates()` SHALL return an empty array (not an error)
+
+#### Scenario: Invalid JSON
+
+- WHEN a `*.json` file fails to parse or is not an object
+- THEN the service SHALL log a warning `'Invalid template file: <basename>'` and skip the file (other files still surface)
+
+#### Scenario: id fallback
+
+- WHEN a template JSON lacks an `id` field
+- THEN the service SHALL fall back to the file's basename (without `.json`)
+
+#### Scenario: Default values
+
+- WHEN a template JSON omits `category` or `version`
+- THEN they SHALL default to `'general'` and `'1.0.0'` respectively
+
+### REQ-003: Template lookup by id with filename-fallback
+
+The system SHALL match `loadTemplate(templateId)` against either the JSON's explicit `id` field or — when absent — the file's basename, returning the full parsed payload on match or `null` on miss.
+
+#### Scenario: Match against explicit id
+
+- WHEN a template file declares `"id": "vth-omgevingsvergunning"`
+- THEN `loadTemplate('vth-omgevingsvergunning')` SHALL return its full parsed payload
+
+#### Scenario: Match against filename fallback
+
+- WHEN a file `omgevingsplan.json` has no explicit `id`
+- THEN `loadTemplate('omgevingsplan')` SHALL return its parsed payload
+
+#### Scenario: No match
+
+- WHEN no file matches by either id or basename
+- THEN the service SHALL return `null`
+
+### REQ-004: Template activation expands JSON into linked OpenRegister objects
+
+The system SHALL activate a template by creating one `caseType` object, then iterating the template's `statusTypes`, `propertyDefinitions`, `documentTypes`, `decisionTypes`, and `roleTypes` collections — each child object SHALL have its `caseType` foreign key set to the newly-created case-type UUID before persistence. The result SHALL be `{templateId, caseType: <uuid>, statuses: [uuid...], properties: [uuid...], documents: [uuid...], decisions: [uuid...], roles: [uuid...]}`.
+
+#### Scenario: Template not found
+
+- WHEN `activateTemplate(<unknown id>)` is called
+- THEN it SHALL throw `\RuntimeException('Template not found: <id>')`
+
+#### Scenario: OpenRegister or register guards
+
+- WHEN OpenRegister is unavailable
+- THEN the service SHALL throw `\RuntimeException('OpenRegister is not available')`
+- AND when `register` config is unset it SHALL throw `\RuntimeException('Procest register not configured')`
+
+#### Scenario: Child objects linked to caseType
+
+- WHEN activation processes any of the five child collections
+- THEN every child payload SHALL be mutated to set `caseType = <new caseTypeId>` before `saveObject`
+
+#### Scenario: Empty collections
+
+- WHEN a template omits one of the child collections (e.g. `decisionTypes`)
+- THEN activation SHALL treat it as `[]` and the corresponding result array SHALL be empty
+
+#### Notes
+
+- Activation is **not transactional** — partial failure leaves the case type and any already-created children persisted with the rest missing. Future hardening should wrap in a transaction or compensating rollback.


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Describes observed behavior of 2 files (~8 methods) under `template-library` as 4 new REQs covering filesystem-template discovery, single-template lookup with filename fallback, and atomic OpenRegister expansion of a template into caseType + 5 child collections.

Ghost change: `retrofit-2026-05-24-template-library` (archived inline).

### What this PR does

- Drafts 4 REQs in `openspec/specs/template-library/spec.md` with `retrofit: true`
- Creates ghost change scaffold (proposal/design/tasks/specs delta)
- Annotates 2 files with `@spec ...tasks.md#task-N`
- Archives the change inline

### What this PR does NOT do

- No code behavior changes
- Notes flag that activation is NOT transactional — partial failure leaves orphans

Source: `openspec/coverage-report.md` generated 2026-05-24 | Cluster: `template-library`

Refs #565.