### PR TITLE
retrofit: reverse-spec ai-assistance (5 REQs / 2 files)

### DIFF
--- a/lib/Controller/AiController.php
+++ b/lib/Controller/AiController.php
@@ -20,6 +20,10 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md#task-1
+ * @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md#task-2
+ * @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md#task-5
  */
 
 declare(strict_types=1);

--- a/lib/Service/AiService.php
+++ b/lib/Service/AiService.php
@@ -20,6 +20,11 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md#task-2
+ * @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md#task-3
+ * @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md#task-4
+ * @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md#task-5
  */
 
 declare(strict_types=1);

--- a/openspec/changes/retrofit-2026-05-24-ai-assistance/design.md
+++ b/openspec/changes/retrofit-2026-05-24-ai-assistance/design.md
@@ -1,0 +1,3 @@
+# Design — retrofit ai-assistance
+
+Retrofit change. Tasks describe retroactive annotation of existing code, not new implementation work.

--- a/openspec/changes/retrofit-2026-05-24-ai-assistance/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-ai-assistance/proposal.md
@@ -1,0 +1,10 @@
+# Retrofit — ai-assistance
+
+Describes observed behavior of 2 PHP files (~35 methods) — AI controller and service — as 5 new REQs covering the human-in-the-loop AI surface for procest. (Distinct from `mcp-integration` which covers the per-app MCP tool provider registered with the OR AI orchestrator.)
+
+## Affected code units
+
+- lib/Controller/AiController.php (13 methods) — classify / extract / ask / summarize / suggestRouting / suggestNext / recordAction / auditIndex / settings (get/update) / healthCheck
+- lib/Service/AiService.php (22 methods) — enablement flags, PII stripping, AI feature implementations, audit-trail recording, n8n MCP orchestration
+
+Source: openspec/coverage-report.md generated 2026-05-24. Tracks ConductionNL/procest#565.

