### PR TITLE
fix(archival): an open beroep never placed a legal hold

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -765,7 +765,7 @@ class Application extends App implements IBootstrap
             event: ObjectCreatedEvent::class,
             listener: BezwaarLegalHoldListener::class,
             registers: ['procest'],
-            schemas: ['objection', 'bezwaar', 'bezwaarDecision', 'appealDecision']
+            schemas: ['objection', 'bezwaar', 'beroep', 'bezwaarDecision', 'appealDecision']
         );
 
     }//end subscribeBezwaarListeners()

--- a/lib/Listener/BezwaarLegalHoldListener.php
+++ b/lib/Listener/BezwaarLegalHoldListener.php
@@ -71,9 +71,16 @@ class BezwaarLegalHoldListener implements IEventListener
     /**
      * Schemas whose creation opens an Awb proceeding (places a hold).
      *
+     * `beroep` (appeal, Awb hoofdstuk 8) opens a proceeding exactly as
+     * `bezwaar`/`objection` do, and its terminal artefact `appealDecision` is
+     * already listed in {@see PROCEEDING_CLOSED_SCHEMAS}. It was missing here,
+     * so a case under appeal was never held and stayed destruction-eligible
+     * while the appeal was still running — the release side was wired up and
+     * the place side was not.
+     *
      * @var array<int, string>
      */
-    private const PROCEEDING_OPENED_SCHEMAS = ['objection', 'bezwaar'];
+    private const PROCEEDING_OPENED_SCHEMAS = ['objection', 'bezwaar', 'beroep'];
 
     /**
      * Schemas whose creation ends an Awb proceeding (releases a hold).

--- a/tests/Unit/Listener/BezwaarLegalHoldSchemaCoverageTest.php
+++ b/tests/Unit/Listener/BezwaarLegalHoldSchemaCoverageTest.php
@@ -1,0 +1,144 @@
+<?php
+
+/**
+ * Procest BezwaarLegalHoldListener schema-coverage tests
+ *
+ * Guards the Awb proceeding schema lists on
+ * {@see \OCA\Procest\Listener\BezwaarLegalHoldListener} against the drift that
+ * left `beroep` off the opening list: the release side (`appealDecision`) was
+ * wired up while the place side was not, so a case under appeal carried no
+ * legal hold and stayed destruction-eligible for the whole appeal.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Test
+ * @package  OCA\Procest\Tests\Unit\Listener
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.procest.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Listener;
+
+use OCA\Procest\Listener\BezwaarLegalHoldListener;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * @coversDefaultClass \OCA\Procest\Listener\BezwaarLegalHoldListener
+ */
+class BezwaarLegalHoldSchemaCoverageTest extends TestCase
+{
+    /**
+     * Read a private constant off the listener.
+     *
+     * @param string $name The constant name.
+     *
+     * @return array<int, string> The constant value.
+     */
+    private function constant(string $name): array
+    {
+        $reflection = new ReflectionClass(objectOrClass: BezwaarLegalHoldListener::class);
+
+        return (array) $reflection->getConstant(name: $name);
+    }//end constant()
+
+    /**
+     * Every Awb proceeding that can be OPENED must place a hold. `beroep`
+     * (appeal) suspends destruction exactly as `bezwaar`/`objection` do.
+     *
+     * @return void
+     */
+    public function testOpeningSchemasCoverEveryAwbProceeding(): void
+    {
+        $opens = $this->constant(name: 'PROCEEDING_OPENED_SCHEMAS');
+
+        $this->assertContains(needle: 'bezwaar', haystack: $opens);
+        $this->assertContains(needle: 'objection', haystack: $opens);
+        $this->assertContains(
+            needle: 'beroep',
+            haystack: $opens,
+            message: 'An open beroep must place a legal hold; without it a case under appeal is destruction-eligible.'
+        );
+    }//end testOpeningSchemasCoverEveryAwbProceeding()
+
+    /**
+     * The place and release sides must stay symmetric: every terminal artefact
+     * on the closing list must correspond to a proceeding on the opening list.
+     * `appealDecision` terminates `beroep`, `bezwaarDecision` terminates
+     * `bezwaar`/`objection`. A closing schema with no opening counterpart is
+     * precisely the defect this test exists to catch.
+     *
+     * @return void
+     */
+    public function testClosingSchemasHaveAnOpeningCounterpart(): void
+    {
+        $opens  = $this->constant(name: 'PROCEEDING_OPENED_SCHEMAS');
+        $closes = $this->constant(name: 'PROCEEDING_CLOSED_SCHEMAS');
+
+        $counterparts = [
+            'appealDecision'  => 'beroep',
+            'bezwaarDecision' => 'bezwaar',
+        ];
+
+        foreach ($closes as $closingSchema) {
+            $this->assertArrayHasKey(
+                key: $closingSchema,
+                array: $counterparts,
+                message: 'Unmapped closing schema "'.$closingSchema.'" — add its opening counterpart.'
+            );
+            $this->assertContains(
+                needle: $counterparts[$closingSchema],
+                haystack: $opens,
+                message: '"'.$closingSchema.'" releases a hold that "'
+                    .$counterparts[$closingSchema].'" never places.'
+            );
+        }
+    }//end testClosingSchemasHaveAnOpeningCounterpart()
+
+    /**
+     * The listener is subscribed with a register/schema filter in
+     * `Application::subscribeBezwaarListeners()`. That filter is a SECOND,
+     * independent list: a schema missing there never reaches `handle()` at all,
+     * however correct the constants are. `beroep` was missing from both.
+     *
+     * @return void
+     */
+    public function testSubscriptionFilterCoversEveryProceedingSchema(): void
+    {
+        $application = file_get_contents(filename: __DIR__.'/../../../lib/AppInfo/Application.php');
+        $this->assertIsString(actual: $application);
+
+        $matched = preg_match(
+            pattern: '/BezwaarLegalHoldListener::class,\s*registers:\s*\[[^\]]*\],\s*schemas:\s*\[([^\]]*)\]/',
+            subject: $application,
+            matches: $matches
+        );
+        $this->assertSame(
+            expected: 1,
+            actual: $matched,
+            message: 'Could not locate the BezwaarLegalHoldListener subscription filter.'
+        );
+
+        $declared = $matches[1];
+        $expected = array_merge(
+            $this->constant(name: 'PROCEEDING_OPENED_SCHEMAS'),
+            $this->constant(name: 'PROCEEDING_CLOSED_SCHEMAS')
+        );
+
+        foreach ($expected as $schemaSlug) {
+            $this->assertStringContainsString(
+                needle: "'".$schemaSlug."'",
+                haystack: $declared,
+                message: 'Schema "'.$schemaSlug.'" is handled by the listener but absent from its '
+                    .'subscription filter, so the listener never runs for it.'
+            );
+        }
+    }//end testSubscriptionFilterCoversEveryProceedingSchema()
+}//end class


