### PR TITLE
retrofit: reverse-spec ops-observability (3 REQs / 1 file)

### DIFF
--- a/lib/Controller/HealthController.php
+++ b/lib/Controller/HealthController.php
@@ -18,6 +18,10 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-ops-observability/tasks.md#task-1
+ * @spec openspec/changes/retrofit-2026-05-24-ops-observability/tasks.md#task-2
+ * @spec openspec/changes/retrofit-2026-05-24-ops-observability/tasks.md#task-3
  */
 
 declare(strict_types=1);

--- a/openspec/changes/retrofit-2026-05-24-ops-observability/design.md
+++ b/openspec/changes/retrofit-2026-05-24-ops-observability/design.md
@@ -1,0 +1,3 @@
+# Design — retrofit ops-observability
+
+Retrofit change. Tasks describe retroactive annotation of existing code, not new implementation work.

--- a/openspec/changes/retrofit-2026-05-24-ops-observability/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-ops-observability/proposal.md
@@ -1,0 +1,13 @@
+# Retrofit — ops-observability
+
+Describes observed behavior of 1 PHP file (~6 methods) — procest's health-check controller for container orchestration and monitoring — as 3 new REQs.
+
+## Affected code units
+
+- lib/Controller/HealthController.php (6 methods) — `index` aggregate health-check JSON endpoint with DB / OpenRegister / filesystem sub-checks and app-version reporting
+
+## Note on observed vs reported
+
+The coverage report mentions `/health/db` / `/health/<sub>` paths; the implementation only exposes a single `index()` endpoint that aggregates all three sub-checks. The spec captures the implemented behavior; per-component endpoints remain a future-work item.
+
+Source: openspec/coverage-report.md generated 2026-05-24. Tracks ConductionNL/procest#565.

--- a/openspec/changes/retrofit-2026-05-24-ops-observability/specs/ops-observability/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-ops-observability/specs/ops-observability/spec.md
@@ -1,0 +1,72 @@
+---
+retrofit: true
+---
+
+# Ops Observability Specification
+
+## Purpose
+
+Expose a single health-check endpoint that container orchestrators (k8s, docker-compose `healthcheck`) and external monitoring (Prometheus blackbox-exporter, uptime checks) can probe to determine whether procest is serving correctly. The endpoint reports an aggregate `status`, the running `version`, and per-component sub-checks (database, OpenRegister hard-dep, filesystem) so that a failing probe gives operators enough context to triage without needing a separate logs query.
+
+## Requirements
+
+### REQ-001: Aggregate health-check JSON endpoint with status / version / checks shape
+
+The system SHALL expose `HealthController::index` as a `@NoCSRFRequired` JSON endpoint that returns `{status: 'ok' | 'degraded' | 'error', version: <appVersion>, checks: {database: ..., openregister: ..., filesystem: ...}}`.
+
+#### Scenario: Shape stability
+
+- WHEN any probe calls the health endpoint
+- THEN the response SHALL always include the three keys `status`, `version`, `checks` (even when individual sub-checks fail) so monitoring parsers can rely on the schema
+
+#### Scenario: Version reporting
+
+- WHEN the endpoint returns
+- THEN `version` SHALL be `IAppManager::getAppVersion(APP_ID)` or literal `'unknown'` when the lookup throws
+
+#### Notes
+
+- `@NoCSRFRequired` is required so external probes don't need a Nextcloud session.
+
+### REQ-002: Three sub-checks (database, OpenRegister hard-dep, filesystem) with severity tiering
+
+The system SHALL run three sub-checks on every probe — `database` (executes `SELECT 1`), `openregister` (verifies the app is enabled — hard dependency), and `filesystem` (writes + deletes a temp file at `sys_get_temp_dir()/procest_health_<pid>`). Each sub-check returns `'ok'` or `'failed: <reason>'`. Severity tiers: database OR openregister fail → aggregate `status='error'`; only filesystem fails → aggregate `status='degraded'`.
+
+#### Scenario: Database check
+
+- WHEN the database sub-check runs
+- THEN it SHALL execute `SELECT 1` via the Nextcloud query builder, close the cursor, and return `'ok'` on success, `'failed: <message>'` on `\Exception` (also logged via `LoggerInterface::error`)
+
+#### Scenario: OpenRegister hard-dep
+
+- WHEN the OpenRegister sub-check runs
+- THEN it SHALL call `IAppManager::isEnabledForUser('openregister')` and return `'ok'` when enabled, `'failed: app not enabled'` when disabled, or `'failed: <message>'` on exception
+
+#### Scenario: Filesystem check
+
+- WHEN the filesystem sub-check runs
+- THEN it SHALL write `'health'` to `sys_get_temp_dir() . '/procest_health_' . getmypid()`, unlink it, and return `'ok'` on success or `'failed: <reason>'` on failure
+
+#### Scenario: Severity tiering
+
+- WHEN computing aggregate `status`
+- THEN database OR openregister failure SHALL set `status='error'`
+- AND only filesystem failure (with DB + OR both `'ok'`) SHALL set `status='degraded'`
+- AND all three `'ok'` SHALL set `status='ok'`
+
+#### Notes
+
+- The filesystem check uses the system temp dir, not the Nextcloud data dir — a degraded result here means PHP can't even reach `/tmp`. A real "data dir writable" check is observed-but-stubbed.
+
+### REQ-003: HTTP status reflects aggregate health
+
+The system SHALL return HTTP `200 OK` when `status === 'ok'` and HTTP `503 Service Unavailable` for both `'degraded'` and `'error'` — so a probe that only inspects status code (typical for k8s readiness probes) still routes traffic correctly.
+
+#### Scenario: 503 covers both degraded and error
+
+- WHEN aggregate `status` is `'degraded'` OR `'error'`
+- THEN the HTTP status SHALL be `503` (not `200`) — the body's `status` field carries the gradation
+
+#### Notes
+
+- This is intentional: k8s readiness probes are binary; the `'degraded'` JSON tier exists for humans + Prometheus alerting rules but a degraded probe still pulls the pod out of rotation. Future work may split into liveness (200/503) and readiness (200/503) endpoints if finer control is needed.

