### PR TITLE
retrofit: reverse-spec appointment-booking (5 REQs / 8 files, new capability)

### DIFF
--- a/lib/BackgroundJob/AppointmentReminderJob.php
+++ b/lib/BackgroundJob/AppointmentReminderJob.php
@@ -16,6 +16,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-25-appointment-booking/tasks.md#task-5
  */
 
 declare(strict_types=1);

--- a/lib/Controller/AppointmentController.php
+++ b/lib/Controller/AppointmentController.php
@@ -16,6 +16,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-25-appointment-booking/tasks.md#task-3
  */
 
 declare(strict_types=1);

--- a/lib/Controller/PublicAppointmentController.php
+++ b/lib/Controller/PublicAppointmentController.php
@@ -16,6 +16,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-25-appointment-booking/tasks.md#task-4
  */
 
 declare(strict_types=1);

--- a/lib/Service/AppointmentBackend/AppointmentBackendInterface.php
+++ b/lib/Service/AppointmentBackend/AppointmentBackendInterface.php
@@ -15,6 +15,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-25-appointment-booking/tasks.md#task-1
  */
 
 declare(strict_types=1);

--- a/lib/Service/AppointmentBackend/JccBackend.php
+++ b/lib/Service/AppointmentBackend/JccBackend.php
@@ -16,6 +16,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-25-appointment-booking/tasks.md#task-1
  */
 
 declare(strict_types=1);

--- a/lib/Service/AppointmentBackend/LocalBackend.php
+++ b/lib/Service/AppointmentBackend/LocalBackend.php
@@ -16,6 +16,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-25-appointment-booking/tasks.md#task-1
  */
 
 declare(strict_types=1);

--- a/lib/Service/AppointmentBackend/QmaticBackend.php
+++ b/lib/Service/AppointmentBackend/QmaticBackend.php
@@ -15,6 +15,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-25-appointment-booking/tasks.md#task-1
  */
 
 declare(strict_types=1);

--- a/lib/Service/AppointmentService.php
+++ b/lib/Service/AppointmentService.php
@@ -17,6 +17,8 @@
  * @version GIT: <git-id>
  *
  * @link https://procest.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-25-appointment-booking/tasks.md#task-2
  */
 
 declare(strict_types=1);

--- a/openspec/changes/retrofit-2026-05-25-appointment-booking/design.md
+++ b/openspec/changes/retrofit-2026-05-25-appointment-booking/design.md
@@ -1,0 +1,3 @@
+# Design — retrofit appointment-booking
+
+Retrofit change. Tasks describe retroactive annotation, not new implementation work.

--- a/openspec/changes/retrofit-2026-05-25-appointment-booking/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-appointment-booking/proposal.md
@@ -1,0 +1,20 @@
+# Retrofit — appointment-booking (new capability)
+
+Mints a new `appointment-booking` capability spec describing observed behavior of the Procest appointment subsystem. Code already exists across 8 PHP files (controller pair, service orchestrator, pluggable backend interface + 3 implementations, reminder background job) — this change retroactively specifies it.
+
+The cluster spans:
+- Pluggable backend pattern (interface + JCC / Qmatic / Local impls)
+- Internal `AppointmentController` for case-handler CRUD
+- Public `PublicAppointmentController` for citizen-side token-based access
+- `AppointmentService` orchestrator that ties backends to OpenRegister persistence
+- `AppointmentReminderJob` background reminder dispatcher
+
+## Affected code units
+- lib/Service/AppointmentBackend/AppointmentBackendInterface.php (4 methods)
+- lib/Service/AppointmentBackend/JccBackend.php / QmaticBackend.php / LocalBackend.php (4 methods each)
+- lib/Controller/AppointmentController.php (5 action methods)
+- lib/Controller/PublicAppointmentController.php (2 action methods: view, cancel)
+- lib/Service/AppointmentService.php (6 public methods)
+- lib/BackgroundJob/AppointmentReminderJob.php (1 run method via TimedJob)
+
+Source: openspec/coverage-report.md generated 2026-05-24. Tracks ConductionNL/procest#565.

