### PR TITLE
feat(icons): extend ADR-077 to page, widget and action icons

### DIFF
--- a/src/icons.js
+++ b/src/icons.js
@@ -66,6 +66,8 @@ import ClipboardPulseOutline from 'vue-material-design-icons/ClipboardPulseOutli
 import ClipboardSearchOutline from 'vue-material-design-icons/ClipboardSearchOutline.vue'
 import ClipboardTextOutline from 'vue-material-design-icons/ClipboardTextOutline.vue'
 import ClockAlertOutline from 'vue-material-design-icons/ClockAlertOutline.vue'
+import Close from 'vue-material-design-icons/Close.vue'
+import CloudUploadOutline from 'vue-material-design-icons/CloudUploadOutline.vue'
 import Cog from 'vue-material-design-icons/Cog.vue'
 import CogOutline from 'vue-material-design-icons/CogOutline.vue'
 import CommentOutline from 'vue-material-design-icons/CommentOutline.vue'
@@ -79,6 +81,7 @@ import Earth from 'vue-material-design-icons/Earth.vue'
 import EmailAlert from 'vue-material-design-icons/EmailAlert.vue'
 import EmailOutline from 'vue-material-design-icons/EmailOutline.vue'
 import EmoticonSad from 'vue-material-design-icons/EmoticonSad.vue'
+import EyeOutline from 'vue-material-design-icons/EyeOutline.vue'
 import Factory from 'vue-material-design-icons/Factory.vue'
 import FileAlertOutline from 'vue-material-design-icons/FileAlertOutline.vue'
 import FileCertificateOutline from 'vue-material-design-icons/FileCertificateOutline.vue'
@@ -136,6 +139,7 @@ import PhoneReturn from 'vue-material-design-icons/PhoneReturn.vue'
 import Plus from 'vue-material-design-icons/Plus.vue'
 import ProgressClock from 'vue-material-design-icons/ProgressClock.vue'
 import Receipt from 'vue-material-design-icons/Receipt.vue'
+import Refresh from 'vue-material-design-icons/Refresh.vue'
 import RobotOutline from 'vue-material-design-icons/RobotOutline.vue'
 import RoutesClock from 'vue-material-design-icons/RoutesClock.vue'
 import ScaleBalance from 'vue-material-design-icons/ScaleBalance.vue'
