### PR TITLE
chore(nav): adopt three-section nav model + bump nc-vue to beta.97

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -48,7 +48,7 @@ Vrij en open source onder de AGPL-licentie.
 
 **Ondersteuning:** Voor ondersteuning, neem contact op via support@conduction.nl. Voor een Service Level Agreement (SLA), neem contact op via sales@conduction.nl.
     ]]></description>
-    <version>0.2.0</version>
+    <version>0.2.1</version>
     <licence>agpl</licence>
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>Procest</namespace>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.0",
 			"license": "EUPL-1.2",
 			"dependencies": {
-				"@conduction/nextcloud-vue": "^1.0.0-beta.66",
+				"@conduction/nextcloud-vue": "^1.0.0-beta.97",
 				"@nextcloud/auth": "^2.6.0",
 				"@nextcloud/axios": "~2.5.2",
 				"@nextcloud/dialogs": "^3.2.0",
@@ -153,6 +153,7 @@
 			"version": "7.29.1",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
 			"integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+			"dev": true,
 			"dependencies": {
 				"@babel/parser": "^7.29.0",
 				"@babel/types": "^7.29.0",
@@ -340,22 +341,6 @@
 				"node-fetch": "^3.3.0"
 			}
 		},
-		"node_modules/@ckpack/vue-color": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@ckpack/vue-color/-/vue-color-1.6.0.tgz",
-			"integrity": "sha512-b9kFTKhYbNArfgP1lmnaVm0VNsWdZjqIbyHUYry7mZ+E7JeTQclbjq1+2xWn0SE3wzqRYlXmAVjECPOgteWmMQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@ctrl/tinycolor": "^3.6.0",
-				"material-colors": "^1.2.6"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"peerDependencies": {
-				"vue": "^3.2.0"
-			}
-		},
 		"node_modules/@codemirror/autocomplete": {
 			"version": "6.20.2",
 			"resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.2.tgz",
@@ -507,9 +492,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "1.0.0-beta.66",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.66.tgz",
-			"integrity": "sha512-Igd9KdaA90JA0i96CG4zyQxM7NmAyYfkdrT6rBWjuNZBkNwwW2TnxbP1NG3Qev6bc99yqWYbRcBVgnnP8SJnNw==",
+			"version": "1.0.0-beta.97",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.97.tgz",
+			"integrity": "sha512-jlRpA1tjIX3ysP8a42S6lrbrcZfN63yHDzgWMBNaf9Ofs0jvVqqkYawLuEj8vGMU1H4hwvyb0lEOHIsNRmHP6g==",
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.0.0",
@@ -523,8 +508,10 @@
 				"@codemirror/state": "^6.0.0",
 				"@codemirror/view": "^6.0.0",
 				"@microsoft/fetch-event-source": "^2.0.1",
-				"@nextcloud/dialogs": "^7.3.0",
+				"@nextcloud/dialogs": "^6.4.2",
+				"@nextcloud/event-bus": "^3.3.3",
 				"@nextcloud/notify_push": "^1.0.0",
+				"@types/react": "^18.0.0",
 				"@uiw/codemirror-theme-github": "^4.25.8",
 				"@vueuse/core": "^10.0.0",
 				"ajv": "^8.20.0",
@@ -535,6 +522,7 @@
 				"gridstack": "^10.3.1",
 				"leaflet": "^1.9.0",
 				"leaflet.markercluster": "^1.5.3",
+				"linkifyjs": "^4.3.3",
 				"lodash": "^4.17.21",
 				"marked": "^15.0.0",
 				"style-mod": "^4.0.0",
@@ -553,7 +541,6 @@
 				"@nextcloud/l10n": "^2.0.0 || ^3.0.0",
 				"@nextcloud/router": "^2.0.0 || ^3.0.0",
 				"@nextcloud/vue": "^8.0.0",
-				"bootstrap-vue": "^2.23.1",
 				"pinia": "^2.0.0",
 				"vue": "^2.7.0",
 				"vue-frag": "^1.4.3",
@@ -561,9 +548,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue/node_modules/@nextcloud/dialogs": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/dialogs/-/dialogs-7.3.0.tgz",
-			"integrity": "sha512-pFuM10Dkvip+wSBaElcbSAN7Jynp41HJUh5kndRYpJipYl0SpNfjIe32+uNfOI43/tln4ScTlrfjIX6cK+3uHg==",
+			"version": "6.4.2",
+			"resolved": "https://registry.npmjs.org/@nextcloud/dialogs/-/dialogs-6.4.2.tgz",
+			"integrity": "sha512-xj6fyUdb56StWt1DWeDHYnqK0Ck7EWQLUEyWtXHnneknoOV3x/Y0HPRL5L2PTJaDuVQB8TcVW53JjR38JG9W6Q==",
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
 				"@mdi/js": "^7.4.47",
@@ -571,91 +558,50 @@
 				"@nextcloud/axios": "^2.5.2",
 				"@nextcloud/browser-storage": "^0.5.0",
 				"@nextcloud/event-bus": "^3.3.3",
-				"@nextcloud/files": "^4.0.0",
+				"@nextcloud/files": "^3.12.2",
 				"@nextcloud/initial-state": "^3.0.0",
 				"@nextcloud/l10n": "^3.4.1",
 				"@nextcloud/paths": "^3.0.0",
 				"@nextcloud/router": "^3.1.0",
-				"@nextcloud/sharing": "^0.4.0",
-				"@nextcloud/vue": "^9.5.0",
+				"@nextcloud/sharing": "^0.3.0",
 				"@types/toastify-js": "^1.12.4",
-				"@vueuse/core": "^14.2.1",
+				"@vueuse/core": "^11.3.0",
+				"cancelable-promise": "^4.3.1",
 				"p-queue": "^9.0.1",
 				"toastify-js": "^1.12.0",
-				"vue": "^3.5.28",
+				"vue-frag": "^1.4.3",
 				"webdav": "^5.8.0"
-			},
-			"engines": {
-				"node": "^20 || ^22 || ^24"
-			}
-		},
-		"node_modules/@conduction/nextcloud-vue/node_modules/@nextcloud/dialogs/node_modules/@nextcloud/sharing": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/sharing/-/sharing-0.4.0.tgz",
-			"integrity": "sha512-1hUNyc7uJdBpnimOnEshJjEtAPAjzDYVl6qmWqF5ZxoN9wOvbExw0QjX3xFIbHbX2dmvbRNLBj0RzLzipmZyeg==",
-			"license": "GPL-3.0-or-later",
-			"dependencies": {
-				"@nextcloud/initial-state": "^3.0.0",
-				"is-svg": "^6.1.0"
 			},
 			"engines": {
 				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
 			},
-			"optionalDependencies": {
-				"@nextcloud/files": "^3.12.2 || ^4.0.0"
+			"peerDependencies": {
+				"@nextcloud/vue": "^8.24.0",
+				"vue": "^2.7.16"
 			}
 		},