--- a/openspec/changes/retrofit-2026-05-25-appointment-booking/specs/appointment-booking/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-appointment-booking/specs/appointment-booking/spec.md
@@ -1,0 +1,132 @@
+---
+retrofit: true
+---
+
+# Appointment Booking Specification
+
+## Purpose
+
+Enable Procest cases to schedule, manage, and cancel citizen appointments through pluggable backend integrations with external municipal appointment systems (JCC Afspraken, Qmatic Orchestra) or a local-storage fallback. Citizens receive a token-protected URL for viewing and cancelling their appointment without authentication; case handlers manage appointments through authenticated endpoints; a background job dispatches reminders before each appointment.
+
+**Standards**: JCC Afspraken API, Qmatic Orchestra REST API
+**Feature tier**: V1
+
+## Requirements
+
+### REQ-001: AppointmentBackendInterface SHALL define a 4-method contract for pluggable appointment-scheduling backends
+
+`OCA\Procest\Service\AppointmentBackend\AppointmentBackendInterface` SHALL define exactly four methods that every backend implementation SHALL implement:
+- `getTimeslots(string $productId, string $locationId, string $date): array` — return the list of available timeslots `[{time, duration, available}]` for a (product, location, date) triple.
+- `bookAppointment(array $data): array` — book an appointment in the external system and return a result containing `externalId`.
+- `cancelAppointment(string $externalId): bool` — cancel by external ID; return `true` on success.
+- `rescheduleAppointment(string $externalId, string $newDateTime): array` — reschedule and return the updated booking.
+
+The interface SHALL be the only point of coupling between `AppointmentService` and external systems. Three implementations SHALL ship with Procest: `JccBackend` (JCC Afspraken), `QmaticBackend` (Qmatic Orchestra), and `LocalBackend` (no external system — appointments stored only in OpenRegister).
+
+#### Scenario: Every shipped backend implements the contract
+- **GIVEN** the three shipped backends `JccBackend`, `QmaticBackend`, `LocalBackend`
+- **WHEN** the autoloader resolves each class
+- **THEN** each SHALL be `instanceof AppointmentBackendInterface`
+- **AND** each SHALL expose the four contract methods with matching signatures
+
+#### Scenario: LocalBackend short-circuits external calls
+- **GIVEN** the active backend is `LocalBackend`
+- **WHEN** `bookAppointment($data)` is invoked
+- **THEN** no outbound HTTP call SHALL be issued — the result SHALL be generated locally and returned
+
+#### Notes
+- Adding a new municipal-system backend requires only a new class implementing the interface plus a config entry — no `AppointmentService` changes.
+
+### REQ-002: AppointmentService SHALL persist every booked appointment to OpenRegister and SHALL generate per-appointment cancel tokens
+
+`OCA\Procest\Service\AppointmentService` SHALL be the single orchestrator that ties backends to OpenRegister persistence. The service SHALL expose six public methods:
+- `getTimeslots(string $productId, string $locationId, string $date): array` — delegate to the active backend.
+- `bookAppointment(string $caseId, array $data): array` — book via backend, then persist to OpenRegister with `status: 'scheduled'`, `externalId: <backend result>`, `cancelToken: bin2hex(random_bytes(16))` (32-char hex), `reminderSent: false`, and the `caseId`. Return `['error' => 'OpenRegister is not available']` when `ObjectService` resolves to null.
+- `cancelAppointment(string $appointmentId): array` — load, cancel via backend, flip persisted status.
+- `markNoShow(string $appointmentId): array` — flip persisted status to no-show (no backend call).
+- `getAppointmentsForCase(string $caseId): array` — list persisted appointments by case.
+- `getAppointmentByToken(string $token): ?array` — lookup by the `cancelToken` for the public controller.
+
+The persisted appointment SHALL live in the configured `register` + `appointment_schema` (read from `SettingsService::getConfigValue`).
+
+#### Scenario: Booking generates a 32-char hex cancel token
+- **WHEN** `bookAppointment('uuid-case', $data)` is invoked
+- **THEN** the persisted record SHALL contain `cancelToken` matching `^[0-9a-f]{32}$`
+- **AND** SHALL contain `status: 'scheduled'` and `reminderSent: false`
+
+#### Scenario: OpenRegister unavailable returns structured error
+- **GIVEN** `SettingsService::getObjectService()` returns null
+- **WHEN** `bookAppointment('uuid-case', $data)` is invoked
+- **THEN** the result SHALL be `['error' => 'OpenRegister is not available']`
+- **AND** the backend's `bookAppointment` SHALL NOT have been called
+
+#### Scenario: Token lookup returns null when token unknown
+- **WHEN** `getAppointmentByToken('not-a-real-token')` is invoked
+- **THEN** the method SHALL return `null` (NOT throw)
+
+#### Notes
+- The cancel token's entropy (128 bits) is sufficient to prevent brute-forcing; rotation on cancel/reschedule is a future TODO.
+- The "book in backend first, then persist" order means a successful backend booking with a failed OpenRegister persist leaves an orphan in the external system — flagged in observed behavior; a future REQ may codify the compensating cancel.
+
+### REQ-003: AppointmentController SHALL expose the internal handler-facing CRUD endpoints
+
+`OCA\Procest\Controller\AppointmentController` SHALL expose five authenticated action methods (default `#[NoAdminRequired]`):
+- `index()` — list appointments for the current handler / filter context.
+- `create()` — book a new appointment for a case (delegates to `AppointmentService::bookAppointment`).
+- `cancel(string $appointmentId)` — cancel an existing appointment.
+- `noShow(string $appointmentId)` — mark as no-show.
+- `timeslots()` — proxy to `AppointmentService::getTimeslots` so the UI can render the picker.
+
+#### Scenario: Cancel returns the updated appointment record
+- **GIVEN** a scheduled appointment `appt-uuid-1`
+- **WHEN** an authenticated handler calls `cancel('appt-uuid-1')`
+- **THEN** the response SHALL be a JSONResponse containing the appointment record with `status: 'cancelled'`
+
+#### Scenario: noShow does not touch the external backend
+- **WHEN** `noShow('appt-uuid-1')` is invoked
+- **THEN** the persisted status SHALL flip to `noShow` (or equivalent)
+- **AND** no outbound backend cancel/reschedule call SHALL be issued
+
+### REQ-004: PublicAppointmentController SHALL serve token-gated view + cancel for citizens
+
+`OCA\Procest\Controller\PublicAppointmentController` SHALL expose two unauthenticated (`#[PublicPage] #[NoCSRFRequired]`) action methods keyed by the `cancelToken` from REQ-002:
+- `view(string $token)` — return the appointment record (date, time, location, status) for the matching token, or `404` when the token does not match.
+- `cancel(string $token)` — cancel the matched appointment via `AppointmentService::cancelAppointment`, or `404` when the token does not match.
+
+The controller SHALL NEVER expose the persisted appointment UUID, caseId, or backend externalId in either response — only the citizen-facing fields.
+
+#### Scenario: Unknown token returns 404
+- **WHEN** `view('not-a-real-token')` is invoked
+- **THEN** the response SHALL have status 404 (or an equivalent error envelope)
+- **AND** SHALL NOT leak appointment data
+
+#### Scenario: Valid token returns citizen-safe fields
+- **GIVEN** an appointment with `cancelToken = 'abc...32hex'` and `caseId = 'uuid-1'`
+- **WHEN** `view('abc...32hex')` is invoked
+- **THEN** the response SHALL contain the appointment date, time, location, and status
+- **AND** SHALL NOT contain the appointment UUID, `caseId`, or `externalId`
+
+#### Notes
+- Rate-limiting the token-validation endpoint is a security TODO; today the controller relies on token entropy alone (128 bits — well above brute-force territory but worth pairing with rate-limit per IP).
+
+### REQ-005: AppointmentReminderJob SHALL dispatch citizen reminders before scheduled appointments via the Nextcloud TimedJob queue
+
+`OCA\Procest\BackgroundJob\AppointmentReminderJob` SHALL extend `\OCP\BackgroundJob\TimedJob`. The `run(...)` method SHALL:
+- Scan persisted appointments for records with `status = 'scheduled'`, `reminderSent = false`, and `dateTime` within the configured reminder window.
+- Dispatch a reminder (email, SMS, or notification — whichever channels the deployment has wired) for each match.
+- Flip `reminderSent = true` after a successful dispatch so the same appointment is never reminded twice.
+- Be IDEMPOTENT — re-running the job within the same window SHALL be a no-op for already-reminded appointments.
+
+#### Scenario: Already-reminded appointment is skipped
+- **GIVEN** an appointment with `reminderSent = true` and `dateTime` within the reminder window
+- **WHEN** `AppointmentReminderJob::run()` executes
+- **THEN** the job SHALL NOT dispatch a second reminder for that appointment
+
+#### Scenario: Successful dispatch flips reminderSent
+- **GIVEN** an appointment with `reminderSent = false` matching the window
+- **WHEN** the reminder is dispatched successfully
+- **THEN** the persisted record SHALL be updated to `reminderSent = true`
+
+#### Notes
+- The reminder window and the dispatch channel set are deployment concerns — left intentionally unspecified to allow per-municipality configuration.
+- The job is registered through the standard Nextcloud `TimedJob` interval; cron cadence is set in the constructor and is part of the deployed contract.

