### PR TITLE
i18n(labels): author status/type labels in English source + NL l10n

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -48,7 +48,7 @@ Vrij en open source onder de EUPL-1.2-licentie.
 
 **Ondersteuning:** Voor ondersteuning, neem contact op via support@conduction.nl. Voor een Service Level Agreement (SLA), neem contact op via sales@conduction.nl.
     ]]></description>
-    <version>0.3.7</version>
+    <version>0.3.8</version>
     <licence>EUPL-1.2</licence>
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>Procest</namespace>

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -2929,7 +2929,21 @@
         "Beslissingen op bezwaar": "Beslissingen op bezwaar",
         "Overzicht van beslissingen op ingediende bezwaarschriften.": "Overzicht van beslissingen op ingediende bezwaarschriften.",
         "BAC-adviezen": "BAC-adviezen",
-        "Adviezen van de Bezwaaradviescommissie (BAC) over ingediende bezwaren.": "Adviezen van de Bezwaaradviescommissie (BAC) over ingediende bezwaren."
+        "Adviezen van de Bezwaaradviescommissie (BAC) over ingediende bezwaren.": "Adviezen van de Bezwaaradviescommissie (BAC) over ingediende bezwaren.",
+        "Awaiting initials": "Awaiting initials",
+        "Awaiting approval": "Awaiting approval",
+        "Approved": "Approved",
+        "Presented": "Presented",
+        "Decided": "Decided",
+        "Management team advice": "Management team advice",
+        "Executive board advice": "Executive board advice",
+        "Council proposal": "Council proposal",
+        "Draft ruling": "Draft ruling",
+        "Approved (mandate)": "Approved (mandate)",
+        "Signed": "Signed",
+        "Receipt confirmation": "Receipt confirmation",
+        "Endorsement": "Endorsement",
+        "Approval": "Approval"
     },
     "plurals": ""
 }

--- a/l10n/nl.json
+++ b/l10n/nl.json
@@ -2929,6 +2929,20 @@
         "Beslissingen op bezwaar": "Beslissingen op bezwaar",
         "Overzicht van beslissingen op ingediende bezwaarschriften.": "Overzicht van beslissingen op ingediende bezwaarschriften.",
         "BAC-adviezen": "BAC-adviezen",
-        "Adviezen van de Bezwaaradviescommissie (BAC) over ingediende bezwaren.": "Adviezen van de Bezwaaradviescommissie (BAC) over ingediende bezwaren."
+        "Adviezen van de Bezwaaradviescommissie (BAC) over ingediende bezwaren.": "Adviezen van de Bezwaaradviescommissie (BAC) over ingediende bezwaren.",
+        "Awaiting initials": "In parafering",
+        "Awaiting approval": "Ter accordering",
+        "Approved": "Geaccordeerd",
+        "Presented": "Aangeboden",
+        "Decided": "Besloten",
+        "Management team advice": "DT-advies",
+        "Executive board advice": "Collegeadvies",
+        "Council proposal": "Raadsvoorstel",
+        "Draft ruling": "Ontwerp",
+        "Approved (mandate)": "Akkoord (mandaat)",
+        "Signed": "Ondertekend",
+        "Receipt confirmation": "Ontvangstbevestiging",
+        "Endorsement": "Parafering",
+        "Approval": "Accordering"
     }
 }

