### PR TITLE
fix(security): bump twig/twig to ^3.27.0 (CVE-2026-48805/06/07/08, CVE-2026-46636)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
 	"require-dev": {
 		"cyclonedx/cyclonedx-php-composer": "^6.2",
 		"edgedesign/phpqa": "^1.27",
+		"twig/twig": "^3.27.0",
 		"nextcloud/coding-standard": "^1.4",
 		"nextcloud/ocp": "^31.0",
 		"phpcsstandards/phpcsextra": "^1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "62d90425388f53bfb9c7a9ba6ea08f54",
+    "content-hash": "2f0c524e7b6411fb15e1591e0b967073",
     "packages": [],
     "packages-dev": [
         {
@@ -6811,16 +6811,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
+                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/14c5439eec4ccff081ac14eca2dc57feb2a66d92",
+                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92",
                 "shasum": ""
             },
             "require": {
@@ -6872,7 +6872,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -6892,7 +6892,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T17:25:58+00:00"
+            "time": "2026-05-26T12:51:13+00:00"
         },
         {
             "name": "symfony/polyfill-php81",
@@ -7424,16 +7424,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v3.26.0",
+            "version": "v3.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "1fcae487b180d78e6351f4e0afa91f9eab96a2bc"
+                "reference": "04ae1bfe9463c816cf72ca0abe7eae2c77a9a9ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/1fcae487b180d78e6351f4e0afa91f9eab96a2bc",
-                "reference": "1fcae487b180d78e6351f4e0afa91f9eab96a2bc",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/04ae1bfe9463c816cf72ca0abe7eae2c77a9a9ed",
+                "reference": "04ae1bfe9463c816cf72ca0abe7eae2c77a9a9ed",
                 "shasum": ""
             },
             "require": {
@@ -7488,7 +7488,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.26.0"
+                "source": "https://github.com/twigphp/Twig/tree/v3.27.0"
             },
             "funding": [
                 {
@@ -7500,7 +7500,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-20T07:31:59+00:00"
+            "time": "2026-05-27T13:05:51+00:00"
         },
         {
             "name": "vimeo/psalm",


### PR DESCRIPTION
## Summary

- Bumps `twig/twig` from v3.26.0 to v3.27.0 to fix 5 sandbox-bypass CVEs disclosed 2026-05-27
- Adds explicit `"twig/twig": "^3.27.0"` to `require-dev` (was purely transitive via `edgedesign/phpqa`)
- `composer audit` is clean after the bump

## CVEs fixed

| CVE | Title |
|-----|-------|
| CVE-2026-48805 | Sandbox state regression in deprecated internal wrappers in `src/Resources/core.php` |
| CVE-2026-48806 | Sandbox `__toString()` policy bypass via dynamic mapping keys |
| CVE-2026-48807 | Sandbox `__toString()` policy bypass via `Traversable` in `join`/`replace` and `in`/`not in` operators |
| CVE-2026-48808 | Sandbox property allowlist bypass via the `column` filter under `SourcePolicyInterface` |
| CVE-2026-46636 | Sandbox filter, tag and function allow-list bypass when sandbox state changes between renders |

## Dependency relationship

`twig/twig` is a transitive dependency pulled in by `edgedesign/phpqa ~1.38|~2.7|>=3`. An explicit floor constraint is added so future `composer update` runs cannot silently pull in a vulnerable version.

## Test plan

- [x] `composer audit` returns "No security vulnerability advisories found."
- [x] `twig/twig` v3.27.0 installed (up from v3.26.0)
- [ ] CI passes