### PR TITLE
chore(openspec): ADR-022 leaf-migration specs (maps/calendar/shares/analytics/forms)

### DIFF
--- a/openspec/changes/migrate-appointments-to-calendar-leaf/.openspec.yaml
+++ b/openspec/changes/migrate-appointments-to-calendar-leaf/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-25

--- a/openspec/changes/migrate-appointments-to-calendar-leaf/design.md
+++ b/openspec/changes/migrate-appointments-to-calendar-leaf/design.md
@@ -1,0 +1,48 @@
+# Design: migrate-appointments-to-calendar-leaf
+
+## Context
+
+OR's calendar integration leaf (ADR-019) contributes a calendar tab + widget on an OR object's
+detail page, backed by NC's calendar (CalDAV) via OR. Creating a "moment" on a case becomes a
+calendar event linked to the case object. The leaf does NOT model external municipal-system
+timeslot booking — that is `QmaticBackend`/`JccBackend` territory.
+
+## File-by-File Mapping
+
+| Existing procest artifact | Disposition |
+|---|---|
+| `lib/Service/AppointmentService.php` (local path) | Removed for the local path — calendar leaf owns event CRUD; the residual orchestration for external backends, if kept, narrows to Qmatic/JCC only |
+| `lib/Service/AppointmentBackend/AppointmentBackendInterface.php` | Kept ONLY if Qmatic/JCC stay in-app (exception (a)); removed if resolution (b) |
+| `lib/Service/AppointmentBackend/LocalBackend.php` | Removed — superseded by the calendar leaf |
+| `lib/Service/AppointmentBackend/QmaticBackend.php` | EXCEPTION — kept in-app (a) or moved to openconnector (b); NOT migrated to the leaf |
+| `lib/Service/AppointmentBackend/JccBackend.php` | EXCEPTION — same as Qmatic |
+| `lib/Controller/PublicAppointmentController.php` | Retained pending Qmatic/JCC resolution (citizen cancel-by-token) |
+| case-appointment metadata (`productId`, `locationId`, `cancelToken`, `reminderSent`, no-show) | **Kept** as case-appointment fields in procest's register |
+
+## What moves vs what stays
+
+- **Moves to the leaf**: local scheduling UI, local event persistence, case-detail surfacing.
+- **Stays in procest**: zaak-specific appointment metadata (the fields the calendar leaf does not
+  model) and the reminder background job that reads that metadata.
+- **Exception (not migrated)**: external Qmatic/JCC timeslot booking.
+
+## ADR-022 exception — Qmatic / JCC
+
+Per ADR-022 exception clause 1 (fundamentally different domain requirements), external
+municipal-system scheduling cannot be served by the calendar leaf. Two resolutions:
+
+- **(a) Keep in-app** behind an app-local ADR referencing ADR-022 and justifying the divergence.
+  Lowest cost; honest exception.
+- **(b) Move to openconnector** as a Qmatic/JCC source, mirroring `shared-pdok-via-openconnector`.
+  Strategically unified (other apps may need the same), higher cost, separate spec.
+
+Recommendation: per the "favor unification" preference, (b) is the long-term answer if any other
+fleet app needs Qmatic/JCC; (a) is acceptable if procest is the sole consumer. A GH issue captures
+the decision; an app-local ADR is required either way.
+
+## DEFERRED_QUESTIONS
+
+- Confirm the OR calendar leaf `id` and pinned `@conduction/nextcloud-vue` version shipping it.
+- DECISION REQUIRED: Qmatic/JCC resolution (a) in-app ADR exception vs (b) openconnector source.
+- Confirm whether citizen public-cancel-by-token is still required for leaf-created (local) events,
+  or only for Qmatic/JCC bookings.

