### PR TITLE
feat(nav): add Features & roadmap page + bump nc-vue beta.101

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -48,7 +48,7 @@ Vrij en open source onder de AGPL-licentie.
 
 **Ondersteuning:** Voor ondersteuning, neem contact op via support@conduction.nl. Voor een Service Level Agreement (SLA), neem contact op via sales@conduction.nl.
     ]]></description>
-    <version>0.2.1</version>
+    <version>0.2.2</version>
     <licence>agpl</licence>
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>Procest</namespace>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.0",
 			"license": "EUPL-1.2",
 			"dependencies": {
-				"@conduction/nextcloud-vue": "^1.0.0-beta.97",
+				"@conduction/nextcloud-vue": "^1.0.0-beta.101",
 				"@nextcloud/auth": "^2.6.0",
 				"@nextcloud/axios": "~2.5.2",
 				"@nextcloud/dialogs": "^3.2.0",
@@ -492,9 +492,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "1.0.0-beta.97",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.97.tgz",
-			"integrity": "sha512-jlRpA1tjIX3ysP8a42S6lrbrcZfN63yHDzgWMBNaf9Ofs0jvVqqkYawLuEj8vGMU1H4hwvyb0lEOHIsNRmHP6g==",
+			"version": "1.0.0-beta.101",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.101.tgz",
+			"integrity": "sha512-UVxKWUU7pf6oHr7Oly5HWPC1e8OK3z2lmdS5xgs28+sYZPNj53co9+xs3tb0mqCGXZ8Oqit9NMapI8ir0fy2iA==",
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"extends @nextcloud/browserslist-config"
 	],
 	"dependencies": {
-		"@conduction/nextcloud-vue": "^1.0.0-beta.97",
+		"@conduction/nextcloud-vue": "^1.0.0-beta.101",
 		"@nextcloud/auth": "^2.6.0",
 		"@nextcloud/axios": "~2.5.2",
 		"@nextcloud/dialogs": "^3.2.0",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2572,7 +2572,10 @@
 			"id": "FeaturesRoadmap",
 			"route": "/features-roadmap",
 			"type": "roadmap",
-			"title": "Features & roadmap"
+			"title": "Features & roadmap",
+			"config": {
+				"documentationUrl": "https://procest.conduction.nl"
+			}
 		}
 	]
 }


### PR DESCRIPTION
## Summary
- Add `documentationUrl` config (`https://procest.conduction.nl`) to the existing `FeaturesRoadmap` roadmap page so the footer "Features & roadmap" nav item fully resolves alongside Documentation and Settings.
- Bump `@conduction/nextcloud-vue` from `beta.97` to `beta.101` (package.json + lockfile).
- Patch bump appinfo version `0.2.1` -> `0.2.2`.

## Test plan
- [ ] Verify all three footer/settings nav items (Documentation, Features & roadmap, Settings) navigate correctly.