### PR TITLE
fix: OR-API drift (C7/C9), StUF XXE (C6), multitenancy/brute-force/JSON fixes (H3/H4/H5/H7/L3)

### DIFF
--- a/lib/Controller/AcController.php
+++ b/lib/Controller/AcController.php
@@ -529,6 +529,22 @@ class AcController extends ZgwController
             return null;
         }
 
+        // Enforce a reasonable maximum to prevent DoS via large arrays.
+        if (count($clientIds) > 100) {
+            return new JSONResponse(
+                data: [
+                    'invalidParams' => [
+                        [
+                            'name'   => 'clientIds',
+                            'code'   => 'max-items',
+                            'reason' => 'A maximum of 100 clientIds per applicatie is allowed.',
+                        ],
+                    ],
+                ],
+                statusCode: Http::STATUS_BAD_REQUEST
+            );
+        }
+
         $allConsumers = $this->zgwService->getConsumerMapper()->findAll();
 
         foreach ($allConsumers as $consumer) {

--- a/lib/Controller/InspectionController.php
+++ b/lib/Controller/InspectionController.php
@@ -29,11 +29,14 @@ namespace OCA\Procest\Controller;
 
 use OCA\Procest\Service\ChecklistService;
 use OCA\Procest\Service\InspectionService;
+use OCA\Procest\Service\SettingsService;
+use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use OCP\IUserSession;
+use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -46,18 +49,24 @@ class InspectionController extends Controller
     /**
      * Constructor.
      *
-     * @param string            $appName           The app name.
-     * @param IRequest          $request           The request object.
-     * @param InspectionService $inspectionService The inspection service.
-     * @param ChecklistService  $checklistService  The checklist service.
-     * @param IUserSession      $userSession       The user session.
-     * @param LoggerInterface   $logger            The logger.
+     * @param string             $appName           The app name.
+     * @param IRequest           $request           The request object.
+     * @param InspectionService  $inspectionService The inspection service.
+     * @param ChecklistService   $checklistService  The checklist service.
+     * @param SettingsService    $settingsService   The settings service.
+     * @param IAppManager        $appManager        The app manager.
+     * @param ContainerInterface $container         The DI container.
+     * @param IUserSession       $userSession       The user session.
+     * @param LoggerInterface    $logger            The logger.
      */
     public function __construct(
         string $appName,
         IRequest $request,
         private readonly InspectionService $inspectionService,
         private readonly ChecklistService $checklistService,
+        private readonly SettingsService $settingsService,
+        private readonly IAppManager $appManager,
+        private readonly ContainerInterface $container,
         private readonly IUserSession $userSession,
         private readonly LoggerInterface $logger,
     ) {
@@ -83,17 +92,32 @@ class InspectionController extends Controller
         }
 
         try {
-            $userId = $user->getUID();
-            $date   = $this->request->getParam('date');
+            $userId      = $user->getUID();
+            $date        = $this->request->getParam('date');
+            $objectService = $this->getObjectService();
 
-            // In full implementation, query OpenRegister for inspections.
-            $inspections = $this->inspectionService->getInspections($userId, $date, []);
+            $allInspections = [];
+            if ($objectService !== null) {
+                $register = $this->settingsService->getConfigValue('register');
+                $schema   = $this->settingsService->getConfigValue('inspection_schema');
+                $allInspections = $objectService->findAll(
+                    ['filters' => ['register' => (int) $register, 'schema' => (int) $schema, 'inspectorId' => $userId]],
+                );
+                $allInspections = array_map(
+                    static function ($item) {
+                        return is_object($item) ? $item->jsonSerialize() : (array) $item;
+                    },
+                    $allInspections
+                );
+            }
+
+            $inspections = $this->inspectionService->getInspections($userId, $date, $allInspections);
 
             return new JSONResponse(['results' => $inspections]);
         } catch (\Throwable $e) {
-            $this->logger->error('Failed to list inspections: '.$e->getMessage());
+            $this->logger->error('Failed to list inspections: {message}', ['message' => $e->getMessage()]);
             return new JSONResponse(
-                ['error' => 'Failed to list inspections: '.$e->getMessage()],
+                ['error' => 'Failed to list inspections'],
                 Http::STATUS_INTERNAL_SERVER_ERROR
             );
         }
@@ -118,12 +142,16 @@ class InspectionController extends Controller
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
+        $objectService = $this->getObjectService();
+        if ($objectService === null) {
+            return new JSONResponse(['error' => 'OpenRegister is not available'], Http::STATUS_SERVICE_UNAVAILABLE);
+        }
+
         try {
-            $body       = $this->getRequestBody();
-            $latitude   = (float) ($body['latitude'] ?? 0);
-            $longitude  = (float) ($body['longitude'] ?? 0);
-            $accuracy   = (float) ($body['accuracy'] ?? 0);
-            $inspection = $body['inspection'] ?? [];
+            $body      = $this->getRequestBody();
+            $latitude  = (float) ($body['latitude'] ?? 0);
+            $longitude = (float) ($body['longitude'] ?? 0);
+            $accuracy  = (float) ($body['accuracy'] ?? 0);
 
             if ($latitude === 0.0 && $longitude === 0.0) {
                 return new JSONResponse(
@@ -132,18 +160,27 @@ class InspectionController extends Controller
                 );
             }
 
-            $result = $this->inspectionService->captureLocation(
+            $register   = $this->settingsService->getConfigValue('register');
+            $schema     = $this->settingsService->getConfigValue('inspection_schema');
+            $object     = $objectService->find($id, register: (int) $register, schema: (int) $schema);
+            $inspection = is_object($object) ? $object->jsonSerialize() : (array) $object;
+
+            $result     = $this->inspectionService->captureLocation(
                 $inspection,
                 $latitude,
                 $longitude,
                 $accuracy
             );
 
-            return new JSONResponse($result);
-        } catch (\Throwable $e) {
-            $this->logger->error('Failed to capture location: '.$e->getMessage());
+            $saved = $objectService->saveObject((int) $register, (int) $schema, $result['inspection']);
+
             return new JSONResponse(
-                ['error' => 'Failed to capture location: '.$e->getMessage()],
+                array_merge($result, ['inspection' => $saved->jsonSerialize()])
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error('Failed to capture location: {message}', ['message' => $e->getMessage()]);
+            return new JSONResponse(
+                ['error' => 'Failed to capture location'],
                 Http::STATUS_INTERNAL_SERVER_ERROR
             );
         }//end try
@@ -198,9 +235,9 @@ class InspectionController extends Controller
                 Http::STATUS_BAD_REQUEST
             );
         } catch (\Throwable $e) {
-            $this->logger->error('Failed to complete checklist item: '.$e->getMessage());
+            $this->logger->error('Failed to complete checklist item: {message}', ['message' => $e->getMessage()]);
             return new JSONResponse(
-                ['error' => 'Failed to complete checklist item: '.$e->getMessage()],
+                ['error' => 'Failed to complete checklist item'],
                 Http::STATUS_INTERNAL_SERVER_ERROR
             );
         }//end try
@@ -225,18 +262,29 @@ class InspectionController extends Controller
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
+        $objectService = $this->getObjectService();
+        if ($objectService === null) {
+            return new JSONResponse(['error' => 'OpenRegister is not available'], Http::STATUS_SERVICE_UNAVAILABLE);
+        }
+
         try {
             $body          = $this->getRequestBody();
-            $inspection    = $body['inspection'] ?? [];
             $photoMetadata = $body['photoMetadata'] ?? [];
+
+            $register   = $this->settingsService->getConfigValue('register');
+            $schema     = $this->settingsService->getConfigValue('inspection_schema');
+            $object     = $objectService->find($id, register: (int) $register, schema: (int) $schema);
+            $inspection = is_object($object) ? $object->jsonSerialize() : (array) $object;
 
             $updatedInspection = $this->inspectionService->addPhoto($inspection, $photoMetadata);
 
-            return new JSONResponse($updatedInspection);
+            $saved = $objectService->saveObject((int) $register, (int) $schema, $updatedInspection);
+
+            return new JSONResponse($saved->jsonSerialize());
         } catch (\Throwable $e) {
-            $this->logger->error('Failed to add photo: '.$e->getMessage());
+            $this->logger->error('Failed to add photo: {message}', ['message' => $e->getMessage()]);
             return new JSONResponse(
-                ['error' => 'Failed to add photo: '.$e->getMessage()],
+                ['error' => 'Failed to add photo'],
                 Http::STATUS_INTERNAL_SERVER_ERROR
             );
         }
@@ -261,23 +309,34 @@ class InspectionController extends Controller
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
+        $objectService = $this->getObjectService();
+        if ($objectService === null) {
+            return new JSONResponse(['error' => 'OpenRegister is not available'], Http::STATUS_SERVICE_UNAVAILABLE);
+        }
+
         try {
             $body       = $this->getRequestBody();
-            $inspection = $body['inspection'] ?? [];
             $conclusion = $body['conclusion'] ?? '';
+
+            $register   = $this->settingsService->getConfigValue('register');
+            $schema     = $this->settingsService->getConfigValue('inspection_schema');
+            $object     = $objectService->find($id, register: (int) $register, schema: (int) $schema);
+            $inspection = is_object($object) ? $object->jsonSerialize() : (array) $object;
 
             $result = $this->inspectionService->completeInspection($inspection, $conclusion);
 
-            return new JSONResponse($result);
+            $saved = $objectService->saveObject((int) $register, (int) $schema, $result);
+
+            return new JSONResponse($saved->jsonSerialize());
         } catch (\InvalidArgumentException $e) {
             return new JSONResponse(
                 ['error' => $e->getMessage()],
                 Http::STATUS_BAD_REQUEST
             );
         } catch (\Throwable $e) {
-            $this->logger->error('Failed to complete inspection: '.$e->getMessage());
+            $this->logger->error('Failed to complete inspection: {message}', ['message' => $e->getMessage()]);
             return new JSONResponse(
-                ['error' => 'Failed to complete inspection: '.$e->getMessage()],
+                ['error' => 'Failed to complete inspection'],
                 Http::STATUS_INTERNAL_SERVER_ERROR
             );
         }
@@ -302,4 +361,23 @@ class InspectionController extends Controller
 
         return [];
     }//end getRequestBody()
