### PR TITLE
feat(gis): WFS export endpoint for case locations (ports #483)

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -158,6 +158,11 @@ return [
         // CRUD on wmsLayer objects is served by OpenRegister manifest pages.
         ['name' => 'wms_wfs#proxy', 'url' => '/api/wms-wfs/proxy', 'verb' => 'GET'],
 
+        // WFS export — exposes case locations as a GeoJSON WFS layer for external GIS applications.
+        // gis-integration spec AC 6.
+        ['name' => 'wfsExport#getFeatures', 'url' => '/api/gis/wfs', 'verb' => 'GET'],
+        ['name' => 'wfsExport#getCapabilities', 'url' => '/api/gis/wfs/capabilities', 'verb' => 'GET'],
+
         // ── Parafeerroute (B&W parafering engine) ───────────────────────
         // CRUD on parafeerroute objects is served by OpenRegister's auto-exposed
         // /api/objects/<register>/<schema> endpoints — only engine routes remain.

--- a/lib/Controller/WfsExportController.php
+++ b/lib/Controller/WfsExportController.php
@@ -1,0 +1,168 @@
+<?php
+
+/**
+ * Procest WFS Export Controller
+ *
+ * Exposes case locations as a standard WFS endpoint so external GIS
+ * applications (QGIS, ArcGIS, MapInfo, etc.) can consume Procest case data
+ * as a map layer. Implements AC 6 of the gis-integration spec.
+ *
+ * Endpoint: GET /api/gis/wfs
+ * Auth: NoAdminRequired — any authenticated Nextcloud user (external GIS apps
+ * authenticate via HTTP Basic Auth or OIDC).
+ *
+ * @category Controller
+ * @package  OCA\Procest\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/gis-integration/tasks.md#task-gis-06
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Controller;
+
+use OCA\Procest\Service\WfsExportService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\OCS\OCSForbiddenException;
+use OCP\IRequest;
+use OCP\IUserSession;
+
+/**
+ * Controller exposing case locations as a WFS GeoJSON endpoint.
+ *
+ * @spec openspec/changes/gis-integration/tasks.md#task-gis-06
+ */
+class WfsExportController extends Controller
+{
+    /**
+     * Constructor.
+     *
+     * @param string           $appName          The application name
+     * @param IRequest         $request          The request object
+     * @param WfsExportService $wfsExportService The WFS export service
+     * @param IUserSession     $userSession      The user session
+     *
+     * @return void
+     */
+    public function __construct(
+        string $appName,
+        IRequest $request,
+        private WfsExportService $wfsExportService,
+        private IUserSession $userSession,
+    ) {
+        parent::__construct(appName: $appName, request: $request);
+    }//end __construct()
+
+    /**
+     * Return case locations as a GeoJSON FeatureCollection (WFS GetFeature).
+     *
+     * Query parameters:
+     *   - typeName:     Feature type to return (default: procest:cases)
+     *   - outputFormat: Output format, only application/json supported (default: application/json)
+     *   - maxFeatures:  Maximum features to return (default: 500, hard cap: 2000)
+     *   - bbox:         Bounding box filter as "minLon,minLat,maxLon,maxLat" in WGS84 (optional)
+     *   - status:       Filter by case status (optional)
+     *   - caseType:     Filter by case type name (optional)
+     *
+     * @NoAdminRequired
+     *
+     * @return JSONResponse GeoJSON FeatureCollection
+     *
+     * @throws OCSForbiddenException When user session is not authenticated
+     *
+     * @spec openspec/changes/gis-integration/tasks.md#task-gis-06
+     */
+    public function getFeatures(): JSONResponse
+    {
+        if ($this->userSession->getUser() === null) {
+            throw new OCSForbiddenException('Authentication required');
+        }
+
+        $typeName     = (string) $this->request->getParam('typeName', WfsExportService::TYPE_NAME_CASES);
+        $outputFormat = (string) $this->request->getParam('outputFormat', 'application/json');
+        $maxFeatures  = (int) $this->request->getParam('maxFeatures', WfsExportService::DEFAULT_MAX_FEATURES);
+        $bboxParam    = $this->request->getParam('bbox', null);
+        $statusRaw    = $this->request->getParam('status', null);
+        $caseTypeRaw  = $this->request->getParam('caseType', null);
+
+        $status = null;
+        if ($statusRaw !== null) {
+            $status = (string) $statusRaw;
+        }
+
+        $caseType = null;
+        if ($caseTypeRaw !== null) {
+            $caseType = (string) $caseTypeRaw;
+        }
+
+        if ($typeName !== WfsExportService::TYPE_NAME_CASES) {
+            return new JSONResponse(
+                ['error' => 'Unsupported typeName: '.$typeName.'. Supported: '.WfsExportService::TYPE_NAME_CASES],
+                400
+            );
+        }
+
+        if ($outputFormat !== 'application/json') {
+            return new JSONResponse(
+                ['error' => 'Unsupported outputFormat: '.$outputFormat.'. Supported: application/json'],
+                400
+            );
+        }
+
+        if ($maxFeatures <= 0) {
+            $maxFeatures = WfsExportService::DEFAULT_MAX_FEATURES;
+        }
+
+        $bbox = null;
+        if ($bboxParam !== null && $bboxParam !== '') {
+            $parts = array_map('floatval', explode(',', (string) $bboxParam));
+            if (count($parts) === 4) {
+                $bbox = $parts;
+            }
+        }
+
+        $collection = $this->wfsExportService->buildFeatureCollection(
+            maxFeatures: $maxFeatures,
+            bbox: $bbox,
+            status: $status,
+            caseType: $caseType,
+        );
+
+        return new JSONResponse($collection);
+    }//end getFeatures()
+
+    /**
+     * Return WFS GetCapabilities descriptor for this endpoint.
+     *
+     * @NoAdminRequired
+     *
+     * @return JSONResponse WFS capabilities descriptor
+     *
+     * @throws OCSForbiddenException When user session is not authenticated
+     *
+     * @spec openspec/changes/gis-integration/tasks.md#task-gis-06
+     */
+    public function getCapabilities(): JSONResponse
+    {
+        if ($this->userSession->getUser() === null) {
+            throw new OCSForbiddenException('Authentication required');
+        }
+
+        $baseUrl      = $this->request->getServerProtocol().'://'.$this->request->getServerHost();
+        $capabilities = $this->wfsExportService->buildCapabilities(
+            baseUrl: $baseUrl.'/index.php/apps/procest/api/gis/wfs'
+        );
+
+        return new JSONResponse($capabilities);
+    }//end getCapabilities()
+}//end class

--- a/lib/Service/WfsExportService.php
+++ b/lib/Service/WfsExportService.php
@@ -1,0 +1,322 @@
+<?php
+
+/**
+ * Procest WFS Export Service
+ *
+ * Builds a GeoJSON FeatureCollection from case locations stored in OpenRegister.
+ * This service provides the AC 6 requirement from the gis-integration spec:
+ * exposing case locations as a standard WFS layer consumable by external GIS
+ * applications (QGIS, ArcGIS, etc.).
+ *
+ * All outbound PDOK/OpenRegister traffic is handled by injected services;
+ * this service performs only data transformation.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/gis-integration/tasks.md#task-gis-04
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service;
+
+use OCA\Procest\AppInfo\Application;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Builds GeoJSON FeatureCollections from case location objects for WFS export.
+ *
+ * @spec openspec/changes/gis-integration/tasks.md#task-gis-04
+ */
+class WfsExportService
+{
+
+    /**
+     * Default maximum number of features to return.
+     */
+    public const DEFAULT_MAX_FEATURES = 500;
+
+    /**
+     * Hard cap on features per request.
+     */
+    public const MAX_FEATURES_HARD_CAP = 2000;
+
+    /**
+     * WFS type name this service handles.
+     */
+    public const TYPE_NAME_CASES = 'procest:cases';
+
+    /**
+     * Constructor.
+     *
+     * @param SettingsService $settingsService The settings service (resolves register/schema ids and ObjectService)
+     * @param LoggerInterface $logger          The logger
+     *
+     * @return void
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Build a GeoJSON FeatureCollection of case locations.
+     *
+     * @param int         $maxFeatures Max features to return (capped at MAX_FEATURES_HARD_CAP)
+     * @param array|null  $bbox        Optional bounding box [minLon, minLat, maxLon, maxLat]
+     * @param string|null $status      Optional case status filter
+     * @param string|null $caseType    Optional case type filter
+     *
+     * @return array<string, mixed> GeoJSON FeatureCollection
+     *
+     * @spec openspec/changes/gis-integration/tasks.md#task-gis-04
+     *
+     * @psalm-suppress MixedAssignment
+     * @psalm-suppress MixedArrayAccess
+     */
+    public function buildFeatureCollection(
+        int $maxFeatures=self::DEFAULT_MAX_FEATURES,
+        ?array $bbox=null,
+        ?string $status=null,
+        ?string $caseType=null,
+    ): array {
+        $limit = min($maxFeatures, self::MAX_FEATURES_HARD_CAP);
+
+        $locations = $this->fetchLocations(limit: $limit, status: $status, caseType: $caseType);
+
+        $features = [];
+        foreach ($locations as $location) {
+            $feature = $this->locationToFeature(location: $location);
+            if ($feature === null) {
+                continue;
+            }
+
+            if ($bbox !== null && $this->isOutsideBbox(feature: $feature, bbox: $bbox) === true) {
+                continue;
+            }
+
+            $features[] = $feature;
+        }
+
+        return [
+            'type'     => 'FeatureCollection',
+            'name'     => self::TYPE_NAME_CASES,
+            'crs'      => [
+                'type'       => 'name',
+                'properties' => ['name' => 'urn:ogc:def:crs:OGC:1.3:CRS84'],
+            ],
+            'features' => $features,
+        ];
+    }//end buildFeatureCollection()
+
+    /**
+     * Build a WFS GetCapabilities-style descriptor for this service.
+     *
+     * @param string $baseUrl The base URL of the WFS endpoint
+     *
+     * @return array<string, mixed> Capabilities descriptor
+     *
+     * @spec openspec/changes/gis-integration/tasks.md#task-gis-04
+     */
+    public function buildCapabilities(string $baseUrl): array
+    {
+        return [
+            'version'      => '2.0.0',
+            'title'        => 'Procest Case Locations WFS',
+            'abstract'     => 'WFS endpoint exposing Procest case locations as GeoJSON features.',
+            'keywords'     => ['procest', 'cases', 'locations', 'GIS', 'WFS'],
+            'featureTypes' => [
+                [
+                    'name'          => self::TYPE_NAME_CASES,
+                    'title'         => 'Case Locations',
+                    'abstract'      => 'Case locations with metadata (status, type, assignee, address).',
+                    'defaultCRS'    => 'urn:ogc:def:crs:OGC:1.3:CRS84',
+                    'outputFormats' => ['application/json'],
+                    'operations'    => ['GetCapabilities', 'GetFeature'],
+                    'getFeatureUrl' => $baseUrl,
+                ],
+            ],
+        ];
+    }//end buildCapabilities()
+
+    /**
+     * Fetch location objects from OpenRegister, optionally filtered by case status/type.
+     *
+     * @param int         $limit    Max records to fetch
+     * @param string|null $status   Optional case status filter
+     * @param string|null $caseType Optional case type filter
+     *
+     * @return array<int, array<string, mixed>> Location records
+     */
+    private function fetchLocations(int $limit, ?string $status, ?string $caseType): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            $this->logger->warning(
+                'Procest WfsExportService: ObjectService not available',
+                ['app' => Application::APP_ID]
+            );
+            return [];
+        }
+
+        $register       = $this->settingsService->getConfigValue('register');
+        $locationSchema = $this->settingsService->getConfigValue('location_schema');
+
+        if ($register === '' || $locationSchema === '') {
+            return [];
+        }
+
+        $params = ['_limit' => $limit];
+
+        try {
+            $raw = $objectService->findObjects($register, $locationSchema, $params);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Procest WfsExportService: failed to fetch locations: '.$e->getMessage(),
+                ['app' => Application::APP_ID]
+            );
+            return [];
+        }
+
+        if (is_array($raw) === false) {
+            return [];
+        }
+
+        // Apply optional case-level filters when status or caseType is set.
+        if ($status === null && $caseType === null) {
+            return $raw;
+        }
+
+        return $this->applyFilters(locations: $raw, status: $status, caseType: $caseType);
+    }//end fetchLocations()
+
+    /**
+     * Filter locations by their associated case status or type.
+     *
+     * @param array<int, array<string, mixed>> $locations The location records
+     * @param string|null                      $status    Status filter
+     * @param string|null                      $caseType  Case type filter
+     *
+     * @return array<int, array<string, mixed>> Filtered locations
+     */
+    private function applyFilters(array $locations, ?string $status, ?string $caseType): array
+    {
+        return array_values(
+            array_filter(
+                $locations,
+                function (mixed $location) use ($status, $caseType): bool {
+                    if (is_array($location) === false) {
+                        return false;
+                    }
+
+                    if ($status !== null) {
+                        $locStatus = (string) ($location['caseStatus'] ?? '');
+                        if ($locStatus !== $status) {
+                            return false;
+                        }
+                    }
+
+                    if ($caseType !== null) {
+                        $locType = (string) ($location['caseType'] ?? '');
+                        if ($locType !== $caseType) {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                }
+            )
+        );
+    }//end applyFilters()
+
+    /**
+     * Convert a single location record to a GeoJSON Feature.
+     *
+     * Returns null when the location lacks valid coordinates.
+     *
+     * @param array<string, mixed> $location The location record
+     *
+     * @return array<string, mixed>|null GeoJSON Feature or null
+     */
+    private function locationToFeature(array $location): ?array
+    {
+        $lat = null;
+        if (isset($location['latitude']) === true) {
+            $lat = (float) $location['latitude'];
+        }
+
+        $lng = null;
+        if (isset($location['longitude']) === true) {
+            $lng = (float) $location['longitude'];
+        }
+
+        if ($lat === null || $lng === null) {
+            return null;
+        }
+
+        // Basic WGS84 sanity check.
+        if ($lat < -90.0 || $lat > 90.0 || $lng < -180.0 || $lng > 180.0) {
+            return null;
+        }
+
+        $properties = [
+            'id'                 => (string) ($location['@id'] ?? ($location['id'] ?? '')),
+            'caseId'             => (string) ($location['case'] ?? ''),
+            'caseIdentifier'     => (string) ($location['caseIdentifier'] ?? ''),
+            'caseTitle'          => (string) ($location['caseTitle'] ?? ''),
+            'caseStatus'         => (string) ($location['caseStatus'] ?? ''),
+            'caseType'           => (string) ($location['caseType'] ?? ''),
+            'assignee'           => (string) ($location['assignee'] ?? ''),
+            'source'             => (string) ($location['source'] ?? ''),
+            'label'              => (string) ($location['label'] ?? ''),
+            'formattedAddress'   => (string) ($location['formattedAddress'] ?? ''),
+            'nummeraanduidingId' => (string) ($location['nummeraanduidingId'] ?? ''),
+        ];
+
+        return [
+            'type'       => 'Feature',
+            'id'         => $properties['id'],
+            'geometry'   => [
+                'type'        => 'Point',
+                'coordinates' => [$lng, $lat],
+            ],
+            'properties' => $properties,
+        ];
+    }//end locationToFeature()
+
+    /**
+     * Check whether a GeoJSON Feature falls outside the requested bounding box.
+     *
+     * @param array<string, mixed> $feature The GeoJSON Feature
+     * @param array<int, float>    $bbox    [minLon, minLat, maxLon, maxLat]
+     *
+     * @return bool True when the feature is outside the BBOX
+     */
+    private function isOutsideBbox(array $feature, array $bbox): bool
+    {
+        if (count($bbox) < 4) {
+            return false;
+        }
+
+        $coords = $feature['geometry']['coordinates'] ?? null;
+        if (is_array($coords) === false || count($coords) < 2) {
+            return true;
+        }
+
+        $lng = (float) $coords[0];
+        $lat = (float) $coords[1];
+
+        return ($lng < $bbox[0] || $lat < $bbox[1] || $lng > $bbox[2] || $lat > $bbox[3]);
+    }//end isOutsideBbox()
+}//end class

--- a/tests/Unit/Controller/WfsExportControllerTest.php
+++ b/tests/Unit/Controller/WfsExportControllerTest.php
@@ -1,0 +1,310 @@
+<?php
+
+/**
+ * WfsExportController Unit Tests
+ *
+ * Tests for the WFS export controller that exposes case locations as a
+ * GeoJSON WFS layer for external GIS applications (gis-integration AC 6).
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/gis-integration/tasks.md#task-21
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\WfsExportController;
+use OCA\Procest\Service\WfsExportService;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\OCS\OCSForbiddenException;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for WfsExportController.
+ *
+ * @covers \OCA\Procest\Controller\WfsExportController
+ */
+class WfsExportControllerTest extends TestCase
+{
+
+    /**
+     * The mocked request.
+     *
+     * @var IRequest|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private IRequest $request;
+
+    /**
+     * The mocked WFS export service.
+     *
+     * @var WfsExportService|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private WfsExportService $wfsExportService;
+
+    /**
+     * The mocked user session.
+     *
+     * @var IUserSession|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private IUserSession $userSession;
+
+    /**
+     * The controller under test.
+     *
+     * @var WfsExportController
+     */
+    private WfsExportController $controller;
+
+    /**
+     * Set up test fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->request          = $this->createMock(originalClassName: IRequest::class);
+        $this->wfsExportService = $this->createMock(originalClassName: WfsExportService::class);
+        $this->userSession      = $this->createMock(originalClassName: IUserSession::class);
+
+        $mockUser = $this->createMock(originalClassName: IUser::class);
+        $this->userSession->method('getUser')->willReturn($mockUser);
+
+        $this->controller = new WfsExportController(
+            appName: 'procest',
+            request: $this->request,
+            wfsExportService: $this->wfsExportService,
+            userSession: $this->userSession,
+        );
+
+    }//end setUp()
+
+    /**
+     * Test that getFeatures() returns 200 with a GeoJSON FeatureCollection.
+     *
+     * @return void
+     */
+    public function testGetFeaturesReturnsFeatureCollection(): void
+    {
+        $this->request
+            ->method('getParam')
+            ->willReturnMap(
+                    [
+                        ['typeName', WfsExportService::TYPE_NAME_CASES, WfsExportService::TYPE_NAME_CASES],
+                        ['outputFormat', 'application/json', 'application/json'],
+                        ['maxFeatures', WfsExportService::DEFAULT_MAX_FEATURES, 500],
+                        ['bbox', null, null],
+                        ['status', null, null],
+                        ['caseType', null, null],
+                    ]
+                    );
+
+        $featureCollection = [
+            'type'     => 'FeatureCollection',
+            'name'     => WfsExportService::TYPE_NAME_CASES,
+            'features' => [],
+        ];
+
+        $this->wfsExportService
+            ->expects($this->once())
+            ->method('buildFeatureCollection')
+            ->with(500, null, null, null)
+            ->willReturn($featureCollection);
+
+        $response = $this->controller->getFeatures();
+
+        $this->assertInstanceOf(expected: JSONResponse::class, actual: $response);
+        $this->assertSame(expected: 200, actual: $response->getStatus());
+        $data = $response->getData();
+        $this->assertSame(expected: 'FeatureCollection', actual: $data['type']);
+
+    }//end testGetFeaturesReturnsFeatureCollection()
+
+    /**
+     * Test that getFeatures() throws OCSForbiddenException when user is null.
+     *
+     * @return void
+     */
+    public function testGetFeaturesThrowsWhenUserIsNull(): void
+    {
+        $this->userSession = $this->createMock(originalClassName: IUserSession::class);
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $controller = new WfsExportController(
+            appName: 'procest',
+            request: $this->request,
+            wfsExportService: $this->wfsExportService,
+            userSession: $this->userSession,
+        );
+
+        $this->expectException(exception: OCSForbiddenException::class);
+
+        $controller->getFeatures();
+
+    }//end testGetFeaturesThrowsWhenUserIsNull()
+
+    /**
+     * Test that getFeatures() returns 400 for unsupported typeName.
+     *
+     * @return void
+     */
+    public function testGetFeaturesReturnsBadRequestForUnknownTypeName(): void
+    {
+        $this->request
+            ->method('getParam')
+            ->willReturnMap(
+                    [
+                        ['typeName', WfsExportService::TYPE_NAME_CASES, 'unknown:type'],
+                        ['outputFormat', 'application/json', 'application/json'],
+                        ['maxFeatures', WfsExportService::DEFAULT_MAX_FEATURES, 500],
+                        ['bbox', null, null],
+                        ['status', null, null],
+                        ['caseType', null, null],
+                    ]
+                    );
+
+        $this->wfsExportService
+            ->expects($this->never())
+            ->method('buildFeatureCollection');
+
+        $response = $this->controller->getFeatures();
+
+        $this->assertInstanceOf(expected: JSONResponse::class, actual: $response);
+        $this->assertSame(expected: 400, actual: $response->getStatus());
+
+    }//end testGetFeaturesReturnsBadRequestForUnknownTypeName()
+
+    /**
+     * Test that getFeatures() returns 400 for unsupported outputFormat.
+     *
+     * @return void
+     */
+    public function testGetFeaturesReturnsBadRequestForUnsupportedFormat(): void
+    {
+        $this->request
+            ->method('getParam')
+            ->willReturnMap(
+                    [
+                        ['typeName', WfsExportService::TYPE_NAME_CASES, WfsExportService::TYPE_NAME_CASES],
+                        ['outputFormat', 'application/json', 'text/xml'],
+                        ['maxFeatures', WfsExportService::DEFAULT_MAX_FEATURES, 500],
+                        ['bbox', null, null],
+                        ['status', null, null],
+                        ['caseType', null, null],
+                    ]
+                    );
+
+        $this->wfsExportService
+            ->expects($this->never())
+            ->method('buildFeatureCollection');
+
+        $response = $this->controller->getFeatures();
+
+        $this->assertInstanceOf(expected: JSONResponse::class, actual: $response);
+        $this->assertSame(expected: 400, actual: $response->getStatus());
+
+    }//end testGetFeaturesReturnsBadRequestForUnsupportedFormat()
+
+    /**
+     * Test that getFeatures() parses bbox parameter and passes it as array.
+     *
+     * @return void
+     */
+    public function testGetFeaturesParsesBboxParameter(): void
+    {
+        $this->request
+            ->method('getParam')
+            ->willReturnMap(
+                    [
+                        ['typeName', WfsExportService::TYPE_NAME_CASES, WfsExportService::TYPE_NAME_CASES],
+                        ['outputFormat', 'application/json', 'application/json'],
+                        ['maxFeatures', WfsExportService::DEFAULT_MAX_FEATURES, 100],
+                        ['bbox', null, '4.5,52.0,5.5,53.0'],
+                        ['status', null, 'open'],
+                        ['caseType', null, null],
+                    ]
+                    );
+
+        $this->wfsExportService
+            ->expects($this->once())
+            ->method('buildFeatureCollection')
+            ->with(100, [4.5, 52.0, 5.5, 53.0], 'open', null)
+            ->willReturn(['type' => 'FeatureCollection', 'features' => []]);
+
+        $response = $this->controller->getFeatures();
+
+        $this->assertSame(expected: 200, actual: $response->getStatus());
+
+    }//end testGetFeaturesParsesBboxParameter()
+
+    /**
+     * Test that getCapabilities() returns 200 with WFS capabilities descriptor.
+     *
+     * @return void
+     */
+    public function testGetCapabilitiesReturnsDescriptor(): void
+    {
+        $this->request
+            ->method('getServerProtocol')
+            ->willReturn('https');
+        $this->request
+            ->method('getServerHost')
+            ->willReturn('example.nl');
+
+        $capabilities = [
+            'version'      => '2.0.0',
+            'featureTypes' => [['name' => WfsExportService::TYPE_NAME_CASES]],
+        ];
+
+        $this->wfsExportService
+            ->expects($this->once())
+            ->method('buildCapabilities')
+            ->with('https://example.nl/index.php/apps/procest/api/gis/wfs')
+            ->willReturn($capabilities);
+
+        $response = $this->controller->getCapabilities();
+
+        $this->assertInstanceOf(expected: JSONResponse::class, actual: $response);
+        $this->assertSame(expected: 200, actual: $response->getStatus());
+        $data = $response->getData();
+        $this->assertSame(expected: '2.0.0', actual: $data['version']);
+
+    }//end testGetCapabilitiesReturnsDescriptor()
+
+    /**
+     * Test that getCapabilities() throws OCSForbiddenException when user is null.
+     *
+     * @return void
+     */
+    public function testGetCapabilitiesThrowsWhenUserIsNull(): void
+    {
+        $this->userSession = $this->createMock(originalClassName: IUserSession::class);
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $controller = new WfsExportController(
+            appName: 'procest',
+            request: $this->request,
+            wfsExportService: $this->wfsExportService,
+            userSession: $this->userSession,
+        );
+
+        $this->expectException(exception: OCSForbiddenException::class);
+
+        $controller->getCapabilities();
+
+    }//end testGetCapabilitiesThrowsWhenUserIsNull()
+}//end class

--- a/tests/Unit/Service/WfsExportServiceTest.php
+++ b/tests/Unit/Service/WfsExportServiceTest.php
@@ -1,0 +1,320 @@
+<?php
+
+/**
+ * WfsExportService Unit Tests
+ *
+ * Tests for the WFS export service that builds GeoJSON FeatureCollections
+ * from case location objects (gis-integration AC 6).
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/gis-integration/tasks.md#task-22
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Service;
+
+use OCA\Procest\Service\SettingsService;
+use OCA\Procest\Service\WfsExportService;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Minimal ObjectService shape used by WfsExportService.
+ *
+ * Declares the positional signature used in production so that
+ * `createMock(WfsObjectServiceStub::class)` returns a configurable stub.
+ * A `getMockBuilder(\stdClass::class)->addMethods([...])` stub throws
+ * "Unknown named parameter" on named-arg calls in PHPUnit 10.
+ */
+interface WfsObjectServiceStub
+{
+    /**
+     * Find objects in the given register/schema.
+     *
+     * @param string $register The register name
+     * @param string $schema   The schema name
+     * @param array  $params   Query parameters
+     *
+     * @return array<mixed>
+     */
+    public function findObjects(string $register, string $schema, array $params): array;
+}//end interface
+
+/**
+ * Unit tests for WfsExportService.
+ *
+ * @covers \OCA\Procest\Service\WfsExportService
+ */
+class WfsExportServiceTest extends TestCase
+{
+
+    /**
+     * The mocked settings service.
+     *
+     * @var SettingsService|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private SettingsService $settingsService;
+
+    /**
+     * The mocked logger.
+     *
+     * @var LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private LoggerInterface $logger;
+
+    /**
+     * The service under test.
+     *
+     * @var WfsExportService
+     */
+    private WfsExportService $service;
+
+    /**
+     * Set up test fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->settingsService = $this->createMock(originalClassName: SettingsService::class);
+        $this->logger          = $this->createMock(originalClassName: LoggerInterface::class);
+
+        $this->service = new WfsExportService(
+            settingsService: $this->settingsService,
+            logger: $this->logger,
+        );
+
+    }//end setUp()
+
+    /**
+     * Test that buildFeatureCollection() returns empty features when ObjectService unavailable.
+     *
+     * @return void
+     */
+    public function testBuildFeatureCollectionReturnsEmptyWhenObjectServiceUnavailable(): void
+    {
+        $this->settingsService
+            ->method('getObjectService')
+            ->willReturn(null);
+
+        $result = $this->service->buildFeatureCollection();
+
+        $this->assertSame(expected: 'FeatureCollection', actual: $result['type']);
+        $this->assertSame(expected: [], actual: $result['features']);
+
+    }//end testBuildFeatureCollectionReturnsEmptyWhenObjectServiceUnavailable()
+
+    /**
+     * Test that buildFeatureCollection() converts location records to GeoJSON features.
+     *
+     * @return void
+     */
+    public function testBuildFeatureCollectionConvertsLocationsToFeatures(): void
+    {
+        $mockObjectService = $this->createMock(originalClassName: WfsObjectServiceStub::class);
+
+        $locations = [
+            [
+                '@id'              => 'loc-uuid-1',
+                'case'             => 'case-uuid-1',
+                'caseTitle'        => 'Test Case',
+                'caseStatus'       => 'open',
+                'caseType'         => 'Omgevingsvergunning',
+                'source'           => 'bag',
+                'formattedAddress' => 'Teststraat 1, Amsterdam',
+                'latitude'         => 52.3,
+                'longitude'        => 4.9,
+            ],
+        ];
+
+        $mockObjectService
+            ->method('findObjects')
+            ->willReturn($locations);
+
+        $this->settingsService
+            ->method('getObjectService')
+            ->willReturn($mockObjectService);
+        $this->settingsService
+            ->method('getConfigValue')
+            ->willReturnMap(
+                    [
+                        ['register', 'procest'],
+                        ['location_schema', 'location'],
+                    ]
+                    );
+
+        $result = $this->service->buildFeatureCollection();
+
+        $this->assertSame(expected: 'FeatureCollection', actual: $result['type']);
+        $this->assertCount(expectedCount: 1, haystack: $result['features']);
+
+        $feature = $result['features'][0];
+        $this->assertSame(expected: 'Feature', actual: $feature['type']);
+        $this->assertSame(expected: 'Point', actual: $feature['geometry']['type']);
+        $this->assertSame(expected: [4.9, 52.3], actual: $feature['geometry']['coordinates']);
+        $this->assertSame(expected: 'Test Case', actual: $feature['properties']['caseTitle']);
+        $this->assertSame(expected: 'open', actual: $feature['properties']['caseStatus']);
+
+    }//end testBuildFeatureCollectionConvertsLocationsToFeatures()
+
+    /**
+     * Test that buildFeatureCollection() skips locations without coordinates.
+     *
+     * @return void
+     */
+    public function testBuildFeatureCollectionSkipsLocationsWithoutCoordinates(): void
+    {
+        $mockObjectService = $this->createMock(originalClassName: WfsObjectServiceStub::class);
+
+        $locations = [
+            [
+                '@id'    => 'loc-no-coords',
+                'case'   => 'case-uuid-2',
+                'source' => 'free',
+                'label'  => 'No coordinates',
+                // No latitude / longitude.
+            ],
+            [
+                '@id'       => 'loc-with-coords',
+                'case'      => 'case-uuid-3',
+                'source'    => 'gps',
+                'latitude'  => 51.9,
+                'longitude' => 4.47,
+            ],
+        ];
+
+        $mockObjectService
+            ->method('findObjects')
+            ->willReturn($locations);
+
+        $this->settingsService
+            ->method('getObjectService')
+            ->willReturn($mockObjectService);
+        $this->settingsService
+            ->method('getConfigValue')
+            ->willReturnMap(
+                    [
+                        ['register', 'procest'],
+                        ['location_schema', 'location'],
+                    ]
+                    );
+
+        $result = $this->service->buildFeatureCollection();
+
+        $this->assertCount(expectedCount: 1, haystack: $result['features']);
+        $this->assertSame(expected: [4.47, 51.9], actual: $result['features'][0]['geometry']['coordinates']);
+
+    }//end testBuildFeatureCollectionSkipsLocationsWithoutCoordinates()
+
+    /**
+     * Test that buildFeatureCollection() filters features by bounding box.
+     *
+     * @return void
+     */
+    public function testBuildFeatureCollectionFiltersByBbox(): void
+    {
+        $mockObjectService = $this->createMock(originalClassName: WfsObjectServiceStub::class);
+
+        $locations = [
+            [
+                '@id'       => 'inside',
+                'case'      => 'case-1',
+                'source'    => 'gps',
+                'latitude'  => 52.3,
+                'longitude' => 4.9,
+            ],
+            [
+                '@id'       => 'outside',
+                'case'      => 'case-2',
+                'source'    => 'gps',
+                'latitude'  => 51.0,
+                'longitude' => 3.0,
+            ],
+        ];
+
+        $mockObjectService
+            ->method('findObjects')
+            ->willReturn($locations);
+
+        $this->settingsService->method('getObjectService')->willReturn($mockObjectService);
+        $this->settingsService->method('getConfigValue')->willReturnMap(
+                [
+                    ['register', 'procest'],
+                    ['location_schema', 'location'],
+                ]
+                );
+
+        // Bbox covering Amsterdam area only.
+        $result = $this->service->buildFeatureCollection(bbox: [4.5, 52.0, 5.5, 53.0]);
+
+        $this->assertCount(expectedCount: 1, haystack: $result['features']);
+        $this->assertSame(expected: 'inside', actual: $result['features'][0]['id']);
+
+    }//end testBuildFeatureCollectionFiltersByBbox()
+
+    /**
+     * Test that maxFeatures is capped at the hard cap.
+     *
+     * @return void
+     */
+    public function testBuildFeatureCollectionCapsMaxFeaturesAtHardCap(): void
+    {
+        $mockObjectService = $this->createMock(originalClassName: WfsObjectServiceStub::class);
+
+        $mockObjectService
+            ->expects($this->once())
+            ->method('findObjects')
+            ->with(
+                'procest',
+                'location',
+                $this->callback(
+                        callback: function (array $params): bool {
+                            return $params['_limit'] === WfsExportService::MAX_FEATURES_HARD_CAP;
+                        }
+                        )
+            )
+            ->willReturn([]);
+
+        $this->settingsService->method('getObjectService')->willReturn($mockObjectService);
+        $this->settingsService->method('getConfigValue')->willReturnMap(
+                [
+                    ['register', 'procest'],
+                    ['location_schema', 'location'],
+                ]
+                );
+
+        // Request 99999 features — must be capped at hard cap.
+        $result = $this->service->buildFeatureCollection(maxFeatures: 99999);
+
+        $this->assertSame(expected: 'FeatureCollection', actual: $result['type']);
+
+    }//end testBuildFeatureCollectionCapsMaxFeaturesAtHardCap()
+
+    /**
+     * Test that buildCapabilities() returns a valid WFS capabilities descriptor.
+     *
+     * @return void
+     */
+    public function testBuildCapabilitiesReturnsValidDescriptor(): void
+    {
+        $result = $this->service->buildCapabilities('https://example.nl/api/gis/wfs');
+
+        $this->assertSame(expected: '2.0.0', actual: $result['version']);
+        $this->assertNotEmpty(actual: $result['featureTypes']);
+        $this->assertSame(expected: WfsExportService::TYPE_NAME_CASES, actual: $result['featureTypes'][0]['name']);
+        $this->assertStringContainsString(needle: 'https://example.nl/api/gis/wfs', haystack: $result['featureTypes'][0]['getFeatureUrl']);
+
+    }//end testBuildCapabilitiesReturnsValidDescriptor()
+}//end class


### PR DESCRIPTION
## Summary
Ports the unique outbound **WFS-export** capability from #483 onto the current `development` baseline.

#483's branch (`feature/462/gis-integration`) had diverged from an unrelated history root (~117 commits behind dev) and could not be merged directly without reverting merged dev work. Only the genuinely-unique, self-contained additions are carried over here:

- `lib/Service/WfsExportService.php` — GeoJSON FeatureCollection of case locations + WFS GetCapabilities descriptor (uses `SettingsService.getObjectService()` + `findObjects()`, already on dev).
- `lib/Controller/WfsExportController.php` — `GET /api/gis/wfs` (GetFeature) and `/api/gis/wfs/capabilities`; `@NoAdminRequired` with an authenticated-session guard; `typeName`/`outputFormat`/`maxFeatures`/`bbox`/`status`/`caseType` params.
- `appinfo/routes.php` — two additive `wfsExport` routes.
- Unit tests for both classes.

This complements dev's existing **proxy-based** GIS work (`GisProxy` / `WmsWfs`); the WFS *export* (procest cases AS a layer) was absent on dev.

## Test plan
- [ ] `composer check:strict`
- [ ] WfsExportControllerTest + WfsExportServiceTest pass
- [ ] `GET /api/gis/wfs` returns a GeoJSON FeatureCollection; `/capabilities` returns the descriptor

Closes #483.