### PR TITLE
feat(icons): adopt the ADR-077 semantic icon vocabulary

### DIFF
--- a/lib/Settings/procest_register.json
+++ b/lib/Settings/procest_register.json
@@ -3945,7 +3945,7 @@
             },
             "appealDecision": {
                 "slug": "appealDecision",
-                "icon": "GavelOutline",
+                "icon": "Gavel",
                 "version": "1.0.0",
                 "x-schema-org": "schema:LegalForceStatus",
                 "x-zgw-equivalent": "BeslissingOpBezwaar",
@@ -4058,7 +4058,7 @@
             },
             "bezwaarDecision": {
                 "slug": "bezwaarDecision",
-                "icon": "GavelOutline",
+                "icon": "Gavel",
                 "version": "1.0.0",
                 "x-schema-org": "schema:Action",
                 "x-zgw-equivalent": "BeslissingOpBezwaar",
@@ -7543,7 +7543,7 @@
             },
             "hearing": {
                 "slug": "hearing",
-                "icon": "AccountVoiceOutline",
+                "icon": "AccountVoice",
                 "version": "1.0.0",
                 "title": "Hearing",
                 "description": "Hoorgesprek (hearing) linked to a complaint — captures scheduling, participants, outcome, and video/calendar integration.",
@@ -7971,7 +7971,7 @@
             },
             "tenantMandate": {
                 "slug": "tenantMandate",
-                "icon": "FileSignOutline",
+                "icon": "FileSign",
                 "version": "1.0.0",
                 "title": "Tenant Mandate",
                 "description": "Signed mandate authorising a tenant to act on behalf of the issuing authority — backs ketenmachtiging (chain-mandate) flows.",

--- a/lib/Settings/register.d/30-beschikking.json
+++ b/lib/Settings/register.d/30-beschikking.json
@@ -205,7 +205,7 @@
       },
       "stateMachineLog": {
         "slug": "stateMachineLog",
-        "icon": "HistoryOutline",
+        "icon": "History",
         "version": "1.0.0",
         "x-schema-org": "schema:Action",
         "title": "State Machine Log",
@@ -248,7 +248,7 @@
       },
       "bezwaarTrigger": {
         "slug": "bezwaarTrigger",
-        "icon": "AlarmOutline",
+        "icon": "Alarm",
         "version": "1.0.0",
         "x-schema-org": "schema:Schedule",
         "title": "Bezwaar Trigger",

--- a/lib/Settings/register.d/40-mobiel-inspectie-offline.json
+++ b/lib/Settings/register.d/40-mobiel-inspectie-offline.json
@@ -242,7 +242,7 @@
       },
       "syncQueue": {
         "slug": "syncQueue",
-        "icon": "SyncOutline",
+        "icon": "Sync",
         "version": "1.0.0",
         "x-schema-org": "schema:Action",
         "title": "Sync Queue Operation",

--- a/lib/Settings/register.d/70-document-zaakdossier.json
+++ b/lib/Settings/register.d/70-document-zaakdossier.json
@@ -92,7 +92,7 @@
       },
       "besluitinformatieobject": {
         "slug": "besluitinformatieobject",
-        "icon": "GavelOutline",
+        "icon": "Gavel",
         "version": "1.0.0",
         "title": "Besluitinformatieobject",
         "description": "ZGW DRC join between a besluit (decision) and an informatieobject.",

--- a/src/icons.js
+++ b/src/icons.js
@@ -1,0 +1,317 @@
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+//
+// Icon registry for procest (ADR-077 semantic icon vocabulary).
+//
+// CnAppNav, CnIcon, CnIndexPage / CnDetailPage headers and empty states resolve
+// an `icon` by PascalCase name through the registry that `registerIcons()`
+// populates. A name that is not registered renders NO icon in the navigation —
+// not a fallback glyph — so this file must cover every `icon` the manifests and
+// register files name. Keep it in sync when you add a menu entry.
+//
+// Generated from the app's own manifests; every name is verified to exist in
+// vue-material-design-icons.
+
+import Account from 'vue-material-design-icons/Account.vue'
+import AccountArrowRight from 'vue-material-design-icons/AccountArrowRight.vue'
+import AccountClock from 'vue-material-design-icons/AccountClock.vue'
+import AccountGroup from 'vue-material-design-icons/AccountGroup.vue'
+import AccountGroupOutline from 'vue-material-design-icons/AccountGroupOutline.vue'
+import AccountHardHat from 'vue-material-design-icons/AccountHardHat.vue'
+import AccountMultipleOutline from 'vue-material-design-icons/AccountMultipleOutline.vue'
+import AccountOutline from 'vue-material-design-icons/AccountOutline.vue'
+import AccountPlusOutline from 'vue-material-design-icons/AccountPlusOutline.vue'
+import AccountSwitch from 'vue-material-design-icons/AccountSwitch.vue'
+import AccountSwitchOutline from 'vue-material-design-icons/AccountSwitchOutline.vue'
+import AccountTieOutline from 'vue-material-design-icons/AccountTieOutline.vue'
+import AccountVoice from 'vue-material-design-icons/AccountVoice.vue'
+import Alarm from 'vue-material-design-icons/Alarm.vue'
+import AlertCircleOutline from 'vue-material-design-icons/AlertCircleOutline.vue'
+import AlertOctagonOutline from 'vue-material-design-icons/AlertOctagonOutline.vue'
+import AlertOutline from 'vue-material-design-icons/AlertOutline.vue'
+import ArrowUpBoldCircle from 'vue-material-design-icons/ArrowUpBoldCircle.vue'
+import BadgeAccountOutline from 'vue-material-design-icons/BadgeAccountOutline.vue'
+import BankTransfer from 'vue-material-design-icons/BankTransfer.vue'
+import BellCogOutline from 'vue-material-design-icons/BellCogOutline.vue'
+import BellPlusOutline from 'vue-material-design-icons/BellPlusOutline.vue'
+import BellRing from 'vue-material-design-icons/BellRing.vue'
+import BellRingOutline from 'vue-material-design-icons/BellRingOutline.vue'
+import BookOpenPageVariant from 'vue-material-design-icons/BookOpenPageVariant.vue'
+import BookOpenVariantOutline from 'vue-material-design-icons/BookOpenVariantOutline.vue'
+import BriefcaseAccountOutline from 'vue-material-design-icons/BriefcaseAccountOutline.vue'
+import BriefcaseOutline from 'vue-material-design-icons/BriefcaseOutline.vue'
+import BriefcaseVariantOutline from 'vue-material-design-icons/BriefcaseVariantOutline.vue'
+import Calculator from 'vue-material-design-icons/Calculator.vue'
+import Calendar from 'vue-material-design-icons/Calendar.vue'
+import CalendarTextOutline from 'vue-material-design-icons/CalendarTextOutline.vue'
+import CameraOutline from 'vue-material-design-icons/CameraOutline.vue'
+import Cash from 'vue-material-design-icons/Cash.vue'
+import CashMultiple from 'vue-material-design-icons/CashMultiple.vue'
+import CashRefund from 'vue-material-design-icons/CashRefund.vue'
+import CashRegister from 'vue-material-design-icons/CashRegister.vue'
+import ChartBoxOutline from 'vue-material-design-icons/ChartBoxOutline.vue'
+import ChartLine from 'vue-material-design-icons/ChartLine.vue'
+import ChartSankey from 'vue-material-design-icons/ChartSankey.vue'
+import CheckCircleOutline from 'vue-material-design-icons/CheckCircleOutline.vue'
+import CheckDecagram from 'vue-material-design-icons/CheckDecagram.vue'
+import CheckboxMarkedCircleOutline from 'vue-material-design-icons/CheckboxMarkedCircleOutline.vue'
+import CheckboxMarkedOutline from 'vue-material-design-icons/CheckboxMarkedOutline.vue'
+import CheckboxOutline from 'vue-material-design-icons/CheckboxOutline.vue'
+import ClipboardAccountOutline from 'vue-material-design-icons/ClipboardAccountOutline.vue'
+import ClipboardCheckMultipleOutline from 'vue-material-design-icons/ClipboardCheckMultipleOutline.vue'
+import ClipboardCheckOutline from 'vue-material-design-icons/ClipboardCheckOutline.vue'
+import ClipboardList from 'vue-material-design-icons/ClipboardList.vue'
+import ClipboardListOutline from 'vue-material-design-icons/ClipboardListOutline.vue'
+import ClipboardPulseOutline from 'vue-material-design-icons/ClipboardPulseOutline.vue'
+import ClipboardSearchOutline from 'vue-material-design-icons/ClipboardSearchOutline.vue'
+import ClipboardTextOutline from 'vue-material-design-icons/ClipboardTextOutline.vue'
+import ClockAlertOutline from 'vue-material-design-icons/ClockAlertOutline.vue'
+import Cog from 'vue-material-design-icons/Cog.vue'
+import CogOutline from 'vue-material-design-icons/CogOutline.vue'
+import CommentOutline from 'vue-material-design-icons/CommentOutline.vue'
+import CommentQuestionOutline from 'vue-material-design-icons/CommentQuestionOutline.vue'
+import CommentTextOutline from 'vue-material-design-icons/CommentTextOutline.vue'
+import Connection from 'vue-material-design-icons/Connection.vue'
+import Creation from 'vue-material-design-icons/Creation.vue'
+import CubeOutline from 'vue-material-design-icons/CubeOutline.vue'
+import Domain from 'vue-material-design-icons/Domain.vue'
+import Earth from 'vue-material-design-icons/Earth.vue'
+import EmailAlert from 'vue-material-design-icons/EmailAlert.vue'
+import EmailOutline from 'vue-material-design-icons/EmailOutline.vue'
+import EmoticonSad from 'vue-material-design-icons/EmoticonSad.vue'
+import Factory from 'vue-material-design-icons/Factory.vue'
+import FileAlertOutline from 'vue-material-design-icons/FileAlertOutline.vue'
+import FileCertificateOutline from 'vue-material-design-icons/FileCertificateOutline.vue'
+import FileChartOutline from 'vue-material-design-icons/FileChartOutline.vue'
+import FileCheckOutline from 'vue-material-design-icons/FileCheckOutline.vue'
+import FileCompare from 'vue-material-design-icons/FileCompare.vue'
+import FileDocument from 'vue-material-design-icons/FileDocument.vue'
+import FileDocumentAlertOutline from 'vue-material-design-icons/FileDocumentAlertOutline.vue'
+import FileDocumentCheckOutline from 'vue-material-design-icons/FileDocumentCheckOutline.vue'
+import FileDocumentEditOutline from 'vue-material-design-icons/FileDocumentEditOutline.vue'
+import FileDocumentMultiple from 'vue-material-design-icons/FileDocumentMultiple.vue'
+import FileDocumentMultipleOutline from 'vue-material-design-icons/FileDocumentMultipleOutline.vue'
+import FileDocumentOutline from 'vue-material-design-icons/FileDocumentOutline.vue'
+import FileEyeOutline from 'vue-material-design-icons/FileEyeOutline.vue'
+import FileSign from 'vue-material-design-icons/FileSign.vue'
+import FileTreeOutline from 'vue-material-design-icons/FileTreeOutline.vue'
+import FlagCheckered from 'vue-material-design-icons/FlagCheckered.vue'
+import FlagOutline from 'vue-material-design-icons/FlagOutline.vue'
+import FolderAccountOutline from 'vue-material-design-icons/FolderAccountOutline.vue'
+import FolderCogOutline from 'vue-material-design-icons/FolderCogOutline.vue'
+import FolderOutline from 'vue-material-design-icons/FolderOutline.vue'
+import FolderTextOutline from 'vue-material-design-icons/FolderTextOutline.vue'
+import FormatListBulletedType from 'vue-material-design-icons/FormatListBulletedType.vue'
+import Forum from 'vue-material-design-icons/Forum.vue'
+import Gauge from 'vue-material-design-icons/Gauge.vue'
+import GaugeFull from 'vue-material-design-icons/GaugeFull.vue'
+import Gavel from 'vue-material-design-icons/Gavel.vue'
+import GestureTapButton from 'vue-material-design-icons/GestureTapButton.vue'
+import HandHeartOutline from 'vue-material-design-icons/HandHeartOutline.vue'
+import HandshakeOutline from 'vue-material-design-icons/HandshakeOutline.vue'
+import Headset from 'vue-material-design-icons/Headset.vue'
+import History from 'vue-material-design-icons/History.vue'
+import HumanMaleChild from 'vue-material-design-icons/HumanMaleChild.vue'
+import HumanWheelchair from 'vue-material-design-icons/HumanWheelchair.vue'
+import LayersOutline from 'vue-material-design-icons/LayersOutline.vue'
+import Lightbulb from 'vue-material-design-icons/Lightbulb.vue'
+import LinkVariant from 'vue-material-design-icons/LinkVariant.vue'
+import ListBoxOutline from 'vue-material-design-icons/ListBoxOutline.vue'
+import ListStatus from 'vue-material-design-icons/ListStatus.vue'
+import MapMarker from 'vue-material-design-icons/MapMarker.vue'
+import MapMarkerOutline from 'vue-material-design-icons/MapMarkerOutline.vue'
+import MapMarkerPath from 'vue-material-design-icons/MapMarkerPath.vue'
+import MapOutline from 'vue-material-design-icons/MapOutline.vue'
+import MessageAlertOutline from 'vue-material-design-icons/MessageAlertOutline.vue'
+import MessageOutline from 'vue-material-design-icons/MessageOutline.vue'
+import MessageText from 'vue-material-design-icons/MessageText.vue'
+import MessageTextOutline from 'vue-material-design-icons/MessageTextOutline.vue'
+import NoteTextOutline from 'vue-material-design-icons/NoteTextOutline.vue'
+import OfficeBuilding from 'vue-material-design-icons/OfficeBuilding.vue'
+import OfficeBuildingOutline from 'vue-material-design-icons/OfficeBuildingOutline.vue'
+import PaperclipCheck from 'vue-material-design-icons/PaperclipCheck.vue'
+import PhoneForward from 'vue-material-design-icons/PhoneForward.vue'
+import PhoneInTalk from 'vue-material-design-icons/PhoneInTalk.vue'
+import PhoneReturn from 'vue-material-design-icons/PhoneReturn.vue'
+import Plus from 'vue-material-design-icons/Plus.vue'
+import ProgressClock from 'vue-material-design-icons/ProgressClock.vue'
+import Receipt from 'vue-material-design-icons/Receipt.vue'
+import RobotOutline from 'vue-material-design-icons/RobotOutline.vue'
+import RoutesClock from 'vue-material-design-icons/RoutesClock.vue'
+import ScaleBalance from 'vue-material-design-icons/ScaleBalance.vue'
+import ScriptText from 'vue-material-design-icons/ScriptText.vue'
+import Send from 'vue-material-design-icons/Send.vue'
+import ShareVariant from 'vue-material-design-icons/ShareVariant.vue'
+import ShieldCheckOutline from 'vue-material-design-icons/ShieldCheckOutline.vue'
+import ShieldKeyOutline from 'vue-material-design-icons/ShieldKeyOutline.vue'
+import ShieldLockOutline from 'vue-material-design-icons/ShieldLockOutline.vue'
+import SignDirection from 'vue-material-design-icons/SignDirection.vue'
+import Sitemap from 'vue-material-design-icons/Sitemap.vue'
+import SitemapOutline from 'vue-material-design-icons/SitemapOutline.vue'
+import SourceBranch from 'vue-material-design-icons/SourceBranch.vue'
+import StairsUp from 'vue-material-design-icons/StairsUp.vue'
+import SwapHorizontal from 'vue-material-design-icons/SwapHorizontal.vue'
+import Sync from 'vue-material-design-icons/Sync.vue'
+import TableColumn from 'vue-material-design-icons/TableColumn.vue'
+import TableLarge from 'vue-material-design-icons/TableLarge.vue'
+import TableSettings from 'vue-material-design-icons/TableSettings.vue'
+import TagOutline from 'vue-material-design-icons/TagOutline.vue'
+import Timeline from 'vue-material-design-icons/Timeline.vue'
+import TimerOutline from 'vue-material-design-icons/TimerOutline.vue'
+import TimerSandFull from 'vue-material-design-icons/TimerSandFull.vue'
+import Tune from 'vue-material-design-icons/Tune.vue'
+import ViewColumnOutline from 'vue-material-design-icons/ViewColumnOutline.vue'
+import ViewDashboardOutline from 'vue-material-design-icons/ViewDashboardOutline.vue'
+
+export default {
+	Account,
+	AccountArrowRight,
+	AccountClock,
+	AccountGroup,
+	AccountGroupOutline,
+	AccountHardHat,
+	AccountMultipleOutline,
+	AccountOutline,
+	AccountPlusOutline,
+	AccountSwitch,
+	AccountSwitchOutline,
+	AccountTieOutline,
+	AccountVoice,
+	Alarm,
+	AlertCircleOutline,
+	AlertOctagonOutline,
+	AlertOutline,
+	ArrowUpBoldCircle,
+	BadgeAccountOutline,
+	BankTransfer,
+	BellCogOutline,
+	BellPlusOutline,
+	BellRing,
+	BellRingOutline,
+	BookOpenPageVariant,
+	BookOpenVariantOutline,
+	BriefcaseAccountOutline,
+	BriefcaseOutline,
+	BriefcaseVariantOutline,
+	Calculator,
+	Calendar,
+	CalendarTextOutline,
+	CameraOutline,
+	Cash,
+	CashMultiple,
+	CashRefund,
+	CashRegister,
+	ChartBoxOutline,
+	ChartLine,
+	ChartSankey,
+	CheckCircleOutline,
+	CheckDecagram,
+	CheckboxMarkedCircleOutline,
+	CheckboxMarkedOutline,
+	CheckboxOutline,
+	ClipboardAccountOutline,
+	ClipboardCheckMultipleOutline,
+	ClipboardCheckOutline,
+	ClipboardList,
+	ClipboardListOutline,
+	ClipboardPulseOutline,
+	ClipboardSearchOutline,
+	ClipboardTextOutline,
+	ClockAlertOutline,
+	Cog,
+	CogOutline,
+	CommentOutline,
+	CommentQuestionOutline,
+	CommentTextOutline,
+	Connection,
+	Creation,
+	CubeOutline,
+	Domain,
+	Earth,
+	EmailAlert,
+	EmailOutline,
+	EmoticonSad,
+	Factory,
+	FileAlertOutline,
+	FileCertificateOutline,
+	FileChartOutline,
+	FileCheckOutline,
+	FileCompare,
+	FileDocument,
+	FileDocumentAlertOutline,
+	FileDocumentCheckOutline,
+	FileDocumentEditOutline,
+	FileDocumentMultiple,
+	FileDocumentMultipleOutline,
+	FileDocumentOutline,
+	FileEyeOutline,
+	FileSign,
+	FileTreeOutline,
+	FlagCheckered,
+	FlagOutline,
+	FolderAccountOutline,
+	FolderCogOutline,
+	FolderOutline,
+	FolderTextOutline,
+	FormatListBulletedType,
+	Forum,
+	Gauge,
+	GaugeFull,
+	Gavel,
+	GestureTapButton,
+	HandHeartOutline,
+	HandshakeOutline,
+	Headset,
+	History,
+	HumanMaleChild,
+	HumanWheelchair,
+	LayersOutline,
+	Lightbulb,
+	LinkVariant,
+	ListBoxOutline,
+	ListStatus,
+	MapMarker,
+	MapMarkerOutline,
+	MapMarkerPath,
+	MapOutline,
+	MessageAlertOutline,
+	MessageOutline,
+	MessageText,
+	MessageTextOutline,
+	NoteTextOutline,
+	OfficeBuilding,
+	OfficeBuildingOutline,
+	PaperclipCheck,
+	PhoneForward,
+	PhoneInTalk,
+	PhoneReturn,
+	Plus,
+	ProgressClock,
+	Receipt,
+	RobotOutline,
+	RoutesClock,
+	ScaleBalance,
+	ScriptText,
+	Send,
+	ShareVariant,
+	ShieldCheckOutline,
+	ShieldKeyOutline,
+	ShieldLockOutline,
+	SignDirection,
+	Sitemap,
+	SitemapOutline,
+	SourceBranch,
+	StairsUp,
+	SwapHorizontal,
+	Sync,
+	TableColumn,
+	TableLarge,
+	TableSettings,
+	TagOutline,
+	Timeline,
+	TimerOutline,
+	TimerSandFull,
+	Tune,
+	ViewColumnOutline,
+	ViewDashboardOutline,
+}

--- a/src/main.js
+++ b/src/main.js
@@ -27,6 +27,7 @@ import bundledManifest from './manifest.json'
 import menuLayout from './menu-layout.json'
 import customComponents from './customComponents.js'
 import registry from './registry.js'
+import appIcons from './icons.js'
 import mapFormatters from './services/mapFormatters.js'
 import formatters from './services/formatters.js'
 
@@ -47,7 +48,7 @@ import './assets/app.css'
 // after createApp (below), not Vue.mixin. pinia + router install via app.use.
 
 // Register library-side icon set + lib translations once at bootstrap.
-registerIcons()
+registerIcons(appIcons)
 try {
 	registerTranslations()
 } catch (e) {

--- a/src/manifest.d/50-besluitvorming.json
+++ b/src/manifest.d/50-besluitvorming.json
@@ -21,7 +21,7 @@
 		{
 			"id": "BesluitvormingAgenda",
 			"label": "Agenda",
-			"icon": "icon-calendar-dark",
+			"icon": "CalendarTextOutline",
 			"route": "AgendaCompiler",
 			"order": 72,
 			"requiresRole": ["Behandelaar", "Agendabeheerder", "Griffier"]

--- a/src/manifest.d/50-subsidie.json
+++ b/src/manifest.d/50-subsidie.json
@@ -14,7 +14,7 @@
 		{
 			"id": "Subsidieregelingen",
 			"label": "Subsidy schemes",
-			"icon": "icon-settings",
+			"icon": "HandHeartOutline",
 			"route": "Subsidieregelingen",
 			"order": 96
 		}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -39,108 +39,108 @@
 		{
 			"id": "Dashboard",
 			"label": "Dashboard",
-			"icon": "icon-category-dashboard",
+			"icon": "ViewDashboardOutline",
 			"route": "Dashboard",
 			"order": 10
 		},
 		{
 			"id": "MyWork",
 			"label": "My work",
-			"icon": "icon-checkmark",
+			"icon": "ClipboardAccountOutline",
 			"route": "MyWork",
 			"order": 20
 		},
 		{
 			"id": "WorkGroup",
 			"label": "Work queue",
-			"icon": "icon-toggle",
+			"icon": "ClipboardAccountOutline",
 			"order": 20
 		},
 		{
 			"id": "Cases",
 			"label": "Cases",
-			"icon": "icon-folder",
+			"icon": "FolderAccountOutline",
 			"route": "Cases",
 			"order": 30
 		},
 		{
 			"id": "WorkflowBoard",
 			"label": "Workflow board",
-			"icon": "icon-category-workflow",
+			"icon": "ViewColumnOutline",
 			"route": "WorkflowBoard",
 			"order": 35
 		},
 		{
 			"id": "Bezwaren",
 			"label": "Objections",
-			"icon": "icon-toggle-filelist",
+			"icon": "FileAlertOutline",
 			"route": "Bezwaren",
 			"order": 45
 		},
 		{
 			"id": "Beroepen",
 			"label": "Appeals",
-			"icon": "icon-toggle-filelist",
+			"icon": "ScaleBalance",
 			"route": "Beroepen",
 			"order": 46
 		},
 		{
 			"id": "AnalyticsGroup",
 			"label": "Reports",
-			"icon": "icon-category-monitoring",
+			"icon": "ChartBoxOutline",
 			"order": 55
 		},
 		{
 			"id": "Analytics",
 			"label": "Processing time",
-			"icon": "icon-category-monitoring",
+			"icon": "ChartLine",
 			"route": "Doorlooptijd",
 			"order": 55
 		},
 		{
 			"id": "ProcessMiningDashboardMenu",
 			"label": "Process mining",
-			"icon": "icon-category-monitoring",
+			"icon": "ChartSankey",
 			"route": "ProcessMiningDashboard",
 			"order": 56
 		},
 		{
 			"id": "CaseMap",
 			"label": "Map",
-			"icon": "icon-address",
+			"icon": "MapOutline",
 			"route": "CaseMap",
 			"order": 60
 		},
 		{
 			"id": "BesluitvormingGroup",
 			"label": "Decision-making",
-			"icon": "icon-comment",
+			"icon": "Gavel",
 			"order": 70
 		},
 		{
 			"id": "Voorstellen",
 			"label": "Proposals",
-			"icon": "icon-comment",
+			"icon": "CommentOutline",
 			"route": "Voorstellen",
 			"order": 70
 		},
 		{
 			"id": "Advice",
 			"label": "Advice",
-			"icon": "icon-comment",
+			"icon": "CommentOutline",
 			"route": "Advice",
 			"order": 75
 		},
 		{
 			"id": "SettingsGroup",
 			"label": "Settings",
-			"icon": "icon-settings",
+			"icon": "CogOutline",
 			"order": 200
 		},
 		{
 			"id": "Documentation",
 			"label": "Documentation",
-			"icon": "icon-info",
+			"icon": "BookOpenVariantOutline",
 			"href": "https://procest.conduction.nl",
 			"section": "footer",
 			"order": 90
@@ -148,7 +148,7 @@
 		{
 			"id": "CaseTypesMenu",
 			"label": "Case types",
-			"icon": "icon-category-customization",
+			"icon": "FolderCogOutline",
 			"route": "Settings",
 			"section": "settings",
 			"order": 95
@@ -156,7 +156,7 @@
 		{
 			"id": "PartnersMenu",
 			"label": "Partner organisations",
-			"icon": "icon-group",
+			"icon": "OfficeBuildingOutline",
 			"route": "Partners",
 			"section": "settings",
 			"order": 97
@@ -164,7 +164,7 @@
 		{
 			"id": "TenantsMenu",
 			"label": "Organisations",
-			"icon": "icon-group",
+			"icon": "OfficeBuildingOutline",
 			"route": "Tenants",
 			"section": "settings",
 			"order": 98,
@@ -173,7 +173,7 @@
 		{
 			"id": "ParafeerroutesMenu",
 			"label": "Approval routes",
-			"icon": "icon-category-workflow",
+			"icon": "SitemapOutline",
 			"route": "Parafeerroutes",
 			"section": "settings",
 			"order": 96
@@ -181,7 +181,7 @@
 		{
 			"id": "AiOversightMenu",
 			"label": "AI oversight",
-			"icon": "icon-category-monitoring",
+			"icon": "ChartLine",
 			"route": "AiOversight",
 			"section": "settings",
 			"order": 96
@@ -189,7 +189,7 @@
 		{
 			"id": "WmsLayersMenu",
 			"label": "Map layers",
-			"icon": "icon-category-files",
+			"icon": "LayersOutline",
 			"route": "WmsLayers",
 			"section": "settings",
 			"order": 97,
@@ -198,7 +198,7 @@
 		{
 			"id": "WorkflowDefinitionsMenu",
 			"label": "Workflow definitions",
-			"icon": "icon-category-workflow",
+			"icon": "SitemapOutline",
 			"route": "WorkflowDefinitions",
 			"section": "settings",
 			"order": 97
@@ -206,7 +206,7 @@
 		{
 			"id": "AutomaticActionsMenu",
 			"label": "Automatic actions",
-			"icon": "icon-category-workflow",
+			"icon": "Sitemap",
 			"route": "AutomaticActions",
 			"section": "settings",
 			"order": 96
@@ -214,7 +214,7 @@
 		{
 			"id": "LhsMatricesMenu",
 			"label": "Enforcement strategy",
-			"icon": "icon-category-customization",
+			"icon": "Tune",
 			"route": "LhsMatrices",
 			"section": "settings",
 			"order": 96,
@@ -223,7 +223,7 @@
 		{
 			"id": "LhsRecommendationsMenu",
 			"label": "LHS recommendations",
-			"icon": "icon-comment",
+			"icon": "CommentOutline",
 			"route": "LhsRecommendations",
 			"section": "settings",
 			"order": 97
@@ -231,7 +231,7 @@
 		{
 			"id": "LocationsMenu",
 			"label": "Case locations",
-			"icon": "icon-address",
+			"icon": "MapMarkerOutline",
 			"route": "Locations",
 			"section": "settings",
 			"order": 98,
@@ -240,28 +240,28 @@
 		{
 			"id": "BezwaarCommitteesMenu",
 			"label": "Objection advisory committees",
-			"icon": "icon-group",
+			"icon": "FileAlertOutline",
 			"route": "BezwaarCommittees",
 			"order": 49
 		},
 		{
 			"id": "TermijnDashboardMenu",
 			"label": "Deadline monitoring",
-			"icon": "icon-history",
+			"icon": "ClockAlertOutline",
 			"route": "TermijnDashboard",
 			"order": 71
 		},
 		{
 			"id": "Iv3ReportDashboardMenu",
 			"label": "IV3 cost report",
-			"icon": "icon-category-monitoring",
+			"icon": "ChartBoxOutline",
 			"route": "Iv3ReportDashboard",
 			"order": 72
 		},
 		{
 			"id": "TenantOnboardingMenu",
 			"label": "Organisation onboarding",
-			"icon": "icon-user",
+			"icon": "AccountPlusOutline",
 			"route": "TenantOnboardingDashboard",
 			"section": "settings",
 			"order": 92
@@ -269,7 +269,7 @@
 		{
 			"id": "SubstitutionMenu",
 			"label": "Substitution",
-			"icon": "icon-user",
+			"icon": "AccountSwitchOutline",
 			"route": "SubstitutionSettings",
 			"section": "settings",
 			"order": 93
@@ -277,7 +277,7 @@
 		{
 			"id": "SubstitutionAdminMenu",
 			"label": "Substitutions & reassignment",
-			"icon": "icon-group",
+			"icon": "AccountSwitchOutline",
 			"route": "SubstitutionAdmin",
 			"section": "settings",
 			"order": 94,
@@ -286,7 +286,7 @@
 		{
 			"id": "VerwerkingenOverviewMenu",
 			"label": "Processing activities (AVG)",
-			"icon": "icon-password",
+			"icon": "ShieldLockOutline",
 			"route": "VerwerkingenOverview",
 			"section": "settings",
 			"order": 95,
@@ -295,7 +295,7 @@
 		{
 			"id": "SettingsMenu",
 			"label": "Settings",
-			"icon": "icon-settings",
+			"icon": "CogOutline",
 			"route": "Settings",
 			"section": "settings",
 			"order": 99
@@ -303,7 +303,7 @@
 		{
 			"id": "FeaturesRoadmapMenu",
 			"label": "Features & roadmap",
-			"icon": "icon-toggle",
+			"icon": "MapMarkerPath",
 			"route": "FeaturesRoadmap",
 			"section": "footer",
 			"order": 100


### PR DESCRIPTION
## Why

Menu icons across the fleet had drifted into meaninglessness. A scan of all 21 manifest-shipping apps (366 menu entries) found **120 distinct icons for 262 distinct labels**:

| Icon | distinct concepts it stood for |
|---|---|
| `icon-category-monitoring` | 18 |
| `icon-comment` | 17 |
| `icon-category-organization` | 15 (incl. **Store**, Cases, Contracts, Pipeline) |

…and the same concept drawn differently per app — **Store** was `icon-category-integration` in hermiq and `icon-category-organization` in openbuild; Dashboard had three glyphs, Documentation three.

## What

Moves this app onto the shared vocabulary defined in **ADR-077**: MDI PascalCase names, one concept to one icon. Tier A entries (Dashboard, Documentation, Settings, Store, Features & roadmap) now match every other Conduction app — which is the point: a glyph should mean the same thing wherever a user meets it.

Two defect classes fixed along the way:

- **Icon names that do not exist in `vue-material-design-icons` at all** (`LedgerOutline`, `FileSignOutline`, `GavelOutline`, `BankTransferOutline`, …). They could never resolve — a help-circle at best, nothing in the navigation.
- **Menu entries that rendered with NO icon.** `CnAppNav` resolves an MDI name only through the registry `registerIcons()` populates, with no fallback and no CSS class for non-`icon-*` values. Apps that relied on legacy `icon-*` registered nothing at all and were fine right up until the first MDI name appeared. Live-verified on hrmq before this change: **29 of 72 nav entries rendered blank**.

`src/icons.js` is generated from this app’s own manifests and register files, so every referenced name is registered and the migration **stands on its own against the currently released `@conduction/nextcloud-vue`** — it does not wait on the library-side vocabulary (ConductionNL/nextcloud-vue#563).

## Verification

- **0** menu entries render without an icon (was 51 fleet-wide).
- Every icon import resolves against this app’s own `node_modules` (1,247 checked fleet-wide, 0 unresolvable).
- hydra **gate-60 `icon-vocabulary`** passes: 0 failures, 0 warnings.
- ESLint clean on every changed file.

Spec: ADR-077 — ConductionNL/hydra#408.