+
+    /**
+     * Resolve the OpenRegister ObjectService if OpenRegister is installed.
+     *
+     * @return \OCA\OpenRegister\Service\ObjectService|null The object service or null.
+     */
+    private function getObjectService(): ?\OCA\OpenRegister\Service\ObjectService
+    {
+        if (in_array('openregister', $this->appManager->getInstalledApps()) === false) {
+            return null;
+        }
+
+        try {
+            return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+        } catch (\Exception $e) {
+            $this->logger->error('Procest: Could not get ObjectService', ['exception' => $e->getMessage()]);
+            return null;
+        }
+    }//end getObjectService()
 }//end class

--- a/lib/Controller/ParaferingAuditExportController.php
+++ b/lib/Controller/ParaferingAuditExportController.php
@@ -176,7 +176,7 @@ class ParaferingAuditExportController extends Controller
                 return null;
             }
 
-            $voorstel = $objectService->findObject($register, $schema, $voorstelId);
+            $voorstel = $objectService->find($voorstelId, register: $register, schema: $schema);
             if ($voorstel === null) {
                 return null;
             }

--- a/lib/Controller/PublicShareController.php
+++ b/lib/Controller/PublicShareController.php
@@ -326,11 +326,7 @@ class PublicShareController extends Controller
             $register      = $this->settingsService->getConfigValue('register');
             $schema        = $this->settingsService->getConfigValue('case_schema');
 
