### PR TITLE
fix(events): resolve the schema slug listeners compare against — 3 procest listeners had never run

### DIFF
--- a/lib/Listener/BezwaarLegalHoldListener.php
+++ b/lib/Listener/BezwaarLegalHoldListener.php
@@ -38,6 +38,7 @@ namespace OCA\Procest\Listener;
 
 use OCA\OpenRegister\Event\ObjectCreatedEvent;
 use OCA\Procest\AppInfo\Application;
+use OCA\Procest\Service\ObjectSchemaSlugResolver;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use Psr\Container\ContainerInterface;
@@ -87,11 +88,13 @@ class BezwaarLegalHoldListener implements IEventListener
     /**
      * Constructor.
      *
-     * @param ContainerInterface $container The DI container (OR services resolved lazily).
-     * @param LoggerInterface    $logger    Logger.
+     * @param ContainerInterface       $container    The DI container (OR services resolved lazily).
+     * @param ObjectSchemaSlugResolver $slugResolver Schema id-to-slug resolver.
+     * @param LoggerInterface          $logger       Logger.
      */
     public function __construct(
         private readonly ContainerInterface $container,
+        private readonly ObjectSchemaSlugResolver $slugResolver,
         private readonly LoggerInterface $logger,
     ) {
     }//end __construct()
@@ -325,31 +328,19 @@ class BezwaarLegalHoldListener implements IEventListener
     /**
      * Resolve the schema slug for an OR object payload.
      *
+     * The payload carries the schema as an ID (`@self.schema` is
+     * `ObjectEntity::$schema`, written as `(string) $schemaId`), and `@self`
+     * has no `schemaSlug` key. Reading those keys directly — as this method
+     * used to — returned an id or an empty string, so the strict `in_array()`
+     * checks below never matched and no Awb legal hold has ever been placed.
+     * Resolution goes through the shared {@see ObjectSchemaSlugResolver}.
+     *
      * @param array<string, mixed> $payload Object payload.
      *
      * @return string
      */
     private function resolveSchemaSlug(array $payload): string
     {
-        if (isset($payload['@self']) === true && is_array($payload['@self']) === true) {
-            $self = $payload['@self'];
-            if (isset($self['schemaSlug']) === true) {
-                return (string) $self['schemaSlug'];
-            }
-
-            if (isset($self['schema']) === true && is_string($self['schema']) === true) {
-                return $self['schema'];
-            }
-        }
-
-        if (isset($payload['_schemaSlug']) === true) {
-            return (string) $payload['_schemaSlug'];
-        }
-
-        if (isset($payload['schemaSlug']) === true) {
-            return (string) $payload['schemaSlug'];
-        }
-
-        return '';
+        return $this->slugResolver->resolveFromPayload(payload: $payload);
     }//end resolveSchemaSlug()
 }//end class

--- a/lib/Listener/BezwaarLifecycleListener.php
+++ b/lib/Listener/BezwaarLifecycleListener.php
@@ -39,6 +39,7 @@ namespace OCA\Procest\Listener;
 use OCA\OpenRegister\Event\ObjectCreatedEvent;
 use OCA\OpenRegister\Event\ObjectUpdatedEvent;
 use OCA\Procest\AppInfo\Application;
+use OCA\Procest\Service\ObjectSchemaSlugResolver;
 use OCA\Procest\Service\SettingsService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
@@ -69,11 +70,13 @@ class BezwaarLifecycleListener implements IEventListener
     /**
      * Constructor.
      *
-     * @param SettingsService $settingsService Settings service
-     * @param LoggerInterface $logger          Logger
+     * @param SettingsService          $settingsService Settings service
+     * @param ObjectSchemaSlugResolver $slugResolver    Schema id-to-slug resolver
+     * @param LoggerInterface          $logger          Logger
      */
     public function __construct(
         private SettingsService $settingsService,
+        private ObjectSchemaSlugResolver $slugResolver,
         private LoggerInterface $logger,
     ) {
     }//end __construct()