--- a/src/services/formatters.js
+++ b/src/services/formatters.js
@@ -99,20 +99,20 @@ function lookupRelatedName(type, uuid) {
 }
 
 const VOORSTEL_STATUS_LABELS = {
-	concept: 'Concept',
-	in_parafering: 'In parafering',
-	ter_accordering: 'Ter accordering',
-	geaccordeerd: 'Geaccordeerd',
-	aangeboden: 'Aangeboden',
-	besloten: 'Besloten',
-	gearchiveerd: 'Gearchiveerd',
-	teruggestuurd: 'Teruggestuurd',
+	concept: 'Draft',
+	in_parafering: 'Awaiting initials',
+	ter_accordering: 'Awaiting approval',
+	geaccordeerd: 'Approved',
+	aangeboden: 'Presented',
+	besloten: 'Decided',
+	gearchiveerd: 'Archived',
+	teruggestuurd: 'Returned',
 }
 
 const VOORSTEL_TYPE_LABELS = {
-	dt_advies: 'DT-advies',
-	collegeadvies: 'Collegeadvies',
-	raadsvoorstel: 'Raadsvoorstel',
+	dt_advies: 'Management team advice',
+	collegeadvies: 'Executive board advice',
+	raadsvoorstel: 'Council proposal',
 }
 
 /**

--- a/src/views/cases/components/BeschikkingDetailView.vue
+++ b/src/views/cases/components/BeschikkingDetailView.vue
@@ -81,12 +81,12 @@ import { getBeschikking } from '../../../services/beschikkingApi.js'
 import BeschikkingActionBar from './BeschikkingActionBar.vue'
 
 const STATUS_LABELS = {
-	ontwerp: 'Ontwerp',
-	'akkoord-mandaat': 'Akkoord (mandaat)',
-	ondertekend: 'Ondertekend',
-	verzonden: 'Verzonden',
-	'ontvangen-bevestiging': 'Ontvangstbevestiging',
-	gearchiveerd: 'Gearchiveerd',
+	ontwerp: 'Draft ruling',
+	'akkoord-mandaat': 'Approved (mandate)',
+	ondertekend: 'Signed',
+	verzonden: 'Sent',
+	'ontvangen-bevestiging': 'Receipt confirmation',
+	gearchiveerd: 'Archived',
 }
 
 export default {

--- a/src/views/cases/components/VoorstellenPanel.vue
+++ b/src/views/cases/components/VoorstellenPanel.vue
@@ -52,20 +52,20 @@ import VoorstelCreateDialog from '../../voorstellen/components/VoorstelCreateDia
 import { useObjectStore } from '../../../store/modules/object.js'
 
 const STATUS_LABELS = {
-	concept: 'Concept',
-	in_parafering: 'In parafering',
-	ter_accordering: 'Ter accordering',
-	geaccordeerd: 'Geaccordeerd',
-	aangeboden: 'Aangeboden',
-	besloten: 'Besloten',
-	gearchiveerd: 'Gearchiveerd',
-	teruggestuurd: 'Teruggestuurd',
+	concept: 'Draft',
+	in_parafering: 'Awaiting initials',
+	ter_accordering: 'Awaiting approval',
+	geaccordeerd: 'Approved',
+	aangeboden: 'Presented',
+	besloten: 'Decided',
+	gearchiveerd: 'Archived',
+	teruggestuurd: 'Returned',
 }
 
 const TYPE_LABELS = {
-	dt_advies: 'DT-advies',
-	collegeadvies: 'Collegeadvies',
-	raadsvoorstel: 'Raadsvoorstel',
+	dt_advies: 'Management team advice',
+	collegeadvies: 'Executive board advice',
+	raadsvoorstel: 'Council proposal',
 }
 
 export default {
@@ -130,14 +130,14 @@ export default {
 		 * @spec openspec/specs/parafering-actions/spec.md
 		 */
 		formatType(type) {
-			return TYPE_LABELS[type] || type || '-'
+			return t('procest', TYPE_LABELS[type] || type || '-')
 		},
 		/**
 		 * @param status
 		 * @spec openspec/specs/parafering-actions/spec.md
 		 */
 		formatStatus(status) {
-			return STATUS_LABELS[status] || status || '-'
+			return t('procest', STATUS_LABELS[status] || status || '-')
 		},
 		/**
 		 * @param voorstel

--- a/src/views/voorstellen/VoorstelDetail.vue
+++ b/src/views/voorstellen/VoorstelDetail.vue
@@ -172,20 +172,20 @@ import { useObjectStore } from '../../store/modules/object.js'
 import { initializeStores } from '../../store/store.js'
 
 const STATUS_LABELS = {
-	concept: 'Concept',
-	in_parafering: 'In parafering',
-	ter_accordering: 'Ter accordering',
-	geaccordeerd: 'Geaccordeerd',
-	aangeboden: 'Aangeboden',
-	besloten: 'Besloten',
-	gearchiveerd: 'Gearchiveerd',
-	teruggestuurd: 'Teruggestuurd',
+	concept: 'Draft',
+	in_parafering: 'Awaiting initials',
+	ter_accordering: 'Awaiting approval',
+	geaccordeerd: 'Approved',
+	aangeboden: 'Presented',
+	besloten: 'Decided',
+	gearchiveerd: 'Archived',
+	teruggestuurd: 'Returned',
 }
 
 const TYPE_LABELS = {
-	dt_advies: 'DT-advies',
-	collegeadvies: 'Collegeadvies',
-	raadsvoorstel: 'Raadsvoorstel',
+	dt_advies: 'Management team advice',
+	collegeadvies: 'Executive board advice',
+	raadsvoorstel: 'Council proposal',
 }
 
 export default {
@@ -325,14 +325,14 @@ export default {
 		 * @spec openspec/specs/parafering-actions/spec.md
 		 */
 		formatType(type) {
-			return TYPE_LABELS[type] || type || '-'
+			return t('procest', TYPE_LABELS[type] || type || '-')
 		},
 		/**
 		 * @param status
 		 * @spec openspec/specs/parafering-actions/spec.md
 		 */
 		formatStatus(status) {
-			return STATUS_LABELS[status] || status || '-'
+			return t('procest', STATUS_LABELS[status] || status || '-')
 		},
 		/** @spec openspec/specs/parafering-actions/spec.md */
 		async onActionCompleted() {

--- a/src/views/voorstellen/components/AuditTrail.vue
+++ b/src/views/voorstellen/components/AuditTrail.vue
@@ -59,10 +59,10 @@
 import { NcButton, NcLoadingIcon } from '@nextcloud/vue'
 
 const ACTION_LABELS = {
-	parafered: 'Geparafeerd',
-	returned: 'Teruggestuurd',
-	advised: 'Geadviseerd',
-	skipped: 'Overgeslagen',
+	parafered: 'Endorsed',
+	returned: 'Returned',
+	advised: 'Advised',
+	skipped: 'Skipped',
 }
 
 export default {
@@ -87,7 +87,7 @@ export default {
 		 * @spec openspec/specs/parafering-actions/spec.md
 		 */
 		formatAction(action) {
-			return ACTION_LABELS[action] || action
+			return t('procest', ACTION_LABELS[action] || action)
 		},
 		/**
 		 * @param actie

--- a/src/views/voorstellen/components/ParafeerInbox.vue
+++ b/src/views/voorstellen/components/ParafeerInbox.vue
@@ -43,9 +43,9 @@ import { useObjectStore } from '../../../store/modules/object.js'
 import { isActiveActor } from '../../../utils/parafeerEngine.js'
 
 const TYPE_LABELS = {
-	dt_advies: 'DT-advies',
-	collegeadvies: 'Collegeadvies',
-	raadsvoorstel: 'Raadsvoorstel',
+	dt_advies: 'Management team advice',
+	collegeadvies: 'Executive board advice',
+	raadsvoorstel: 'Council proposal',
 }
 
 export default {
@@ -101,7 +101,7 @@ export default {
 		 * @spec openspec/specs/parafering-actions/spec.md
 		 */
 		formatType(type) {
-			return TYPE_LABELS[type] || type || '-'
+			return t('procest', TYPE_LABELS[type] || type || '-')
 		},
 		/**
 		 * @param voorstel

--- a/src/views/voorstellen/components/ProgressTimeline.vue
+++ b/src/views/voorstellen/components/ProgressTimeline.vue
@@ -35,9 +35,9 @@ import ProgressClock from 'vue-material-design-icons/ProgressClock.vue'
 import CircleOutline from 'vue-material-design-icons/CircleOutline.vue'
 
 const STEP_TYPE_LABELS = {
-	advies: 'Advies',
-	parafering: 'Parafering',
-	accordering: 'Accordering',
+	advies: 'Advice',
+	parafering: 'Endorsement',
+	accordering: 'Approval',
 }
 
 export default {
@@ -82,7 +82,7 @@ export default {
 		 * @spec openspec/specs/parafering-actions/spec.md
 		 */
 		formatStepType(type) {
-			return STEP_TYPE_LABELS[type] || type || ''
+			return t('procest', STEP_TYPE_LABELS[type] || type || '')
 		},
 		/**
 		 * @param step


### PR DESCRIPTION
## What
Author procest's Dutch-valued label constants as **English source strings** and
move the Dutch to the l10n layer (`t()`), per the fleet convention (English source →
Dutch at display via `t()`). English-locale users no longer see hard-coded Dutch labels;
Dutch users keep their Dutch via `nl.json`.

Only string **values** changed — object **keys** (data/API enums like `in_parafering`)
are untouched.

## Constants converted (Dutch → English)
**Voorstel status** (`formatters.js VOORSTEL_STATUS_LABELS`, `VoorstelDetail STATUS_LABELS`,
`VoorstellenPanel STATUS_LABELS` — identical sets):
| key | old (nl) | new (en) |
|---|---|---|
| concept | Concept | Draft |
| in_parafering | In parafering | Awaiting initials |
| ter_accordering | Ter accordering | Awaiting approval |
| geaccordeerd | Geaccordeerd | Approved |
| aangeboden | Aangeboden | Presented |
| besloten | Besloten | Decided |
| gearchiveerd | Gearchiveerd | Archived |
| teruggestuurd | Teruggestuurd | Returned |

**Voorstel type** (`VOORSTEL_TYPE_LABELS` + `TYPE_LABELS` in VoorstelDetail, VoorstellenPanel, ParafeerInbox):
| dt_advies | DT-advies | Management team advice |
| collegeadvies | Collegeadvies | Executive board advice |
| raadsvoorstel | Raadsvoorstel | Council proposal |

**AuditTrail ACTION_LABELS** (aligned with the already-English `ParafeerActieTimeline`):
| parafered | Geparafeerd | Endorsed |
| returned | Teruggestuurd | Returned |
| advised | Geadviseerd | Advised |
| skipped | Overgeslagen | Skipped |

**BeschikkingDetailView STATUS_LABELS:**
| ontwerp | Ontwerp | Draft ruling |
| akkoord-mandaat | Akkoord (mandaat) | Approved (mandate) |
| ondertekend | Ondertekend | Signed |
| verzonden | Verzonden | Sent |
| ontvangen-bevestiging | Ontvangstbevestiging | Receipt confirmation |
| gearchiveerd | Gearchiveerd | Archived |

**ProgressTimeline STEP_TYPE_LABELS:**
| advies | Advies | Advice |
| parafering | Parafering | Endorsement |
| accordering | Accordering | Approval |

## Skipped (verified against the decision tree)
- `ParafeerActieTimeline ACTION_LABELS` — **already English** (advised/Endorsed/Accorded/Returned/Skipped).
- `RoleTypesTab GENERIC_ROLE_LABELS` — already English.
- `TenantOnboardingDashboard STEP_LABELS` — already English (and already `t()`-wrapped).
- `taskLifecycle.js TASK_STATUSES` — enum identifiers (`available: 'available'`), not human labels; the labels are produced by `getStatusLabels()` which is already `t()`-wrapped.

## Call sites wrapped in t() (decision-tree case b — were rendered without t())
`VoorstelDetail.formatType/formatStatus`, `VoorstellenPanel.formatType/formatStatus`,
`AuditTrail.formatAction`, `ProgressTimeline.formatStepType`, `ParafeerInbox.formatType`.
The formatters.js entries and `BeschikkingDetailView.statusLabel` were already `t()`-wrapped (case a) — values only.

## ⚠️ FLAGGED English choices — please review (Dutch admin-law terminology)
These are precision-sensitive; I picked the clearest accurate English and reused nl.json precedent where it existed:
- **parafering / parafered / geparafeerd → "Endorsed" / "Endorsement"** (initialing/sign-off). Chosen to match the app's **existing** English in `ParafeerActieTimeline` (`parafered: 'Endorsed'`) and the pre-existing `nl.json` key `"Endorsed": "Geparafeerd"`. Literal alternative: "Initialed".
- **in_parafering → "Awaiting initials"** (status = waiting in the parafering step). Alt: "In initialing".
- **accordering / ter_accordering / geaccordeerd → "Approval" / "Awaiting approval" / "Approved"** (accordering = formal sign-off/approval). Alt: "Concurrence".
- **aangeboden → "Presented"** — NOT reused as "Submitted" on purpose: `nl.json` already maps `"Submitted"→"Ingediend"`, which would regress the Dutch word. "Presented"→"Aangeboden" keeps the original Dutch. Alt: "Offered".
- **beschikking ontwerp → "Draft ruling"** — a *beschikking* is an administrative decision/ruling. Used "Draft ruling" (not plain "Draft") because `"Draft"→"Concept"` already exists for the voorstel status; a flat l10n map can't hold both "Concept" and "Ontwerp" under one English key, so the beschikking draft needs a distinct key. Alt for beschikking: "Draft".
- **dt_advies → "Management team advice"** (DT = *directieteam*). Alt: keep "DT advice".
- **collegeadvies → "Executive board advice"** (advies to the *College van B&W*, the municipal executive). Alt: "College advice".
- **raadsvoorstel → "Council proposal"** (voorstel to the *gemeenteraad*). Fairly standard.
- **ontvangen-bevestiging → "Receipt confirmation"** (*ontvangstbevestiging* = acknowledgement of receipt). Alt: "Acknowledgement of receipt".
- **besloten → "Decided"** (voorstel has been decided on).

## l10n
Added 14 new `en.json`→`nl.json` pairs (Dutch preserved). Reused 8 pre-existing keys
(Draft, Archived, Returned, Endorsed, Advice, Sent, Advised, Skipped) whose nl values already matched.

## Verify
- `npm run test:l10n` → **OK** (every used key in en.json; en/nl key sets match).
- `python3 json.load` both files → valid.
- Object keys unchanged (values-only diff, 56 ins / 56 del in src).
- webpack/eslint not installed in this worktree; `node --check` on formatters.js passed and edits are trivial value swaps + wrapping existing expressions.