--- a/openspec/changes/migrate-appointments-to-calendar-leaf/proposal.md
+++ b/openspec/changes/migrate-appointments-to-calendar-leaf/proposal.md
@@ -1,0 +1,85 @@
+# Proposal: migrate-appointments-to-calendar-leaf
+
+## Why
+
+Procest ships an in-app appointment-scheduling engine: `AppointmentService` orchestrates booking
+and persists appointments to OR, while `lib/Service/AppointmentBackend/*` provides pluggable
+backends (`LocalBackend`, plus the external `QmaticBackend` and `JccBackend`). The consumer-facing
+surface is the `appointment-booking` spec.
+
+OpenRegister provides a **calendar** integration leaf (ADR-019). For the common case — scheduling
+a moment against a case and surfacing it on the case detail page — the calendar leaf already
+provides event creation, listing, and a tab/widget rendered by the OR object sidebar. The
+`LocalBackend` path (appointments that exist only inside the app, no external municipal system) is
+a direct **ADR-022** duplication of what the calendar leaf provides:
+
+- **Duplicate scheduling UI + persistence** for the local path that the calendar leaf already owns.
+- **Orphaned code**: `AppointmentService` + `LocalBackend` re-implement event CRUD + sidebar
+  surfacing the leaf provides for free.
+- **No cross-app calendar view**: locally-stored appointments can't appear in a fleet-wide calendar.
+
+## What
+
+This change migrates procest's **local** appointment scheduling to the OR calendar leaf, while
+keeping zaak-specific appointment metadata as case fields:
+
+1. The `LocalBackend` scheduling path is replaced by the OR calendar leaf on the `case` detail
+   page. A scheduled moment becomes a calendar event linked to the case via the leaf.
+2. Zaak-specific appointment metadata that the calendar leaf does not model (e.g. `productId`,
+   `locationId`, citizen `cancelToken`, `reminderSent`, no-show status) is kept as fields on a
+   case-appointment object in procest's register — the *data* stays, the *scheduling UI* moves.
+3. `AppointmentService` and `LocalBackend` are removed for the local path once the leaf is wired.
+
+### External Qmatic / JCC scheduling — ADR-022 EXCEPTION (flagged)
+
+`QmaticBackend` (Qmatic Orchestra) and `JccBackend` (JCC Afspraken) integrate with **external
+municipal appointment systems** that own real-world counter capacity, timeslots, and queue
+management. The calendar leaf models NC/CalDAV events, not external municipal-system timeslot
+booking with `getTimeslots`/`bookAppointment`/`rescheduleAppointment` against a third-party API.
+
+This is an **ADR-022 exception candidate** under exception clause 1 ("fundamentally different
+domain requirements" — external municipal-system integration the leaf cannot satisfy). The
+recommended resolution is one of:
+
+- **(a)** Keep `QmaticBackend`/`JccBackend` in-app behind an app-local ADR (the honest exception),
+  OR
+- **(b)** Move external timeslot booking to an **openconnector** source (the fleet's external-API
+  abstraction, mirroring the PDOK pattern in `shared-pdok-via-openconnector`) — the strategically
+  unified answer, since other apps may also need Qmatic/JCC.
+
+This proposal does NOT migrate Qmatic/JCC to the calendar leaf (it cannot host external timeslot
+booking). The decision between (a) and (b) is recorded as a DEFERRED_QUESTION + a GH issue, per
+ADR-022's "every exception requires an app-local ADR" rule.
+
+## Capabilities
+
+### New Capabilities
+
+- `case-appointment-via-calendar-leaf`: Local case appointments are scheduled and surfaced through
+  OR's calendar integration leaf; zaak-specific appointment metadata is retained as case fields.
+
+### Modified Capabilities
+
+- `appointment-booking` (spec: `procest/openspec/specs/appointment-booking/spec.md`) — the local
+  scheduling path now routes through the calendar leaf; the external Qmatic/JCC backend contract is
+  retained pending the ADR-022 exception decision (a) or (b).
+
+## Affected Projects
+
+- [x] Project: `procest` — all implementation tasks are in this repo
+- [x] Project: `openregister` — no code change; the calendar leaf is consumed, not modified
+- [ ] Project: `openconnector` — only if resolution (b) is chosen for Qmatic/JCC (separate spec)
+
+## Out of Scope
+
+- The calendar leaf's own implementation in OR.
+- Migrating Qmatic/JCC external scheduling to the calendar leaf (impossible — flagged as exception).
+- Citizen public-cancel-by-token UX, which depends on the chosen Qmatic/JCC resolution.
+- Reminder background job redesign (kept; it reads the retained appointment metadata).
+
+## Success Criteria
+
+- `openspec validate migrate-appointments-to-calendar-leaf --strict` exits 0.
+- Local case appointments are created/listed through the calendar leaf on the case detail page.
+- `AppointmentService` + `LocalBackend` local-path code is removed; zaak metadata fields retained.
+- The Qmatic/JCC exception is recorded as a GH issue + DEFERRED_QUESTION.

--- a/openspec/changes/migrate-appointments-to-calendar-leaf/specs/case-appointment-via-calendar-leaf/spec.md
+++ b/openspec/changes/migrate-appointments-to-calendar-leaf/specs/case-appointment-via-calendar-leaf/spec.md
@@ -1,0 +1,59 @@
+# case-appointment-via-calendar-leaf Specification
+
+## ADDED Requirements
+
+### Requirement: Local Case Appointments Are Scheduled Through The OR Calendar Leaf
+
+Scheduling a moment against a case (the former `LocalBackend` path) SHALL be performed through
+OpenRegister's `calendar` integration leaf (ADR-019). Procest SHALL NOT persist or render local
+appointment events through its own `AppointmentService`/`LocalBackend` after this migration.
+
+#### Scenario: Scheduling a moment creates a calendar-leaf event on the case
+
+- **GIVEN** a `case` object and the OR calendar leaf enabled + whitelisted on the `case` schema
+- **WHEN** a handler schedules an appointment moment on the case
+- **THEN** a calendar event SHALL be created via the calendar leaf, linked to the case
+- **AND** the event SHALL appear in the calendar leaf tab/widget on the case detail page
+- **AND** no `LocalBackend` HTTP/persistence path SHALL be invoked
+
+#### Scenario: LocalBackend is removed
+
+- **GIVEN** the procest codebase after this migration
+- **WHEN** `lib/Service/AppointmentBackend/` is inspected
+- **THEN** `LocalBackend.php` SHALL NOT be present
+- **AND** the local scheduling path SHALL NOT exist in `AppointmentService`
+
+---
+
+### Requirement: Zaak-Specific Appointment Metadata Is Retained As Case Fields
+
+Procest SHALL retain appointment metadata that the calendar leaf does not model (product,
+location, citizen cancel token, reminder-sent flag, no-show status) as fields on a
+case-appointment object in its register. The calendar leaf SHALL own the event; procest SHALL
+own the zaak-domain metadata.
+
+#### Scenario: Zaak metadata survives the migration
+
+- **GIVEN** a case-appointment after this migration
+- **WHEN** the appointment record is inspected
+- **THEN** `productId`, `locationId`, `cancelToken`, `reminderSent`, and no-show status SHALL be
+  retained as case-appointment fields
+- **AND** the reminder background job SHALL continue to read these fields
+
+---
+
+### Requirement: External Qmatic/JCC Scheduling Is An ADR-022 Exception Not Served By The Leaf
+
+Procest SHALL NOT migrate external municipal-system scheduling via `QmaticBackend` (Qmatic
+Orchestra) and `JccBackend` (JCC Afspraken) to the calendar leaf, because the leaf does not
+model external-system timeslot booking. This divergence SHALL be documented in an app-local ADR
+referencing ADR-022 exception clause 1.
+
+#### Scenario: Qmatic/JCC remain a documented exception
+
+- **GIVEN** the migration is applied
+- **WHEN** the external scheduling path is reviewed
+- **THEN** Qmatic/JCC SHALL either remain in-app behind an app-local ADR (resolution a) OR be moved
+  to an openconnector source (resolution b)
+- **AND** the calendar leaf SHALL NOT be used for external timeslot booking
+- **AND** a GH issue SHALL record the chosen resolution

--- a/openspec/changes/migrate-appointments-to-calendar-leaf/tasks.md
+++ b/openspec/changes/migrate-appointments-to-calendar-leaf/tasks.md
@@ -1,0 +1,39 @@
+# Tasks: migrate-appointments-to-calendar-leaf
+
+All tasks are in the `procest` repo. Estimates: S = half-day, M = 1–2 days, L = 3+ days.
+Implementation runs through Hydra; this change is specs-only.
+
+## [procest] Pre-migration Verification
+
+### P0. Confirm calendar leaf + Qmatic/JCC decision (S)
+
+- [ ] P0.1 Confirm the OR calendar leaf `id` and the pinned `@conduction/nextcloud-vue` version.
+  Record in design.md DEFERRED_QUESTIONS.
+- [ ] P0.2 DECIDE Qmatic/JCC resolution: (a) in-app app-local ADR exception vs (b) openconnector
+  source. Open a GH issue capturing the decision and (if b) a follow-up openconnector spec.
+
+## [procest] Wire the leaf (local path)
+
+### P1. Calendar leaf scheduling (M)
+
+- [ ] P1.1 Whitelist the calendar leaf on the `case` schema `configuration.linkedTypes`.
+- [ ] P1.2 Replace local scheduling UI with the calendar leaf tab/widget on the case detail page.
+- [ ] P1.3 Define/retain the case-appointment metadata object fields (`productId`, `locationId`,
+  `cancelToken`, `reminderSent`, no-show) in `lib/Settings/procest_register.json`.
+
+## [procest] Remove the local backend
+
+### P2. Delete superseded code (M)
+
+- [ ] P2.1 Remove `lib/Service/AppointmentBackend/LocalBackend.php` and the local path in
+  `AppointmentService`.
+- [ ] P2.2 If resolution (a): narrow `AppointmentService` + `AppointmentBackendInterface` to
+  Qmatic/JCC only and write the app-local ADR. If (b): remove the in-app backends after the
+  openconnector source lands.
+
+## [procest] Quality gates
+
+### P3. Verify (S)
+
+- [ ] P3.1 `openspec validate migrate-appointments-to-calendar-leaf --strict` exits 0.
+- [ ] P3.2 `composer check:strict` and `npm run lint` pass; reminder job still reads retained fields.

--- a/openspec/changes/migrate-inspection-forms-to-forms-leaf/.openspec.yaml
+++ b/openspec/changes/migrate-inspection-forms-to-forms-leaf/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-25

--- a/openspec/changes/migrate-inspection-forms-to-forms-leaf/design.md
+++ b/openspec/changes/migrate-inspection-forms-to-forms-leaf/design.md
@@ -1,0 +1,43 @@
+# Design: migrate-inspection-forms-to-forms-leaf
+
+## Context
+
+OR's forms leaf (ADR-019) renders a form definition and captures responses against an OR object.
+OR's photos leaf attaches/displays images as files-attached-to-object. Procest's checklist +
+advice/consultation features couple form *rendering* and photo *storage* (the shared abstractions)
+with inspection *domain rules* (immutability, photo gates, lifecycle) that must stay in-app.
+
+## File-by-File Mapping
+
+| Existing procest artifact | Disposition |
+|---|---|
+| `src/views/cases/components/InspectionChecklistPanel.vue` | Reduced — forms leaf renders items, photos leaf holds photos; panel runs domain gates against results |
+| `src/views/cases/components/DocumentChecklist.vue` | Reduced — forms leaf renders the checklist |
+| `lib/Service/Inspection/ChecklistService.php` | **Kept** — photo-gate rules (`fotoRequired: altijd / bij_nee / nooit`) + run lifecycle validate leaf-captured data |
+| `lib/Listener/ChecklistRunImmutabilityListener.php` | **Kept** — append-only enforcement (REQ-IC-8) |
+| `lib/Service/InspectionService.php` | Reduced to orchestration over leaf-captured results |
+| inline `photos[]` payloads in checklist items | Replaced by photos-leaf file attachments |
+| advice/consultation request input forms | Rendered by the forms leaf |
+| advice/consultation lifecycle + deadline tracking | **Kept** — zaak-domain logic |
+
+## ADR-022 boundary (what stays vs moves)
+
+- **Moves to leaves**: form question rendering + response capture (forms leaf); photo storage +
+  display (photos leaf).
+- **Stays in procest (domain logic)**: checklist append-only immutability, the `fotoRequired`
+  photo-gate rules, the inspection-run lifecycle, and the advice/consultation lifecycle/deadlines.
+
+The leaves render and store; procest *validates* the captured data against its domain rules. The
+photo gate becomes "the run is invalid unless the photos leaf has ≥1 attachment when `fotoRequired`
+demands it" — the gate logic is unchanged, only the photo *source* moves to the leaf.
+
+## DEFERRED_QUESTIONS
+
+- Confirm the OR forms leaf `id` + whether it supports the checklist question types procest uses
+  (yes/no/`foto`/free-text) and the pinned `@conduction/nextcloud-vue` version.
+- Confirm the OR photos leaf `id` and how `ChecklistService` queries attached photos to run the
+  `fotoRequired` gate (file-count on the run/case object).
+- DECISION: backfill existing inline `photos[]` into the photos leaf, or sunset-window read of the
+  old shape?
+- Confirm whether the forms leaf can render a definition stored as a procest
+  `inspectionChecklistTemplate` object, or whether a thin mapping is needed.

--- a/openspec/changes/migrate-inspection-forms-to-forms-leaf/proposal.md
+++ b/openspec/changes/migrate-inspection-forms-to-forms-leaf/proposal.md
@@ -1,0 +1,78 @@
+# Proposal: migrate-inspection-forms-to-forms-leaf
+
+## Why
+
+Procest ships bespoke form-style data collection: advice/consultation requests
+(`advice-management`, `consultation-management` specs) and inspection checklists
+(`inspection-checklists` spec — `ChecklistService`, `InspectionService`, `InspectionController`,
+`InspectionChecklistPanel.vue`, `DocumentChecklist.vue`). Checklist items support free-form
+question types and a "photo required" affordance with inline photo payloads.
+
+OpenRegister provides a **forms** integration leaf and a **photos** integration leaf (ADR-019).
+The forms leaf renders structured form definitions and captures responses against an OR object;
+the photos leaf attaches and displays images on an OR object. Procest's hand-rolled checklist
+question rendering, advice-request input forms, and inline photo handling duplicate these leaves —
+an **ADR-022** violation:
+
+- **Duplicate form-rendering** of question/answer collection that the forms leaf provides + tests.
+- **Duplicate photo handling**: inline `photos[]` payloads in checklist items re-implement what
+  the photos leaf (file-attached-to-object) provides.
+- **No cross-app form/photo reuse**: in-app checklist UI can't be reused by other fleet apps.
+
+**What stays — checklist domain rules.** The append-only/immutability enforcement
+(`ChecklistRunImmutabilityListener`, REQ-IC-8), the photo-gate business rules (`fotoRequired:
+altijd | bij_nee | nooit`), and the checklist-run lifecycle are **zaak-domain logic** that the
+forms/photos leaves do not own. Per ADR-022, only the **form rendering + photo storage** are the
+shared abstractions; the **inspection gating + immutability rules stay in-app**.
+
+## What
+
+This change migrates the form **rendering** and photo **storage** to the leaves while keeping the
+inspection domain rules:
+
+1. Advice/consultation request **input forms** and inspection **checklist item rendering** are
+   rendered by the OR forms leaf on the case detail page, fed the form/checklist definition.
+2. Inspection **photos** move from inline `photos[]` payloads to the OR photos leaf (files attached
+   to the inspection-run / case object).
+3. The checklist-run lifecycle, the photo-gate rules, and the append-only immutability listener are
+   **kept** in `ChecklistService` / `ChecklistRunImmutabilityListener` — they validate the leaf's
+   captured responses + attached photos rather than rendering them.
+4. `InspectionChecklistPanel.vue` / `DocumentChecklist.vue` are reduced to: invoke the forms leaf,
+   reference the photos leaf, and run the domain gates against the results.
+
+## Capabilities
+
+### New Capabilities
+
+- `inspection-forms-via-forms-leaf`: Advice/consultation requests and inspection checklists are
+  rendered and captured through OR's forms integration leaf; inspection photos are stored through
+  OR's photos integration leaf. Procest retains the checklist domain gates and immutability rules.
+
+### Modified Capabilities
+
+- `inspection-checklists` (spec: `procest/openspec/specs/inspection-checklists/spec.md`) — checklist
+  rendering + photo capture delegate to the forms/photos leaves; the immutability + photo-gate
+  requirements are unchanged (domain logic stays).
+- `advice-management` (spec: `procest/openspec/specs/advice-management/spec.md`) — the advice-request
+  input form delegates to the forms leaf; the advice lifecycle/deadline tracking stays in-app.
+- `consultation-management` (spec: `procest/openspec/specs/consultation-management/spec.md`) — the
+  consultation input form delegates to the forms leaf.
+
+## Affected Projects
+
+- [x] Project: `procest` — all implementation tasks are in this repo
+- [x] Project: `openregister` — no code change; the forms + photos leaves are consumed, not modified
+
+## Out of Scope
+
+- The forms/photos leaves' own implementation in OR.
+- The checklist photo-gate rules (`fotoRequired`) and append-only immutability — they STAY in-app.
+- The advice/consultation lifecycle + deadline tracking — domain logic, stays in-app.
+- Backfill of existing inline checklist `photos[]` into the photos leaf store (sunset window;
+  confirm in design.md).
+
+## Success Criteria
+
+- `openspec validate migrate-inspection-forms-to-forms-leaf --strict` exits 0.
+- Advice/consultation/checklist forms render through the forms leaf; photos via the photos leaf.
+- `ChecklistService` photo-gate + `ChecklistRunImmutabilityListener` immutability rules remain.

--- a/openspec/changes/migrate-inspection-forms-to-forms-leaf/specs/inspection-forms-via-forms-leaf/spec.md
+++ b/openspec/changes/migrate-inspection-forms-to-forms-leaf/specs/inspection-forms-via-forms-leaf/spec.md
@@ -1,0 +1,60 @@
+# inspection-forms-via-forms-leaf Specification
+
+## ADDED Requirements
+
+### Requirement: Checklist And Advice Forms Render Through The OR Forms Leaf
+
+Procest SHALL render inspection checklist items and advice/consultation request forms through
+OpenRegister's `forms` integration leaf (ADR-019). Procest SHALL NOT hand-render form question
+inputs in `InspectionChecklistPanel.vue` / `DocumentChecklist.vue` after this migration.
+
+#### Scenario: Checklist items render via the forms leaf
+
+- **GIVEN** an inspection checklist template and the OR forms leaf available
+- **WHEN** an inspector opens the checklist on a case
+- **THEN** the checklist items SHALL be rendered by the forms leaf
+- **AND** responses SHALL be captured by the leaf against the inspection run / case object
+
+#### Scenario: Advice request form renders via the forms leaf
+
+- **GIVEN** a case and the OR forms leaf available
+- **WHEN** a behandelaar starts an advice request ("Advies aanvragen")
+- **THEN** the advice-request input form SHALL be rendered by the forms leaf
+
+---
+
+### Requirement: Inspection Photos Are Stored Through The OR Photos Leaf
+
+Procest SHALL store and display inspection photos through OpenRegister's `photos` integration leaf
+(files attached to the object). Procest SHALL NOT persist inline `photos[]` payloads inside
+checklist items after this migration.
+
+#### Scenario: Inspection photos attach via the photos leaf
+
+- **GIVEN** a checklist item that captures a photo
+- **WHEN** the inspector adds a photo
+- **THEN** the photo SHALL be stored via the photos leaf as a file attached to the run / case object
+- **AND** no inline `photos[]` payload SHALL be written into the checklist item
+
+---
+
+### Requirement: Inspection Domain Rules Stay In-App And Validate Leaf Data
+
+Procest SHALL retain the checklist photo-gate rules (`fotoRequired: altijd | bij_nee | nooit`), the
+checklist-run lifecycle, the append-only immutability enforcement
+(`ChecklistRunImmutabilityListener`, REQ-IC-8), and the advice/consultation lifecycle in-app. These
+rules SHALL validate the data captured by the forms/photos leaves rather than render it.
+
+#### Scenario: Photo gate validates against photos-leaf attachments
+
+- **GIVEN** a checklist item with `fotoRequired: altijd`
+- **WHEN** the run is submitted with no photo attached via the photos leaf
+- **THEN** `ChecklistService` SHALL reject the submission with `PHOTO_REQUIRED`
+- **AND** the gate SHALL count attachments held by the photos leaf, not an inline payload
+
+#### Scenario: Append-only immutability is preserved
+
+- **GIVEN** a completed checklist run
+- **WHEN** an edit to a finalized run is attempted
+- **THEN** `ChecklistRunImmutabilityListener` SHALL block the mutation
+- **AND** the immutability rule SHALL remain in procest, not the forms leaf

--- a/openspec/changes/migrate-inspection-forms-to-forms-leaf/tasks.md
+++ b/openspec/changes/migrate-inspection-forms-to-forms-leaf/tasks.md
@@ -1,0 +1,38 @@
+# Tasks: migrate-inspection-forms-to-forms-leaf
+
+All tasks are in the `procest` repo. Estimates: S = half-day, M = 1–2 days, L = 3+ days.
+Implementation runs through Hydra; this change is specs-only.
+
+## [procest] Pre-migration Verification
+
+### P0. Confirm forms + photos leaf contracts (S)
+
+- [ ] P0.1 Confirm the OR forms leaf `id`, that it supports the checklist question types
+  (yes/no/`foto`/free-text), and the photos leaf `id`. Record in design.md DEFERRED_QUESTIONS.
+- [ ] P0.2 DECIDE backfill vs sunset-window for existing inline `photos[]`; open a GH issue.
+
+## [procest] Wire the leaves
+
+### P1. Forms + photos rendering (L)
+
+- [ ] P1.1 Whitelist the forms + photos leaves on the relevant schema(s)
+  (`inspectionChecklistRun` / `case`) `configuration.linkedTypes`.
+- [ ] P1.2 Render checklist items + advice/consultation forms through the forms leaf.
+- [ ] P1.3 Store inspection photos through the photos leaf; remove inline `photos[]` write path.
+
+## [procest] Keep domain rules
+
+### P2. Retain gates + immutability (M)
+
+- [ ] P2.1 Re-point `ChecklistService` photo-gate (`fotoRequired`) to count photos-leaf attachments.
+- [ ] P2.2 Confirm `ChecklistRunImmutabilityListener` append-only enforcement is unchanged.
+- [ ] P2.3 Confirm advice/consultation lifecycle + deadline tracking stays in-app.
+- [ ] P2.4 Reduce `InspectionChecklistPanel.vue` / `DocumentChecklist.vue` to leaf invocation + gate
+  feedback.
+
+## [procest] Quality gates
+
+### P3. Verify (S)
+
+- [ ] P3.1 `openspec validate migrate-inspection-forms-to-forms-leaf --strict` exits 0.
+- [ ] P3.2 `composer check:strict` and `npm run lint` pass; inspection gate + immutability tests pass.

--- a/openspec/changes/migrate-maps-to-maps-leaf/.openspec.yaml
+++ b/openspec/changes/migrate-maps-to-maps-leaf/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-25

--- a/openspec/changes/migrate-maps-to-maps-leaf/design.md
+++ b/openspec/changes/migrate-maps-to-maps-leaf/design.md
@@ -1,0 +1,50 @@
+# Design: migrate-maps-to-maps-leaf
+
+## Context
+
+OR's maps integration leaf (ADR-019 two-sided registry) ships a paired backend
+`IntegrationProvider` + frontend `OCA.OpenRegister.integrations.register({ id: 'maps', ... })`
+registration. Once enabled and whitelisted on the `case` schema's `configuration.linkedTypes`,
+the leaf contributes a map tab + card widget rendered by `CnObjectSidebar` /
+`@conduction/nextcloud-vue` on any page that hosts the OR object sidebar. The map marker is
+derived from the object's geo-typed property. Procest consumes this leaf; it does not modify it.
+
+## File-by-File Mapping
+
+| Existing procest artifact | Disposition |
+|---|---|
+| `src/components/map/MapComponent.vue` | Removed — leaf renders the map |
+| `src/components/map/CaseMap.vue` | Removed — replaced by maps leaf tab on case detail |
+| `src/components/map/LocationPicker.vue` | Removed — leaf provides location input affordance; geo-field edit stays via OR form |
+| `src/components/map/AddressSearch.vue` | Removed — address search is the PDOK shim (`migrate-pdok-to-openconnector`) |
+| `src/components/map/MapLayerSwitcher.vue` | Removed — layer switching is leaf-owned |
+| `src/components/map/MapLegend.vue` | Removed — leaf-owned |
+| `src/components/map/SpatialFilter.vue` | Removed — see "Multi-object overview" risk below |
+| `src/components/map/CasePopup.vue` | Removed — leaf marker popup |
+| `lib/Service/WmsWfsService.php` | Removed — WMS/WFS layer config is leaf-owned |
+| `lib/Service/WfsExportService.php` | Removed — leaf/OR export surface |
+| `lib/Service/LocationService.php` | Removed — geo data is a plain OR object property |
+| `case` schema `location` geo property | **Kept** — unchanged data contract |
+
+## Data contract (kept in procest)
+
+The `case` schema's `location` property remains a `geo`-typed field (GeoJSON, per OR's
+`geo-metadata-kaart`). The leaf reads this property to place the marker. No procest service
+writes map UI state; the geo value is edited through OR's standard object form and the leaf's
+location affordance.
+
+## Multi-object case-overview risk
+
+The `case-map-overview` spec describes a clustered map of MANY cases (workload heat-map). The
+maps leaf is an object-scoped tab/widget — it renders ONE object's geo. If the leaf cannot yet
+render a multi-object overview surface, the overview map is **not** re-implemented in-app:
+it is flagged as a follow-up against the OR maps leaf (open a GH issue at planning time per
+the "always file issues" rule). Single-case map (the common path) is fully covered by the leaf.
+
+## DEFERRED_QUESTIONS
+
+- Confirm the exact leaf `id` (`maps` assumed) and that its frontend registration is shipped in
+  the `@conduction/nextcloud-vue` version procest pins.
+- Confirm whether the maps leaf supports a multi-object overview surface or whether
+  `case-map-overview` needs an OR follow-up issue.
+- Confirm `configuration.linkedTypes` whitelist entry name for the maps leaf on the `case` schema.