@@ -158,32 +161,20 @@ class BezwaarLifecycleListener implements IEventListener
     /**
      * Resolve the schema slug for an OR object payload.
      *
+     * The payload carries the schema as an ID (`@self.schema` is
+     * `ObjectEntity::$schema`, written as `(string) $schemaId`), and no
+     * `schemaSlug` key exists on `@self`. Reading those keys directly — as this
+     * method used to — yielded an id or an empty string, so the strict
+     * `in_array()` against {@see self::RELEVANT_SCHEMAS} never matched and this
+     * listener's body had never run. Resolution goes through the shared
+     * {@see ObjectSchemaSlugResolver} so every listener uses one lookup.
+     *
      * @param array<string, mixed> $payload Object payload
      *
      * @return string
      */
     private function resolveSchemaSlug(array $payload): string
     {
-        // Common shapes: explicit slug, or numeric schema id requiring lookup.
-        if (isset($payload['@self']) === true && is_array($payload['@self']) === true) {
-            $self = $payload['@self'];
-            if (isset($self['schemaSlug']) === true) {
-                return (string) $self['schemaSlug'];
-            }
-
-            if (isset($self['schema']) === true && is_string($self['schema']) === true) {
-                return $self['schema'];
-            }
-        }
-
-        if (isset($payload['_schemaSlug']) === true) {
-            return (string) $payload['_schemaSlug'];
-        }
-
-        if (isset($payload['schemaSlug']) === true) {
-            return (string) $payload['schemaSlug'];
-        }
-
-        return '';
+        return $this->slugResolver->resolveFromPayload(payload: $payload);
     }//end resolveSchemaSlug()
 }//end class

--- a/lib/Listener/TermijnCaseCreatedListener.php
+++ b/lib/Listener/TermijnCaseCreatedListener.php
@@ -31,6 +31,7 @@ declare(strict_types=1);
 namespace OCA\Procest\Listener;
 
 use OCA\OpenRegister\Event\ObjectCreatedEvent;
+use OCA\Procest\Service\ObjectSchemaSlugResolver;
 use OCA\Procest\Service\TermijnService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
@@ -46,11 +47,13 @@ class TermijnCaseCreatedListener implements IEventListener
     /**
      * Constructor.
      *
-     * @param TermijnService  $termijnService TermijnService.
-     * @param LoggerInterface $logger         Logger.
+     * @param TermijnService           $termijnService TermijnService.
+     * @param ObjectSchemaSlugResolver $slugResolver   Schema id-to-slug resolver.
+     * @param LoggerInterface          $logger         Logger.
      */
     public function __construct(
         private readonly TermijnService $termijnService,
+        private readonly ObjectSchemaSlugResolver $slugResolver,
         private readonly LoggerInterface $logger,
     ) {
     }//end __construct()
@@ -126,31 +129,20 @@ class TermijnCaseCreatedListener implements IEventListener
     /**
      * Resolve the schema slug.
      *
+     * The payload carries the schema as an ID (`@self.schema` is
+     * `ObjectEntity::$schema`, written as `(string) $schemaId`), and `@self`
+     * has no `schemaSlug` key. Reading those keys directly — as this method
+     * used to — returned an id or an empty string, so the `!== 'case'` guard in
+     * {@see self::handle()} always short-circuited and no AWB TermijnInstance
+     * has ever been bound to a case. Resolution goes through the shared
+     * {@see ObjectSchemaSlugResolver}.
+     *
      * @param array<string, mixed> $payload Payload.
      *
      * @return string
      */
     private function resolveSchemaSlug(array $payload): string
     {
-        if (isset($payload['@self']) === true && is_array($payload['@self']) === true) {
-            $self = $payload['@self'];
-            if (isset($self['schemaSlug']) === true) {
-                return (string) $self['schemaSlug'];
-            }
-
-            if (isset($self['schema']) === true && is_string($self['schema']) === true) {
-                return $self['schema'];
-            }
-        }
-
-        if (isset($payload['_schemaSlug']) === true) {
-            return (string) $payload['_schemaSlug'];
-        }
-
-        if (isset($payload['schemaSlug']) === true) {
-            return (string) $payload['schemaSlug'];
-        }
-
-        return '';
+        return $this->slugResolver->resolveFromPayload(payload: $payload);
     }//end resolveSchemaSlug()
 }//end class

