### PR TITLE
chore(deps): bump nextcloud-vue to 2.0.5 (OpenBuild glyph fix, vue3 line)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.0",
 			"license": "EUPL-1.2",
 			"dependencies": {
-				"@conduction/nextcloud-vue": "^2.0.1",
+				"@conduction/nextcloud-vue": "^2.0.5",
 				"@nextcloud/auth": "^2.6.0",
 				"@nextcloud/axios": "~2.5.2",
 				"@nextcloud/dialogs": "^6.4.2",
@@ -605,9 +605,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.0.1.tgz",
-			"integrity": "sha512-824Q/FibjBM9Yv26mk+ikTDBVbP40EFUVm1ZQhUNicUwA93Sl+Z1XOMYaNbwjwucUlfykz28wtk1tCj0yddISQ==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.0.5.tgz",
+			"integrity": "sha512-IhSbN0usGFj0P4NNl9wTog28TCy1RSNGqGZcUz95ZqlY/uyJRtMsdxM+1FEy6ih7M0IAKNBo1cjW8gqOECPZ3w==",
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"extends @nextcloud/browserslist-config"
 	],
 	"dependencies": {
-		"@conduction/nextcloud-vue": "^2.0.1",
+		"@conduction/nextcloud-vue": "^2.0.5",
 		"@nextcloud/auth": "^2.6.0",
 		"@nextcloud/axios": "~2.5.2",
 		"@nextcloud/dialogs": "^6.4.2",


### PR DESCRIPTION
Bumps `@conduction/nextcloud-vue` `^2.0.1` → `^2.0.5`, picking up the OpenBuild edit-button glyph fix (package/cube → OpenBuild stacked-layers) on the **vue3** line.

procest **stays on pure Vue 3** — the rebuilt bundle has zero `$scopedSlots`/`$listeners`/`configureCompat` residue.

**Live-verified on 8080** (Cases index): edit button renders with the layers glyph (`M12 0L3 7L4.63 8.27…`), `isCube: false`, **0 console errors**.

⚠️ Note for CI/release: a build against the **published dist** (`USE_LOCAL_LIB=false`) tree-shook `CnOpenBuildEditButton` out of the bundle entirely — the verified bundle was built with `LOCAL_LIB_PATH` against the vue3 lib `src`, which is how procest currently ships. Worth confirming the release path before relying on the published dist.