### PR TITLE
retrofit: reverse-spec prometheus-metrics (1 REQ / 1 file)

### DIFF
--- a/lib/Controller/MetricsController.php
+++ b/lib/Controller/MetricsController.php
@@ -20,6 +20,7 @@
  * @link https://procest.nl
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-procest/tasks.md#task-2
+ * @spec openspec/changes/retrofit-2026-05-25-prometheus-metrics/tasks.md#task-1
  */
 
 declare(strict_types=1);

--- a/openspec/changes/retrofit-2026-05-25-prometheus-metrics/design.md
+++ b/openspec/changes/retrofit-2026-05-25-prometheus-metrics/design.md
@@ -1,0 +1,3 @@
+# Design — retrofit prometheus-metrics
+
+Retrofit change. Tasks describe retroactive annotation, not new implementation work.

--- a/openspec/changes/retrofit-2026-05-25-prometheus-metrics/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-prometheus-metrics/proposal.md
@@ -1,0 +1,10 @@
+# Retrofit — prometheus-metrics
+
+Adds 1 new REQ to the `prometheus-metrics` capability that ties the existing `REQ-PROM-001..010` requirement set to its single implementation surface — the `MetricsController::index()` text-exposition endpoint — and codifies the observed controller-level contract (cache TTLs, Content-Type header version, NoCSRFRequired posture).
+
+The existing REQ-PROM-001 spec mandates "MUST provide a /metrics endpoint", but does not lock down the cache TTLs (`CACHE_TTL_DEFAULT=30`, `CACHE_TTL_OVERDUE=60`) or the Prometheus exposition version (`0.0.4`) actually emitted by the controller. This retrofit captures those values as observed-behavior contracts.
+
+## Affected code units
+- lib/Controller/MetricsController.php — `index()` action endpoint + internal `collectMetrics()` helper (1 public method, 1 cluster covering all 10 REQ-PROM-NN requirements)
+
+Source: openspec/coverage-report.md generated 2026-05-24. Tracks ConductionNL/procest#565.

--- a/openspec/changes/retrofit-2026-05-25-prometheus-metrics/specs/prometheus-metrics/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-prometheus-metrics/specs/prometheus-metrics/spec.md
@@ -1,0 +1,35 @@
+---
+retrofit_extensions:
+  - REQ-PROM-011
+---
+
+# Prometheus Metrics — controller contract (retrofit)
+
+## Requirements
+
+### REQ-PROM-011: MetricsController::index SHALL be the single Prometheus exposition surface and SHALL honor the observed cache + header contract
+
+`OCA\Procest\Controller\MetricsController` SHALL expose a single action method `index()` that returns a `TextPlainResponse` containing the full metric set defined in REQ-PROM-001..010. The controller SHALL:
+- Be annotated `#[NoCSRFRequired]` so Prometheus scrape jobs can poll without a CSRF token.
+- Emit `Content-Type: text/plain; version=0.0.4; charset=utf-8` exactly (the Prometheus 0.0.4 text exposition version is part of the wire contract — scrapers reject anything else).
+- Cache individual metric queries with `CACHE_TTL_DEFAULT = 30` seconds for most series and `CACHE_TTL_OVERDUE = 60` seconds for the overdue-case series (which change less often and are expensive to compute).
+- Delegate metric collection to a private `collectMetrics(): string` helper that concatenates app-info / case-management / ZGW / SLA / StUF sections into the canonical exposition format.
+
+#### Scenario: Response Content-Type carries the 0.0.4 version
+- **WHEN** a Prometheus scraper hits `/apps/procest/metrics`
+- **THEN** the response SHALL have status 200
+- **AND** the `Content-Type` header SHALL be `text/plain; version=0.0.4; charset=utf-8`
+
+#### Scenario: Endpoint is reachable without CSRF token
+- **GIVEN** a Prometheus scrape job with no CSRF token
+- **WHEN** it requests `/apps/procest/metrics`
+- **THEN** the request SHALL succeed (Nextcloud CSRF middleware is bypassed via `#[NoCSRFRequired]`)
+
+#### Scenario: Overdue-case metric uses longer cache TTL
+- **GIVEN** the overdue-case metric was computed and cached at t=0
+- **WHEN** `/metrics` is hit again at t=45
+- **THEN** the cached value SHALL still be served (TTL = 60s, not expired)
+
+#### Notes
+- This REQ does NOT replace REQ-PROM-001..010 — those define the metric set; this REQ defines the controller-level transport contract that exposes them.
+- The `CACHE_TTL_*` constants live as `private const` on the controller; if a future REQ requires longer/shorter TTLs, both this REQ and the constants must move together.

