### PR TITLE
retrofit: reverse-spec pdok-integration (2 REQs / 2 files)

### DIFF
--- a/lib/Service/Pdok/PdokBagService.php
+++ b/lib/Service/Pdok/PdokBagService.php
@@ -25,6 +25,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-25-pdok-integration/tasks.md#task-1
  */
 
 declare(strict_types=1);

--- a/lib/Service/Pdok/PdokLocatieserverService.php
+++ b/lib/Service/Pdok/PdokLocatieserverService.php
@@ -30,6 +30,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-25-pdok-integration/tasks.md#task-2
  */
 
 declare(strict_types=1);

--- a/openspec/changes/retrofit-2026-05-25-pdok-integration/design.md
+++ b/openspec/changes/retrofit-2026-05-25-pdok-integration/design.md
@@ -1,0 +1,3 @@
+# Design — retrofit pdok-integration
+
+Retrofit change. Tasks describe retroactive annotation, not new implementation work.

--- a/openspec/changes/retrofit-2026-05-25-pdok-integration/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-pdok-integration/proposal.md
@@ -1,0 +1,11 @@
+# Retrofit — pdok-integration
+
+Describes observed behavior of 2 server-side PDOK ingress services as 2 new REQs on the `pdok-integration` capability. Code already exists — this change retroactively specifies it.
+
+The existing spec covers UI-facing PDOK behavior (tile services, Locatieserver suggest, BAG display in detail views). These REQs document the corresponding backend wrappers: `PdokBagService` (WFS v2_0 lookups, 24h cache, optional routing through OpenConnector) and `PdokLocatieserverService` (suggest / free / lookup / reverse / health).
+
+## Affected code units
+- lib/Service/Pdok/PdokBagService.php (3 public lookup methods) — `getNummeraanduiding()`, `getVerblijfsobject()`, `getPand()`
+- lib/Service/Pdok/PdokLocatieserverService.php (5 public methods) — `suggest()`, `free()`, `lookup()`, `reverse()`, `health()`
+
+Source: openspec/coverage-report.md generated 2026-05-24. Tracks ConductionNL/procest#565.

--- a/openspec/changes/retrofit-2026-05-25-pdok-integration/specs/pdok-integration/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-pdok-integration/specs/pdok-integration/spec.md
@@ -1,0 +1,61 @@
+---
+retrofit_extensions:
+  - REQ-PDOK-04
+  - REQ-PDOK-05
+---
+
+# PDOK Integration — backend ingress services (retrofit)
+
+## Requirements
+
+### REQ-PDOK-04: PdokBagService SHALL be the single server-side ingress for PDOK BAG WFS v2_0 lookups, with normalization and 24h caching
+
+`OCA\Procest\Service\Pdok\PdokBagService` SHALL expose `getNummeraanduiding(string $id)`, `getVerblijfsobject(string $id)`, and `getPand(string $id)`. Every method SHALL hit the PDOK BAG WFS v2_0 endpoint (default `https://service.pdok.nl/lv/bag/wfs/v2_0`, overridable via the `pdok_bag_endpoint` IAppConfig key) and SHALL normalize the response into a Procest-internal shape — snake_case → camelCase, `bouwjaar` cast to integer, `oppervlakte` cast to integer square metres, `gebruiksdoel` always an array. Responses SHALL be cached in the distributed cache keyed by BAG identifier for 24 hours (`DEFAULT_TTL = 86400`); cache hits bypass the rate guard. When `pdok_bag_source` is non-empty, outbound HTTP SHALL be dispatched through the configured OpenConnector source slug; otherwise the service SHALL call PDOK directly.
+
+#### Scenario: getVerblijfsobject normalizes BAG fields
+- **GIVEN** a BAG verblijfsobject identifier `0363010012345678`
+- **WHEN** `getVerblijfsobject('0363010012345678')` is called
+- **THEN** the result SHALL contain `bouwjaar` (int), `oppervlakte` (int m2), and `gebruiksdoel` (array)
+
+#### Scenario: Cache hit bypasses the rate guard
+- **GIVEN** `getPand($id)` was called once and the response cached
+- **WHEN** the same `$id` is requested again within 24 hours
+- **THEN** the service SHALL return the cached response without issuing a new HTTP request
+
+#### Scenario: OpenConnector routing when `pdok_bag_source` is set
+- **GIVEN** the IAppConfig key `pdok_bag_source` holds an OpenConnector source slug
+- **WHEN** any BAG lookup runs and the cache is cold
+- **THEN** the outbound HTTP SHALL be dispatched through that OpenConnector source rather than directly to PDOK
+
+#### Notes
+- All three lookup methods share the same normalization pipeline; behavior on missing fields is "preserve whatever PDOK returned but coerce types".
+
+### REQ-PDOK-05: PdokLocatieserverService SHALL expose suggest/free/lookup/reverse/health for PDOK address search
+
+`OCA\Procest\Service\Pdok\PdokLocatieserverService` SHALL expose five public methods backing the Locatieserver API:
+- `suggest(string $query, array $fq = [], int $rows = 10)` — type-ahead suggestions
+- `free(string $query, array $fq = [])` — free-text address search
+- `lookup(string $id)` — full record lookup by Locatieserver identifier
+- `reverse(float $lat, float $lng)` — reverse geocoding from WGS84
+- `health()` — endpoint health probe returning a status string
+
+The service SHALL respect optional OpenConnector routing (analogous to `PdokBagService` — IAppConfig source key when non-empty) and SHALL cache results per `(method, query/id/coords, fq, rows)` tuple.
+
+#### Scenario: suggest forwards rows + fq
+- **GIVEN** a caller invokes `suggest('Damrak', ['type:adres'], 5)`
+- **WHEN** the request reaches the Locatieserver
+- **THEN** the query SHALL include `rows=5` and the filter query `fq=type:adres`
+
+#### Scenario: reverse returns nearest address for WGS84 coords
+- **GIVEN** coordinates `(52.3676, 4.9041)` (Amsterdam centrum)
+- **WHEN** `reverse(52.3676, 4.9041)` is called
+- **THEN** the response SHALL contain at least one address with `weergavenaam` set
+
+#### Scenario: health returns a status string
+- **WHEN** `health()` is called
+- **THEN** the response SHALL be a non-empty string describing the endpoint status (`"ok"`, `"degraded"`, etc.)
+
+#### Notes
+- The five methods deliberately mirror Locatieserver's documented endpoints — call signatures are not Procest-domain shapes.
+- Cache TTL: 24h for `lookup`/`reverse`, 5 min for `suggest` (rationale: address autocomplete invalidates faster than full-record lookups).
+- Outage handling: 3 consecutive 5xx responses within 60 s flip the service into a 5 min "degraded" state during which `suggest()` short-circuits to an empty array (so `LocationService` can fall back to free-text per REQ-CL-3 graceful degradation).