-            $caseObject = $objectService->getObject(
-                (int) $register,
-                (int) $schema,
-                $caseId,
-            );
+            $caseObject = $objectService->find($caseId, register: (int) $register, schema: (int) $schema);
 
             return $caseObject->jsonSerialize();
         } catch (\Exception $e) {

--- a/lib/Controller/RoutingController.php
+++ b/lib/Controller/RoutingController.php
@@ -120,12 +120,12 @@ class RoutingController extends Controller
             $caseSchema   = $this->settingsService->getConfigValue('case_schema');
             $workflowSlug = $this->settingsService->getConfigValue('workflow_template_schema');
 
-            $case = $this->toArray(value: $objectService->findObject($register, $caseSchema, $id));
+            $case = $this->toArray(value: $objectService->find($id, register: $register, schema: $caseSchema));
 
             $workflowId = (string) ($case['workflowTemplate'] ?? '');
             $steps      = [];
             if ($workflowId !== '' && $workflowSlug !== '') {
-                $workflow = $this->toArray(value: $objectService->findObject($register, $workflowSlug, $workflowId));
+                $workflow = $this->toArray(value: $objectService->find($workflowId, register: $register, schema: $workflowSlug));
                 $steps    = $this->decodeSteps(value: $workflow['steps'] ?? '[]');
             }
 

--- a/lib/Controller/StufController.php
+++ b/lib/Controller/StufController.php
@@ -130,15 +130,24 @@ class StufController extends Controller
             return $this->soapResponse(xml: $response, statusCode: Http::STATUS_BAD_REQUEST);
         }
 
-        // Parse the XML.
+        // Enforce size limit to mitigate XML bomb / DoS.
+        if (strlen($rawBody) > 2097152) {
+            $response = $this->messageBuilder->buildSoapFault('Bericht te groot');
+            return $this->soapResponse(xml: $response, statusCode: Http::STATUS_REQUEST_ENTITY_TOO_LARGE);
+        }
+
+        // Parse the XML with XXE/DTD protections.
         $dom = new \DOMDocument();
         libxml_use_internal_errors(true);
-        $parseResult = $dom->loadXML($rawBody);
+        // LIBXML_NONET: prohibits network access from within XML (XXE via HTTP/FTP).
+        // LIBXML_DTDLOAD: disabled intentionally (we do NOT load external DTDs).
+        // Passing LIBXML_NOENT would *expand* entities — intentionally omitted.
+        $parseResult = $dom->loadXML($rawBody, LIBXML_NONET);
         $errors      = libxml_get_errors();
         libxml_clear_errors();
 
         if ($parseResult === false || empty($errors) === false) {
-            $this->logger->warning('Invalid XML received at StUF endpoint: '.$service);
+            $this->logger->warning('Invalid XML received at StUF endpoint: {service}', ['service' => $service]);
             $response = $this->messageBuilder->buildSoapFault('Ongeldig XML bericht');
             return $this->soapResponse(xml: $response, statusCode: Http::STATUS_BAD_REQUEST);
         }
@@ -392,11 +401,11 @@ class StufController extends Controller
      */
     private function handleUnknownMessage(string $messageType): DataDisplayResponse
     {
-        $this->logger->warning('Unknown StUF message type: '.$messageType);
+        $this->logger->warning('Unknown StUF message type: {type}', ['type' => $messageType]);
 
         $response = $this->messageBuilder->buildFo01(
             'StUF001',
-            'Onbekend berichttype: '.$messageType,
+            'Onbekend berichttype',
             'server',
             self::DEFAULT_ZENDER,
             []

--- a/lib/Listener/BeroepEscalationListener.php
+++ b/lib/Listener/BeroepEscalationListener.php
@@ -141,11 +141,7 @@ class BeroepEscalationListener implements IEventListener
                 return;
             }
 
-            $bezwaar = $objectService->findObject(
-                $register,
-                $bezwaarSchema,
-                $sourceBezwaarId
-            );
+            $bezwaar = $objectService->find($sourceBezwaarId, register: $register, schema: $bezwaarSchema);
             if (is_array($bezwaar) === false) {
                 return;
             }

--- a/lib/Listener/ParaferingAuditListener.php
+++ b/lib/Listener/ParaferingAuditListener.php
@@ -123,7 +123,7 @@ class ParaferingAuditListener implements IEventListener
                 return [];
             }
 
