### PR TITLE
fix: use force:false in repair step to prevent overwriting operator schema customisations

### DIFF
--- a/lib/Repair/InitializeSettings.php
+++ b/lib/Repair/InitializeSettings.php
@@ -77,7 +77,7 @@ class InitializeSettings implements IRepairStep
         }
 
         try {
-            $result = $this->settingsService->loadConfiguration(force: true);
+            $result = $this->settingsService->loadConfiguration(force: false);
 
             if ($result['success'] === true) {
                 $version = ($result['version'] ?? 'unknown');


### PR DESCRIPTION
## Summary

Fixes the `loadConfiguration(force: true)` anti-pattern in the Nextcloud repair step that was inherited from the app template scaffold.

- Changes `lib/Repair/InitializeSettings.php` from `force: true` to `force: false`
- Leaves `SettingsController::load()` on `force: true` (intentional admin reset button)

## Why

`force: true` caused the seed register to be **re-imported on every Nextcloud upgrade**, silently overwriting any operator-customised schema fields, properties, and permissions.

`force: false` seeds only when not yet imported — the correct behaviour for an automatic repair step.

Closes #665

## References

- Upstream template fix: ConductionNL/nextcloud-app-template#74
- Source: nextcloud-app-template C1 propagation sweep 2026-05-27