--- a/openspec/changes/retrofit-2026-05-25-prometheus-metrics/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-prometheus-metrics/tasks.md
@@ -1,0 +1,3 @@
+# Tasks
+
+- [x] task-1: prometheus-metrics#REQ-PROM-011 — MetricsController::index() text exposition endpoint contract (cache TTLs, Content-Type version, NoCSRFRequired) (retroactive annotation)

--- a/openspec/specs/prometheus-metrics/spec.md
+++ b/openspec/specs/prometheus-metrics/spec.md
@@ -1,5 +1,7 @@
 ---
 status: implemented
+retrofit_extensions:
+  - REQ-PROM-011
 ---
 
 # Prometheus Metrics Endpoint
@@ -562,3 +564,32 @@ When StUF support is implemented (see `../stuf-support/spec.md`), the system MUS
 The spec defines 10 requirements with 3-5 scenarios each, covering the full monitoring lifecycle from basic metrics through SLA dashboards. The existing `MetricsController` and `HealthController` provide a foundation.
 
 **Competitive context**: Dimpact ZAC uses OpenTelemetry with Prometheus, Grafana, and Tempo for observability. Flowable exposes JMX and REST metrics. Procest's native Prometheus endpoint provides equivalent monitoring capability without requiring a separate APM agent.
+
+---
+
+### REQ-PROM-011: MetricsController::index SHALL be the single Prometheus exposition surface and SHALL honor the observed cache + header contract
+
+`OCA\Procest\Controller\MetricsController` SHALL expose a single action method `index()` that returns a `TextPlainResponse` containing the full metric set defined in REQ-PROM-001..010. The controller SHALL:
+- Be annotated `#[NoCSRFRequired]` so Prometheus scrape jobs can poll without a CSRF token.
+- Emit `Content-Type: text/plain; version=0.0.4; charset=utf-8` exactly (the Prometheus 0.0.4 text exposition version is part of the wire contract — scrapers reject anything else).
+- Cache individual metric queries with `CACHE_TTL_DEFAULT = 30` seconds for most series and `CACHE_TTL_OVERDUE = 60` seconds for the overdue-case series (which change less often and are expensive to compute).
+- Delegate metric collection to a private `collectMetrics(): string` helper that concatenates app-info / case-management / ZGW / SLA / StUF sections into the canonical exposition format.
+
+#### Scenario: Response Content-Type carries the 0.0.4 version
+- **WHEN** a Prometheus scraper hits `/apps/procest/metrics`
+- **THEN** the response SHALL have status 200
+- **AND** the `Content-Type` header SHALL be `text/plain; version=0.0.4; charset=utf-8`
+
+#### Scenario: Endpoint is reachable without CSRF token
+- **GIVEN** a Prometheus scrape job with no CSRF token
+- **WHEN** it requests `/apps/procest/metrics`
+- **THEN** the request SHALL succeed (Nextcloud CSRF middleware is bypassed via `#[NoCSRFRequired]`)
+
+#### Scenario: Overdue-case metric uses longer cache TTL
+- **GIVEN** the overdue-case metric was computed and cached at t=0
+- **WHEN** `/metrics` is hit again at t=45
+- **THEN** the cached value SHALL still be served (TTL = 60s, not expired)
+
+#### Notes
+- This REQ does NOT replace REQ-PROM-001..010 — those define the metric set; this REQ defines the controller-level transport contract that exposes them.
+- The `CACHE_TTL_*` constants live as `private const` on the controller; if a future REQ requires longer/shorter TTLs, both this REQ and the constants must move together.


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Adds REQ-PROM-011 (controller-level transport contract: cache TTLs, Content-Type version, NoCSRFRequired) to the \`prometheus-metrics\` capability.

The existing REQ-PROM-001..010 define the metric set; this REQ ties them to the single MetricsController::index() surface and locks the observed wire contract.

Ghost change: \`retrofit-2026-05-25-prometheus-metrics\` (archived in same PR).

### What this PR does
- Drafts 1 REQ: \`retrofit_extensions: [REQ-PROM-011]\`
- Adds a second \`@spec\` tag to MetricsController (alongside the existing Bucket 1 annotation)
- Merges spec delta into \`openspec/specs/prometheus-metrics/spec.md\`

Source: \`openspec/coverage-report.md\` generated 2026-05-24 | Cluster: \`prometheus-metrics\` | Refs #565