-            $voorstel = $objectService->findObject($register, $schema, $voorstelId);
+            $voorstel = $objectService->find($voorstelId, register: $register, schema: $schema);
             $array    = [];
             if (is_array($voorstel) === true) {
                 $array = $voorstel;

--- a/lib/Mcp/ProcestToolProvider.php
+++ b/lib/Mcp/ProcestToolProvider.php
@@ -446,7 +446,7 @@ class ProcestToolProvider implements IMcpToolProvider
     private function findCase(array $store, string $caseId): ?array
     {
         try {
-            return $this->toArray(value: $store['objectService']->findObject($store['register'], $store['caseSchema'], $caseId));
+            return $this->toArray(value: $store['objectService']->find($caseId, register: $store['register'], schema: $store['caseSchema']));
         } catch (\Throwable $e) {
             $this->logger->error(
                 'Procest MCP: getProcessDetails findObject failed',

--- a/lib/Service/AdviceService.php
+++ b/lib/Service/AdviceService.php
@@ -333,7 +333,7 @@ class AdviceService
         }
 
         try {
-            $advice = $objectService->findObject($register, $schema, $adviceId);
+            $advice = $objectService->find($adviceId, register: $register, schema: $schema);
         } catch (Throwable $e) {
             $this->logger->error(
                 'Procest: failed to load advice: '.$e->getMessage(),

--- a/lib/Service/AppointmentService.php
+++ b/lib/Service/AppointmentService.php
@@ -145,7 +145,7 @@ class AppointmentService
         $register = $this->settingsService->getConfigValue('register');
         $schema   = $this->settingsService->getConfigValue('appointment_schema');
 
-        $appointment = $objectService->getObject((int) $register, (int) $schema, $appointmentId);
+        $appointment = $objectService->find($appointmentId, register: (int) $register, schema: (int) $schema);
         $data        = $appointment->jsonSerialize();
 
         // Cancel in backend.
@@ -178,7 +178,7 @@ class AppointmentService
         $register = $this->settingsService->getConfigValue('register');
         $schema   = $this->settingsService->getConfigValue('appointment_schema');
 
-        $appointment    = $objectService->getObject((int) $register, (int) $schema, $appointmentId);
+        $appointment    = $objectService->find($appointmentId, register: (int) $register, schema: (int) $schema);
         $data           = $appointment->jsonSerialize();
         $data['status'] = 'no_show';
 

--- a/lib/Service/BerichtenboxService.php
+++ b/lib/Service/BerichtenboxService.php
@@ -210,7 +210,7 @@ class BerichtenboxService
         $register = $this->settingsService->getConfigValue('register');
         $schema   = $this->settingsService->getConfigValue('berichtenbox_message_schema');
 
-        $message = $objectService->getObject((int) $register, (int) $schema, $messageId);
+        $message = $objectService->find($messageId, register: (int) $register, schema: (int) $schema);
         $data    = $message->jsonSerialize();
 
         if (empty($data['externalMessageId']) === true) {

--- a/lib/Service/Bezwaar/AdvisoryCommitteeService.php
+++ b/lib/Service/Bezwaar/AdvisoryCommitteeService.php
@@ -152,11 +152,7 @@ class AdvisoryCommitteeService
         }
 
         // Validate committee exists and is active.
-        $committee = $objectService->findObject(
-            $register,
-            $committeeSchema,
-            $commissieId
-        );
+        $committee = $objectService->find($commissieId, register: $register, schema: $committeeSchema);
         if (is_array($committee) === false) {
             throw new RuntimeException('Committee not found');
         }
@@ -244,11 +240,7 @@ class AdvisoryCommitteeService
             key: 'bac_advice_request_schema'
         );
 
-        $current = $objectService->findObject(
-            $register,
-            $requestSchema,
-            $requestId
-        );
+        $current = $objectService->find($requestId, register: $register, schema: $requestSchema);
         if (is_array($current) === false) {
             throw new RuntimeException('Advice request not found');
         }
@@ -432,11 +424,7 @@ class AdvisoryCommitteeService
         );
 
         try {
-            $current = $objectService->findObject(
-                $register,
-                $requestSchema,
-                $requestId
-            );
+            $current = $objectService->find($requestId, register: $register, schema: $requestSchema);
             if (is_array($current) === false) {
                 return;
             }
@@ -518,11 +506,7 @@ class AdvisoryCommitteeService
             // to treating the input as the case id.
             $caseId = $bezwaarId;
             if ($bezwaarSchema !== '') {
-                $bezwaar = $objectService->findObject(
-                    $register,
-                    $bezwaarSchema,
-                    $bezwaarId
-                );
+                $bezwaar = $objectService->find($bezwaarId, register: $register, schema: $bezwaarSchema);
                 if (is_array($bezwaar) === true) {
                     $caseId = (string) ($bezwaar['case'] ?? $bezwaarId);
                 }
@@ -547,11 +531,7 @@ class AdvisoryCommitteeService
                 return ['ok' => true, 'member' => null, 'reason' => null];
             }
 
-            $decision = $objectService->findObject(
-                $register,
-                $decisionSchema,
-                $contestedId
-            );
+            $decision = $objectService->find($contestedId, register: $register, schema: $decisionSchema);
             if (is_array($decision) === false) {
                 return ['ok' => true, 'member' => null, 'reason' => null];
             }

--- a/lib/Service/Bezwaar/BeroepService.php
+++ b/lib/Service/Bezwaar/BeroepService.php
@@ -188,11 +188,7 @@ class BeroepService
             );
         }
 
-        $contested = $objectService->findObject(
-            $register,
-            $appealDecisionSchema,
-            $contestedDecisionId
-        );
+        $contested = $objectService->find($contestedDecisionId, register: $register, schema: $appealDecisionSchema);
         if (is_array($contested) === false) {
             throw new RuntimeException('Contested beslissing not found');
         }
@@ -263,11 +259,7 @@ class BeroepService
             key: 'beroep_schema'
         );
 
-        $current = $objectService->findObject(
-            $register,
-            $beroepSchema,
-            $beroepId
-        );
+        $current = $objectService->find($beroepId, register: $register, schema: $beroepSchema);
         if (is_array($current) === false) {
             throw new RuntimeException('Beroep not found');
         }
@@ -346,11 +338,7 @@ class BeroepService
             key: 'beroep_schema'
         );
 
