### PR TITLE
retrofit: reverse-spec dso-omgevingsloket-client (3 REQs / 1 file)

### DIFF
--- a/lib/Service/DsoIntakeService.php
+++ b/lib/Service/DsoIntakeService.php
@@ -16,6 +16,10 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-dso-omgevingsloket-client/tasks.md#task-1
+ * @spec openspec/changes/retrofit-2026-05-24-dso-omgevingsloket-client/tasks.md#task-2
+ * @spec openspec/changes/retrofit-2026-05-24-dso-omgevingsloket-client/tasks.md#task-3
  */
 
 declare(strict_types=1);

--- a/openspec/changes/retrofit-2026-05-24-dso-omgevingsloket-client/design.md
+++ b/openspec/changes/retrofit-2026-05-24-dso-omgevingsloket-client/design.md
@@ -1,0 +1,3 @@
+# Design — retrofit dso-omgevingsloket-client
+
+Retrofit change. Tasks describe retroactive annotation of existing code, not new implementation work.

--- a/openspec/changes/retrofit-2026-05-24-dso-omgevingsloket-client/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-dso-omgevingsloket-client/proposal.md
@@ -1,0 +1,9 @@
+# Retrofit — dso-omgevingsloket-client
+
+Describes observed behavior of 1 PHP file (~3 methods) — procest's DSO intake adapter — as 3 new REQs. **Named `dso-omgevingsloket-client` (not `dso-omgevingsloket`) to avoid overlap with openconnector's full DSO protocol spec** — procest only owns intake (DSO vergunningaanvraag → procest zaak) here; the DSO-LV koppelvlak / mTLS / status pushback live in openconnector. There is also an in-flight design change at `openspec/changes/dso-omgevingsloket/` (also unarchived) that captures the broader scope.
+
+## Affected code units
+
+- lib/Service/DsoIntakeService.php (3 methods) — `processAanvraag(dsoMessage)`, `getDeadlineDuration(procedureType)`, constructor
+
+Source: openspec/coverage-report.md generated 2026-05-24. Tracks ConductionNL/procest#565.

--- a/openspec/changes/retrofit-2026-05-24-dso-omgevingsloket-client/specs/dso-omgevingsloket-client/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-dso-omgevingsloket-client/specs/dso-omgevingsloket-client/spec.md
@@ -1,0 +1,83 @@
+---
+retrofit: true
+---
+
+# DSO Omgevingsloket Client Specification
+
+## Purpose
+
+Convert an inbound DSO Omgevingsloket `vergunningaanvraag` message — delivered to procest by openconnector's DSO adapter (which owns the DSO-LV koppelvlak, mTLS, PKIoverheid, status pushback per its own spec) — into a procest `zaak` of type "Omgevingsvergunning" with the right deadline, title, and DSO-specific side records. Procest does NOT own the DSO protocol or the back-channel; this spec is deliberately scoped to the intake-adapter slice.
+
+## Requirements
+
+### REQ-001: DSO vergunningaanvraag intake creates procest zaak
+
+The system SHALL accept a `dsoMessage` array, extract `activiteiten`, `locatie`, `aanvrager`, `bouwkosten`, `procedureType`, `zaaknummer`, and `bijlagen`, build a human-readable title from the activity names, and persist a new procest case via OpenRegister with `priority: 'normal'` and `startDate: today`. The result SHALL be `{caseId, dsoZaaknummer, activiteiten, procedureType, deadline}`.
+
+#### Scenario: OpenRegister or register guards
+
+- WHEN OpenRegister is unavailable
+- THEN `processAanvraag` SHALL throw `\RuntimeException('OpenRegister is not available')`
+- AND when the procest register is unconfigured it SHALL throw `\RuntimeException('Procest register not configured')`
+
+#### Scenario: Title composition
+
+- WHEN one or more activities are provided as `{naam: <string>}` items or bare strings
+- THEN the case title SHALL be `'Omgevingsvergunning'` optionally suffixed with `: <activity1>, <activity2>, ...` (empty-filtered, comma-joined)
+
+#### Scenario: Description provenance
+
+- WHEN the dsoMessage carries a `zaaknummer`
+- THEN the case description SHALL be `'Vergunningaanvraag ontvangen via DSO/Omgevingsloket (DSO: <zaaknummer>)'`
+- AND when absent the suffix SHALL be omitted
+
+#### Scenario: Logging
+
+- WHEN intake succeeds
+- THEN the service SHALL log `'DSO intake processed: case <caseId> (DSO: <dsoZaaknummer>)'`
+
+### REQ-002: DSO-specific case properties stored as side records
+
+The system SHALL persist DSO-specific properties as separate `case_property` records — one per attribute (`dsoZaaknummer`, `activiteiten`, `locatie`, `bouwkosten`, `procedureType`, `aanvragerNaam`) — rather than denormalising them onto the case. Empty values SHALL be skipped; array `locatie` SHALL be JSON-encoded before storage.
+
+#### Scenario: Empty value skip
+
+- WHEN a property value resolves to `''`
+- THEN the service SHALL NOT call `saveObject` for that property
+
+#### Scenario: locatie JSON encoding
+
+- WHEN `locatie` is supplied as an array
+- THEN it SHALL be `json_encode`d before persistence; when supplied as a string it SHALL be stored verbatim
+
+#### Scenario: bouwkosten coercion
+
+- WHEN `bouwkosten` is supplied (number or string)
+- THEN it SHALL be coerced to string before persistence
+
+#### Scenario: aanvragerNaam fallback
+
+- WHEN `aanvrager` is absent or lacks `naam`
+- THEN `aanvragerNaam` SHALL fall back to `''` and (per REQ-002 empty-skip) NOT be persisted
+
+#### Notes
+
+- Side-record storage keeps the case schema lean and lets the property schema evolve independently. The trade-off is that querying DSO cases requires joining `case` to `case_property` filtered by `name`.
+
+### REQ-003: Procedure-type deadline duration lookup
+
+The system SHALL expose `getDeadlineDuration(procedureType)` returning the ISO 8601 duration for the standard Omgevingswet procedure: `regulier` → `P56D` (8 weeks) and `uiTGEBREID` (typed `uitgebreid`) → `P182D` (26 weeks). Unknown procedure types SHALL fall back to `regulier`.
+
+#### Scenario: Default fallback
+
+- WHEN `procedureType` is missing or not in the lookup table
+- THEN the service SHALL return `'P56D'` (the regulier default)
+
+#### Scenario: Intake forwards deadline
+
+- WHEN `processAanvraag` runs
+- THEN the returned `deadline` field SHALL match `getDeadlineDuration(procedureType)`
+
+#### Notes
+
+- The two values mirror the Omgevingswet deadlines: reguliere procedure 8 weken (P56D), uitgebreide procedure 26 weken (P182D). The actual deadline-event creation (when the 8/26-week timer starts ticking and how procest reminds casehandlers as the deadline approaches) is observed-but-stubbed in `DsoIntakeService` — the case is persisted with `startDate = today` but no explicit deadline timer object. The in-flight `openspec/changes/dso-omgevingsloket/` change will spec that side.

