### PR TITLE
retrofit: reverse-spec admin-settings (2 REQs / 2 files)

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -18,6 +18,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-25-admin-settings/tasks.md#task-1
  */
 
 declare(strict_types=1);

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -15,6 +15,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-25-admin-settings/tasks.md#task-2
  */
 
 declare(strict_types=1);

--- a/openspec/changes/retrofit-2026-05-25-admin-settings/design.md
+++ b/openspec/changes/retrofit-2026-05-25-admin-settings/design.md
@@ -1,0 +1,3 @@
+# Design — retrofit admin-settings
+
+Retrofit change. Tasks describe retroactive annotation, not new implementation work.

--- a/openspec/changes/retrofit-2026-05-25-admin-settings/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-admin-settings/proposal.md
@@ -1,0 +1,11 @@
+# Retrofit — admin-settings
+
+Describes observed behavior of `SettingsController` + `SettingsService` runtime endpoints as 2 new REQs on the `admin-settings` capability. Code already exists — this change retroactively specifies it.
+
+The existing 15 REQs (REQ-ADMIN-001..015) cover the admin panel UX surface (case types / status types / decision types / publishing / validation). These REQs document the underlying runtime contracts: the JSON settings endpoints (`index`/`create`/`load`) and the OpenRegister-aware resolver helpers that every other Procest service uses to reach the configured register/schema IDs.
+
+## Affected code units
+- lib/Controller/SettingsController.php (3 action methods) — `index()`, `create()`, `load()`
+- lib/Service/SettingsService.php (5 public methods central to ADR-022) — `isOpenRegisterAvailable()`, `getObjectService()`, `loadConfiguration()`, `getSettings()`/`updateSettings()`, `getConfigValue()`/`setConfigValue()`
+
+Source: openspec/coverage-report.md generated 2026-05-24. Tracks ConductionNL/procest#565.

--- a/openspec/changes/retrofit-2026-05-25-admin-settings/specs/admin-settings/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-admin-settings/specs/admin-settings/spec.md
@@ -1,0 +1,68 @@
+---
+retrofit_extensions:
+  - REQ-ADMIN-016
+  - REQ-ADMIN-017
+---
+
+# Admin Settings — controller + service runtime (retrofit)
+
+## Requirements
+
+### REQ-ADMIN-016: SettingsController SHALL expose `index`, `create`, and `load` JSON endpoints for the admin UI runtime
+
+`OCA\Procest\Controller\SettingsController` SHALL expose three action endpoints:
+- `index()` — `#[NoAdminRequired]`. SHALL return `{success: true, openRegisters: <bool>, isAdmin: <bool>, config: <SettingsService::getSettings()>}` so the admin Vue app can render itself for both admins and non-admins (read-only view).
+- `create()` — admin-only (no `#[NoAdminRequired]`). SHALL take the raw request params, delegate to `SettingsService::updateSettings($data)`, and return `{success: true, config: <updated>}`.
+- `load()` — admin-only. SHALL force a fresh re-import of the procest register from `procest_register.json` via `SettingsService::loadConfiguration(force: true)` and return the raw result envelope from that service.
+
+#### Scenario: index reports admin status correctly
+- **GIVEN** a logged-in user `alice` who is a member of the `admin` group
+- **WHEN** `GET /apps/procest/api/settings` (index) is invoked
+- **THEN** the response SHALL contain `"isAdmin": true`
+- **AND** SHALL contain `"openRegisters": true` if the `openregister` app is installed
+
+#### Scenario: index works for non-admins
+- **GIVEN** a logged-in user `bob` who is NOT in the `admin` group
+- **WHEN** `index()` is invoked
+- **THEN** the response SHALL contain `"isAdmin": false`
+- **AND** SHALL still return the current `config` so the Vue app renders in read-only mode
+
+#### Scenario: load forces a fresh register re-import
+- **WHEN** an admin invokes `load()`
+- **THEN** the controller SHALL call `SettingsService::loadConfiguration(force: true)`
+- **AND** SHALL return the result envelope unchanged (no `success: true` wrapper)
+
+### REQ-ADMIN-017: SettingsService SHALL be the single resolver for OpenRegister wiring and SHALL persist all Procest config as IAppConfig key/value pairs
+
+`OCA\Procest\Service\SettingsService` SHALL provide the central OpenRegister resolver and IAppConfig persistence layer for Procest. The service SHALL expose:
+- `isOpenRegisterAvailable(): bool` — returns true iff the `openregister` app is installed AND the `OCA\OpenRegister\Service\ObjectService` class can be resolved from the DI container.
+- `getObjectService(): ?object` — returns the resolved `ObjectService`, or `null` (NOT throw) when OpenRegister is unavailable. Per ADR-022, every Procest data-access call SHALL obtain its `ObjectService` through this single resolver.
+- `loadConfiguration(bool $force = false): array` — idempotent register import. SHALL read `procest_register.json`, import it via the OpenRegister `ConfigurationService`, auto-configure every schema and register ID returned, and persist them via `setConfigValue()`. When `$force` is true, SHALL re-import unconditionally; otherwise SHALL skip when the persisted version matches the manifest version.
+- `getSettings(): array` / `updateSettings(array $data): array` — bulk read/write of the Procest config namespace.
+- `getConfigValue(string $key, string $default = ''): string` / `setConfigValue(string $key, string $value): void` — single-key accessors backed by `IAppConfig` under the `procest` app namespace.
+
+#### Scenario: getObjectService returns null when OpenRegister is uninstalled
+- **GIVEN** the `openregister` app is not installed
+- **WHEN** `getObjectService()` is called
+- **THEN** the method SHALL return `null` (NOT throw)
+- **AND** `isOpenRegisterAvailable()` SHALL return `false`
+
+#### Scenario: loadConfiguration is idempotent without --force
+- **GIVEN** the persisted `procest_register_version` equals the version in `procest_register.json`
+- **WHEN** `loadConfiguration()` is called with default `$force = false`
+- **THEN** the service SHALL skip the re-import and return the cached configuration envelope
+
+#### Scenario: loadConfiguration(force: true) re-imports unconditionally
+- **GIVEN** the persisted version equals the manifest version (no diff)
+- **WHEN** `loadConfiguration(force: true)` is called
+- **THEN** the service SHALL still call `ConfigurationService::importFromApp(...)`
+- **AND** SHALL refresh every persisted schema/register ID from the import result
+
+#### Scenario: config keys survive process restart
+- **WHEN** `setConfigValue('register', 'procest')` is called
+- **AND** a new request hits the process pool
+- **THEN** `getConfigValue('register')` SHALL return `'procest'`
+
+#### Notes
+- Both `getObjectService()` and `getConfigurationService()` look up services from the DI container at call time (NOT injection-time) — this is deliberate so Procest can boot even when `openregister` is not yet installed.
+- ADR-022 calls out that every register-aware service in Procest MUST go through `SettingsService::getObjectService()` rather than wiring its own ObjectService injection.