--- a/openspec/changes/retrofit-2026-05-24-ops-observability/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-ops-observability/tasks.md
@@ -1,0 +1,5 @@
+# Tasks
+
+- [x] task-1: ops-observability#REQ-001 — Aggregate health-check JSON endpoint with status / version / checks shape (retroactive annotation)
+- [x] task-2: ops-observability#REQ-002 — Three sub-checks (database / OpenRegister hard-dep / filesystem) with severity tiering (retroactive annotation)
+- [x] task-3: ops-observability#REQ-003 — HTTP status reflects aggregate health (200 ok, 503 error/degraded) (retroactive annotation)

--- a/openspec/specs/ops-observability/spec.md
+++ b/openspec/specs/ops-observability/spec.md
@@ -1,0 +1,72 @@
+---
+retrofit: true
+---
+
+# Ops Observability Specification
+
+## Purpose
+
+Expose a single health-check endpoint that container orchestrators (k8s, docker-compose `healthcheck`) and external monitoring (Prometheus blackbox-exporter, uptime checks) can probe to determine whether procest is serving correctly. The endpoint reports an aggregate `status`, the running `version`, and per-component sub-checks (database, OpenRegister hard-dep, filesystem) so that a failing probe gives operators enough context to triage without needing a separate logs query.
+
+## Requirements
+
+### REQ-001: Aggregate health-check JSON endpoint with status / version / checks shape
+
+The system SHALL expose `HealthController::index` as a `@NoCSRFRequired` JSON endpoint that returns `{status: 'ok' | 'degraded' | 'error', version: <appVersion>, checks: {database: ..., openregister: ..., filesystem: ...}}`.
+
+#### Scenario: Shape stability
+
+- WHEN any probe calls the health endpoint
+- THEN the response SHALL always include the three keys `status`, `version`, `checks` (even when individual sub-checks fail) so monitoring parsers can rely on the schema
+
+#### Scenario: Version reporting
+
+- WHEN the endpoint returns
+- THEN `version` SHALL be `IAppManager::getAppVersion(APP_ID)` or literal `'unknown'` when the lookup throws
+
+#### Notes
+
+- `@NoCSRFRequired` is required so external probes don't need a Nextcloud session.
+
+### REQ-002: Three sub-checks (database, OpenRegister hard-dep, filesystem) with severity tiering
+
+The system SHALL run three sub-checks on every probe — `database` (executes `SELECT 1`), `openregister` (verifies the app is enabled — hard dependency), and `filesystem` (writes + deletes a temp file at `sys_get_temp_dir()/procest_health_<pid>`). Each sub-check returns `'ok'` or `'failed: <reason>'`. Severity tiers: database OR openregister fail → aggregate `status='error'`; only filesystem fails → aggregate `status='degraded'`.
+
+#### Scenario: Database check
+
+- WHEN the database sub-check runs
+- THEN it SHALL execute `SELECT 1` via the Nextcloud query builder, close the cursor, and return `'ok'` on success, `'failed: <message>'` on `\Exception` (also logged via `LoggerInterface::error`)
+
+#### Scenario: OpenRegister hard-dep
+
+- WHEN the OpenRegister sub-check runs
+- THEN it SHALL call `IAppManager::isEnabledForUser('openregister')` and return `'ok'` when enabled, `'failed: app not enabled'` when disabled, or `'failed: <message>'` on exception
+
+#### Scenario: Filesystem check
+
+- WHEN the filesystem sub-check runs
+- THEN it SHALL write `'health'` to `sys_get_temp_dir() . '/procest_health_' . getmypid()`, unlink it, and return `'ok'` on success or `'failed: <reason>'` on failure
+
+#### Scenario: Severity tiering
+
+- WHEN computing aggregate `status`
+- THEN database OR openregister failure SHALL set `status='error'`
+- AND only filesystem failure (with DB + OR both `'ok'`) SHALL set `status='degraded'`
+- AND all three `'ok'` SHALL set `status='ok'`
+
+#### Notes
+
+- The filesystem check uses the system temp dir, not the Nextcloud data dir — a degraded result here means PHP can't even reach `/tmp`. A real "data dir writable" check is observed-but-stubbed.
+
+### REQ-003: HTTP status reflects aggregate health
+
+The system SHALL return HTTP `200 OK` when `status === 'ok'` and HTTP `503 Service Unavailable` for both `'degraded'` and `'error'` — so a probe that only inspects status code (typical for k8s readiness probes) still routes traffic correctly.
+
+#### Scenario: 503 covers both degraded and error
+
+- WHEN aggregate `status` is `'degraded'` OR `'error'`
+- THEN the HTTP status SHALL be `503` (not `200`) — the body's `status` field carries the gradation
+
+#### Notes
+
+- This is intentional: k8s readiness probes are binary; the `'degraded'` JSON tier exists for humans + Prometheus alerting rules but a degraded probe still pulls the pod out of rotation. Future work may split into liveness (200/503) and readiness (200/503) endpoints if finer control is needed.


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Describes observed behavior of `lib/Controller/HealthController.php` (6 methods) — procest's container-orchestration health-check endpoint — as 3 new REQs.

Ghost change: `retrofit-2026-05-24-ops-observability` (archived inline).

### What this PR does

- Drafts 3 REQs in `openspec/specs/ops-observability/spec.md` with `retrofit: true`
- Creates ghost change scaffold
- Annotates `HealthController.php` with `@spec ...tasks.md#task-1..3`
- Archives the change inline

### Note: spec captures implemented, not advertised

Coverage report mentions `/health/db` / `/health/<sub>` per-component endpoints; the implementation only exposes a single aggregate `index()`. The spec captures observed behavior; per-component endpoints stay a future-work item.

### What this PR does NOT do

- No code changes
- Notes that the filesystem check probes `/tmp`, not the NC data dir, and that the 503-covers-both-degraded-and-error mapping is intentional for binary k8s readiness probes

Source: `openspec/coverage-report.md` generated 2026-05-24 | Cluster: `ops-observability`

Refs #565.