--- a/openspec/changes/migrate-maps-to-maps-leaf/proposal.md
+++ b/openspec/changes/migrate-maps-to-maps-leaf/proposal.md
@@ -1,0 +1,78 @@
+# Proposal: migrate-maps-to-maps-leaf
+
+## Why
+
+Procest ships an entire in-app geographic stack: a Leaflet-based Vue map (`src/components/map/*.vue`
+— `MapComponent`, `CaseMap`, `LocationPicker`, `AddressSearch`, `MapLayerSwitcher`, `MapLegend`,
+`SpatialFilter`, `CasePopup`), PDOK base-tile + geocoding services (`lib/Service/Pdok/*`), a
+WMS/WFS layer client (`WmsWfsService`, `WfsExportService`), and a `LocationService`. The
+consumer-facing surface lives in specs `map-component`, `pdok-integration`, `wms-wfs-layers`,
+`case-map-overview`, and `case-location`.
+
+OpenRegister now provides a **maps** integration leaf (ADR-019 integration registry). The leaf
+renders an object's geo data as a map tab + widget on any OR-backed detail page, with base-tile,
+layer-switching, and marker interaction handled by the leaf — not the consuming app. Maintaining a
+parallel Leaflet/WMS/WFS stack in procest is a direct **ADR-022** violation (Apps Consume
+OpenRegister Abstractions). Concrete harms:
+
+- **Duplicate map UI**: procest re-implements pan/zoom/cluster/layer-switch that the maps leaf
+  already provides and tests; every other Conduction app that needs a map re-solves the same.
+- **Drift risk**: WMS/WFS layer config, tile sources, and marker styling evolve independently of
+  the fleet's shared map.
+- **Orphaned code**: eight map Vue components plus `WmsWfsService`/`WfsExportService`/`LocationService`
+  are maintenance surface with no architectural benefit once the leaf renders the map.
+- **PDOK already centralised**: address resolution is being moved into openconnector by the Hydra
+  umbrella `shared-pdok-via-openconnector` (procest-side: `migrate-pdok-to-openconnector`). The map
+  UI is the remaining in-app duplication.
+
+## What
+
+This change replaces procest's in-app map **UI** with the OR maps leaf on the `case` detail page,
+while keeping case-location **data** (the geo-typed field on the case schema) in procest's register:
+
+1. The `case` detail page renders the OR maps leaf tab/widget instead of `CaseMap.vue`. The case's
+   geo field supplies the marker; the leaf owns tiles, layers, zoom, and interaction.
+2. The eight `src/components/map/*.vue` components are removed once the leaf is wired in.
+3. `WmsWfsService`, `WfsExportService`, and `LocationService` are removed; layer rendering is the
+   leaf's responsibility. (PDOK geocoding is handled by `migrate-pdok-to-openconnector`, not here.)
+4. The `case` schema retains its `location` geo property — the geo *data* contract is unchanged;
+   only the *rendering* moves to the leaf.
+
+The existing procest specs (`case-location`) remain as the data contract. The map-rendering specs
+(`map-component`, `wms-wfs-layers`, `case-map-overview`) are superseded by the leaf and marked for
+sunset; `pdok-integration` is owned by the PDOK migration.
+
+## Capabilities
+
+### New Capabilities
+
+- `case-map-via-maps-leaf`: The case detail page renders its location through OR's maps integration
+  leaf instead of an in-app Leaflet component; procest stores only the geo field and registers no
+  map UI of its own.
+
+### Modified Capabilities
+
+- `case-location` (spec: `procest/openspec/specs/case-location/spec.md`) — the geo *data* contract
+  is unchanged; the spec note clarifies that rendering is delegated to the maps leaf, not an in-app
+  component.
+
+## Affected Projects
+
+- [x] Project: `procest` — all implementation tasks are in this repo
+- [x] Project: `openregister` — no code change; the maps leaf is consumed, not modified
+
+## Out of Scope
+
+- PDOK geocoding/address resolution — owned by `migrate-pdok-to-openconnector` and the Hydra
+  umbrella `shared-pdok-via-openconnector`. This change does NOT duplicate that work.
+- The maps leaf's own implementation in OR.
+- Backfill/migration of existing case `location` data (the geo field shape is unchanged).
+- The case-overview clustered map across many cases — if the maps leaf cannot render a
+  multi-object overview surface, that gap is flagged in design.md (possible follow-up), not
+  re-implemented in-app.
+
+## Success Criteria
+
+- `openspec validate migrate-maps-to-maps-leaf --strict` exits 0.
+- The case detail page shows the maps leaf tab/widget driven by the case `location` field.
+- `src/components/map/*.vue`, `WmsWfsService`, `WfsExportService`, `LocationService` are removed.