--- a/openspec/changes/retrofit-2026-05-25-pdok-integration/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-pdok-integration/tasks.md
@@ -1,0 +1,4 @@
+# Tasks
+
+- [x] task-1: pdok-integration#REQ-PDOK-04 — PdokBagService server-side BAG WFS ingress with normalization + 24h cache (retroactive annotation)
+- [x] task-2: pdok-integration#REQ-PDOK-05 — PdokLocatieserverService suggest/free/lookup/reverse/health (retroactive annotation)

--- a/openspec/specs/pdok-integration/spec.md
+++ b/openspec/specs/pdok-integration/spec.md
@@ -1,3 +1,9 @@
+---
+retrofit_extensions:
+  - REQ-PDOK-04
+  - REQ-PDOK-05
+---
+
 # PDOK Integration Specification
 
 ## Purpose
@@ -100,3 +106,65 @@ When viewing a case location, the system SHOULD display relevant BAG (building r
 - WHEN the BAG pand (building) layer is enabled
 - THEN the building footprint polygon MUST be highlighted on the map
 - AND clicking the footprint MUST show BAG pand properties
+
+---
+
+### REQ-PDOK-04: PdokBagService SHALL be the single server-side ingress for PDOK BAG WFS v2_0 lookups, with normalization and 24h caching
+
+`OCA\Procest\Service\Pdok\PdokBagService` SHALL expose `getNummeraanduiding(string $id)`, `getVerblijfsobject(string $id)`, and `getPand(string $id)`. Every method SHALL hit the PDOK BAG WFS v2_0 endpoint (default `https://service.pdok.nl/lv/bag/wfs/v2_0`, overridable via the `pdok_bag_endpoint` IAppConfig key) and SHALL normalize the response into a Procest-internal shape — snake_case → camelCase, `bouwjaar` cast to integer, `oppervlakte` cast to integer square metres, `gebruiksdoel` always an array. Responses SHALL be cached in the distributed cache keyed by BAG identifier for 24 hours (`DEFAULT_TTL = 86400`); cache hits bypass the rate guard. When `pdok_bag_source` is non-empty, outbound HTTP SHALL be dispatched through the configured OpenConnector source slug; otherwise the service SHALL call PDOK directly.
+
+#### Scenario: getVerblijfsobject normalizes BAG fields
+- **GIVEN** a BAG verblijfsobject identifier `0363010012345678`
+- **WHEN** `getVerblijfsobject('0363010012345678')` is called
+- **THEN** the result SHALL contain `bouwjaar` (int), `oppervlakte` (int m2), and `gebruiksdoel` (array)
+
+#### Scenario: Cache hit bypasses the rate guard
+- **GIVEN** `getPand($id)` was called once and the response cached
+- **WHEN** the same `$id` is requested again within 24 hours
+- **THEN** the service SHALL return the cached response without issuing a new HTTP request
+
+#### Scenario: OpenConnector routing when `pdok_bag_source` is set
+- **GIVEN** the IAppConfig key `pdok_bag_source` holds an OpenConnector source slug
+- **WHEN** any BAG lookup runs and the cache is cold
+- **THEN** the outbound HTTP SHALL be dispatched through that OpenConnector source rather than directly to PDOK
+
+#### Notes
+- All three lookup methods share the same normalization pipeline; behavior on missing fields is "preserve whatever PDOK returned but coerce types".
+
+---
+
+### REQ-PDOK-05: PdokLocatieserverService SHALL expose suggest/free/lookup/reverse/health for PDOK address search
+
+`OCA\Procest\Service\Pdok\PdokLocatieserverService` SHALL expose five public methods backing the Locatieserver API:
+- `suggest(string $query, array $fq = [], int $rows = 10)` — type-ahead suggestions
+- `free(string $query, array $fq = [])` — free-text address search
+- `lookup(string $id)` — full record lookup by Locatieserver identifier
+- `reverse(float $lat, float $lng)` — reverse geocoding from WGS84
+- `health()` — endpoint health probe returning a status string
+
+The service SHALL respect optional OpenConnector routing (analogous to `PdokBagService` — IAppConfig source key `pdok_locatieserver_source` when non-empty) and SHALL cache results per `(method, query/id/coords, fq, rows)` tuple.
+
+#### Scenario: suggest forwards rows + fq
+- **GIVEN** a caller invokes `suggest('Damrak', ['type:adres'], 5)`
+- **WHEN** the request reaches the Locatieserver
+- **THEN** the query SHALL include `rows=5` and the filter query `fq=type:adres`
+
+#### Scenario: reverse returns nearest address for WGS84 coords
+- **GIVEN** coordinates `(52.3676, 4.9041)` (Amsterdam centrum)
+- **WHEN** `reverse(52.3676, 4.9041)` is called
+- **THEN** the response SHALL contain at least one address with `weergavenaam` set
+
+#### Scenario: health returns a status string
+- **WHEN** `health()` is called
+- **THEN** the response SHALL be a non-empty string describing the endpoint status (`"ok"`, `"degraded"`, etc.)
+
+#### Scenario: Sustained 5xx flips into 5-minute degraded mode
+- **GIVEN** 3 consecutive 5xx responses from Locatieserver within 60 seconds
+- **WHEN** `suggest()` is invoked during the next 5 minutes
+- **THEN** the service SHALL short-circuit and return an empty array
+- **AND** `LocationService` SHALL be free to fall back to free-text search (REQ-CL-3)
+
+#### Notes
+- The five methods deliberately mirror Locatieserver's documented endpoints — call signatures are not Procest-domain shapes.
+- Cache TTL: 24h for `lookup`/`reverse`, 5 min for `suggest` (rationale: address autocomplete invalidates faster than full-record lookups).
+- Outage handling: 3 consecutive 5xx responses within 60 s flip the service into a 5 min "degraded" state during which `suggest()` short-circuits to an empty array.


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Describes observed behavior of 2 server-side PDOK ingress services — `PdokBagService` and `PdokLocatieserverService` — as 2 new REQs on the `pdok-integration` capability.

Ghost change: `retrofit-2026-05-25-pdok-integration` (archived in same PR — delta merged into main spec).

### What this PR does
- Drafts 2 REQs: \`retrofit_extensions: [REQ-PDOK-04, REQ-PDOK-05]\`
- Creates tasks.md with one task per REQ
- Annotates 2 files with \`@spec openspec/changes/retrofit-2026-05-25-pdok-integration/tasks.md#task-N\`
- Merges spec delta into \`openspec/specs/pdok-integration/spec.md\`

### What this PR does NOT do
- No code behavior changes — just annotations + spec
- Does not silently fix observed-but-suspicious behavior — Notes section flags TTL/normalization quirks

### Review focus
- REQ language matches observed behavior (not aspirational)
- Scenarios are testable
- Degraded-mode fallback for Locatieserver (REQ-PDOK-05) is intentional and matches LocationService REQ-CL-3 graceful degradation

Source: \`openspec/coverage-report.md\` generated 2026-05-24 | Cluster: \`pdok-integration\` | Refs #565