### PR TITLE
fix: make composer check:strict pass on development

### DIFF
--- a/lib/Controller/AcController.php
+++ b/lib/Controller/AcController.php
@@ -166,7 +166,6 @@ class AcController extends ZgwController
      * @spec openspec/changes/retrofit-2026-05-25-zgw-autorisaties-api/tasks.md#task-5
      *
      * @NoCSRFRequired
-     * @PublicPage
      * @CORS
      */
     public function create(): JSONResponse
@@ -309,7 +308,6 @@ class AcController extends ZgwController
      * @spec openspec/changes/retrofit-2026-05-25-zgw-autorisaties-api/tasks.md#task-5
      *
      * @NoCSRFRequired
-     * @PublicPage
      * @CORS
      */
     public function update(string $uuid): JSONResponse
@@ -417,7 +415,6 @@ class AcController extends ZgwController
      * @spec openspec/changes/retrofit-2026-05-25-zgw-autorisaties-api/tasks.md#task-5
      *
      * @NoCSRFRequired
-     * @PublicPage
      * @CORS
      */
     public function patch(string $uuid): JSONResponse
@@ -436,7 +433,6 @@ class AcController extends ZgwController
      * @spec openspec/changes/retrofit-2026-05-25-zgw-autorisaties-api/tasks.md#task-5
      *
      * @NoCSRFRequired
-     * @PublicPage
      * @CORS
      */
     public function destroy(string $uuid): JSONResponse

--- a/lib/Controller/InspectionController.php
+++ b/lib/Controller/InspectionController.php
@@ -92,20 +92,24 @@ class InspectionController extends Controller
         }
 
         try {
-            $userId      = $user->getUID();
-            $date        = $this->request->getParam('date');
+            $userId        = $user->getUID();
+            $date          = $this->request->getParam('date');
             $objectService = $this->getObjectService();
 
             $allInspections = [];
             if ($objectService !== null) {
-                $register = $this->settingsService->getConfigValue('register');
-                $schema   = $this->settingsService->getConfigValue('inspection_schema');
+                $register       = $this->settingsService->getConfigValue('register');
+                $schema         = $this->settingsService->getConfigValue('inspection_schema');
                 $allInspections = $objectService->findAll(
                     ['filters' => ['register' => (int) $register, 'schema' => (int) $schema, 'inspectorId' => $userId]],
                 );
                 $allInspections = array_map(
                     static function ($item) {
-                        return is_object($item) ? $item->jsonSerialize() : (array) $item;
+                        if (is_object($item) === true) {
+                            return $item->jsonSerialize();
+                        }
+
+                        return (array) $item;
                     },
                     $allInspections
                 );
@@ -120,7 +124,7 @@ class InspectionController extends Controller
                 ['error' => 'Failed to list inspections'],
                 Http::STATUS_INTERNAL_SERVER_ERROR
             );
-        }
+        }//end try
     }//end index()
 
     /**
@@ -160,12 +164,16 @@ class InspectionController extends Controller
                 );
             }
 
-            $register   = $this->settingsService->getConfigValue('register');
-            $schema     = $this->settingsService->getConfigValue('inspection_schema');
-            $object     = $objectService->find($id, register: (int) $register, schema: (int) $schema);
-            $inspection = is_object($object) ? $object->jsonSerialize() : (array) $object;
+            $register = $this->settingsService->getConfigValue('register');
+            $schema   = $this->settingsService->getConfigValue('inspection_schema');
+            $object   = $objectService->find($id, register: (int) $register, schema: (int) $schema);
+            if (is_object($object) === true) {
+                $inspection = $object->jsonSerialize();
+            } else {
+                $inspection = (array) $object;
+            }
 
-            $result     = $this->inspectionService->captureLocation(
+            $result = $this->inspectionService->captureLocation(
                 $inspection,
                 $latitude,
                 $longitude,
@@ -271,10 +279,14 @@ class InspectionController extends Controller
             $body          = $this->getRequestBody();
             $photoMetadata = $body['photoMetadata'] ?? [];
 
-            $register   = $this->settingsService->getConfigValue('register');
-            $schema     = $this->settingsService->getConfigValue('inspection_schema');
-            $object     = $objectService->find($id, register: (int) $register, schema: (int) $schema);
-            $inspection = is_object($object) ? $object->jsonSerialize() : (array) $object;
+            $register = $this->settingsService->getConfigValue('register');
+            $schema   = $this->settingsService->getConfigValue('inspection_schema');
+            $object   = $objectService->find($id, register: (int) $register, schema: (int) $schema);
+            if (is_object($object) === true) {
+                $inspection = $object->jsonSerialize();
+            } else {
+                $inspection = (array) $object;
+            }
 
             $updatedInspection = $this->inspectionService->addPhoto($inspection, $photoMetadata);
 
@@ -287,7 +299,7 @@ class InspectionController extends Controller
                 ['error' => 'Failed to add photo'],
                 Http::STATUS_INTERNAL_SERVER_ERROR
             );
-        }
+        }//end try
     }//end addPhoto()
 
     /**
@@ -318,10 +330,14 @@ class InspectionController extends Controller
             $body       = $this->getRequestBody();
             $conclusion = $body['conclusion'] ?? '';
 
-            $register   = $this->settingsService->getConfigValue('register');
-            $schema     = $this->settingsService->getConfigValue('inspection_schema');
-            $object     = $objectService->find($id, register: (int) $register, schema: (int) $schema);
-            $inspection = is_object($object) ? $object->jsonSerialize() : (array) $object;
+            $register = $this->settingsService->getConfigValue('register');
+            $schema   = $this->settingsService->getConfigValue('inspection_schema');
+            $object   = $objectService->find($id, register: (int) $register, schema: (int) $schema);
+            if (is_object($object) === true) {
+                $inspection = $object->jsonSerialize();
+            } else {
+                $inspection = (array) $object;
+            }
 
             $result = $this->inspectionService->completeInspection($inspection, $conclusion);
 
@@ -339,7 +355,7 @@ class InspectionController extends Controller
                 ['error' => 'Failed to complete inspection'],
                 Http::STATUS_INTERNAL_SERVER_ERROR
             );
-        }
+        }//end try
     }//end complete()
 
     /**

--- a/lib/Service/Bezwaar/HearingService.php
+++ b/lib/Service/Bezwaar/HearingService.php
@@ -354,10 +354,6 @@ class HearingService
         $audit    = (array) ($current['auditTrail'] ?? []);
 
         foreach ($entries as $entry) {
-            if (is_array($entry) === false) {
-                continue;
-            }
-
             if ($isFrozen === true) {
                 $hasReason = isset($entry['correctionReason'])
                     && trim((string) $entry['correctionReason']) !== '';

--- a/lib/Service/CaseSharingService.php
+++ b/lib/Service/CaseSharingService.php
@@ -401,7 +401,7 @@ class CaseSharingService
      * @param string      $token    The plaintext token supplied by the user
      * @param string|null $password Optional plaintext password
      *
-     * @return array{valid: bool, share?: array, error?: string}
+     * @return array{valid: bool, share?: array, error?: string, requiresPassword?: bool}
 
      * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
      */
@@ -492,7 +492,7 @@ class CaseSharingService
                     );
                 }
 
-                return ['valid' => false, 'error' => 'Onjuist wachtwoord'];
+                return ['valid' => false, 'error' => 'Onjuist wachtwoord', 'requiresPassword' => true];
             }
         }
 
@@ -502,6 +502,98 @@ class CaseSharingService
 
         return ['valid' => true, 'share' => $share];
     }//end validateToken()
+
+    /**
+     * Revoke a case share by marking it as revoked in OpenRegister.
+     *
+     * @param string $shareId The UUID of the share to revoke
+     * @param string $userId  The user ID performing the revocation
+     *
+     * @return array The updated share data
+
+     * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+     */
+    public function revokeShare(string $shareId, string $userId): array
+    {
+        $objectService = $this->getObjectService();
+        if ($objectService === null) {
+            return ['error' => 'OpenRegister is not available'];
+        }
+
+        $register    = $this->settingsService->getConfigValue('register');
+        $shareSchema = $this->settingsService->getConfigValue('case_share_schema');
+
+        if (empty($register) === true || empty($shareSchema) === true) {
+            return ['error' => 'Service unavailable'];
+        }
+
+        $shareObj = $objectService->find($shareId, register: (int) $register, schema: (int) $shareSchema);
+        if ($shareObj === null) {
+            return ['error' => 'Share not found'];
+        }
+
+        if (is_array($shareObj) === true) {
+            $shareData = $shareObj;
+        } else {
+            $shareData = $shareObj->jsonSerialize();
+        }
+
+        $shareData['status']    = 'revoked';
+        $shareData['revokedBy'] = $userId;
+        $shareData['revokedAt'] = (new \DateTime())->format('c');
+
+        $result = $objectService->saveObject((int) $register, (int) $shareSchema, $shareData);
+
+        $this->logger->info(
+            'Procest: Case share revoked',
+            ['shareId' => $shareId, 'revokedBy' => $userId]
+        );
+
+        if (is_array($result) === true) {
+            return $result;
+        }
+
+        return $result->jsonSerialize();
+    }//end revokeShare()
+
+    /**
+     * Filter case data according to the share's permission level and field exclusions.
+     *
+     * @param array<string, mixed> $shareData Share configuration (permissionLevel, fieldExclusions, shareType)
+     * @param array<string, mixed> $caseData  Full case data to be filtered
+     *
+     * @return array<string, mixed> Filtered case data safe to expose to the share recipient
+
+     * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+     */
+    public function getFilteredCaseData(array $shareData, array $caseData): array
+    {
+        // Decode field exclusions stored as JSON string or array.
+        $exclusions = $shareData['fieldExclusions'] ?? [];
+        if (is_string($exclusions) === true) {
+            $decoded = json_decode($exclusions, true);
+            if (is_array($decoded) === true) {
+                $exclusions = $decoded;
+            } else {
+                $exclusions = [];
+            }
+        }
+
+        if (is_array($exclusions) === false) {
+            $exclusions = [];
+        }
+
+        // Merge the configured exclusions with the default set.
+        $allExclusions = array_unique(array_merge(self::DEFAULT_EXCLUDED_FIELDS, (array) $exclusions));
+
+        // Remove excluded fields from the case data.
+        $filtered = $caseData;
+        foreach ($allExclusions as $field) {
+            unset($filtered[(string) $field]);
+        }
+
+        return $filtered;
+    }//end getFilteredCaseData()
 
     /**
      * Resolve the ObjectService from the DI container.

--- a/lib/Service/CaseTransferService.php
+++ b/lib/Service/CaseTransferService.php
@@ -130,12 +130,18 @@ class CaseTransferService
         $register = $this->settingsService->getConfigValue('register');
         $schema   = $this->settingsService->getConfigValue('case_transfer_schema');
 
-        $transfer     = $objectService->find($transferId, register: (int) $register, schema: (int) $schema);
-        $transferData = is_object($transfer) ? $transfer->jsonSerialize() : (array) $transfer;
+        $transfer = $objectService->find($transferId, register: (int) $register, schema: (int) $schema);
+        if (is_object($transfer) === true) {
+            $transferData = $transfer->jsonSerialize();
+        } else {
+            $transferData = (array) $transfer;
+        }
 
         if ($transferData['status'] !== 'pending') {
             return ['error' => 'Transfer is not in pending state'];
         }
+
+        $caseId = (string) ($transferData['caseId'] ?? '');
 
         $transferData['status']      = 'accepted';
         $transferData['completedAt'] = (new \DateTime())->format('c');
@@ -150,7 +156,7 @@ class CaseTransferService
             'Procest: Case transfer accepted',
             [
                 'transferId' => $transferId,
-                'caseId'     => $transferData['caseId'],
+                'caseId'     => $caseId,
             ]
         );
 
@@ -177,8 +183,12 @@ class CaseTransferService
         $register = $this->settingsService->getConfigValue('register');
         $schema   = $this->settingsService->getConfigValue('case_transfer_schema');
 
-        $transfer     = $objectService->find($transferId, register: (int) $register, schema: (int) $schema);
-        $transferData = is_object($transfer) ? $transfer->jsonSerialize() : (array) $transfer;
+        $transfer = $objectService->find($transferId, register: (int) $register, schema: (int) $schema);
+        if (is_object($transfer) === true) {
+            $transferData = $transfer->jsonSerialize();
+        } else {
+            $transferData = (array) $transfer;
+        }
 
         if ($transferData['status'] !== 'pending') {
             return ['error' => 'Transfer is not in pending state'];

--- a/lib/Service/Inspection/ChecklistService.php
+++ b/lib/Service/Inspection/ChecklistService.php
@@ -283,10 +283,6 @@ class ChecklistService
         $skipped      = 0;
 
         foreach ($responses as $response) {
-            if (is_array($response) === false) {
-                continue;
-            }
-
             $itemId  = (string) ($response['itemId'] ?? '');
             $item    = $itemsByOrder[$itemId] ?? null;
             $verdict = $this->classifyResponse(response: $response, item: $item);
@@ -654,10 +650,6 @@ class ChecklistService
         $best   = -1;
 
         foreach ($responses as $response) {
-            if (is_array($response) === false) {
-                continue;
-            }
-
             $itemId = (string) ($response['itemId'] ?? '');
             $item   = $items[$itemId] ?? null;
             if ($item === null) {

--- a/lib/Service/Transitions/GuardRegistry.php
+++ b/lib/Service/Transitions/GuardRegistry.php
@@ -98,10 +98,6 @@ class GuardRegistry
     {
         $results = [];
         foreach ($guards as $guard) {
-            if (is_array($guard) === false) {
-                continue;
-            }
-
             $type = (string) ($guard['type'] ?? '');
             if ($type === '') {
                 continue;
@@ -142,7 +138,7 @@ class GuardRegistry
     public function allPassed(array $results): bool
     {
         foreach ($results as $result) {
-            if (($result['passed'] ?? false) !== true) {
+            if ($result['passed'] !== true) {
                 return false;
             }
         }

--- a/lib/Service/Transitions/SideEffectDispatcher.php
+++ b/lib/Service/Transitions/SideEffectDispatcher.php
@@ -64,10 +64,6 @@ class SideEffectDispatcher
     {
         $results = [];
         foreach ($actions as $action) {
-            if (is_array($action) === false) {
-                continue;
-            }
-
             $type = (string) ($action['type'] ?? '');
             if ($type === '') {
                 continue;

--- a/lib/Service/WfsExportService.php
+++ b/lib/Service/WfsExportService.php
@@ -215,11 +215,7 @@ class WfsExportService
         return array_values(
             array_filter(
                 $locations,
-                function (mixed $location) use ($status, $caseType): bool {
-                    if (is_array($location) === false) {
-                        return false;
-                    }
-
+                function (array $location) use ($status, $caseType): bool {
                     if ($status !== null) {
                         $locStatus = (string) ($location['caseStatus'] ?? '');
                         if ($locStatus !== $status) {

--- a/lib/Service/ZgwService.php
+++ b/lib/Service/ZgwService.php
@@ -500,7 +500,6 @@ class ZgwService
             $decoded = json_decode($rawBody, true);
             // Do not attempt to repair malformed JSON — it risks data corruption
             // and may be used to smuggle crafted values through the regex transform.
-
             if ($decoded !== null) {
                 // Merge route params so they remain available downstream.
                 $routeParams = $request->getParams();
@@ -632,7 +631,7 @@ class ZgwService
                 ],
                 statusCode: Http::STATUS_FORBIDDEN
             );
-        }
+        }//end try
 
         return null;
     }//end validateJwtAuth()

--- a/lib/Validator/ParaferingAuditAppendOnlyValidator.php
+++ b/lib/Validator/ParaferingAuditAppendOnlyValidator.php
@@ -124,13 +124,10 @@ class ParaferingAuditAppendOnlyValidator implements IEventListener
             }
         } catch (OCSForbiddenException $e) {
             // Block the operation by stopping propagation and recording the error.
-            if ($event instanceof ObjectCreatingEvent === true
-                || $event instanceof ObjectUpdatingEvent === true
-                || $event instanceof ObjectDeletingEvent === true
-            ) {
-                $event->setErrors([$e->getMessage()]);
-                $event->stopPropagation();
-            }
+            // At this point $event is always one of ObjectCreatingEvent|ObjectUpdatingEvent|ObjectDeletingEvent
+            // (the only non-early-return branches above), so setErrors/stopPropagation are always safe.
+            $event->setErrors([$e->getMessage()]);
+            $event->stopPropagation();
 
             $this->logger->warning(
                 'Procest: paraferingAuditEntry append-only violation',

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -116,11 +116,6 @@ parameters:
 			path: lib/Service/CaseDefinitionImportService.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between true and false will always evaluate to false\\.$#"
-			count: 1
-			path: lib/Service/Inspection/ChecklistService.php
-
-		-
 			message: "#^Property OCA\\\\Procest\\\\Service\\\\InspectionService\\:\\:\\$settingsService is never read, only written\\.$#"
 			count: 1
 			path: lib/Service/InspectionService.php

--- a/src/App.vue
+++ b/src/App.vue
@@ -122,7 +122,10 @@ export default {
 		 * @param {string} key Translation key.
 		 * @return {string} Translated string (or the key on miss).
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-25-procest-app-scaffold/tasks.md */
+		/**
+		 * @param key
+		 * @spec openspec/changes/retrofit-2026-05-25-procest-app-scaffold/tasks.md
+		 */
 		translateForApp(key) {
 			return ncT('procest', key)
 		},