--- a/openspec/changes/retrofit-2026-05-24-dso-omgevingsloket-client/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-dso-omgevingsloket-client/tasks.md
@@ -1,0 +1,5 @@
+# Tasks
+
+- [x] task-1: dso-omgevingsloket-client#REQ-001 — DSO vergunningaanvraag intake creates procest zaak (retroactive annotation)
+- [x] task-2: dso-omgevingsloket-client#REQ-002 — DSO-specific case properties stored as side records (retroactive annotation)
+- [x] task-3: dso-omgevingsloket-client#REQ-003 — Procedure-type deadline duration lookup (retroactive annotation)

--- a/openspec/specs/dso-omgevingsloket-client/spec.md
+++ b/openspec/specs/dso-omgevingsloket-client/spec.md
@@ -1,0 +1,83 @@
+---
+retrofit: true
+---
+
+# DSO Omgevingsloket Client Specification
+
+## Purpose
+
+Convert an inbound DSO Omgevingsloket `vergunningaanvraag` message — delivered to procest by openconnector's DSO adapter (which owns the DSO-LV koppelvlak, mTLS, PKIoverheid, status pushback per its own spec) — into a procest `zaak` of type "Omgevingsvergunning" with the right deadline, title, and DSO-specific side records. Procest does NOT own the DSO protocol or the back-channel; this spec is deliberately scoped to the intake-adapter slice.
+
+## Requirements
+
+### REQ-001: DSO vergunningaanvraag intake creates procest zaak
+
+The system SHALL accept a `dsoMessage` array, extract `activiteiten`, `locatie`, `aanvrager`, `bouwkosten`, `procedureType`, `zaaknummer`, and `bijlagen`, build a human-readable title from the activity names, and persist a new procest case via OpenRegister with `priority: 'normal'` and `startDate: today`. The result SHALL be `{caseId, dsoZaaknummer, activiteiten, procedureType, deadline}`.
+
+#### Scenario: OpenRegister or register guards
+
+- WHEN OpenRegister is unavailable
+- THEN `processAanvraag` SHALL throw `\RuntimeException('OpenRegister is not available')`
+- AND when the procest register is unconfigured it SHALL throw `\RuntimeException('Procest register not configured')`
+
+#### Scenario: Title composition
+
+- WHEN one or more activities are provided as `{naam: <string>}` items or bare strings
+- THEN the case title SHALL be `'Omgevingsvergunning'` optionally suffixed with `: <activity1>, <activity2>, ...` (empty-filtered, comma-joined)
+
+#### Scenario: Description provenance
+
+- WHEN the dsoMessage carries a `zaaknummer`
+- THEN the case description SHALL be `'Vergunningaanvraag ontvangen via DSO/Omgevingsloket (DSO: <zaaknummer>)'`
+- AND when absent the suffix SHALL be omitted
+
+#### Scenario: Logging
+
+- WHEN intake succeeds
+- THEN the service SHALL log `'DSO intake processed: case <caseId> (DSO: <dsoZaaknummer>)'`
+
+### REQ-002: DSO-specific case properties stored as side records
+
+The system SHALL persist DSO-specific properties as separate `case_property` records — one per attribute (`dsoZaaknummer`, `activiteiten`, `locatie`, `bouwkosten`, `procedureType`, `aanvragerNaam`) — rather than denormalising them onto the case. Empty values SHALL be skipped; array `locatie` SHALL be JSON-encoded before storage.
+
+#### Scenario: Empty value skip
+
+- WHEN a property value resolves to `''`
+- THEN the service SHALL NOT call `saveObject` for that property
+
+#### Scenario: locatie JSON encoding
+
+- WHEN `locatie` is supplied as an array
+- THEN it SHALL be `json_encode`d before persistence; when supplied as a string it SHALL be stored verbatim
+
+#### Scenario: bouwkosten coercion
+
+- WHEN `bouwkosten` is supplied (number or string)
+- THEN it SHALL be coerced to string before persistence
+
+#### Scenario: aanvragerNaam fallback
+
+- WHEN `aanvrager` is absent or lacks `naam`
+- THEN `aanvragerNaam` SHALL fall back to `''` and (per REQ-002 empty-skip) NOT be persisted
+
+#### Notes
+
+- Side-record storage keeps the case schema lean and lets the property schema evolve independently. The trade-off is that querying DSO cases requires joining `case` to `case_property` filtered by `name`.
+
+### REQ-003: Procedure-type deadline duration lookup
+
+The system SHALL expose `getDeadlineDuration(procedureType)` returning the ISO 8601 duration for the standard Omgevingswet procedure: `regulier` → `P56D` (8 weeks) and `uiTGEBREID` (typed `uitgebreid`) → `P182D` (26 weeks). Unknown procedure types SHALL fall back to `regulier`.
+
+#### Scenario: Default fallback
+
+- WHEN `procedureType` is missing or not in the lookup table
+- THEN the service SHALL return `'P56D'` (the regulier default)
+
+#### Scenario: Intake forwards deadline
+
+- WHEN `processAanvraag` runs
+- THEN the returned `deadline` field SHALL match `getDeadlineDuration(procedureType)`
+
+#### Notes
+
+- The two values mirror the Omgevingswet deadlines: reguliere procedure 8 weken (P56D), uitgebreide procedure 26 weken (P182D). The actual deadline-event creation (when the 8/26-week timer starts ticking and how procest reminds casehandlers as the deadline approaches) is observed-but-stubbed in `DsoIntakeService` — the case is persisted with `startDate = today` but no explicit deadline timer object. The in-flight `openspec/changes/dso-omgevingsloket/` change will spec that side.


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Describes observed behavior of `lib/Service/DsoIntakeService.php` (3 methods) — the procest-side DSO intake adapter — as 3 new REQs.

Ghost change: `retrofit-2026-05-24-dso-omgevingsloket-client` (archived inline).

### Naming choice (notable)

Named **`dso-omgevingsloket-client`** rather than `dso-omgevingsloket` to keep procest's intake adapter spec clearly separate from openconnector's full DSO protocol spec (mTLS, PKIoverheid, koppelvlak handlers, status pushback). An in-flight design change at `openspec/changes/dso-omgevingsloket/` will spec the broader VTH case-management story; this retrofit captures only the implemented intake slice.

### What this PR does

- Drafts 3 REQs in `openspec/specs/dso-omgevingsloket-client/spec.md` with `retrofit: true`
- Creates ghost change scaffold
- Annotates `DsoIntakeService.php` with `@spec ...tasks.md#task-1..3`
- Archives the change inline

### What this PR does NOT do

- No code changes
- Notes the side-record storage trade-off (lean case schema, join cost on queries)
- Notes that deadline-timer creation is observed-but-stubbed (no DeadlineEvent persisted at intake)

Source: `openspec/coverage-report.md` generated 2026-05-24 | Cluster: `dso-omgevingsloket` (spec named `*-client`)

Refs #565.