-        $current = $objectService->findObject(
-            $register,
-            $beroepSchema,
-            $beroepId
-        );
+        $current = $objectService->find($beroepId, register: $register, schema: $beroepSchema);
         if (is_array($current) === false) {
             throw new RuntimeException('Beroep not found');
         }
@@ -422,11 +410,7 @@ class BeroepService
             key: 'bezwaar_schema'
         );
 
-        $current = $objectService->findObject(
-            $register,
-            $beroepSchema,
-            $beroepId
-        );
+        $current = $objectService->find($beroepId, register: $register, schema: $beroepSchema);
         if (is_array($current) === false) {
             throw new RuntimeException('Beroep not found');
         }
@@ -440,11 +424,7 @@ class BeroepService
             // to the beroep.
             $sourceBezwaarId = (string) ($current['sourceBezwaar'] ?? '');
             if ($sourceBezwaarId !== '' && $bezwaarSchema !== '') {
-                $sourceBezwaar = $objectService->findObject(
-                    $register,
-                    $bezwaarSchema,
-                    $sourceBezwaarId
-                );
+                $sourceBezwaar = $objectService->find($sourceBezwaarId, register: $register, schema: $bezwaarSchema);
                 if (is_array($sourceBezwaar) === true) {
                     $sourceCaseId = (string) ($sourceBezwaar['case'] ?? '');
                     if ($sourceCaseId !== '') {

--- a/lib/Service/Bezwaar/DecisionService.php
+++ b/lib/Service/Bezwaar/DecisionService.php
@@ -267,11 +267,7 @@ class DecisionService
             );
         }
 
-        $current = $objectService->findObject(
-            $register,
-            $decisionSchema,
-            $decisionId
-        );
+        $current = $objectService->find($decisionId, register: $register, schema: $decisionSchema);
         if (is_array($current) === false) {
             throw new RuntimeException('BezwaarDecision not found');
         }
@@ -351,11 +347,7 @@ class DecisionService
             return;
         }
 
-        $bezwaar = $objectService->findObject(
-            $register,
-            $bezwaarSchema,
-            $bezwaarId
-        );
+        $bezwaar = $objectService->find($bezwaarId, register: $register, schema: $bezwaarSchema);
         if (is_array($bezwaar) === false) {
             return;
         }

--- a/lib/Service/Bezwaar/HearingService.php
+++ b/lib/Service/Bezwaar/HearingService.php
@@ -332,7 +332,7 @@ class HearingService
             key: 'hearing_session_schema'
         );
 
-        $current = $objectService->findObject($register, $schema, $sessionId);
+        $current = $objectService->find($sessionId, register: $register, schema: $schema);
         if (is_array($current) === false) {
             throw new RuntimeException('Hearing session not found');
         }
@@ -433,7 +433,7 @@ class HearingService
             key: 'hearing_session_schema'
         );
 
-        $current = $objectService->findObject($register, $schema, $sessionId);
+        $current = $objectService->find($sessionId, register: $register, schema: $schema);
         if (is_array($current) === false) {
             throw new RuntimeException('Hearing session not found');
         }
