### PR TITLE
chore(spec): restore gate-16 coverage on ZgwMappingDialog

### DIFF
--- a/src/dialogs/ZgwMappingDialog.vue
+++ b/src/dialogs/ZgwMappingDialog.vue
@@ -120,6 +120,7 @@ export default {
 	watch: {
 		open: {
 			immediate: true,
+			/** @spec openspec/changes/retrofit-2026-05-24-zgw-api-mapping/tasks.md */
 			handler(value) {
 				if (value) {
 					this.initFromMapping()


### PR DESCRIPTION
Adds @spec to the handler method in the dialog extracted from ZgwMappingSettings during modal-isolation. gate-16 scoped=0.