### PR TITLE
chore(deps): nc-vue 2.0.6 (vue3) — activate schema-label translation

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -48,7 +48,7 @@ Vrij en open source onder de EUPL-1.2-licentie.
 
 **Ondersteuning:** Voor ondersteuning, neem contact op via support@conduction.nl. Voor een Service Level Agreement (SLA), neem contact op via sales@conduction.nl.
     ]]></description>
-    <version>0.3.4</version>
+    <version>0.3.5</version>
     <licence>EUPL-1.2</licence>
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>Procest</namespace>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.0",
 			"license": "EUPL-1.2",
 			"dependencies": {
-				"@conduction/nextcloud-vue": "^2.0.1",
+				"@conduction/nextcloud-vue": "^2.0.6",
 				"@nextcloud/auth": "^2.6.0",
 				"@nextcloud/axios": "~2.5.2",
 				"@nextcloud/dialogs": "^6.4.2",
@@ -605,9 +605,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.0.1.tgz",
-			"integrity": "sha512-824Q/FibjBM9Yv26mk+ikTDBVbP40EFUVm1ZQhUNicUwA93Sl+Z1XOMYaNbwjwucUlfykz28wtk1tCj0yddISQ==",
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.0.6.tgz",
+			"integrity": "sha512-r6kLnZeBUcKW4ifS/1bjj6+sJmpqWoNQfBpBg2/tSCk7KLIix+zD0W5milsQu5Va6JIG+Z6LpSD7VogC2KyFXw==",
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"extends @nextcloud/browserslist-config"
 	],
 	"dependencies": {
-		"@conduction/nextcloud-vue": "^2.0.1",
+		"@conduction/nextcloud-vue": "^2.0.6",
 		"@nextcloud/auth": "^2.6.0",
 		"@nextcloud/axios": "~2.5.2",
 		"@nextcloud/dialogs": "^6.4.2",


### PR DESCRIPTION
Bumps procest to `@conduction/nextcloud-vue@2.0.6` (vue3 tag, carries the cnTranslate display-layer translation). procest's schema titles are English + EN/NL l10n (#679), so labels resolve per user language.

Local build verified via **direct webpack** (webpack compiled, 0 errors) — procest's `npm run build` prebuild runs `vue-demi-switch 2.7` which sabotages the Vue-3 build (23 pinia/vue-demi export errors), a known procest toolchain quirk, NOT this bump. js/ is gitignored → CI builds the bundle. info.xml 0.3.4→0.3.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)