### PR DESCRIPTION
## The defect

`BezwaarLegalHoldListener` **released** a hold on `appealDecision` but never **placed** one on `beroep`. The place and release sides were asymmetric, so a case under appeal carried no legal hold and stayed **destruction-eligible for the entire duration of the appeal** — the same compliance class as #693/#695.

## `beroep` was missing from TWO places

Fixing either one alone changes nothing:

1. **`PROCEEDING_OPENED_SCHEMAS`** on the listener — actual contents before this PR were `['objection', 'bezwaar']`. This decides whether a reaching event opens a proceeding.
2. **the `schemas:` filter** on `registerFilteredObjectListener()` in `Application::subscribeBezwaarListeners()` — was `['objection', 'bezwaar', 'bezwaarDecision', 'appealDecision']`. This decides whether the event reaches `handle()` **at all**.

## The slug

Verified against the database, not assumed: **`beroep`**, schema id **122**, title "Appeal", in registers `procest` (17) and `procest-default` (2424). `appealDecision` is id 120.

⚠️ `BezwaarBeroep` (id 1158, "Bezwaar / Beroep") also exists but belongs to **shillinq** and is unrelated — a reminder that OR slugs are not reliably lower-kebab.

## Already known, worked around instead of fixed

`BackfillLegalHoldsCommand::OPENING_SCHEMAS` **already lists `beroep`**, with this docblock:

> `beroep` is included here even though the listener itself does not act on it: an appeal suspends destruction exactly as an objection does, and a case sitting in beroep with no hold is the same compliance defect.

So the gap was known and patched in the backfill rather than at the source. This fixes the source.

## Live verification

**Positive control** — created a `beroep` on case `bf6f6b2d` (no prior hold):

```json
"legalHold": {
  "active": true,
  "reason": "Awb-procedure (beroep) geregistreerd — archivering opgeschort",
  "placedBy": "admin",
  "placedDate": "2026-08-02T10:11:14+00:00"
}
```

**Negative control** — created an `appealDecision` (a *concluded* proceeding) on case `d1e4e995` (no prior hold): hold stayed `none`. So the schema filter genuinely discriminates, and the positive result is not "any write places a hold". That distinction matters — the inverse defect (filter off entirely) was the one that hit the backfill command.

**Backfill** — `occ procest:legal-hold:backfill` dry-run after the fix:

```
candidates  = 4
would hold  = 0
already held= 4
unresolved  = 0
```

Nothing outstanding to apply; #695 had already caught the one pre-existing open beroep (case `f9013ce5`). Not run with `--apply` — there was nothing to write.

## Regression guard

New test asserts the three things whose drift caused this:

- `beroep` is on the opening list
- every **closing** schema has an **opening** counterpart (the asymmetry check)
- the subscription filter covers the union of both constants (the second-list check)

Confirmed the test genuinely fails without the fix — reverting the constant produces 2 failures including *"Failed asserting that an array contains 'beroep'"*. 3/3 green with the fix.

`phpcs` clean on both touched `lib/` files (0 findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