-		"node_modules/@conduction/nextcloud-vue/node_modules/@nextcloud/dialogs/node_modules/@types/web-bluetooth": {
-			"version": "0.0.21",
-			"resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
-			"integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
-			"license": "MIT"
-		},
 		"node_modules/@conduction/nextcloud-vue/node_modules/@nextcloud/dialogs/node_modules/@vueuse/core": {
-			"version": "14.3.0",
-			"resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.3.0.tgz",
-			"integrity": "sha512-aHfz47g0ZhMtTVHmIzMVpJy8ePhhOy68GY5bv110+5DVtZ+W7BsOx+m61UNQqfrWyPztIHIanWa3E2tib3NFIw==",
+			"version": "11.3.0",
+			"resolved": "https://registry.npmjs.org/@vueuse/core/-/core-11.3.0.tgz",
+			"integrity": "sha512-7OC4Rl1f9G8IT6rUfi9JrKiXy4bfmHhZ5x2Ceojy0jnd3mHNEvV4JaRygH362ror6/NZ+Nl+n13LPzGiPN8cKA==",
 			"license": "MIT",
 			"dependencies": {
-				"@types/web-bluetooth": "^0.0.21",
-				"@vueuse/metadata": "14.3.0",
-				"@vueuse/shared": "14.3.0"
+				"@types/web-bluetooth": "^0.0.20",
+				"@vueuse/metadata": "11.3.0",
+				"@vueuse/shared": "11.3.0",
+				"vue-demi": ">=0.14.10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
-			},
-			"peerDependencies": {
-				"vue": "^3.5.0"
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue/node_modules/@nextcloud/dialogs/node_modules/@vueuse/metadata": {
-			"version": "14.3.0",
-			"resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.3.0.tgz",
-			"integrity": "sha512-BwxmbAzwAVF50+MW57GXOUEV61nFBGnlBvrTqj49PqWJu3uw7hdu72ztXeZ33RdZtDY6kO+bfCAE1PCn88Tktw==",
+			"version": "11.3.0",
+			"resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-11.3.0.tgz",
+			"integrity": "sha512-pwDnDspTqtTo2HwfLw4Rp6yywuuBdYnPYDq+mO38ZYKGebCUQC/nVj/PXSiK9HX5otxLz8Fn7ECPbjiRz2CC3g==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
-			}
-		},
-		"node_modules/@conduction/nextcloud-vue/node_modules/@nextcloud/files": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-4.0.0.tgz",
-			"integrity": "sha512-TmecnZIS+PGWGtRh7RpGEboCT4K6iTbHULUcfR6hs3eEzjDVsCc1Ldf8popGY/70lbpdlfYle8xbXnPIo3qaXA==",
-			"license": "AGPL-3.0-or-later",
-			"dependencies": {
-				"@nextcloud/auth": "^2.5.3",
-				"@nextcloud/capabilities": "^1.2.1",
-				"@nextcloud/l10n": "^3.4.1",
-				"@nextcloud/logger": "^3.0.3",
-				"@nextcloud/paths": "^3.0.0",
-				"@nextcloud/router": "^3.1.0",
-				"@nextcloud/sharing": "^0.3.0",
-				"is-svg": "^6.1.0",
-				"typescript-event-target": "^1.1.2",
-				"webdav": "^5.9.0"
-			},
-			"engines": {
-				"node": "^24.0.0"
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue/node_modules/@nextcloud/initial-state": {
@@ -695,192 +641,6 @@
 				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
 			}
 		},