--- a/openspec/changes/retrofit-2026-05-25-appointment-booking/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-appointment-booking/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] task-1: appointment-booking#REQ-001 — AppointmentBackendInterface 4-method contract for pluggable scheduling backends (retroactive annotation)
+- [x] task-2: appointment-booking#REQ-002 — AppointmentService orchestrator persists every appointment to OpenRegister and generates cancel tokens (retroactive annotation)
+- [x] task-3: appointment-booking#REQ-003 — AppointmentController internal handler endpoints (retroactive annotation)
+- [x] task-4: appointment-booking#REQ-004 — PublicAppointmentController token-gated citizen view + cancel (retroactive annotation)
+- [x] task-5: appointment-booking#REQ-005 — AppointmentReminderJob background reminder dispatcher (retroactive annotation)

--- a/openspec/specs/appointment-booking/spec.md
+++ b/openspec/specs/appointment-booking/spec.md
@@ -1,0 +1,132 @@
+---
+retrofit: true
+---
+
+# Appointment Booking Specification
+
+## Purpose
+
+Enable Procest cases to schedule, manage, and cancel citizen appointments through pluggable backend integrations with external municipal appointment systems (JCC Afspraken, Qmatic Orchestra) or a local-storage fallback. Citizens receive a token-protected URL for viewing and cancelling their appointment without authentication; case handlers manage appointments through authenticated endpoints; a background job dispatches reminders before each appointment.
+
+**Standards**: JCC Afspraken API, Qmatic Orchestra REST API
+**Feature tier**: V1
+
+## Requirements
+
+### REQ-001: AppointmentBackendInterface SHALL define a 4-method contract for pluggable appointment-scheduling backends
+
+`OCA\Procest\Service\AppointmentBackend\AppointmentBackendInterface` SHALL define exactly four methods that every backend implementation SHALL implement:
+- `getTimeslots(string $productId, string $locationId, string $date): array` — return the list of available timeslots `[{time, duration, available}]` for a (product, location, date) triple.
+- `bookAppointment(array $data): array` — book an appointment in the external system and return a result containing `externalId`.
+- `cancelAppointment(string $externalId): bool` — cancel by external ID; return `true` on success.
+- `rescheduleAppointment(string $externalId, string $newDateTime): array` — reschedule and return the updated booking.
+
+The interface SHALL be the only point of coupling between `AppointmentService` and external systems. Three implementations SHALL ship with Procest: `JccBackend` (JCC Afspraken), `QmaticBackend` (Qmatic Orchestra), and `LocalBackend` (no external system — appointments stored only in OpenRegister).
+
+#### Scenario: Every shipped backend implements the contract
+- **GIVEN** the three shipped backends `JccBackend`, `QmaticBackend`, `LocalBackend`
+- **WHEN** the autoloader resolves each class
+- **THEN** each SHALL be `instanceof AppointmentBackendInterface`
+- **AND** each SHALL expose the four contract methods with matching signatures
+
+#### Scenario: LocalBackend short-circuits external calls
+- **GIVEN** the active backend is `LocalBackend`
+- **WHEN** `bookAppointment($data)` is invoked
+- **THEN** no outbound HTTP call SHALL be issued — the result SHALL be generated locally and returned
+
+#### Notes
+- Adding a new municipal-system backend requires only a new class implementing the interface plus a config entry — no `AppointmentService` changes.
+
+### REQ-002: AppointmentService SHALL persist every booked appointment to OpenRegister and SHALL generate per-appointment cancel tokens
+
+`OCA\Procest\Service\AppointmentService` SHALL be the single orchestrator that ties backends to OpenRegister persistence. The service SHALL expose six public methods:
+- `getTimeslots(string $productId, string $locationId, string $date): array` — delegate to the active backend.
+- `bookAppointment(string $caseId, array $data): array` — book via backend, then persist to OpenRegister with `status: 'scheduled'`, `externalId: <backend result>`, `cancelToken: bin2hex(random_bytes(16))` (32-char hex), `reminderSent: false`, and the `caseId`. Return `['error' => 'OpenRegister is not available']` when `ObjectService` resolves to null.
+- `cancelAppointment(string $appointmentId): array` — load, cancel via backend, flip persisted status.
+- `markNoShow(string $appointmentId): array` — flip persisted status to no-show (no backend call).
+- `getAppointmentsForCase(string $caseId): array` — list persisted appointments by case.
+- `getAppointmentByToken(string $token): ?array` — lookup by the `cancelToken` for the public controller.
+
+The persisted appointment SHALL live in the configured `register` + `appointment_schema` (read from `SettingsService::getConfigValue`).
+
+#### Scenario: Booking generates a 32-char hex cancel token
+- **WHEN** `bookAppointment('uuid-case', $data)` is invoked
+- **THEN** the persisted record SHALL contain `cancelToken` matching `^[0-9a-f]{32}$`
+- **AND** SHALL contain `status: 'scheduled'` and `reminderSent: false`
+
+#### Scenario: OpenRegister unavailable returns structured error
+- **GIVEN** `SettingsService::getObjectService()` returns null
+- **WHEN** `bookAppointment('uuid-case', $data)` is invoked
+- **THEN** the result SHALL be `['error' => 'OpenRegister is not available']`
+- **AND** the backend's `bookAppointment` SHALL NOT have been called
+
+#### Scenario: Token lookup returns null when token unknown
+- **WHEN** `getAppointmentByToken('not-a-real-token')` is invoked
+- **THEN** the method SHALL return `null` (NOT throw)
+
+#### Notes
+- The cancel token's entropy (128 bits) is sufficient to prevent brute-forcing; rotation on cancel/reschedule is a future TODO.
+- The "book in backend first, then persist" order means a successful backend booking with a failed OpenRegister persist leaves an orphan in the external system — flagged in observed behavior; a future REQ may codify the compensating cancel.
+
+### REQ-003: AppointmentController SHALL expose the internal handler-facing CRUD endpoints
+
+`OCA\Procest\Controller\AppointmentController` SHALL expose five authenticated action methods (default `#[NoAdminRequired]`):
+- `index()` — list appointments for the current handler / filter context.
+- `create()` — book a new appointment for a case (delegates to `AppointmentService::bookAppointment`).
+- `cancel(string $appointmentId)` — cancel an existing appointment.
+- `noShow(string $appointmentId)` — mark as no-show.
+- `timeslots()` — proxy to `AppointmentService::getTimeslots` so the UI can render the picker.
+
+#### Scenario: Cancel returns the updated appointment record
+- **GIVEN** a scheduled appointment `appt-uuid-1`
+- **WHEN** an authenticated handler calls `cancel('appt-uuid-1')`
+- **THEN** the response SHALL be a JSONResponse containing the appointment record with `status: 'cancelled'`
+
+#### Scenario: noShow does not touch the external backend
+- **WHEN** `noShow('appt-uuid-1')` is invoked
+- **THEN** the persisted status SHALL flip to `noShow` (or equivalent)
+- **AND** no outbound backend cancel/reschedule call SHALL be issued
+
+### REQ-004: PublicAppointmentController SHALL serve token-gated view + cancel for citizens
+
+`OCA\Procest\Controller\PublicAppointmentController` SHALL expose two unauthenticated (`#[PublicPage] #[NoCSRFRequired]`) action methods keyed by the `cancelToken` from REQ-002:
+- `view(string $token)` — return the appointment record (date, time, location, status) for the matching token, or `404` when the token does not match.
+- `cancel(string $token)` — cancel the matched appointment via `AppointmentService::cancelAppointment`, or `404` when the token does not match.
+
+The controller SHALL NEVER expose the persisted appointment UUID, caseId, or backend externalId in either response — only the citizen-facing fields.
+
+#### Scenario: Unknown token returns 404
+- **WHEN** `view('not-a-real-token')` is invoked
+- **THEN** the response SHALL have status 404 (or an equivalent error envelope)
+- **AND** SHALL NOT leak appointment data
+
+#### Scenario: Valid token returns citizen-safe fields
+- **GIVEN** an appointment with `cancelToken = 'abc...32hex'` and `caseId = 'uuid-1'`
+- **WHEN** `view('abc...32hex')` is invoked
+- **THEN** the response SHALL contain the appointment date, time, location, and status
+- **AND** SHALL NOT contain the appointment UUID, `caseId`, or `externalId`
+
+#### Notes
+- Rate-limiting the token-validation endpoint is a security TODO; today the controller relies on token entropy alone (128 bits — well above brute-force territory but worth pairing with rate-limit per IP).
+
+### REQ-005: AppointmentReminderJob SHALL dispatch citizen reminders before scheduled appointments via the Nextcloud TimedJob queue
+
+`OCA\Procest\BackgroundJob\AppointmentReminderJob` SHALL extend `\OCP\BackgroundJob\TimedJob`. The `run(...)` method SHALL:
+- Scan persisted appointments for records with `status = 'scheduled'`, `reminderSent = false`, and `dateTime` within the configured reminder window.
+- Dispatch a reminder (email, SMS, or notification — whichever channels the deployment has wired) for each match.
+- Flip `reminderSent = true` after a successful dispatch so the same appointment is never reminded twice.
+- Be IDEMPOTENT — re-running the job within the same window SHALL be a no-op for already-reminded appointments.
+
+#### Scenario: Already-reminded appointment is skipped
+- **GIVEN** an appointment with `reminderSent = true` and `dateTime` within the reminder window
+- **WHEN** `AppointmentReminderJob::run()` executes
+- **THEN** the job SHALL NOT dispatch a second reminder for that appointment
+
+#### Scenario: Successful dispatch flips reminderSent
+- **GIVEN** an appointment with `reminderSent = false` matching the window
+- **WHEN** the reminder is dispatched successfully
+- **THEN** the persisted record SHALL be updated to `reminderSent = true`
+
+#### Notes
+- The reminder window and the dispatch channel set are deployment concerns — left intentionally unspecified to allow per-municipality configuration.
+- The job is registered through the standard Nextcloud `TimedJob` interval; cron cadence is set in the constructor and is part of the deployed contract.


