### PR TITLE
chore: add publiccode.yml

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -1,0 +1,64 @@
+publiccodeYmlVersion: "0.4"
+
+name: Procest
+url: "https://github.com/ConductionNL/procest"
+softwareVersion: "0.2.2"
+releaseDate: "2026-05-26"
+developmentStatus: beta
+softwareType: "standalone/other"
+
+platforms:
+  - nextcloud
+
+categories:
+  - workflow-management
+  - process-management
+
+description:
+  en:
+    shortDescription: >
+      Business process and workflow management for Nextcloud.
+    longDescription: >
+      Procest is a business process and workflow management application for Nextcloud.
+      It enables organisations to model, execute, and monitor business processes and
+      workflows. Built on Open Register, it integrates with the Nextcloud ecosystem
+      and supports process automation and standardisation for both government and
+      commercial organisations.
+    features:
+      - Business process modelling and execution
+      - Workflow automation
+      - Process monitoring and reporting
+      - Integration with Nextcloud collaboration tools
+
+  nl:
+    shortDescription: >
+      Bedrijfsproces- en workflowbeheer voor Nextcloud.
+    longDescription: >
+      Procest is een bedrijfsprocesbeheers- en workflowtoepassing voor Nextcloud.
+      Het stelt organisaties in staat bedrijfsprocessen en workflows te modelleren,
+      uit te voeren en te monitoren. Gebouwd op Open Register integreert het met het
+      Nextcloud-ecosysteem en ondersteunt procesautomatisering en -standaardisatie
+      voor zowel overheids- als commerciële organisaties.
+    features:
+      - Bedrijfsprocessen modelleren en uitvoeren
+      - Workflowautomatisering
+      - Procesmonitoring en rapportage
+      - Integratie met Nextcloud-samenwerkingstools
+
+legal:
+  license: EUPL-1.2
+  mainCopyrightOwner: "Conduction B.V."
+  repoOwner: "Conduction B.V."
+
+maintenance:
+  type: community
+  contacts:
+    - name: Conduction B.V.
+      email: info@conduction.nl
+      affiliation: Conduction B.V.
+
+localisation:
+  localisationReady: true
+  availableLanguages:
+    - nl
+    - en


### PR DESCRIPTION
## Summary

- Adds `publiccode.yml` following the Standard for Public Code specification (v0.4)
- Mirrors the fleet format used by opencatalogi, openconnector, and docudesk
- Metadata (version, app name) sourced from `appinfo/info.xml`
- License set to EUPL-1.2; nl + en localisation declared

## Test plan

- [ ] Validate YAML parses correctly
- [ ] Verify `softwareVersion` matches current `appinfo/info.xml` version
- [ ] Confirm `url` points to the correct GitHub repository