-		"node_modules/@conduction/nextcloud-vue/node_modules/@nextcloud/vue": {
-			"version": "9.8.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-9.8.0.tgz",
-			"integrity": "sha512-pEYtoVRavaI8EQv7pERfIs16MI11LqFW3+S01b5c54PMsfG+vqXtxR3I8Pyapf39sond6Sjg8Yx5cyBxQ2Y+2A==",
-			"license": "AGPL-3.0-or-later",
-			"dependencies": {
-				"@ckpack/vue-color": "^1.6.0",
-				"@floating-ui/dom": "^1.7.6",
-				"@nextcloud/auth": "^2.6.0",
-				"@nextcloud/axios": "^2.6.0",
-				"@nextcloud/browser-storage": "^0.5.0",
-				"@nextcloud/capabilities": "^1.2.1",
-				"@nextcloud/event-bus": "^3.3.3",
-				"@nextcloud/initial-state": "^3.0.0",
-				"@nextcloud/l10n": "^3.4.1",
-				"@nextcloud/logger": "^3.0.3",
-				"@nextcloud/router": "^3.1.0",
-				"@nextcloud/sharing": "^0.4.0",
-				"@nextcloud/vue-select": "^4.1.0",
-				"@vuepic/vue-datepicker": "^11.0.3",
-				"@vueuse/components": "^14.3.0",
-				"@vueuse/core": "^14.3.0",
-				"blurhash": "^2.0.5",
-				"clone": "^2.1.2",
-				"debounce": "^3.0.0",
-				"dompurify": "^3.4.2",
-				"emoji-mart-vue-fast": "^15.0.5",
-				"escape-html": "^1.0.3",
-				"floating-vue": "^5.2.2",
-				"focus-trap": "^8.1.0",
-				"linkifyjs": "^4.3.2",
-				"mdast-util-to-string": "^4.0.0",
-				"p-queue": "^9.2.0",
-				"rehype-external-links": "^3.0.0",
-				"rehype-highlight": "^7.0.2",
-				"rehype-react": "^8.0.0",
-				"remark-breaks": "^4.0.0",
-				"remark-parse": "^11.0.0",
-				"remark-rehype": "^11.1.2",
-				"remark-unlink-protocols": "^1.0.0",
-				"splitpanes": "^4.0.4",
-				"striptags": "^3.2.0",
-				"tabbable": "^6.4.0",
-				"tributejs": "^5.1.3",
-				"ts-md5": "^2.0.1",
-				"unified": "^11.0.5",
-				"unist-builder": "^4.0.0",
-				"unist-util-visit-parents": "^6.0.2",
-				"vue": "^3.5.18",
-				"vue-router": "^5.0.6"
-			},
-			"engines": {
-				"node": "^20.11.0 || ^22 || ^24"
-			}
-		},
-		"node_modules/@conduction/nextcloud-vue/node_modules/@nextcloud/vue-select": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue-select/-/vue-select-4.1.0.tgz",
-			"integrity": "sha512-jQIu4XuUAuJr6qL/IKa63h3Vv/4OrP9latl2E6kqtffwLBV+qMSU4Gm+vsOfyqBbBSY4i3eeMfdyJi14O1Yqbg==",
-			"license": "MIT",
-			"engines": {
-				"node": "^22 || ^24"
-			},
-			"peerDependencies": {
-				"vue": "^3"
-			}
-		},
-		"node_modules/@conduction/nextcloud-vue/node_modules/@nextcloud/vue/node_modules/@nextcloud/sharing": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/sharing/-/sharing-0.4.0.tgz",
-			"integrity": "sha512-1hUNyc7uJdBpnimOnEshJjEtAPAjzDYVl6qmWqF5ZxoN9wOvbExw0QjX3xFIbHbX2dmvbRNLBj0RzLzipmZyeg==",
-			"license": "GPL-3.0-or-later",
-			"dependencies": {
-				"@nextcloud/initial-state": "^3.0.0",
-				"is-svg": "^6.1.0"
-			},
-			"engines": {
-				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
-			},
-			"optionalDependencies": {
-				"@nextcloud/files": "^3.12.2 || ^4.0.0"
-			}
-		},
-		"node_modules/@conduction/nextcloud-vue/node_modules/@nextcloud/vue/node_modules/@types/web-bluetooth": {
-			"version": "0.0.21",
-			"resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
-			"integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
-			"license": "MIT"
-		},
-		"node_modules/@conduction/nextcloud-vue/node_modules/@nextcloud/vue/node_modules/@vueuse/core": {
-			"version": "14.3.0",
-			"resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.3.0.tgz",
-			"integrity": "sha512-aHfz47g0ZhMtTVHmIzMVpJy8ePhhOy68GY5bv110+5DVtZ+W7BsOx+m61UNQqfrWyPztIHIanWa3E2tib3NFIw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/web-bluetooth": "^0.0.21",
-				"@vueuse/metadata": "14.3.0",
-				"@vueuse/shared": "14.3.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/antfu"
-			},
-			"peerDependencies": {
-				"vue": "^3.5.0"
-			}
-		},
-		"node_modules/@conduction/nextcloud-vue/node_modules/@nextcloud/vue/node_modules/@vueuse/metadata": {
-			"version": "14.3.0",
-			"resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.3.0.tgz",
-			"integrity": "sha512-BwxmbAzwAVF50+MW57GXOUEV61nFBGnlBvrTqj49PqWJu3uw7hdu72ztXeZ33RdZtDY6kO+bfCAE1PCn88Tktw==",
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/antfu"
-			}
-		},
-		"node_modules/@conduction/nextcloud-vue/node_modules/@vue/compiler-sfc": {
-			"version": "3.5.34",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
-			"integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/parser": "^7.29.3",
-				"@vue/compiler-core": "3.5.34",
-				"@vue/compiler-dom": "3.5.34",
-				"@vue/compiler-ssr": "3.5.34",
-				"@vue/shared": "3.5.34",
-				"estree-walker": "^2.0.2",
-				"magic-string": "^0.30.21",
-				"postcss": "^8.5.14",
-				"source-map-js": "^1.2.1"
-			}
-		},
-		"node_modules/@conduction/nextcloud-vue/node_modules/@vue/devtools-api": {
-			"version": "8.1.2",
-			"resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-8.1.2.tgz",
-			"integrity": "sha512-vA0O112YqyDuNA1s7Yb2gCgToQ/OxOWiFDO5ThLCcDy0ldHnSd1dUTaSYhOldbqoNgumE4dxtGAoAaSUKUD1Zg==",
-			"license": "MIT",
-			"dependencies": {
-				"@vue/devtools-kit": "^8.1.2"
-			}
-		},
-		"node_modules/@conduction/nextcloud-vue/node_modules/@vueuse/components": {
-			"version": "14.3.0",
-			"resolved": "https://registry.npmjs.org/@vueuse/components/-/components-14.3.0.tgz",
-			"integrity": "sha512-jnrJrecSfa8H+G6wtAwsCnMtKbKZDSpu5JZDuulZikWrHb6uuS5SyXP6M2b79tofxipm78VWDSzW+58pu1yglA==",
-			"license": "MIT",
-			"dependencies": {
-				"@vueuse/core": "14.3.0",
-				"@vueuse/shared": "14.3.0"
-			},
-			"peerDependencies": {
-				"vue": "^3.5.0"
-			}
-		},
-		"node_modules/@conduction/nextcloud-vue/node_modules/@vueuse/components/node_modules/@types/web-bluetooth": {
-			"version": "0.0.21",
-			"resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
-			"integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
-			"license": "MIT"
-		},
-		"node_modules/@conduction/nextcloud-vue/node_modules/@vueuse/components/node_modules/@vueuse/core": {
-			"version": "14.3.0",
-			"resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.3.0.tgz",
-			"integrity": "sha512-aHfz47g0ZhMtTVHmIzMVpJy8ePhhOy68GY5bv110+5DVtZ+W7BsOx+m61UNQqfrWyPztIHIanWa3E2tib3NFIw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/web-bluetooth": "^0.0.21",
-				"@vueuse/metadata": "14.3.0",
-				"@vueuse/shared": "14.3.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/antfu"
-			},
-			"peerDependencies": {
-				"vue": "^3.5.0"
-			}
-		},
-		"node_modules/@conduction/nextcloud-vue/node_modules/@vueuse/components/node_modules/@vueuse/metadata": {
-			"version": "14.3.0",
-			"resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.3.0.tgz",
-			"integrity": "sha512-BwxmbAzwAVF50+MW57GXOUEV61nFBGnlBvrTqj49PqWJu3uw7hdu72ztXeZ33RdZtDY6kO+bfCAE1PCn88Tktw==",
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/antfu"
-			}
-		},
 		"node_modules/@conduction/nextcloud-vue/node_modules/@vueuse/core": {
 			"version": "10.11.1",
 			"resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.11.1.tgz",
@@ -915,18 +675,6 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
-			}
-		},
-		"node_modules/@conduction/nextcloud-vue/node_modules/@vueuse/shared": {
-			"version": "14.3.0",
-			"resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.3.0.tgz",
-			"integrity": "sha512-bZpge9eSXwa4ToSiqJ7j6KRwhAsneMFoSz3LMWKQDkqimm3D/tbFlrklrs/IOqC8tEcYmXQZJ6N0UrjhBirVCg==",
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/antfu"
-			},
-			"peerDependencies": {
-				"vue": "^3.5.0"
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue/node_modules/ajv": {
@@ -976,70 +724,6 @@
 				"@yr/monotone-cubic-spline": "^1.0.3"
 			}
 		},
