### PR TITLE
fix(ui): bump @nextcloud/vue to ^8.39.0 (nav corner sliver on NC<34)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"@nextcloud/initial-state": "^2.2.0",
 				"@nextcloud/l10n": "^2.0.1",
 				"@nextcloud/router": "^2.0.1",
-				"@nextcloud/vue": "^8.16.0",
+				"@nextcloud/vue": "^8.39.0",
 				"@vue-flow/background": "^1.3.2",
 				"@vue-flow/controls": "^1.1.3",
 				"@vue-flow/core": "^1.48.2",
@@ -2020,13 +2020,14 @@
 			}
 		},
 		"node_modules/@nextcloud/vue": {
-			"version": "8.36.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.36.0.tgz",
-			"integrity": "sha512-x1MEh4nvCrD1zoJ3ybhtbSDox+1wyHRP7st95Uu14Wm630quRrfXGaQ1bxqaZ7en/wqaihR0NPyQKfmjrPmseg==",
+			"version": "8.39.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.39.0.tgz",
+			"integrity": "sha512-TJgrFeVr82CN8ng4y+IxMBb7mKlww7Fot22z33+Q0zKgWvi5EoQ0vYescA3Drl8cIRSGktUdFm3xO2gAqvnwoA==",
+			"license": "AGPL-3.0-or-later",
 			"dependencies": {
-				"@floating-ui/dom": "^1.7.5",
+				"@floating-ui/dom": "^1.7.6",
 				"@linusborg/vue-simple-portal": "^0.1.5",
-				"@nextcloud/auth": "^2.5.3",
+				"@nextcloud/auth": "^2.6.0",
 				"@nextcloud/axios": "^2.5.2",
 				"@nextcloud/browser-storage": "^0.5.0",
 				"@nextcloud/capabilities": "^1.2.1",
@@ -2035,20 +2036,21 @@
 				"@nextcloud/l10n": "^3.4.1",
 				"@nextcloud/logger": "^3.0.3",
 				"@nextcloud/router": "^3.1.0",
-				"@nextcloud/sharing": "^0.3.0",
+				"@nextcloud/sharing": "^0.4.0",
 				"@nextcloud/vue-select": "^3.26.0",
 				"@vueuse/components": "^11.0.0",
 				"@vueuse/core": "^11.0.0",
 				"blurhash": "^2.0.5",
 				"clone": "^2.1.2",
 				"debounce": "^2.2.0",
-				"dompurify": "^3.3.1",
+				"dompurify": "^3.4.2",
 				"emoji-mart-vue-fast": "^15.0.5",
 				"escape-html": "^1.0.3",
 				"floating-vue": "^1.0.0-beta.19",
 				"focus-trap": "^7.8.0",
 				"linkify-string": "^4.3.2",
 				"md5": "^2.3.0",
+				"mdast-util-to-string": "^4.0.0",
 				"p-queue": "^8.1.1",
 				"rehype-external-links": "^3.0.0",
 				"rehype-highlight": "^7.0.2",
@@ -2064,7 +2066,7 @@
 				"tributejs": "^5.1.3",
 				"unified": "^11.0.1",
 				"unist-builder": "^4.0.0",
-				"unist-util-visit": "^5.1.0",
+				"unist-util-visit-parents": "^6.0.2",
 				"vue": "^2.7.16",
 				"vue-color": "^2.8.1",
 				"vue-frag": "^1.4.3",
@@ -2108,6 +2110,31 @@
 			"dependencies": {
 				"@nextcloud/typings": "^1.10.0"
 			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/@nextcloud/sharing": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/sharing/-/sharing-0.4.0.tgz",
+			"integrity": "sha512-1hUNyc7uJdBpnimOnEshJjEtAPAjzDYVl6qmWqF5ZxoN9wOvbExw0QjX3xFIbHbX2dmvbRNLBj0RzLzipmZyeg==",
+			"license": "GPL-3.0-or-later",
+			"dependencies": {
+				"@nextcloud/initial-state": "^3.0.0",
+				"is-svg": "^6.1.0"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+			},
+			"optionalDependencies": {
+				"@nextcloud/files": "^3.12.2 || ^4.0.0"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/@nextcloud/sharing/node_modules/@nextcloud/initial-state": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/initial-state/-/initial-state-3.0.0.tgz",
+			"integrity": "sha512-cV+HBdkQJGm8FxkBI5rFT/FbMNWNBvpbj6OPrg4Ae4YOOsQ15CL8InPOAw1t4XkOkQK2NEdUGQLVUz/19wXbdQ==",
+			"license": "GPL-3.0-or-later",
 			"engines": {
 				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
 			}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"@nextcloud/initial-state": "^2.2.0",
 		"@nextcloud/l10n": "^2.0.1",
 		"@nextcloud/router": "^2.0.1",
-		"@nextcloud/vue": "^8.16.0",
+		"@nextcloud/vue": "^8.39.0",
 		"@vue-flow/background": "^1.3.2",
 		"@vue-flow/controls": "^1.1.3",
 		"@vue-flow/core": "^1.48.2",


### PR DESCRIPTION
## What

Bumps `@nextcloud/vue` from `^8.16.0` to `^8.39.0`.

## Why

`@nextcloud/vue` versions before 8.39.0 unconditionally render the Nextcloud 34 rounded `.app-content` layout. On Nextcloud < 34 the rounded white corner pokes past the square `.app-navigation`, producing a visible white sliver near the navigation toggle.

Version 8.39.0 adds an `isLegacy34` guard (NC major < 34) that restores the square layout on older Nextcloud versions, eliminating the sliver.

## Changes

- Bumped the direct `@nextcloud/vue` dependency pin to `^8.39.0`.
- Updated `package-lock.json` accordingly (resolves to 8.39.0).

The JS bundle (`js/`) is gitignored, so the only committed changes are `package.json` + `package-lock.json`.

Part of a fleet-wide sweep.