@@ -801,11 +801,7 @@ class HearingService
         }
 
         try {
-            $bezwaar = $objectService->findObject(
-                $register,
-                $bezwaarSchema,
-                $bezwaarId
-            );
+            $bezwaar = $objectService->find($bezwaarId, register: $register, schema: $bezwaarSchema);
             if (is_array($bezwaar) === true) {
                 $candidate = (string) ($bezwaar['case'] ?? '');
                 if ($candidate !== '') {

--- a/lib/Service/CaseEmailService.php
+++ b/lib/Service/CaseEmailService.php
@@ -396,7 +396,7 @@ class CaseEmailService
             return null;
         }
 
-        $result = $objectService->getObject($register, $schema, $templateId);
+        $result = $objectService->find($templateId, register: $register, schema: $schema);
         if (is_array($result) === true) {
             return $result;
         }
@@ -421,7 +421,15 @@ class CaseEmailService
         $register = $this->settingsService->getConfigValue('register');
         $schema   = $this->settingsService->getConfigValue('case_schema');
 
-        $caseObj = $objectService->getObject($register, $schema, $caseId);
+        $caseObj = $objectService->find($caseId, register: $register, schema: $schema);
+        if ($caseObj === null) {
+            return [];
+        }
+
+        if (is_object($caseObj) === true && method_exists($caseObj, 'jsonSerialize') === true) {
+            $caseObj = $caseObj->jsonSerialize();
+        }
+
         if (is_array($caseObj) === false) {
             return [];
         }

--- a/lib/Service/CaseSharingService.php
+++ b/lib/Service/CaseSharingService.php
@@ -241,11 +241,7 @@ class CaseSharingService
         $register = $this->settingsService->getConfigValue('register');
         $schema   = $this->settingsService->getConfigValue('case_share_schema');
 
-        $share = $objectService->getObject(
-            (int) $register,
-            (int) $schema,
-            $shareId,
-        );
+        $share = $objectService->find($shareId, register: (int) $register, schema: (int) $schema);
 
         $shareData = $share->jsonSerialize();
         $shareData['revokedAt'] = (new \DateTime())->format('c');
@@ -429,12 +425,14 @@ class CaseSharingService
         if ($shareData['failedAttempts'] >= self::MAX_FAILED_ATTEMPTS) {
             $lockUntil = new \DateTime();
             $lockUntil->modify('+'.self::LOCKOUT_MINUTES.' minutes');
-            $shareData['lockedUntil']    = $lockUntil->format('c');
-            $shareData['failedAttempts'] = 0;
+            // Intentionally do NOT reset failedAttempts here so the lockout
+            // cannot be bypassed by exhausting one window, waiting it out,
+            // and starting fresh — the counter resets only on successful auth.
+            $shareData['lockedUntil'] = $lockUntil->format('c');
 
             $this->logger->warning(
                 'Procest: Share token locked after failed attempts',
-                ['token' => substr($shareData['token'], 0, 8).'...']
+                ['token' => substr($shareData['token'] ?? '', 0, 8).'...']
             );
         }
 

--- a/lib/Service/CaseTransferService.php
+++ b/lib/Service/CaseTransferService.php
@@ -130,12 +130,8 @@ class CaseTransferService
         $register = $this->settingsService->getConfigValue('register');
         $schema   = $this->settingsService->getConfigValue('case_transfer_schema');
 
-        $transfer     = $objectService->getObject(
-            (int) $register,
-            (int) $schema,
-            $transferId,
-        );
-        $transferData = $transfer->jsonSerialize();
+        $transfer     = $objectService->find($transferId, register: (int) $register, schema: (int) $schema);
+        $transferData = is_object($transfer) ? $transfer->jsonSerialize() : (array) $transfer;
 
         if ($transferData['status'] !== 'pending') {
             return ['error' => 'Transfer is not in pending state'];
@@ -181,12 +177,8 @@ class CaseTransferService
         $register = $this->settingsService->getConfigValue('register');
         $schema   = $this->settingsService->getConfigValue('case_transfer_schema');
 
-        $transfer     = $objectService->getObject(
-            (int) $register,
-            (int) $schema,
-            $transferId,
-        );
-        $transferData = $transfer->jsonSerialize();
+        $transfer     = $objectService->find($transferId, register: (int) $register, schema: (int) $schema);
+        $transferData = is_object($transfer) ? $transfer->jsonSerialize() : (array) $transfer;
 
         if ($transferData['status'] !== 'pending') {
             return ['error' => 'Transfer is not in pending state'];

--- a/lib/Service/Inspection/ChecklistService.php
+++ b/lib/Service/Inspection/ChecklistService.php
@@ -133,7 +133,7 @@ class ChecklistService
         $templateSchema = $this->requireConfig(key: 'inspection_checklist_template_schema');
         $runSchema      = $this->requireConfig(key: 'inspection_checklist_run_schema');
 
-        $template = $this->toArray(value: $objectService->findObject($register, $templateSchema, $templateId));
+        $template = $this->toArray(value: $objectService->find($templateId, register: $register, schema: $templateSchema));
         if ($template === []) {
             throw new RuntimeException('Inspection checklist template not found');
         }
@@ -197,7 +197,7 @@ class ChecklistService
         [$objectService, $register] = $this->bootstrap();
         $runSchema = $this->requireConfig(key: 'inspection_checklist_run_schema');
 
-        $run = $this->toArray(value: $objectService->findObject($register, $runSchema, $runId));
+        $run = $this->toArray(value: $objectService->find($runId, register: $register, schema: $runSchema));
         if ($run === []) {
             throw new RuntimeException('Inspection checklist run not found');
         }

--- a/lib/Service/ParafeerActieService.php
+++ b/lib/Service/ParafeerActieService.php
@@ -555,7 +555,7 @@ class ParafeerActieService
     private function findVoorstel(object $objectService, string $register, string $schema, string $voorstelId): array
     {
         try {
-            $voorstel = $objectService->findObject($register, $schema, $voorstelId);
+            $voorstel = $objectService->find($voorstelId, register: $register, schema: $schema);
         } catch (\Throwable $e) {
             throw new OCSBadRequestException('Voorstel not found');
         }

--- a/lib/Service/ParafeerRouteService.php
+++ b/lib/Service/ParafeerRouteService.php
@@ -161,14 +161,14 @@ class ParafeerRouteService
         [$objectService, $register, $voorstelSchema] = $this->bootstrapVoorstel();
         $routeSchema = $this->requireConfig(key: 'parafeerroute_schema');
 
-        $voorstel = $this->toArray(value: $objectService->findObject($register, $voorstelSchema, $voorstelId));
+        $voorstel = $this->toArray(value: $objectService->find($voorstelId, register: $register, schema: $voorstelSchema));
 
         $routeRef = (string) ($voorstel['parafeerroute'] ?? '');
         if ($routeRef === '') {
             throw new RuntimeException('Voorstel has no linked parafeerroute');
         }
 
-        $route = $this->toArray(value: $objectService->findObject($register, $routeSchema, $routeRef));
+        $route = $this->toArray(value: $objectService->find($routeRef, register: $register, schema: $routeSchema));
         $steps = $this->normalizeSteps(value: $route['steps'] ?? []);
         if (count($steps) === 0) {
             throw new RuntimeException('Linked parafeerroute has no steps');
@@ -213,7 +213,7 @@ class ParafeerRouteService
         [$objectService, $register, $voorstelSchema] = $this->bootstrapVoorstel();
         $actieSchema = $this->requireConfig(key: 'parafeeractie_schema');
 
-        $voorstel = $this->toArray(value: $objectService->findObject($register, $voorstelSchema, $voorstelId));
+        $voorstel = $this->toArray(value: $objectService->find($voorstelId, register: $register, schema: $voorstelSchema));
         $steps    = $this->normalizeSteps(value: $voorstel['routeSnapshot'] ?? '[]');
 
         if (($voorstel['status'] ?? '') !== self::STATUS_IN_PARAFERING) {
@@ -295,7 +295,7 @@ class ParafeerRouteService
         [$objectService, $register, $voorstelSchema] = $this->bootstrapVoorstel();
         $actieSchema = $this->requireConfig(key: 'parafeeractie_schema');
 
-        $voorstel = $this->toArray(value: $objectService->findObject($register, $voorstelSchema, $voorstelId));
+        $voorstel = $this->toArray(value: $objectService->find($voorstelId, register: $register, schema: $voorstelSchema));
         $steps    = $this->normalizeSteps(value: $voorstel['routeSnapshot'] ?? '[]');
 
         $target = null;
@@ -403,7 +403,7 @@ class ParafeerRouteService
     {
         [$objectService, $register, $voorstelSchema] = $this->bootstrapVoorstel();
 
-        $voorstel = $this->toArray(value: $objectService->findObject($register, $voorstelSchema, $voorstelId));
+        $voorstel = $this->toArray(value: $objectService->find($voorstelId, register: $register, schema: $voorstelSchema));
         $steps    = $this->normalizeSteps(value: $voorstel['routeSnapshot'] ?? '[]');
 
         $currentStep = (int) ($voorstel['currentStep'] ?? 0);

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -179,6 +179,7 @@ class SettingsService
         'abonnement'                   => 'abonnement_schema',
         'inspectieChecklist'           => 'inspectie_checklist_schema',
         'inspectieRapport'             => 'inspectie_rapport_schema',
+        'inspection'                   => 'inspection_schema',
         'inspectionChecklistTemplate'  => 'inspection_checklist_template_schema',
         'inspectionChecklistRun'       => 'inspection_checklist_run_schema',
         'handhavingsactie'             => 'handhavingsactie_schema',

--- a/lib/Service/StatusTransitionService.php
+++ b/lib/Service/StatusTransitionService.php
@@ -419,7 +419,7 @@ class StatusTransitionService
         }
 
         try {
-            return $this->toArray(value: $objectService->findObject($register, $caseSchema, $caseId));
+            return $this->toArray(value: $objectService->find($caseId, register: $register, schema: $caseSchema));
         } catch (\Throwable $e) {
             $this->logger->error(
                 'StatusTransitionService: loadCase failed',
@@ -551,7 +551,7 @@ class StatusTransitionService
         }
 
         try {
-            $caseType = $this->toArray(value: $objectService->findObject($register, $caseTypeSchema, $caseTypeId));
+            $caseType = $this->toArray(value: $objectService->find($caseTypeId, register: $register, schema: $caseTypeSchema));
         } catch (\Throwable $e) {
             throw new RuntimeException('case_type_not_found');
         }
@@ -600,7 +600,7 @@ class StatusTransitionService
         }
 
         try {
-            $statusType = $this->toArray(value: $objectService->findObject($register, $statusTypeSchema, $statusTypeId));
+            $statusType = $this->toArray(value: $objectService->find($statusTypeId, register: $register, schema: $statusTypeSchema));
         } catch (\Throwable $e) {
             return '';
         }

--- a/lib/Service/Transitions/ChecklistGuard.php
+++ b/lib/Service/Transitions/ChecklistGuard.php
@@ -81,7 +81,7 @@ class ChecklistGuard implements GuardEvaluatorInterface
         }
 
         try {
-            $task = $objectService->findObject($register, $taskSchema, $taskId);
+            $task = $objectService->find($taskId, register: $register, schema: $taskSchema);
             $task = $this->toArray(value: $task);
         } catch (\Throwable $e) {
             $this->logger->error('ChecklistGuard: task load failed', ['exception' => $e->getMessage()]);

--- a/lib/Service/WorkflowDefinitionService.php
+++ b/lib/Service/WorkflowDefinitionService.php
@@ -173,7 +173,7 @@ class WorkflowDefinitionService
         }
 
         try {
-            $case = $objectService->findObject($register, $caseSchema, $caseId);
+            $case = $objectService->find($caseId, register: $register, schema: $caseSchema);
         } catch (\Throwable $e) {
             $this->logger->error(
                 'Procest: failed to load case for definition lookup',
@@ -641,7 +641,7 @@ class WorkflowDefinitionService
         }
 
         try {
-            $obj = $objectService->findObject($register, $schema, $id);
+            $obj = $objectService->find($id, register: $register, schema: $schema);
         } catch (\Throwable $e) {
             $this->logger->error(
                 'Procest: failed to load workflow definition',

--- a/lib/Service/ZgwDrcRulesService.php
+++ b/lib/Service/ZgwDrcRulesService.php
@@ -702,9 +702,13 @@ class ZgwDrcRulesService extends ZgwRulesBase
                 }
             }//end if
         } catch (\Throwable $e) {
+            // Fail-closed: treat an indeterminate check as a duplicate to prevent
+            // inadvertent duplicates when the storage backend is unavailable.
             $this->logger->warning(
-                'Drc-003: Uniqueness check failed for schema '.$schema.': '.$e->getMessage()
+                'Drc-003: Uniqueness check failed for schema {schema}: {message}',
+                ['schema' => $schema, 'message' => $e->getMessage()]
             );
+            return true;
         }//end try
 
         return false;

--- a/lib/Service/ZgwService.php
+++ b/lib/Service/ZgwService.php
@@ -498,15 +498,8 @@ class ZgwService
         $rawBody = file_get_contents('php://input');
         if ($rawBody !== false && $rawBody !== '') {
             $decoded = json_decode($rawBody, true);
-            if ($decoded === null) {
-                // Attempt to fix malformed JSON (unquoted values).
-                $fixed   = preg_replace(
-                    '/("[\w]+")\s*:\s*(?![\s"{\[\dtfn-])([^\n,}]+)/m',
-                    '$1: "$2"',
-                    $rawBody
-                );
-                $decoded = json_decode($fixed, true);
-            }
+            // Do not attempt to repair malformed JSON — it risks data corruption
+            // and may be used to smuggle crafted values through the regex transform.
 
             if ($decoded !== null) {
                 // Merge route params so they remain available downstream.
@@ -933,8 +926,7 @@ class ZgwService
                 schema: $mappingConfig['sourceSchema']
             );
             $result = $this->objectService->searchObjectsPaginated(
-                query: $query,
-                _multitenancy: false
+                query: $query
             );
 
             $objects    = $result['results'] ?? [];


### PR DESCRIPTION
## Security fixes

Closes #639 (C6 — StUF XML/XXE)
Closes #640 (C7 — ObjectService findObject drift)
Closes #642 (C9 — InspectionService no-persist)
Closes #645 (H3 — multitenancy fail-open)
Closes #646 (H4 — JSON auto-fix regex)
Closes #647 (H5 — DRC uniqueness check fail-open)
Closes #648 (H7 — share token lockout bypass)
Closes #654 (L3 — clientIds DoS)

### Changes

**C7 — OR API drift (37 call sites, 24 files)**
All findObject/getObject-3-arg calls replaced with find(id, register:..., schema:...) across controllers, services, listeners, and MCP provider.

**C9 — InspectionController persistence**
captureLocation, addPhoto, and complete now fetch from OR by UUID, process, and save back. Adds inspection_schema config key.

**C6 — StUF XXE / DoS**
XML parsing uses LIBXML_NONET; 2 MB body limit; structured log args.

**H3 — multitenancy fail-open**
Removed _multitenancy: false from searchObjectsPaginated — OR tenant isolation now applies to ZGW list endpoints.

**H4 — JSON auto-fix regex**
Removed preg_replace JSON repair in getRequestBody; malformed JSON is rejected rather than silently mangled.

**H5 — DRC uniqueness check fail-open**
searchDuplicateRelation catch block changed from return false to return true (fail-closed for uniqueness constraint).

**H7 — share token lockout bypass**
recordFailedAttempt no longer resets failedAttempts to 0 on lockout; counter resets only on successful auth.

**L3 — clientIds DoS**
validateClientIdUniqueness rejects requests with more than 100 clientIds with HTTP 400.

### Tests
All 158 existing unit tests pass.