-		"node_modules/@conduction/nextcloud-vue/node_modules/chokidar": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-			"integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-			"license": "MIT",
-			"dependencies": {
-				"readdirp": "^5.0.0"
-			},
-			"engines": {
-				"node": ">= 20.19.0"
-			},
-			"funding": {
-				"url": "https://paulmillr.com/funding/"
-			}
-		},
-		"node_modules/@conduction/nextcloud-vue/node_modules/debounce": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/debounce/-/debounce-3.0.0.tgz",
-			"integrity": "sha512-64byRbF0/AirwbuHqB3/ZpMG9/nckDa6ZA0yd6UnaQNwbbemCOwvz2sL5sjXLHhZHADyiwLm0M5qMhltUUx+TA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@conduction/nextcloud-vue/node_modules/floating-vue": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/floating-vue/-/floating-vue-5.2.2.tgz",
-			"integrity": "sha512-afW+h2CFafo+7Y9Lvw/xsqjaQlKLdJV7h1fCHfcYQ1C4SVMlu7OAekqWgu5d4SgvkBVU0pVpLlVsrSTBURFRkg==",
-			"license": "MIT",
-			"dependencies": {
-				"@floating-ui/dom": "~1.1.1",
-				"vue-resize": "^2.0.0-alpha.1"
-			},
-			"peerDependencies": {
-				"@nuxt/kit": "^3.2.0",
-				"vue": "^3.2.0"
-			},
-			"peerDependenciesMeta": {
-				"@nuxt/kit": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@conduction/nextcloud-vue/node_modules/floating-vue/node_modules/@floating-ui/dom": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.1.1.tgz",
-			"integrity": "sha512-TpIO93+DIujg3g7SykEAGZMDtbJRrmnYRCNYSjJlvIbGhBjRSNTLVbNeDQBrzy9qDgUbiWdc7KA0uZHZ2tJmiw==",
-			"license": "MIT",
-			"dependencies": {
-				"@floating-ui/core": "^1.1.0"
-			}
-		},
-		"node_modules/@conduction/nextcloud-vue/node_modules/focus-trap": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-8.2.0.tgz",
-			"integrity": "sha512-CaBdQ9P4fa/yCA6pDf/3aJd8bf9IOG5QGK21/E+86o2V4V8kzXaR4A9E6tNR7KkkS1+T5ZIU1tJDBDLwsucz9g==",
-			"license": "MIT",
-			"dependencies": {
-				"tabbable": "^6.4.0"
-			}
-		},
 		"node_modules/@conduction/nextcloud-vue/node_modules/json-schema-traverse": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -1047,9 +731,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@conduction/nextcloud-vue/node_modules/p-queue": {
-			"version": "9.2.0",
-			"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.2.0.tgz",
-			"integrity": "sha512-dWgLE8AH0HjQ9fe74pUkKkvzzYT18Inp4zra3lKHnnwqGvcfcUBrvF2EAVX+envufDNBOzpPq/IBUONDbI7+3g==",
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.0.tgz",
+			"integrity": "sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==",
 			"license": "MIT",
 			"dependencies": {
 				"eventemitter3": "^5.0.4",
@@ -1072,133 +756,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@conduction/nextcloud-vue/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/@conduction/nextcloud-vue/node_modules/readdirp": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-			"integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 20.19.0"
-			},
-			"funding": {
-				"type": "individual",
-				"url": "https://paulmillr.com/funding/"
-			}
-		},
-		"node_modules/@conduction/nextcloud-vue/node_modules/rehype-react": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/rehype-react/-/rehype-react-8.0.0.tgz",
-			"integrity": "sha512-vzo0YxYbB2HE+36+9HWXVdxNoNDubx63r5LBzpxBGVWM8s9mdnMdbmuJBAX6TTyuGdZjZix6qU3GcSuKCIWivw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/hast": "^3.0.0",
-				"hast-util-to-jsx-runtime": "^2.0.0",
-				"unified": "^11.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/@conduction/nextcloud-vue/node_modules/splitpanes": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/splitpanes/-/splitpanes-4.0.4.tgz",
-			"integrity": "sha512-RbysugZhjbCw5fgplvk3hOXr41stahQDtZhHVkhnnJI6H4wlGDhM2kIpbehy7v92duy9GnMa8zIhHigIV1TWtg==",
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/antoniandre"
-			},
-			"peerDependencies": {
-				"vue": "^3.2.0"
-			}
-		},
-		"node_modules/@conduction/nextcloud-vue/node_modules/vue": {
-			"version": "3.5.34",
-			"resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
-			"integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
-			"license": "MIT",
-			"dependencies": {
-				"@vue/compiler-dom": "3.5.34",
-				"@vue/compiler-sfc": "3.5.34",
-				"@vue/runtime-dom": "3.5.34",
-				"@vue/server-renderer": "3.5.34",
-				"@vue/shared": "3.5.34"
-			},
-			"peerDependencies": {
-				"typescript": "*"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@conduction/nextcloud-vue/node_modules/vue-resize": {
-			"version": "2.0.0-alpha.1",
-			"resolved": "https://registry.npmjs.org/vue-resize/-/vue-resize-2.0.0-alpha.1.tgz",
-			"integrity": "sha512-7+iqOueLU7uc9NrMfrzbG8hwMqchfVfSzpVlCMeJQe4pyibqyoifDNbKTZvwxZKDvGkB+PdFeKvnGZMoEb8esg==",
-			"license": "MIT",
-			"peerDependencies": {
-				"vue": "^3.0.0"
-			}
-		},
-		"node_modules/@conduction/nextcloud-vue/node_modules/vue-router": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/vue-router/-/vue-router-5.0.6.tgz",
-			"integrity": "sha512-9+kmUTGbKMyW9Asoy98IXXYIzrTMT7JDAdpDDeEkorHvybpUvBI2wsrSM5jFOXrFydpzRFJ9vAh+80DN2PGu9w==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/generator": "^7.28.6",
-				"@vue-macros/common": "^3.1.1",
-				"@vue/devtools-api": "^8.0.6",
-				"ast-walker-scope": "^0.8.3",
-				"chokidar": "^5.0.0",
-				"json5": "^2.2.3",
-				"local-pkg": "^1.1.2",
-				"magic-string": "^0.30.21",
-				"mlly": "^1.8.0",
-				"muggle-string": "^0.4.1",
-				"pathe": "^2.0.3",
-				"picomatch": "^4.0.3",
-				"scule": "^1.3.0",
-				"tinyglobby": "^0.2.15",
-				"unplugin": "^3.0.0",
-				"unplugin-utils": "^0.3.1",
-				"yaml": "^2.8.2"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/posva"
-			},
-			"peerDependencies": {
-				"@pinia/colada": ">=0.21.2",
-				"@vue/compiler-sfc": "^3.5.17",
-				"pinia": "^3.0.4",
-				"vue": "^3.5.0"
-			},
-			"peerDependenciesMeta": {
-				"@pinia/colada": {
-					"optional": true
-				},
-				"@vue/compiler-sfc": {
-					"optional": true
-				},
-				"pinia": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/@csstools/css-parser-algorithms": {
@@ -1289,15 +846,6 @@
 			},
 			"peerDependencies": {
 				"postcss-selector-parser": "^6.0.13"
-			}
-		},
-		"node_modules/@ctrl/tinycolor": {
-			"version": "3.6.1",
-			"resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz",
-			"integrity": "sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/@cyclonedx/cyclonedx-npm": {
@@ -1903,6 +1451,7 @@
 			"version": "0.3.13",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
 			"integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+			"dev": true,
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.0",
 				"@jridgewell/trace-mapping": "^0.3.24"
@@ -1912,6 +1461,7 @@
 			"version": "2.3.5",
 			"resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
 			"integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+			"dev": true,
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.24"
@@ -1921,6 +1471,7 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
 			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -1938,12 +1489,14 @@
 		"node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.5.5",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+			"dev": true
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.31",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
 			"integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+			"dev": true,
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
@@ -2304,7 +1857,6 @@
 			"version": "3.12.2",
 			"resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.12.2.tgz",
 			"integrity": "sha512-vBo8tf3Xh6efiF8CrEo3pKj9AtvAF6RdDGO1XKL65IxV8+UUd9Uxl2lUExHlzoDRRczCqfGfaWfRRaFhYqce5Q==",
-			"optional": true,
 			"dependencies": {
 				"@nextcloud/auth": "^2.5.3",
 				"@nextcloud/capabilities": "^1.2.1",
@@ -2326,7 +1878,6 @@
 			"version": "3.4.1",
 			"resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-3.4.1.tgz",
 			"integrity": "sha512-aTFinTcKiK2gEXwLgutXekpZZ8/v/4QiC8C3QCLH5m0o+WtxsBC+fqV142ebC/rfDnzCLhY4ZtswSu8bFbZocg==",
-			"optional": true,
 			"dependencies": {
 				"@nextcloud/router": "^3.0.1",
 				"@nextcloud/typings": "^1.9.1",
@@ -2342,7 +1893,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-3.1.0.tgz",
 			"integrity": "sha512-e4dkIaxRSwdZJlZFpn9x03QgBn/Sa2hN1hp/BA7+AbzykmSAlKuWfdmX8j/8ewrLpQwYmZR23IZO9XwpJXq2Uw==",
-			"optional": true,
 			"dependencies": {
 				"@nextcloud/typings": "^1.10.0"
 			},
@@ -2891,16 +2441,8 @@
 		"node_modules/@types/estree": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="
-		},
-		"node_modules/@types/estree-jsx": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
-			"integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/estree": "*"
-			}
+			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+			"dev": true
 		},
 		"node_modules/@types/hast": {
 			"version": "3.0.4",
@@ -2966,6 +2508,22 @@
 			"integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@types/prop-types": {
+			"version": "15.7.15",
+			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+			"integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+			"license": "MIT"
+		},
+		"node_modules/@types/react": {
+			"version": "18.3.29",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.29.tgz",
+			"integrity": "sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/prop-types": "*",
+				"csstype": "^3.2.2"
+			}
 		},
 		"node_modules/@types/semver": {
 			"version": "7.7.1",
@@ -3613,85 +3171,6 @@
 				"url": "https://github.com/sponsors/antfu"
 			}
 		},