--- a/src/components/map/AddressSearch.vue
+++ b/src/components/map/AddressSearch.vue
@@ -50,7 +50,10 @@ export default {
 		}
 	},
 	methods: {
-		/** @spec openspec/changes/retrofit-2026-05-25-map-component/tasks.md */
+		/**
+		 * @param value
+		 * @spec openspec/changes/retrofit-2026-05-25-map-component/tasks.md
+		 */
 		async onInput(value) {
 			this.query = value
 			if (value.length < 3) {
@@ -80,7 +83,10 @@ export default {
 			}
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-25-map-component/tasks.md */
+		/**
+		 * @param result
+		 * @spec openspec/changes/retrofit-2026-05-25-map-component/tasks.md
+		 */
 		async selectResult(result) {
 			// Look up full details if we have an ID
 			let fullResult = result
@@ -114,7 +120,10 @@ export default {
 			this.results = []
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-25-map-component/tasks.md */
+		/**
+		 * @param type
+		 * @spec openspec/changes/retrofit-2026-05-25-map-component/tasks.md
+		 */
 		getTypeIcon(type) {
 			switch (type) {
 			case 'adres': return '\uD83C\uDFE0'

--- a/src/components/map/CaseMap.vue
+++ b/src/components/map/CaseMap.vue
@@ -282,7 +282,10 @@ export default {
 			}
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-25-map-component/tasks.md */
+		/**
+		 * @param cluster
+		 * @spec openspec/changes/retrofit-2026-05-25-map-component/tasks.md
+		 */
 		createClusterIcon(cluster) {
 			const count = cluster.getChildCount()
 			let className = 'case-map-cluster case-map-cluster--green'
@@ -353,7 +356,10 @@ export default {
 			}
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-25-map-component/tasks.md */
+		/**
+		 * @param event
+		 * @spec openspec/changes/retrofit-2026-05-25-map-component/tasks.md
+		 */
 		onKeydown(event) {
 			if (!this.map) return
 			const panStep = 100

--- a/src/components/map/LocationPicker.vue
+++ b/src/components/map/LocationPicker.vue
@@ -144,7 +144,10 @@ export default {
 			this.$nextTick(() => this.map.invalidateSize())
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-25-map-component/tasks.md */
+		/**
+		 * @param mode
+		 * @spec openspec/changes/retrofit-2026-05-25-map-component/tasks.md
+		 */
 		setMode(mode) {
 			this.mode = mode
 
@@ -191,7 +194,10 @@ export default {
 			}
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-25-map-component/tasks.md */
+		/**
+		 * @param latlng
+		 * @spec openspec/changes/retrofit-2026-05-25-map-component/tasks.md
+		 */
 		placeMarker(latlng) {
 			if (this.marker) {
 				this.marker.setLatLng(latlng)
@@ -204,7 +210,11 @@ export default {
 			}
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-25-map-component/tasks.md */
+		/**
+		 * @param root0
+		 * @param root0.coordinates
+		 * @spec openspec/changes/retrofit-2026-05-25-map-component/tasks.md
+		 */
 		onAddressSelect({ coordinates }) {
 			if (!coordinates) return
 			const latlng = L.latLng(coordinates.lat, coordinates.lng)
@@ -238,7 +248,10 @@ export default {
 			}
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-25-map-component/tasks.md */
+		/**
+		 * @param sqm
+		 * @spec openspec/changes/retrofit-2026-05-25-map-component/tasks.md
+		 */
 		formatArea(sqm) {
 			if (sqm > 10000) {
 				return `${(sqm / 10000).toFixed(2)} ha`

--- a/src/components/map/MapComponent.vue
+++ b/src/components/map/MapComponent.vue
@@ -198,7 +198,10 @@ export default {
 		 *
 		 * @param {object} marker The formatted marker descriptor.
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-25-map-component/tasks.md */
+		/**
+		 * @param marker
+		 * @spec openspec/changes/retrofit-2026-05-25-map-component/tasks.md
+		 */
 		onMarkerClick(marker) {
 			const location = marker && marker.__sourceLocation
 				? marker.__sourceLocation
@@ -213,7 +216,10 @@ export default {
 		 *
 		 * @param {object} payload `{ center, zoom, bbox }` from the lib.
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-25-map-component/tasks.md */
+		/**
+		 * @param payload
+		 * @spec openspec/changes/retrofit-2026-05-25-map-component/tasks.md
+		 */
 		onViewportChangeRaw(payload) {
 			if (this.viewportDebounceTimer) {
 				clearTimeout(this.viewportDebounceTimer)
@@ -229,7 +235,10 @@ export default {
 		 *
 		 * @param {object} payload `{ map }` from the lib.
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-25-map-component/tasks.md */
+		/**
+		 * @param payload
+		 * @spec openspec/changes/retrofit-2026-05-25-map-component/tasks.md
+		 */
 		onReady(payload) {
 			this.$emit('ready', payload)
 		},

--- a/src/components/map/MapLayerSwitcher.vue
+++ b/src/components/map/MapLayerSwitcher.vue
@@ -53,7 +53,10 @@ export default {
 			.map(l => l.title)
 	},
 	methods: {
-		/** @spec openspec/changes/retrofit-2026-05-25-map-component/tasks.md */
+		/**
+		 * @param layer
+		 * @spec openspec/changes/retrofit-2026-05-25-map-component/tasks.md
+		 */
 		toggleLayer(layer) {
 			const idx = this.enabledLayers.indexOf(layer.title)
 			if (idx >= 0) {
@@ -63,7 +66,11 @@ export default {
 			}
 			this.$emit('toggle', { layer, enabled: this.enabledLayers.includes(layer.title) })
 		},
-		/** @spec openspec/changes/retrofit-2026-05-25-map-component/tasks.md */
+		/**
+		 * @param layer
+		 * @param event
+		 * @spec openspec/changes/retrofit-2026-05-25-map-component/tasks.md
+		 */
 		onOpacityChange(layer, event) {
 			const opacity = parseInt(event.target.value, 10) / 100
 			this.$emit('opacity-change', { layer, opacity })

--- a/src/components/map/SpatialFilter.vue
+++ b/src/components/map/SpatialFilter.vue
@@ -54,7 +54,10 @@ export default {
 		}
 	},
 	watch: {
-		/** @spec openspec/changes/retrofit-2026-05-25-map-component/tasks.md */
+		/**
+		 * @param newMap
+		 * @spec openspec/changes/retrofit-2026-05-25-map-component/tasks.md
+		 */
 		map(newMap) {
 			if (newMap && !this.drawnItems) {
 				this.initDrawLayer()

--- a/src/components/workflow/EdgeProperties.vue
+++ b/src/components/workflow/EdgeProperties.vue
@@ -104,11 +104,18 @@ export default {
 		},
 	},
 	methods: {
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param key
+		 * @param value
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		updateField(key, value) {
 			this.$emit('update', { edgeId: this.edge.id, patch: { [key]: value } })
 		},
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param raw
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		updateGuards(raw) {
 			let parsed = []
 			try {
@@ -119,7 +126,10 @@ export default {
 			}
 			this.$emit('update', { edgeId: this.edge.id, patch: { guards: parsed } })
 		},
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param raw
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		updateRoles(raw) {
 			const roles = raw.split(',').map((r) => r.trim()).filter(Boolean)
 			this.$emit('update', { edgeId: this.edge.id, patch: { allowedRoles: roles } })

--- a/src/components/workflow/NodePalette.vue
+++ b/src/components/workflow/NodePalette.vue
@@ -52,7 +52,11 @@ export default {
 		},
 	},
 	methods: {
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param event
+		 * @param type
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		onDragStart(event, type) {
 			event.dataTransfer.setData('application/vue-flow-type', type)
 			event.dataTransfer.effectAllowed = 'move'

--- a/src/components/workflow/NodeProperties.vue
+++ b/src/components/workflow/NodeProperties.vue
@@ -110,7 +110,11 @@ export default {
 		},
 	},
 	methods: {
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param key
+		 * @param value
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		updateField(key, value) {
 			this.$emit('update', { nodeId: this.node.id, patch: { [key]: value } })
 		},

--- a/src/components/workflow/VisualWorkflowEditor.vue
+++ b/src/components/workflow/VisualWorkflowEditor.vue
@@ -256,7 +256,10 @@ export default {
 				this.loading = false
 			}
 		},
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param template
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		parseTemplate(template) {
 			const parseField = (raw, fallback) => {
 				if (Array.isArray(raw) || typeof raw === 'object') {
@@ -285,7 +288,10 @@ export default {
 				layout: this.workingCopy.layout,
 			}
 		},
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param nodes
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		onNodesUpdate(nodes) {
 			// Capture position changes back into the layout block.
 			const layout = { ...(this.workingCopy.layout || {}) }
@@ -303,7 +309,10 @@ export default {
 				this.isDirty = true
 			}
 		},
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param edges
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		onEdgesUpdate(edges) {
 			// Keep transitions in working copy aligned with rendered edges
 			// (e.g. when vue-flow signals deletes from the user).
@@ -317,17 +326,28 @@ export default {
 				this.isDirty = true
 			}
 		},
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param node
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		onSelectNode(node) {
 			this.selectedNode = node
 			this.selectedEdge = null
 		},
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param edge
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		onSelectEdge(edge) {
 			this.selectedEdge = edge
 			this.selectedNode = null
 		},
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param root0
+		 * @param root0.type
+		 * @param root0.position
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		onDropNode({ type, position }) {
 			const id = `step-${Date.now()}`
 			const newStep = {
@@ -345,7 +365,12 @@ export default {
 			}
 			this.isDirty = true
 		},
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param root0
+		 * @param root0.source
+		 * @param root0.target
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		onConnect({ source, target }) {
 			if (!source || !target) return
 			const id = `tr-${Date.now()}`
@@ -360,7 +385,12 @@ export default {
 			this.workingCopy = { ...this.workingCopy, transitions: next }
 			this.isDirty = true
 		},
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param root0
+		 * @param root0.nodeId
+		 * @param root0.patch
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		onNodePropsUpdate({ nodeId, patch }) {
 			const steps = (this.workingCopy.steps || []).map((step, idx) => {
 				const id = step.id || step.status || `step-${idx}`
@@ -374,7 +404,12 @@ export default {
 			this.workingCopy = { ...this.workingCopy, steps }
 			this.isDirty = true
 		},
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param root0
+		 * @param root0.edgeId
+		 * @param root0.patch
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		onEdgePropsUpdate({ edgeId, patch }) {
 			const transitions = (this.workingCopy.transitions || []).map((tr, idx) => {
 				const id = tr.id || `edge-${idx}`
@@ -390,7 +425,10 @@ export default {
 			if (this.autosaveTimer) clearTimeout(this.autosaveTimer)
 			this.autosaveTimer = setTimeout(() => this.onSaveDraft(true), 2000)
 		},
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param silent
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		async onSaveDraft(silent = false) {
 			if (!this.template || this.readOnly) return
 			this.saving = true
@@ -451,7 +489,10 @@ export default {
 		onImport() {
 			this.$refs.importInput.click()
 		},
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param event
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		async onImportFile(event) {
 			const file = event.target.files && event.target.files[0]
 			if (!file) return

--- a/src/components/workflow/WorkflowCanvas.vue
+++ b/src/components/workflow/WorkflowCanvas.vue
@@ -117,14 +117,20 @@ export default {
 	},
 	watch: {
 		nodes: {
-			/** @spec openspec/specs/workflow-definition-model/spec.md */
+			/**
+			 * @param next
+			 * @spec openspec/specs/workflow-definition-model/spec.md
+			 */
 			handler(next) {
 				this.localNodes = [...next]
 			},
 			deep: true,
 		},
 		edges: {
-			/** @spec openspec/specs/workflow-definition-model/spec.md */
+			/**
+			 * @param next
+			 * @spec openspec/specs/workflow-definition-model/spec.md
+			 */
 			handler(next) {
 				this.localEdges = [...next]
 			},
@@ -135,7 +141,10 @@ export default {
 		hasIssue(id, level) {
 			return this.issues.some((issue) => (issue.nodeId === id || issue.edgeId === id) && issue.level === level)
 		},
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param event
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		onDrop(event) {
 			if (this.readOnly) {
 				return
@@ -159,18 +168,29 @@ export default {
 		onEdgesChange() {
 			this.$emit('update:edges', this.localEdges)
 		},
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param params
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		onConnect(params) {
 			if (this.readOnly) {
 				return
 			}
 			this.$emit('connect', params)
 		},
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param root0
+		 * @param root0.node
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		onNodeClick({ node }) {
 			this.$emit('select-node', node)
 		},
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param root0
+		 * @param root0.edge
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		onEdgeClick({ edge }) {
 			this.$emit('select-edge', edge)
 		},

--- a/src/dialogs/AddStepDialog.vue
+++ b/src/dialogs/AddStepDialog.vue
@@ -121,7 +121,10 @@ export default {
 		},
 	},
 	watch: {
-		/** @spec openspec/specs/parafering-actions/spec.md */
+		/**
+		 * @param value
+		 * @spec openspec/specs/parafering-actions/spec.md
+		 */
 		open(value) {
 			if (value) {
 				this.afterStep = null

--- a/src/dialogs/SkipStepDialog.vue
+++ b/src/dialogs/SkipStepDialog.vue
@@ -86,7 +86,10 @@ export default {
 		},
 	},
 	watch: {
-		/** @spec openspec/specs/parafering-actions/spec.md */
+		/**
+		 * @param value
+		 * @spec openspec/specs/parafering-actions/spec.md
+		 */
 		open(value) {
 			if (value) {
 				this.reason = ''

--- a/src/dialogs/ZgwMappingDialog.vue
+++ b/src/dialogs/ZgwMappingDialog.vue
@@ -120,7 +120,10 @@ export default {
 	watch: {
 		open: {
 			immediate: true,
-			/** @spec openspec/changes/retrofit-2026-05-24-zgw-api-mapping/tasks.md */
+			/**
+			 * @param value
+			 * @spec openspec/changes/retrofit-2026-05-24-zgw-api-mapping/tasks.md
+			 */
 			handler(value) {
 				if (value) {
 					this.initFromMapping()

--- a/src/services/adviceApi.js
+++ b/src/services/adviceApi.js
@@ -52,7 +52,10 @@ function actionUrl(path) {
  * @param {string} caseId Case UUID
  * @return {Promise<Array>} List of advice records
  */
-/** @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md */
+/**
+ * @param caseId
+ * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
+ */
 export async function getAdviceForCase(caseId) {
 	const response = await axios.get(orUrl(), {
 		params: { _filters: JSON.stringify({ case: caseId }), _limit: 200 },
@@ -72,7 +75,11 @@ export async function getAdviceForCase(caseId) {
  * @param {object} body Transition payload (to, adviesDocument, ...)
  * @return {Promise<object>} Updated record
  */
-/** @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md */
+/**
+ * @param id
+ * @param body
+ * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
+ */
 export async function transitionStatus(id, body) {
 	const response = await axios.post(actionUrl(`${id}/transition`), body)
 	return response.data
@@ -84,7 +91,10 @@ export async function transitionStatus(id, body) {
  * @param {string} id Advice UUID
  * @return {Promise<object>} Server confirmation
  */
-/** @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md */
+/**
+ * @param id
+ * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
+ */
 export async function dispatchReminder(id) {
 	const response = await axios.post(actionUrl(`${id}/remind`))
 	return response.data
@@ -100,7 +110,10 @@ export async function dispatchReminder(id) {
  * @param {object} data Advice payload (case, adviseur, type, deadline, ...)
  * @return {Promise<object>} Created record
  */
-/** @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md */
+/**
+ * @param data
+ * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
+ */
 export async function createAdviceWithNotification(data) {
 	const payload = {
 		...data,

--- a/src/services/aiApi.js
+++ b/src/services/aiApi.js
@@ -16,7 +16,11 @@ const baseUrl = generateUrl('/apps/procest/api/ai')
  * @param {string} documentId The document UUID
  * @return {Promise<object>} Classification suggestion with confidence
  */
-/** @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md */
+/**
+ * @param caseId
+ * @param documentId
+ * @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md
+ */
 export async function classifyDocument(caseId, documentId) {
 	const response = await axios.post(`${baseUrl}/classify`, { caseId, documentId })
 	return response.data
@@ -29,7 +33,11 @@ export async function classifyDocument(caseId, documentId) {
  * @param {string|null} documentId Optional document UUID
  * @return {Promise<object>} Extracted fields with confidence scores
  */
-/** @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md */
+/**
+ * @param caseId
+ * @param documentId
+ * @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md
+ */
 export async function extractData(caseId, documentId = null) {
 	const response = await axios.post(`${baseUrl}/extract`, { caseId, documentId })
 	return response.data
@@ -42,7 +50,11 @@ export async function extractData(caseId, documentId = null) {
  * @param {string} question The question to ask
  * @return {Promise<object>} Answer with source citations
  */
-/** @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md */
+/**
+ * @param caseId
+ * @param question
+ * @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md
+ */
 export async function askQuestion(caseId, question) {
 	const response = await axios.post(`${baseUrl}/ask`, { caseId, question })
 	return response.data
@@ -56,7 +68,12 @@ export async function askQuestion(caseId, question) {
  * @param {string|null} documentId Optional document UUID
  * @return {Promise<object>} Generated summary
  */
-/** @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md */
+/**
+ * @param caseId
+ * @param type
+ * @param documentId
+ * @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md
+ */
 export async function summarize(caseId, type = 'case', documentId = null) {
 	const response = await axios.post(`${baseUrl}/summarize`, { caseId, type, documentId })
 	return response.data
@@ -68,7 +85,10 @@ export async function summarize(caseId, type = 'case', documentId = null) {
  * @param {string} caseId The case UUID
  * @return {Promise<object>} Routing suggestion
  */
-/** @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md */
+/**
+ * @param caseId
+ * @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md
+ */
 export async function suggestRouting(caseId) {
 	const response = await axios.post(`${baseUrl}/suggest-routing`, { caseId })
 	return response.data
@@ -80,7 +100,10 @@ export async function suggestRouting(caseId) {
  * @param {string} caseId The case UUID
  * @return {Promise<object>} Next-step suggestion
  */
-/** @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md */
+/**
+ * @param caseId
+ * @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md
+ */
 export async function suggestNext(caseId) {
 	const response = await axios.post(`${baseUrl}/suggest-next`, { caseId })
 	return response.data
@@ -92,7 +115,10 @@ export async function suggestNext(caseId) {
  * @param {object} filters Query filters (caseId, type, limit, offset)
  * @return {Promise<object>} Audit log entries
  */
-/** @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md */
+/**
+ * @param filters
+ * @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md
+ */
 export async function getAuditLog(filters = {}) {
 	const response = await axios.get(`${baseUrl}/audit`, { params: filters })
 	return response.data
@@ -115,7 +141,10 @@ export async function getAiSettings() {
  * @param {object} settings Settings to update
  * @return {Promise<object>} Updated settings
  */
-/** @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md */
+/**
+ * @param settings
+ * @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md
+ */
 export async function updateAiSettings(settings) {
 	const response = await axios.post(`${baseUrl}/settings`, settings)
 	return response.data

--- a/src/services/appointmentApi.js
+++ b/src/services/appointmentApi.js
@@ -3,31 +3,48 @@ import { generateUrl } from '@nextcloud/router'
 
 const baseUrl = generateUrl('/apps/procest/api/appointments')
 
-/** @spec openspec/changes/retrofit-2026-05-25-appointment-booking/tasks.md */
+/**
+ * @param caseId
+ * @spec openspec/changes/retrofit-2026-05-25-appointment-booking/tasks.md
+ */
 export async function listAppointments(caseId) {
 	const response = await axios.get(baseUrl, { params: { caseId } })
 	return response.data
 }
 
-/** @spec openspec/changes/retrofit-2026-05-25-appointment-booking/tasks.md */
+/**
+ * @param data
+ * @spec openspec/changes/retrofit-2026-05-25-appointment-booking/tasks.md
+ */
 export async function bookAppointment(data) {
 	const response = await axios.post(baseUrl, data)
 	return response.data
 }
 
-/** @spec openspec/changes/retrofit-2026-05-25-appointment-booking/tasks.md */
+/**
+ * @param appointmentId
+ * @spec openspec/changes/retrofit-2026-05-25-appointment-booking/tasks.md
+ */
 export async function cancelAppointment(appointmentId) {
 	const response = await axios.delete(`${baseUrl}/${appointmentId}`)
 	return response.data
 }
 
-/** @spec openspec/changes/retrofit-2026-05-25-appointment-booking/tasks.md */
+/**
+ * @param appointmentId
+ * @spec openspec/changes/retrofit-2026-05-25-appointment-booking/tasks.md
+ */
 export async function markNoShow(appointmentId) {
 	const response = await axios.post(`${baseUrl}/${appointmentId}/no-show`)
 	return response.data
 }
 
-/** @spec openspec/changes/retrofit-2026-05-25-appointment-booking/tasks.md */
+/**
+ * @param productId
+ * @param locationId
+ * @param date
+ * @spec openspec/changes/retrofit-2026-05-25-appointment-booking/tasks.md
+ */
 export async function getTimeslots(productId, locationId, date) {
 	const response = await axios.get(`${baseUrl}/timeslots`, { params: { productId, locationId, date } })
 	return response.data

--- a/src/services/berichtenboxApi.js
+++ b/src/services/berichtenboxApi.js
@@ -3,13 +3,19 @@ import { generateUrl } from '@nextcloud/router'
 
 const baseUrl = generateUrl('/apps/procest/api/berichtenbox')
 
-/** @spec openspec/changes/retrofit-2026-05-24-berichtenbox-integration/tasks.md */
+/**
+ * @param data
+ * @spec openspec/changes/retrofit-2026-05-24-berichtenbox-integration/tasks.md
+ */
 export async function sendMessage(data) {
 	const response = await axios.post(`${baseUrl}/send`, data)
 	return response.data
 }
 
-/** @spec openspec/changes/retrofit-2026-05-24-berichtenbox-integration/tasks.md */
+/**
+ * @param caseId
+ * @spec openspec/changes/retrofit-2026-05-24-berichtenbox-integration/tasks.md
+ */
 export async function listMessages(caseId) {
 	const response = await axios.get(`${baseUrl}/messages`, { params: { caseId } })
 	return response.data
@@ -21,7 +27,10 @@ export async function getTypeCodes() {
 	return response.data
 }
 
-/** @spec openspec/changes/retrofit-2026-05-24-berichtenbox-integration/tasks.md */
+/**
+ * @param messageId
+ * @spec openspec/changes/retrofit-2026-05-24-berichtenbox-integration/tasks.md
+ */
 export async function pollReadStatus(messageId) {
 	const response = await axios.post(`${baseUrl}/poll/${messageId}`)
 	return response.data

--- a/src/services/coordinateService.js
+++ b/src/services/coordinateService.js
@@ -23,7 +23,11 @@ proj4.defs(
  * @param {number} y The y coordinate (or latitude)
  * @return {boolean} True if coordinates appear to be RD
  */
-/** @spec openspec/changes/retrofit-2026-05-25-pdok-integration/tasks.md */
+/**
+ * @param x
+ * @param y
+ * @spec openspec/changes/retrofit-2026-05-25-pdok-integration/tasks.md
+ */
 export function isRDCoordinate(x, y) {
 	return x >= 0 && x <= 300000 && y >= 300000 && y <= 625000
 }
@@ -35,7 +39,11 @@ export function isRDCoordinate(x, y) {
  * @param {number} y RD y coordinate
  * @return {{ lat: number, lng: number }} WGS84 coordinates
  */
-/** @spec openspec/changes/retrofit-2026-05-25-pdok-integration/tasks.md */
+/**
+ * @param x
+ * @param y
+ * @spec openspec/changes/retrofit-2026-05-25-pdok-integration/tasks.md
+ */
 export function rdToWgs84(x, y) {
 	const [lng, lat] = proj4('EPSG:28992', 'EPSG:4326', [x, y])
 	return { lat, lng }
@@ -48,7 +56,11 @@ export function rdToWgs84(x, y) {
  * @param {number} lng Longitude
  * @return {{ x: number, y: number }} RD coordinates
  */
-/** @spec openspec/changes/retrofit-2026-05-25-pdok-integration/tasks.md */
+/**
+ * @param lat
+ * @param lng
+ * @spec openspec/changes/retrofit-2026-05-25-pdok-integration/tasks.md
+ */
 export function wgs84ToRd(lat, lng) {
 	const [x, y] = proj4('EPSG:4326', 'EPSG:28992', [lng, lat])
 	return { x, y }
@@ -62,7 +74,11 @@ export function wgs84ToRd(lat, lng) {
  * @param {string} crs     Optional CRS identifier (e.g., "EPSG:28992")
  * @return {object} GeoJSON geometry in WGS84
  */
-/** @spec openspec/changes/retrofit-2026-05-25-pdok-integration/tasks.md */
+/**
+ * @param geojson
+ * @param crs
+ * @spec openspec/changes/retrofit-2026-05-25-pdok-integration/tasks.md
+ */
 export function ensureWgs84(geojson, crs = null) {
 	if (!geojson || !geojson.type) {
 		return geojson

--- a/src/services/gisProxyService.js
+++ b/src/services/gisProxyService.js
@@ -18,7 +18,14 @@ import { generateUrl } from '@nextcloud/router'
  * @param {string} params.responseType Expected response type: 'image', 'json', 'xml'
  * @return {Promise<*>} The proxied response data
  */
-/** @spec openspec/changes/retrofit-2026-05-24-wms-wfs-layers/tasks.md */
+/**
+ * @param root0
+ * @param root0.url
+ * @param root0.query
+ * @param root0.type
+ * @param root0.responseType
+ * @spec openspec/changes/retrofit-2026-05-24-wms-wfs-layers/tasks.md
+ */
 export async function proxyRequest({ url, query = {}, type = 'wms', responseType = 'json' }) {
 	const apiUrl = generateUrl('/apps/procest/api/gis/proxy')
 	const axiosConfig = {}
@@ -43,7 +50,11 @@ export async function proxyRequest({ url, query = {}, type = 'wms', responseType
  * @param {string} type   Service type: 'wms' or 'wfs'
  * @return {Promise<object>} Parsed capabilities with available layers
  */
-/** @spec openspec/changes/retrofit-2026-05-24-wms-wfs-layers/tasks.md */
+/**
+ * @param url
+ * @param type
+ * @spec openspec/changes/retrofit-2026-05-24-wms-wfs-layers/tasks.md
+ */
 export async function getCapabilities(url, type = 'wms') {
 	const apiUrl = generateUrl('/apps/procest/api/gis/capabilities')
 	const response = await axios.get(apiUrl, {

--- a/src/services/mapFormatters.js
+++ b/src/services/mapFormatters.js
@@ -27,7 +27,10 @@
  * @param {string} status The case status.
  * @return {string} CSS variable reference.
  */
-/** @spec openspec/changes/retrofit-2026-05-25-map-component/tasks.md */
+/**
+ * @param status
+ * @spec openspec/changes/retrofit-2026-05-25-map-component/tasks.md
+ */
 export function statusColor(status) {
 	switch (status) {
 	case 'blocked':
@@ -49,7 +52,10 @@ export function statusColor(status) {
  * @param {string} status The case status.
  * @return {string} Icon glyph name.
  */
-/** @spec openspec/changes/retrofit-2026-05-25-map-component/tasks.md */
+/**
+ * @param status
+ * @spec openspec/changes/retrofit-2026-05-25-map-component/tasks.md
+ */
 export function statusIcon(status) {
 	switch (status) {
 	case 'blocked':
@@ -115,7 +121,10 @@ function extractCoords(geometry) {
  * @param {object} caseObj Case object from OpenRegister.
  * @return {object|null}   Marker descriptor or `null` if no geometry.
  */
-/** @spec openspec/changes/retrofit-2026-05-25-map-component/tasks.md */
+/**
+ * @param caseObj
+ * @spec openspec/changes/retrofit-2026-05-25-map-component/tasks.md
+ */
 export function caseMarkerFormatter(caseObj) {
 	if (!caseObj || typeof caseObj !== 'object') {
 		return null

--- a/src/services/parafeerActieApi.js
+++ b/src/services/parafeerActieApi.js
@@ -25,7 +25,10 @@ const ENDPOINT = generateUrl('/apps/procest/api/parafeer-actie')
  * @param {string} [data.mandate]   Mandate reference when acting as delegate.
  * @return {Promise<object>} The created parafeeractie and updated voorstel.
  */
-/** @spec openspec/specs/parafering-actions/spec.md */
+/**
+ * @param data
+ * @spec openspec/specs/parafering-actions/spec.md
+ */
 export async function recordAction(data) {
 	const response = await axios.post(ENDPOINT, data)
 	return response.data
@@ -37,7 +40,10 @@ export async function recordAction(data) {
  * @param {string} voorstelId The voorstel UUID.
  * @return {Promise<Array<object>>} The parafeeractie array.
  */
-/** @spec openspec/specs/parafering-actions/spec.md */
+/**
+ * @param voorstelId
+ * @spec openspec/specs/parafering-actions/spec.md
+ */
 export async function listActions(voorstelId) {
 	const response = await axios.get(ENDPOINT, { params: { voorstel: voorstelId } })
 	return Array.isArray(response.data) ? response.data : []

--- a/src/services/parafeerRouteApi.js
+++ b/src/services/parafeerRouteApi.js
@@ -24,7 +24,10 @@ const baseUrl = () => generateUrl('/apps/procest/api/parafeer-route')
  * @param {string} voorstelId Voorstel UUID
  * @return {Promise<object>}
  */
-/** @spec openspec/specs/parafering-actions/spec.md */
+/**
+ * @param voorstelId
+ * @spec openspec/specs/parafering-actions/spec.md
+ */
 export async function startParafering(voorstelId) {
 	const response = await axios.post(`${baseUrl()}/voorstel/${encodeURIComponent(voorstelId)}/start`)
 	return response.data
@@ -37,7 +40,11 @@ export async function startParafering(voorstelId) {
  * @param {object} data       Parafeeractie payload
  * @return {Promise<object>}
  */
-/** @spec openspec/specs/parafering-actions/spec.md */
+/**
+ * @param voorstelId
+ * @param data
+ * @spec openspec/specs/parafering-actions/spec.md
+ */
 export async function completeStep(voorstelId, data) {
 	const response = await axios.post(`${baseUrl()}/voorstel/${encodeURIComponent(voorstelId)}/complete-step`, data)
 	return response.data
@@ -50,7 +57,11 @@ export async function completeStep(voorstelId, data) {
  * @param {object} data       { step: number, reason: string }
  * @return {Promise<object>}
  */
-/** @spec openspec/specs/parafering-actions/spec.md */
+/**
+ * @param voorstelId
+ * @param data
+ * @spec openspec/specs/parafering-actions/spec.md
+ */
 export async function skipStep(voorstelId, data) {
 	const response = await axios.post(`${baseUrl()}/voorstel/${encodeURIComponent(voorstelId)}/skip-step`, data)
 	return response.data
@@ -63,7 +74,11 @@ export async function skipStep(voorstelId, data) {
  * @param {object} data       { afterStep: number, stepData: object }
  * @return {Promise<object>}
  */
-/** @spec openspec/specs/parafering-actions/spec.md */
+/**
+ * @param voorstelId
+ * @param data
+ * @spec openspec/specs/parafering-actions/spec.md
+ */
 export async function addStep(voorstelId, data) {
 	const response = await axios.post(`${baseUrl()}/voorstel/${encodeURIComponent(voorstelId)}/add-step`, data)
 	return response.data

--- a/src/services/pdokService.js
+++ b/src/services/pdokService.js
@@ -91,7 +91,10 @@ function handleNetworkError(error, fallback) {
  * @param {string} query Search query (min 3 characters).
  * @return {Promise<Array|null>} Suggestions array, empty array, or null.
  */
-/** @spec openspec/changes/retrofit-2026-05-25-pdok-integration/tasks.md */
+/**
+ * @param query
+ * @spec openspec/changes/retrofit-2026-05-25-pdok-integration/tasks.md
+ */
 export async function suggest(query) {
 	if (!query || query.length < 3) {
 		return []
@@ -120,7 +123,10 @@ export async function suggest(query) {
  * @param {string} id The PDOK object id.
  * @return {Promise<object|null>} The full result object, or null when degraded.
  */
-/** @spec openspec/changes/retrofit-2026-05-25-pdok-integration/tasks.md */
+/**
+ * @param id
+ * @spec openspec/changes/retrofit-2026-05-25-pdok-integration/tasks.md
+ */
 export async function lookup(id) {
 	if (!id) {
 		return null
@@ -141,7 +147,11 @@ export async function lookup(id) {
  * @param {number} rows  Max results (default 10).
  * @return {Promise<Array|null>} Results array, empty array, or null.
  */
-/** @spec openspec/changes/retrofit-2026-05-25-pdok-integration/tasks.md */
+/**
+ * @param query
+ * @param rows
+ * @spec openspec/changes/retrofit-2026-05-25-pdok-integration/tasks.md
+ */
 export async function free(query, rows = 10) {
 	if (!query) {
 		return []
@@ -162,7 +172,11 @@ export async function free(query, rows = 10) {
  * @param {number} lng Longitude (WGS84).
  * @return {Promise<object|null>} Nearest address, or null when degraded.
  */
-/** @spec openspec/changes/retrofit-2026-05-25-pdok-integration/tasks.md */
+/**
+ * @param lat
+ * @param lng
+ * @spec openspec/changes/retrofit-2026-05-25-pdok-integration/tasks.md
+ */
 export async function reverse(lat, lng) {
 	clearWarning()
 	try {
@@ -185,7 +199,10 @@ export async function reverse(lat, lng) {
  * @param {object|string} resultOrWkt A PDOK result object or a raw WKT string.
  * @return {{ lat: number, lng: number }|null} Coordinates or null.
  */
-/** @spec openspec/changes/retrofit-2026-05-25-pdok-integration/tasks.md */
+/**
+ * @param resultOrWkt
+ * @spec openspec/changes/retrofit-2026-05-25-pdok-integration/tasks.md
+ */
 export function extractCoordinates(resultOrWkt) {
 	if (!resultOrWkt) {
 		return null
@@ -229,7 +246,10 @@ function parseWkt(wkt) {
  * @param {object} result A result object.
  * @return {string} Formatted address.
  */
-/** @spec openspec/changes/retrofit-2026-05-25-pdok-integration/tasks.md */
+/**
+ * @param result
+ * @spec openspec/changes/retrofit-2026-05-25-pdok-integration/tasks.md
+ */
 export function formatAddress(result) {
 	if (!result) {
 		return ''

--- a/src/services/taskApi.js
+++ b/src/services/taskApi.js
@@ -44,7 +44,10 @@ function mapCalDavPriority(icalPriority) {
  * @param {object} task CalDAV task object from API
  * @return {object} Normalized work item
  */
-/** @spec openspec/changes/task-management/tasks.md */
+/**
+ * @param task
+ * @spec openspec/changes/task-management/tasks.md
+ */
 export function normalizeCalDavTask(task) {
 	const due = task.due || null
 	const isCompleted = task.status === 'completed'
@@ -99,7 +102,12 @@ export function normalizeCalDavTask(task) {
  * @param {string} objectId The object UUID
  * @return {Promise<object[]>} Array of normalized task work items
  */
-/** @spec openspec/changes/task-management/tasks.md */
+/**
+ * @param registerId
+ * @param schemaId
+ * @param objectId
+ * @spec openspec/changes/task-management/tasks.md
+ */
 export async function fetchTasksForObject(registerId, schemaId, objectId) {
 	const url = `/apps/openregister/api/objects/${registerId}/${schemaId}/${objectId}/tasks`
 
@@ -130,7 +138,10 @@ export async function fetchTasksForObject(registerId, schemaId, objectId) {
  * @param {object[]} cases Array of case objects (must have id property)
  * @return {Promise<object[]>} Array of normalized task work items
  */
-/** @spec openspec/changes/task-management/tasks.md */
+/**
+ * @param cases
+ * @spec openspec/changes/task-management/tasks.md
+ */
 export async function fetchTasksForCases(cases) {
 	const objectStore = useObjectStore()
 	const caseConfig = objectStore.objectTypeRegistry.case

--- a/src/store/modules/advice.js
+++ b/src/store/modules/advice.js
@@ -24,7 +24,10 @@ export const useAdviceStore = defineStore('advice', {
 		 * @param {object} state Store state
 		 * @return {Array} Pending requests
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md */
+		/**
+		 * @param state
+		 * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
+		 */
 		pendingRequests(state) {
 			return state.requests.filter((r) => r.status === 'aangevraagd')
 		},
@@ -35,7 +38,10 @@ export const useAdviceStore = defineStore('advice', {
 		 * @param {object} state Store state
 		 * @return {Array} Overdue requests
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md */
+		/**
+		 * @param state
+		 * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
+		 */
 		overdueRequests(state) {
 			const now = new Date()
 			return state.requests.filter((r) => {
@@ -52,7 +58,10 @@ export const useAdviceStore = defineStore('advice', {
 		 * @param {object} state Store state
 		 * @return {Array} Received requests
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md */
+		/**
+		 * @param state
+		 * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
+		 */
 		receivedRequests(state) {
 			return state.requests.filter((r) => r.status === 'ontvangen')
 		},
@@ -63,7 +72,10 @@ export const useAdviceStore = defineStore('advice', {
 		 * @param {object} state Store state
 		 * @return {boolean} True if all received
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md */
+		/**
+		 * @param state
+		 * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
+		 */
 		allAdviceReceived(state) {
 			return state.requests.length > 0
 				&& state.requests.every((r) => r.status === 'ontvangen' || r.status === 'verlopen')
@@ -77,7 +89,10 @@ export const useAdviceStore = defineStore('advice', {
 		 * @param {string} caseId UUID of the case
 		 * @return {Promise<Array>} Advice requests
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md */
+		/**
+		 * @param caseId
+		 * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
+		 */
 		async fetchRequests(caseId) {
 			this.loading = true
 			this.error = null
@@ -104,7 +119,10 @@ export const useAdviceStore = defineStore('advice', {
 		 * @param {object} requestData The request data
 		 * @return {Promise<object|null>} Created request
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md */
+		/**
+		 * @param requestData
+		 * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
+		 */
 		async createRequest(requestData) {
 			this.loading = true
 			this.error = null
@@ -146,7 +164,11 @@ export const useAdviceStore = defineStore('advice', {
 		 * @param {string} documentId    Nextcloud file ID of the advice document
 		 * @return {Promise<object|null>} Updated request
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md */
+		/**
+		 * @param requestId
+		 * @param documentId
+		 * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
+		 */
 		async markReceived(requestId, documentId) {
 			this.loading = true
 			try {
@@ -182,7 +204,10 @@ export const useAdviceStore = defineStore('advice', {
 		 * @param {string} requestId UUID of the request
 		 * @return {Promise<object|null>} Updated request
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md */
+		/**
+		 * @param requestId
+		 * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
+		 */
 		async markExpired(requestId) {
 			this.loading = true
 			try {
@@ -224,7 +249,10 @@ export const useAdviceStore = defineStore('advice', {
 		 * @param {object} request The advice request
 		 * @return {number} Positive = days remaining, negative = days overdue
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md */
+		/**
+		 * @param request
+		 * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
+		 */
 		getDaysToDeadline(request) {
 			if (!request.deadline) {
 				return null

--- a/src/store/modules/bezwaar.js
+++ b/src/store/modules/bezwaar.js
@@ -127,7 +127,10 @@ export const useBezwaarStore = defineStore('bezwaar', {
 		 * @param {string} caseId The case UUID
 		 * @return {Promise<void>}
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md */
+		/**
+		 * @param caseId
+		 * @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md
+		 */
 		async loadBezwaarData(caseId) {
 			this.loading = true
 			this.error = null
@@ -177,7 +180,10 @@ export const useBezwaarStore = defineStore('bezwaar', {
 		 * @param {object} data The objection data
 		 * @return {Promise<object|null>} The created objection
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md */
+		/**
+		 * @param data
+		 * @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md
+		 */
 		async createObjection(data) {
 			this.loading = true
 			this.error = null
@@ -202,7 +208,10 @@ export const useBezwaarStore = defineStore('bezwaar', {
 		 * @param {object} data The updated objection data
 		 * @return {Promise<object|null>} The updated objection
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md */
+		/**
+		 * @param data
+		 * @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md
+		 */
 		async updateObjection(data) {
 			this.loading = true
 			this.error = null
@@ -227,7 +236,10 @@ export const useBezwaarStore = defineStore('bezwaar', {
 		 * @param {string} objectionId The objection UUID
 		 * @return {Promise<boolean>} Whether the deletion succeeded
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md */
+		/**
+		 * @param objectionId
+		 * @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md
+		 */
 		async deleteObjection(objectionId) {
 			this.loading = true
 			this.error = null
@@ -254,7 +266,10 @@ export const useBezwaarStore = defineStore('bezwaar', {
 		 * @param {object} data The hearing session data
 		 * @return {Promise<object|null>} The created hearing
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md */
+		/**
+		 * @param data
+		 * @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md
+		 */
 		async createHearingSession(data) {
 			this.loading = true
 			this.error = null
@@ -279,7 +294,10 @@ export const useBezwaarStore = defineStore('bezwaar', {
 		 * @param {object} data The updated hearing data
 		 * @return {Promise<object|null>} The updated hearing
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md */
+		/**
+		 * @param data
+		 * @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md
+		 */
 		async updateHearingSession(data) {
 			this.loading = true
 			this.error = null
@@ -309,7 +327,10 @@ export const useBezwaarStore = defineStore('bezwaar', {
 		 * @param {object} data The advisory report data
 		 * @return {Promise<object|null>} The created report
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md */
+		/**
+		 * @param data
+		 * @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md
+		 */
 		async createAdvisoryReport(data) {
 			this.loading = true
 			this.error = null
@@ -334,7 +355,10 @@ export const useBezwaarStore = defineStore('bezwaar', {
 		 * @param {object} data The updated report data
 		 * @return {Promise<object|null>} The updated report
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md */
+		/**
+		 * @param data
+		 * @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md
+		 */
 		async updateAdvisoryReport(data) {
 			this.loading = true
 			this.error = null
@@ -361,7 +385,10 @@ export const useBezwaarStore = defineStore('bezwaar', {
 		 * @param {object} data The appeal decision data
 		 * @return {Promise<object|null>} The created decision
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md */
+		/**
+		 * @param data
+		 * @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md
+		 */
 		async createAppealDecision(data) {
 			this.loading = true
 			this.error = null
@@ -386,7 +413,10 @@ export const useBezwaarStore = defineStore('bezwaar', {
 		 * @param {object} data The updated decision data
 		 * @return {Promise<object|null>} The updated decision
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md */
+		/**
+		 * @param data
+		 * @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md
+		 */
 		async updateAppealDecision(data) {
 			this.loading = true
 			this.error = null
@@ -413,7 +443,10 @@ export const useBezwaarStore = defineStore('bezwaar', {
 		 * @param {string} ontvangstDatum The date the bezwaarschrift was received (ISO string)
 		 * @return {object} Calculated deadlines
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md */
+		/**
+		 * @param ontvangstDatum
+		 * @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md
+		 */
 		calculateDeadlines(ontvangstDatum) {
 			const received = new Date(ontvangstDatum)
 
@@ -440,7 +473,10 @@ export const useBezwaarStore = defineStore('bezwaar', {
 		 * @param {string} currentDeadline The current deadline (ISO string)
 		 * @return {string} The new extended deadline (ISO date string)
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md */
+		/**
+		 * @param currentDeadline
+		 * @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md
+		 */
 		calculateExtendedDeadline(currentDeadline) {
 			const current = new Date(currentDeadline)
 			const extended = addWeeks(current, 6)
@@ -454,7 +490,11 @@ export const useBezwaarStore = defineStore('bezwaar', {
 		 * @param {boolean} isSuspended Whether the deadline is currently suspended
 		 * @return {object} Deadline status with daysRemaining, isAtRisk, isOverdue
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md */
+		/**
+		 * @param deadline
+		 * @param isSuspended
+		 * @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md
+		 */
 		getDeadlineStatus(deadline, isSuspended = false) {
 			if (isSuspended) {
 				return {
@@ -502,7 +542,11 @@ export const useBezwaarStore = defineStore('bezwaar', {
 		 * @param {object} options Additional options (voorzieningRequested)
 		 * @return {Promise<object|null>} The created beroep case
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md */
+		/**
+		 * @param bezwaarCase
+		 * @param options
+		 * @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md
+		 */
 		async escalateToBeroep(bezwaarCase, options = {}) {
 			this.loading = true
 			this.error = null
@@ -550,7 +594,11 @@ export const useBezwaarStore = defineStore('bezwaar', {
 		 * @param {string} bezwaarReceivedDate The date the bezwaar was received
 		 * @return {object} Timeliness assessment
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md */
+		/**
+		 * @param besluitDate
+		 * @param bezwaarReceivedDate
+		 * @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md
+		 */
 		checkTimeliness(besluitDate, bezwaarReceivedDate) {
 			const besluit = new Date(besluitDate)
 			const received = new Date(bezwaarReceivedDate)

--- a/src/store/modules/enforcement.js
+++ b/src/store/modules/enforcement.js
@@ -53,7 +53,10 @@ export const useEnforcementStore = defineStore('enforcement', {
 		 * @param {object} state Store state
 		 * @return {object|null} Active action
 		 */
-		/** @spec openspec/changes/vth-module/tasks.md */
+		/**
+		 * @param state
+		 * @spec openspec/changes/vth-module/tasks.md
+		 */
 		activeAction(state) {
 			return state.actions.find((a) => a.status === 'opgelegd') || null
 		},
@@ -64,7 +67,10 @@ export const useEnforcementStore = defineStore('enforcement', {
 		 * @param {object} state Store state
 		 * @return {number} Total verbeurd amount
 		 */
-		/** @spec openspec/changes/vth-module/tasks.md */
+		/**
+		 * @param state
+		 * @spec openspec/changes/vth-module/tasks.md
+		 */
 		totalVerbeurd(state) {
 			return state.actions
 				.filter((a) => a.status === 'verbeurd')
@@ -77,7 +83,10 @@ export const useEnforcementStore = defineStore('enforcement', {
 		 * @param {object} state Store state
 		 * @return {Array} Ernst levels
 		 */
-		/** @spec openspec/changes/vth-module/tasks.md */
+		/**
+		 * @param state
+		 * @spec openspec/changes/vth-module/tasks.md
+		 */
 		ernstLevels(state) {
 			return Object.keys(state.lhsMatrix)
 		},
@@ -88,7 +97,10 @@ export const useEnforcementStore = defineStore('enforcement', {
 		 * @param {object} state Store state
 		 * @return {Array} Gedrag levels
 		 */
-		/** @spec openspec/changes/vth-module/tasks.md */
+		/**
+		 * @param state
+		 * @spec openspec/changes/vth-module/tasks.md
+		 */
 		gedragLevels(state) {
 			const first = Object.values(state.lhsMatrix)[0]
 			return first ? Object.keys(first) : []
@@ -102,7 +114,10 @@ export const useEnforcementStore = defineStore('enforcement', {
 		 * @param {string} caseId UUID of the case
 		 * @return {Promise<Array>} Actions
 		 */
-		/** @spec openspec/changes/vth-module/tasks.md */
+		/**
+		 * @param caseId
+		 * @spec openspec/changes/vth-module/tasks.md
+		 */
 		async fetchActions(caseId) {
 			this.loading = true
 			this.error = null
@@ -130,7 +145,11 @@ export const useEnforcementStore = defineStore('enforcement', {
 		 * @param {string} gedrag Behavior type (goedwillend/onverschillig/calculerend/crimineel)
 		 * @return {string|null} Suggested intervention
 		 */
-		/** @spec openspec/changes/vth-module/tasks.md */
+		/**
+		 * @param ernst
+		 * @param gedrag
+		 * @spec openspec/changes/vth-module/tasks.md
+		 */
 		lookupLhs(ernst, gedrag) {
 			if (!this.lhsMatrix[ernst]) {
 				return null
@@ -178,7 +197,10 @@ export const useEnforcementStore = defineStore('enforcement', {
 		 * @param {object} matrix The matrix to save
 		 * @return {Promise<boolean>} Success
 		 */
-		/** @spec openspec/changes/vth-module/tasks.md */
+		/**
+		 * @param matrix
+		 * @spec openspec/changes/vth-module/tasks.md
+		 */
 		async saveLhsMatrix(matrix) {
 			try {
 				const response = await fetch('/apps/procest/api/settings', {
@@ -207,7 +229,10 @@ export const useEnforcementStore = defineStore('enforcement', {
 		 * @param {object} actionData The action data
 		 * @return {Promise<object|null>} Created action
 		 */
-		/** @spec openspec/changes/vth-module/tasks.md */
+		/**
+		 * @param actionData
+		 * @spec openspec/changes/vth-module/tasks.md
+		 */
 		async createAction(actionData) {
 			this.loading = true
 			this.error = null
@@ -240,7 +265,11 @@ export const useEnforcementStore = defineStore('enforcement', {
 		 * @param {string} newStatus New status (verbeurd/geeffectueerd/ingetrokken)
 		 * @return {Promise<object|null>} Updated action
 		 */
-		/** @spec openspec/changes/vth-module/tasks.md */
+		/**
+		 * @param actionId
+		 * @param newStatus
+		 * @spec openspec/changes/vth-module/tasks.md
+		 */
 		async updateStatus(actionId, newStatus) {
 			this.loading = true
 			try {
@@ -275,7 +304,11 @@ export const useEnforcementStore = defineStore('enforcement', {
 		 * @param {object} action    The enforcement action
 		 * @return {Promise<object|null>} Created task
 		 */
-		/** @spec openspec/changes/vth-module/tasks.md */
+		/**
+		 * @param caseId
+		 * @param action
+		 * @spec openspec/changes/vth-module/tasks.md
+		 */
 		async createBegunstigingTask(caseId, action) {
 			try {
 				const objectStore = useObjectStore()

--- a/src/store/modules/gis.js
+++ b/src/store/modules/gis.js
@@ -27,11 +27,17 @@ export const useGisStore = defineStore('gis', {
 	}),
 
 	getters: {
-		/** @spec openspec/changes/retrofit-2026-05-24-wms-wfs-layers/tasks.md */
+		/**
+		 * @param state
+		 * @spec openspec/changes/retrofit-2026-05-24-wms-wfs-layers/tasks.md
+		 */
 		overlayLayers(state) {
 			return state.layers.filter(l => !l.isBaseLayer)
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-wms-wfs-layers/tasks.md */
+		/**
+		 * @param state
+		 * @spec openspec/changes/retrofit-2026-05-24-wms-wfs-layers/tasks.md
+		 */
 		baseLayers(state) {
 			return state.layers.filter(l => l.isBaseLayer)
 		},
@@ -61,7 +67,10 @@ export const useGisStore = defineStore('gis', {
 		 * @param {object} layerData The layer configuration
 		 * @return {object} The created layer
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-wms-wfs-layers/tasks.md */
+		/**
+		 * @param layerData
+		 * @spec openspec/changes/retrofit-2026-05-24-wms-wfs-layers/tasks.md
+		 */
 		async createLayer(layerData) {
 			const objectStore = useObjectStore()
 			const created = await objectStore.saveObject('mapLayer', layerData)
@@ -76,7 +85,11 @@ export const useGisStore = defineStore('gis', {
 		 * @param {object} layerData The updated configuration
 		 * @return {object} The updated layer
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-wms-wfs-layers/tasks.md */
+		/**
+		 * @param id
+		 * @param layerData
+		 * @spec openspec/changes/retrofit-2026-05-24-wms-wfs-layers/tasks.md
+		 */
 		async updateLayer(id, layerData) {
 			const objectStore = useObjectStore()
 			const updated = await objectStore.saveObject('mapLayer', { id, ...layerData })
@@ -89,7 +102,10 @@ export const useGisStore = defineStore('gis', {
 		 *
 		 * @param {string} id The layer ID
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-wms-wfs-layers/tasks.md */
+		/**
+		 * @param id
+		 * @spec openspec/changes/retrofit-2026-05-24-wms-wfs-layers/tasks.md
+		 */
 		async deleteLayer(id) {
 			const objectStore = useObjectStore()
 			await objectStore.deleteObject('mapLayer', id)
@@ -102,7 +118,11 @@ export const useGisStore = defineStore('gis', {
 		 * @param {object|null} geometry GeoJSON geometry or null to clear
 		 * @param {string}      mode     Filter mode identifier
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-wms-wfs-layers/tasks.md */
+		/**
+		 * @param geometry
+		 * @param mode
+		 * @spec openspec/changes/retrofit-2026-05-24-wms-wfs-layers/tasks.md
+		 */
 		setSpatialFilter(geometry, mode = null) {
 			this.selectedArea = geometry
 			this.filterMode = mode
@@ -125,7 +145,11 @@ export const useGisStore = defineStore('gis', {
 		 * @param {number} lng Longitude
 		 * @return {Promise<string>} The formatted address
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-wms-wfs-layers/tasks.md */
+		/**
+		 * @param lat
+		 * @param lng
+		 * @spec openspec/changes/retrofit-2026-05-24-wms-wfs-layers/tasks.md
+		 */
 		async reverseGeocode(lat, lng) {
 			const key = `${lat.toFixed(5)},${lng.toFixed(5)}`
 

--- a/src/store/modules/inspection.js
+++ b/src/store/modules/inspection.js
@@ -28,7 +28,10 @@ export const useInspectionStore = defineStore('inspection', {
 		 * @param {object} state Store state
 		 * @return {Array} Active checklists
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md */
+		/**
+		 * @param state
+		 * @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md
+		 */
 		activeChecklists(state) {
 			return state.checklists.filter((c) => c.status === 'active')
 		},
@@ -39,7 +42,10 @@ export const useInspectionStore = defineStore('inspection', {
 		 * @param {object} state Store state
 		 * @return {number} Number of completed reports
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md */
+		/**
+		 * @param state
+		 * @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md
+		 */
 		completedReportsCount(state) {
 			return state.reports.length
 		},
@@ -50,7 +56,10 @@ export const useInspectionStore = defineStore('inspection', {
 		 * @param {object} state Store state
 		 * @return {Array} Reports with failed items
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md */
+		/**
+		 * @param state
+		 * @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md
+		 */
 		nonConformReports(state) {
 			return state.reports.filter((r) => r.result === 'niet_conform' || r.result === 'deels_conform')
 		},
@@ -63,7 +72,10 @@ export const useInspectionStore = defineStore('inspection', {
 		 * @param {string} caseTypeId UUID of the case type
 		 * @return {Promise<Array>} Checklists
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md */
+		/**
+		 * @param caseTypeId
+		 * @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md
+		 */
 		async fetchChecklists(caseTypeId) {
 			this.loading = true
 			this.error = null
@@ -90,7 +102,10 @@ export const useInspectionStore = defineStore('inspection', {
 		 * @param {object} checklistData The checklist data
 		 * @return {Promise<object|null>} Saved checklist
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md */
+		/**
+		 * @param checklistData
+		 * @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md
+		 */
 		async saveChecklist(checklistData) {
 			this.loading = true
 			this.error = null
@@ -120,7 +135,10 @@ export const useInspectionStore = defineStore('inspection', {
 		 * @param {object} checklist The checklist to version
 		 * @return {Promise<object|null>} New version
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md */
+		/**
+		 * @param checklist
+		 * @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md
+		 */
 		async createNewVersion(checklist) {
 			const newVersion = {
 				...checklist,
@@ -141,7 +159,10 @@ export const useInspectionStore = defineStore('inspection', {
 		 * @param {string} checklistId UUID of the checklist
 		 * @return {Promise<boolean>} Success
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md */
+		/**
+		 * @param checklistId
+		 * @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md
+		 */
 		async deleteChecklist(checklistId) {
 			this.loading = true
 			try {
@@ -163,7 +184,10 @@ export const useInspectionStore = defineStore('inspection', {
 		 * @param {string} caseId UUID of the case
 		 * @return {Promise<Array>} Reports
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md */
+		/**
+		 * @param caseId
+		 * @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md
+		 */
 		async fetchReports(caseId) {
 			this.loading = true
 			this.error = null
@@ -190,7 +214,10 @@ export const useInspectionStore = defineStore('inspection', {
 		 * @param {object} reportData Report data with items array
 		 * @return {Promise<object|null>} Created report
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md */
+		/**
+		 * @param reportData
+		 * @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md
+		 */
 		async createReport(reportData) {
 			this.loading = true
 			this.error = null
@@ -246,7 +273,11 @@ export const useInspectionStore = defineStore('inspection', {
 		 * @param {File}   file    The photo file
 		 * @return {Promise<string|null>} Nextcloud file ID
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md */
+		/**
+		 * @param caseId
+		 * @param file
+		 * @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md
+		 */
 		async uploadPhoto(caseId, file) {
 			try {
 				const objectStore = useObjectStore()
@@ -269,7 +300,12 @@ export const useInspectionStore = defineStore('inspection', {
 		 * @param {string} reportId    UUID of the inspection report
 		 * @return {Promise<object|null>} Created task
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md */
+		/**
+		 * @param caseId
+		 * @param failedCount
+		 * @param reportId
+		 * @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md
+		 */
 		async createFollowUpTask(caseId, failedCount, reportId) {
 			try {
 				const objectStore = useObjectStore()

--- a/src/store/modules/settings.js
+++ b/src/store/modules/settings.js
@@ -54,7 +54,10 @@ export const useSettingsStore = defineStore('settings', {
 			}
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-25-admin-settings/tasks.md */
+		/**
+		 * @param settingsData
+		 * @spec openspec/changes/retrofit-2026-05-25-admin-settings/tasks.md
+		 */
 		async saveSettings(settingsData) {
 			this.loading = true
 			this.error = null

--- a/src/store/modules/workflow.js
+++ b/src/store/modules/workflow.js
@@ -117,7 +117,10 @@ export const useWorkflowStore = defineStore('workflow', {
 		 * @param {string} caseTypeId UUID of the case type
 		 * @return {Promise<Array>} Array of workflow templates
 		 */
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param caseTypeId
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		async listVersions(caseTypeId) {
 			this.loading = true
 			this.error = null
@@ -144,7 +147,10 @@ export const useWorkflowStore = defineStore('workflow', {
 		 * @param {string} templateId UUID of the workflow template
 		 * @return {Promise<object|null>} The workflow template or null
 		 */
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param templateId
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		async getTemplate(templateId) {
 			this.loading = true
 			this.error = null
@@ -167,7 +173,10 @@ export const useWorkflowStore = defineStore('workflow', {
 		 * @param {string} caseTypeId UUID of the case type
 		 * @return {Promise<object|null>} The active workflow template or null
 		 */
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param caseTypeId
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		async getActiveVersion(caseTypeId) {
 			this.loading = true
 			this.error = null
@@ -196,7 +205,11 @@ export const useWorkflowStore = defineStore('workflow', {
 		 * @param {string} title      Name of the workflow
 		 * @return {Promise<object|null>} The created template or null
 		 */
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param caseTypeId
+		 * @param title
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		async createTemplate(caseTypeId, title) {
 			this.loading = true
 			this.error = null
@@ -228,7 +241,10 @@ export const useWorkflowStore = defineStore('workflow', {
 		 * @param {object} templateData The template data to save
 		 * @return {Promise<object|null>} The saved template or null
 		 */
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param templateData
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		async saveTemplate(templateData) {
 			this.loading = true
 			this.error = null
@@ -262,7 +278,10 @@ export const useWorkflowStore = defineStore('workflow', {
 		 * @param {string} templateId UUID of the template
 		 * @return {Promise<boolean>} Success
 		 */
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param templateId
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		async deleteTemplate(templateId) {
 			this.loading = true
 			this.error = null
@@ -287,7 +306,10 @@ export const useWorkflowStore = defineStore('workflow', {
 		 * @param {string} templateId UUID of the template to publish
 		 * @return {Promise<object|null>} The published template or null
 		 */
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param templateId
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		async publishVersion(templateId) {
 			this.error = null
 
@@ -347,7 +369,10 @@ export const useWorkflowStore = defineStore('workflow', {
 		 * @param {string} sourceTemplateId UUID of the source template
 		 * @return {Promise<object|null>} The new draft version or null
 		 */
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param sourceTemplateId
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		async createDraftFromVersion(sourceTemplateId) {
 			this.loading = true
 			this.error = null
@@ -400,7 +425,14 @@ export const useWorkflowStore = defineStore('workflow', {
 		 * @param {Array}  caseDocuments Documents linked to this case
 		 * @return {Array} Available transitions with guard status
 		 */
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param caseData
+		 * @param userRoles
+		 * @param workflow
+		 * @param caseTasks
+		 * @param caseDocuments
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		computeAvailableTransitions(caseData, userRoles, workflow, caseTasks, caseDocuments) {
 			if (!workflow?.transitions) return []
 
@@ -471,7 +503,15 @@ export const useWorkflowStore = defineStore('workflow', {
 		 * @param {string} currentStatus Current status UUID
 		 * @return {Array} Array of {met: boolean, message: string}
 		 */
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param guards
+		 * @param caseData
+		 * @param caseTasks
+		 * @param caseDocuments
+		 * @param steps
+		 * @param currentStatus
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		evaluateGuards(guards, caseData, caseTasks, caseDocuments, steps, currentStatus) {
 			return guards.map((guard) => {
 				switch (guard.type) {
@@ -497,7 +537,11 @@ export const useWorkflowStore = defineStore('workflow', {
 		 * @param {Array}  caseTasks Tasks linked to the case
 		 * @return {object} {met: boolean, message: string}
 		 */
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param guard
+		 * @param caseTasks
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		evaluateChecklistGuard(guard, caseTasks) {
 			// Find tasks with checklists and check completion
 			const tasksWithChecklists = caseTasks.filter((task) => {
@@ -534,7 +578,11 @@ export const useWorkflowStore = defineStore('workflow', {
 		 * @param {object} caseData The case object
 		 * @return {object} {met: boolean, message: string}
 		 */
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param guard
+		 * @param caseData
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		evaluateRequiredFieldGuard(guard, caseData) {
 			const fieldName = guard.fieldName
 			const value = caseData[fieldName]
@@ -554,7 +602,11 @@ export const useWorkflowStore = defineStore('workflow', {
 		 * @param {Array}  caseDocuments Documents linked to the case
 		 * @return {object} {met: boolean, message: string}
 		 */
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param guard
+		 * @param caseDocuments
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		evaluateRequiredDocumentGuard(guard, caseDocuments) {
 			const requiredType = guard.documentTypeName
 			const hasDocument = caseDocuments.some(
@@ -577,7 +629,12 @@ export const useWorkflowStore = defineStore('workflow', {
 		 * @param {Array}  caseTasks     Tasks linked to the case
 		 * @return {object} {met: boolean, messages: Array<string>}
 		 */
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param steps
+		 * @param currentStatus
+		 * @param caseTasks
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		evaluateRequiredSteps(steps, currentStatus, caseTasks) {
 			const stepsInStatus = steps.filter(
 				(s) => s.status === currentStatus && s.isRequired,
@@ -611,7 +668,12 @@ export const useWorkflowStore = defineStore('workflow', {
 		 * @param {object} transition The transition that triggered the actions
 		 * @return {Promise<Array>} Array of {action, success, error} results
 		 */
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param actions
+		 * @param caseData
+		 * @param transition
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		async dispatchActions(actions, caseData, transition) {
 			const results = []
 			for (const action of actions) {
@@ -660,7 +722,12 @@ export const useWorkflowStore = defineStore('workflow', {
 		 * @param {object} transition The transition context
 		 * @return {Promise<void>}
 		 */
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param action
+		 * @param caseData
+		 * @param transition
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		async dispatchEmailAction(action, caseData, transition) {
 			// Delegate to n8n webhook for email sending
 			const webhookUrl = action.webhookUrl || '/apps/procest/api/workflow/actions/email'
@@ -694,7 +761,11 @@ export const useWorkflowStore = defineStore('workflow', {
 		 * @param {object} caseData The case object
 		 * @return {Promise<void>}
 		 */
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param action
+		 * @param caseData
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		async dispatchCreateTaskAction(action, caseData) {
 			const objectStore = useObjectStore()
 			await objectStore.saveObject('task', {
@@ -714,7 +785,11 @@ export const useWorkflowStore = defineStore('workflow', {
 		 * @param {object} caseData The parent case object
 		 * @return {Promise<void>}
 		 */
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param action
+		 * @param caseData
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		async dispatchCreateSubCaseAction(action, caseData) {
 			const objectStore = useObjectStore()
 			await objectStore.saveObject('case', {
@@ -733,7 +808,12 @@ export const useWorkflowStore = defineStore('workflow', {
 		 * @param {object} transition The transition context
 		 * @return {Promise<void>}
 		 */
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param action
+		 * @param caseData
+		 * @param transition
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		async dispatchWebhookAction(action, caseData, transition) {
 			const controller = new AbortController()
 			const timeoutId = setTimeout(() => controller.abort(), 10000)
@@ -771,7 +851,11 @@ export const useWorkflowStore = defineStore('workflow', {
 		 * @param {object} caseData The case object
 		 * @return {Promise<void>}
 		 */
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param action
+		 * @param caseData
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		async dispatchSetFieldAction(action, caseData) {
 			const objectStore = useObjectStore()
 			await objectStore.saveObject('case', {
@@ -787,7 +871,11 @@ export const useWorkflowStore = defineStore('workflow', {
 		 * @param {object} caseData The case object
 		 * @return {Promise<void>}
 		 */
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param action
+		 * @param caseData
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		async dispatchNotifyAction(action, caseData) {
 			// Use Nextcloud OCS notification API
 			await fetch('/ocs/v2.php/apps/admin_notifications/api/v1/notifications/admin', {
@@ -816,7 +904,12 @@ export const useWorkflowStore = defineStore('workflow', {
 		 * @param {object} transition The transition context (optional)
 		 * @return {string} Interpolated string
 		 */
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param template
+		 * @param caseData
+		 * @param transition
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		interpolateTemplate(template, caseData, transition) {
 			return template.replace(/\{\{(\w+(?:\.\w+)*)\}\}/g, (match, path) => {
 				const parts = path.split('.')
@@ -903,7 +996,13 @@ export const useWorkflowStore = defineStore('workflow', {
 		 * @param {Array}    docTypes    Document types of the case type
 		 * @return {object} Portable workflow definition
 		 */
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param template
+		 * @param statusTypes
+		 * @param roleTypes
+		 * @param docTypes
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		exportWorkflow(template, statusTypes, roleTypes, docTypes) {
 			const statusMap = {}
 			statusTypes.forEach((s) => { statusMap[s.id] = s.name })
@@ -959,7 +1058,14 @@ export const useWorkflowStore = defineStore('workflow', {
 		 * @param {Array}  docTypes     Document types of the target case type
 		 * @return {object} {success, template, missingTypes}
 		 */
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param importData
+		 * @param caseTypeId
+		 * @param statusTypes
+		 * @param roleTypes
+		 * @param docTypes
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		async importWorkflow(importData, caseTypeId, statusTypes, roleTypes, docTypes) {
 			// Build reverse maps (name -> UUID)
 			const statusNameMap = {}
@@ -1032,7 +1138,11 @@ export const useWorkflowStore = defineStore('workflow', {
 		 * @param {object} stepData Step properties (optional overrides)
 		 * @return {object} The new step
 		 */
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param statusId
+		 * @param stepData
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		addStep(statusId, stepData = {}) {
 			const steps = [...this.parsedSteps]
 			const stepsInStatus = steps.filter((s) => s.status === statusId)
@@ -1059,7 +1169,10 @@ export const useWorkflowStore = defineStore('workflow', {
 		 *
 		 * @param {string} stepId UUID of the step to remove
 		 */
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param stepId
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		removeStep(stepId) {
 			let steps = [...this.parsedSteps]
 			const removed = steps.find((s) => s.id === stepId)
@@ -1084,7 +1197,11 @@ export const useWorkflowStore = defineStore('workflow', {
 		 * @param {string} stepId  UUID of the step to update
 		 * @param {object} updates Properties to update
 		 */
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param stepId
+		 * @param updates
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		updateStep(stepId, updates) {
 			const steps = [...this.parsedSteps]
 			const index = steps.findIndex((s) => s.id === stepId)
@@ -1104,7 +1221,12 @@ export const useWorkflowStore = defineStore('workflow', {
 		 * @param {object} data       Optional transition properties
 		 * @return {object} The new transition
 		 */
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param fromStatus
+		 * @param toStatus
+		 * @param data
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		addTransition(fromStatus, toStatus, data = {}) {
 			const transitions = [...this.parsedTransitions]
 			const newTransition = {
@@ -1128,7 +1250,10 @@ export const useWorkflowStore = defineStore('workflow', {
 		 *
 		 * @param {string} transitionId UUID of the transition to remove
 		 */
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param transitionId
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		removeTransition(transitionId) {
 			const transitions = this.parsedTransitions.filter(
 				(t) => t.id !== transitionId,
@@ -1144,7 +1269,11 @@ export const useWorkflowStore = defineStore('workflow', {
 		 * @param {string} transitionId UUID of the transition to update
 		 * @param {object} updates      Properties to update
 		 */
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param transitionId
+		 * @param updates
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		updateTransition(transitionId, updates) {
 			const transitions = [...this.parsedTransitions]
 			const index = transitions.findIndex((t) => t.id === transitionId)
@@ -1163,7 +1292,12 @@ export const useWorkflowStore = defineStore('workflow', {
 		 * @param {number} x        X coordinate
 		 * @param {number} y        Y coordinate
 		 */
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param statusId
+		 * @param x
+		 * @param y
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		updateNodePosition(statusId, x, y) {
 			const positions = { ...this.parsedNodePositions }
 			positions[statusId] = { x, y }

--- a/src/store/modules/zgwMapping.js
+++ b/src/store/modules/zgwMapping.js
@@ -44,7 +44,11 @@ export const useZgwMappingStore = defineStore('zgwMapping', {
 			}
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-zgw-api-mapping/tasks.md */
+		/**
+		 * @param resourceKey
+		 * @param config
+		 * @spec openspec/changes/retrofit-2026-05-24-zgw-api-mapping/tasks.md
+		 */
 		async saveMapping(resourceKey, config) {
 			this.loading = true
 			this.error = null
@@ -76,7 +80,10 @@ export const useZgwMappingStore = defineStore('zgwMapping', {
 			}
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-zgw-api-mapping/tasks.md */
+		/**
+		 * @param resourceKey
+		 * @spec openspec/changes/retrofit-2026-05-24-zgw-api-mapping/tasks.md
+		 */
 		async resetMapping(resourceKey) {
 			this.loading = true
 			this.error = null

--- a/src/utils/caseHelpers.js
+++ b/src/utils/caseHelpers.js
@@ -12,7 +12,11 @@ import { parseDuration, formatDuration } from './durationHelpers.js'
  * @param {string} durationString ISO 8601 duration (e.g., "P56D")
  * @return {Date|null} The calculated deadline, or null if inputs are invalid
  */
-/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+/**
+ * @param startDate
+ * @param durationString
+ * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+ */
 export function calculateDeadline(startDate, durationString) {
 	if (!startDate || !durationString) return null
 	const parsed = parseDuration(durationString)
@@ -49,7 +53,11 @@ export function generateIdentifier() {
  * @param {boolean} isFinal Whether the case is at a final status
  * @return {boolean}
  */
-/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+/**
+ * @param caseObj
+ * @param isFinal
+ * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+ */
 export function isCaseOverdue(caseObj, isFinal = false) {
 	if (!caseObj.deadline) return false
 	if (isFinal) return false
@@ -67,7 +75,11 @@ export function isCaseOverdue(caseObj, isFinal = false) {
  * @param {boolean} isFinal Whether the case is at a final status
  * @return {boolean}
  */
-/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+/**
+ * @param caseObj
+ * @param isFinal
+ * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+ */
 export function isCaseDueToday(caseObj, isFinal = false) {
 	if (!caseObj.deadline) return false
 	if (isFinal) return false
@@ -85,7 +97,11 @@ export function isCaseDueToday(caseObj, isFinal = false) {
  * @param {boolean} isFinal Whether the case is at a final status
  * @return {boolean}
  */
-/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+/**
+ * @param caseObj
+ * @param isFinal
+ * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+ */
 export function isCaseDueTomorrow(caseObj, isFinal = false) {
 	if (!caseObj.deadline) return false
 	if (isFinal) return false
@@ -104,7 +120,11 @@ export function isCaseDueTomorrow(caseObj, isFinal = false) {
  * @param {boolean} isFinal Whether the case is at a final status
  * @return {string|null} Overdue text or null if not overdue
  */
-/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+/**
+ * @param caseObj
+ * @param isFinal
+ * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+ */
 export function getCaseOverdueText(caseObj, isFinal = false) {
 	if (!isCaseOverdue(caseObj, isFinal)) return null
 	const deadline = new Date(caseObj.deadline)
@@ -126,7 +146,11 @@ export function getCaseOverdueText(caseObj, isFinal = false) {
  * @param {boolean} isFinal Whether the case is at a final status
  * @return {{ text: string, style: string }} Countdown text and style class
  */
-/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+/**
+ * @param caseObj
+ * @param isFinal
+ * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+ */
 export function formatDeadlineCountdown(caseObj, isFinal = false) {
 	if (!caseObj.deadline) return { text: '—', style: '' }
 	if (isFinal) {
@@ -154,7 +178,10 @@ export function formatDeadlineCountdown(caseObj, isFinal = false) {
  * @param {string} startDate ISO date string
  * @return {number} Days elapsed (0 if today or invalid)
  */
-/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+/**
+ * @param startDate
+ * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+ */
 export function getDaysElapsed(startDate) {
 	if (!startDate) return 0
 	const start = new Date(startDate)
@@ -171,7 +198,10 @@ export function getDaysElapsed(startDate) {
  * @param {string} deadline ISO date string
  * @return {number} Days remaining (negative if overdue)
  */
-/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+/**
+ * @param deadline
+ * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+ */
 export function getDaysRemaining(deadline) {
 	if (!deadline) return 0
 	const dl = new Date(deadline)
@@ -188,7 +218,10 @@ export function getDaysRemaining(deadline) {
  * @param {string} dateString ISO date string
  * @return {string} Formatted date
  */
-/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+/**
+ * @param dateString
+ * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+ */
 export function formatDate(dateString) {
 	if (!dateString) return '—'
 	const date = new Date(dateString)
@@ -201,7 +234,10 @@ export function formatDate(dateString) {
  * @param {string} dateString ISO date string
  * @return {string} Formatted date
  */
-/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+/**
+ * @param dateString
+ * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+ */
 export function formatDateShort(dateString) {
 	if (!dateString) return '—'
 	const date = new Date(dateString)

--- a/src/utils/caseTypeValidation.js
+++ b/src/utils/caseTypeValidation.js
@@ -40,7 +40,10 @@ export function getConfidentialityOptions() {
  * @param {object} data Case type data
  * @return {{ valid: boolean, errors: object }}
  */
-/** @spec openspec/changes/retrofit-2026-05-24-case-types/tasks.md */
+/**
+ * @param data
+ * @spec openspec/changes/retrofit-2026-05-24-case-types/tasks.md
+ */
 export function validateCaseType(data) {
 	const errors = {}
 
@@ -83,7 +86,11 @@ export function validateCaseType(data) {
  * @param {Array} statusTypes Array of status type objects linked to this case type
  * @return {{ valid: boolean, errors: string[] }}
  */
-/** @spec openspec/changes/retrofit-2026-05-24-case-types/tasks.md */
+/**
+ * @param caseType
+ * @param statusTypes
+ * @spec openspec/changes/retrofit-2026-05-24-case-types/tasks.md
+ */
 export function validateForPublish(caseType, statusTypes) {
 	const errors = []
 

--- a/src/utils/caseValidation.js
+++ b/src/utils/caseValidation.js
@@ -9,7 +9,10 @@
  * @param {object} caseType Case type object
  * @return {boolean}
  */
-/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+/**
+ * @param caseType
+ * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+ */
 export function isCaseTypeUsable(caseType) {
 	if (!caseType) return false
 	if (caseType.isDraft === true || caseType.isDraft === 'true') return false
@@ -38,7 +41,10 @@ export function isCaseTypeUsable(caseType) {
  * @param {object} caseType Case type object
  * @return {string|null} Reason why the case type cannot be used, or null if usable
  */
-/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+/**
+ * @param caseType
+ * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+ */
 export function getCaseTypeUnusableReason(caseType) {
 	if (!caseType) return t('procest', 'Case type not found')
 
@@ -77,7 +83,11 @@ export function getCaseTypeUnusableReason(caseType) {
  * @param {object[]} caseTypes Available case types for validation context
  * @return {{ valid: boolean, errors: object }} Validation result
  */
-/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+/**
+ * @param form
+ * @param caseTypes
+ * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+ */
 export function validateCaseCreate(form, caseTypes = []) {
 	const errors = {}
 
@@ -109,7 +119,10 @@ export function validateCaseCreate(form, caseTypes = []) {
  * @param {object} form The form data with title
  * @return {{ valid: boolean, errors: object }} Validation result
  */
-/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+/**
+ * @param form
+ * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+ */
 export function validateCaseUpdate(form) {
 	const errors = {}
 
@@ -131,7 +144,12 @@ export function validateCaseUpdate(form) {
  * @param {object[]} statusTypes Available status types for the case type
  * @return {{ valid: boolean, error: string|null }} Validation result
  */
-/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+/**
+ * @param targetStatus
+ * @param caseObj
+ * @param statusTypes
+ * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+ */
 export function validateStatusChange(targetStatus, caseObj, statusTypes) {
 	if (!targetStatus) {
 		return { valid: false, error: t('procest', 'Target status is required') }

--- a/src/utils/dashboardHelpers.js
+++ b/src/utils/dashboardHelpers.js
@@ -25,7 +25,12 @@ function todayString() {
  * @param {object[]} myTasks Tasks assigned to current user (available/active)
  * @return {object} KPI values
  */
-/** @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md */
+/**
+ * @param openCases
+ * @param completedCases
+ * @param myTasks
+ * @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md
+ */
 export function computeKpis(openCases, completedCases, myTasks) {
 	const today = todayString()
 
@@ -64,7 +69,11 @@ export function computeKpis(openCases, completedCases, myTasks) {
  * @param {object[]} statusTypes All status types
  * @return {Array<{ name: string, count: number }>} Sorted by status type order
  */
-/** @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md */
+/**
+ * @param openCases
+ * @param statusTypes
+ * @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md
+ */
 export function aggregateByStatus(openCases, statusTypes) {
 	const statusMap = new Map()
 	const orderMap = new Map()
@@ -97,7 +106,11 @@ export function aggregateByStatus(openCases, statusTypes) {
  * @param {object[]} caseTypes All case types (for name resolution)
  * @return {Array<{ id, identifier, title, caseTypeName, daysOverdue, handler }>}
  */
-/** @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md */
+/**
+ * @param openCases
+ * @param caseTypes
+ * @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md
+ */
 export function getOverdueCases(openCases, caseTypes) {
 	const typeMap = new Map()
 	for (const ct of caseTypes) {
@@ -124,7 +137,11 @@ export function getOverdueCases(openCases, caseTypes) {
  * @param {number} limit Max entries to return
  * @return {Array<{ date, type, description, user, caseIdentifier }>}
  */
-/** @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md */
+/**
+ * @param cases
+ * @param limit
+ * @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md
+ */
 export function getRecentActivity(cases, limit = 10) {
 	const entries = []
 
@@ -153,7 +170,12 @@ export function getRecentActivity(cases, limit = 10) {
  * @param {number} limit Max items to return
  * @return {Array<{ type, id, title, reference, deadline, daysText, isOverdue, priority }>}
  */
-/** @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md */
+/**
+ * @param cases
+ * @param tasks
+ * @param limit
+ * @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md
+ */
 export function getMyWorkItems(cases, tasks, limit = 5) {
 	const items = []
 
@@ -238,7 +260,11 @@ function endOfWeek() {
  * @param {object[]} normalizedTasks Already-normalized CalDAV task work items
  * @return {{ overdue: object[], dueThisWeek: object[], upcoming: object[], noDeadline: object[], totalCount: number }}
  */
-/** @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md */
+/**
+ * @param cases
+ * @param normalizedTasks
+ * @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md
+ */
 export function getGroupedMyWorkItems(cases, normalizedTasks) {
 	const items = []
 	const today = new Date()
@@ -338,7 +364,12 @@ export const STALLED_THRESHOLD_DAYS = 7
  * @param {number} warningDays Number of days before deadline to flag as at-risk
  * @return {{ overdue: object[], atRisk: object[] }}
  */
-/** @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md */
+/**
+ * @param openCases
+ * @param caseTypes
+ * @param warningDays
+ * @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md
+ */
 export function getDeadlineAlerts(openCases, caseTypes, warningDays = DEADLINE_WARNING_DAYS) {
 	const typeMap = new Map()
 	for (const ct of caseTypes) {
@@ -387,7 +418,11 @@ export function getDeadlineAlerts(openCases, caseTypes, warningDays = DEADLINE_W
  * @param {number} warningDays Number of days before due date to flag as due-soon
  * @return {{ overdue: object[], dueSoon: object[] }}
  */
-/** @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md */
+/**
+ * @param tasks
+ * @param warningDays
+ * @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md
+ */
 export function getTaskDueReminders(tasks, warningDays = DEADLINE_WARNING_DAYS) {
 	const today = new Date()
 	today.setHours(0, 0, 0, 0)
@@ -434,7 +469,12 @@ export function getTaskDueReminders(tasks, warningDays = DEADLINE_WARNING_DAYS) 
  * @param {number} stalledDays Number of days without activity to consider stalled
  * @return {Array<{ id, title, identifier, caseTypeName, daysSinceActivity, handler }>}
  */
-/** @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md */
+/**
+ * @param openCases
+ * @param caseTypes
+ * @param stalledDays
+ * @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md
+ */
 export function getStalledCases(openCases, caseTypes, stalledDays = STALLED_THRESHOLD_DAYS) {
 	const typeMap = new Map()
 	for (const ct of caseTypes) {
@@ -478,7 +518,10 @@ export function getStalledCases(openCases, caseTypes, stalledDays = STALLED_THRE
  * @param {string} dateString ISO date string
  * @return {string}
  */
-/** @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md */
+/**
+ * @param dateString
+ * @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md
+ */
 export function formatRelativeTime(dateString) {
 	if (!dateString) return '—'
 	const date = new Date(dateString)

--- a/src/utils/decisionHelpers.js
+++ b/src/utils/decisionHelpers.js
@@ -8,7 +8,10 @@
  * @param {object} decision Decision object with effectiveDate and expiryDate
  * @return {{ status: string, label: string, style: string, remaining: string|null }}
  */
-/** @spec openspec/changes/roles-decisions/tasks.md */
+/**
+ * @param decision
+ * @spec openspec/changes/roles-decisions/tasks.md
+ */
 export function getDecisionValidity(decision) {
 	const today = new Date()
 	today.setHours(0, 0, 0, 0)
@@ -83,7 +86,10 @@ export function getDecisionValidity(decision) {
  * @param {string} dateString ISO date string
  * @return {string}
  */
-/** @spec openspec/changes/roles-decisions/tasks.md */
+/**
+ * @param dateString
+ * @spec openspec/changes/roles-decisions/tasks.md
+ */
 export function formatDecisionDate(dateString) {
 	if (!dateString) return '—'
 	const date = new Date(dateString)
@@ -96,7 +102,10 @@ export function formatDecisionDate(dateString) {
  * @param {object} form Decision form data
  * @return {{ valid: boolean, errors: object }}
  */
-/** @spec openspec/changes/roles-decisions/tasks.md */
+/**
+ * @param form
+ * @spec openspec/changes/roles-decisions/tasks.md
+ */
 export function validateDecision(form) {
 	const errors = {}
 

--- a/src/utils/doorlooptijdHelpers.js
+++ b/src/utils/doorlooptijdHelpers.js
@@ -16,7 +16,10 @@ import { translate as t } from '@nextcloud/l10n'
  * @param {string} duration ISO 8601 duration (e.g., "P30D")
  * @return {number|null} Number of days, or null if unparseable
  */
-/** @spec openspec/changes/doorlooptijd-dashboard/tasks.md */
+/**
+ * @param duration
+ * @spec openspec/changes/doorlooptijd-dashboard/tasks.md
+ */
 export function parseDurationToDays(duration) {
 	if (!duration || typeof duration !== 'string') return null
 
@@ -38,7 +41,10 @@ export function parseDurationToDays(duration) {
  * @param {object} caseObj Case object with startDate and endDate
  * @return {number|null} Processing days, or null if dates are missing
  */
-/** @spec openspec/changes/doorlooptijd-dashboard/tasks.md */
+/**
+ * @param caseObj
+ * @spec openspec/changes/doorlooptijd-dashboard/tasks.md
+ */
 export function getProcessingDays(caseObj) {
 	if (!caseObj.startDate || !caseObj.endDate) return null
 
@@ -58,7 +64,11 @@ export function getProcessingDays(caseObj) {
  * @param {Map<string, object>} caseTypeMap Map of caseType id to caseType object
  * @return {number|null} Target days from processingDeadline, or null
  */
-/** @spec openspec/changes/doorlooptijd-dashboard/tasks.md */
+/**
+ * @param caseObj
+ * @param caseTypeMap
+ * @spec openspec/changes/doorlooptijd-dashboard/tasks.md
+ */
 export function getSlaTargetDays(caseObj, caseTypeMap) {
 	const ct = caseTypeMap.get(caseObj.caseType)
 	if (!ct || !ct.processingDeadline) return null
@@ -71,7 +81,10 @@ export function getSlaTargetDays(caseObj, caseTypeMap) {
  * @param {object[]} caseTypes Array of case type objects
  * @return {Map<string, object>}
  */
-/** @spec openspec/changes/doorlooptijd-dashboard/tasks.md */
+/**
+ * @param caseTypes
+ * @spec openspec/changes/doorlooptijd-dashboard/tasks.md
+ */
 export function buildCaseTypeMap(caseTypes) {
 	const map = new Map()
 	for (const ct of caseTypes) {
@@ -87,7 +100,11 @@ export function buildCaseTypeMap(caseTypes) {
  * @param {object[]} caseTypes All case types
  * @return {{ overallRate: number|null, withinSla: number, total: number, excluded: number, byType: Array<{ id, name, total, withinSla, rate, avgActual, targetDays }> }}
  */
-/** @spec openspec/changes/doorlooptijd-dashboard/tasks.md */
+/**
+ * @param completedCases
+ * @param caseTypes
+ * @spec openspec/changes/doorlooptijd-dashboard/tasks.md
+ */
 export function computeSlaCompliance(completedCases, caseTypes) {
 	const caseTypeMap = buildCaseTypeMap(caseTypes)
 	const byType = new Map()
@@ -172,7 +189,12 @@ const DEFAULT_BINS = [
  * @param {Array<{ label, min, max }>} [bins] Custom bin definitions
  * @return {{ bins: Array<{ label, count }>, slaTargetDays: number|null }}
  */
-/** @spec openspec/changes/doorlooptijd-dashboard/tasks.md */
+/**
+ * @param completedCases
+ * @param caseTypes
+ * @param bins
+ * @spec openspec/changes/doorlooptijd-dashboard/tasks.md
+ */
 export function computeProcessingTimeDistribution(completedCases, caseTypes, bins) {
 	const useBins = bins || DEFAULT_BINS
 	const caseTypeMap = buildCaseTypeMap(caseTypes)
@@ -216,7 +238,12 @@ export function computeProcessingTimeDistribution(completedCases, caseTypes, bin
  * @param {number} [months] Number of months to look back (defaults to 12)
  * @return {Array<{ month: string, rate: number|null, withinSla: number, total: number }>}
  */
-/** @spec openspec/changes/doorlooptijd-dashboard/tasks.md */
+/**
+ * @param completedCases
+ * @param caseTypes
+ * @param months
+ * @spec openspec/changes/doorlooptijd-dashboard/tasks.md
+ */
 export function computeMonthlyTrend(completedCases, caseTypes, months) {
 	const lookback = months || 12
 	const caseTypeMap = buildCaseTypeMap(caseTypes)
@@ -265,7 +292,12 @@ export function computeMonthlyTrend(completedCases, caseTypes, months) {
  * @param {number} [thresholdPct] Threshold as fraction (defaults to 0.25 = 25%)
  * @return {Array<{ id, title, identifier, caseTypeName, targetDays, elapsedDays, remainingDays, percentUsed, isOverdue }>}
  */
-/** @spec openspec/changes/doorlooptijd-dashboard/tasks.md */
+/**
+ * @param openCases
+ * @param caseTypes
+ * @param thresholdPct
+ * @spec openspec/changes/doorlooptijd-dashboard/tasks.md
+ */
 export function getAtRiskCases(openCases, caseTypes, thresholdPct) {
 	const threshold = thresholdPct ?? 0.25
 	const caseTypeMap = buildCaseTypeMap(caseTypes)
@@ -319,7 +351,11 @@ export function getAtRiskCases(openCases, caseTypes, thresholdPct) {
  * @param {object[]} caseTypes All case types
  * @return {Array<{ id, name, targetDays, avgActualDays, complianceRate, total, withinSla, status: 'good'|'warning'|'critical'|'no-target' }>}
  */
-/** @spec openspec/changes/doorlooptijd-dashboard/tasks.md */
+/**
+ * @param completedCases
+ * @param caseTypes
+ * @spec openspec/changes/doorlooptijd-dashboard/tasks.md
+ */
 export function computePerformanceTable(completedCases, caseTypes) {
 	const byType = new Map()
 

--- a/src/utils/durationHelpers.js
+++ b/src/utils/durationHelpers.js
@@ -13,7 +13,10 @@ const DURATION_REGEX = /^P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?$/
  * @param {string} value The string to validate
  * @return {boolean}
  */
-/** @spec openspec/changes/milestone-tracking/tasks.md */
+/**
+ * @param value
+ * @spec openspec/changes/milestone-tracking/tasks.md
+ */
 export function isValidDuration(value) {
 	if (!value || typeof value !== 'string') return false
 	return DURATION_REGEX.test(value) && value !== 'P'
@@ -25,7 +28,10 @@ export function isValidDuration(value) {
  * @param {string} iso ISO 8601 duration string (e.g., "P56D", "P2M", "P1Y6M")
  * @return {{ years: number, months: number, weeks: number, days: number } | null}
  */
-/** @spec openspec/changes/milestone-tracking/tasks.md */
+/**
+ * @param iso
+ * @spec openspec/changes/milestone-tracking/tasks.md
+ */
 export function parseDuration(iso) {
 	if (!isValidDuration(iso)) return null
 	const match = iso.match(DURATION_REGEX)
@@ -43,7 +49,10 @@ export function parseDuration(iso) {
  * @param {string} iso ISO 8601 duration string
  * @return {string} Human-readable text (e.g., "56 days", "2 months", "1 year, 6 months")
  */
-/** @spec openspec/changes/milestone-tracking/tasks.md */
+/**
+ * @param iso
+ * @spec openspec/changes/milestone-tracking/tasks.md
+ */
 export function formatDuration(iso) {
 	const parsed = parseDuration(iso)
 	if (!parsed) return iso || ''
@@ -83,7 +92,10 @@ export function formatDuration(iso) {
  * @param {string} value The value to validate
  * @return {string} Error message or empty string
  */
-/** @spec openspec/changes/milestone-tracking/tasks.md */
+/**
+ * @param value
+ * @spec openspec/changes/milestone-tracking/tasks.md
+ */
 export function getDurationError(value) {
 	if (!value) return ''
 	if (!isValidDuration(value)) {

--- a/src/utils/i18nResolver.js
+++ b/src/utils/i18nResolver.js
@@ -47,7 +47,12 @@ export function getUserLocale() {
  * @param {string} [fallbackLocale] The fallback locale (defaults to app default 'nl')
  * @return {{ text: string, lang: string|null, isFallback: boolean }}
  */
-/** @spec openspec/changes/retrofit-2026-05-25-procest-app-scaffold/tasks.md */
+/**
+ * @param value
+ * @param locale
+ * @param fallbackLocale
+ * @spec openspec/changes/retrofit-2026-05-25-procest-app-scaffold/tasks.md
+ */
 export function resolveTranslatable(value, locale, fallbackLocale) {
 	// Null/undefined -> empty string
 	if (value === null || value === undefined) {
@@ -107,7 +112,12 @@ export function resolveTranslatable(value, locale, fallbackLocale) {
  * @param {string} [locale] The preferred locale
  * @return {{ text: string, lang: string|null, isFallback: boolean }}
  */
-/** @spec openspec/changes/retrofit-2026-05-25-procest-app-scaffold/tasks.md */
+/**
+ * @param obj
+ * @param field
+ * @param locale
+ * @spec openspec/changes/retrofit-2026-05-25-procest-app-scaffold/tasks.md
+ */
 export function resolveField(obj, field, locale) {
 	if (!obj || typeof obj !== 'object') {
 		return { text: '', lang: null, isFallback: false }
@@ -123,7 +133,12 @@ export function resolveField(obj, field, locale) {
  * @param {string} [locale] The preferred locale
  * @return {string} The resolved text
  */
-/** @spec openspec/changes/retrofit-2026-05-25-procest-app-scaffold/tasks.md */
+/**
+ * @param obj
+ * @param field
+ * @param locale
+ * @spec openspec/changes/retrofit-2026-05-25-procest-app-scaffold/tasks.md
+ */
 export function resolveText(obj, field, locale) {
 	return resolveField(obj, field, locale).text
 }

--- a/src/utils/openregisterCheck.js
+++ b/src/utils/openregisterCheck.js
@@ -43,7 +43,10 @@ export async function checkOpenRegisterStatus() {
  * @param {{ available: boolean, configured: boolean, error: string|null }} status
  * @return {string}
  */
-/** @spec openspec/changes/openregister-integration/tasks.md */
+/**
+ * @param status
+ * @spec openspec/changes/openregister-integration/tasks.md
+ */
 export function getStatusMessage(status) {
 	if (status.error) {
 		return t('procest', 'Could not check OpenRegister status: {error}', { error: status.error })

--- a/src/utils/parafeerEngine.js
+++ b/src/utils/parafeerEngine.js
@@ -11,7 +11,10 @@
  * @param {object} voorstel The voorstel object
  * @return {Array} Ordered array of step objects
  */
-/** @spec openspec/specs/parafering-actions/spec.md */
+/**
+ * @param voorstel
+ * @spec openspec/specs/parafering-actions/spec.md
+ */
 export function getRouteSteps(voorstel) {
 	if (!voorstel?.routeSnapshot) return []
 	try {
@@ -29,7 +32,10 @@ export function getRouteSteps(voorstel) {
  * @param {object} voorstel The voorstel object
  * @return {object|null} Current step or null
  */
-/** @spec openspec/specs/parafering-actions/spec.md */
+/**
+ * @param voorstel
+ * @spec openspec/specs/parafering-actions/spec.md
+ */
 export function getCurrentStep(voorstel) {
 	const steps = getRouteSteps(voorstel)
 	if (!steps.length || !voorstel.currentStep) return null
@@ -43,7 +49,11 @@ export function getCurrentStep(voorstel) {
  * @param {string} userId   The Nextcloud user UID
  * @return {boolean}
  */
-/** @spec openspec/specs/parafering-actions/spec.md */
+/**
+ * @param voorstel
+ * @param userId
+ * @spec openspec/specs/parafering-actions/spec.md
+ */
 export function isActiveActor(voorstel, userId) {
 	const step = getCurrentStep(voorstel)
 	if (!step) return false
@@ -56,7 +66,10 @@ export function isActiveActor(voorstel, userId) {
  * @param {object} voorstel The voorstel object
  * @return {number|null} Next step number, or null if this was the last step
  */
-/** @spec openspec/specs/parafering-actions/spec.md */
+/**
+ * @param voorstel
+ * @spec openspec/specs/parafering-actions/spec.md
+ */
 export function getNextStep(voorstel) {
 	const steps = getRouteSteps(voorstel)
 	const current = voorstel.currentStep || 0
@@ -70,7 +83,10 @@ export function getNextStep(voorstel) {
  * @param {object} voorstel The voorstel object
  * @return {string} New status ('in_parafering', 'ter_accordering', or 'geaccordeerd')
  */
-/** @spec openspec/specs/parafering-actions/spec.md */
+/**
+ * @param voorstel
+ * @spec openspec/specs/parafering-actions/spec.md
+ */
 export function getStatusAfterAdvance(voorstel) {
 	const steps = getRouteSteps(voorstel)
 	const nextStepNum = getNextStep(voorstel)
@@ -94,7 +110,10 @@ export function getStatusAfterAdvance(voorstel) {
  * @param {object} route The parafeerroute object
  * @return {Array} Snapshot of steps
  */
-/** @spec openspec/specs/parafering-actions/spec.md */
+/**
+ * @param route
+ * @spec openspec/specs/parafering-actions/spec.md
+ */
 export function createRouteSnapshot(route) {
 	if (!route?.steps) return []
 	const steps = typeof route.steps === 'string' ? JSON.parse(route.steps) : route.steps
@@ -116,7 +135,12 @@ export function createRouteSnapshot(route) {
  * @param {object} newStep   The new step to insert (without order)
  * @return {Array} Updated steps with renumbered orders
  */
-/** @spec openspec/specs/parafering-actions/spec.md */
+/**
+ * @param steps
+ * @param afterOrder
+ * @param newStep
+ * @spec openspec/specs/parafering-actions/spec.md
+ */
 export function insertAdHocStep(steps, afterOrder, newStep) {
 	const result = []
 	let orderCounter = 1
@@ -144,7 +168,11 @@ export function insertAdHocStep(steps, afterOrder, newStep) {
  * @param {number} stepOrder The step order to skip
  * @return {Array} Updated steps with the step marked as skipped
  */
-/** @spec openspec/specs/parafering-actions/spec.md */
+/**
+ * @param steps
+ * @param stepOrder
+ * @spec openspec/specs/parafering-actions/spec.md
+ */
 export function markStepSkipped(steps, stepOrder) {
 	return steps.map(step => {
 		if (step.order === stepOrder) {
@@ -162,7 +190,12 @@ export function markStepSkipped(steps, stepOrder) {
  * @param {string} voorstelType The voorstel type (dt_advies, collegeadvies, raadsvoorstel)
  * @return {object|null} The matching default route, or null
  */
-/** @spec openspec/specs/parafering-actions/spec.md */
+/**
+ * @param routes
+ * @param caseTypeId
+ * @param voorstelType
+ * @spec openspec/specs/parafering-actions/spec.md
+ */
 export function findDefaultRoute(routes, caseTypeId, voorstelType) {
 	return routes.find(r =>
 		r.isDefault === true

--- a/src/utils/taskHelpers.js
+++ b/src/utils/taskHelpers.js
@@ -35,7 +35,10 @@ export function getPriorityLevels() {
  * @param {object} task Task object with dueDate and status
  * @return {boolean}
  */
-/** @spec openspec/changes/task-management/tasks.md */
+/**
+ * @param task
+ * @spec openspec/changes/task-management/tasks.md
+ */
 export function isOverdue(task) {
 	if (!task.dueDate) return false
 	if (isTerminalStatus(task.status)) return false
@@ -52,7 +55,10 @@ export function isOverdue(task) {
  * @param {object} task Task object with dueDate and status
  * @return {boolean}
  */
-/** @spec openspec/changes/task-management/tasks.md */
+/**
+ * @param task
+ * @spec openspec/changes/task-management/tasks.md
+ */
 export function isDueToday(task) {
 	if (!task.dueDate) return false
 	if (isTerminalStatus(task.status)) return false
@@ -69,7 +75,10 @@ export function isDueToday(task) {
  * @param {object} task Task object with dueDate
  * @return {string|null} Overdue text or null if not overdue
  */
-/** @spec openspec/changes/task-management/tasks.md */
+/**
+ * @param task
+ * @spec openspec/changes/task-management/tasks.md
+ */
 export function getOverdueText(task) {
 	if (!isOverdue(task)) return null
 	const due = new Date(task.dueDate)
@@ -90,7 +99,10 @@ export function getOverdueText(task) {
  * @param {string} dateString ISO 8601 date string
  * @return {string} Formatted date
  */
-/** @spec openspec/changes/task-management/tasks.md */
+/**
+ * @param dateString
+ * @spec openspec/changes/task-management/tasks.md
+ */
 export function formatDueDate(dateString) {
 	if (!dateString) return '—'
 	const date = new Date(dateString)
@@ -103,7 +115,10 @@ export function formatDueDate(dateString) {
  * @param {string} priority One of urgent, high, normal, low
  * @return {number}
  */
-/** @spec openspec/changes/task-management/tasks.md */
+/**
+ * @param priority
+ * @spec openspec/changes/task-management/tasks.md
+ */
 export function prioritySortWeight(priority) {
 	return PRIORITY_WEIGHTS[priority] ?? 3
 }
@@ -132,7 +147,10 @@ function statusGroupWeight(status) {
  * @param {object[]} tasks Array of task objects
  * @return {object[]} Sorted copy of the array
  */
-/** @spec openspec/changes/task-management/tasks.md */
+/**
+ * @param tasks
+ * @spec openspec/changes/task-management/tasks.md
+ */
 export function sortTasks(tasks) {
 	return [...tasks].sort((a, b) => {
 		const statusDiff = statusGroupWeight(a.status) - statusGroupWeight(b.status)

--- a/src/utils/taskLifecycle.js
+++ b/src/utils/taskLifecycle.js
@@ -50,7 +50,10 @@ const TERMINAL_STATUSES = new Set(['completed', 'terminated', 'disabled'])
  * @param {string} currentStatus One of the TASK_STATUSES values
  * @return {string[]} Array of valid target statuses
  */
-/** @spec openspec/changes/task-management/tasks.md */
+/**
+ * @param currentStatus
+ * @spec openspec/changes/task-management/tasks.md
+ */
 export function getAllowedTransitions(currentStatus) {
 	return TRANSITION_MAP[currentStatus] || []
 }
@@ -62,7 +65,11 @@ export function getAllowedTransitions(currentStatus) {
  * @param {string} to   Target status
  * @return {boolean}
  */
-/** @spec openspec/changes/task-management/tasks.md */
+/**
+ * @param from
+ * @param to
+ * @spec openspec/changes/task-management/tasks.md
+ */
 export function validateTransition(from, to) {
 	const allowed = TRANSITION_MAP[from]
 	return Array.isArray(allowed) && allowed.includes(to)
@@ -74,7 +81,10 @@ export function validateTransition(from, to) {
  * @param {string} status One of the TASK_STATUSES values
  * @return {string}
  */
-/** @spec openspec/changes/task-management/tasks.md */
+/**
+ * @param status
+ * @spec openspec/changes/task-management/tasks.md
+ */
 export function getStatusLabel(status) {
 	return getStatusLabels()[status] || status
 }
@@ -85,7 +95,10 @@ export function getStatusLabel(status) {
  * @param {string} targetStatus The status being transitioned to
  * @return {string}
  */
-/** @spec openspec/changes/task-management/tasks.md */
+/**
+ * @param targetStatus
+ * @spec openspec/changes/task-management/tasks.md
+ */
 export function getTransitionLabel(targetStatus) {
 	return getTransitionLabels()[targetStatus] || targetStatus
 }
@@ -96,7 +109,10 @@ export function getTransitionLabel(targetStatus) {
  * @param {string} status One of the TASK_STATUSES values
  * @return {boolean}
  */
-/** @spec openspec/changes/task-management/tasks.md */
+/**
+ * @param status
+ * @spec openspec/changes/task-management/tasks.md
+ */
 export function isTerminalStatus(status) {
 	return TERMINAL_STATUSES.has(status)
 }

--- a/src/utils/taskValidation.js
+++ b/src/utils/taskValidation.js
@@ -10,7 +10,10 @@ import { validateTransition } from './taskLifecycle.js'
  * @param {object} form The form data
  * @return {{ valid: boolean, errors: object }} Validation result
  */
-/** @spec openspec/changes/task-management/tasks.md */
+/**
+ * @param form
+ * @spec openspec/changes/task-management/tasks.md
+ */
 export function validateTaskCreate(form) {
 	const errors = {}
 
@@ -34,7 +37,10 @@ export function validateTaskCreate(form) {
  * @param {object} form The form data
  * @return {{ valid: boolean, errors: object }} Validation result
  */
-/** @spec openspec/changes/task-management/tasks.md */
+/**
+ * @param form
+ * @spec openspec/changes/task-management/tasks.md
+ */
 export function validateTaskUpdate(form) {
 	const errors = {}
 
@@ -55,7 +61,11 @@ export function validateTaskUpdate(form) {
  * @param {string} to Target status
  * @return {{ valid: boolean, error: string|null }} Validation result
  */
-/** @spec openspec/changes/task-management/tasks.md */
+/**
+ * @param from
+ * @param to
+ * @spec openspec/changes/task-management/tasks.md
+ */
 export function validateTaskTransition(from, to) {
 	if (!from || !to) {
 		return { valid: false, error: t('procest', 'Invalid status transition') }

--- a/src/views/DoorlooptijdDashboard.vue
+++ b/src/views/DoorlooptijdDashboard.vue
@@ -702,11 +702,17 @@ export default {
 				this.loading = false
 			}
 		},
-		/** @spec openspec/changes/doorlooptijd-dashboard/tasks.md */
+		/**
+		 * @param key
+		 * @spec openspec/changes/doorlooptijd-dashboard/tasks.md
+		 */
 		applyPreset(key) {
 			this.selectedPreset = key
 		},
-		/** @spec openspec/changes/doorlooptijd-dashboard/tasks.md */
+		/**
+		 * @param column
+		 * @spec openspec/changes/doorlooptijd-dashboard/tasks.md
+		 */
 		sortTable(column) {
 			if (this.sortColumn === column) {
 				this.sortDirection = this.sortDirection === 'asc' ? 'desc' : 'asc'

--- a/src/views/MyWork.vue
+++ b/src/views/MyWork.vue
@@ -423,7 +423,10 @@ export default {
 				console.warn('Failed to fetch completed items:', err)
 			}
 		},
-		/** @spec openspec/changes/my-work/tasks.md */
+		/**
+		 * @param item
+		 * @spec openspec/changes/my-work/tasks.md
+		 */
 		onItemClick(item) {
 			if (item.type === 'case') {
 				this.$router.push({ name: 'CaseDetail', params: { id: item.id } })

--- a/src/views/Werkvoorraad.vue
+++ b/src/views/Werkvoorraad.vue
@@ -271,13 +271,19 @@ export default {
 			this.activeFilter = filter
 		},
 
-		/** @spec openspec/changes/my-work/tasks.md */
+		/**
+		 * @param caseTypeId
+		 * @spec openspec/changes/my-work/tasks.md
+		 */
 		getCaseTypeName(caseTypeId) {
 			const ct = this.caseTypes.find(t => t.id === caseTypeId)
 			return ct?.title || '—'
 		},
 
-		/** @spec openspec/changes/my-work/tasks.md */
+		/**
+		 * @param statusId
+		 * @spec openspec/changes/my-work/tasks.md
+		 */
 		getStatusName(statusId) {
 			const st = this.statusTypes.find(s => s.id === statusId)
 			return st?.name || '—'
@@ -287,7 +293,10 @@ export default {
 			return isCaseOverdue(caseItem, false)
 		},
 
-		/** @spec openspec/changes/my-work/tasks.md */
+		/**
+		 * @param caseItem
+		 * @spec openspec/changes/my-work/tasks.md
+		 */
 		formatDeadline(caseItem) {
 			if (!caseItem.deadline) return '—'
 			const days = getDaysRemaining(caseItem.deadline)
@@ -299,7 +308,10 @@ export default {
 			return `${dateStr} (${days} ${t('procest', 'days')})`
 		},
 
-		/** @spec openspec/changes/my-work/tasks.md */
+		/**
+		 * @param caseItem
+		 * @spec openspec/changes/my-work/tasks.md
+		 */
 		openCase(caseItem) {
 			this.$router.push({ name: 'CaseDetail', params: { id: caseItem.id } })
 		},

--- a/src/views/cases/CaseCreateDialog.vue
+++ b/src/views/cases/CaseCreateDialog.vue
@@ -237,7 +237,10 @@ export default {
 			this.loadingTypes = false
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+		/**
+		 * @param caseType
+		 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+		 */
 		async onCaseTypeSelected(caseType) {
 			this.form.caseType = caseType?.id || null
 			this.errors.caseType = ''

--- a/src/views/cases/components/ActivityTimeline.vue
+++ b/src/views/cases/components/ActivityTimeline.vue
@@ -77,7 +77,10 @@ export default {
 		},
 	},
 	methods: {
-		/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+		/**
+		 * @param type
+		 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+		 */
 		getIcon(type) {
 			const icons = {
 				created: '+',
@@ -88,7 +91,10 @@ export default {
 			}
 			return icons[type] || '•'
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+		/**
+		 * @param dateString
+		 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+		 */
 		formatEntryDate(dateString) {
 			return formatDate(dateString)
 		},

--- a/src/views/cases/components/AddParticipantDialog.vue
+++ b/src/views/cases/components/AddParticipantDialog.vue
@@ -7,7 +7,8 @@
 				<label>{{ t('procest', 'Role type') }} *</label>
 				<NcSelect
 					v-model="selectedRoleType"
-					:options="roleTypes" :aria-label-combobox="t('procest', 'Role type')"
+					:options="roleTypes"
+					:aria-label-combobox="t('procest', 'Role type')"
 					label="name"
 					track-by="id"
 					:placeholder="t('procest', 'Select role type...')" />
@@ -17,7 +18,8 @@
 				<label>{{ t('procest', 'Participant') }} *</label>
 				<NcSelect
 					v-model="selectedUser"
-					:options="userOptions" :aria-label-combobox="t('procest', 'Participant')"
+					:options="userOptions"
+					:aria-label-combobox="t('procest', 'Participant')"
 					label="label"
 					track-by="id"
 					:placeholder="t('procest', 'Select user...')" />

--- a/src/views/cases/components/AdvicePanel.vue
+++ b/src/views/cases/components/AdvicePanel.vue
@@ -183,7 +183,10 @@ export default {
 	watch: {
 		caseId: {
 			immediate: true,
-			/** @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md */
+			/**
+			 * @param newId
+			 * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
+			 */
 			handler(newId) {
 				if (newId) {
 					this.adviceStore.fetchRequests(newId)
@@ -202,7 +205,10 @@ export default {
 			return d.toISOString().split('T')[0]
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md */
+		/**
+		 * @param request
+		 * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
+		 */
 		isOverdue(request) {
 			if (request.status !== 'aangevraagd' || !request.deadline) {
 				return false
@@ -214,7 +220,10 @@ export default {
 			return this.adviceStore.getDaysToDeadline(request)
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md */
+		/**
+		 * @param dateStr
+		 * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
+		 */
 		formatDate(dateStr) {
 			if (!dateStr) {
 				return ''
@@ -222,7 +231,10 @@ export default {
 			return new Date(dateStr).toLocaleDateString()
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md */
+		/**
+		 * @param status
+		 * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
+		 */
 		statusLabel(status) {
 			const labels = {
 				aangevraagd: t('procest', 'Requested'),
@@ -232,7 +244,10 @@ export default {
 			return labels[status] || status
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md */
+		/**
+		 * @param status
+		 * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
+		 */
 		statusClass(status) {
 			return {
 				'advice-panel__status-badge--aangevraagd': status === 'aangevraagd',
@@ -262,12 +277,18 @@ export default {
 			}
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md */
+		/**
+		 * @param request
+		 * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
+		 */
 		async markReceived(request) {
 			await this.adviceStore.markReceived(request.id)
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md */
+		/**
+		 * @param request
+		 * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
+		 */
 		viewDocument(request) {
 			if (request.adviesDocument) {
 				window.open(`/apps/files/?fileid=${request.adviesDocument}`, '_blank')

--- a/src/views/cases/components/AdviceRequestPanel.vue
+++ b/src/views/cases/components/AdviceRequestPanel.vue
@@ -121,7 +121,10 @@ export default {
 		},
 	},
 	methods: {
-		/** @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md */
+		/**
+		 * @param status
+		 * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
+		 */
 		getStatusLabel(status) {
 			const labels = {
 				open: this.t('procest', 'Open'),
@@ -131,7 +134,10 @@ export default {
 			}
 			return labels[status] || status
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md */
+		/**
+		 * @param response
+		 * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
+		 */
 		getResponseLabel(response) {
 			const labels = {
 				positief: this.t('procest', 'Positive'),
@@ -141,14 +147,20 @@ export default {
 			}
 			return labels[response] || response
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md */
+		/**
+		 * @param dateStr
+		 * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
+		 */
 		formatDate(dateStr) {
 			if (!dateStr) return '---'
 			const date = new Date(dateStr)
 			if (isNaN(date.getTime())) return dateStr
 			return date.toLocaleDateString('nl-NL')
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md */
+		/**
+		 * @param req
+		 * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
+		 */
 		isOverdue(req) {
 			if (!req.deadline || req.status === 'afgesloten' || req.status === 'advies_uitgebracht') {
 				return false

--- a/src/views/cases/components/AdviesPanel.vue
+++ b/src/views/cases/components/AdviesPanel.vue
@@ -111,7 +111,10 @@ export default {
 	watch: {
 		caseId: {
 			immediate: true,
-			/** @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md */
+			/**
+			 * @param value
+			 * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
+			 */
 			handler(value) {
 				if (value) {
 					this.fetchAdvies()
@@ -141,7 +144,10 @@ export default {
 			this.showDialog = false
 			this.fetchAdvies()
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md */
+		/**
+		 * @param item
+		 * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
+		 */
 		async onRemind(item) {
 			try {
 				await dispatchReminder(item.id || item.uuid)
@@ -149,7 +155,10 @@ export default {
 				console.error('Procest: failed to send reminder', error)
 			}
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md */
+		/**
+		 * @param item
+		 * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
+		 */
 		async onMarkReceived(item) {
 			try {
 				await transitionStatus(item.id || item.uuid, {
@@ -161,23 +170,35 @@ export default {
 				console.error('Procest: failed to mark received', error)
 			}
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md */
+		/**
+		 * @param item
+		 * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
+		 */
 		onViewDocument(item) {
 			if (item.adviesDocument) {
 				window.open(`/index.php/f/${item.adviesDocument}`, '_blank')
 			}
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md */
+		/**
+		 * @param type
+		 * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
+		 */
 		typeLabel(type) {
 			return type === 'intern'
 				? this.t(this.appName, 'Intern')
 				: this.t(this.appName, 'Extern')
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md */
+		/**
+		 * @param type
+		 * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
+		 */
 		typeBadgeType(type) {
 			return type === 'intern' ? 'neutral' : 'info'
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md */
+		/**
+		 * @param status
+		 * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
+		 */
 		statusLabel(status) {
 			const labels = {
 				aangevraagd: this.t(this.appName, 'Aangevraagd'),
@@ -186,7 +207,10 @@ export default {
 			}
 			return labels[status] || status
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md */
+		/**
+		 * @param status
+		 * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
+		 */
 		statusBadgeType(status) {
 			const types = {
 				aangevraagd: 'info',
@@ -195,14 +219,20 @@ export default {
 			}
 			return types[status] || 'neutral'
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md */
+		/**
+		 * @param item
+		 * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
+		 */
 		isOverdue(item) {
 			if (item.status !== 'aangevraagd' || !item.deadline) {
 				return false
 			}
 			return new Date(item.deadline) < new Date()
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md */
+		/**
+		 * @param item
+		 * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
+		 */
 		daysOverdue(item) {
 			if (!item.deadline) {
 				return 0
@@ -210,7 +240,10 @@ export default {
 			const diff = Date.now() - new Date(item.deadline).getTime()
 			return Math.max(0, Math.floor(diff / (1000 * 60 * 60 * 24)))
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md */
+		/**
+		 * @param value
+		 * @spec openspec/changes/retrofit-2026-05-24-advice-management/tasks.md
+		 */
 		formatDate(value) {
 			if (!value) {
 				return ''

--- a/src/views/cases/components/AiAssistantPanel.vue
+++ b/src/views/cases/components/AiAssistantPanel.vue
@@ -137,11 +137,18 @@ export default {
 				this.summaryLoading = false
 			}
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md */
+		/**
+		 * @param suggestion
+		 * @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md
+		 */
 		handleAccept(suggestion) {
 			this.$emit('suggestion-accepted', suggestion)
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md */
+		/**
+		 * @param suggestion
+		 * @param reason
+		 * @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md
+		 */
 		handleReject(suggestion, reason) {
 			this.$emit('suggestion-rejected', suggestion, reason)
 		},

--- a/src/views/cases/components/AiClassifyDialog.vue
+++ b/src/views/cases/components/AiClassifyDialog.vue
@@ -73,7 +73,10 @@ export default {
 		}
 	},
 	watch: {
-		/** @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md */
+		/**
+		 * @param val
+		 * @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md
+		 */
 		show(val) {
 			if (val) this.classify()
 		},

--- a/src/views/cases/components/AiExtractDialog.vue
+++ b/src/views/cases/components/AiExtractDialog.vue
@@ -100,7 +100,10 @@ export default {
 		},
 	},
 	watch: {
-		/** @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md */
+		/**
+		 * @param val
+		 * @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md
+		 */
 		show(val) {
 			if (val) this.extract()
 		},
@@ -124,11 +127,17 @@ export default {
 				this.loading = false
 			}
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md */
+		/**
+		 * @param checked
+		 * @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md
+		 */
 		toggleAll(checked) {
 			this.selectedFields = checked ? this.fields.map((f) => f.name) : []
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md */
+		/**
+		 * @param name
+		 * @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md
+		 */
 		toggleField(name) {
 			const idx = this.selectedFields.indexOf(name)
 			if (idx >= 0) {

--- a/src/views/cases/components/AiSuggestionCard.vue
+++ b/src/views/cases/components/AiSuggestionCard.vue
@@ -64,7 +64,10 @@ export default {
 	},
 	methods: {
 		t,
-		/** @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md */
+		/**
+		 * @param value
+		 * @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md
+		 */
 		formatValue(value) {
 			if (typeof value === 'object') return JSON.stringify(value, null, 2)
 			return String(value)

--- a/src/views/cases/components/AppointmentSection.vue
+++ b/src/views/cases/components/AppointmentSection.vue
@@ -67,12 +67,18 @@ export default {
 				this.appointments = []
 			}
 		},
-		/** @spec openspec/changes/retrofit-2026-05-25-appointment-booking/tasks.md */
+		/**
+		 * @param dt
+		 * @spec openspec/changes/retrofit-2026-05-25-appointment-booking/tasks.md
+		 */
 		formatDateTime(dt) {
 			if (!dt) return '-'
 			return new Date(dt).toLocaleString('nl-NL', { dateStyle: 'long', timeStyle: 'short' })
 		},
-		/** @spec openspec/changes/retrofit-2026-05-25-appointment-booking/tasks.md */
+		/**
+		 * @param status
+		 * @spec openspec/changes/retrofit-2026-05-25-appointment-booking/tasks.md
+		 */
 		statusLabel(status) {
 			const labels = {
 				scheduled: t('procest', 'Scheduled'),
@@ -83,12 +89,18 @@ export default {
 			}
 			return labels[status] || status
 		},
-		/** @spec openspec/changes/retrofit-2026-05-25-appointment-booking/tasks.md */
+		/**
+		 * @param apt
+		 * @spec openspec/changes/retrofit-2026-05-25-appointment-booking/tasks.md
+		 */
 		async cancel(apt) {
 			await cancelAppointment(apt.uuid || apt.id)
 			await this.loadAppointments()
 		},
-		/** @spec openspec/changes/retrofit-2026-05-25-appointment-booking/tasks.md */
+		/**
+		 * @param apt
+		 * @spec openspec/changes/retrofit-2026-05-25-appointment-booking/tasks.md
+		 */
 		async noShow(apt) {
 			await markNoShow(apt.uuid || apt.id)
 			await this.loadAppointments()

--- a/src/views/cases/components/BerichtenboxTab.vue
+++ b/src/views/cases/components/BerichtenboxTab.vue
@@ -64,12 +64,18 @@ export default {
 				this.messages = []
 			}
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-berichtenbox-integration/tasks.md */
+		/**
+		 * @param dt
+		 * @spec openspec/changes/retrofit-2026-05-24-berichtenbox-integration/tasks.md
+		 */
 		formatDate(dt) {
 			if (!dt) return '-'
 			return new Date(dt).toLocaleString('nl-NL', { dateStyle: 'short', timeStyle: 'short' })
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-berichtenbox-integration/tasks.md */
+		/**
+		 * @param status
+		 * @spec openspec/changes/retrofit-2026-05-24-berichtenbox-integration/tasks.md
+		 */
 		statusLabel(status) {
 			const labels = {
 				draft: t('procest', 'Draft'),

--- a/src/views/cases/components/ConsultationPanel.vue
+++ b/src/views/cases/components/ConsultationPanel.vue
@@ -170,7 +170,10 @@ export default {
 		},
 	},
 	methods: {
-		/** @spec openspec/changes/retrofit-2026-05-24-consultation-management/tasks.md */
+		/**
+		 * @param status
+		 * @spec openspec/changes/retrofit-2026-05-24-consultation-management/tasks.md
+		 */
 		getStatusLabel(status) {
 			const labels = {
 				open: this.t('procest', 'Open'),
@@ -180,7 +183,10 @@ export default {
 			}
 			return labels[status] || status
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-consultation-management/tasks.md */
+		/**
+		 * @param advies
+		 * @spec openspec/changes/retrofit-2026-05-24-consultation-management/tasks.md
+		 */
 		getAdviceLabel(advies) {
 			const labels = {
 				positief: this.t('procest', 'Positive'),
@@ -190,20 +196,29 @@ export default {
 			}
 			return labels[advies] || advies
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-consultation-management/tasks.md */
+		/**
+		 * @param dateStr
+		 * @spec openspec/changes/retrofit-2026-05-24-consultation-management/tasks.md
+		 */
 		formatDate(dateStr) {
 			if (!dateStr) return '---'
 			const d = new Date(dateStr)
 			if (isNaN(d.getTime())) return dateStr
 			return d.toLocaleDateString('nl-NL')
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-consultation-management/tasks.md */
+		/**
+		 * @param cons
+		 * @spec openspec/changes/retrofit-2026-05-24-consultation-management/tasks.md
+		 */
 		isOverdue(cons) {
 			if (!cons.uiterlijkeReactiedatum) return false
 			if (cons.status === 'afgesloten' || cons.status === 'advies_uitgebracht') return false
 			return new Date(cons.uiterlijkeReactiedatum) < new Date()
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-consultation-management/tasks.md */
+		/**
+		 * @param cons
+		 * @spec openspec/changes/retrofit-2026-05-24-consultation-management/tasks.md
+		 */
 		conditions(cons) {
 			if (!cons.voorwaarden) return []
 			try {

--- a/src/views/cases/components/CustomPropertiesPanel.vue
+++ b/src/views/cases/components/CustomPropertiesPanel.vue
@@ -139,13 +139,19 @@ export default {
 			this.loading = false
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+		/**
+		 * @param propDefId
+		 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+		 */
 		getPropertyValue(propDefId) {
 			const prop = this.caseProperties.find(cp => cp.propertyDefinition === propDefId)
 			return prop?.value || ''
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+		/**
+		 * @param propDef
+		 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+		 */
 		startEdit(propDef) {
 			if (this.isReadOnly) return
 			this.editing = true
@@ -167,7 +173,10 @@ export default {
 			this.editValue = ''
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+		/**
+		 * @param propDef
+		 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+		 */
 		async saveProperty(propDef) {
 			const objectStore = useObjectStore()
 			const existing = this.caseProperties.find(cp => cp.propertyDefinition === propDef.id)

--- a/src/views/cases/components/DecisionsSection.vue
+++ b/src/views/cases/components/DecisionsSection.vue
@@ -215,18 +215,27 @@ export default {
 			return getDecisionValidity(decision)
 		},
 
-		/** @spec openspec/changes/roles-decisions/tasks.md */
+		/**
+		 * @param dateStr
+		 * @spec openspec/changes/roles-decisions/tasks.md
+		 */
 		formatDate(dateStr) {
 			return formatDecisionDate(dateStr)
 		},
 
-		/** @spec openspec/changes/roles-decisions/tasks.md */
+		/**
+		 * @param typeId
+		 * @spec openspec/changes/roles-decisions/tasks.md
+		 */
 		getDecisionTypeName(typeId) {
 			const dt = this.decisionTypes.find(t => t.id === typeId)
 			return dt?.name || ''
 		},
 
-		/** @spec openspec/changes/roles-decisions/tasks.md */
+		/**
+		 * @param decision
+		 * @spec openspec/changes/roles-decisions/tasks.md
+		 */
 		editDecision(decision) {
 			if (this.isReadOnly) return
 			this.editingDecision = decision

--- a/src/views/cases/components/DocumentAssessmentPanel.vue
+++ b/src/views/cases/components/DocumentAssessmentPanel.vue
@@ -144,7 +144,11 @@ export default {
 		getGrounds(docId) {
 			return this.assessments[docId]?.grounds || []
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+		/**
+		 * @param docId
+		 * @param value
+		 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+		 */
 		setAssessment(docId, value) {
 			this.$emit('update:assessment', {
 				documentId: docId,
@@ -152,7 +156,11 @@ export default {
 				grounds: value === 'niet_openbaar' ? (this.assessments[docId]?.grounds || []) : [],
 			})
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+		/**
+		 * @param docId
+		 * @param value
+		 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+		 */
 		setGrounds(docId, value) {
 			this.$emit('update:assessment', {
 				documentId: docId,

--- a/src/views/cases/components/DocumentChecklist.vue
+++ b/src/views/cases/components/DocumentChecklist.vue
@@ -127,7 +127,10 @@ export default {
 			return this.caseDocuments.some(cd => cd.documentType === docTypeId)
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+		/**
+		 * @param docTypeId
+		 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+		 */
 		getUploadDate(docTypeId) {
 			const doc = this.caseDocuments.find(cd => cd.documentType === docTypeId)
 			if (!doc?.registrationDate) return null
@@ -137,7 +140,10 @@ export default {
 			})
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+		/**
+		 * @param statusTypeId
+		 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+		 */
 		getStatusName(statusTypeId) {
 			const st = this.statusTypes.find(s => s.id === statusTypeId)
 			return st?.name || statusTypeId

--- a/src/views/cases/components/EmailComposer.vue
+++ b/src/views/cases/components/EmailComposer.vue
@@ -166,17 +166,26 @@ export default {
 		},
 	},
 	methods: {
-		/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+		/**
+		 * @param varName
+		 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+		 */
 		formatVariable(varName) {
 			return '{{' + varName + '}}'
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+		/**
+		 * @param template
+		 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+		 */
 		onTemplateSelected(template) {
 			if (!template) return
 			this.form.subject = template.subjectPattern || ''
 			this.form.body = template.body || ''
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+		/**
+		 * @param varName
+		 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+		 */
 		insertVariable(varName) {
 			this.form.body += '{{' + varName + '}}'
 		},
@@ -186,7 +195,10 @@ export default {
 			this.previewBody = this.resolveVars(this.form.body)
 			this.showPreview = true
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+		/**
+		 * @param text
+		 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+		 */
 		resolveVars(text) {
 			return text.replace(/\{\{(\w+)\}\}/g, (match, key) => {
 				return this.caseData[key] || match

--- a/src/views/cases/components/EmailThread.vue
+++ b/src/views/cases/components/EmailThread.vue
@@ -97,7 +97,10 @@ export default {
 		},
 	},
 	methods: {
-		/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+		/**
+		 * @param dateStr
+		 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+		 */
 		formatDateTime(dateStr) {
 			if (!dateStr) return '---'
 			const d = new Date(dateStr)
@@ -110,7 +113,10 @@ export default {
 				minute: '2-digit',
 			})
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+		/**
+		 * @param body
+		 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+		 */
 		truncateBody(body) {
 			if (!body) return ''
 			const id = 'temp'
@@ -122,7 +128,10 @@ export default {
 		isExpanded(id) {
 			return this.expandedMessages[id] === true
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+		/**
+		 * @param id
+		 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+		 */
 		toggleExpand(id) {
 			this.$set(this.expandedMessages, id, !this.expandedMessages[id])
 		},

--- a/src/views/cases/components/EnforcementPanel.vue
+++ b/src/views/cases/components/EnforcementPanel.vue
@@ -139,7 +139,10 @@ export default {
 	watch: {
 		caseId: {
 			immediate: true,
-			/** @spec openspec/changes/vth-module/tasks.md */
+			/**
+			 * @param newId
+			 * @spec openspec/changes/vth-module/tasks.md
+			 */
 			handler(newId) {
 				if (newId) {
 					this.enforcementStore.fetchActions(newId)
@@ -151,7 +154,10 @@ export default {
 	methods: {
 		t,
 
-		/** @spec openspec/changes/vth-module/tasks.md */
+		/**
+		 * @param status
+		 * @spec openspec/changes/vth-module/tasks.md
+		 */
 		statusLabel(status) {
 			const labels = {
 				opgelegd: t('procest', 'Imposed'),

--- a/src/views/cases/components/EnforcementWizard.vue
+++ b/src/views/cases/components/EnforcementWizard.vue
@@ -234,7 +234,10 @@ export default {
 	},
 
 	watch: {
-		/** @spec openspec/changes/vth-module/tasks.md */
+		/**
+		 * @param val
+		 * @spec openspec/changes/vth-module/tasks.md
+		 */
 		suggestedIntervention(val) {
 			if (val && !this.interventie) {
 				this.interventie = val
@@ -272,7 +275,10 @@ export default {
 			}
 		},
 
-		/** @spec openspec/changes/vth-module/tasks.md */
+		/**
+		 * @param intervention
+		 * @spec openspec/changes/vth-module/tasks.md
+		 */
 		mapInterventionToType(intervention) {
 			const lower = (intervention || '').toLowerCase()
 			if (lower.includes('bestuursdwang')) {

--- a/src/views/cases/components/InspectionChecklistPanel.vue
+++ b/src/views/cases/components/InspectionChecklistPanel.vue
@@ -154,14 +154,22 @@ export default {
 			this.activeChecklist = { ...this.selectedChecklist }
 			this.itemResults = {}
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md */
+		/**
+		 * @param index
+		 * @param value
+		 * @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md
+		 */
 		setResult(index, value) {
 			this.$set(this.itemResults, index, {
 				...(this.itemResults[index] || {}),
 				result: value,
 			})
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md */
+		/**
+		 * @param index
+		 * @param value
+		 * @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md
+		 */
 		setComment(index, value) {
 			this.$set(this.itemResults, index, {
 				...(this.itemResults[index] || {}),

--- a/src/views/cases/components/InspectionPanel.vue
+++ b/src/views/cases/components/InspectionPanel.vue
@@ -252,7 +252,10 @@ export default {
 	watch: {
 		caseId: {
 			immediate: true,
-			/** @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md */
+			/**
+			 * @param newId
+			 * @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md
+			 */
 			handler(newId) {
 				if (newId) {
 					this.inspectionStore.fetchReports(newId)
@@ -261,14 +264,20 @@ export default {
 		},
 		caseTypeId: {
 			immediate: true,
-			/** @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md */
+			/**
+			 * @param newId
+			 * @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md
+			 */
 			handler(newId) {
 				if (newId) {
 					this.inspectionStore.fetchChecklists(newId)
 				}
 			},
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md */
+		/**
+		 * @param checklist
+		 * @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md
+		 */
 		selectedChecklist(checklist) {
 			if (checklist) {
 				this.formResults = (checklist.items || []).map((item) => ({
@@ -285,7 +294,10 @@ export default {
 	methods: {
 		t,
 
-		/** @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md */
+		/**
+		 * @param result
+		 * @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md
+		 */
 		resultLabel(result) {
 			const labels = {
 				conform: t('procest', 'Conform'),
@@ -295,7 +307,10 @@ export default {
 			return labels[result] || result
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md */
+		/**
+		 * @param dateStr
+		 * @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md
+		 */
 		formatDate(dateStr) {
 			if (!dateStr) {
 				return ''
@@ -303,7 +318,10 @@ export default {
 			return new Date(dateStr).toLocaleDateString()
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md */
+		/**
+		 * @param reportId
+		 * @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md
+		 */
 		toggleReport(reportId) {
 			this.expandedReport = this.expandedReport === reportId ? null : reportId
 		},

--- a/src/views/cases/components/LocationTab.vue
+++ b/src/views/cases/components/LocationTab.vue
@@ -172,13 +172,19 @@ export default {
 			this.address = await gisStore.reverseGeocode(center[0], center[1])
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-25-case-location/tasks.md */
+		/**
+		 * @param newGeometry
+		 * @spec openspec/changes/retrofit-2026-05-25-case-location/tasks.md
+		 */
 		onLocationSave(newGeometry) {
 			this.showPicker = false
 			this.$emit('update-geometry', newGeometry)
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-25-case-location/tasks.md */
+		/**
+		 * @param geo
+		 * @spec openspec/changes/retrofit-2026-05-25-case-location/tasks.md
+		 */
 		calculateCentroid(geo) {
 			if (geo.type === 'Point') {
 				return [geo.coordinates[1], geo.coordinates[0]]
@@ -196,7 +202,10 @@ export default {
 			return [52.1326, 5.2913]
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-25-case-location/tasks.md */
+		/**
+		 * @param ring
+		 * @spec openspec/changes/retrofit-2026-05-25-case-location/tasks.md
+		 */
 		calculateArea(ring) {
 			// Shoelace formula for approximate area in m2
 			if (!ring || ring.length < 3) return 0
@@ -210,7 +219,10 @@ export default {
 			return Math.abs(area / 2) * 111320 * 111320 * Math.cos((ring[0][1] * Math.PI) / 180)
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-25-case-location/tasks.md */
+		/**
+		 * @param sqm
+		 * @spec openspec/changes/retrofit-2026-05-25-case-location/tasks.md
+		 */
 		formatArea(sqm) {
 			if (sqm > 10000) {
 				return `${(sqm / 10000).toFixed(2)} ha`

--- a/src/views/cases/components/MilestoneProgress.vue
+++ b/src/views/cases/components/MilestoneProgress.vue
@@ -72,7 +72,11 @@ export default {
 		},
 	},
 	methods: {
-		/** @spec openspec/changes/retrofit-2026-05-24-milestone-tracking/tasks.md */
+		/**
+		 * @param milestone
+		 * @param index
+		 * @spec openspec/changes/retrofit-2026-05-24-milestone-tracking/tasks.md
+		 */
 		stepClass(milestone, index) {
 			return {
 				'milestone-progress__step--reached': milestone.reached,
@@ -83,7 +87,11 @@ export default {
 					&& (index === 0 || !this.milestones[index - 1]?.reached),
 			}
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-milestone-tracking/tasks.md */
+		/**
+		 * @param milestone
+		 * @param index
+		 * @spec openspec/changes/retrofit-2026-05-24-milestone-tracking/tasks.md
+		 */
 		dotClass(milestone, index) {
 			return {
 				'milestone-progress__dot--reached': milestone.reached,
@@ -94,14 +102,21 @@ export default {
 					&& (index === 0 || !this.milestones[index - 1]?.reached),
 			}
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-milestone-tracking/tasks.md */
+		/**
+		 * @param dateStr
+		 * @spec openspec/changes/retrofit-2026-05-24-milestone-tracking/tasks.md
+		 */
 		formatDate(dateStr) {
 			if (!dateStr) return ''
 			const date = new Date(dateStr)
 			if (isNaN(date.getTime())) return dateStr
 			return date.toLocaleDateString('nl-NL', { day: 'numeric', month: 'short' })
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-milestone-tracking/tasks.md */
+		/**
+		 * @param milestone
+		 * @param index
+		 * @spec openspec/changes/retrofit-2026-05-24-milestone-tracking/tasks.md
+		 */
 		onDotClick(milestone, index) {
 			if (milestone.reached) {
 				this.$emit('reverse', { milestone, index })

--- a/src/views/cases/components/ParticipantsSection.vue
+++ b/src/views/cases/components/ParticipantsSection.vue
@@ -64,7 +64,8 @@
 				<label>{{ t('procest', 'Reassign handler to:') }}</label>
 				<NcSelect
 					v-model="reassignUser"
-					:options="userOptions" :aria-label-combobox="t('procest', 'Reassign handler to')"
+					:options="userOptions"
+					:aria-label-combobox="t('procest', 'Reassign handler to')"
 					label="label"
 					track-by="id"
 					:placeholder="t('procest', 'Select user...')"
@@ -225,7 +226,10 @@ export default {
 			}
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+		/**
+		 * @param name
+		 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+		 */
 		getInitials(name) {
 			if (!name) return '?'
 			const parts = name.split(/[\s.]+/)
@@ -235,7 +239,10 @@ export default {
 			return name.slice(0, 2).toUpperCase()
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+		/**
+		 * @param role
+		 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+		 */
 		isHandlerRole(role) {
 			const rt = this.roleTypeMap[role.roleType]
 			return rt?.genericRole === 'handler'
@@ -253,7 +260,10 @@ export default {
 			this.preSelectHandler = false
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+		/**
+		 * @param newRole
+		 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+		 */
 		async onRoleCreated(newRole) {
 			this.closeAddDialog()
 			await this.fetchData()
@@ -262,14 +272,20 @@ export default {
 			}
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+		/**
+		 * @param role
+		 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+		 */
 		async removeRole(role) {
 			if (!confirm(t('procest', 'Remove this participant?'))) return
 			await this.objectStore.deleteObject('role', role.id)
 			await this.fetchData()
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+		/**
+		 * @param role
+		 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+		 */
 		startReassign(role) {
 			this.reassigningHandler = true
 			this.reassignRole = role
@@ -283,7 +299,10 @@ export default {
 			this.reassignUser = null
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+		/**
+		 * @param user
+		 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+		 */
 		async onReassignSelected(user) {
 			if (!user || !this.reassignRole) return
 

--- a/src/views/cases/components/QuickStatusDropdown.vue
+++ b/src/views/cases/components/QuickStatusDropdown.vue
@@ -53,7 +53,10 @@ export default {
 		this.selectedStatus = this.statusTypes.find(st => st.id === this.caseObj.status) || null
 	},
 	methods: {
-		/** @spec openspec/specs/status-transition-engine/spec.md */
+		/**
+		 * @param newStatus
+		 * @spec openspec/specs/status-transition-engine/spec.md
+		 */
 		async onStatusChange(newStatus) {
 			if (!newStatus || newStatus.id === this.caseObj.status) return
 

--- a/src/views/cases/components/ResultSection.vue
+++ b/src/views/cases/components/ResultSection.vue
@@ -77,7 +77,10 @@ export default {
 		},
 	},
 	methods: {
-		/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+		/**
+		 * @param isoDuration
+		 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+		 */
 		formatPeriod(isoDuration) {
 			if (!isoDuration) return ''
 			const match = isoDuration.match(/P(\d+)Y/)

--- a/src/views/cases/components/ShareTab.vue
+++ b/src/views/cases/components/ShareTab.vue
@@ -70,7 +70,10 @@ export default {
 	},
 	emits: ['revoke', 'create-token-share', 'create-partner-share'],
 	methods: {
-		/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+		/**
+		 * @param level
+		 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+		 */
 		permissionLabel(level) {
 			const labels = {
 				bekijken: t('procest', 'View only'),
@@ -79,7 +82,10 @@ export default {
 			}
 			return labels[level] || level
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+		/**
+		 * @param dateString
+		 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+		 */
 		formatDate(dateString) {
 			if (!dateString) return ''
 			return new Date(dateString).toLocaleDateString('nl-NL', {

--- a/src/views/cases/components/StatusTimeline.vue
+++ b/src/views/cases/components/StatusTimeline.vue
@@ -56,7 +56,10 @@ export default {
 		},
 	},
 	methods: {
-		/** @spec openspec/specs/status-transition-engine/spec.md */
+		/**
+		 * @param statusType
+		 * @spec openspec/specs/status-transition-engine/spec.md
+		 */
 		isPassed(statusType) {
 			const idx = this.statusTypes.findIndex(st => st.id === statusType.id)
 			return idx < this.currentIndex
@@ -64,12 +67,18 @@ export default {
 		isCurrent(statusType) {
 			return statusType.id === this.currentStatusId
 		},
-		/** @spec openspec/specs/status-transition-engine/spec.md */
+		/**
+		 * @param statusType
+		 * @spec openspec/specs/status-transition-engine/spec.md
+		 */
 		isFuture(statusType) {
 			const idx = this.statusTypes.findIndex(st => st.id === statusType.id)
 			return idx > this.currentIndex
 		},
-		/** @spec openspec/specs/status-transition-engine/spec.md */
+		/**
+		 * @param statusType
+		 * @spec openspec/specs/status-transition-engine/spec.md
+		 */
 		stepClass(statusType) {
 			return {
 				'status-timeline__step--passed': this.isPassed(statusType),
@@ -77,7 +86,10 @@ export default {
 				'status-timeline__step--future': this.isFuture(statusType),
 			}
 		},
-		/** @spec openspec/specs/status-transition-engine/spec.md */
+		/**
+		 * @param statusType
+		 * @spec openspec/specs/status-transition-engine/spec.md
+		 */
 		dotClass(statusType) {
 			return {
 				'status-timeline__dot--passed': this.isPassed(statusType),
@@ -85,13 +97,19 @@ export default {
 				'status-timeline__dot--future': this.isFuture(statusType),
 			}
 		},
-		/** @spec openspec/specs/status-transition-engine/spec.md */
+		/**
+		 * @param statusType
+		 * @spec openspec/specs/status-transition-engine/spec.md
+		 */
 		lineClass(statusType) {
 			return {
 				'status-timeline__line--passed': this.isPassed(statusType) || this.isCurrent(statusType),
 			}
 		},
-		/** @spec openspec/specs/status-transition-engine/spec.md */
+		/**
+		 * @param statusType
+		 * @spec openspec/specs/status-transition-engine/spec.md
+		 */
 		getStatusDate(statusType) {
 			const date = this.historyMap[statusType.id]
 			if (!date) return null

--- a/src/views/cases/components/SubCasesSection.vue
+++ b/src/views/cases/components/SubCasesSection.vue
@@ -145,13 +145,19 @@ export default {
 			}
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+		/**
+		 * @param subCase
+		 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+		 */
 		getStatusName(subCase) {
 			if (!subCase.status) return '\u2014'
 			return this.statusTypeCache[subCase.status]?.name || '\u2014'
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+		/**
+		 * @param subCase
+		 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+		 */
 		getStatusClass(subCase) {
 			if (!subCase.status) return ''
 			const st = this.statusTypeCache[subCase.status]
@@ -159,13 +165,19 @@ export default {
 			return 'status-badge--active'
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+		/**
+		 * @param deadline
+		 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+		 */
 		formatDeadline(deadline) {
 			if (!deadline) return '\u2014'
 			return formatDate(deadline)
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+		/**
+		 * @param subCase
+		 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+		 */
 		openSubCase(subCase) {
 			this.$router.push({ name: 'CaseDetail', params: { id: subCase.id } })
 		},

--- a/src/views/cases/components/VoorstellenPanel.vue
+++ b/src/views/cases/components/VoorstellenPanel.vue
@@ -125,15 +125,24 @@ export default {
 		isActive(voorstel) {
 			return !['besloten', 'gearchiveerd'].includes(voorstel.status)
 		},
-		/** @spec openspec/specs/parafering-actions/spec.md */
+		/**
+		 * @param type
+		 * @spec openspec/specs/parafering-actions/spec.md
+		 */
 		formatType(type) {
 			return TYPE_LABELS[type] || type || '-'
 		},
-		/** @spec openspec/specs/parafering-actions/spec.md */
+		/**
+		 * @param status
+		 * @spec openspec/specs/parafering-actions/spec.md
+		 */
 		formatStatus(status) {
 			return STATUS_LABELS[status] || status || '-'
 		},
-		/** @spec openspec/specs/parafering-actions/spec.md */
+		/**
+		 * @param voorstel
+		 * @spec openspec/specs/parafering-actions/spec.md
+		 */
 		formatStepProgress(voorstel) {
 			let steps = []
 			if (voorstel.routeSnapshot) {

--- a/src/views/cases/components/WooIntakeForm.vue
+++ b/src/views/cases/components/WooIntakeForm.vue
@@ -175,7 +175,11 @@ export default {
 		},
 	},
 	methods: {
-		/** @spec openspec/changes/woo-case-type/tasks.md */
+		/**
+		 * @param field
+		 * @param value
+		 * @spec openspec/changes/woo-case-type/tasks.md
+		 */
 		update(field, value) {
 			this.$emit('update', { field, value })
 		},

--- a/src/views/cases/components/WorkflowTransitions.vue
+++ b/src/views/cases/components/WorkflowTransitions.vue
@@ -185,7 +185,10 @@ export default {
 			)
 		},
 
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param transition
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		async executeTransition(transition) {
 			if (!transition.available) return
 
@@ -225,7 +228,10 @@ export default {
 			}
 		},
 
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param statusId
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		async createStepTasks(statusId) {
 			if (!this.workflowTemplate) return
 
@@ -259,7 +265,10 @@ export default {
 			}
 		},
 
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param fromStatusId
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		async terminateOptionalTasks(fromStatusId) {
 			if (!this.workflowTemplate) return
 

--- a/src/views/cases/components/beroep/CourtProceedingsPanel.vue
+++ b/src/views/cases/components/beroep/CourtProceedingsPanel.vue
@@ -95,7 +95,10 @@ export default {
 		}
 	},
 	methods: {
-		/** @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md */
+		/**
+		 * @param outcome
+		 * @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md
+		 */
 		getRulingLabel(outcome) {
 			const labels = {
 				beroep_gegrond: t('procest', 'Appeal upheld'),

--- a/src/views/cases/components/bezwaar/AdvisoryReportPanel.vue
+++ b/src/views/cases/components/bezwaar/AdvisoryReportPanel.vue
@@ -181,7 +181,10 @@ export default {
 		},
 	},
 	methods: {
-		/** @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md */
+		/**
+		 * @param type
+		 * @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md
+		 */
 		getAdviceTypeLabel(type) {
 			const labels = {
 				gegrond: t('procest', 'Upheld'),

--- a/src/views/cases/components/bezwaar/BezwaarDecisionForm.vue
+++ b/src/views/cases/components/bezwaar/BezwaarDecisionForm.vue
@@ -211,7 +211,10 @@ export default {
 		},
 	},
 	methods: {
-		/** @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md */
+		/**
+		 * @param type
+		 * @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md
+		 */
 		getDispositionLabel(type) {
 			const labels = {
 				gegrond: t('procest', 'Upheld'),

--- a/src/views/cases/components/bezwaar/BezwaarTimeline.vue
+++ b/src/views/cases/components/bezwaar/BezwaarTimeline.vue
@@ -123,7 +123,10 @@ export default {
 		},
 	},
 	methods: {
-		/** @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md */
+		/**
+		 * @param type
+		 * @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md
+		 */
 		getAdviceTypeLabel(type) {
 			const labels = {
 				gegrond: t('procest', 'Upheld'),
@@ -133,7 +136,10 @@ export default {
 			}
 			return labels[type] || type
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md */
+		/**
+		 * @param type
+		 * @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md
+		 */
 		getDispositionLabel(type) {
 			const labels = {
 				gegrond: t('procest', 'Upheld'),

--- a/src/views/cases/components/bezwaar/HearingPanel.vue
+++ b/src/views/cases/components/bezwaar/HearingPanel.vue
@@ -219,7 +219,10 @@ export default {
 		},
 	},
 	methods: {
-		/** @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md */
+		/**
+		 * @param status
+		 * @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md
+		 */
 		getHearingStatusLabel(status) {
 			const labels = {
 				gepland: t('procest', 'Scheduled'),
@@ -230,7 +233,10 @@ export default {
 			}
 			return labels[status] || status
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md */
+		/**
+		 * @param dateStr
+		 * @spec openspec/changes/retrofit-2026-05-24-bezwaar-lifecycle/tasks.md
+		 */
 		formatDateTime(dateStr) {
 			if (!dateStr) return '—'
 			try {

--- a/src/views/cases/widgets/CaseDocumentsWidget.vue
+++ b/src/views/cases/widgets/CaseDocumentsWidget.vue
@@ -37,7 +37,10 @@ export default {
 	},
 	methods: {
 		formatDate,
-		/** @spec openspec/changes/retrofit-2026-05-24-signalering-widgets/tasks.md */
+		/**
+		 * @param mimeType
+		 * @spec openspec/changes/retrofit-2026-05-24-signalering-widgets/tasks.md
+		 */
 		getFileIcon(mimeType) {
 			if (!mimeType) return '📄'
 			if (mimeType.includes('pdf')) return '📕'

--- a/src/views/cases/widgets/CasePropertiesWidget.vue
+++ b/src/views/cases/widgets/CasePropertiesWidget.vue
@@ -161,7 +161,10 @@ export default {
 	watch: {
 		caseData: {
 			immediate: true,
-			/** @spec openspec/changes/retrofit-2026-05-24-signalering-widgets/tasks.md */
+			/**
+			 * @param data
+			 * @spec openspec/changes/retrofit-2026-05-24-signalering-widgets/tasks.md
+			 */
 			handler(data) {
 				if (data && data.title !== undefined) {
 					this.form = {

--- a/src/views/cases/widgets/CaseTasksWidget.vue
+++ b/src/views/cases/widgets/CaseTasksWidget.vue
@@ -77,7 +77,10 @@ export default {
 		isDueToday,
 		getOverdueText,
 		formatDueDate,
-		/** @spec openspec/changes/retrofit-2026-05-24-signalering-widgets/tasks.md */
+		/**
+		 * @param task
+		 * @spec openspec/changes/retrofit-2026-05-24-signalering-widgets/tasks.md
+		 */
 		dueDateClass(task) {
 			if (isOverdue(task)) return 'task-due--overdue'
 			if (isDueToday(task)) return 'task-due--today'

--- a/src/views/cases/widgets/CaseTimelineWidget.vue
+++ b/src/views/cases/widgets/CaseTimelineWidget.vue
@@ -102,7 +102,10 @@ export default {
 		}
 	},
 	methods: {
-		/** @spec openspec/changes/retrofit-2026-05-24-signalering-widgets/tasks.md */
+		/**
+		 * @param status
+		 * @spec openspec/changes/retrofit-2026-05-24-signalering-widgets/tasks.md
+		 */
 		onStatusSelected(status) {
 			if (!status || status.id === this.currentStatusId) {
 				this.selectedStatus = null

--- a/src/views/complaints/components/ComplaintCreateDialog.vue
+++ b/src/views/complaints/components/ComplaintCreateDialog.vue
@@ -46,14 +46,14 @@
 					<NcSelect
 						v-model="form.ontvangstkanaal"
 						:options="channelOptions"
-							:aria-label-combobox="t('procest', 'Intake channel')" />
+						:aria-label-combobox="t('procest', 'Intake channel')" />
 				</div>
 				<div class="form-group">
 					<label>{{ t('procest', 'Priority') }}</label>
 					<NcSelect
 						v-model="form.prioriteit"
 						:options="priorityOptions"
-							:aria-label-combobox="t('procest', 'Priority')" />
+						:aria-label-combobox="t('procest', 'Priority')" />
 				</div>
 			</div>
 

--- a/src/views/dashboard/ActivityFeed.vue
+++ b/src/views/dashboard/ActivityFeed.vue
@@ -74,11 +74,17 @@ export default {
 	},
 	emits: ['view-all', 'retry'],
 	methods: {
-		/** @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md */
+		/**
+		 * @param type
+		 * @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md
+		 */
 		typeIcon(type) {
 			return TYPE_ICONS[type] || '&#8226;'
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md */
+		/**
+		 * @param date
+		 * @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md
+		 */
 		formatTime(date) {
 			return formatRelativeTime(date)
 		},

--- a/src/views/dashboard/CaseMapWidget.vue
+++ b/src/views/dashboard/CaseMapWidget.vue
@@ -62,7 +62,10 @@ export default {
 		}
 	},
 	methods: {
-		/** @spec openspec/specs/case-map-overview/spec.md */
+		/**
+		 * @param caseObj
+		 * @spec openspec/specs/case-map-overview/spec.md
+		 */
 		getColor(caseObj) {
 			if (caseObj.endDate) return '#4CAF50'
 			if (caseObj.deadline) {
@@ -71,7 +74,10 @@ export default {
 			}
 			return '#2196F3'
 		},
-		/** @spec openspec/specs/case-map-overview/spec.md */
+		/**
+		 * @param properties
+		 * @spec openspec/specs/case-map-overview/spec.md
+		 */
 		onMarkerClick(properties) {
 			if (properties?.id) {
 				this.$router?.push({ name: 'CaseDetail', params: { id: properties.id } })

--- a/src/views/dashboard/CasesByType.vue
+++ b/src/views/dashboard/CasesByType.vue
@@ -93,16 +93,25 @@ export default {
 		},
 	},
 	methods: {
-		/** @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md */
+		/**
+		 * @param count
+		 * @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md
+		 */
 		barWidth(count) {
 			const pct = (count / this.maxCount) * 100
 			return `max(20px, ${pct}%)`
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md */
+		/**
+		 * @param index
+		 * @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md
+		 */
 		barColor(index) {
 			return BAR_COLORS[index % BAR_COLORS.length]
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md */
+		/**
+		 * @param item
+		 * @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md
+		 */
 		onBarClick(item) {
 			// Default behaviour: navigate to /cases filtered by caseType.
 			// Consumers can override by listening for `@bar-click` and

--- a/src/views/dashboard/OverduePanel.vue
+++ b/src/views/dashboard/OverduePanel.vue
@@ -75,7 +75,10 @@ export default {
 	},
 	emits: ['click-case', 'view-all', 'retry'],
 	methods: {
-		/** @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md */
+		/**
+		 * @param daysOverdue
+		 * @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md
+		 */
 		severityClass(daysOverdue) {
 			if (daysOverdue > 7) return 'overdue-panel__row--severe'
 			if (daysOverdue > 2) return 'overdue-panel__row--moderate'

--- a/src/views/dashboard/StatusChart.vue
+++ b/src/views/dashboard/StatusChart.vue
@@ -72,12 +72,18 @@ export default {
 		},
 	},
 	methods: {
-		/** @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md */
+		/**
+		 * @param count
+		 * @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md
+		 */
 		barWidth(count) {
 			const pct = (count / this.maxCount) * 100
 			return `max(20px, ${pct}%)`
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md */
+		/**
+		 * @param index
+		 * @spec openspec/changes/retrofit-2026-05-24-dashboard/tasks.md
+		 */
 		barColor(index) {
 			return BAR_COLORS[index % BAR_COLORS.length]
 		},

--- a/src/views/public/PublicAppointmentPage.vue
+++ b/src/views/public/PublicAppointmentPage.vue
@@ -61,12 +61,18 @@ export default {
 	},
 	methods: {
 		t,
-		/** @spec openspec/changes/retrofit-2026-05-25-appointment-booking/tasks.md */
+		/**
+		 * @param dt
+		 * @spec openspec/changes/retrofit-2026-05-25-appointment-booking/tasks.md
+		 */
 		formatDateTime(dt) {
 			if (!dt) return '-'
 			return new Date(dt).toLocaleString('nl-NL', { dateStyle: 'long', timeStyle: 'short' })
 		},
-		/** @spec openspec/changes/retrofit-2026-05-25-appointment-booking/tasks.md */
+		/**
+		 * @param status
+		 * @spec openspec/changes/retrofit-2026-05-25-appointment-booking/tasks.md
+		 */
 		statusLabel(status) {
 			const labels = {
 				scheduled: t('procest', 'Scheduled'),

--- a/src/views/public/PublicCaseView.vue
+++ b/src/views/public/PublicCaseView.vue
@@ -177,7 +177,10 @@ export default {
 				// Comment submission failed silently
 			}
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+		/**
+		 * @param dateString
+		 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+		 */
 		formatDate(dateString) {
 			if (!dateString) return ''
 			return new Date(dateString).toLocaleDateString('nl-NL', {

--- a/src/views/public/PublicStatusPage.vue
+++ b/src/views/public/PublicStatusPage.vue
@@ -90,7 +90,10 @@ export default {
 				this.loading = false
 			}
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md */
+		/**
+		 * @param dateString
+		 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+		 */
 		formatDate(dateString) {
 			if (!dateString) return ''
 			return new Date(dateString).toLocaleDateString('nl-NL', {

--- a/src/views/settings/CaseTypeAdmin.vue
+++ b/src/views/settings/CaseTypeAdmin.vue
@@ -29,7 +29,10 @@ export default {
 		}
 	},
 	methods: {
-		/** @spec openspec/changes/retrofit-2026-05-24-case-types/tasks.md */
+		/**
+		 * @param id
+		 * @spec openspec/changes/retrofit-2026-05-24-case-types/tasks.md
+		 */
 		openDetail(id) {
 			this.currentId = id
 			this.currentView = 'detail'
@@ -44,7 +47,10 @@ export default {
 			this.currentView = 'list'
 			this.currentId = null
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-case-types/tasks.md */
+		/**
+		 * @param id
+		 * @spec openspec/changes/retrofit-2026-05-24-case-types/tasks.md
+		 */
 		onSaved(id) {
 			this.currentId = id
 		},

--- a/src/views/settings/CaseTypeDetail.vue
+++ b/src/views/settings/CaseTypeDetail.vue
@@ -226,7 +226,11 @@ export default {
 			this.loadingDetail = false
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-case-types/tasks.md */
+		/**
+		 * @param field
+		 * @param value
+		 * @spec openspec/changes/retrofit-2026-05-24-case-types/tasks.md
+		 */
 		onFieldUpdate(field, value) {
 			this.form[field] = value
 			// Clear validation error for this field

--- a/src/views/settings/CaseTypeList.vue
+++ b/src/views/settings/CaseTypeList.vue
@@ -122,7 +122,10 @@ export default {
 			}
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-case-types/tasks.md */
+		/**
+		 * @param caseTypeId
+		 * @spec openspec/changes/retrofit-2026-05-24-case-types/tasks.md
+		 */
 		async loadStatusTypeCount(caseTypeId) {
 			const statusTypes = await this.objectStore.fetchCollection('statusType', {
 				'_filters[caseType]': caseTypeId,
@@ -136,12 +139,18 @@ export default {
 			return this.defaultCaseTypeId === id
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-case-types/tasks.md */
+		/**
+		 * @param duration
+		 * @spec openspec/changes/retrofit-2026-05-24-case-types/tasks.md
+		 */
 		formatDeadline(duration) {
 			return formatDuration(duration)
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-case-types/tasks.md */
+		/**
+		 * @param ct
+		 * @spec openspec/changes/retrofit-2026-05-24-case-types/tasks.md
+		 */
 		formatValidity(ct) {
 			if (!ct.validFrom) return '\u2014'
 			const from = new Date(ct.validFrom).toLocaleDateString('nl-NL', { month: 'short', year: 'numeric' })
@@ -152,7 +161,10 @@ export default {
 			return t('procest', '{from} \u2014 (no end)', { from })
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-case-types/tasks.md */
+		/**
+		 * @param ct
+		 * @spec openspec/changes/retrofit-2026-05-24-case-types/tasks.md
+		 */
 		validityClass(ct) {
 			if (!ct.validUntil) return ''
 			const now = new Date()
@@ -161,12 +173,18 @@ export default {
 			return ''
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-case-types/tasks.md */
+		/**
+		 * @param row
+		 * @spec openspec/changes/retrofit-2026-05-24-case-types/tasks.md
+		 */
 		selectCaseType(row) {
 			this.$emit('select', row.id)
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-case-types/tasks.md */
+		/**
+		 * @param ct
+		 * @spec openspec/changes/retrofit-2026-05-24-case-types/tasks.md
+		 */
 		async setDefault(ct) {
 			this.error = ''
 			if (ct.isDraft) {
@@ -177,7 +195,10 @@ export default {
 			await this.settingsStore.saveSettings(config)
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-case-types/tasks.md */
+		/**
+		 * @param ct
+		 * @spec openspec/changes/retrofit-2026-05-24-case-types/tasks.md
+		 */
 		async confirmDelete(ct) {
 			this.error = ''
 

--- a/src/views/settings/MapLayerSettings.vue
+++ b/src/views/settings/MapLayerSettings.vue
@@ -83,7 +83,7 @@
 					<NcSelect
 						v-model="form.layerType"
 						:options="['tile', 'wms', 'wfs', 'geojson']"
-							:aria-label-combobox="t('procest', 'Type')" />
+						:aria-label-combobox="t('procest', 'Type')" />
 				</div>
 				<div class="form-group">
 					<label>{{ t('procest', 'URL') }} *</label>
@@ -211,7 +211,10 @@ export default {
 			}
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-wms-wfs-layers/tasks.md */
+		/**
+		 * @param layer
+		 * @spec openspec/changes/retrofit-2026-05-24-wms-wfs-layers/tasks.md
+		 */
 		editLayer(layer) {
 			this.editingLayer = layer
 			this.form = { ...layer }
@@ -230,7 +233,10 @@ export default {
 			this.closeDialog()
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-wms-wfs-layers/tasks.md */
+		/**
+		 * @param layer
+		 * @spec openspec/changes/retrofit-2026-05-24-wms-wfs-layers/tasks.md
+		 */
 		async removeLayer(layer) {
 			if (!confirm(this.t('procest', 'Delete layer "{title}"?', { title: layer.title }))) {
 				return
@@ -240,14 +246,20 @@ export default {
 			this.layers = gisStore.layers
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-wms-wfs-layers/tasks.md */
+		/**
+		 * @param preset
+		 * @spec openspec/changes/retrofit-2026-05-24-wms-wfs-layers/tasks.md
+		 */
 		addPreset(preset) {
 			this.form = { ...this.emptyForm(), ...preset }
 			this.showAddDialog = true
 			this.showPresets = false
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-wms-wfs-layers/tasks.md */
+		/**
+		 * @param layer
+		 * @spec openspec/changes/retrofit-2026-05-24-wms-wfs-layers/tasks.md
+		 */
 		async testLayer(layer) {
 			this.testResult = null
 			try {
@@ -272,7 +284,10 @@ export default {
 			this.form = this.emptyForm()
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-wms-wfs-layers/tasks.md */
+		/**
+		 * @param url
+		 * @spec openspec/changes/retrofit-2026-05-24-wms-wfs-layers/tasks.md
+		 */
 		truncateUrl(url) {
 			if (!url) return ''
 			return url.length > 60 ? url.substring(0, 57) + '...' : url

--- a/src/views/settings/WorkflowEditor.vue
+++ b/src/views/settings/WorkflowEditor.vue
@@ -256,14 +256,20 @@ export default {
 			}
 		},
 
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param statusId
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		getStepsForStatus(statusId) {
 			return this.steps
 				.filter((s) => s.status === statusId)
 				.sort((a, b) => a.order - b.order)
 		},
 
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param statusId
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		getNodeCenter(statusId) {
 			const pos = this.nodePositions[statusId]
 			if (!pos) return { x: 0, y: 0 }
@@ -274,26 +280,38 @@ export default {
 		},
 
 		// --- Selection ---
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param statusId
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		selectNode(statusId) {
 			this.selectedNode = statusId
 			this.selectedTransition = null
 			this.selectedStep = null
 		},
 
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param transitionId
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		selectTransition(transitionId) {
 			this.selectedTransition = transitionId
 			this.selectedNode = null
 			this.selectedStep = null
 		},
 
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param transitionId
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		editTransition(transitionId) {
 			this.selectTransition(transitionId)
 		},
 
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param step
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		onStepClick(step) {
 			this.selectedStep = { ...step }
 			this.selectedNode = null
@@ -301,7 +319,11 @@ export default {
 		},
 
 		// --- Node drag ---
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param statusId
+		 * @param event
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		onNodeDragStart(statusId, event) {
 			this.draggingNode = {
 				statusId,
@@ -310,7 +332,10 @@ export default {
 			}
 		},
 
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param event
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		onCanvasMouseMove(event) {
 			if (this.draggingNode) {
 				const rect = this.$refs.canvas.getBoundingClientRect()
@@ -345,7 +370,10 @@ export default {
 			this.panning = false
 		},
 
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param event
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		onCanvasMouseDown(event) {
 			// Only pan if clicking empty canvas area
 			if (event.target === this.$refs.canvas || event.target.classList.contains('workflow-editor__svg')) {
@@ -360,7 +388,10 @@ export default {
 			}
 		},
 
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param event
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		onCanvasWheel(event) {
 			event.preventDefault()
 			const delta = event.deltaY > 0 ? -0.1 : 0.1
@@ -368,7 +399,11 @@ export default {
 		},
 
 		// --- Connection drawing ---
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param statusId
+		 * @param event
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		onConnectionStart(statusId, event) {
 			const center = this.getNodeCenter(statusId)
 			this.drawingConnection = {
@@ -380,7 +415,10 @@ export default {
 			}
 		},
 
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param statusId
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		onConnectionEnd(statusId) {
 			if (this.drawingConnection && this.drawingConnection.fromStatus !== statusId) {
 				this.workflowStore.addTransition(
@@ -393,12 +431,18 @@ export default {
 		},
 
 		// --- Palette drag & drop ---
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param type
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		onPaletteDragStart(type) {
 			this.paletteDragType = type
 		},
 
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param event
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		async onCanvasDrop(event) {
 			if (this.paletteDragType === 'status') {
 				const rect = this.$refs.canvas.getBoundingClientRect()
@@ -423,14 +467,20 @@ export default {
 		},
 
 		// --- Step management ---
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param statusId
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		onAddStep(statusId) {
 			const step = this.workflowStore.addStep(statusId)
 			this.selectedStep = { ...step }
 			this.$emit('dirty')
 		},
 
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param updatedStep
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		onStepUpdate(updatedStep) {
 			this.workflowStore.updateStep(updatedStep.id, updatedStep)
 			this.selectedStep = { ...updatedStep }
@@ -438,13 +488,19 @@ export default {
 		},
 
 		// --- Transition management ---
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param updatedTransition
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		onTransitionUpdate(updatedTransition) {
 			this.workflowStore.updateTransition(updatedTransition.id, updatedTransition)
 			this.$emit('dirty')
 		},
 
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param transitionId
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		onTransitionDelete(transitionId) {
 			this.workflowStore.removeTransition(transitionId)
 			this.selectedTransition = null

--- a/src/views/settings/ZgwMappingSettings.vue
+++ b/src/views/settings/ZgwMappingSettings.vue
@@ -88,12 +88,18 @@ export default {
 		await this.store.fetchMappings()
 	},
 	methods: {
-		/** @spec openspec/changes/retrofit-2026-05-24-zgw-api-mapping/tasks.md */
+		/**
+		 * @param key
+		 * @spec openspec/changes/retrofit-2026-05-24-zgw-api-mapping/tasks.md
+		 */
 		editMapping(key) {
 			this.editingKey = key
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-zgw-api-mapping/tasks.md */
+		/**
+		 * @param config
+		 * @spec openspec/changes/retrofit-2026-05-24-zgw-api-mapping/tasks.md
+		 */
 		async saveMapping(config) {
 			const result = await this.store.saveMapping(this.editingKey, config)
 			if (result) {
@@ -103,7 +109,10 @@ export default {
 			}
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-zgw-api-mapping/tasks.md */
+		/**
+		 * @param key
+		 * @spec openspec/changes/retrofit-2026-05-24-zgw-api-mapping/tasks.md
+		 */
 		async resetMapping(key) {
 			await this.store.resetMapping(key)
 			this.saved = true

--- a/src/views/settings/components/DurationPicker.vue
+++ b/src/views/settings/components/DurationPicker.vue
@@ -89,7 +89,10 @@ export default {
 		},
 	},
 	methods: {
-		/** @spec openspec/changes/retrofit-2026-05-24-milestone-tracking/tasks.md */
+		/**
+		 * @param val
+		 * @spec openspec/changes/retrofit-2026-05-24-milestone-tracking/tasks.md
+		 */
 		onDaysChange(val) {
 			const days = parseInt(val, 10)
 			if (!days || days < 0) {
@@ -98,7 +101,10 @@ export default {
 			}
 			this.$emit('input', `P${days}D`)
 		},
-		/** @spec openspec/changes/retrofit-2026-05-24-milestone-tracking/tasks.md */
+		/**
+		 * @param preset
+		 * @spec openspec/changes/retrofit-2026-05-24-milestone-tracking/tasks.md
+		 */
 		selectPreset(preset) {
 			this.$emit('input', preset.value)
 		},

--- a/src/views/settings/components/LhsMatrixAdmin.vue
+++ b/src/views/settings/components/LhsMatrixAdmin.vue
@@ -131,7 +131,12 @@ export default {
 	methods: {
 		t,
 
-		/** @spec openspec/changes/vth-module/tasks.md */
+		/**
+		 * @param ernst
+		 * @param gedrag
+		 * @param value
+		 * @spec openspec/changes/vth-module/tasks.md
+		 */
 		updateCell(ernst, gedrag, value) {
 			if (!this.matrix[ernst]) {
 				this.matrix[ernst] = {}

--- a/src/views/settings/components/ParafeerStapEditor.vue
+++ b/src/views/settings/components/ParafeerStapEditor.vue
@@ -103,12 +103,20 @@ export default {
 		}
 	},
 	methods: {
-		/** @spec openspec/specs/parafering-actions/spec.md */
+		/**
+		 * @param steps
+		 * @spec openspec/specs/parafering-actions/spec.md
+		 */
 		emitUpdate(steps) {
 			const renumbered = steps.map((s, i) => ({ ...s, order: i + 1 }))
 			this.$emit('update:steps', renumbered)
 		},
-		/** @spec openspec/specs/parafering-actions/spec.md */
+		/**
+		 * @param idx
+		 * @param key
+		 * @param value
+		 * @spec openspec/specs/parafering-actions/spec.md
+		 */
 		updateStep(idx, key, value) {
 			const next = this.steps.map((s, i) => i === idx ? { ...s, [key]: value } : s)
 			this.emitUpdate(next)
@@ -126,12 +134,19 @@ export default {
 				},
 			])
 		},
-		/** @spec openspec/specs/parafering-actions/spec.md */
+		/**
+		 * @param idx
+		 * @spec openspec/specs/parafering-actions/spec.md
+		 */
 		removeStep(idx) {
 			const next = this.steps.filter((_, i) => i !== idx)
 			this.emitUpdate(next)
 		},
-		/** @spec openspec/specs/parafering-actions/spec.md */
+		/**
+		 * @param idx
+		 * @param delta
+		 * @spec openspec/specs/parafering-actions/spec.md
+		 */
 		moveStep(idx, delta) {
 			const target = idx + delta
 			if (target < 0 || target >= this.steps.length) return

--- a/src/views/settings/components/StepConfigPanel.vue
+++ b/src/views/settings/components/StepConfigPanel.vue
@@ -345,7 +345,10 @@ export default {
 	},
 	watch: {
 		step: {
-			/** @spec openspec/changes/retrofit-2026-05-25-process-step-configuration/tasks.md */
+			/**
+			 * @param newStep
+			 * @spec openspec/changes/retrofit-2026-05-25-process-step-configuration/tasks.md
+			 */
 			handler(newStep) {
 				this.localStep = { ...newStep }
 				this.localChecklist = this.parseChecklist(newStep.checklist)
@@ -357,7 +360,10 @@ export default {
 		},
 	},
 	methods: {
-		/** @spec openspec/changes/retrofit-2026-05-25-process-step-configuration/tasks.md */
+		/**
+		 * @param config
+		 * @spec openspec/changes/retrofit-2026-05-25-process-step-configuration/tasks.md
+		 */
 		parseConfig(config) {
 			let raw = config
 			if (typeof raw === 'string') {
@@ -416,7 +422,10 @@ export default {
 			this.emitUpdate()
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-25-process-step-configuration/tasks.md */
+		/**
+		 * @param index
+		 * @spec openspec/changes/retrofit-2026-05-25-process-step-configuration/tasks.md
+		 */
 		removeRequiredField(index) {
 			this.localConfig.requiredFields.splice(index, 1)
 			this.emitUpdate()
@@ -427,7 +436,10 @@ export default {
 			this.emitUpdate()
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-25-process-step-configuration/tasks.md */
+		/**
+		 * @param checklist
+		 * @spec openspec/changes/retrofit-2026-05-25-process-step-configuration/tasks.md
+		 */
 		parseChecklist(checklist) {
 			if (!checklist) return []
 			if (typeof checklist === 'string') {
@@ -436,7 +448,10 @@ export default {
 			return [...checklist]
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-25-process-step-configuration/tasks.md */
+		/**
+		 * @param actions
+		 * @spec openspec/changes/retrofit-2026-05-25-process-step-configuration/tasks.md
+		 */
 		parseActions(actions) {
 			if (!actions) return []
 			if (typeof actions === 'string') {
@@ -471,19 +486,30 @@ export default {
 			this.emitUpdate()
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-25-process-step-configuration/tasks.md */
+		/**
+		 * @param index
+		 * @spec openspec/changes/retrofit-2026-05-25-process-step-configuration/tasks.md
+		 */
 		removeChecklistItem(index) {
 			this.localChecklist.splice(index, 1)
 			this.emitUpdate()
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-25-process-step-configuration/tasks.md */
+		/**
+		 * @param index
+		 * @param event
+		 * @spec openspec/changes/retrofit-2026-05-25-process-step-configuration/tasks.md
+		 */
 		onCheckDragStart(index, event) {
 			this.dragCheckIndex = index
 			event.dataTransfer.effectAllowed = 'move'
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-25-process-step-configuration/tasks.md */
+		/**
+		 * @param targetIndex
+		 * @param event
+		 * @spec openspec/changes/retrofit-2026-05-25-process-step-configuration/tasks.md
+		 */
 		onCheckDrop(targetIndex, event) {
 			if (this.dragCheckIndex !== null && this.dragCheckIndex !== targetIndex) {
 				const item = this.localChecklist.splice(this.dragCheckIndex, 1)[0]
@@ -499,7 +525,10 @@ export default {
 			this.emitUpdate()
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-25-process-step-configuration/tasks.md */
+		/**
+		 * @param index
+		 * @spec openspec/changes/retrofit-2026-05-25-process-step-configuration/tasks.md
+		 */
 		removeAction(index) {
 			this.localActions.splice(index, 1)
 			this.emitUpdate()

--- a/src/views/settings/components/TransitionConfigPanel.vue
+++ b/src/views/settings/components/TransitionConfigPanel.vue
@@ -287,7 +287,10 @@ export default {
 	},
 	watch: {
 		transition: {
-			/** @spec openspec/specs/status-transition-engine/spec.md */
+			/**
+			 * @param newVal
+			 * @spec openspec/specs/status-transition-engine/spec.md
+			 */
 			handler(newVal) {
 				this.localTransition = { ...newVal }
 				this.localAllowedRoles = [...(newVal.allowedRoles || [])]
@@ -298,7 +301,10 @@ export default {
 		},
 	},
 	methods: {
-		/** @spec openspec/specs/status-transition-engine/spec.md */
+		/**
+		 * @param guards
+		 * @spec openspec/specs/status-transition-engine/spec.md
+		 */
 		parseGuards(guards) {
 			if (!guards) return []
 			if (typeof guards === 'string') {
@@ -307,7 +313,10 @@ export default {
 			return [...guards]
 		},
 
-		/** @spec openspec/specs/status-transition-engine/spec.md */
+		/**
+		 * @param actions
+		 * @spec openspec/specs/status-transition-engine/spec.md
+		 */
 		parseActions(actions) {
 			if (!actions) return []
 			if (typeof actions === 'string') {
@@ -326,7 +335,10 @@ export default {
 			})
 		},
 
-		/** @spec openspec/specs/status-transition-engine/spec.md */
+		/**
+		 * @param roleId
+		 * @spec openspec/specs/status-transition-engine/spec.md
+		 */
 		toggleRole(roleId) {
 			const index = this.localAllowedRoles.indexOf(roleId)
 			if (index >= 0) {
@@ -343,7 +355,10 @@ export default {
 			this.emitUpdate()
 		},
 
-		/** @spec openspec/specs/status-transition-engine/spec.md */
+		/**
+		 * @param index
+		 * @spec openspec/specs/status-transition-engine/spec.md
+		 */
 		removeGuard(index) {
 			this.localGuards.splice(index, 1)
 			this.emitUpdate()
@@ -355,7 +370,10 @@ export default {
 			this.emitUpdate()
 		},
 
-		/** @spec openspec/specs/status-transition-engine/spec.md */
+		/**
+		 * @param index
+		 * @spec openspec/specs/status-transition-engine/spec.md
+		 */
 		removeAction(index) {
 			this.localActions.splice(index, 1)
 			this.emitUpdate()

--- a/src/views/settings/components/VthTemplateLibrary.vue
+++ b/src/views/settings/components/VthTemplateLibrary.vue
@@ -174,12 +174,18 @@ export default {
 	methods: {
 		t,
 
-		/** @spec openspec/changes/retrofit-2026-05-25-vth-workflow-templates/tasks.md */
+		/**
+		 * @param template
+		 * @spec openspec/changes/retrofit-2026-05-25-vth-workflow-templates/tasks.md
+		 */
 		selectTemplate(template) {
 			this.selectedTemplate = template
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-25-vth-workflow-templates/tasks.md */
+		/**
+		 * @param category
+		 * @spec openspec/changes/retrofit-2026-05-25-vth-workflow-templates/tasks.md
+		 */
 		getIcon(category) {
 			// Return simple SVG path based on category
 			const icons = {

--- a/src/views/settings/components/WorkflowNode.vue
+++ b/src/views/settings/components/WorkflowNode.vue
@@ -103,7 +103,10 @@ export default {
 		},
 	},
 	methods: {
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param event
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		onMouseDown(event) {
 			this.$emit('drag-start', {
 				offsetX: event.offsetX,
@@ -111,19 +114,30 @@ export default {
 			})
 		},
 
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param event
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		onConnectionStartFromPort(event) {
 			this.$emit('connection-start', event)
 		},
 
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param step
+		 * @param event
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		onStepDragStart(step, event) {
 			this.draggedStepId = step.id
 			event.dataTransfer.setData('text/plain', step.id)
 			event.dataTransfer.effectAllowed = 'move'
 		},
 
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param targetStep
+		 * @param event
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		onStepDrop(targetStep, event) {
 			const draggedId = event.dataTransfer.getData('text/plain')
 			if (draggedId && draggedId !== targetStep.id) {

--- a/src/views/settings/components/WorkflowPalette.vue
+++ b/src/views/settings/components/WorkflowPalette.vue
@@ -35,7 +35,11 @@ export default {
 	name: 'WorkflowPalette',
 	emits: ['drag-start'],
 	methods: {
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param type
+		 * @param event
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		onDragStart(type, event) {
 			event.dataTransfer.setData('text/plain', type)
 			event.dataTransfer.effectAllowed = 'copy'

--- a/src/views/settings/tabs/AiSettingsTab.vue
+++ b/src/views/settings/tabs/AiSettingsTab.vue
@@ -162,7 +162,11 @@ export default {
 	},
 	methods: {
 		t,
-		/** @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md */
+		/**
+		 * @param key
+		 * @param value
+		 * @spec openspec/changes/retrofit-2026-05-24-ai-assistance/tasks.md
+		 */
 		async updateSetting(key, value) {
 			this.settings[key] = value
 			try {

--- a/src/views/settings/tabs/ChecklistAdmin.vue
+++ b/src/views/settings/tabs/ChecklistAdmin.vue
@@ -208,7 +208,10 @@ export default {
 	watch: {
 		caseTypeId: {
 			immediate: true,
-			/** @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md */
+			/**
+			 * @param newId
+			 * @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md
+			 */
 			handler(newId) {
 				if (newId) {
 					this.inspectionStore.fetchChecklists(newId)
@@ -231,7 +234,10 @@ export default {
 			}
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md */
+		/**
+		 * @param checklist
+		 * @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md
+		 */
 		editChecklist(checklist) {
 			this.editingChecklist = JSON.parse(JSON.stringify(checklist))
 		},
@@ -258,12 +264,18 @@ export default {
 			}
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md */
+		/**
+		 * @param checklist
+		 * @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md
+		 */
 		async createVersion(checklist) {
 			await this.inspectionStore.createNewVersion(checklist)
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md */
+		/**
+		 * @param checklist
+		 * @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md
+		 */
 		async deleteChecklist(checklist) {
 			if (confirm(t('procest', 'Are you sure you want to delete this checklist?'))) {
 				await this.inspectionStore.deleteChecklist(checklist.id)
@@ -286,23 +298,37 @@ export default {
 			})
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md */
+		/**
+		 * @param index
+		 * @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md
+		 */
 		removeItem(index) {
 			this.editingChecklist.items.splice(index, 1)
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md */
+		/**
+		 * @param index
+		 * @param event
+		 * @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md
+		 */
 		onDragStart(index, event) {
 			this.dragIndex = index
 			event.dataTransfer.effectAllowed = 'move'
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md */
+		/**
+		 * @param index
+		 * @param event
+		 * @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md
+		 */
 		onDragOver(index, event) {
 			event.dataTransfer.dropEffect = 'move'
 		},
 
-		/** @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md */
+		/**
+		 * @param index
+		 * @spec openspec/changes/retrofit-2026-05-24-inspection-checklists/tasks.md
+		 */
 		onDrop(index) {
 			if (this.dragIndex === null || this.dragIndex === index) {
 				return

--- a/src/views/settings/tabs/DocumentTypesTab.vue
+++ b/src/views/settings/tabs/DocumentTypesTab.vue
@@ -135,7 +135,10 @@ export default {
 			this.editError = ''
 			this.items.push({ id: 'new', name: '' })
 		},
-		/** @spec openspec/changes/retrofit-2026-05-25-admin-settings/tasks.md */
+		/**
+		 * @param item
+		 * @spec openspec/changes/retrofit-2026-05-25-admin-settings/tasks.md
+		 */
 		startEdit(item) {
 			this.editingId = item.id
 			this.editForm = {
@@ -171,7 +174,10 @@ export default {
 			this.editingId = null
 			await this.loadItems()
 		},
-		/** @spec openspec/changes/retrofit-2026-05-25-admin-settings/tasks.md */
+		/**
+		 * @param item
+		 * @spec openspec/changes/retrofit-2026-05-25-admin-settings/tasks.md
+		 */
 		async deleteItem(item) {
 			if (!confirm(t('procest', 'Delete document type "{name}"?', { name: item.name }))) return
 			const objectStore = useObjectStore()

--- a/src/views/settings/tabs/GeneralTab.vue
+++ b/src/views/settings/tabs/GeneralTab.vue
@@ -70,7 +70,8 @@
 			<label class="required">{{ t('procest', 'Origin') }}</label>
 			<NcSelect
 				:value="selectedOrigin"
-				:options="originOptions" :aria-label-combobox="t('procest', 'Origin')"
+				:options="originOptions"
+				:aria-label-combobox="t('procest', 'Origin')"
 				@input="v => $emit('update', 'origin', v ? v.id : '')" />
 			<span v-if="errors.origin" class="field-error">{{ errors.origin }}</span>
 		</div>
@@ -119,7 +120,8 @@
 			<label class="required">{{ t('procest', 'Confidentiality') }}</label>
 			<NcSelect
 				:value="selectedConfidentiality"
-				:options="confidentialityOptions" :aria-label-combobox="t('procest', 'Confidentiality')"
+				:options="confidentialityOptions"
+				:aria-label-combobox="t('procest', 'Confidentiality')"
 				@input="v => $emit('update', 'confidentiality', v ? v.id : '')" />
 			<span v-if="errors.confidentiality" class="field-error">{{ errors.confidentiality }}</span>
 		</div>

--- a/src/views/settings/tabs/PropertiesTab.vue
+++ b/src/views/settings/tabs/PropertiesTab.vue
@@ -265,7 +265,10 @@ export default {
 				this.addError = this.objectStore.getError('propertyDefinition') || t('procest', 'Failed to add property')
 			}
 		},
-		/** @spec openspec/changes/retrofit-2026-05-25-admin-settings/tasks.md */
+		/**
+		 * @param pd
+		 * @spec openspec/changes/retrofit-2026-05-25-admin-settings/tasks.md
+		 */
 		startEdit(pd) { this.editingId = pd.id; this.editForm = { ...pd }; this.editError = '' },
 		/** @spec openspec/changes/retrofit-2026-05-25-admin-settings/tasks.md */
 		cancelEdit() { this.editingId = null; this.editForm = {}; this.editError = '' },
@@ -284,7 +287,10 @@ export default {
 				this.editError = this.objectStore.getError('propertyDefinition') || t('procest', 'Failed to save')
 			}
 		},
-		/** @spec openspec/changes/retrofit-2026-05-25-admin-settings/tasks.md */
+		/**
+		 * @param pd
+		 * @spec openspec/changes/retrofit-2026-05-25-admin-settings/tasks.md
+		 */
 		async deleteProperty(pd) {
 			if (!confirm(t('procest', 'Delete property "{name}"?', { name: pd.name }))) return
 			const ok = await this.objectStore.deleteObject('propertyDefinition', pd.id)

--- a/src/views/settings/tabs/ResultTypesTab.vue
+++ b/src/views/settings/tabs/ResultTypesTab.vue
@@ -137,7 +137,10 @@ export default {
 			this.editError = ''
 			this.items.push({ id: 'new', name: '' })
 		},
-		/** @spec openspec/changes/retrofit-2026-05-25-admin-settings/tasks.md */
+		/**
+		 * @param item
+		 * @spec openspec/changes/retrofit-2026-05-25-admin-settings/tasks.md
+		 */
 		startEdit(item) {
 			this.editingId = item.id
 			this.editForm = { name: item.name, description: item.description || '', archivalAction: item.archivalAction || '', archivalPeriod: item.archivalPeriod || '' }
@@ -170,7 +173,10 @@ export default {
 			this.editingId = null
 			await this.loadItems()
 		},
-		/** @spec openspec/changes/retrofit-2026-05-25-admin-settings/tasks.md */
+		/**
+		 * @param item
+		 * @spec openspec/changes/retrofit-2026-05-25-admin-settings/tasks.md
+		 */
 		async deleteItem(item) {
 			if (!confirm(t('procest', 'Delete result type "{name}"?', { name: item.name }))) return
 			const objectStore = useObjectStore()

--- a/src/views/settings/tabs/ResultsTab.vue
+++ b/src/views/settings/tabs/ResultsTab.vue
@@ -204,7 +204,10 @@ export default {
 		}
 	},
 	methods: {
-		/** @spec openspec/changes/retrofit-2026-05-25-admin-settings/tasks.md */
+		/**
+		 * @param period
+		 * @spec openspec/changes/retrofit-2026-05-25-admin-settings/tasks.md
+		 */
 		formatPeriod(period) {
 			if (!period) return '—'
 			const match = period.match(/^P(\d+)([YDMW])$/)
@@ -242,7 +245,10 @@ export default {
 				this.addError = this.objectStore.getError('resultType') || t('procest', 'Failed to add result type')
 			}
 		},
-		/** @spec openspec/changes/retrofit-2026-05-25-admin-settings/tasks.md */
+		/**
+		 * @param rt
+		 * @spec openspec/changes/retrofit-2026-05-25-admin-settings/tasks.md
+		 */
 		startEdit(rt) { this.editingId = rt.id; this.editForm = { ...rt }; this.editError = '' },
 		/** @spec openspec/changes/retrofit-2026-05-25-admin-settings/tasks.md */
 		cancelEdit() { this.editingId = null; this.editForm = {}; this.editError = '' },
@@ -265,7 +271,10 @@ export default {
 				this.editError = this.objectStore.getError('resultType') || t('procest', 'Failed to save')
 			}
 		},
-		/** @spec openspec/changes/retrofit-2026-05-25-admin-settings/tasks.md */
+		/**
+		 * @param rt
+		 * @spec openspec/changes/retrofit-2026-05-25-admin-settings/tasks.md
+		 */
 		async deleteResultType(rt) {
 			if (!confirm(t('procest', 'Delete result type "{name}"?', { name: rt.name }))) return
 			const ok = await this.objectStore.deleteObject('resultType', rt.id)

--- a/src/views/settings/tabs/RoleTypesTab.vue
+++ b/src/views/settings/tabs/RoleTypesTab.vue
@@ -120,7 +120,10 @@ export default {
 			this.editError = ''
 			this.items.push({ id: 'new', name: '' })
 		},
-		/** @spec openspec/specs/role-based-step-routing/spec.md */
+		/**
+		 * @param item
+		 * @spec openspec/specs/role-based-step-routing/spec.md
+		 */
 		startEdit(item) {
 			this.editingId = item.id
 			this.editForm = { name: item.name, genericRole: item.genericRole || '' }
@@ -149,7 +152,10 @@ export default {
 			this.editingId = null
 			await this.loadItems()
 		},
-		/** @spec openspec/specs/role-based-step-routing/spec.md */
+		/**
+		 * @param item
+		 * @spec openspec/specs/role-based-step-routing/spec.md
+		 */
 		async deleteItem(item) {
 			if (!confirm(t('procest', 'Delete role type "{name}"?', { name: item.name }))) return
 			const objectStore = useObjectStore()

--- a/src/views/settings/tabs/RolesTab.vue
+++ b/src/views/settings/tabs/RolesTab.vue
@@ -172,7 +172,10 @@ export default {
 		if (!this.isCreate && this.caseTypeId) await this.fetchRoleTypes()
 	},
 	methods: {
-		/** @spec openspec/specs/role-based-step-routing/spec.md */
+		/**
+		 * @param value
+		 * @spec openspec/specs/role-based-step-routing/spec.md
+		 */
 		genericRoleLabel(value) {
 			const opt = GENERIC_ROLES.find(r => r.value === value)
 			return opt ? opt.label : value || '—'
@@ -202,7 +205,10 @@ export default {
 				this.addError = this.objectStore.getError('roleType') || t('procest', 'Failed to add role type')
 			}
 		},
-		/** @spec openspec/specs/role-based-step-routing/spec.md */
+		/**
+		 * @param rt
+		 * @spec openspec/specs/role-based-step-routing/spec.md
+		 */
 		startEdit(rt) { this.editingId = rt.id; this.editForm = { ...rt }; this.editError = '' },
 		/** @spec openspec/specs/role-based-step-routing/spec.md */
 		cancelEdit() { this.editingId = null; this.editForm = {}; this.editError = '' },
@@ -221,7 +227,10 @@ export default {
 				this.editError = this.objectStore.getError('roleType') || t('procest', 'Failed to save')
 			}
 		},
-		/** @spec openspec/specs/role-based-step-routing/spec.md */
+		/**
+		 * @param rt
+		 * @spec openspec/specs/role-based-step-routing/spec.md
+		 */
 		async deleteRoleType(rt) {
 			if (!confirm(t('procest', 'Delete role type "{name}"?', { name: rt.name }))) return
 			const ok = await this.objectStore.deleteObject('roleType', rt.id)

--- a/src/views/settings/tabs/StatusesTab.vue
+++ b/src/views/settings/tabs/StatusesTab.vue
@@ -289,7 +289,10 @@ export default {
 			}
 		},
 
-		/** @spec openspec/specs/status-transition-engine/spec.md */
+		/**
+		 * @param st
+		 * @spec openspec/specs/status-transition-engine/spec.md
+		 */
 		startEdit(st) {
 			this.editingId = st.id
 			this.editForm = { ...st }
@@ -349,7 +352,10 @@ export default {
 			}
 		},
 
-		/** @spec openspec/specs/status-transition-engine/spec.md */
+		/**
+		 * @param st
+		 * @spec openspec/specs/status-transition-engine/spec.md
+		 */
 		async deleteStatusType(st) {
 			this.error = ''
 
@@ -375,13 +381,20 @@ export default {
 		},
 
 		// Drag and drop
-		/** @spec openspec/specs/status-transition-engine/spec.md */
+		/**
+		 * @param index
+		 * @param event
+		 * @spec openspec/specs/status-transition-engine/spec.md
+		 */
 		onDragStart(index, event) {
 			this.dragIndex = index
 			event.dataTransfer.effectAllowed = 'move'
 		},
 
-		/** @spec openspec/specs/status-transition-engine/spec.md */
+		/**
+		 * @param index
+		 * @spec openspec/specs/status-transition-engine/spec.md
+		 */
 		onDragOver(index) {
 			if (this.dragIndex === null || this.dragIndex === index) return
 			this.dragOverIndex = index
@@ -392,7 +405,10 @@ export default {
 			this.dragOverIndex = null
 		},
 
-		/** @spec openspec/specs/status-transition-engine/spec.md */
+		/**
+		 * @param targetIndex
+		 * @spec openspec/specs/status-transition-engine/spec.md
+		 */
 		async onDrop(targetIndex) {
 			if (this.dragIndex === null || this.dragIndex === targetIndex) {
 				this.dragOverIndex = null

--- a/src/views/settings/tabs/TemplatesTab.vue
+++ b/src/views/settings/tabs/TemplatesTab.vue
@@ -99,7 +99,10 @@ export default {
 				this.loading = false
 			}
 		},
-		/** @spec openspec/specs/template-library/spec.md */
+		/**
+		 * @param templateId
+		 * @spec openspec/specs/template-library/spec.md
+		 */
 		async activate(templateId) {
 			this.activating = templateId
 			this.activationResult = null

--- a/src/views/settings/tabs/WorkflowTab.vue
+++ b/src/views/settings/tabs/WorkflowTab.vue
@@ -327,7 +327,10 @@ export default {
 			this.$refs.importInput.click()
 		},
 
-		/** @spec openspec/specs/workflow-definition-model/spec.md */
+		/**
+		 * @param event
+		 * @spec openspec/specs/workflow-definition-model/spec.md
+		 */
 		async handleImport(event) {
 			const file = event.target.files[0]
 			if (!file) return

--- a/src/views/voorstellen/VoorstelDetail.vue
+++ b/src/views/voorstellen/VoorstelDetail.vue
@@ -315,11 +315,17 @@ export default {
 				this.loadingActies = false
 			}
 		},
-		/** @spec openspec/specs/parafering-actions/spec.md */
+		/**
+		 * @param type
+		 * @spec openspec/specs/parafering-actions/spec.md
+		 */
 		formatType(type) {
 			return TYPE_LABELS[type] || type || '-'
 		},
-		/** @spec openspec/specs/parafering-actions/spec.md */
+		/**
+		 * @param status
+		 * @spec openspec/specs/parafering-actions/spec.md
+		 */
 		formatStatus(status) {
 			return STATUS_LABELS[status] || status || '-'
 		},

--- a/src/views/voorstellen/components/AuditTrail.vue
+++ b/src/views/voorstellen/components/AuditTrail.vue
@@ -82,11 +82,17 @@ export default {
 		},
 	},
 	methods: {
-		/** @spec openspec/specs/parafering-actions/spec.md */
+		/**
+		 * @param action
+		 * @spec openspec/specs/parafering-actions/spec.md
+		 */
 		formatAction(action) {
 			return ACTION_LABELS[action] || action
 		},
-		/** @spec openspec/specs/parafering-actions/spec.md */
+		/**
+		 * @param actie
+		 * @spec openspec/specs/parafering-actions/spec.md
+		 */
 		formatTimestamp(actie) {
 			const ts = actie._self?.created || actie.timestamp
 			if (!ts) return '-'

--- a/src/views/voorstellen/components/DelegateSelectorField.vue
+++ b/src/views/voorstellen/components/DelegateSelectorField.vue
@@ -50,7 +50,10 @@ export default {
 		}
 	},
 	methods: {
-		/** @spec openspec/specs/parafering-actions/spec.md */
+		/**
+		 * @param entry
+		 * @spec openspec/specs/parafering-actions/spec.md
+		 */
 		formatOption(entry) {
 			const name = entry.principalDisplayName || entry.principalUid
 			return this.t('procest', 'On behalf of {name} (mandate {ref})', {
@@ -58,7 +61,10 @@ export default {
 				ref: entry.mandateReference,
 			})
 		},
-		/** @spec openspec/specs/parafering-actions/spec.md */
+		/**
+		 * @param event
+		 * @spec openspec/specs/parafering-actions/spec.md
+		 */
 		onChange(event) {
 			const value = event.target.value
 			this.selected = value

--- a/src/views/voorstellen/components/ParafeerActieDialog.vue
+++ b/src/views/voorstellen/components/ParafeerActieDialog.vue
@@ -178,7 +178,10 @@ export default {
 		},
 	},
 	methods: {
-		/** @spec openspec/specs/parafering-actions/spec.md */
+		/**
+		 * @param type
+		 * @spec openspec/specs/parafering-actions/spec.md
+		 */
 		formatStepType(type) {
 			const labels = {
 				advies: this.t('procest', 'Advise'),
@@ -204,7 +207,10 @@ export default {
 			this.errorMessage = ''
 			this.validationError = ''
 		},
-		/** @spec openspec/specs/parafering-actions/spec.md */
+		/**
+		 * @param action
+		 * @spec openspec/specs/parafering-actions/spec.md
+		 */
 		buildPayload(action) {
 			const payload = {
 				voorstel: this.voorstelId,
@@ -244,7 +250,10 @@ export default {
 			}
 			await this.submit(payload)
 		},
-		/** @spec openspec/specs/parafering-actions/spec.md */
+		/**
+		 * @param payload
+		 * @spec openspec/specs/parafering-actions/spec.md
+		 */
 		async submit(payload) {
 			this.submitting = true
 			this.errorMessage = ''

--- a/src/views/voorstellen/components/ParafeerActieTimeline.vue
+++ b/src/views/voorstellen/components/ParafeerActieTimeline.vue
@@ -87,7 +87,10 @@ export default {
 				this.loading = false
 			}
 		},
-		/** @spec openspec/specs/parafering-actions/spec.md */
+		/**
+		 * @param actie
+		 * @spec openspec/specs/parafering-actions/spec.md
+		 */
 		formatStageLabel(actie) {
 			const englishKey = ACTION_LABELS[actie.action] || actie.action || ''
 			const localized = this.t('procest', englishKey)
@@ -96,7 +99,10 @@ export default {
 				action: localized,
 			})
 		},
-		/** @spec openspec/specs/parafering-actions/spec.md */
+		/**
+		 * @param actie
+		 * @spec openspec/specs/parafering-actions/spec.md
+		 */
 		formatActor(actie) {
 			if (actie.actorType === 'delegate' && actie.onBehalfOf) {
 				return this.t('procest', 'On behalf of {name} (mandate {ref})', {
@@ -106,7 +112,10 @@ export default {
 			}
 			return actie.actor || '—'
 		},
-		/** @spec openspec/specs/parafering-actions/spec.md */
+		/**
+		 * @param actie
+		 * @spec openspec/specs/parafering-actions/spec.md
+		 */
 		formatTimestamp(actie) {
 			const raw = actie.createdAt || actie.created || actie['@self']?.created
 			if (!raw) return ''

--- a/src/views/voorstellen/components/ParafeerActionBar.vue
+++ b/src/views/voorstellen/components/ParafeerActionBar.vue
@@ -124,7 +124,10 @@ export default {
 		},
 	},
 	methods: {
-		/** @spec openspec/specs/parafering-actions/spec.md */
+		/**
+		 * @param type
+		 * @spec openspec/specs/parafering-actions/spec.md
+		 */
 		formatStepType(type) {
 			const labels = { advies: 'Advies', parafering: 'Parafering', accordering: 'Accordering' }
 			return labels[type] || type || ''

--- a/src/views/voorstellen/components/ParafeerInbox.vue
+++ b/src/views/voorstellen/components/ParafeerInbox.vue
@@ -96,11 +96,17 @@ export default {
 				this.loading = false
 			}
 		},
-		/** @spec openspec/specs/parafering-actions/spec.md */
+		/**
+		 * @param type
+		 * @spec openspec/specs/parafering-actions/spec.md
+		 */
 		formatType(type) {
 			return TYPE_LABELS[type] || type || '-'
 		},
-		/** @spec openspec/specs/parafering-actions/spec.md */
+		/**
+		 * @param voorstel
+		 * @spec openspec/specs/parafering-actions/spec.md
+		 */
 		formatDate(voorstel) {
 			const date = voorstel._self?.updated || voorstel.updatedAt
 			if (!date) return '-'

--- a/src/views/voorstellen/components/ProgressTimeline.vue
+++ b/src/views/voorstellen/components/ProgressTimeline.vue
@@ -68,17 +68,26 @@ export default {
 		isCurrent(step) {
 			return step.order === this.currentStep
 		},
-		/** @spec openspec/specs/parafering-actions/spec.md */
+		/**
+		 * @param step
+		 * @spec openspec/specs/parafering-actions/spec.md
+		 */
 		stepClass(step) {
 			if (this.isCompleted(step)) return 'progress-timeline__step--completed'
 			if (this.isCurrent(step)) return 'progress-timeline__step--current'
 			return 'progress-timeline__step--pending'
 		},
-		/** @spec openspec/specs/parafering-actions/spec.md */
+		/**
+		 * @param type
+		 * @spec openspec/specs/parafering-actions/spec.md
+		 */
 		formatStepType(type) {
 			return STEP_TYPE_LABELS[type] || type || ''
 		},
-		/** @spec openspec/specs/parafering-actions/spec.md */
+		/**
+		 * @param step
+		 * @spec openspec/specs/parafering-actions/spec.md
+		 */
 		getCompletionInfo(step) {
 			const actie = this.acties.find(a => a.step === step.order)
 			if (!actie) return ''

--- a/src/views/voorstellen/components/VoorstelCreateDialog.vue
+++ b/src/views/voorstellen/components/VoorstelCreateDialog.vue
@@ -129,7 +129,10 @@ export default {
 		}
 	},
 	methods: {
-		/** @spec openspec/specs/parafering-actions/spec.md */
+		/**
+		 * @param caseObj
+		 * @spec openspec/specs/parafering-actions/spec.md
+		 */
 		onCaseSelected(caseObj) {
 			if (caseObj && !this.form.onderwerp) {
 				this.form.onderwerp = caseObj.title || ''

--- a/src/views/widgets/CasesOverviewWidget.vue
+++ b/src/views/widgets/CasesOverviewWidget.vue
@@ -70,7 +70,10 @@ export default {
 		 * @param {object} item The case item to show
 		 * @return {void}
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-signalering-widgets/tasks.md */
+		/**
+		 * @param item
+		 * @spec openspec/changes/retrofit-2026-05-24-signalering-widgets/tasks.md
+		 */
 		onShow(item) {
 			window.location.href = `/index.php/apps/procest/#/cases/${item.id}`
 		},

--- a/src/views/widgets/DeadlineAlertsWidget.vue
+++ b/src/views/widgets/DeadlineAlertsWidget.vue
@@ -78,7 +78,10 @@ export default {
 		 * @param {object} item The case item to show
 		 * @return {void}
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-signalering-widgets/tasks.md */
+		/**
+		 * @param item
+		 * @spec openspec/changes/retrofit-2026-05-24-signalering-widgets/tasks.md
+		 */
 		onShow(item) {
 			window.location.href = `/index.php/apps/procest/#/cases/${item.id}`
 		},

--- a/src/views/widgets/MyTasksWidget.vue
+++ b/src/views/widgets/MyTasksWidget.vue
@@ -70,7 +70,10 @@ export default {
 		 * @param {object} item The task item to show
 		 * @return {void}
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-signalering-widgets/tasks.md */
+		/**
+		 * @param item
+		 * @spec openspec/changes/retrofit-2026-05-24-signalering-widgets/tasks.md
+		 */
 		onShow(item) {
 			window.location.href = `/index.php/apps/procest/#/tasks/${item.id}`
 		},

--- a/src/views/widgets/OverdueCasesWidget.vue
+++ b/src/views/widgets/OverdueCasesWidget.vue
@@ -71,7 +71,10 @@ export default {
 		 * @param {object} item The case item to show
 		 * @return {void}
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-signalering-widgets/tasks.md */
+		/**
+		 * @param item
+		 * @spec openspec/changes/retrofit-2026-05-24-signalering-widgets/tasks.md
+		 */
 		onShow(item) {
 			window.location.href = `/index.php/apps/procest/#/cases/${item.id}`
 		},

--- a/src/views/widgets/StalledCasesWidget.vue
+++ b/src/views/widgets/StalledCasesWidget.vue
@@ -69,7 +69,10 @@ export default {
 		 * @param {object} item The case item to show
 		 * @return {void}
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-signalering-widgets/tasks.md */
+		/**
+		 * @param item
+		 * @spec openspec/changes/retrofit-2026-05-24-signalering-widgets/tasks.md
+		 */
 		onShow(item) {
 			window.location.href = `/index.php/apps/procest/#/cases/${item.id}`
 		},

--- a/src/views/widgets/StartCaseWidget.vue
+++ b/src/views/widgets/StartCaseWidget.vue
@@ -88,7 +88,10 @@ export default {
 		 * @param {object} caseType The case type to start
 		 * @return {Promise<void>}
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-signalering-widgets/tasks.md */
+		/**
+		 * @param caseType
+		 * @spec openspec/changes/retrofit-2026-05-24-signalering-widgets/tasks.md
+		 */
 		async startCase(caseType) {
 			if (this.creating) {
 				return

--- a/src/views/widgets/TaskRemindersWidget.vue
+++ b/src/views/widgets/TaskRemindersWidget.vue
@@ -78,7 +78,10 @@ export default {
 		 * @param {object} item The task item to show
 		 * @return {void}
 		 */
-		/** @spec openspec/changes/retrofit-2026-05-24-signalering-widgets/tasks.md */
+		/**
+		 * @param item
+		 * @spec openspec/changes/retrofit-2026-05-24-signalering-widgets/tasks.md
+		 */
 		onShow(item) {
 			window.location.href = `/index.php/apps/procest/#/tasks/${item.id}`
 		},


### PR DESCRIPTION
## Summary
- **PHPStan** (15 errors → 0): removed dead-code is_array===false guards; fixed caseId offset bug in CaseTransferService; removed redundant ?? in GuardRegistry::allPassed; removed always-true || in ParaferingAuditAppendOnlyValidator; removed stale baseline entry; added missing revokeShare() + getFilteredCaseData() to CaseSharingService + fixed validateToken return type
- **gate-9 semantic-auth**: dropped @PublicPage from AcController::create, update, patch, destroy
- **PHPCS** (all errors → 0): fixed inline ternaries, assignment alignment, missing //end try comments, blank line after inline comment
- **ESLint** (8 errors → 0): auto-fixed vue/max-attributes-per-line and vue/html-indent

## Test plan
- [ ] composer check:strict exits 0 (verified locally: PHPStan OK, PHPCS OK, PHPMD OK, Psalm info-only, 171/0/0 PHPUnit)
- [ ] npm run lint exits 0 (0 errors)
- [ ] gate-9: AcController create/update/patch/destroy no longer have @PublicPage