--- a/openspec/changes/retrofit-2026-05-24-ai-assistance/specs/ai-assistance/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-ai-assistance/specs/ai-assistance/spec.md
@@ -1,0 +1,108 @@
+---
+retrofit: true
+---
+
+# AI Assistance Specification
+
+## Purpose
+
+Provide a human-in-the-loop AI surface for casehandlers: classify documents, extract structured data, answer knowledge-base questions in case context, summarize cases / documents / timelines, suggest routing and next steps, record every user response to every AI suggestion in an Algoritmeregister-compliant audit trail, and operate behind global + per-feature enablement flags so deployments can roll out one capability at a time. PII is stripped before content leaves the procest process. (The procest-side MCP tool provider for the AI orchestrator is specified separately under `mcp-integration`.)
+
+## Requirements
+
+### REQ-001: AI REST surface for classify / extract / ask / summarize / suggestRouting / suggestNext
+
+The system SHALL expose six `@NoAdminRequired` JSON endpoints on `AiController` — `classify`, `extract`, `ask`, `summarize`, `suggestRouting`, `suggestNext` — that validate required parameters, resolve the calling user (or `'anonymous'`), delegate to `AiService`, and return the service result as JSON.
+
+#### Scenario: Required parameters
+
+- WHEN `classify` is called without `caseId` or `documentId`, OR `ask` without `caseId` or `question`, OR `summarize` / `suggestRouting` / `suggestNext` without `caseId`
+- THEN the controller SHALL return HTTP 400 `{error: '<param> [and <param>] are required'}`
+
+#### Scenario: Summarize type whitelist
+
+- WHEN `summarize` is called with `type` outside `['case', 'document', 'timeline']`
+- THEN the controller SHALL return HTTP 400 `{error: 'type must be one of: case, document, timeline'}` (default `type` is `'case'`)
+
+#### Scenario: Anonymous fallback
+
+- WHEN no session user is present
+- THEN `getCurrentUserId()` SHALL return `'anonymous'` and downstream service calls SHALL still proceed
+
+### REQ-002: Human-in-the-loop action recording and audit-trail listing
+
+The system SHALL expose `recordAction` (record what the user did with a given AI suggestion: accepted / rejected / overridden / etc.) and `auditIndex` (list AI audit entries filterable by `caseId`, `type`, `limit`, `offset`) endpoints — these underpin Algoritmeregister-style traceability for every AI suggestion.
+
+#### Scenario: recordAction required fields
+
+- WHEN `recordAction` is called without `caseId`, `type`, or `userAction`
+- THEN the controller SHALL return HTTP 400 `{error: 'caseId, type, and userAction are required'}`
+
+#### Scenario: recordAction payload
+
+- WHEN `recordAction` is called with all required fields plus optional `suggestion`, `actualValue`, `reason`
+- THEN the controller SHALL forward all six to `AiService::recordUserAction(caseId, type, userAction, suggestion, actualValue, reason, userId)`
+
+#### Scenario: auditIndex query
+
+- WHEN `auditIndex` is called
+- THEN the controller SHALL build `{caseId, type, limit (default 50), offset (default 0)}` and return `{success: true, filters: array_filter($filters), message: ...}`
+
+#### Notes
+
+- `auditIndex` currently returns a placeholder message `'Audit trail query — implement with OpenRegister object listing'` — the real OR listing is observed-but-stubbed at the controller layer. Audit-record persistence inside `AiService::recordUserAction` is the canonical write path; reads need to be wired to OR before production rollout.
+
+### REQ-003: Global + per-feature AI enablement flags
+
+The system SHALL gate every AI call behind a global `ai_enabled` IAppConfig flag and a per-feature `ai_feature_<name>` flag, where `<name>` is one of `classification`, `extraction`, `qa`, `summary`, `routing`, `decision_support`. Both flags hold the string `'1'` for enabled.
+
+#### Scenario: Global off short-circuits everything
+
+- WHEN `isEnabled()` returns `false`
+- THEN `isFeatureEnabled(<any>)` SHALL also return `false` without inspecting the per-feature flag
+
+#### Scenario: Per-feature toggle
+
+- WHEN `isEnabled()` returns `true` but `ai_feature_<name>` is not `'1'`
+- THEN `isFeatureEnabled(<name>)` SHALL return `false`
+
+#### Notes
+
+- The flag-format is string-typed `'1'` not boolean — caller code must match this convention.
+
+### REQ-004: Dutch PII stripping before model dispatch
+
+The system SHALL strip four Dutch PII patterns from any content sent to an AI model: BSN (9-digit number), IBAN (NL/EU layout), Dutch phone numbers (`0xxxxxxxxx` or `+31xxxxxxxxx`), and postcode (`9999 AA`).
+
+#### Scenario: PII pattern set
+
+- WHEN content is prepared for the AI model
+- THEN every match of the four regexes in `PII_PATTERNS` SHALL be replaced with a redacted placeholder before transmission
+- AND the originals SHALL not be transmitted to the model
+
+#### Notes
+
+- The patterns are deliberately broad (e.g. any 9-digit number triggers `bsn`); the safe default prefers redaction false-positives over leaking real PII. Tightening must keep the redaction-first bias.
+
+### REQ-005: Settings management and AI-model health check
+
+The system SHALL expose `getSettings`, `updateSettings`, and `healthCheck` JSON endpoints that surface the current AI configuration, accept settings updates via `SettingsService::updateSettings`, and report on AI-model connectivity / latency via `AiService::testHealth`.
+
+#### Scenario: getSettings
+
+- WHEN `getSettings` is called
+- THEN the controller SHALL return `AiService::getAiSettings()` verbatim
+
+#### Scenario: updateSettings
+
+- WHEN `updateSettings` is called with a request body
+- THEN the controller SHALL pass `$this->request->getParams()` to `SettingsService::updateSettings($data)` and return its result
+
+#### Scenario: healthCheck
+
+- WHEN `healthCheck` is called
+- THEN the controller SHALL return `AiService::testHealth()` verbatim — this is the operator-facing probe for the n8n MCP backend
+
+#### Notes
+
+- `getSettings`, `updateSettings`, and `healthCheck` do NOT carry `@NoAdminRequired` and are intended for admin use. Routes wiring SHOULD enforce that (current routes file is the source of truth for admin-gating).

