### PR TITLE
fix(security): enforce JWT auth on ZRC read endpoints to prevent BSN/PII leak (#634)

### DIFF
--- a/lib/Controller/ZrcController.php
+++ b/lib/Controller/ZrcController.php
@@ -117,6 +117,11 @@ class ZrcController extends Controller
      */
     public function index(string $resource): JSONResponse
     {
+        $authError = $this->zgwService->validateJwtAuth($this->request);
+        if ($authError !== null) {
+            return $authError;
+        }
+
         $response = $this->zgwService->handleIndex($this->request, self::ZGW_API, $resource);
 
         // Zrc-006a: Filter zaken results based on consumer's vertrouwelijkheidaanduiding.
@@ -319,13 +324,13 @@ class ZrcController extends Controller
      */
     public function show(string $resource, string $uuid): JSONResponse
     {
+        $authError = $this->zgwService->validateJwtAuth($this->request);
+        if ($authError !== null) {
+            return $authError;
+        }
+
         // Zrc-006b: Check zaken.lezen scope and vertrouwelijkheidaanduiding.
         if ($resource === 'zaken') {
-            $authError = $this->zgwService->validateJwtAuth($this->request);
-            if ($authError !== null) {
-                return $authError;
-            }
-
             $scopeError = $this->checkZaakReadAccess(uuid: $uuid);
             if ($scopeError !== null) {
                 return $scopeError;
@@ -746,6 +751,11 @@ class ZrcController extends Controller
      */
     public function audittrailIndex(string $resource, string $uuid): JSONResponse
     {
+        $authError = $this->zgwService->validateJwtAuth($this->request);
+        if ($authError !== null) {
+            return $authError;
+        }
+
         return $this->zgwService->handleAudittrailIndex($this->request, self::ZGW_API, $resource, $uuid);
     }//end audittrailIndex()
 
@@ -766,6 +776,11 @@ class ZrcController extends Controller
      */
     public function audittrailShow(string $resource, string $uuid, string $auditUuid): JSONResponse
     {
+        $authError = $this->zgwService->validateJwtAuth($this->request);
+        if ($authError !== null) {
+            return $authError;
+        }
+
         return $this->zgwService->handleAudittrailShow($this->request, self::ZGW_API, $resource, $uuid, $auditUuid);
     }//end audittrailShow()
 

--- a/tests/Unit/Controller/ZrcControllerAuthTest.php
+++ b/tests/Unit/Controller/ZrcControllerAuthTest.php
@@ -1,0 +1,260 @@
+<?php
+
+/**
+ * ZrcController Authentication Guard Tests
+ *
+ * Verifies that index(), show(), audittrailIndex(), and audittrailShow()
+ * return 401 for unauthenticated requests (security fix for issue #634).
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\ZrcController;
+use OCA\Procest\Service\ZgwService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IL10N;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Auth guard tests for ZrcController (issue #634 fix).
+ *
+ * Ensures every read endpoint that was previously @PublicPage without JWT
+ * validation now enforces authentication.
+ *
+ * @covers \OCA\Procest\Controller\ZrcController
+ */
+class ZrcControllerAuthTest extends TestCase
+{
+
+    /**
+     * The mocked request.
+     *
+     * @var IRequest|MockObject
+     */
+    private IRequest $request;
+
+    /**
+     * The mocked ZGW service.
+     *
+     * @var ZgwService|MockObject
+     */
+    private ZgwService $zgwService;
+
+    /**
+     * The mocked l10n service.
+     *
+     * @var IL10N|MockObject
+     */
+    private IL10N $l10n;
+
+    /**
+     * The controller under test.
+     *
+     * @var ZrcController
+     */
+    private ZrcController $controller;
+
+    /**
+     * A pre-built 401 JSONResponse returned by validateJwtAuth when no token is present.
+     *
+     * @var JSONResponse
+     */
+    private JSONResponse $unauthResponse;
+
+
+    /**
+     * Set up test fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->request    = $this->createMock(originalClassName: IRequest::class);
+        $this->zgwService = $this->createMock(originalClassName: ZgwService::class);
+        $this->l10n       = $this->createMock(originalClassName: IL10N::class);
+
+        $this->unauthResponse = new JSONResponse(
+            data: [
+                'type'   => 'NotAuthenticated',
+                'code'   => 'not_authenticated',
+                'title'  => 'Authenticatiegegevens zijn niet opgegeven.',
+                'status' => 401,
+                'detail' => 'Authenticatiegegevens zijn niet opgegeven.',
+            ],
+            statusCode: Http::STATUS_UNAUTHORIZED
+        );
+
+        $this->controller = new ZrcController(
+            appName: 'procest',
+            request: $this->request,
+            zgwService: $this->zgwService,
+            l10n: $this->l10n,
+        );
+    }//end setUp()
+
+
+    /**
+     * Test that index() returns 401 when no Authorization header is present.
+     *
+     * @return void
+     */
+    public function testIndexReturns401WhenUnauthenticated(): void
+    {
+        $this->zgwService
+            ->expects($this->once())
+            ->method('validateJwtAuth')
+            ->with($this->request)
+            ->willReturn($this->unauthResponse);
+
+        // HandleIndex must NOT be called — auth should short-circuit first.
+        $this->zgwService->expects($this->never())->method('handleIndex');
+
+        $response = $this->controller->index(resource: 'zaken');
+
+        $this->assertSame(expected: Http::STATUS_UNAUTHORIZED, actual: $response->getStatus());
+    }//end testIndexReturns401WhenUnauthenticated()
+
+
+    /**
+     * Test that show() returns 401 for all resources when unauthenticated.
+     *
+     * @return void
+     */
+    public function testShowReturns401WhenUnauthenticated(): void
+    {
+        $this->zgwService
+            ->expects($this->once())
+            ->method('validateJwtAuth')
+            ->with($this->request)
+            ->willReturn($this->unauthResponse);
+
+        $this->zgwService->expects($this->never())->method('handleShow');
+
+        $response = $this->controller->show(resource: 'zaken', uuid: 'some-uuid');
+
+        $this->assertSame(expected: Http::STATUS_UNAUTHORIZED, actual: $response->getStatus());
+    }//end testShowReturns401WhenUnauthenticated()
+
+
+    /**
+     * Test that show() for non-zaken resources also returns 401 when unauthenticated.
+     *
+     * Previously the auth check was only applied when $resource === 'zaken', leaving
+     * other resources (statussen, resultaten, rollen, etc.) publicly accessible.
+     *
+     * @return void
+     */
+    public function testShowNonZaakResourceReturns401WhenUnauthenticated(): void
+    {
+        $this->zgwService
+            ->expects($this->once())
+            ->method('validateJwtAuth')
+            ->with($this->request)
+            ->willReturn($this->unauthResponse);
+
+        $this->zgwService->expects($this->never())->method('handleShow');
+
+        $response = $this->controller->show(resource: 'statussen', uuid: 'some-uuid');
+
+        $this->assertSame(expected: Http::STATUS_UNAUTHORIZED, actual: $response->getStatus());
+    }//end testShowNonZaakResourceReturns401WhenUnauthenticated()
+
+
+    /**
+     * Test that audittrailIndex() returns 401 when unauthenticated.
+     *
+     * @return void
+     */
+    public function testAudittrailIndexReturns401WhenUnauthenticated(): void
+    {
+        $this->zgwService
+            ->expects($this->once())
+            ->method('validateJwtAuth')
+            ->with($this->request)
+            ->willReturn($this->unauthResponse);
+
+        $this->zgwService->expects($this->never())->method('handleAudittrailIndex');
+
+        $response = $this->controller->audittrailIndex(resource: 'zaken', uuid: 'some-uuid');
+
+        $this->assertSame(expected: Http::STATUS_UNAUTHORIZED, actual: $response->getStatus());
+    }//end testAudittrailIndexReturns401WhenUnauthenticated()
+
+
+    /**
+     * Test that audittrailShow() returns 401 when unauthenticated.
+     *
+     * @return void
+     */
+    public function testAudittrailShowReturns401WhenUnauthenticated(): void
+    {
+        $this->zgwService
+            ->expects($this->once())
+            ->method('validateJwtAuth')
+            ->with($this->request)
+            ->willReturn($this->unauthResponse);
+
+        $this->zgwService->expects($this->never())->method('handleAudittrailShow');
+
+        $response = $this->controller->audittrailShow(
+            resource: 'zaken',
+            uuid: 'some-uuid',
+            auditUuid: 'audit-uuid'
+        );
+
+        $this->assertSame(expected: Http::STATUS_UNAUTHORIZED, actual: $response->getStatus());
+    }//end testAudittrailShowReturns401WhenUnauthenticated()
+
+
+    /**
+     * Test that index() proceeds past auth when validateJwtAuth returns null (valid token).
+     *
+     * @return void
+     */
+    public function testIndexProceedsWhenAuthenticated(): void
+    {
+        $this->zgwService
+            ->method('validateJwtAuth')
+            ->with($this->request)
+            ->willReturn(null);
+
+        $expectedResponse = new JSONResponse(
+            data: ['count' => 0, 'next' => null, 'previous' => null, 'results' => []],
+            statusCode: Http::STATUS_OK
+        );
+
+        $this->zgwService
+            ->expects($this->once())
+            ->method('handleIndex')
+            ->willReturn($expectedResponse);
+
+        // GetConsumerAuthorisaties is called by filterZakenByAuthorisation (returns null = superuser).
+        $this->zgwService
+            ->method('getConsumerAuthorisaties')
+            ->willReturn(null);
+
+        $response = $this->controller->index(resource: 'zaken');
+
+        $this->assertSame(expected: Http::STATUS_OK, actual: $response->getStatus());
+    }//end testIndexProceedsWhenAuthenticated()
+
+}//end class


### PR DESCRIPTION
## Summary

- CRITICAL fix for issue #634: unauthenticated ZRC list/audit-trail leaks BSN+PII
- index(), show(), audittrailIndex(), audittrailShow() in ZrcController were all @PublicPage without a validateJwtAuth call, returning live case data (including BSN) to anonymous callers
- Inserts validateJwtAuth at the top of all four methods — a missing Authorization header now returns 401 before any data is fetched
- Also hardens show(): the auth check was previously applied only when resource === zaken; it now applies to all resources (statussen, resultaten, rollen, etc.)
- Adds ZrcControllerAuthTest with 6 tests (5 unauth + 1 authenticated happy path) covering all four endpoints

## Test plan

- [x] vendor/bin/phpunit — 146 tests / 409 assertions green
- [x] vendor/bin/phpstan analyse lib/Controller/ZrcController.php — no errors
- [x] vendor/bin/phpcs (lib/ only) — 0 errors, pre-existing warnings only
- [x] New ZrcControllerAuthTest — 6 tests / 12 assertions green

Fixes #634