### PR TITLE
fix(security): fail closed in ZgwService auth checks (CWE-863)

### DIFF
--- a/lib/Service/ZgwService.php
+++ b/lib/Service/ZgwService.php
@@ -692,7 +692,8 @@ class ZgwService
             $this->logger->warning(
                 'Could not check consumer scope: '.$e->getMessage()
             );
-            return true;
+            // Fail closed (CWE-863): on error, deny the scope rather than grant it.
+            return false;
         }//end try
     }//end consumerHasScope()
 
@@ -761,7 +762,10 @@ class ZgwService
             $this->logger->warning(
                 'Could not get consumer autorisaties: '.$e->getMessage()
             );
-            return null;
+            // Fail closed (CWE-863): on error, return an empty authorisation set
+            // (caller treats [] as "no scopes granted" → deny) rather than null,
+            // which the caller treats as "unrestricted / allow all".
+            return [];
         }//end try
     }//end getConsumerAuthorisaties()
 


### PR DESCRIPTION
## What
`consumerHasScope()` and `getConsumerAuthorisaties()` in `ZgwService` caught `\Throwable` and returned a **granting** value on error — `true` (has-scope) and `null` (= unrestricted per the contract, the caller treats null as allow-all). So any exception during the authorisation check **silently granted full access** (OWASP A01 / CWE-863, gate-8 unsafe-auth-resolver).

## Fix
Fail closed on error: `return false` / `return []` (deny). Normal-path returns are unchanged — only the `catch(\Throwable)` paths flip grant→deny.

## Note on gate-8
`validateJwtAuth()` is also flagged by gate-8 but its catch returns a **403** (already fail-closed); the `return null` is its success path. That's a gate false-positive addressed by a precision fix to gate-8 in hydra (only flag `return null` *inside* the catch block) — analogous to the gate-7 CORS-preflight refinement.