--- a/openspec/changes/migrate-maps-to-maps-leaf/specs/case-map-via-maps-leaf/spec.md
+++ b/openspec/changes/migrate-maps-to-maps-leaf/specs/case-map-via-maps-leaf/spec.md
@@ -1,0 +1,61 @@
+# case-map-via-maps-leaf Specification
+
+## ADDED Requirements
+
+### Requirement: Case Detail Renders Its Location Through The OR Maps Leaf
+
+The case detail page SHALL render the case's geographic location using OpenRegister's `maps`
+integration leaf (ADR-019) instead of an in-app Leaflet component. Procest SHALL NOT register
+its own map UI, tile source, or layer switcher.
+
+#### Scenario: Case with a location shows the maps leaf tab
+
+- **GIVEN** a `case` object whose `location` geo property contains a valid GeoJSON Point
+- **AND** the OR maps leaf is enabled and whitelisted on the `case` schema `configuration.linkedTypes`
+- **WHEN** a handler opens the case detail page
+- **THEN** the maps leaf tab SHALL be present in the object sidebar
+- **AND** the leaf SHALL place a marker at the coordinates from the case `location` property
+- **AND** no in-app `CaseMap.vue` / Leaflet component SHALL be mounted
+
+#### Scenario: Case without a location degrades gracefully
+
+- **GIVEN** a `case` object whose `location` property is empty
+- **WHEN** a handler opens the case detail page
+- **THEN** the maps leaf SHALL render its empty/no-location state
+- **AND** the page SHALL NOT error
+
+---
+
+### Requirement: Geo Data Contract Stays In Procest's Register
+
+The `case` schema SHALL retain its `location` geo-typed property as the single source of truth
+for case coordinates. The maps leaf SHALL read this property; procest SHALL NOT introduce a
+parallel location store or write map-UI state to its register.
+
+#### Scenario: Geo field remains a first-class case property
+
+- **GIVEN** the `case` schema after this migration
+- **WHEN** the schema is inspected
+- **THEN** the `location` property SHALL still be present and `geo`-typed (GeoJSON)
+- **AND** editing the case `location` through OR's object form SHALL update the marker the leaf renders
+
+#### Scenario: In-app geo services are removed
+
+- **GIVEN** the procest codebase after this migration
+- **WHEN** `lib/Service/` is inspected
+- **THEN** `WmsWfsService`, `WfsExportService`, and `LocationService` SHALL NOT be present
+- **AND** `src/components/map/` SHALL NOT contain in-app map rendering components
+
+---
+
+### Requirement: WMS/WFS And Layer Rendering Are Delegated To The Leaf
+
+WMS/WFS background layers, layer switching, and legend rendering SHALL be the maps leaf's
+responsibility. Procest SHALL NOT ship a WMS/WFS client or a layer-switcher component.
+
+#### Scenario: Layer controls come from the leaf
+
+- **GIVEN** the maps leaf rendered on a case detail page
+- **WHEN** the user interacts with map layers
+- **THEN** layer switching SHALL be provided by the leaf
+- **AND** procest SHALL issue no direct WMS/WFS HTTP request from its own service classes

