### PR TITLE
fix(tests): OCP\Files\IRootFolder unmockable — 19 errors from a stub loaded too late

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
 		}
 	},
 	"require": {
-		"php": "^8.3"
+		"php": "^8.3",
+		"ext-zip": "*"
 	},
 	"require-dev": {
 		"cyclonedx/cyclonedx-php-composer": "^6.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2f0c524e7b6411fb15e1591e0b967073",
+    "content-hash": "82b3d1ffdc1b0cc992d9c3edb533cc11",
     "packages": [],
     "packages-dev": [
         {
@@ -7679,7 +7679,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.3"
+        "php": "^8.3",
+        "ext-zip": "*"
     },
     "platform-dev": {},
     "platform-overrides": {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -92,6 +92,28 @@ if (function_exists('easter_date') === false) {
     }//end easter_date()
 }//end if
 
+// Load the OC-internal and Doctrine stubs FIRST — before the OCP pre-load and
+// before any OCP autoloader is registered.
+//
+// These used to be required at the BOTTOM of this file, which made them useless
+// to the two consumers that actually need them:
+//
+//   1. The multi-pass OCP classmap pre-load below filters the Nextcloud
+//      classmap down to `OCP\` / `NCU\` entries only, so it never loads
+//      `OC\Hooks\Emitter`. `OCP\Files\IRootFolder extends Folder, Emitter`, so
+//      IRootFolder failed to declare on every one of the 10 passes and ended up
+//      cached nowhere — producing "Class or interface OCP\Files\IRootFolder
+//      does not exist" for every test that mocks it.
+//   2. `OCP\DB\QueryBuilder\IQueryBuilder` evaluates class constants that
+//      reference `Doctrine\DBAL\ParameterType` at parse time, so the Doctrine
+//      placeholders must likewise already be in the class table.
+//
+// Every declaration in both files is class_exists()/interface_exists()-guarded,
+// so loading them this early is a no-op when a real Nextcloud runtime later
+// supplies the genuine classes.
+require_once __DIR__.'/Unit/Stubs/DoctrineStubs.php';
+require_once __DIR__.'/Unit/Stubs/OcInternalStubs.php';
+
 // Pre-load ALL OCP\ / NCU\ classes from the real Nextcloud lib/public tree
 // BEFORE lib/base.php runs. This ensures every OCP interface/class is already
 // in PHP's class cache before any installed-app vendor autoloader (e.g.
@@ -196,7 +218,16 @@ if (defined('OC_CONSOLE') === false) {
 // When a real Nextcloud is present (base.php was loaded above), the NC classmap
 // loader already owns the OCP\ namespace, so we skip the stub registration to
 // avoid overriding real OCP classes with an older stub version.
-$ncBaseLoaded = file_exists(__DIR__.'/../../../lib/base.php');
+//
+// This must test whether Nextcloud ACTUALLY BOOTSTRAPPED, not whether its
+// `lib/base.php` merely exists on disk. In the standard `apps-extra/` checkout
+// layout that file always exists, so the previous `file_exists()` check
+// unconditionally suppressed the fallback registration — including in the
+// common case where base.php was never loaded at all because phpunit.xml
+// defines OC_CONSOLE (see the guard above), leaving the OCP\ namespace with no
+// autoloader whatsoever. `\OC_App` is declared by base.php and by nothing else,
+// so its presence is a true "NC runtime is live" signal.
+$ncBaseLoaded = class_exists('\OC_App', false);
 if ($ncBaseLoaded === false) {
     $loaders = spl_autoload_functions();
     foreach ($loaders as $loader) {
@@ -208,19 +239,9 @@ if ($ncBaseLoaded === false) {
     }
 }
 
-// Load Doctrine DBAL and OC internal stubs so that PHPUnit can mock
-// OCP\IDBConnection and OCP\DB\QueryBuilder\IQueryBuilder, which reference
-// Doctrine types not present in this repository's vendor directory. Every
-// declaration here is guarded by class_exists()/interface_exists(), so this is
-// a no-op when a real Nextcloud (loaded above) already provides the classes.
-require_once __DIR__.'/Unit/Stubs/DoctrineStubs.php';
-
-// OC\Hooks\Emitter + OC\User\NoUserException stubs — OCP\Files\IRootFolder
-// extends these OC-internal types, but they are not shipped in nextcloud/ocp.
-// Without these stubs PHPUnit cannot mock IRootFolder in tests.
-// Must be loaded BEFORE the real Nextcloud base.php (which self-skips via
-// interface_exists guards when a real Nextcloud runtime is present).
-require_once __DIR__.'/Unit/Stubs/OcInternalStubs.php';
+// (DoctrineStubs.php and OcInternalStubs.php are loaded near the top of this
+// file — they must precede the OCP pre-load, not follow it. See the comment
+// above the pre-load block.)
 
 // Shared in-memory ObjectService fake. Lives in tests/Unit/Fixtures/ so
 // every termijnbewaking + archief-edepot unit test file can resolve


### PR DESCRIPTION
## Problem

`vendor/bin/phpunit -c phpunit.xml` reported **19 errors**, 15 of them `Class or interface "OCP\Files\IRootFolder" does not exist`, confined to `LibresignSigningAdapterTest` and `CaseEmailServiceTest`. Pre-existing on `development`.

## Root cause — two independent bootstrap defects

**1. The OC-internal stub was loaded after the code that needs it.**

`tests/Unit/Stubs/OcInternalStubs.php` declares `OC\Hooks\Emitter`, and `OCP\Files\IRootFolder extends Folder, Emitter`. The stub was `require_once`d at the *bottom* of `tests/bootstrap.php`, but the multi-pass OCP pre-load that needs it runs near the top — and that pre-load deliberately filters the Nextcloud classmap down to `OCP\`/`NCU\` entries, so it never loads `OC\Hooks\Emitter` itself. IRootFolder therefore failed to declare on all 10 passes and ended up cached nowhere.

The stub's own docblock already asserted it "must be loaded BEFORE the real Nextcloud base.php". It was not.

**2. The vendored-OCP fallback was gated on the wrong predicate.**

```php
$ncBaseLoaded = file_exists(__DIR__.'/../../../lib/base.php');
if ($ncBaseLoaded === false) { /* register OCP\ PSR-4 */ }
```

That checks whether the file is **present**, not whether Nextcloud **bootstrapped**. In the standard `apps-extra/` layout the path always exists, so the fallback was permanently suppressed — including in the normal case where `base.php` is never loaded at all, because `phpunit.xml` defines `OC_CONSOLE`. The `OCP\` namespace was left with no autoloader whatsoever.

Now `class_exists('\OC_App', false)`, which is true only when `base.php` really ran.

## Also: undeclared `ext-zip`

`ZipManifestBuilder`, `CaseDefinitionExportService`, `CaseDefinitionImportService` and `BeschikkingService` all use `ZipArchive` unconditionally, but `composer.json` did not declare `ext-zip`. Four tests error on any runner without it. Declaring it makes the requirement fail loudly at install time instead of as four opaque test errors. (`scholiq` already declares it.)

## Verification

PHP 8.3.32 + ext-zip, in **both** layouts — repo standalone at `/app`, and mounted at `/var/www/html/apps-extra/procest` under an NC 33 source tree:

| | before | after |
|---|---|---|
| tests | 1684 | 1684 |
| errors | **19** (NC-mounted) / 4 (standalone) | **0** |
| failures | 0 | 0 |
| skipped | 5 | 5 |

The suite ran the same 1684 tests before and after — the fix converts 19 *errors* into 19 executing tests, it does not change collection.

### Positive control (proof the suite can fail)

Inverting one assertion in the previously-**erroring** `CaseEmailServiceTest::testResolveVariablesEscapesHtml`:

```
1) OCA\Procest\Tests\Unit\Service\CaseEmailServiceTest::testResolveVariablesEscapesHtml
Failed asserting that 'Beste Jan &lt;script&gt;...' contains "DELIBERATE-HARNESS-PROOF-CANARY".
FAILURES! Tests: 1, Assertions: 1, Failures: 1.
```

That test previously *errored* rather than running. Canary reverted; not in this branch.

## Not addressed here

`composer test:unit` / `test:all` still end in `|| echo 'Tests require Nextcloud environment, skipping...'`, so they exit 0 regardless. Left alone deliberately — that is the same green-but-dead pattern openregister#2256 fixed for openregister, and it deserves its own PR per repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