-		"node_modules/@vue-macros/common": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@vue-macros/common/-/common-3.1.2.tgz",
-			"integrity": "sha512-h9t4ArDdniO9ekYHAD95t9AZcAbb19lEGK+26iAjUODOIJKmObDNBSe4+6ELQAA3vtYiFPPBtHh7+cQCKi3Dng==",
-			"license": "MIT",
-			"dependencies": {
-				"@vue/compiler-sfc": "^3.5.22",
-				"ast-kit": "^2.1.2",
-				"local-pkg": "^1.1.2",
-				"magic-string-ast": "^1.0.2",
-				"unplugin-utils": "^0.3.0"
-			},
-			"engines": {
-				"node": ">=20.19.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/vue-macros"
-			},
-			"peerDependencies": {
-				"vue": "^2.7.0 || ^3.2.25"
-			},
-			"peerDependenciesMeta": {
-				"vue": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@vue-macros/common/node_modules/@vue/compiler-sfc": {
-			"version": "3.5.34",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
-			"integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/parser": "^7.29.3",
-				"@vue/compiler-core": "3.5.34",
-				"@vue/compiler-dom": "3.5.34",
-				"@vue/compiler-ssr": "3.5.34",
-				"@vue/shared": "3.5.34",
-				"estree-walker": "^2.0.2",
-				"magic-string": "^0.30.21",
-				"postcss": "^8.5.14",
-				"source-map-js": "^1.2.1"
-			}
-		},
-		"node_modules/@vue/compiler-core": {
-			"version": "3.5.34",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
-			"integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/parser": "^7.29.3",
-				"@vue/shared": "3.5.34",
-				"entities": "^7.0.1",
-				"estree-walker": "^2.0.2",
-				"source-map-js": "^1.2.1"
-			}
-		},
-		"node_modules/@vue/compiler-core/node_modules/entities": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
-			"integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=0.12"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
-		},
-		"node_modules/@vue/compiler-dom": {
-			"version": "3.5.34",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
-			"integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
-			"license": "MIT",
-			"dependencies": {
-				"@vue/compiler-core": "3.5.34",
-				"@vue/shared": "3.5.34"
-			}
-		},
 		"node_modules/@vue/compiler-sfc": {
 			"version": "2.7.16",
 			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.16.tgz",
@@ -3711,16 +3190,6 @@
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/@vue/compiler-ssr": {
-			"version": "3.5.34",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
-			"integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@vue/compiler-dom": "3.5.34",
-				"@vue/shared": "3.5.34"
 			}
 		},
 		"node_modules/@vue/component-compiler-utils": {
@@ -3795,24 +3264,6 @@
 			"resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
 			"integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g=="
 		},