--- a/openspec/changes/migrate-maps-to-maps-leaf/tasks.md
+++ b/openspec/changes/migrate-maps-to-maps-leaf/tasks.md
@@ -1,0 +1,47 @@
+# Tasks: migrate-maps-to-maps-leaf
+
+All tasks are in the `procest` repo. Estimates: S = half-day, M = 1–2 days, L = 3+ days.
+Implementation runs through Hydra; this change is specs-only.
+
+## [procest] Pre-migration Verification
+
+### P0. Confirm maps leaf contract (S)
+
+- [ ] P0.1 Confirm the OR maps leaf `id`, its frontend registration call, and the pinned
+  `@conduction/nextcloud-vue` version that ships it. Record in design.md DEFERRED_QUESTIONS.
+- [ ] P0.2 Confirm whether the maps leaf supports a multi-object overview surface; if not, open a
+  GH issue against OR for `case-map-overview` and link it here.
+
+## [procest] Wire the leaf
+
+### P1. Whitelist + render (M)
+
+- [ ] P1.1 Add the maps leaf to the `case` schema `configuration.linkedTypes` whitelist in the
+  register definition (`lib/Settings/procest_register.json`).
+- [ ] P1.2 Render the maps leaf tab/widget on the case detail page; confirm the marker reads the
+  case `location` geo property.
+- [ ] P1.3 Verify empty-location graceful degradation.
+
+## [procest] Remove in-app stack
+
+### P2. Delete superseded UI + services (M)
+
+- [ ] P2.1 Remove `src/components/map/*.vue` (MapComponent, CaseMap, LocationPicker, AddressSearch,
+  MapLayerSwitcher, MapLegend, SpatialFilter, CasePopup) and their imports.
+- [ ] P2.2 Remove `lib/Service/WmsWfsService.php`, `lib/Service/WfsExportService.php`,
+  `lib/Service/LocationService.php` and any DI registration.
+- [ ] P2.3 Confirm the `case` schema `location` geo property is unchanged.
+
+## [procest] Spec housekeeping
+
+### P3. Sunset superseded specs (S)
+
+- [ ] P3.1 Mark `map-component`, `wms-wfs-layers`, `case-map-overview` for sunset; keep
+  `case-location` as the geo data contract with a note that rendering is leaf-delegated.
+
+## [procest] Quality gates
+
+### P4. Verify (S)
+
+- [ ] P4.1 `openspec validate migrate-maps-to-maps-leaf --strict` exits 0.
+- [ ] P4.2 `composer check:strict` and `npm run lint` pass after removals.

--- a/openspec/changes/migrate-public-share-to-shares-leaf/.openspec.yaml
+++ b/openspec/changes/migrate-public-share-to-shares-leaf/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-25