--- a/openspec/changes/retrofit-2026-05-25-admin-settings/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-admin-settings/tasks.md
@@ -1,0 +1,4 @@
+# Tasks
+
+- [x] task-1: admin-settings#REQ-ADMIN-016 — SettingsController JSON endpoints (index/create/load) for the admin UI runtime (retroactive annotation)
+- [x] task-2: admin-settings#REQ-ADMIN-017 — SettingsService OpenRegister resolver + config key/value persistence (retroactive annotation)

--- a/openspec/specs/admin-settings/spec.md
+++ b/openspec/specs/admin-settings/spec.md
@@ -1,5 +1,8 @@
 ---
 status: implemented
+retrofit_extensions:
+  - REQ-ADMIN-016
+  - REQ-ADMIN-017
 ---
 
 # Admin Settings Specification
@@ -638,3 +641,121 @@ This spec is highly specific and implementation-ready. Requirements are well-str
 1. Should the admin settings enforce backend validation (server-side) or is frontend validation sufficient for MVP?
 2. How should the system handle case type versioning -- can a published case type be edited, or must it be unpublished first?
 3. Should delete of status types cascade to status records on existing cases?
+
+### REQ-ADMIN-016: SettingsController SHALL expose `index`, `create`, and `load` JSON endpoints for the admin UI runtime
+
+`OCA\Procest\Controller\SettingsController` SHALL expose three action endpoints:
+- `index()` — `#[NoAdminRequired]`. SHALL return `{success: true, openRegisters: <bool>, isAdmin: <bool>, config: <SettingsService::getSettings()>}` so the admin Vue app can render itself for both admins and non-admins (read-only view).
+- `create()` — admin-only (no `#[NoAdminRequired]`). SHALL take the raw request params, delegate to `SettingsService::updateSettings($data)`, and return `{success: true, config: <updated>}`.
+- `load()` — admin-only. SHALL force a fresh re-import of the procest register from `procest_register.json` via `SettingsService::loadConfiguration(force: true)` and return the raw result envelope from that service.
+
+#### Scenario: index reports admin status correctly
+- **GIVEN** a logged-in user `alice` who is a member of the `admin` group
+- **WHEN** `GET /apps/procest/api/settings` (index) is invoked
+- **THEN** the response SHALL contain `"isAdmin": true`
+- **AND** SHALL contain `"openRegisters": true` if the `openregister` app is installed
+
+#### Scenario: index works for non-admins
+- **GIVEN** a logged-in user `bob` who is NOT in the `admin` group
+- **WHEN** `index()` is invoked
+- **THEN** the response SHALL contain `"isAdmin": false`
+- **AND** SHALL still return the current `config` so the Vue app renders in read-only mode
+
+#### Scenario: load forces a fresh register re-import
+- **WHEN** an admin invokes `load()`
+- **THEN** the controller SHALL call `SettingsService::loadConfiguration(force: true)`
+- **AND** SHALL return the result envelope unchanged (no `success: true` wrapper)
+
+### REQ-ADMIN-017: SettingsService SHALL be the single resolver for OpenRegister wiring and SHALL persist all Procest config as IAppConfig key/value pairs
+
+`OCA\Procest\Service\SettingsService` SHALL provide the central OpenRegister resolver and IAppConfig persistence layer for Procest. The service SHALL expose:
+- `isOpenRegisterAvailable(): bool` — returns true iff the `openregister` app is installed AND the `OCA\OpenRegister\Service\ObjectService` class can be resolved from the DI container.
+- `getObjectService(): ?object` — returns the resolved `ObjectService`, or `null` (NOT throw) when OpenRegister is unavailable. Per ADR-022, every Procest data-access call SHALL obtain its `ObjectService` through this single resolver.
+- `loadConfiguration(bool $force = false): array` — idempotent register import. SHALL read `procest_register.json`, import it via the OpenRegister `ConfigurationService`, auto-configure every schema and register ID returned, and persist them via `setConfigValue()`. When `$force` is true, SHALL re-import unconditionally; otherwise SHALL skip when the persisted version matches the manifest version.
+- `getSettings(): array` / `updateSettings(array $data): array` — bulk read/write of the Procest config namespace.
+- `getConfigValue(string $key, string $default = ''): string` / `setConfigValue(string $key, string $value): void` — single-key accessors backed by `IAppConfig` under the `procest` app namespace.
+
+#### Scenario: getObjectService returns null when OpenRegister is uninstalled
+- **GIVEN** the `openregister` app is not installed
+- **WHEN** `getObjectService()` is called
+- **THEN** the method SHALL return `null` (NOT throw)
+- **AND** `isOpenRegisterAvailable()` SHALL return `false`
+
+#### Scenario: loadConfiguration is idempotent without --force
+- **GIVEN** the persisted `procest_register_version` equals the version in `procest_register.json`
+- **WHEN** `loadConfiguration()` is called with default `$force = false`
+- **THEN** the service SHALL skip the re-import and return the cached configuration envelope
+
+#### Scenario: loadConfiguration(force: true) re-imports unconditionally
+- **GIVEN** the persisted version equals the manifest version (no diff)
+- **WHEN** `loadConfiguration(force: true)` is called
+- **THEN** the service SHALL still call `ConfigurationService::importFromApp(...)`
+- **AND** SHALL refresh every persisted schema/register ID from the import result
+
+#### Scenario: config keys survive process restart
+- **WHEN** `setConfigValue('register', 'procest')` is called
+- **AND** a new request hits the process pool
+- **THEN** `getConfigValue('register')` SHALL return `'procest'`
+
+#### Notes
+- Both `getObjectService()` and `getConfigurationService()` look up services from the DI container at call time (NOT injection-time) — this is deliberate so Procest can boot even when `openregister` is not yet installed.
+- ADR-022 calls out that every register-aware service in Procest MUST go through `SettingsService::getObjectService()` rather than wiring its own ObjectService injection.
+
+### REQ-ADMIN-016: SettingsController SHALL expose `index`, `create`, and `load` JSON endpoints for the admin UI runtime
+
+`OCA\Procest\Controller\SettingsController` SHALL expose three action endpoints:
+- `index()` — `#[NoAdminRequired]`. SHALL return `{success: true, openRegisters: <bool>, isAdmin: <bool>, config: <SettingsService::getSettings()>}` so the admin Vue app can render itself for both admins and non-admins (read-only view).
+- `create()` — admin-only (no `#[NoAdminRequired]`). SHALL take the raw request params, delegate to `SettingsService::updateSettings($data)`, and return `{success: true, config: <updated>}`.
+- `load()` — admin-only. SHALL force a fresh re-import of the procest register from `procest_register.json` via `SettingsService::loadConfiguration(force: true)` and return the raw result envelope from that service.
+
+#### Scenario: index reports admin status correctly
+- **GIVEN** a logged-in user `alice` who is a member of the `admin` group
+- **WHEN** `GET /apps/procest/api/settings` (index) is invoked
+- **THEN** the response SHALL contain `"isAdmin": true`
+- **AND** SHALL contain `"openRegisters": true` if the `openregister` app is installed
+
+#### Scenario: index works for non-admins
+- **GIVEN** a logged-in user `bob` who is NOT in the `admin` group
+- **WHEN** `index()` is invoked
+- **THEN** the response SHALL contain `"isAdmin": false`
+- **AND** SHALL still return the current `config` so the Vue app renders in read-only mode
+
+#### Scenario: load forces a fresh register re-import
+- **WHEN** an admin invokes `load()`
+- **THEN** the controller SHALL call `SettingsService::loadConfiguration(force: true)`
+- **AND** SHALL return the result envelope unchanged (no `success: true` wrapper)
+
+### REQ-ADMIN-017: SettingsService SHALL be the single resolver for OpenRegister wiring and SHALL persist all Procest config as IAppConfig key/value pairs
+
+`OCA\Procest\Service\SettingsService` SHALL provide the central OpenRegister resolver and IAppConfig persistence layer for Procest. The service SHALL expose:
+- `isOpenRegisterAvailable(): bool` — returns true iff the `openregister` app is installed AND the `OCA\OpenRegister\Service\ObjectService` class can be resolved from the DI container.
+- `getObjectService(): ?object` — returns the resolved `ObjectService`, or `null` (NOT throw) when OpenRegister is unavailable. Per ADR-022, every Procest data-access call SHALL obtain its `ObjectService` through this single resolver.
+- `loadConfiguration(bool $force = false): array` — idempotent register import. SHALL read `procest_register.json`, import it via the OpenRegister `ConfigurationService`, auto-configure every schema and register ID returned, and persist them via `setConfigValue()`. When `$force` is true, SHALL re-import unconditionally; otherwise SHALL skip when the persisted version matches the manifest version.
+- `getSettings(): array` / `updateSettings(array $data): array` — bulk read/write of the Procest config namespace.
+- `getConfigValue(string $key, string $default = ''): string` / `setConfigValue(string $key, string $value): void` — single-key accessors backed by `IAppConfig` under the `procest` app namespace.
+
+#### Scenario: getObjectService returns null when OpenRegister is uninstalled
+- **GIVEN** the `openregister` app is not installed
+- **WHEN** `getObjectService()` is called
+- **THEN** the method SHALL return `null` (NOT throw)
+- **AND** `isOpenRegisterAvailable()` SHALL return `false`
+
+#### Scenario: loadConfiguration is idempotent without --force
+- **GIVEN** the persisted `procest_register_version` equals the version in `procest_register.json`
+- **WHEN** `loadConfiguration()` is called with default `$force = false`
+- **THEN** the service SHALL skip the re-import and return the cached configuration envelope
+
+#### Scenario: loadConfiguration(force: true) re-imports unconditionally
+- **GIVEN** the persisted version equals the manifest version (no diff)
+- **WHEN** `loadConfiguration(force: true)` is called
+- **THEN** the service SHALL still call `ConfigurationService::importFromApp(...)`
+- **AND** SHALL refresh every persisted schema/register ID from the import result
+
+#### Scenario: config keys survive process restart
+- **WHEN** `setConfigValue('register', 'procest')` is called
+- **AND** a new request hits the process pool
+- **THEN** `getConfigValue('register')` SHALL return `'procest'`
+
+#### Notes
+- Both `getObjectService()` and `getConfigurationService()` look up services from the DI container at call time (NOT injection-time) — this is deliberate so Procest can boot even when `openregister` is not yet installed.
+- ADR-022 calls out that every register-aware service in Procest MUST go through `SettingsService::getObjectService()` rather than wiring its own ObjectService injection.


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Describes observed behavior of `SettingsController` + `SettingsService` runtime endpoints as 2 new REQs (REQ-ADMIN-016/017) on the `admin-settings` capability.

The existing 15 REQs cover the admin panel UX; these REQs document the JSON endpoints behind it plus the central OpenRegister resolver mandated by ADR-022.

Ghost change: \`retrofit-2026-05-25-admin-settings\` (archived in same PR).

### What this PR does
- Drafts 2 REQs: \`retrofit_extensions: [REQ-ADMIN-016, REQ-ADMIN-017]\`
- Annotates SettingsController + SettingsService
- Merges spec delta into \`openspec/specs/admin-settings/spec.md\`

### Review focus
- REQ-ADMIN-017 codifies the ADR-022 pattern (every Procest service obtains ObjectService through SettingsService::getObjectService())
- Scenarios are testable

Source: \`openspec/coverage-report.md\` generated 2026-05-24 | Cluster: \`admin-settings\` | Refs #565