### PR TITLE
feat(notifications): notify assignee on case/task creation

### DIFF
--- a/lib/Settings/procest_register.json
+++ b/lib/Settings/procest_register.json
@@ -525,6 +525,20 @@
       },
       "case": {
         "slug": "case",
+        "x-openregister-notifications": {
+          "caseAssigned": {
+            "trigger": { "type": "created" },
+            "enabled": true,
+            "channels": ["nc-notification"],
+            "recipients": [
+              { "kind": "field", "field": "assignee" }
+            ],
+            "subject": {
+              "nl": "Zaak \"{{title}}\" aan je toegewezen",
+              "en": "Case \"{{title}}\" assigned to you"
+            }
+          }
+        },
         "icon": "BriefcaseOutline",
         "version": "1.0.0",
         "x-schema-org-type": "schema:Project",
@@ -748,6 +762,20 @@
       },
       "task": {
         "slug": "task",
+        "x-openregister-notifications": {
+          "taskAssigned": {
+            "trigger": { "type": "created" },
+            "enabled": true,
+            "channels": ["nc-notification"],
+            "recipients": [
+              { "kind": "field", "field": "assignee" }
+            ],
+            "subject": {
+              "nl": "Taak \"{{title}}\" aan je toegewezen",
+              "en": "Task \"{{title}}\" assigned to you"
+            }
+          }
+        },
         "icon": "CheckboxMarkedOutline",
         "version": "1.1.0",
         "x-schema-org-type": "schema:Action",


### PR DESCRIPTION
Declares `x-openregister-notifications` on the **case** and **task** schemas so the OpenRegister notification engine notifies the assignee when a case or task is created and assigned to them:

- **case** `object.created` → `assignee` field
- **task** `object.created` → `assignee` field

Schema-object-level annotation (folded into the schema `configuration` on register import), verified engine dialect, nl/en subjects. Users can opt out per-notification via OpenRegister's override-only notification preferences.

Note: "notify on re-assignment" (assignee changed on update) is intentionally not declared — the engine's `updated` trigger has no field-changed condition yet (tracked as a fleet engine-gap follow-up). Creation-time assignment is the precise, expressible case.

Part of the fleet notification rollout (hydra/openspec/fleet-notification-plan.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)