--- a/openspec/changes/migrate-public-share-to-shares-leaf/design.md
+++ b/openspec/changes/migrate-public-share-to-shares-leaf/design.md
@@ -1,0 +1,40 @@
+# Design: migrate-public-share-to-shares-leaf
+
+## Context
+
+OR's shares integration leaf (ADR-019) contributes a shares tab + widget on an OR object's detail
+page. It creates share links with token generation, optional expiry, and revocation, and resolves
+public access through OR's standard public-share path. Procest consumes the leaf; it does not mint
+tokens or run its own public-access controller for the migrated path.
+
+## File-by-File Mapping
+
+| Existing procest artifact | Disposition |
+|---|---|
+| `lib/Controller/PublicShareController.php` | Token-resolution path removed/thinned — public access resolves via the shares leaf. Confirm whether a thin redirect/delegation route remains |
+| `src/views/cases/components/CreateShareDialog.vue` | Token "Share link" path removed; if the "Partner organization" path stays, the dialog is reduced to that concern only |
+| `src/views/cases/components/ShareTab.vue` | Token-share UI replaced by the shares leaf tab; removed if it only hosted token sharing |
+
+## What moves vs what stays
+
+- **Moves to the leaf**: share-link creation, token generation, listing, revocation, public-access
+  resolution for the case.
+- **Stays in procest (flagged out-of-scope)**: the "Partner organization" handover path, if it is
+  zaak-domain org-to-org logic rather than a generic share token.
+- **Decision needed**: whether historical tokens minted by `PublicShareController` must keep
+  resolving during a sunset window (legacy-compat read path) or are dropped at cutover.
+
+## Security note
+
+Removing the bespoke public controller removes a hand-maintained auth surface (token entropy,
+expiry, revocation, IDOR on case IDs). The shares leaf's audited public-access path is the
+ADR-022-preferred mechanism; this migration is a net security improvement, not just code removal.
+
+## DEFERRED_QUESTIONS
+
+- Confirm the OR shares leaf `id` and the pinned `@conduction/nextcloud-vue` version shipping it.
+- Confirm the shares leaf's public-access resolution surface (route shape) so `PublicShareController`
+  can be removed or thinned to a delegation.
+- DECISION: must legacy `PublicShareController` tokens keep resolving during a sunset window?
+- Confirm whether the "Partner organization" share type is zaak-domain handover (stays in-app) or a
+  generic share (also leaf-able).