--- a/lib/Service/ObjectSchemaSlugResolver.php
+++ b/lib/Service/ObjectSchemaSlugResolver.php
@@ -1,0 +1,177 @@
+<?php
+
+/**
+ * Resolve an OpenRegister object payload's schema SLUG.
+ *
+ * OpenRegister object events carry the schema as an **id**, never as a slug.
+ * `ObjectEntity::jsonSerialize()` builds `@self` from `getObjectArray()`, which
+ * sets `'schema' => $this->schema`, and `$this->schema` is written by
+ * `SaveObject` as `setSchema((string) $schemaId)`. There is no `schemaSlug`
+ * key on `@self` and never has been.
+ *
+ * Listeners that read `@self.schema` and compared it against a slug literal
+ * (`'bezwaar'`, `'case'`, …) therefore never matched, so their handler bodies
+ * had never executed once — silently, with no exception and no log line. This
+ * service is the single place that turns the id the payload actually carries
+ * into the slug the handlers are written against, so the fix is one shared
+ * lookup rather than a per-listener variant.
+ *
+ * The lookup goes through OpenRegister's `SchemaMapper::find()`, which keeps a
+ * request-scoped cache, so repeated resolutions inside one request cost one
+ * query. OpenRegister is resolved through the container rather than injected,
+ * matching {@see SettingsService} — Procest degrades to "unknown schema" when
+ * OpenRegister is absent instead of failing to boot.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service;
+
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Turns the schema id an OpenRegister object payload carries into its slug.
+ */
+class ObjectSchemaSlugResolver
+{
+
+    /**
+     * Resolved slugs keyed by schema id, for the lifetime of the request.
+     *
+     * `SchemaMapper::find()` caches too, but memoising here also caches the
+     * misses, so a payload referencing a schema this instance does not have
+     * costs one failed lookup per request rather than one per event.
+     *
+     * @var array<string, string>
+     */
+    private array $slugs = [];
+
+    /**
+     * Constructor.
+     *
+     * @param ContainerInterface $container The DI container, used to reach
+     *                                      OpenRegister's SchemaMapper.
+     * @param LoggerInterface    $logger    Logger.
+     */
+    public function __construct(
+        private readonly ContainerInterface $container,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Resolve the schema slug for a serialised OpenRegister object.
+     *
+     * @param array<string, mixed> $payload The object payload, as produced by
+     *                                      `ObjectEntity::jsonSerialize()`.
+     *
+     * @return string The schema slug, or an empty string when it cannot be
+     *                resolved. An empty string never matches a slug literal,
+     *                so an unresolvable schema keeps the previous fail-closed
+     *                behaviour rather than invoking a handler blindly.
+     *
+     * @spec openspec/specs/bezwaar-lifecycle/spec.md
+     */
+    public function resolveFromPayload(array $payload): string
+    {
+        return $this->resolve(schema: $this->readSchemaValue(payload: $payload));
+
+    }//end resolveFromPayload()
+
+    /**
+     * Resolve a schema slug from the raw schema value on an object.
+     *
+     * Accepts a slug straight through: a caller that already holds a slug (for
+     * instance because a future OpenRegister release starts emitting one) must
+     * not be forced through a lookup that would fail.
+     *
+     * @param string $schema The schema id or slug carried by the object.
+     *
+     * @return string The schema slug, or an empty string when unresolvable.
+     *
+     * @spec openspec/specs/bezwaar-lifecycle/spec.md
+     */
+    public function resolve(string $schema): string
+    {
+        $schema = trim($schema);
+        if ($schema === '') {
+            return '';
+        }
+
+        // A non-numeric value is already a slug; ids are always digits.
+        if (ctype_digit($schema) === false) {
+            return $schema;
+        }
+
+        if (array_key_exists($schema, $this->slugs) === true) {
+            return $this->slugs[$schema];
+        }
+
+        $slug = '';
+
+        try {
+            $schemaMapper = $this->container->get('OCA\OpenRegister\Db\SchemaMapper');
+            // Signature is find($id, $_extend, $_rbac, $_multitenancy). RBAC and
+            // multi-tenancy are disabled deliberately: this runs inside an event
+            // handler that may have no active organisation, and the slug is
+            // schema metadata rather than tenant data.
+            $slug = (string) $schemaMapper->find($schema, [], false, false)->getSlug();
+        } catch (\Throwable $e) {
+            $this->logger->debug(
+                'Procest: could not resolve schema slug for id '.$schema,
+                ['exception' => $e->getMessage()]
+            );
+        }
+
+        $this->slugs[$schema] = $slug;
+
+        return $slug;
+
+    }//end resolve()
+
+    /**
+     * Read the raw schema value out of an object payload.
+     *
+     * @param array<string, mixed> $payload The object payload.
+     *
+     * @return string The raw schema id or slug, or an empty string.
+     */
+    private function readSchemaValue(array $payload): string
+    {
+        $self = ($payload['@self'] ?? null);
+        if (is_array($self) === true) {
+            // An extended payload carries the whole schema as an array.
+            $schema = ($self['schema'] ?? null);
+            if (is_array($schema) === true) {
+                return (string) ($schema['slug'] ?? ($schema['id'] ?? ''));
+            }
+
+            if (is_scalar($schema) === true) {
+                return (string) $schema;
+            }
+        }
+
+        $schema = ($payload['schema'] ?? null);
+        if (is_scalar($schema) === true) {
+            return (string) $schema;
+        }
+
+        return '';
+
+    }//end readSchemaValue()
+}//end class


### PR DESCRIPTION
Fixes part of #690 (the issue is filed on procest but the bug class is fleet-wide).

## The bug

OpenRegister object events carry the schema as an **id**, never a slug:

- `ObjectEntity::jsonSerialize()` builds `@self` from `getObjectArray()`, which sets `'schema' => $this->schema` (`lib/Db/ObjectEntity.php:947`).
- `$this->schema` is written by `SaveObject` as `setSchema((string) $schemaId)`.
- There is **no `schemaSlug` key on `@self`**, and there never has been.

Three procest listeners resolved the slug by reading `@self.schemaSlug` (absent), then falling back to `@self.schema` (an id). Their strict slug comparisons therefore could never match, and their handler bodies **had never executed once**. Green-but-dead: no exception, no log, no failing test — while still paying full DI construction and invocation on every matching object write.

| Listener | Guard that never matched | Consequence |
|---|---|---|
| `BezwaarLifecycleListener` | `in_array($slug, ['bezwaar','objection','hearingSession','advisoryReport','decision'], true)` | observability logging never emitted |
| `BezwaarLegalHoldListener` | `in_array($slug, ['objection','bezwaar'] / ['bezwaarDecision','appealDecision'], true)` | **no Awb legal hold has ever been placed** — cases under bezwaar/beroep have been eligible for OR retention/destruction the whole time |
| `TermijnCaseCreatedListener` | `$slug !== 'case'` | no AWB `TermijnInstance` has ever been auto-bound — termijn/dwangsom tracking never started |

## The fix

One shared `ObjectSchemaSlugResolver` (`lib/Service/ObjectSchemaSlugResolver.php`) rather than three per-listener variants. It turns the id the payload actually carries into the slug the handlers are written against, via OpenRegister's `SchemaMapper::find()` (which keeps a request-scoped cache), memoising hits *and* misses for the request.

OpenRegister is reached through the container rather than constructor-injected, matching `SettingsService` — procest carries no hard dependency on OpenRegister and still boots without it. An unresolvable schema yields `''`, which matches no literal, so the previous fail-closed behaviour is preserved.

## What is NOT affected

The other **ten** procest listeners are fine and are deliberately untouched. They compare `@self.schema` against a `*_schema` app-config value, and `SettingsService::reconcileSingleSchemaKey()` resolves slug→id and stores `(string) $schema->getId()` — so they were already comparing **id against id**. Verified live: `occ config:app:get procest bezwaar_schema` → `116`, which is exactly what `@self.schema` carries.

A naive "count the slug comparisons" scan reports 12 dead listeners in procest. The real number is 3.

## Positive control (live, on the shared dev instance)

A negative-only control passes against a listener that does nothing at all, so both directions were measured on a real API write of a `bezwaar` object (register `procest`=17, schema `bezwaar`=116).

**Before** — proxy invoked the listener, body did nothing:
```
proxy subscriptions=5 dispatches=4 invoked=2 skipped=4 listenerUs=118.1
grep -c 'bezwaar-lifecycle' nextcloud.log  ->  0
```
The same request wrote 270 `"level":0` (debug) entries, so the log channel itself was demonstrably working — the zero is the listener, not the instrument.

**After** — same write, same instance:
```
proxy subscriptions=5 dispatches=4 invoked=2 skipped=4 listenerUs=4624.5
{"app":"procest","message":"Procest bezwaar-lifecycle: observed bezwaar OCA\\OpenRegister\\Event\\ObjectCreatedEvent",
 "data":{"schema":"bezwaar","objectId":"f8288a96-...","caseId":"f9013ce5-...","status":"In behandeling"}}
```

`"schema":"bezwaar"` is the resolver turning id `116` into the slug. The independent corroboration is `listenerUs` 118 us -> 4624 us: the handlers are now doing real work instead of returning at the first guard. Host load average at measurement: 32.47.

## Behaviour change — read before merging

These listeners have never run. Waking them is a behaviour change, not a no-op.

- **`BezwaarLifecycleListener` — safe.** Its body is a single `logger->debug()`; no side effects.
- **`TermijnCaseCreatedListener` — writes objects.** Creates an AWB `TermijnInstance` per new case. Correct intended behaviour, but it will start writing on every case create.
- **`BezwaarLegalHoldListener` — writes OpenRegister legal holds.** Suppresses retention/destruction for cases under an Awb procedure. Correct and compliance-relevant, but it changes archival behaviour.

## Honest limits of this verification

- **`BezwaarLifecycleListener`: verified end-to-end.**
- **`BezwaarLegalHoldListener`: comparison fixed, end-to-end UNVERIFIED.** After the fix a `bezwaar` create still produced no legal hold on the linked case. The guard is proven fixed (same resolver, same payload, same request as the verified listener), but `applyHold()` returns silently when `resolveOr()` or `resolveCaseObject()` yields null — `resolveCaseObject()` calls `ObjectEntityMapper::findByUuid()` with an unscoped UUID. That looks like a **second, independent defect downstream of the guard** and is deliberately not fixed here.
- **`TermijnCaseCreatedListener`: comparison fixed, end-to-end UNVERIFIED.** A `case` create (schema 92, slug `case`) produced neither a `TermijnInstance` nor the `catch` branch's debug line, so something downstream of the guard is also not working. Not chased here.
- **Three slug literals cannot be valid on any instance.** `hearingSession` and `advisoryReport` (`BezwaarLifecycleListener`) and `bezwaarDecision` / `appealDecision` (`BezwaarLegalHoldListener`) are camelCase; OpenRegister slugs are lower-kebab (`assessment-result`, `grade-entry`). None of these four schemas exists on the dev instance, so the comparison cannot be exercised and the literals were left alone rather than guessed at. **These branches remain dead after this PR.**
- `phpcs` is clean on all four files. The three remaining warnings are the pre-existing "missing `@spec` PHPDoc tag" class-level warnings; no `@spec` value was invented for them.
