### PR TITLE
chore(deps): bump @conduction/nextcloud-vue to 2.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"extends @nextcloud/browserslist-config"
 	],
 	"dependencies": {
-		"@conduction/nextcloud-vue": "^2.0.6",
+		"@conduction/nextcloud-vue": "^2.0.7",
 		"@nextcloud/auth": "^2.6.0",
 		"@nextcloud/axios": "~2.5.2",
 		"@nextcloud/dialogs": "^6.4.2",


### PR DESCRIPTION
Patch bump for the settings-widget `h is not a function` render fix in nc-vue 2.0.7 (built settings pages no longer crash-render version-info/register-mapping). No source changes.