-		"node_modules/@vue/devtools-kit": {
-			"version": "8.1.2",
-			"resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.1.2.tgz",
-			"integrity": "sha512-f75/upc+GCyjXErpgPGz4582ujS0L/adAltGy+tqXMGUJpgAcfGr6CxnnhpZY8BHuMYt6KpbF8uaFrrQG66rGQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@vue/devtools-shared": "^8.1.2",
-				"birpc": "^2.6.1",
-				"hookable": "^5.5.3",
-				"perfect-debounce": "^2.0.0"
-			}
-		},
-		"node_modules/@vue/devtools-shared": {
-			"version": "8.1.2",
-			"resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.1.2.tgz",
-			"integrity": "sha512-X9RyVFYAdkBe4IUf5v48TxBF/6QPmF8CmWrDAjXzfUHrgQ/HGfTC1A6TqgXqZ03ye66l3AD51BAGD69IvKM9sw==",
-			"license": "MIT"
-		},
 		"node_modules/@vue/eslint-config-typescript": {
 			"version": "13.0.0",
 			"resolved": "https://registry.npmjs.org/@vue/eslint-config-typescript/-/eslint-config-typescript-13.0.0.tgz",
@@ -3836,71 +3287,6 @@
 				"typescript": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/@vue/reactivity": {
-			"version": "3.5.34",
-			"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
-			"integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@vue/shared": "3.5.34"
-			}
-		},
-		"node_modules/@vue/runtime-core": {
-			"version": "3.5.34",
-			"resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
-			"integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
-			"license": "MIT",
-			"dependencies": {
-				"@vue/reactivity": "3.5.34",
-				"@vue/shared": "3.5.34"
-			}
-		},
-		"node_modules/@vue/runtime-dom": {
-			"version": "3.5.34",
-			"resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
-			"integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
-			"license": "MIT",
-			"dependencies": {
-				"@vue/reactivity": "3.5.34",
-				"@vue/runtime-core": "3.5.34",
-				"@vue/shared": "3.5.34",
-				"csstype": "^3.2.3"
-			}
-		},
-		"node_modules/@vue/server-renderer": {
-			"version": "3.5.34",
-			"resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
-			"integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
-			"license": "MIT",
-			"dependencies": {
-				"@vue/compiler-ssr": "3.5.34",
-				"@vue/shared": "3.5.34"
-			},
-			"peerDependencies": {
-				"vue": "3.5.34"
-			}
-		},
-		"node_modules/@vue/shared": {
-			"version": "3.5.34",
-			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
-			"integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
-			"license": "MIT"
-		},
-		"node_modules/@vuepic/vue-datepicker": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/@vuepic/vue-datepicker/-/vue-datepicker-11.0.3.tgz",
-			"integrity": "sha512-sb2adwqwK2PizLQOpxCYps2SwhVT6/ic2HMIOqHJXuYa6iAJZWGL5YVlS7O4aW+sk6ZyxlDURLO7kDZPL4HB/w==",
-			"license": "MIT",
-			"dependencies": {
-				"date-fns": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=18.12.0"
-			},
-			"peerDependencies": {
-				"vue": ">=3.3.0"
 			}
 		},
 		"node_modules/@vueuse/components": {
@@ -4182,6 +3568,7 @@
 			"version": "8.16.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
 			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
@@ -4524,38 +3911,6 @@
 				"util": "^0.12.5"
 			}
 		},
-		"node_modules/ast-kit": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-2.2.0.tgz",
-			"integrity": "sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/parser": "^7.28.5",
-				"pathe": "^2.0.3"
-			},
-			"engines": {
-				"node": ">=20.19.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sxzz"
-			}
-		},
-		"node_modules/ast-walker-scope": {
-			"version": "0.8.3",
-			"resolved": "https://registry.npmjs.org/ast-walker-scope/-/ast-walker-scope-0.8.3.tgz",
-			"integrity": "sha512-cbdCP0PGOBq0ASG+sjnKIoYkWMKhhz+F/h9pRexUdX2Hd38+WOlBkRKlqkGOSm0YQpcFMQBJeK4WspUAkwsEdg==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/parser": "^7.28.4",
-				"ast-kit": "^2.1.3"
-			},
-			"engines": {
-				"node": ">=20.19.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sxzz"
-			}
-		},
 		"node_modules/astral-regex": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -4675,15 +4030,6 @@
 			"optional": true,
 			"dependencies": {
 				"file-uri-to-path": "1.0.0"
-			}
-		},
-		"node_modules/birpc": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
-			"integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/antfu"
 			}
 		},
 		"node_modules/bl": {
@@ -5206,8 +4552,7 @@
 		"node_modules/cancelable-promise": {
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/cancelable-promise/-/cancelable-promise-4.3.1.tgz",
-			"integrity": "sha512-A/8PwLk/T7IJDfUdQ68NR24QHa8rIlnN/stiJEBo6dmVUkD4K14LswG0w3VwdeK/o7qOwRUR1k2MhK5Rpy2m7A==",
-			"optional": true
+			"integrity": "sha512-A/8PwLk/T7IJDfUdQ68NR24QHa8rIlnN/stiJEBo6dmVUkD4K14LswG0w3VwdeK/o7qOwRUR1k2MhK5Rpy2m7A=="
 		},
 		"node_modules/caniuse-lite": {
 			"version": "1.0.30001770",
@@ -5228,16 +4573,6 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			]
-		},
-		"node_modules/ccount": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
-			"integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
 		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
@@ -5267,36 +4602,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
 			"integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/character-entities-html4": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
-			"integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/character-entities-legacy": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
-			"integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/character-reference-invalid": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
-			"integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
-			"license": "MIT",
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
@@ -5464,12 +4769,6 @@
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true
-		},
-		"node_modules/confbox": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
-			"integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
-			"license": "MIT"
 		},
 		"node_modules/console-browserify": {
 			"version": "1.2.0",
@@ -5903,16 +5202,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/date-fns": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-			"integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/kossnocorp"
 			}
 		},
 		"node_modules/date-format-parse": {
@@ -7337,22 +6626,6 @@
 				"node": ">=4.0"
 			}
 		},
-		"node_modules/estree-util-is-identifier-name": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
-			"integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
-			"license": "MIT",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/estree-walker": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-			"license": "MIT"
-		},
 		"node_modules/esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -7415,12 +6688,6 @@
 			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true
-		},
-		"node_modules/exsolve": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
-			"integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
-			"license": "MIT"
 		},
 		"node_modules/extend": {
 			"version": "3.0.2",
@@ -8291,56 +7558,6 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
-		"node_modules/hast-util-to-jsx-runtime": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
-			"integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/estree": "^1.0.0",
-				"@types/hast": "^3.0.0",
-				"@types/unist": "^3.0.0",
-				"comma-separated-tokens": "^2.0.0",
-				"devlop": "^1.0.0",
-				"estree-util-is-identifier-name": "^3.0.0",
-				"hast-util-whitespace": "^3.0.0",
-				"mdast-util-mdx-expression": "^2.0.0",
-				"mdast-util-mdx-jsx": "^3.0.0",
-				"mdast-util-mdxjs-esm": "^2.0.0",
-				"property-information": "^7.0.0",
-				"space-separated-tokens": "^2.0.0",
-				"style-to-js": "^1.0.0",
-				"unist-util-position": "^5.0.0",
-				"vfile-message": "^4.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/hast-util-to-jsx-runtime/node_modules/hast-util-whitespace": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
-			"integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/hast": "^3.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/hast-util-to-jsx-runtime/node_modules/property-information": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
-			"integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/hast-util-to-text": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
@@ -8392,12 +7609,6 @@
 				"minimalistic-assert": "^1.0.0",
 				"minimalistic-crypto-utils": "^1.0.1"
 			}