--- a/openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] task-1: ai-assistance#REQ-001 — AI REST surface for classify/extract/ask/summarize/suggestRouting/suggestNext (retroactive annotation)
+- [x] task-2: ai-assistance#REQ-002 — Human-in-the-loop action recording and audit-trail listing (retroactive annotation)
+- [x] task-3: ai-assistance#REQ-003 — Global + per-feature AI enablement flags (retroactive annotation)
+- [x] task-4: ai-assistance#REQ-004 — Dutch PII stripping before model dispatch (retroactive annotation)
+- [x] task-5: ai-assistance#REQ-005 — Settings management and AI-model health check (retroactive annotation)

--- a/openspec/specs/ai-assistance/spec.md
+++ b/openspec/specs/ai-assistance/spec.md
@@ -1,0 +1,108 @@
+---
+retrofit: true
+---
+
+# AI Assistance Specification
+
+## Purpose
+
+Provide a human-in-the-loop AI surface for casehandlers: classify documents, extract structured data, answer knowledge-base questions in case context, summarize cases / documents / timelines, suggest routing and next steps, record every user response to every AI suggestion in an Algoritmeregister-compliant audit trail, and operate behind global + per-feature enablement flags so deployments can roll out one capability at a time. PII is stripped before content leaves the procest process. (The procest-side MCP tool provider for the AI orchestrator is specified separately under `mcp-integration`.)
+
+## Requirements
+
+### REQ-001: AI REST surface for classify / extract / ask / summarize / suggestRouting / suggestNext
+
+The system SHALL expose six `@NoAdminRequired` JSON endpoints on `AiController` — `classify`, `extract`, `ask`, `summarize`, `suggestRouting`, `suggestNext` — that validate required parameters, resolve the calling user (or `'anonymous'`), delegate to `AiService`, and return the service result as JSON.
+
+#### Scenario: Required parameters
+
+- WHEN `classify` is called without `caseId` or `documentId`, OR `ask` without `caseId` or `question`, OR `summarize` / `suggestRouting` / `suggestNext` without `caseId`
+- THEN the controller SHALL return HTTP 400 `{error: '<param> [and <param>] are required'}`
+
+#### Scenario: Summarize type whitelist
+
+- WHEN `summarize` is called with `type` outside `['case', 'document', 'timeline']`
+- THEN the controller SHALL return HTTP 400 `{error: 'type must be one of: case, document, timeline'}` (default `type` is `'case'`)
+
+#### Scenario: Anonymous fallback
+
+- WHEN no session user is present
+- THEN `getCurrentUserId()` SHALL return `'anonymous'` and downstream service calls SHALL still proceed
+
+### REQ-002: Human-in-the-loop action recording and audit-trail listing
+
+The system SHALL expose `recordAction` (record what the user did with a given AI suggestion: accepted / rejected / overridden / etc.) and `auditIndex` (list AI audit entries filterable by `caseId`, `type`, `limit`, `offset`) endpoints — these underpin Algoritmeregister-style traceability for every AI suggestion.
+
+#### Scenario: recordAction required fields
+
+- WHEN `recordAction` is called without `caseId`, `type`, or `userAction`
+- THEN the controller SHALL return HTTP 400 `{error: 'caseId, type, and userAction are required'}`
+
+#### Scenario: recordAction payload
+
+- WHEN `recordAction` is called with all required fields plus optional `suggestion`, `actualValue`, `reason`
+- THEN the controller SHALL forward all six to `AiService::recordUserAction(caseId, type, userAction, suggestion, actualValue, reason, userId)`
+
+#### Scenario: auditIndex query
+
+- WHEN `auditIndex` is called
+- THEN the controller SHALL build `{caseId, type, limit (default 50), offset (default 0)}` and return `{success: true, filters: array_filter($filters), message: ...}`
+
+#### Notes
+
+- `auditIndex` currently returns a placeholder message `'Audit trail query — implement with OpenRegister object listing'` — the real OR listing is observed-but-stubbed at the controller layer. Audit-record persistence inside `AiService::recordUserAction` is the canonical write path; reads need to be wired to OR before production rollout.
+
+### REQ-003: Global + per-feature AI enablement flags
+
+The system SHALL gate every AI call behind a global `ai_enabled` IAppConfig flag and a per-feature `ai_feature_<name>` flag, where `<name>` is one of `classification`, `extraction`, `qa`, `summary`, `routing`, `decision_support`. Both flags hold the string `'1'` for enabled.
+
+#### Scenario: Global off short-circuits everything
+
+- WHEN `isEnabled()` returns `false`
+- THEN `isFeatureEnabled(<any>)` SHALL also return `false` without inspecting the per-feature flag
+
+#### Scenario: Per-feature toggle
+
+- WHEN `isEnabled()` returns `true` but `ai_feature_<name>` is not `'1'`
+- THEN `isFeatureEnabled(<name>)` SHALL return `false`
+
+#### Notes
+
+- The flag-format is string-typed `'1'` not boolean — caller code must match this convention.
+
+### REQ-004: Dutch PII stripping before model dispatch
+
+The system SHALL strip four Dutch PII patterns from any content sent to an AI model: BSN (9-digit number), IBAN (NL/EU layout), Dutch phone numbers (`0xxxxxxxxx` or `+31xxxxxxxxx`), and postcode (`9999 AA`).
+
+#### Scenario: PII pattern set
+
+- WHEN content is prepared for the AI model
+- THEN every match of the four regexes in `PII_PATTERNS` SHALL be replaced with a redacted placeholder before transmission
+- AND the originals SHALL not be transmitted to the model
+
+#### Notes
+
+- The patterns are deliberately broad (e.g. any 9-digit number triggers `bsn`); the safe default prefers redaction false-positives over leaking real PII. Tightening must keep the redaction-first bias.
+
+### REQ-005: Settings management and AI-model health check
+
+The system SHALL expose `getSettings`, `updateSettings`, and `healthCheck` JSON endpoints that surface the current AI configuration, accept settings updates via `SettingsService::updateSettings`, and report on AI-model connectivity / latency via `AiService::testHealth`.
+
+#### Scenario: getSettings
+
+- WHEN `getSettings` is called
+- THEN the controller SHALL return `AiService::getAiSettings()` verbatim
+
+#### Scenario: updateSettings
+
+- WHEN `updateSettings` is called with a request body
+- THEN the controller SHALL pass `$this->request->getParams()` to `SettingsService::updateSettings($data)` and return its result
+
+#### Scenario: healthCheck
+
+- WHEN `healthCheck` is called
+- THEN the controller SHALL return `AiService::testHealth()` verbatim — this is the operator-facing probe for the n8n MCP backend
+
+#### Notes
+
+- `getSettings`, `updateSettings`, and `healthCheck` do NOT carry `@NoAdminRequired` and are intended for admin use. Routes wiring SHOULD enforce that (current routes file is the source of truth for admin-gating).


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Describes observed behavior of 2 files (~35 methods) under `ai-assistance` as 5 new REQs covering the human-in-the-loop AI surface, audit-trail recording, enablement flags, PII redaction, and admin operations.

Ghost change: `retrofit-2026-05-24-ai-assistance` (archived inline).

### What this PR does

- Drafts 5 REQs in `openspec/specs/ai-assistance/spec.md` with `retrofit: true`
- Creates ghost change scaffold (proposal/design/tasks/specs delta)
- Annotates 2 files with `@spec ...tasks.md#task-N`
- Archives the change inline

### Note: distinct from mcp-integration

`mcp-integration` covers the per-app `IMcpToolProvider` skeleton procest registers with the OR AI orchestrator. This cluster covers the human-facing AI features (classify / extract / ask / summarize / suggest / record-action / audit / settings / health).

### What this PR does NOT do

- No code behavior changes
- Notes flag the `auditIndex` placeholder ("implement with OpenRegister object listing")
- Notes flag the string-typed `'1'` enablement convention and the broad PII regexes' false-positive bias

Source: `openspec/coverage-report.md` generated 2026-05-24 | Cluster: `ai-assistance`

Refs #565.