--- a/openspec/changes/migrate-public-share-to-shares-leaf/proposal.md
+++ b/openspec/changes/migrate-public-share-to-shares-leaf/proposal.md
@@ -1,0 +1,71 @@
+# Proposal: migrate-public-share-to-shares-leaf
+
+## Why
+
+Procest ships a bespoke token-sharing mechanism: `PublicShareController` serves unauthenticated
+access to a shared case via a generated token, and `CreateShareDialog.vue` (with `ShareTab.vue`)
+mints those share links from the case detail page. This re-implements share-link creation, token
+generation, and public-access gating in-app.
+
+OpenRegister provides a **shares** integration leaf (ADR-019). The leaf creates, lists, and revokes
+share links for an OR object, with token generation, expiry, and public-access resolution owned by
+the leaf + OR's standard mechanism. Procest's in-app token sharing is a direct **ADR-022** violation
+(Apps Consume OpenRegister Abstractions):
+
+- **Duplicate token mechanism**: procest generates and validates share tokens that the shares leaf
+  already provides and tests.
+- **Drift + security surface**: a parallel public-access controller is an independent auth surface
+  to maintain (token entropy, expiry, revocation, IDOR risk) instead of consuming the audited leaf.
+- **No cross-app share inventory**: links minted in-app can't appear in a fleet-wide shares view.
+
+## What
+
+This change replaces procest's in-app token sharing with the OR shares leaf on the `case` detail
+page:
+
+1. The `CreateShareDialog.vue` "Share link" (token) path is replaced by the shares leaf tab/widget;
+   the case detail page surfaces share creation/listing/revocation through the leaf.
+2. `PublicShareController` token resolution is replaced by the shares leaf's public-access path.
+   The procest public case-view route is either removed or thinned to delegate to the leaf's
+   resolution (decided in design.md once the leaf's public surface is confirmed).
+3. `CreateShareDialog.vue` and `ShareTab.vue` are removed (or reduced to a non-token concern — see
+   the partner-organisation note below).
+
+### Partner-organisation sharing note
+
+`CreateShareDialog.vue` also offers a "Partner organization" share type that is NOT token-based
+public sharing — it is an org-to-org case-handover concern. This change migrates ONLY the **token
+public-share** path to the shares leaf. If the partner-organisation path is zaak-domain handover
+logic (not a generic share), it stays in-app and is flagged in design.md as out-of-scope for this
+leaf migration.
+
+## Capabilities
+
+### New Capabilities
+
+- `case-share-via-shares-leaf`: Public token sharing of a case is created, listed, and revoked
+  through OR's shares integration leaf; procest mints no share tokens of its own.
+
+### Modified Capabilities
+
+- (no existing org-wide spec changes requirements; procest has no canonical `public-share` spec —
+  the token sharing lives only in code. This change establishes the consumer contract.)
+
+## Affected Projects
+
+- [x] Project: `procest` — all implementation tasks are in this repo
+- [x] Project: `openregister` — no code change; the shares leaf is consumed, not modified
+
+## Out of Scope
+
+- The shares leaf's own implementation in OR.
+- Partner-organisation case handover (zaak-domain logic, not generic sharing) — stays in-app.
+- Migration of historical share tokens already minted by `PublicShareController` (sunset window;
+  confirm in design.md whether old tokens must keep resolving).
+- The citizen status page content itself (only the share/token gating moves to the leaf).
+
+## Success Criteria
+
+- `openspec validate migrate-public-share-to-shares-leaf --strict` exits 0.
+- The case detail page creates/lists/revokes public share links through the shares leaf.
+- `PublicShareController` token path and `CreateShareDialog.vue` token path are removed.

--- a/openspec/changes/migrate-public-share-to-shares-leaf/specs/case-share-via-shares-leaf/spec.md
+++ b/openspec/changes/migrate-public-share-to-shares-leaf/specs/case-share-via-shares-leaf/spec.md
@@ -1,0 +1,54 @@
+# case-share-via-shares-leaf Specification
+
+## ADDED Requirements
+
+### Requirement: Public Case Sharing Is Created Through The OR Shares Leaf
+
+Procest SHALL create, list, and revoke public share links for a case through OpenRegister's
+`shares` integration leaf (ADR-019). Procest SHALL NOT generate share tokens of its own after this
+migration.
+
+#### Scenario: Creating a share link uses the shares leaf
+
+- **GIVEN** a `case` object and the OR shares leaf enabled + whitelisted on the `case` schema
+- **WHEN** a handler creates a public share link from the case detail page
+- **THEN** the share link SHALL be created via the shares leaf, linked to the case
+- **AND** the link SHALL appear in the shares leaf tab/widget
+- **AND** no procest-minted share token SHALL be generated
+
+#### Scenario: Revoking a share link uses the shares leaf
+
+- **GIVEN** a case with an existing share link created via the leaf
+- **WHEN** a handler revokes the link
+- **THEN** the revocation SHALL be performed by the shares leaf
+- **AND** subsequent public access via that link SHALL be denied
+
+---
+
+### Requirement: The Bespoke Public-Share Controller And Dialog Token Path Are Removed
+
+Procest SHALL remove the in-app token-sharing path: the `PublicShareController` token-resolution
+logic and the `CreateShareDialog.vue` "Share link" token path SHALL NOT remain after this
+migration.
+
+#### Scenario: In-app token path is gone
+
+- **GIVEN** the procest codebase after this migration
+- **WHEN** `lib/Controller/PublicShareController.php` and `src/views/cases/components/` are inspected
+- **THEN** the bespoke share-token generation/resolution path SHALL NOT be present
+- **AND** any remaining public route SHALL delegate to the shares leaf's public-access resolution
+
+---
+
+### Requirement: Partner-Organisation Handover Is Out Of Scope For The Shares Leaf
+
+Procest SHALL treat the "Partner organization" share type as zaak-domain handover logic, not a
+generic share, and SHALL NOT migrate it to the shares leaf unless it is confirmed to be a generic
+share token.
+
+#### Scenario: Partner handover is not forced onto the leaf
+
+- **GIVEN** the "Partner organization" share type in the former dialog
+- **WHEN** this migration is applied
+- **THEN** only the public token-share path SHALL move to the shares leaf
+- **AND** the partner-organisation handover path SHALL remain in-app if it is zaak-domain logic

--- a/openspec/changes/migrate-public-share-to-shares-leaf/tasks.md
+++ b/openspec/changes/migrate-public-share-to-shares-leaf/tasks.md
@@ -1,0 +1,38 @@
+# Tasks: migrate-public-share-to-shares-leaf
+
+All tasks are in the `procest` repo. Estimates: S = half-day, M = 1–2 days, L = 3+ days.
+Implementation runs through Hydra; this change is specs-only.
+
+## [procest] Pre-migration Verification
+
+### P0. Confirm shares leaf contract (S)
+
+- [ ] P0.1 Confirm the OR shares leaf `id`, its public-access resolution route shape, and the
+  pinned `@conduction/nextcloud-vue` version. Record in design.md DEFERRED_QUESTIONS.
+- [ ] P0.2 DECIDE whether legacy `PublicShareController` tokens must keep resolving during a sunset
+  window; open a GH issue if a legacy-compat read path is required.
+
+## [procest] Wire the leaf
+
+### P1. Shares leaf on the case (M)
+
+- [ ] P1.1 Whitelist the shares leaf on the `case` schema `configuration.linkedTypes`.
+- [ ] P1.2 Replace the token "Share link" path with the shares leaf tab/widget on the case detail page.
+- [ ] P1.3 Verify create / list / revoke through the leaf.
+
+## [procest] Remove in-app token path
+
+### P2. Delete superseded code (M)
+
+- [ ] P2.1 Remove the token-resolution path from `lib/Controller/PublicShareController.php`
+  (or thin to a delegation to the leaf's public route).
+- [ ] P2.2 Remove the token path from `CreateShareDialog.vue`; reduce/remove `ShareTab.vue`. Keep
+  the "Partner organization" handover path if it is zaak-domain logic.
+
+## [procest] Quality gates
+
+### P3. Verify (S)
+
+- [ ] P3.1 `openspec validate migrate-public-share-to-shares-leaf --strict` exits 0.
+- [ ] P3.2 `composer check:strict` and `npm run lint` pass; route-auth gate clean for any remaining
+  public route.

--- a/openspec/changes/migrate-sla-dashboard-to-analytics-leaf/.openspec.yaml
+++ b/openspec/changes/migrate-sla-dashboard-to-analytics-leaf/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-25

--- a/openspec/changes/migrate-sla-dashboard-to-analytics-leaf/design.md
+++ b/openspec/changes/migrate-sla-dashboard-to-analytics-leaf/design.md
@@ -1,0 +1,41 @@
+# Design: migrate-sla-dashboard-to-analytics-leaf
+
+## Context
+
+OR's analytics integration leaf (ADR-019) renders chart/series widgets over data. The doorlooptijd
+dashboard currently couples two concerns that ADR-022 separates: (1) SLA-compliance **computation**
+(case-domain logic) and (2) chart **rendering** (generic plumbing). Only (2) is the shared
+abstraction. This change splits them: the leaf renders, procest computes.
+
+## File-by-File Mapping
+
+| Existing procest artifact | Disposition |
+|---|---|
+| `src/views/DoorlooptijdDashboard.vue` | Chart cards / apexcharts embedding replaced by the analytics leaf; view reduced to "compute then hand series to leaf" |
+| `src/utils/doorlooptijdHelpers.js` | **Kept** — `parseDurationToDays`, `getProcessingDays`, `getSlaTargetDays`, `buildCaseTypeMap`, `computeSlaCompliance` are case-domain logic |
+| direct `apexchart` imports in the view | Removed — the leaf owns the chart engine |
+
+## Why the SLA calc stays (ADR-022 boundary)
+
+`computeSlaCompliance` derives the SLA target from each case type's `processingDeadline`, applies
+case-type-specific exclusions, and produces a per-case-type compliance breakdown (`overallRate`,
+`withinSla`, `total`, `excluded`, `byType[]`). This is zaak-domain knowledge — the analytics leaf
+renders series but does not know what "within SLA" means for a VTH case vs a bezwaar. ADR-022's
+boundary is: shared *visualisation* abstraction (leaf) vs app *domain* logic (procest). The calc
+stays.
+
+### Optional unification (favor-unification preference)
+
+The long-term unified answer is to express the SLA target/compliance as a **schema-declarative
+derived field** on the case / case-type via OR's `x-openregister-calculations` (ADR-031), so the
+compliance number is computed once in the schema engine and the analytics leaf reads a plain field.
+That is a larger follow-up; this change keeps the calc in `doorlooptijdHelpers.js` and flags the
+ADR-031 path as the eventual unification (GH issue at planning time).
+
+## DEFERRED_QUESTIONS
+
+- Confirm the OR analytics leaf `id`, its series/input contract, and whether it renders dashboard-page
+  widgets (not just object-sidebar widgets) — the doorlooptijd dashboard is a page, not an object tab.
+- Confirm whether the analytics leaf accepts pre-computed series (procest computes) or expects to
+  query OR objects itself (would require the ADR-031 derived-field path).
+- Confirm `@conduction/nextcloud-vue` version shipping the analytics leaf.

--- a/openspec/changes/migrate-sla-dashboard-to-analytics-leaf/proposal.md
+++ b/openspec/changes/migrate-sla-dashboard-to-analytics-leaf/proposal.md
@@ -1,0 +1,66 @@
+# Proposal: migrate-sla-dashboard-to-analytics-leaf
+
+## Why
+
+Procest ships a bespoke SLA dashboard: `src/views/DoorlooptijdDashboard.vue` renders processing-time
+(doorlooptijd) charts with hand-rolled apexcharts, backed by the consumer spec `doorlooptijd-dashboard`.
+The chart-rendering surface — donut/series cards, skeletons, chart layout — is generic analytics
+plumbing that the fleet now provides centrally.
+
+OpenRegister provides an **analytics** integration leaf (ADR-019) that renders charts/widgets over
+OR object data. Re-implementing chart layout, series binding, and skeletons in-app is an **ADR-022**
+duplication of the analytics leaf's rendering responsibility.
+
+**Important distinction — domain calc stays, only charts move.** The SLA compliance computation in
+`src/utils/doorlooptijdHelpers.js` (`parseDurationToDays`, `getProcessingDays`, `getSlaTargetDays`,
+`buildCaseTypeMap`, `computeSlaCompliance`) is **case-domain logic**: it derives SLA targets from the
+case-type `processingDeadline`, applies exclusions, and produces per-case-type compliance
+breakdowns. That is zaak-domain knowledge OpenRegister's analytics leaf does not own. Per ADR-022,
+only the **chart/visualisation** layer is the shared abstraction; the **SLA calculation stays
+in-app** (and ideally surfaces as a case/case-type derived field via OR schema extensions — see
+design.md).
+
+## What
+
+This change moves the doorlooptijd dashboard's **chart rendering** to the analytics leaf while
+keeping the SLA calculation in procest:
+
+1. `DoorlooptijdDashboard.vue` stops embedding apexcharts directly; chart cards are rendered by the
+   OR analytics leaf, fed the series produced by `computeSlaCompliance`.
+2. `src/utils/doorlooptijdHelpers.js` SLA calculation functions are **kept** — they are case-domain
+   logic. They produce the data series the analytics leaf renders.
+3. The dashboard view is reduced to: invoke the domain calc, hand the resulting series to the
+   analytics leaf widget(s).
+
+## Capabilities
+
+### New Capabilities
+
+- `sla-charts-via-analytics-leaf`: The doorlooptijd dashboard renders its compliance charts through
+  OR's analytics integration leaf; procest embeds no chart library of its own. The SLA compliance
+  calculation remains an in-app case-domain function feeding the leaf.
+
+### Modified Capabilities
+
+- `doorlooptijd-dashboard` (spec: `procest/openspec/specs/doorlooptijd-dashboard/spec.md`) — the SLA
+  compliance calculation requirements are unchanged (domain logic stays); the chart-rendering
+  requirements now delegate to the analytics leaf instead of in-app apexcharts.
+
+## Affected Projects
+
+- [x] Project: `procest` — all implementation tasks are in this repo
+- [x] Project: `openregister` — no code change; the analytics leaf is consumed, not modified
+
+## Out of Scope
+
+- The analytics leaf's own implementation in OR.
+- The SLA compliance calculation logic in `doorlooptijdHelpers.js` — it STAYS (case-domain logic).
+- Replacing apexcharts as the underlying chart engine (the leaf owns the engine choice).
+- New SLA metrics beyond what `computeSlaCompliance` already produces.
+
+## Success Criteria
+
+- `openspec validate migrate-sla-dashboard-to-analytics-leaf --strict` exits 0.
+- The doorlooptijd dashboard renders compliance charts through the analytics leaf.
+- `doorlooptijdHelpers.js` SLA calculation functions remain in-app and feed the leaf.
+- `DoorlooptijdDashboard.vue` no longer imports apexcharts directly.

--- a/openspec/changes/migrate-sla-dashboard-to-analytics-leaf/specs/sla-charts-via-analytics-leaf/spec.md
+++ b/openspec/changes/migrate-sla-dashboard-to-analytics-leaf/specs/sla-charts-via-analytics-leaf/spec.md
@@ -1,0 +1,47 @@
+# sla-charts-via-analytics-leaf Specification
+
+## ADDED Requirements
+
+### Requirement: Doorlooptijd Charts Render Through The OR Analytics Leaf
+
+Procest SHALL render the doorlooptijd (SLA) dashboard charts through OpenRegister's `analytics`
+integration leaf (ADR-019). Procest SHALL NOT embed a chart library (apexcharts) directly in the
+dashboard view after this migration.
+
+#### Scenario: Compliance charts come from the analytics leaf
+
+- **GIVEN** completed cases and the OR analytics leaf available
+- **WHEN** a team lead opens the doorlooptijd dashboard
+- **THEN** the compliance charts SHALL be rendered by the analytics leaf
+- **AND** `DoorlooptijdDashboard.vue` SHALL NOT import apexcharts directly
+
+#### Scenario: Empty data degrades gracefully
+
+- **GIVEN** no completed cases match the current filter
+- **WHEN** the dashboard renders
+- **THEN** the analytics leaf SHALL render its empty state
+- **AND** the dashboard SHALL NOT error
+
+---
+
+### Requirement: The SLA Compliance Calculation Stays In-App As Case-Domain Logic
+
+Procest SHALL retain the SLA compliance calculation (`doorlooptijdHelpers.js`:
+`parseDurationToDays`, `getProcessingDays`, `getSlaTargetDays`, `buildCaseTypeMap`,
+`computeSlaCompliance`) in-app, because deriving SLA targets from case-type `processingDeadline`
+and applying case-type exclusions is zaak-domain logic the analytics leaf does not own.
+
+#### Scenario: Domain calc feeds the leaf
+
+- **GIVEN** the dashboard after this migration
+- **WHEN** the compliance series is produced
+- **THEN** `computeSlaCompliance` SHALL still compute `overallRate`, `withinSla`, `total`,
+  `excluded`, and the per-case-type `byType` breakdown
+- **AND** the resulting series SHALL be handed to the analytics leaf for rendering
+
+#### Scenario: SLA target still derives from case type
+
+- **GIVEN** a case whose case type defines `processingDeadline`
+- **WHEN** SLA compliance is computed
+- **THEN** `getSlaTargetDays` SHALL derive the target from the case-type `processingDeadline`
+- **AND** the analytics leaf SHALL NOT be responsible for this derivation

--- a/openspec/changes/migrate-sla-dashboard-to-analytics-leaf/tasks.md
+++ b/openspec/changes/migrate-sla-dashboard-to-analytics-leaf/tasks.md
@@ -1,0 +1,38 @@
+# Tasks: migrate-sla-dashboard-to-analytics-leaf
+
+All tasks are in the `procest` repo. Estimates: S = half-day, M = 1–2 days, L = 3+ days.
+Implementation runs through Hydra; this change is specs-only.
+
+## [procest] Pre-migration Verification
+
+### P0. Confirm analytics leaf contract (S)
+
+- [ ] P0.1 Confirm the OR analytics leaf `id`, its series-input contract, whether it renders
+  page-level (not just object-sidebar) widgets, and the pinned `@conduction/nextcloud-vue` version.
+  Record in design.md DEFERRED_QUESTIONS.
+- [ ] P0.2 Open a GH issue tracking the optional ADR-031 unification (SLA target/compliance as a
+  schema-declarative derived field) as a future follow-up.
+
+## [procest] Wire the leaf
+
+### P1. Analytics leaf charts (M)
+
+- [ ] P1.1 Replace the apexcharts chart cards in `DoorlooptijdDashboard.vue` with the analytics leaf
+  widget(s), fed the series from `computeSlaCompliance`.
+- [ ] P1.2 Verify empty-data graceful degradation through the leaf.
+
+## [procest] Keep domain calc
+
+### P2. Retain SLA logic (S)
+
+- [ ] P2.1 Confirm `doorlooptijdHelpers.js` SLA functions are unchanged and still produce the
+  `byType` breakdown consumed by the leaf.
+- [ ] P2.2 Remove direct apexcharts imports from the dashboard view.
+
+## [procest] Quality gates
+
+### P3. Verify (S)
+
+- [ ] P3.1 `openspec validate migrate-sla-dashboard-to-analytics-leaf --strict` exits 0.
+- [ ] P3.2 `composer check:strict` and `npm run lint` pass; doorlooptijd unit tests for the SLA calc
+  still pass.


### PR DESCRIPTION
## Summary

SPECS-ONLY (opsx artifacts). Five OpenSpec **migration changes** moving procest from building in-app Nextcloud-feature stacks to consuming OpenRegister **integration leaves**, per hydra **ADR-022** (apps consume OR abstractions). No code applied — apply runs through Hydra later.

Each change ships `proposal.md` + `design.md` + `specs/<cap>/spec.md` (`## ADDED Requirements`) + `tasks.md` and passes `openspec validate <name> --strict`.

| Change | Scope |
|---|---|
| `migrate-maps-to-maps-leaf` | Leaflet/PDOK-tile/WMS-WFS map UI + `WmsWfsService`/`WfsExportService`/`LocationService` → **maps** leaf on case detail; case `location` geo *data* kept. References hydra `shared-pdok-via-openconnector` for PDOK (not duplicated). |
| `migrate-appointments-to-calendar-leaf` | `LocalBackend` scheduling → **calendar** leaf; zaak appointment metadata kept as case fields. **Qmatic/JCC flagged as ADR-022 exception** (external municipal systems the leaf can't model) — keep in-app behind app-local ADR (a) or move to openconnector source (b). |
| `migrate-public-share-to-shares-leaf` | `PublicShareController` + `CreateShareDialog.vue` token sharing → **shares** leaf. Partner-organisation handover stays in-app (zaak-domain). |
| `migrate-sla-dashboard-to-analytics-leaf` | `DoorlooptijdDashboard.vue` apexcharts → **analytics** leaf; **SLA compliance calc (`doorlooptijdHelpers.js`) stays in-app** as case-domain logic feeding the leaf. |
| `migrate-inspection-forms-to-forms-leaf` | Advice/consultation + inspection checklist rendering → **forms** leaf; inspection photos → **photos** leaf. Photo-gate (`fotoRequired`) + append-only immutability listener stay in-app. |

## Kept in-app (documented ADR-022 exceptions — NOT migrated)
- CMMN/ZGW workflow engine.
- Parafering e-signature (already reuses OR NotificationService/ActivityService — the good template; see `migrate-parafering-to-or-approval-workflow`).

## Flagged exception
- **Qmatic / JCC** external appointment scheduling: calendar leaf can't host external municipal timeslot booking — recorded as an ADR-022 exception requiring an app-local ADR; resolution (a) in-app vs (b) openconnector source captured as a DEFERRED_QUESTION + GH issue at apply time.

Do not merge — coordinated via Hydra.