-		},
-		"node_modules/hookable": {
-			"version": "5.5.3",
-			"resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
-			"integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
-			"license": "MIT"
 		},
 		"node_modules/hosted-git-info": {
 			"version": "4.1.0",
@@ -8711,30 +7922,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/is-alphabetical": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
-			"integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/is-alphanumerical": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
-			"integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
-			"license": "MIT",
-			"dependencies": {
-				"is-alphabetical": "^2.0.0",
-				"is-decimal": "^2.0.0"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/is-arguments": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
@@ -8937,16 +8124,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/is-decimal": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
-			"integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -9012,16 +8189,6 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/is-hexadecimal": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
-			"integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/is-map": {
@@ -9384,6 +8551,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
 			"integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+			"dev": true,
 			"bin": {
 				"jsesc": "bin/jsesc"
 			},
@@ -9419,6 +8587,7 @@
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
 			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+			"dev": true,
 			"bin": {
 				"json5": "lib/cli.js"
 			},
@@ -9524,9 +8693,10 @@
 			}
 		},
 		"node_modules/linkifyjs": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
-			"integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA=="
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.3.tgz",
+			"integrity": "sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==",
+			"license": "MIT"
 		},
 		"node_modules/loader-runner": {
 			"version": "4.3.1",
@@ -9565,23 +8735,6 @@
 			},
 			"bin": {
 				"json5": "lib/cli.js"
-			}
-		},
-		"node_modules/local-pkg": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.2.tgz",
-			"integrity": "sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==",
-			"license": "MIT",
-			"dependencies": {
-				"mlly": "^1.7.4",
-				"pkg-types": "^2.3.0",
-				"quansync": "^0.2.11"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/antfu"
 			}
 		},
 		"node_modules/locate-path": {
@@ -9628,16 +8781,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/longest-streak": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
-			"integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/lowlight": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
@@ -9660,30 +8803,6 @@
 			"license": "ISC",
 			"dependencies": {
 				"yallist": "^3.0.2"
-			}
-		},
-		"node_modules/magic-string": {
-			"version": "0.30.21",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@jridgewell/sourcemap-codec": "^1.5.5"
-			}
-		},
-		"node_modules/magic-string-ast": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/magic-string-ast/-/magic-string-ast-1.0.3.tgz",
-			"integrity": "sha512-CvkkH1i81zl7mmb94DsRiFeG9V2fR2JeuK8yDgS8oiZSFa++wWLEgZ5ufEOyLHbvSbD1gTRKv9NdX69Rnvr9JA==",
-			"license": "MIT",
-			"dependencies": {
-				"magic-string": "^0.30.19"
-			},
-			"engines": {
-				"node": ">=20.19.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sxzz"
 			}
 		},
 		"node_modules/make-fetch-happen": {
@@ -9854,66 +8973,6 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
-		"node_modules/mdast-util-mdx-expression": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
-			"integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/estree-jsx": "^1.0.0",
-				"@types/hast": "^3.0.0",
-				"@types/mdast": "^4.0.0",
-				"devlop": "^1.0.0",
-				"mdast-util-from-markdown": "^2.0.0",
-				"mdast-util-to-markdown": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdast-util-mdx-jsx": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
-			"integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/estree-jsx": "^1.0.0",
-				"@types/hast": "^3.0.0",
-				"@types/mdast": "^4.0.0",
-				"@types/unist": "^3.0.0",
-				"ccount": "^2.0.0",
-				"devlop": "^1.1.0",
-				"mdast-util-from-markdown": "^2.0.0",
-				"mdast-util-to-markdown": "^2.0.0",
-				"parse-entities": "^4.0.0",
-				"stringify-entities": "^4.0.0",
-				"unist-util-stringify-position": "^4.0.0",
-				"vfile-message": "^4.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdast-util-mdxjs-esm": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
-			"integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/estree-jsx": "^1.0.0",
-				"@types/hast": "^3.0.0",
-				"@types/mdast": "^4.0.0",
-				"devlop": "^1.0.0",
-				"mdast-util-from-markdown": "^2.0.0",
-				"mdast-util-to-markdown": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
 		"node_modules/mdast-util-newline-to-break": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
@@ -9921,20 +8980,6 @@
 			"dependencies": {
 				"@types/mdast": "^4.0.0",
 				"mdast-util-find-and-replace": "^3.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdast-util-phrasing": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
-			"integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/mdast": "^4.0.0",
-				"unist-util-is": "^6.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -9955,27 +9000,6 @@
 				"unist-util-position": "^5.0.0",
 				"unist-util-visit": "^5.0.0",
 				"vfile": "^6.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdast-util-to-markdown": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
-			"integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/mdast": "^4.0.0",
-				"@types/unist": "^3.0.0",
-				"longest-streak": "^3.0.0",
-				"mdast-util-phrasing": "^4.0.0",
-				"mdast-util-to-string": "^4.0.0",
-				"micromark-util-classify-character": "^2.0.0",
-				"micromark-util-decode-string": "^2.0.0",
-				"unist-util-visit": "^5.0.0",
-				"zwitch": "^2.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -10805,35 +9829,6 @@
 			"license": "MIT",
 			"optional": true
 		},
-		"node_modules/mlly": {
-			"version": "1.8.2",
-			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
-			"integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
-			"license": "MIT",
-			"dependencies": {
-				"acorn": "^8.16.0",
-				"pathe": "^2.0.3",
-				"pkg-types": "^1.3.1",
-				"ufo": "^1.6.3"
-			}
-		},
-		"node_modules/mlly/node_modules/confbox": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-			"integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
-			"license": "MIT"
-		},
-		"node_modules/mlly/node_modules/pkg-types": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
-			"integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
-			"license": "MIT",
-			"dependencies": {
-				"confbox": "^0.1.8",
-				"mlly": "^1.7.4",
-				"pathe": "^2.0.1"
-			}
-		},
 		"node_modules/moo": {
 			"version": "0.5.3",
 			"resolved": "https://registry.npmjs.org/moo/-/moo-0.5.3.tgz",
@@ -10846,12 +9841,6 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-		},
-		"node_modules/muggle-string": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
-			"integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
-			"license": "MIT"
 		},
 		"node_modules/nan": {
 			"version": "2.22.2",
@@ -11547,31 +10536,6 @@
 				"node": ">= 0.10"
 			}
 		},
-		"node_modules/parse-entities": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
-			"integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "^2.0.0",
-				"character-entities-legacy": "^3.0.0",
-				"character-reference-invalid": "^2.0.0",
-				"decode-named-character-reference": "^1.0.0",
-				"is-alphanumerical": "^2.0.0",
-				"is-decimal": "^2.0.0",
-				"is-hexadecimal": "^2.0.0"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/parse-entities/node_modules/@types/unist": {
-			"version": "2.0.11",
-			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
-			"integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
-			"license": "MIT"
-		},
 		"node_modules/parse-json": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -11686,12 +10650,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/pathe": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-			"license": "MIT"
-		},
 		"node_modules/pbkdf2": {
 			"version": "3.1.5",
 			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.5.tgz",
@@ -11709,12 +10667,6 @@
 			"engines": {
 				"node": ">= 0.10"
 			}
-		},
-		"node_modules/perfect-debounce": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
-			"integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
-			"license": "MIT"
 		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