@@ -218,6 +222,8 @@ export default {
 	ClipboardSearchOutline,
 	ClipboardTextOutline,
 	ClockAlertOutline,
+	Close,
+	CloudUploadOutline,
 	Cog,
 	CogOutline,
 	CommentOutline,
@@ -231,6 +237,7 @@ export default {
 	EmailAlert,
 	EmailOutline,
 	EmoticonSad,
+	EyeOutline,
 	Factory,
 	FileAlertOutline,
 	FileCertificateOutline,
@@ -288,6 +295,7 @@ export default {
 	Plus,
 	ProgressClock,
 	Receipt,
+	Refresh,
 	RobotOutline,
 	RoutesClock,
 	ScaleBalance,

--- a/src/manifest.d/50-subsidie.json
+++ b/src/manifest.d/50-subsidie.json
@@ -36,7 +36,7 @@
 					{
 						"id": "view",
 						"label": "View",
-						"icon": "icon-info",
+						"icon": "EyeOutline",
 						"handler": "navigate",
 						"route": "CaseDetail",
 						"type": "handler"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -664,7 +664,7 @@
 					{
 						"id": "view",
 						"label": "View",
-						"icon": "icon-info",
+						"icon": "EyeOutline",
 						"handler": "navigate",
 						"route": "CaseDetail",
 						"type": "handler"
@@ -826,7 +826,7 @@
 					{
 						"id": "view",
 						"label": "View",
-						"icon": "icon-info",
+						"icon": "EyeOutline",
 						"handler": "navigate",
 						"route": "CaseDetail",
 						"type": "handler"
@@ -1022,7 +1022,7 @@
 					{
 						"id": "view",
 						"label": "View",
-						"icon": "icon-info",
+						"icon": "EyeOutline",
 						"handler": "navigate",
 						"route": "TaskDetail",
 						"type": "handler"
@@ -1198,7 +1198,7 @@
 					{
 						"id": "view",
 						"label": "View",
-						"icon": "icon-info",
+						"icon": "EyeOutline",
 						"handler": "navigate",
 						"route": "VoorstelDetail",
 						"type": "handler"
@@ -1256,7 +1256,7 @@
 					{
 						"id": "view",
 						"label": "View",
-						"icon": "icon-info",
+						"icon": "EyeOutline",
 						"handler": "navigate",
 						"route": "AdviceDetail",
 						"type": "handler"
@@ -1392,7 +1392,7 @@
 					{
 						"id": "provision",
 						"label": "Provision",
-						"icon": "icon-add",
+						"icon": "Plus",
 						"permission": "admin",
 						"handler": "emit",
 						"type": "handler"
@@ -1400,7 +1400,7 @@
 					{
 						"id": "view",
 						"label": "View usage",
-						"icon": "icon-info",
+						"icon": "EyeOutline",
 						"permission": "admin",
 						"handler": "navigate",
 						"route": "TenantDetail",
@@ -1441,7 +1441,7 @@
 					{
 						"id": "view",
 						"label": "View",
-						"icon": "icon-info",
+						"icon": "EyeOutline",
 						"handler": "navigate",
 						"route": "ParafeerrouteDetail",
 						"type": "handler"
@@ -1492,7 +1492,7 @@
 					{
 						"id": "view",
 						"label": "View",
-						"icon": "icon-info",
+						"icon": "EyeOutline",
 						"handler": "navigate",
 						"route": "AiOversightDetail",
 						"type": "handler"
@@ -1539,7 +1539,7 @@
 					{
 						"id": "view",
 						"label": "View",
-						"icon": "icon-info",
+						"icon": "EyeOutline",
 						"handler": "navigate",
 						"route": "WmsLayerDetail",
 						"type": "handler"
@@ -1604,7 +1604,7 @@
 					{
 						"id": "provision",
 						"label": "Provision",
-						"icon": "icon-add",
+						"icon": "Plus",
 						"permission": "admin",
 						"primary": true,
 						"handler": "emit",
@@ -1613,7 +1613,7 @@
 					{
 						"id": "refresh-usage",
 						"label": "Refresh usage",
-						"icon": "icon-history",
+						"icon": "Refresh",
 						"permission": "admin",
 						"handler": "emit",
 						"type": "handler"
@@ -1737,7 +1737,7 @@
 					{
 						"id": "view",
 						"label": "View",
-						"icon": "icon-info",
+						"icon": "EyeOutline",
 						"handler": "navigate",
 						"route": "PartnerDetail",
 						"type": "handler"
@@ -1876,7 +1876,7 @@
 					{
 						"id": "view",
 						"label": "View",
-						"icon": "icon-info",
+						"icon": "EyeOutline",
 						"handler": "navigate",
 						"route": "AutomaticActionDetail",
 						"type": "handler"
@@ -1963,7 +1963,7 @@
 					{
 						"id": "view",
 						"label": "View",
-						"icon": "icon-info",
+						"icon": "EyeOutline",
 						"handler": "navigate",
 						"route": "WorkflowDefinitionDetail",
 						"type": "handler"
@@ -1989,7 +1989,7 @@
 					{
 						"id": "publish",
 						"label": "Publish",
-						"icon": "icon-checkmark",
+						"icon": "CloudUploadOutline",
 						"permission": "admin",
 						"primary": true,
 						"handler": "emit",
@@ -1998,7 +1998,7 @@
 					{
 						"id": "deprecate",
 						"label": "Deprecate",
-						"icon": "icon-close",
+						"icon": "Close",
 						"permission": "admin",
 						"handler": "emit",
 						"type": "handler"
@@ -2006,7 +2006,7 @@
 					{
 						"id": "clone",
 						"label": "Clone",
-						"icon": "icon-add",
+						"icon": "Plus",
 						"permission": "admin",
 						"handler": "emit",
 						"type": "handler"
@@ -2081,7 +2081,7 @@
 					{
 						"id": "view",
 						"label": "View",
-						"icon": "icon-info",
+						"icon": "EyeOutline",
 						"handler": "navigate",
 						"route": "LhsMatrixDetail",
 						"type": "handler"
@@ -2130,7 +2130,7 @@
 					{
 						"id": "view",
 						"label": "View",
-						"icon": "icon-info",
+						"icon": "EyeOutline",
 						"handler": "navigate",
 						"route": "LocationDetail",
 						"type": "handler"
@@ -2195,7 +2195,7 @@
 					{
 						"id": "view",
 						"label": "View",
-						"icon": "icon-info",
+						"icon": "EyeOutline",
 						"handler": "navigate",
 						"route": "LhsRecommendationDetail",
 						"type": "handler"
@@ -2295,7 +2295,7 @@
 					{
 						"id": "view",
 						"label": "View",
-						"icon": "icon-info",
+						"icon": "EyeOutline",
 						"handler": "navigate",
 						"route": "BezwaarCommitteeDetail",
 						"type": "handler"
@@ -2465,7 +2465,7 @@
 					{
 						"id": "view",
 						"label": "View",
-						"icon": "icon-info",
+						"icon": "EyeOutline",
 						"handler": "navigate",
 						"route": "CaseDetail",
 						"type": "handler"


### PR DESCRIPTION
## Why

The first ADR-077 pass migrated `menu[]` — the cross-app chrome users meet in every app. Everything else kept its legacy `icon-*` classes: page and tab icons, widget headers, and the `actions[]` / `headerActions[]` entries.

Those render through the same CnIcon registry and carry the same hazard: a legacy name with no `CSS_ICON_TO_MDI` bridge entry falls through to the raw Nextcloud class, and on NC34+ light themes several of those ship a baked white `background-image` — **an invisible glyph, wherever it appears**, not just in the nav.

## What

Every icon field now uses the shared vocabulary — MDI PascalCase, one concept to one icon.

Action icons name a **verb** rather than a domain noun, so the vocabulary gained an actions family (view / create / edit / delete / run / test / publish / upload / download / refresh / …). Where a label named no concept, the conversion used the **CSS bridge target** — exactly the glyph already on screen — so those entries change dialect, not appearance.

`src/icons.js` is regenerated so every name the manifests reference is registered.

## Verification

- hydra **gate-60** clean (0 failures, 0 warnings), with the gate now walking **every** icon field rather than menu entries only
- every icon import resolves against this app’s own `node_modules`
- eslint clean

Spec: ADR-077 — ConductionNL/hydra#416.