### PR DESCRIPTION
## Retrofit — Reverse-Spec (new capability)

Mints a new \`appointment-booking\` capability describing observed behavior across 8 PHP files (backend interface + 3 backends, internal controller, public token controller, orchestrator service, reminder background job) as 5 new REQs.

Ghost change: \`retrofit-2026-05-25-appointment-booking\` (archived in same PR — full spec written to \`openspec/specs/appointment-booking/spec.md\`).

### What this PR does
- Drafts 5 REQs: \`retrofit: true\` (new capability)
- Annotates all 8 source files with \`@spec\` task pointers
- Writes the canonical capability spec at \`openspec/specs/appointment-booking/spec.md\`

### What this PR does NOT do
- No code behavior changes — annotations + spec only
- Does not silently fix observed behavior:
  - Order of "book in backend first, then persist" leaves orphans on persist-failure (flagged in REQ-002 Notes)
  - PublicAppointmentController has no per-IP rate-limit yet (flagged in REQ-004 Notes)

### Review focus
- REQ-001 backend interface contract is observable across all 3 implementations
- REQ-002 cancelToken entropy + idempotency contract is testable
- REQ-004 citizen-safe field exposure is the security-sensitive REQ — review the field allowlist

Source: \`openspec/coverage-report.md\` generated 2026-05-24 | Cluster: \`appointment-booking\` (2b) | Refs #565