@@ -11816,17 +10768,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/pkg-types": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
-			"integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
-			"license": "MIT",
-			"dependencies": {
-				"confbox": "^0.2.4",
-				"exsolve": "^1.0.8",
-				"pathe": "^2.0.3"
 			}
 		},
 		"node_modules/playwright": {
@@ -12286,22 +11227,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/quansync": {
-			"version": "0.2.11",
-			"resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
-			"integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/antfu"
-				},
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/sxzz"
-				}
-			],
-			"license": "MIT"
 		},
 		"node_modules/querystring-es3": {
 			"version": "0.2.1",
@@ -13159,12 +12084,6 @@
 				"extend": "^3.0.0"
 			}
 		},
-		"node_modules/scule": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/scule/-/scule-1.3.0.tgz",
-			"integrity": "sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==",
-			"license": "MIT"
-		},
 		"node_modules/semver": {
 			"version": "6.3.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -13822,20 +12741,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/stringify-entities": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
-			"integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
-			"license": "MIT",
-			"dependencies": {
-				"character-entities-html4": "^2.0.0",
-				"character-entities-legacy": "^3.0.0"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/strip-ansi": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -13959,30 +12864,6 @@
 			"integrity": "sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/style-to-js": {
-			"version": "1.1.21",
-			"resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
-			"integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
-			"license": "MIT",
-			"dependencies": {
-				"style-to-object": "1.0.14"
-			}
-		},
-		"node_modules/style-to-js/node_modules/inline-style-parser": {
-			"version": "0.2.7",
-			"resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
-			"integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
-			"license": "MIT"
-		},
-		"node_modules/style-to-js/node_modules/style-to-object": {
-			"version": "1.0.14",
-			"resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
-			"integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
-			"license": "MIT",
-			"dependencies": {
-				"inline-style-parser": "0.2.7"
-			}
 		},
 		"node_modules/style-to-object": {
 			"version": "0.4.4",
@@ -14563,6 +13444,7 @@
 			"version": "0.2.15",
 			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
 			"integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+			"dev": true,
 			"dependencies": {
 				"fdir": "^6.5.0",
 				"picomatch": "^4.0.3"
@@ -14578,6 +13460,7 @@
 			"version": "6.5.0",
 			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
 			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
 			"engines": {
 				"node": ">=12.0.0"
 			},
@@ -14594,6 +13477,7 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"dev": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -14680,15 +13564,6 @@
 			},
 			"peerDependencies": {
 				"typescript": ">=4.2.0"
-			}
-		},
-		"node_modules/ts-md5": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/ts-md5/-/ts-md5-2.0.1.tgz",
-			"integrity": "sha512-yF35FCoEOFBzOclSkMNEUbFQZuv89KEQ+5Xz03HrMSGUGB1+r+El+JiGOFwsP4p9RFNzwlrydYoTLvPOuICl9w==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
 			}
 		},
 		"node_modules/tsconfig-paths": {
@@ -14867,12 +13742,6 @@
 			"resolved": "https://registry.npmjs.org/typescript-event-target/-/typescript-event-target-1.1.2.tgz",
 			"integrity": "sha512-TvkrTUpv7gCPlcnSoEwUVUBwsdheKm+HF5u2tPAKubkIGMfovdSizCTaZRY/NhR8+Ijy8iZZUapbVQAsNrkFrw=="
 		},
-		"node_modules/ufo": {
-			"version": "1.6.4",
-			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
-			"integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
-			"license": "MIT"
-		},
 		"node_modules/unbox-primitive": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -15030,60 +13899,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/unplugin": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.0.0.tgz",
-			"integrity": "sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==",
-			"license": "MIT",
-			"dependencies": {
-				"@jridgewell/remapping": "^2.3.5",
-				"picomatch": "^4.0.3",
-				"webpack-virtual-modules": "^0.6.2"
-			},
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/unplugin-utils": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.3.1.tgz",
-			"integrity": "sha512-5lWVjgi6vuHhJ526bI4nlCOmkCIF3nnfXkCMDeMJrtdvxTs6ZFCM8oNufGTsDbKv/tJ/xj8RpvXjRuPBZJuJog==",
-			"license": "MIT",
-			"dependencies": {
-				"pathe": "^2.0.3",
-				"picomatch": "^4.0.3"
-			},
-			"engines": {
-				"node": ">=20.19.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sxzz"
-			}
-		},
-		"node_modules/unplugin-utils/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/unplugin/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/unrs-resolver": {
@@ -15739,12 +14554,6 @@
 				"node": ">=10.13.0"
 			}
 		},
-		"node_modules/webpack-virtual-modules": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
-			"integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
-			"license": "MIT"
-		},
 		"node_modules/which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -16044,21 +14853,6 @@
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/yaml": {
-			"version": "2.8.4",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
-			"integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
-			"license": "ISC",
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/eemeli"
-			}
-		},
 		"node_modules/yargs-parser": {
 			"version": "20.2.9",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
@@ -16079,16 +14873,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/zwitch": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
-			"integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"extends @nextcloud/browserslist-config"
 	],
 	"dependencies": {
-		"@conduction/nextcloud-vue": "^1.0.0-beta.66",
+		"@conduction/nextcloud-vue": "^1.0.0-beta.97",
 		"@nextcloud/auth": "^2.6.0",
 		"@nextcloud/axios": "~2.5.2",
 		"@nextcloud/dialogs": "^3.2.0",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -101,7 +101,7 @@
 			"label": "Documentation",
 			"icon": "icon-info",
 			"href": "https://conduction.gitbook.io/procest-nextcloud",
-			"section": "settings",
+			"section": "footer",
 			"order": 90
 		},
 		{
@@ -234,7 +234,7 @@
 			"label": "Features & roadmap",
 			"icon": "icon-toggle",
 			"route": "FeaturesRoadmap",
-			"section": "settings",
+			"section": "footer",
 			"order": 100
 		}
 	],


### PR DESCRIPTION
## Summary
Adopts the new CnAppNav three-section nav model (nc-vue `1.0.0-beta.97`). The OLD bundled CnAppNav drops `section:"footer"` items, so the manifest change and dependency bump land together.

- Bump `@conduction/nextcloud-vue` `^1.0.0-beta.66` -> `^1.0.0-beta.97` (lockfile resolves `1.0.0-beta.97`)
- `src/manifest.json`: move "Documentation" and "Features & roadmap" menu items to `section: "footer"` (bottom-pinned)
- All existing `section: "settings"` config items (Case Types, Tenants, Workflow definitions, etc.) and the no-action "Settings" item left unchanged
- No `action: "user-settings"` item to remove
- Patch bump `appinfo/info.xml` 0.2.0 -> 0.2.1

## Test plan
- [ ] Footer items (Documentation, Features & roadmap) bottom-pin in CnAppNav
- [ ] Settings gear foldout still lists the config items
- [ ] App builds and loads in dev container