### PR TITLE
fix(archival): place the Awb legal hold that has never once been placed

### DIFF
--- a/lib/Listener/BezwaarLegalHoldListener.php
+++ b/lib/Listener/BezwaarLegalHoldListener.php
@@ -165,6 +165,18 @@ class BezwaarLegalHoldListener implements IEventListener
         $legalHoldService = $this->resolveOr(fqn: self::LEGAL_HOLD_SERVICE);
         $caseObject       = $this->resolveCaseObject(caseId: $caseId);
         if ($legalHoldService === null || $caseObject === null) {
+            // This early return used to be completely silent, which is how a dead
+            // compliance control went unnoticed: no hold, no error, no log line.
+            $this->logger->warning(
+                'Procest legal-hold: NOT applied, collaborator or case unresolved',
+                [
+                    'app'            => Application::APP_ID,
+                    'caseId'         => $caseId,
+                    'place'          => $place,
+                    'haveService'    => ($legalHoldService !== null),
+                    'haveCaseObject' => ($caseObject !== null),
+                ]
+            );
             return;
         }
 
@@ -203,15 +215,35 @@ class BezwaarLegalHoldListener implements IEventListener
         }
 
         try {
-            $caseObject = $objectMapper->findByUuid($caseId);
+            // MagicMapper has no findByUuid(); calling it raised a fatal Error that
+            // the \Throwable catch below swallowed on EVERY invocation, so no Awb
+            // legal hold was ever placed. RBAC and multitenancy are disabled because
+            // this runs inside an event handler where there is no session user or
+            // active organisation to filter by — an organisation-scoped read would
+            // find nothing and silently reopen the same hole.
+            $caseObject = $objectMapper->find(
+                identifier: $caseId,
+                _rbac: false,
+                _multitenancy: false
+            );
             if (is_object($caseObject) === true) {
                 return $caseObject;
             }
 
             return null;
         } catch (\Throwable $e) {
+            // A legal hold is an archiving-law control: failing to resolve the case
+            // means the hold is NOT applied, so it must never be silent again.
+            $this->logger->warning(
+                'Procest legal-hold: could not resolve case object',
+                [
+                    'app'    => Application::APP_ID,
+                    'caseId' => $caseId,
+                    'error'  => $e->getMessage(),
+                ]
+            );
             return null;
-        }
+        }//end try
     }//end resolveCaseObject()
 
     /**
@@ -280,7 +312,12 @@ class BezwaarLegalHoldListener implements IEventListener
         }
 
         try {
-            $objection = $objectMapper->findByUuid($bezwaarId);
+            // See resolveCaseObject(): findByUuid() does not exist on MagicMapper.
+            $objection = $objectMapper->find(
+                identifier: $bezwaarId,
+                _rbac: false,
+                _multitenancy: false
+            );
             if ($objection === null || method_exists($objection, 'getObject') === false) {
                 return '';
             }
@@ -292,8 +329,16 @@ class BezwaarLegalHoldListener implements IEventListener
 
             return (string) ($data['case'] ?? '');
         } catch (\Throwable $e) {
+            $this->logger->warning(
+                'Procest legal-hold: could not resolve objection for case linkage',
+                [
+                    'app'       => Application::APP_ID,
+                    'bezwaarId' => $bezwaarId,
+                    'error'     => $e->getMessage(),
+                ]
+            );
             return '';
-        }
+        }//end try
     }//end caseIdOfObjection()
 
     /**


### PR DESCRIPTION
## The exposure

`BezwaarLegalHoldListener` is the control that suspends a case from destruction while it is under bezwaar or beroep. **It has never once placed a hold.** Cases under an Awb proceeding have been destruction-eligible throughout.

On the development instance: **22 bezwaar proceedings, 0 legal holds.**

## Root cause

`resolveCaseObject()` and `caseIdOfObjection()` both called `$objectMapper->findByUuid($uuid)`.

`MagicMapper` has **no `findByUuid()`** and **no `__call()`**, so every invocation raised a fatal `\Error`. Each call site wraps the lookup in `catch (\Throwable)`, which swallowed it and returned `null` / `''`. `applyHold()` then hit an early return that was **completely silent**.

The result is the worst shape a compliance control can have: no hold, no exception, no log line, and nothing that distinguishes it from a healthy listener.

Verified by reflection **in the running container**, with a positive control rather than a grep:

```
class_exists(OCA\OpenRegister\Db\MagicMapper): true
  find         hasMethod=true     <- positive control
  findAll      hasMethod=true     <- positive control
  findByUuid   hasMethod=false
  __call       hasMethod=false
```

`procest#692` fixed the *slug comparison* in the guard above this. This is a second, independent defect downstream of that guard — which is why the end-to-end behaviour did not change after #692.

## The fix

Both call sites now use `find(identifier:, _rbac: false, _multitenancy: false)`.

RBAC and multitenancy are disabled deliberately, not incidentally: this runs inside an event handler where there is no session user and no active organisation, so an organisation-scoped read would match nothing and **silently reopen the same hole**.

Both swallowing catches now log a warning, and the previously-silent "collaborator or case unresolved" early return in `applyHold()` now records why a hold was not applied.

## Positive control (live instance)

Both fixed call sites are exercised.

**Place** — create `case`, then `bezwaar` referencing it:

```json
{"legalHold": {"active": true,
  "reason": "Awb-procedure (bezwaar) geregistreerd — archivering opgeschort",
  "placedBy": "admin", "placedDate": "2026-08-01T18:15:41+00:00"}}
```

**Release** — create `bezwaarDecision` (this path goes through `caseIdOfObjection()`, the *second* `findByUuid()` site):

```json
{"legalHold": {"active": false, "history": [{"active": true,
  "placedDate": "2026-08-01T18:15:41+00:00",
  "releasedBy": "admin", "releasedDate": "2026-08-01T18:16:43+00:00",
  "releaseReason": "Awb-procedure (bezwaarDecision) afgehandeld — archivering hervat"}]}}
```

Before this change the same sequence produced no retention data at all. The new hold is **the only one in a table of 348 cases** — which is simultaneously the positive control and the negative control.

## Checks

`phpcs` clean on the touched file (2 pre-existing `//end try` errors my longer catch blocks triggered are fixed here).

## Not covered

- No unit test yet — the defect is a missing method on a collaborator, which a mock-based test would not have caught (a `getMockBuilder(stdClass)->addMethods(['findByUuid'])` double would have made the broken call *pass*). A structural check that asserts the called method exists on the real class would be the right regression guard; worth a follow-up.
- The **21 historical bezwaar proceedings that never got a hold are not backfilled** by this PR. They need a remediation sweep — filing separately.

Refs procest#692
