### PR TITLE
fix(quality): PHPStan 139 → 7 in check:strict, no baseline and no suppressions

### DIFF
--- a/lib/BackgroundJob/InboundEmailJob.php
+++ b/lib/BackgroundJob/InboundEmailJob.php
@@ -293,10 +293,13 @@ class InboundEmailJob extends TimedJob
             }
 
             if (method_exists($objectService, 'searchObjectsBySlug') === true) {
+                // Positional: the narrowed duck-typed object has no parameter
+                // names for static analysis. Order matches OpenRegister's
+                // searchObjectsBySlug(registerSlug, schemaSlug, filters).
                 $rows = $objectService->searchObjectsBySlug(
-                    registerSlug: (string) $register,
-                    schemaSlug: (string) $schema,
-                    filters: ['mailMessageId' => $messageId, '_limit' => 1]
+                    (string) $register,
+                    (string) $schema,
+                    ['mailMessageId' => $messageId, '_limit' => 1]
                 );
                 return (is_array($rows) === true && $rows !== []);
             }

--- a/lib/BackgroundJob/ResetMonthlyQuotasJob.php
+++ b/lib/BackgroundJob/ResetMonthlyQuotasJob.php
@@ -73,8 +73,10 @@ class ResetMonthlyQuotasJob extends TimedJob
      */
     protected function run($argument): void
     {
-        $installed = $this->appManager->getInstalledApps();
-        if (is_array($installed) === false || in_array('openregister', $installed, true) === false) {
+        // IAppManager::getInstalledApps() declares its array return in PHPDoc
+        // only, so normalise defensively before the membership test.
+        $installed = (array) $this->appManager->getInstalledApps();
+        if (in_array('openregister', $installed, true) === false) {
             return;
         }
 

--- a/lib/BackgroundJob/ResetMonthlyQuotasJob.php
+++ b/lib/BackgroundJob/ResetMonthlyQuotasJob.php
@@ -70,6 +70,9 @@ class ResetMonthlyQuotasJob extends TimedJob
      * @param mixed $argument Job argument (unused).
      *
      * @return void
+     *
+     * @spec exclude phpstan dead-code cleanup only — normalised the IAppManager return and
+     *       dropped the resulting always-false `is_array()` guard; no behavioural change.
      */
     protected function run($argument): void
     {

--- a/lib/Controller/DashboardController.php
+++ b/lib/Controller/DashboardController.php
@@ -83,15 +83,14 @@ class DashboardController extends GenericDashboardController
     #[PublicPage]
     public function serviceWorker(): DataDownloadResponse
     {
-        $body     = (string) @file_get_contents(self::PUBLIC_DIR.'/service-worker.js');
-        $response = new DataDownloadResponse($body, 'service-worker.js', 'application/javascript');
-        $response->addHeader('Service-Worker-Allowed', '/');
+        $body   = (string) @file_get_contents(self::PUBLIC_DIR.'/service-worker.js');
         $status = Http::STATUS_OK;
         if ($body === '') {
             $status = Http::STATUS_NOT_FOUND;
         }
 
-        $response->setStatus($status);
+        $response = new DataDownloadResponse($body, 'service-worker.js', 'application/javascript', $status);
+        $response->addHeader('Service-Worker-Allowed', '/');
         return $response;
     }//end serviceWorker()
 
@@ -106,14 +105,12 @@ class DashboardController extends GenericDashboardController
     #[PublicPage]
     public function webManifest(): DataDownloadResponse
     {
-        $body     = (string) @file_get_contents(self::PUBLIC_DIR.'/manifest.webmanifest');
-        $response = new DataDownloadResponse($body, 'manifest.webmanifest', 'application/manifest+json');
-        $status   = Http::STATUS_OK;
+        $body   = (string) @file_get_contents(self::PUBLIC_DIR.'/manifest.webmanifest');
+        $status = Http::STATUS_OK;
         if ($body === '') {
             $status = Http::STATUS_NOT_FOUND;
         }
 
-        $response->setStatus($status);
-        return $response;
+        return new DataDownloadResponse($body, 'manifest.webmanifest', 'application/manifest+json', $status);
     }//end webManifest()
 }//end class

--- a/lib/Controller/DwangsomController.php
+++ b/lib/Controller/DwangsomController.php
@@ -37,7 +37,6 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use OCP\IUserSession;
-use Psr\Log\LoggerInterface;
 use Throwable;
 
 /**
@@ -56,7 +55,6 @@ class DwangsomController extends Controller
      * @param DwangsomBezwaarService     $bezwaar     Bezwaar service.
      * @param SettingsService            $settings    Settings.
      * @param IUserSession               $userSession User session.
-     * @param LoggerInterface            $logger      Logger.
      */
     public function __construct(
         string $appName,
@@ -65,7 +63,6 @@ class DwangsomController extends Controller
         private readonly DwangsomBezwaarService $bezwaar,
         private readonly SettingsService $settings,
         private readonly IUserSession $userSession,
-        private readonly LoggerInterface $logger,
     ) {
         parent::__construct(appName: $appName, request: $request);
     }//end __construct()

--- a/lib/Controller/StufController.php
+++ b/lib/Controller/StufController.php
@@ -47,6 +47,7 @@ use OCA\Procest\Service\Stuf\StufRegisterAccess;
 use OCA\Procest\Service\Stuf\StufVaultService;
 use OCA\Procest\Service\StufFieldMappingService;
 use OCA\Procest\Service\StufMessageBuilder;
+use OCA\Procest\Settings\AdminSettings;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
@@ -154,7 +155,7 @@ class StufController extends Controller
      *
      * @contract exclude SOAP vrijBericht proxy needs a seeded endpoint + vault + live peer; covered by PHPUnit + env-gated live-e2e/Newman.
      */
-    #[AuthorizedAdminSetting(Application::APP_ID)]
+    #[AuthorizedAdminSetting(AdminSettings::class)]
     public function outbound(): JSONResponse
     {
         $endpointId  = (string) $this->request->getParam(key: 'endpointId', default: '');
@@ -269,7 +270,7 @@ class StufController extends Controller
      *
      * @spec openspec/specs/stuf-zkn-outbound/spec.md#requirement-outbound-rest-surface
      */
-    #[AuthorizedAdminSetting(Application::APP_ID)]
+    #[AuthorizedAdminSetting(AdminSettings::class)]
     public function endpoints(): JSONResponse
     {
         $items = $this->register->findAll(schema: StufRegisterAccess::SCHEMA_ENDPOINT, filters: [], limit: 500);
@@ -284,7 +285,7 @@ class StufController extends Controller
      *
      * @spec openspec/specs/stuf-zkn-outbound/spec.md#requirement-outbound-audit-log
      */
-    #[AuthorizedAdminSetting(Application::APP_ID)]
+    #[AuthorizedAdminSetting(AdminSettings::class)]
     public function messages(): JSONResponse
     {
         $endpointId   = (string) $this->request->getParam(key: 'endpointId', default: '');

--- a/lib/Listener/DecisionConcludedListener.php
+++ b/lib/Listener/DecisionConcludedListener.php
@@ -106,7 +106,7 @@ class DecisionConcludedListener implements IEventListener
                 return;
             }
 
-            $status = strtolower((string) $event->getStatus());
+            $status = strtolower($this->readString(event: $event, getter: 'getStatus'));
             if (in_array($status, self::TERMINAL_STATUSES, true) === false) {
                 // Non-terminal (e.g. pending): nothing to materialise yet.
                 return;
@@ -117,11 +117,11 @@ class DecisionConcludedListener implements IEventListener
                 return;
             }
 
-            $decisionId  = (string) $event->getDecisionId();
-            $register    = (string) ($event->getSubjectRegister() ?? '');
-            $schema      = (string) ($event->getSubjectSchema() ?? '');
-            $subjectId   = (string) ($event->getSubjectId() ?? '');
-            $externalRef = (string) $event->getExternalReference();
+            $decisionId  = $this->readString(event: $event, getter: 'getDecisionId');
+            $register    = $this->readString(event: $event, getter: 'getSubjectRegister');
+            $schema      = $this->readString(event: $event, getter: 'getSubjectSchema');
+            $subjectId   = $this->readString(event: $event, getter: 'getSubjectId');
+            $externalRef = $this->readString(event: $event, getter: 'getExternalReference');
 
             // Locate the procest domain record carrying this decisionRef so we
             // can resolve the owning case and any existing besluitRef. Fall back
@@ -201,7 +201,7 @@ class DecisionConcludedListener implements IEventListener
         }
 
         if (is_array($record) === true) {
-            $caseId    = (string) ($record['case'] ?? $record['caseRef'] ?? $externalRef ?? $subjectId);
+            $caseId    = (string) ($record['case'] ?? $record['caseRef'] ?? $externalRef);
             $besluitId = (string) ($record['besluitRef'] ?? '');
             return [$caseId, $besluitId];
         }
@@ -217,19 +217,43 @@ class DecisionConcludedListener implements IEventListener
     }//end resolveCaseAndBesluit()
 
     /**
+     * Read a duck-typed getter off the decidesk event as a string.
+     *
+     * The event is typed as the base Event class because the concrete
+     * OCA\Decidesk\Event\DecisionConcludedEvent is an optional runtime
+     * dependency that is absent from this app's autoload graph. Every read goes
+     * through this helper so a non-conforming dispatch degrades to an empty
+     * string instead of raising an Error.
+     *
+     * @param Event  $event  The decidesk DecisionConcludedEvent.
+     * @param string $getter The zero-argument getter to invoke.
+     *
+     * @return string The stringified getter result, or '' when absent/null.
+     */
+    private function readString(Event $event, string $getter): string
+    {
+        if (method_exists($event, $getter) === false) {
+            return '';
+        }
+
+        $value = $event->$getter();
+        if ($value === null || is_scalar($value) === false) {
+            return '';
+        }
+
+        return (string) $value;
+    }//end readString()
+
+    /**
      * Project the decidesk event getters into the materialiser's outcome shape.
      *
      * The $event parameter is typed as the base Event class because the concrete
-     * OCA\Decidesk\Event\DecisionConcludedEvent is an optional runtime dependency.
-     * All calls on $event here are guarded at the call-site (callers check
-     * method_exists) or use duck-typing that is safe at runtime. Psalm cannot
-     * infer the concrete type, so we suppress UndefinedMethod for this method.
+     * OCA\Decidesk\Event\DecisionConcludedEvent is an optional runtime dependency,
+     * so every getter is read through the duck-typed {@see readString()} helper.
      *
      * @param Event $event The decidesk DecisionConcludedEvent.
      *
      * @return array<string,mixed> Normalised projection: status, outcome, decidedAt, signer, method, signers, signingReference.
-     *
-     * @psalm-suppress UndefinedMethod
      */
     private function projectOutcome(Event $event): array
     {
@@ -254,19 +278,19 @@ class DecisionConcludedListener implements IEventListener
 
         // The decision method is recorded as "signature" when the outcome was
         // signed, otherwise the decisionType carries the method provenance.
-        $method = (string) $event->getDecisionType();
-        if ($event->isSigned() === true) {
+        $method = $this->readString(event: $event, getter: 'getDecisionType');
+        if (method_exists($event, 'isSigned') === true && $event->isSigned() === true) {
             $method = 'signature';
         }
 
         return [
-            'status'           => (string) $event->getStatus(),
-            'outcome'          => (string) $event->getOutcome(),
-            'decidedAt'        => (string) ($event->getDecidedAt() ?? ''),
+            'status'           => $this->readString(event: $event, getter: 'getStatus'),
+            'outcome'          => $this->readString(event: $event, getter: 'getOutcome'),
+            'decidedAt'        => $this->readString(event: $event, getter: 'getDecidedAt'),
             'signer'           => $signer,
             'method'           => $method,
             'signers'          => $signers,
-            'signingReference' => (string) ($event->getSigningReference() ?? ''),
+            'signingReference' => $this->readString(event: $event, getter: 'getSigningReference'),
         ];
     }//end projectOutcome()
 }//end class

--- a/lib/Middleware/MandateValidationMiddleware.php
+++ b/lib/Middleware/MandateValidationMiddleware.php
@@ -115,7 +115,7 @@ class MandateValidationMiddleware extends Middleware
 
         if ($decision['allowed'] === false) {
             throw new MandateDeniedException(
-                (string) ($decision['reason'] ?? 'Mandate denied'),
+                (string) $decision['reason'],
                 403
             );
         }
@@ -181,8 +181,8 @@ class MandateValidationMiddleware extends Middleware
                 'tenantId' => $tenantId,
                 'userId'   => $userId,
                 'action'   => $action,
-                'allowed'  => (bool) ($decision['allowed'] ?? false),
-                'reason'   => (string) ($decision['reason'] ?? ''),
+                'allowed'  => (bool) $decision['allowed'],
+                'reason'   => (string) $decision['reason'],
             ]
         );
     }//end logDecision()

--- a/lib/Middleware/QuotaEnforcementMiddleware.php
+++ b/lib/Middleware/QuotaEnforcementMiddleware.php
@@ -91,7 +91,7 @@ class QuotaEnforcementMiddleware extends Middleware
             );
         }
 
-        if (($decision['soft'] ?? false) === true) {
+        if ($decision['soft'] === true) {
             $this->logger->info(
                 'Procest quota soft-limit hit',
                 ['tenantId' => $tenantId, 'quotaType' => $quotaType]

--- a/lib/Repair/LinkInFlightContractDecisionsRepair.php
+++ b/lib/Repair/LinkInFlightContractDecisionsRepair.php
@@ -141,15 +141,7 @@ class LinkInFlightContractDecisionsRepair implements IRepairStep
                         continue;
                     }//end try
 
-                    if (is_array($cases) === false) {
-                        continue;
-                    }
-
                     foreach ($cases as $case) {
-                        if (is_array($case) === false) {
-                            continue;
-                        }
-
                         $caseUuid    = (string) ($case['uuid'] ?? $case['id'] ?? '');
                         $besluitRef  = (string) ($case['besluitRef'] ?? '');
                         $decisionRef = (string) ($case['decisionRef'] ?? '');

--- a/lib/Repair/LinkInFlightRemainingDecisionsRepair.php
+++ b/lib/Repair/LinkInFlightRemainingDecisionsRepair.php
@@ -209,15 +209,7 @@ class LinkInFlightRemainingDecisionsRepair implements IRepairStep
                         continue;
                     }
 
-                    if (is_array($objects) === false) {
-                        continue;
-                    }
-
                     foreach ($objects as $obj) {
-                        if (is_array($obj) === false) {
-                            continue;
-                        }
-
                         $objUuid     = (string) ($obj['uuid'] ?? ($obj['id'] ?? ''));
                         $decisionRef = (string) ($obj['decisionRef'] ?? '');
                         $besluitRef  = (string) ($obj['besluitRef'] ?? '');

--- a/lib/Repair/VthSeedDataRepairStep.php
+++ b/lib/Repair/VthSeedDataRepairStep.php
@@ -376,11 +376,7 @@ class VthSeedDataRepairStep implements IRepairStep
         }
 
         $slugs = [];
-        foreach ((array) $rows as $row) {
-            if (is_array($row) === false) {
-                continue;
-            }
-
+        foreach ($rows as $row) {
             $slug = (string) ($row['slug'] ?? '');
             if ($slug !== '') {
                 $slugs[] = $slug;

--- a/lib/Service/AdviceService.php
+++ b/lib/Service/AdviceService.php
@@ -686,7 +686,7 @@ class AdviceService
                     'externalReference' => $caseId,
                     'subjectLabel'      => (string) ($data['vraag'] ?? 'Adviesaanvraag'),
                     'question'          => (string) ($data['vraag'] ?? ''),
-                    'adviseur'          => (string) ($payload['adviseur'] ?? ''),
+                    'adviseur'          => (string) $payload['adviseur'],
                 ],
             );
 

--- a/lib/Service/AdvisoryBodyService.php
+++ b/lib/Service/AdvisoryBodyService.php
@@ -84,11 +84,7 @@ class AdvisoryBodyService
             filters: array_merge($filters, ['_limit' => 200]),
         );
 
-        if (is_array($results) === true) {
-            return $results;
-        }
-
-        return [];
+        return $results;
     }//end findAll()
 
     /**

--- a/lib/Service/CaseTransferService.php
+++ b/lib/Service/CaseTransferService.php
@@ -287,6 +287,10 @@ class CaseTransferService
         $caseId = (string) ($transferData['caseId'] ?? '');
         $now    = (new \DateTime())->format('c');
 
+        // Read the existing custody chain before the status writes below, which
+        // is also where the pre-existing trail must be preserved from.
+        $auditTrail = (array) ($transferData['custodyAuditTrail'] ?? []);
+
         $transferData['status']      = $targetStatus;
         $transferData['completedAt'] = $now;
         if ($targetStatus === 'rejected') {
@@ -299,7 +303,6 @@ class CaseTransferService
             $actorType = 'local';
         }
 
-        $auditTrail   = (array) ($transferData['custodyAuditTrail'] ?? []);
         $auditTrail[] = [
             'event'     => $targetStatus,
             'actor'     => ($remoteCloudId ?? ''),

--- a/lib/Service/ConsultationService.php
+++ b/lib/Service/ConsultationService.php
@@ -164,9 +164,9 @@ class ConsultationService
                 subjectId: (string) $consultationId,
                 payload: [
                     'subjectRegister'   => $register,
-                    'externalReference' => (string) ($data['parentZaak'] ?? ''),
-                    'subjectLabel'      => (string) ($data['consultationNumber'] ?? 'Consultatie'),
-                    'question'          => (string) ($data['vraagstelling'] ?? ''),
+                    'externalReference' => (string) $data['parentZaak'],
+                    'subjectLabel'      => (string) $data['consultationNumber'],
+                    'question'          => (string) $data['vraagstelling'],
                 ],
             );
 

--- a/lib/Service/DoorlooptijdService.php
+++ b/lib/Service/DoorlooptijdService.php
@@ -271,10 +271,6 @@ class DoorlooptijdService
 
         $out = [];
         foreach ($accum as $caseTypeId => $stats) {
-            if ($stats['count'] === 0) {
-                continue;
-            }
-
             if (isset($caseTypeIndex[$caseTypeId]['title']) === true) {
                 $title = (string) $caseTypeIndex[$caseTypeId]['title'];
             } else {

--- a/lib/Service/DwangsomBezwaarService.php
+++ b/lib/Service/DwangsomBezwaarService.php
@@ -112,11 +112,7 @@ class DwangsomBezwaarService
             $uitbetalingen = [];
         }
 
-        foreach ((array) $uitbetalingen as $u) {
-            if (is_array($u) === false) {
-                continue;
-            }
-
+        foreach ($uitbetalingen as $u) {
             $u['status'] = 'on-hold-bezwaar';
             try {
                 $objectService->saveObject($register, $uSchema, $u);
@@ -201,11 +197,7 @@ class DwangsomBezwaarService
             $uitbetalingen = [];
         }
 
-        foreach ((array) $uitbetalingen as $u) {
-            if (is_array($u) === false) {
-                continue;
-            }
-
+        foreach ($uitbetalingen as $u) {
             $u['bedrag'] = $newBedragCents;
             $u['status'] = 'voorbereid';
             try {

--- a/lib/Service/DwangsomUitbetalingService.php
+++ b/lib/Service/DwangsomUitbetalingService.php
@@ -34,7 +34,6 @@ namespace OCA\Procest\Service;
 
 use DateTimeImmutable;
 use OCA\Procest\Service\Support\SearchesObjects;
-use Psr\Log\LoggerInterface;
 use RuntimeException;
 
 /**
@@ -54,11 +53,9 @@ class DwangsomUitbetalingService
      * Constructor.
      *
      * @param SettingsService $settingsService Settings service.
-     * @param LoggerInterface $logger          Logger.
      */
     public function __construct(
         private readonly SettingsService $settingsService,
-        private readonly LoggerInterface $logger,
     ) {
     }//end __construct()
 

--- a/lib/Service/InformatieobjectAccessGuard.php
+++ b/lib/Service/InformatieobjectAccessGuard.php
@@ -229,10 +229,6 @@ class InformatieobjectAccessGuard
 
         $allowed = [];
         foreach ($informatieobjecten as $record) {
-            if (is_array($record) === false) {
-                continue;
-            }
-
             $docOrdinal = $this->ordinalOf(level: (string) ($record['vertrouwelijkheidaanduiding'] ?? ''));
             if ($userOrdinal >= $docOrdinal) {
                 $allowed[] = $record;

--- a/lib/Service/Kcc/BelplanRoutingService.php
+++ b/lib/Service/Kcc/BelplanRoutingService.php
@@ -65,10 +65,6 @@ class BelplanRoutingService
         $normalised = $this->normalisePhone(phoneNumber: $phoneNumber);
 
         foreach ($belplannen as $bp) {
-            if (is_array($bp) === false) {
-                continue;
-            }
-
             if (($bp['isActive'] ?? true) === false) {
                 continue;
             }
@@ -256,10 +252,6 @@ class BelplanRoutingService
         $candidates = [];
         $needle     = mb_strtolower($vaardigheid);
         foreach ($pool as $sp) {
-            if (is_array($sp) === false) {
-                continue;
-            }
-
             $skills = $sp['expertises'] ?? ($sp['vaardigheden'] ?? []);
             if (is_array($skills) === false) {
                 continue;

--- a/lib/Service/KccWerkplekSeedDataService.php
+++ b/lib/Service/KccWerkplekSeedDataService.php
@@ -195,12 +195,10 @@ class KccWerkplekSeedDataService
         }
 
         $ids = [];
-        foreach ((array) $rows as $row) {
+        foreach ($rows as $row) {
             $rowId = '';
-            if (is_array($row) === true && isset($row['id']) === true) {
+            if (isset($row['id']) === true) {
                 $rowId = (string) $row['id'];
-            } else if (is_object($row) === true && isset($row->id) === true) {
-                $rowId = (string) $row->id;
             }
 
             if ($rowId !== '') {

--- a/lib/Service/MandaatCheckService.php
+++ b/lib/Service/MandaatCheckService.php
@@ -77,7 +77,7 @@ class MandaatCheckService
      * @param array<string, mixed>   $caseProperties Case properties for condition matching.
      * @param DateTimeImmutable|null $decisionDate   Optional override (defaults to now).
      *
-     * @return array{authorized:bool, mandaatId?:string, reden?:string, failedConditions?:array<int,string>}
+     * @return array{authorized:bool, mandaatId?:string, reden?:string|null, conflictReason?:string, failedConditions?:array<int,string>}
      *
      * @spec openspec/changes/mandaat-matrix-02-authorization-engine/tasks.md
      */
@@ -108,7 +108,7 @@ class MandaatCheckService
         }
 
         $conflict = $this->conflictService->checkConflict($userId, $caseId, $caseProperties);
-        if (($conflict['conflict'] ?? false) === true) {
+        if ($conflict['conflict'] === true) {
             return [
                 'authorized'     => false,
                 'reden'          => self::REDEN_BELANGENCONFLICT,

--- a/lib/Service/MandaatCheckService.php
+++ b/lib/Service/MandaatCheckService.php
@@ -196,11 +196,7 @@ class MandaatCheckService
         }
 
         $out = [];
-        foreach ((array) $rows as $row) {
-            if (is_array($row) === false) {
-                continue;
-            }
-
+        foreach ($rows as $row) {
             $vf = (string) ($row['validFrom'] ?? '1970-01-01');
             $vu = (string) ($row['validUntil'] ?? '');
             if ($vf > $dateStr) {
@@ -307,11 +303,7 @@ class MandaatCheckService
 
         $dateStr = $date->format('Y-m-d');
         $active  = [];
-        foreach ((array) $rows as $row) {
-            if (is_array($row) === false) {
-                continue;
-            }
-
+        foreach ($rows as $row) {
             $vf = (string) ($row['validFrom'] ?? '1970-01-01');
             $vu = (string) ($row['validUntil'] ?? '');
             if ($vf > $dateStr) {

--- a/lib/Service/MandaatEscalatieService.php
+++ b/lib/Service/MandaatEscalatieService.php
@@ -73,8 +73,8 @@ class MandaatEscalatieService
             'decisionType'    => $decisionType,
             'initiatorId'     => $initiatorId,
             'escalatieReden'  => $escalatieReden,
-            'targetMandaatId' => (string) ($path['mandaatId'] ?? ''),
-            'targetUserId'    => (string) ($path['userId'] ?? ''),
+            'targetMandaatId' => $path['mandaatId'],
+            'targetUserId'    => $path['userId'],
             'status'          => 'open',
             'createdAt'       => (new DateTimeImmutable())->format('Y-m-d\TH:i:sP'),
         ];

--- a/lib/Service/MandaatEscalatieService.php
+++ b/lib/Service/MandaatEscalatieService.php
@@ -128,11 +128,7 @@ class MandaatEscalatieService
         }
 
         $matching = [];
-        foreach ((array) $mandaten as $m) {
-            if (is_array($m) === false) {
-                continue;
-            }
-
+        foreach ($mandaten as $m) {
             $decTypes = (array) (($m['voorwaarden'] ?? [])['decisionTypes'] ?? []);
             if (count($decTypes) > 0 && in_array($decisionType, $decTypes, true) === false) {
                 continue;
@@ -180,11 +176,7 @@ class MandaatEscalatieService
                 }
             );
 
-            foreach ((array) $assigns as $a) {
-                if (is_array($a) === false) {
-                    continue;
-                }
-
+            foreach ($assigns as $a) {
                 $userId = (string) ($a['userId'] ?? '');
                 if ($userId !== '') {
                     return ['mandaatId' => (string) ($m['id'] ?? ''), 'userId' => $userId];
@@ -287,11 +279,7 @@ class MandaatEscalatieService
         }
 
         $count = 0;
-        foreach ((array) $rows as $row) {
-            if (is_array($row) === false) {
-                continue;
-            }
-
+        foreach ($rows as $row) {
             $row['targetUserId'] = $newUserId;
             try {
                 $objectService->saveObject($register, $schema, $row);

--- a/lib/Service/MandaatGebruikService.php
+++ b/lib/Service/MandaatGebruikService.php
@@ -175,11 +175,7 @@ class MandaatGebruikService
         }
 
         $out = [];
-        foreach ((array) $rows as $row) {
-            if (is_array($row) === false) {
-                continue;
-            }
-
+        foreach ($rows as $row) {
             $when = substr((string) ($row['tijdstip'] ?? ''), 0, 10);
             if ($from !== null && $when < $from->format('Y-m-d')) {
                 continue;

--- a/lib/Service/MandaatGebruikService.php
+++ b/lib/Service/MandaatGebruikService.php
@@ -124,12 +124,7 @@ class MandaatGebruikService
         }
 
         try {
-            $rows = $this->searchObjectsAsArrays(objectService: $objectService, register: $register, schema: $schema, filters: ['zaakId' => $zaakId]);
-            if (is_array($rows) === true) {
-                return $rows;
-            }
-
-            return [];
+            return $this->searchObjectsAsArrays(objectService: $objectService, register: $register, schema: $schema, filters: ['zaakId' => $zaakId]);
         } catch (\Throwable $e) {
             return [];
         }
@@ -167,11 +162,7 @@ class MandaatGebruikService
         }
 
         if ($from === null && $until === null) {
-            if (is_array($rows) === true) {
-                return $rows;
-            }
-
-            return [];
+            return $rows;
         }
 
         $out = [];

--- a/lib/Service/MandaatImportService.php
+++ b/lib/Service/MandaatImportService.php
@@ -248,11 +248,7 @@ class MandaatImportService
             $mandaten = [];
         }
 
-        foreach ((array) $mandaten as $m) {
-            if (is_array($m) === false) {
-                continue;
-            }
-
+        foreach ($mandaten as $m) {
             $m['status'] = 'active';
             if (isset($m['validFrom']) === false || $m['validFrom'] === '') {
                 $m['validFrom'] = $now;
@@ -286,11 +282,7 @@ class MandaatImportService
             return [];
         }
 
-        $header = str_getcsv($lines[0]);
-        if (is_array($header) === false) {
-            return [];
-        }
-
+        $header  = str_getcsv($lines[0]);
         $missing = array_diff(self::REQUIRED_COLUMNS, $header);
         if (count($missing) > 0) {
             throw new RuntimeException('Missing required CSV columns: '.implode(', ', $missing));
@@ -304,10 +296,6 @@ class MandaatImportService
             }
 
             $values = str_getcsv($line);
-            if (is_array($values) === false) {
-                continue;
-            }
-
             $rows[] = array_combine($header, array_pad($values, count($header), ''));
         }
 
@@ -335,11 +323,7 @@ class MandaatImportService
         }
 
         $out = [];
-        foreach ((array) $rows as $row) {
-            if (is_array($row) === false) {
-                continue;
-            }
-
+        foreach ($rows as $row) {
             $rolNaam = (string) ($row['rolNaam'] ?? '');
             if ($rolNaam !== '') {
                 $out[$rolNaam] = (string) ($row['id'] ?? '');
@@ -377,11 +361,7 @@ class MandaatImportService
             return null;
         }
 
-        foreach ((array) $rows as $row) {
-            if (is_array($row) === false) {
-                continue;
-            }
-
+        foreach ($rows as $row) {
             if ($excludeId !== null && (string) ($row['id'] ?? '') === $excludeId) {
                 continue;
             }

--- a/lib/Service/MandaatImportService.php
+++ b/lib/Service/MandaatImportService.php
@@ -159,7 +159,7 @@ class MandaatImportService
             $changed       = false;
             $changedFields = [];
             foreach (['omschrijving', 'gemandateerdeRol', 'wettelijkeGrondslag'] as $f) {
-                if ((string) ($existing[$f] ?? '') !== (string) ($payload[$f] ?? '')) {
+                if ((string) ($existing[$f] ?? '') !== (string) $payload[$f]) {
                     $changed         = true;
                     $changedFields[] = $f;
                 }

--- a/lib/Service/MapTileService.php
+++ b/lib/Service/MapTileService.php
@@ -292,7 +292,7 @@ class MapTileService
         }
 
         foreach ($zoomLevels as $z) {
-            if (is_int($z) === false || $z < 0 || $z > self::MAX_ZOOM) {
+            if ($z < 0 || $z > self::MAX_ZOOM) {
                 throw new \InvalidArgumentException(
                     sprintf('zoom %s out of range [0, %d]', (string) $z, self::MAX_ZOOM)
                 );

--- a/lib/Service/ParaferingApprovalBridge.php
+++ b/lib/Service/ParaferingApprovalBridge.php
@@ -254,10 +254,6 @@ class ParaferingApprovalBridge
         $mapped = [];
         $order  = 1;
         foreach ($steps as $step) {
-            if (is_array($step) === false) {
-                continue;
-            }
-
             if (($step['skipped'] ?? false) === true) {
                 continue;
             }

--- a/lib/Service/PdokService.php
+++ b/lib/Service/PdokService.php
@@ -199,7 +199,7 @@ class PdokService
         }
 
         $route = $this->urlGenerator->linkToRoute('openconnector.pdok.parcel');
-        if ($route === '' || $route === null) {
+        if ($route === '') {
             $route = self::SHIM_BASE_PATH.'/parcel';
         }
 

--- a/lib/Service/PdokService.php
+++ b/lib/Service/PdokService.php
@@ -189,6 +189,9 @@ class PdokService
      * @param array<string,mixed> $criteria Search criteria.
      *
      * @return array<int, array<string,mixed>> Matching parcels (may be empty).
+     *
+     * @spec exclude phpstan dead-code cleanup only — dropped an always-false `$route === null`
+     *       branch on a `string`-typed value; no behavioural or contractual change.
      */
     public function searchParcel(array $criteria): array
     {

--- a/lib/Service/ProcessMiningService.php
+++ b/lib/Service/ProcessMiningService.php
@@ -43,7 +43,6 @@ namespace OCA\Procest\Service;
 use DateInterval;
 use DateTimeImmutable;
 use OCA\Procest\Service\Support\SearchesObjects;
-use Psr\Log\LoggerInterface;
 
 /**
  * Computes process-mining bottleneck metrics from recorded status history.
@@ -57,11 +56,9 @@ class ProcessMiningService
      * Constructor.
      *
      * @param SettingsService $settingsService Shared settings/OR resolver.
-     * @param LoggerInterface $logger          Logger.
      */
     public function __construct(
         private readonly SettingsService $settingsService,
-        private readonly LoggerInterface $logger,
     ) {
     }//end __construct()
 

--- a/lib/Service/PublicationService.php
+++ b/lib/Service/PublicationService.php
@@ -74,6 +74,7 @@ class PublicationService
      *
      * @return array<string, mixed> The publication record + updated case ref.
      *
+     * @throws \InvalidArgumentException When the requested publication channel is not supported.
      * @throws \RuntimeException When OR is unavailable or the case can't be loaded.
      *
      * @spec openspec/changes/besluitvorming-workflow/tasks.md#task-7

--- a/lib/Service/Stuf/StufAdapterService.php
+++ b/lib/Service/Stuf/StufAdapterService.php
@@ -147,7 +147,7 @@ class StufAdapterService
         return [
             'success'           => $result['success'],
             'referentienummer'  => $referentienummer,
-            'stufMessageId'     => (string) ($result['messageId'] ?? ($msg['id'] ?? '')),
+            'stufMessageId'     => $result['messageId'],
             'zaakIdentificatie' => $zaakIdentificatie,
             'mappingId'         => ($mapping['id'] ?? null),
             'fout'              => ($result['fout'] ?? null),
@@ -220,8 +220,8 @@ class StufAdapterService
         return [
             'success'          => $result['success'],
             'referentienummer' => $referentienummer,
-            'stufMessageId'    => (string) ($result['messageId'] ?? ($msg['id'] ?? '')),
-            'fout'             => ($result['fout'] ?? null),
+            'stufMessageId'    => $result['messageId'],
+            'fout'             => $result['fout'],
         ];
     }//end actualiseerZaak()
 
@@ -266,7 +266,7 @@ class StufAdapterService
             $this->messageHandler->transitionStatus(
                 msg: $msg,
                 newStatus: 'fout',
-                extras: ['fout' => $response['fout'], 'duurMs' => ($response['durationMs'] ?? 0)]
+                extras: ['fout' => $response['fout'], 'duurMs' => $response['durationMs']]
             );
             $this->needsInput->dispatch(
                 type: 'stuf_timeout',
@@ -284,10 +284,10 @@ class StufAdapterService
             msg: $msg,
             newStatus: $detailStatus,
             extras: [
-                'httpStatus'          => ($response['httpStatus'] ?? 0),
-                'duurMs'              => ($response['durationMs'] ?? 0),
-                'responseEnvelopeXml' => ($response['responseXml'] ?? ''),
-                'fout'                => ($response['fout'] ?? null),
+                'httpStatus'          => $response['httpStatus'],
+                'duurMs'              => $response['durationMs'],
+                'responseEnvelopeXml' => $response['responseXml'],
+                'fout'                => $response['fout'],
             ]
         );
 
@@ -295,7 +295,7 @@ class StufAdapterService
             return null;
         }
 
-        return $this->parser->parseZaakDetails(responseXml: (string) ($response['responseXml'] ?? ''));
+        return $this->parser->parseZaakDetails(responseXml: $response['responseXml']);
     }//end geefZaakDetails()
 
     /**
@@ -345,8 +345,8 @@ class StufAdapterService
         return [
             'success'          => $result['success'],
             'referentienummer' => $referentienummer,
-            'stufMessageId'    => (string) ($result['messageId'] ?? ($msg['id'] ?? '')),
-            'fout'             => ($result['fout'] ?? null),
+            'stufMessageId'    => $result['messageId'],
+            'fout'             => $result['fout'],
         ];
     }//end vrijBericht()
 
@@ -378,7 +378,7 @@ class StufAdapterService
             timeoutSeconds: StufHttpClient::DEFAULT_TIMEOUT_SECONDS
         );
 
-        $bv = $this->parser->parseBevestiging(responseXml: (string) ($response['responseXml'] ?? ''));
+        $bv = $this->parser->parseBevestiging(responseXml: $response['responseXml']);
 
         $vrijStatus = 'fout';
         if ($response['httpStatus'] >= 200 && $response['httpStatus'] < 300) {
@@ -389,9 +389,9 @@ class StufAdapterService
             msg: $msg,
             newStatus: $vrijStatus,
             extras: [
-                'httpStatus'          => ($response['httpStatus'] ?? 0),
-                'duurMs'              => ($response['durationMs'] ?? 0),
-                'responseEnvelopeXml' => ($response['responseXml'] ?? ''),
+                'httpStatus'          => $response['httpStatus'],
+                'duurMs'              => $response['durationMs'],
+                'responseEnvelopeXml' => $response['responseXml'],
                 'zaakIdentificatie'   => ($bv['zaakIdentificatie'] ?? ''),
             ]
         );
@@ -520,10 +520,10 @@ class StufAdapterService
         if ($fout === null && $body !== '') {
             $parsed = $this->parser->parseError(responseXml: $body);
             $fout   = [
-                'code'         => ($parsed['code'] ?? ''),
-                'omschrijving' => ($parsed['omschrijving'] ?? ''),
-                'details'      => ($parsed['details'] ?? ''),
-                'soort'        => ($parsed['soort'] ?? 'permanent'),
+                'code'         => $parsed['code'],
+                'omschrijving' => $parsed['omschrijving'],
+                'details'      => $parsed['details'],
+                'soort'        => $parsed['soort'],
             ];
         }
 

--- a/lib/Service/Stuf/StufAdapterService.php
+++ b/lib/Service/Stuf/StufAdapterService.php
@@ -55,16 +55,15 @@ class StufAdapterService
     /**
      * Constructor.
      *
-     * @param StufMessageBuilder      $builder        The envelope builder (inbound + outbound).
-     * @param StufHttpClient          $httpClient     The HTTP transport.
-     * @param StufMessageHandler      $messageHandler The audit log handler.
-     * @param StufMessageParser       $parser         The response parser.
-     * @param CircuitBreakerService   $circuitBreaker The circuit breaker.
-     * @param ContactBetrokkeneMapper $contactMapper  The contact mapper.
-     * @param StufRegisterAccess      $register       The register access helper.
-     * @param NeedsInputDispatcher    $needsInput     The needs-input dispatcher.
-     * @param IJobList                $jobList        The background job list (for retry scheduling).
-     * @param LoggerInterface         $logger         The logger.
+     * @param StufMessageBuilder    $builder        The envelope builder (inbound + outbound).
+     * @param StufHttpClient        $httpClient     The HTTP transport.
+     * @param StufMessageHandler    $messageHandler The audit log handler.
+     * @param StufMessageParser     $parser         The response parser.
+     * @param CircuitBreakerService $circuitBreaker The circuit breaker.
+     * @param StufRegisterAccess    $register       The register access helper.
+     * @param NeedsInputDispatcher  $needsInput     The needs-input dispatcher.
+     * @param IJobList              $jobList        The background job list (for retry scheduling).
+     * @param LoggerInterface       $logger         The logger.
      */
     public function __construct(
         private StufMessageBuilder $builder,
@@ -72,7 +71,6 @@ class StufAdapterService
         private StufMessageHandler $messageHandler,
         private StufMessageParser $parser,
         private CircuitBreakerService $circuitBreaker,
-        private ContactBetrokkeneMapper $contactMapper,
         private StufRegisterAccess $register,
         private NeedsInputDispatcher $needsInput,
         private IJobList $jobList,

--- a/lib/Service/Stuf/StufMessageHandler.php
+++ b/lib/Service/Stuf/StufMessageHandler.php
@@ -30,7 +30,6 @@ namespace OCA\Procest\Service\Stuf;
 
 use DateTimeImmutable;
 use DateTimeZone;
-use Psr\Log\LoggerInterface;
 
 /**
  * Persists and updates StufMessage audit rows.
@@ -41,11 +40,9 @@ class StufMessageHandler
      * Constructor.
      *
      * @param StufRegisterAccess $register The register access helper.
-     * @param LoggerInterface    $logger   The logger.
      */
     public function __construct(
         private StufRegisterAccess $register,
-        private LoggerInterface $logger,
     ) {
     }//end __construct()
 

--- a/lib/Service/Stuf/StufMessageParser.php
+++ b/lib/Service/Stuf/StufMessageParser.php
@@ -94,7 +94,7 @@ class StufMessageParser
 
         $this->logger->debug(
             message: 'StUF parseBevestiging: crossRef={cross}, zaakId={zaak}',
-            context: ['cross' => $crossRef, 'zaak' => ($zaakId ?? '')]
+            context: ['cross' => $crossRef, 'zaak' => $zaakId]
         );
 
         if ($zaakId === '') {

--- a/lib/Service/TenantAuditTrailService.php
+++ b/lib/Service/TenantAuditTrailService.php
@@ -180,8 +180,10 @@ class TenantAuditTrailService
      */
     private function getAuditTrailMapper(): mixed
     {
-        $installed = $this->appManager->getInstalledApps();
-        if (is_array($installed) === false || in_array('openregister', $installed, true) === false) {
+        // IAppManager::getInstalledApps() declares its array return in PHPDoc
+        // only, so normalise defensively before the membership test.
+        $installed = (array) $this->appManager->getInstalledApps();
+        if (in_array('openregister', $installed, true) === false) {
             return null;
         }
 

--- a/lib/Service/TenantAuthenticationService.php
+++ b/lib/Service/TenantAuthenticationService.php
@@ -275,8 +275,10 @@ class TenantAuthenticationService
      */
     private function getObjectService()
     {
-        $installed = $this->appManager->getInstalledApps();
-        if (is_array($installed) === false || in_array('openregister', $installed, true) === false) {
+        // IAppManager::getInstalledApps() declares its array return in PHPDoc
+        // only, so normalise defensively before the membership test.
+        $installed = (array) $this->appManager->getInstalledApps();
+        if (in_array('openregister', $installed, true) === false) {
             return null;
         }
 

--- a/lib/Service/TenantBillingService.php
+++ b/lib/Service/TenantBillingService.php
@@ -351,8 +351,10 @@ class TenantBillingService
      */
     private function getObjectService()
     {
-        $installed = $this->appManager->getInstalledApps();
-        if (is_array($installed) === false || in_array('openregister', $installed, true) === false) {
+        // IAppManager::getInstalledApps() declares its array return in PHPDoc
+        // only, so normalise defensively before the membership test.
+        $installed = (array) $this->appManager->getInstalledApps();
+        if (in_array('openregister', $installed, true) === false) {
             return null;
         }
 

--- a/lib/Service/TenantBillingService.php
+++ b/lib/Service/TenantBillingService.php
@@ -147,7 +147,7 @@ class TenantBillingService
 
         $payload  = $this->shillinq->buildInvoicePayload(tenantId: $tenantId, month: $month, events: $unbilled);
         $exportRc = $this->shillinq->exportInvoice(payload: $payload);
-        if (($exportRc['success'] ?? false) === true) {
+        if ($exportRc['success'] === true) {
             $invoiceRef           = (string) ($exportRc['invoiceRef'] ?? '');
             $result['exported']   = true;
             $result['invoiceRef'] = $invoiceRef;

--- a/lib/Service/TenantConfigurationService.php
+++ b/lib/Service/TenantConfigurationService.php
@@ -410,8 +410,10 @@ class TenantConfigurationService
      */
     private function getObjectService()
     {
-        $installed = $this->appManager->getInstalledApps();
-        if (is_array($installed) === false || in_array('openregister', $installed, true) === false) {
+        // IAppManager::getInstalledApps() declares its array return in PHPDoc
+        // only, so normalise defensively before the membership test.
+        $installed = (array) $this->appManager->getInstalledApps();
+        if (in_array('openregister', $installed, true) === false) {
             return null;
         }
 

--- a/lib/Service/TenantOnboardingService.php
+++ b/lib/Service/TenantOnboardingService.php
@@ -151,12 +151,9 @@ class TenantOnboardingService
             }
         }
 
-        $total = max(count(self::STEPS), count($rows));
-        if ($total === 0) {
-            $fraction = 0.0;
-        } else {
-            $fraction = ($completed / $total);
-        }
+        // STEPS is non-empty, so $total is always >= 1 and the division is safe.
+        $total    = max(count(self::STEPS), count($rows));
+        $fraction = ($completed / $total);
 
         return [
             'steps'     => array_values($rows),
@@ -356,8 +353,10 @@ class TenantOnboardingService
      */
     private function getObjectService()
     {
-        $installed = $this->appManager->getInstalledApps();
-        if (is_array($installed) === false || in_array('openregister', $installed, true) === false) {
+        // IAppManager::getInstalledApps() declares its array return in PHPDoc
+        // only, so normalise defensively before the membership test.
+        $installed = (array) $this->appManager->getInstalledApps();
+        if (in_array('openregister', $installed, true) === false) {
             return null;
         }
 

--- a/lib/Service/TenantOnboardingService.php
+++ b/lib/Service/TenantOnboardingService.php
@@ -112,6 +112,10 @@ class TenantOnboardingService
      * @param string $tenantId Tenant UUID.
      *
      * @return array{steps: array<int, array<string, mixed>>, completed: int, total: int, fraction: float}
+     *
+     * @spec exclude phpstan dead-code cleanup only — removed an unreachable `$total === 0`
+     *       branch (self::STEPS is non-empty, so max() is always >= 1) and normalised an
+     *       IAppManager return; no behavioural or contractual change.
      */
     public function getProgress(string $tenantId): array
     {

--- a/lib/Service/TenantQuotaService.php
+++ b/lib/Service/TenantQuotaService.php
@@ -352,8 +352,10 @@ class TenantQuotaService
      */
     private function getObjectService()
     {
-        $installed = $this->appManager->getInstalledApps();
-        if (is_array($installed) === false || in_array('openregister', $installed, true) === false) {
+        // IAppManager::getInstalledApps() declares its array return in PHPDoc
+        // only, so normalise defensively before the membership test.
+        $installed = (array) $this->appManager->getInstalledApps();
+        if (in_array('openregister', $installed, true) === false) {
             return null;
         }
 

--- a/lib/Service/TenantSaasService.php
+++ b/lib/Service/TenantSaasService.php
@@ -170,7 +170,7 @@ class TenantSaasService
             'kvkNumber'     => $kvkNumber,
             'status'        => 'onboarding',
             'tier'          => $tier,
-            'isolationMode' => (self::TIER_ISOLATION[$tier] ?? 'schema'),
+            'isolationMode' => self::TIER_ISOLATION[$tier],
             'dataResidency' => 'nl',
             'createdAt'     => (new \DateTimeImmutable('now'))->format(DATE_ATOM),
         ];

--- a/lib/Service/TenantSaasService.php
+++ b/lib/Service/TenantSaasService.php
@@ -470,8 +470,10 @@ class TenantSaasService
      */
     private function getObjectService()
     {
-        $installed = $this->appManager->getInstalledApps();
-        if (is_array($installed) === false || in_array('openregister', $installed, true) === false) {
+        // IAppManager::getInstalledApps() declares its array return in PHPDoc
+        // only, so normalise defensively before the membership test.
+        $installed = (array) $this->appManager->getInstalledApps();
+        if (in_array('openregister', $installed, true) === false) {
             return null;
         }
 

--- a/lib/Service/TermijnDailyScanService.php
+++ b/lib/Service/TermijnDailyScanService.php
@@ -103,11 +103,7 @@ class TermijnDailyScanService
             return $counts;
         }
 
-        foreach ((array) $rows as $row) {
-            if (is_array($row) === false) {
-                continue;
-            }
-
+        foreach ($rows as $row) {
             $counts['scanned']++;
             try {
                 $this->processInstance(row: $row, now: $now, counts: $counts);
@@ -157,11 +153,7 @@ class TermijnDailyScanService
         }
 
         $accrued = 0;
-        foreach ((array) $rows as $row) {
-            if (is_array($row) === false) {
-                continue;
-            }
-
+        foreach ($rows as $row) {
             $id = (string) ($row['id'] ?? '');
             if ($id === '') {
                 continue;

--- a/lib/Service/TermijnExtensionService.php
+++ b/lib/Service/TermijnExtensionService.php
@@ -31,7 +31,6 @@ declare(strict_types=1);
 namespace OCA\Procest\Service;
 
 use DateTimeImmutable;
-use Psr\Log\LoggerInterface;
 use RuntimeException;
 
 /**
@@ -42,12 +41,10 @@ class TermijnExtensionService
     /**
      * Constructor.
      *
-     * @param TermijnService  $termijnService TermijnService.
-     * @param LoggerInterface $logger         Logger.
+     * @param TermijnService $termijnService TermijnService.
      */
     public function __construct(
         private readonly TermijnService $termijnService,
-        private readonly LoggerInterface $logger,
     ) {
     }//end __construct()
 

--- a/lib/Service/TermijnPauseService.php
+++ b/lib/Service/TermijnPauseService.php
@@ -31,7 +31,6 @@ declare(strict_types=1);
 namespace OCA\Procest\Service;
 
 use DateTimeImmutable;
-use Psr\Log\LoggerInterface;
 use RuntimeException;
 
 /**
@@ -42,12 +41,10 @@ class TermijnPauseService
     /**
      * Constructor.
      *
-     * @param TermijnService  $termijnService TermijnService.
-     * @param LoggerInterface $logger         Logger.
+     * @param TermijnService $termijnService TermijnService.
      */
     public function __construct(
         private readonly TermijnService $termijnService,
-        private readonly LoggerInterface $logger,
     ) {
     }//end __construct()
 

--- a/lib/Service/TermijnReportingService.php
+++ b/lib/Service/TermijnReportingService.php
@@ -116,12 +116,10 @@ class TermijnReportingService
         // Reduce per-type aggregates.
         $perType = [];
         foreach ($byType as $type => $b) {
-            $totaal = $b['totaal'];
-            if ($totaal > 0) {
-                $binnenPct = round(($b['binnenTermijn'] / $totaal) * 100, 1);
-            } else {
-                $binnenPct = 0.0;
-            }
+            // $byType entries are only created when a row is counted, so
+            // 'totaal' is always >= 1 here.
+            $totaal    = $b['totaal'];
+            $binnenPct = round(($b['binnenTermijn'] / $totaal) * 100, 1);
 
             $aantalDoorlooptijden = count($b['doorlooptijdenDagen']);
             if ($aantalDoorlooptijden > 0) {

--- a/lib/Service/TermijnReportingService.php
+++ b/lib/Service/TermijnReportingService.php
@@ -36,7 +36,6 @@ namespace OCA\Procest\Service;
 
 use DateTimeImmutable;
 use OCA\Procest\Service\Support\SearchesObjects;
-use Psr\Log\LoggerInterface;
 use RuntimeException;
 
 /**
@@ -50,11 +49,9 @@ class TermijnReportingService
      * Constructor.
      *
      * @param SettingsService $settingsService Settings.
-     * @param LoggerInterface $logger          Logger.
      */
     public function __construct(
         private readonly SettingsService $settingsService,
-        private readonly LoggerInterface $logger,
     ) {
     }//end __construct()
 

--- a/lib/Service/TermijnReportingService.php
+++ b/lib/Service/TermijnReportingService.php
@@ -183,11 +183,7 @@ class TermijnReportingService
         $totaal     = 0;
         $warnings   = [];
 
-        foreach ((array) $rows as $row) {
-            if (is_array($row) === false) {
-                continue;
-            }
-
+        foreach ($rows as $row) {
             $betaal = (string) ($row['werkelijkeBetaaldatum'] ?? '');
             if (str_starts_with($betaal, $jaarPrefix) === false) {
                 continue;
@@ -368,11 +364,7 @@ class TermijnReportingService
         }
 
         $out = [];
-        foreach ((array) $rows as $row) {
-            if (is_array($row) === false) {
-                continue;
-            }
-
+        foreach ($rows as $row) {
             $start = substr((string) ($row['startDatum'] ?? ''), 0, 10);
             if ($start === '' || ($start >= $from && $start <= $until) === false) {
                 continue;

--- a/lib/Service/TermijnService.php
+++ b/lib/Service/TermijnService.php
@@ -194,10 +194,6 @@ class TermijnService
             return null;
         }
 
-        if (is_array($rows) === false) {
-            $rows = [];
-        }
-
         if (count($rows) === 0) {
             return null;
         }
@@ -279,11 +275,7 @@ class TermijnService
 
         $today  = (new DateTimeImmutable())->format('Y-m-d');
         $active = [];
-        foreach ((array) $rows as $row) {
-            if (is_array($row) === false) {
-                continue;
-            }
-
+        foreach ($rows as $row) {
             $validFrom  = (string) ($row['validFrom'] ?? '1970-01-01');
             $validUntil = (string) ($row['validUntil'] ?? '');
             if ($validFrom <= $today && ($validUntil === '' || $validUntil >= $today)) {

--- a/lib/Service/TermijnbewakingSeedDataService.php
+++ b/lib/Service/TermijnbewakingSeedDataService.php
@@ -130,12 +130,10 @@ class TermijnbewakingSeedDataService
         }
 
         $ids = [];
-        foreach ((array) $rows as $row) {
+        foreach ($rows as $row) {
             $rowId = '';
-            if (is_array($row) === true && isset($row['id']) === true) {
+            if (isset($row['id']) === true) {
                 $rowId = (string) $row['id'];
-            } else if (is_object($row) === true && isset($row->id) === true) {
-                $rowId = (string) $row->id;
             }
 
             if ($rowId !== '') {

--- a/lib/Service/WorkQueueService.php
+++ b/lib/Service/WorkQueueService.php
@@ -234,10 +234,6 @@ class WorkQueueService
     {
         $counts = [];
         foreach ($cases as $case) {
-            if (is_array($case) === false) {
-                continue;
-            }
-
             $endDate = (string) ($case['endDate'] ?? '');
             if ($endDate !== '') {
                 // Closed case — not part of the open workload.
@@ -346,10 +342,6 @@ class WorkQueueService
 
         $items = [];
         foreach ($cases as $case) {
-            if (is_array($case) === false) {
-                continue;
-            }
-
             $endDate = (string) ($case['endDate'] ?? '');
             if ($endDate !== '') {
                 // Closed case — not part of the open queue.
@@ -409,10 +401,6 @@ class WorkQueueService
 
         $items = [];
         foreach ($tasks as $task) {
-            if (is_array($task) === false) {
-                continue;
-            }
-
             $status = (string) ($task['status'] ?? '');
             if (in_array($status, self::TASK_TERMINAL_STATUSES, true) === true) {
                 continue;
@@ -504,10 +492,6 @@ class WorkQueueService
 
         $nearest = null;
         foreach ($instances as $instance) {
-            if (is_array($instance) === false) {
-                continue;
-            }
-
             $date = (string) ($instance['einddatumActueel'] ?? '');
             if ($date === '' || ($nearest !== null && $date >= $nearest)) {
                 continue;

--- a/lib/Service/WorkflowEngineService.php
+++ b/lib/Service/WorkflowEngineService.php
@@ -107,7 +107,7 @@ class WorkflowEngineService
      * @param string      $caseId The case id.
      * @param string|null $userId Optional user id; defaults to the current user.
      *
-     * @return array<int, array<string, mixed>> The transitions list.
+     * @return array{transitions: array<int, array<string, mixed>>, current: array<string, mixed>} The transitions envelope.
      *
      * @spec openspec/changes/workflow-engine-enhancement/tasks.md#W-3
      */
@@ -140,7 +140,7 @@ class WorkflowEngineService
 
         $unmet = [];
         foreach ($results as $r) {
-            $passed = (bool) ($r['passed'] ?? ($r['result']['passed'] ?? false));
+            $passed = (bool) $r['passed'];
             if ($passed === false) {
                 $unmet[] = $r;
             }

--- a/lib/Service/ZgwZtcRulesService.php
+++ b/lib/Service/ZgwZtcRulesService.php
@@ -1125,10 +1125,6 @@ class ZgwZtcRulesService extends ZgwRulesBase
         $activeCount = 0;
         $closedCount = 0;
         foreach ($cases as $case) {
-            if (is_array($case) === false) {
-                continue;
-            }
-
             $caseStatus = (string) ($case['status'] ?? '');
             if ($caseStatus !== '' && in_array($caseStatus, $finalSlugs, true) === true) {
                 $closedCount++;

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -17,6 +17,15 @@ parameters:
         - lib/Resources/template
     scanDirectories:
         - vendor/nextcloud/ocp
+    typeAliases:
+        # OCP declares `@psalm-type DataResponseType = ...` in the DataResponse
+        # class docblock and immediately uses it as a @template bound. PHPStan
+        # does not pick the alias up from that position and resolves the bound
+        # to a non-existent class `OCP\AppFramework\Http\DataResponseType`, so
+        # EVERY `new DataResponse(...)` is reported as a type error. This is a
+        # verbatim copy of the OCP alias, not a widening — it makes the generic
+        # bound resolvable instead of silencing the rule.
+        DataResponseType: 'array|int|float|string|bool|object|null|\stdClass|\JsonSerializable'
     reportUnmatchedIgnoredErrors: false
     ignoreErrors:
         # Nextcloud server internals (\OC, OC_App, OC\) not stubbed in nextcloud/ocp

--- a/tests/Unit/Service/DwangsomUitbetalingServiceTest.php
+++ b/tests/Unit/Service/DwangsomUitbetalingServiceTest.php
@@ -53,7 +53,7 @@ class DwangsomUitbetalingServiceTest extends TestCase
             },
         );
 
-        $this->service = new DwangsomUitbetalingService($settings, $this->createMock(LoggerInterface::class));
+        $this->service = new DwangsomUitbetalingService($settings);
 
         // Seed a stopped berekening.
         $this->objects->saveObject('procest', 'dwangsomBerekening', [

--- a/tests/Unit/Service/ProcessMiningServiceTest.php
+++ b/tests/Unit/Service/ProcessMiningServiceTest.php
@@ -64,7 +64,7 @@ class ProcessMiningServiceTest extends TestCase
             },
         );
 
-        $this->service = new ProcessMiningService($settings, $this->createMock(LoggerInterface::class));
+        $this->service = new ProcessMiningService($settings);
     }//end setUp()
 
     /**

--- a/tests/Unit/Service/TermijnPauseExtensionServiceTest.php
+++ b/tests/Unit/Service/TermijnPauseExtensionServiceTest.php
@@ -64,8 +64,8 @@ class TermijnPauseExtensionServiceTest extends TestCase
 
         $logger = $this->createMock(LoggerInterface::class);
         $this->termijnService = new TermijnService($settings, $logger);
-        $this->pauseService   = new TermijnPauseService($this->termijnService, $logger);
-        $this->extService     = new TermijnExtensionService($this->termijnService, $logger);
+        $this->pauseService   = new TermijnPauseService($this->termijnService);
+        $this->extService     = new TermijnExtensionService($this->termijnService);
 
         // Seed an Omgevingsvergunning definition (max 1 extension).
         $this->objects->saveObject('procest', 'termijnDefinitie', [

--- a/tests/Unit/Service/TermijnReportingServiceTest.php
+++ b/tests/Unit/Service/TermijnReportingServiceTest.php
@@ -51,7 +51,7 @@ class TermijnReportingServiceTest extends TestCase
             },
         );
 
-        $this->service = new TermijnReportingService($settings, $this->createMock(LoggerInterface::class));
+        $this->service = new TermijnReportingService($settings);
 
         // Seed 5 instances spread across Q2-2026 for one zaaktype.
         for ($i = 1; $i <= 5; $i++) {

--- a/tests/Unit/Service/TermijnbewakingEndToEndTest.php
+++ b/tests/Unit/Service/TermijnbewakingEndToEndTest.php
@@ -85,11 +85,11 @@ class TermijnbewakingEndToEndTest extends TestCase
 
         $logger = $this->createMock(LoggerInterface::class);
         $this->termijnService = new TermijnService($settings, $logger);
-        $this->pauseService   = new TermijnPauseService($this->termijnService, $logger);
-        $this->extService     = new TermijnExtensionService($this->termijnService, $logger);
+        $this->pauseService   = new TermijnPauseService($this->termijnService);
+        $this->extService     = new TermijnExtensionService($this->termijnService);
         $this->ingService     = new IngebrekestellingService($settings, $this->termijnService, $logger);
         $this->calcService    = new DwangsomCalculationService($settings, $logger);
-        $this->uitService     = new DwangsomUitbetalingService($settings, $logger);
+        $this->uitService     = new DwangsomUitbetalingService($settings);
         $this->bezService     = new DwangsomBezwaarService($settings, $this->termijnService, $logger);
         $this->notifService   = new TermijnNotificationService(
             $this->termijnService,


### PR DESCRIPTION
## PHPStan 139 → 7

Measured at level 5 in a PHP 8.3 container on a fresh `composer install`, against `origin/development`.

**`phpstan-baseline.neon` is untouched, no `ignoreErrors` were added, and there are no inline suppressions.** These are real fixes, not mutes.

| Rule class | Before | Cleared |
|---|---|---|
| Strict comparison always false (dead guards) | 45 | 45 |
| Offset on left of `??` always exists / never exists | 31 | 30 |
| `DataResponse` `T of DataResponseType` | 10 | 10 |
| Undefined method on `OCP\...\Event` (unnarrowed listener) | 13 | 13 |
| Property never read, only written | 10 | 8 |
| `Unknown parameter` on duck-typed `stdClass` | 6 | 3 |
| Unreachable statement / dead catch | 5 | 5 |
| `AuthorizedAdminSetting` class-string | 3 | 3 |
| Return-type mismatches / misc | 16 | 15 |

Other gates on this branch, all measured on the same tree:
`phpcs` 0 errors · `psalm` 0 · `phpunit` **1684 passing, 5 skipped, 0 failures, 5614 assertions** — identical to `origin/development`, assertion count included, not just the test count.

## Two things a reviewer should look at specifically

### 1. `StufController` authorization attribute — a real behavioural change

`#[AuthorizedAdminSetting(Application::APP_ID)]` on 3 methods was passing an **app id** where the attribute requires a `class-string<IDelegatedSettings>`. Nextcloud's delegated-admin lookup could therefore never match, so admin-settings delegation was silently dead on those endpoints (full admins were unaffected).

Changed to `AdminSettings::class` — which `SetupController` in this same app already does, and `AdminSettings implements IDelegatedSettings` is verified.

**This widens access** to whichever group an admin has *explicitly* delegated procest's admin settings to. That is the attribute's intended behaviour, but it is a genuine change to an authorization surface, so it is called out here rather than buried in a lint PR. It is isolated in its own commit if you want it reverted separately.

### 2. `phpstan.neon` gained a `typeAliases` entry — a type definition, not a mute

PHPStan does not resolve a `@psalm-type` that OCP's own `DataResponse` docblock uses as a `@template` bound in the same docblock. It resolved the bound to a non-existent class `OCP\AppFramework\Http\DataResponseType` and reported **every** `new DataResponse(...)` in the app (all 10) as a type error. The alias is copied **verbatim** from OCP's docblock so analysis can resolve it. This is arguably a fleet-wide fix rather than a procest one.

## The 7 remaining — deliberately left, each a real defect

Papering over these would have destroyed the evidence. Each needs a behavioural decision, not a lint fix:

1. `CaseRelationService::$deelzaakService` never read — `isHierarchyLinked()` hand-rolls a **direct-parent-only** check, so a grandparent link is not detected as an overlap.
2. `ConsultationService::STATUS_TRANSITIONS` unused — `updateStatus()` documents "with transition validation" and `@throws` on an invalid transition, but never consults the map.
3–5. `EmailArchivalService` calls `$objectService->logEvent(...)` — **`logEvent` does not exist anywhere in OpenRegister.** The `method_exists` guard always fails and the fallback logger is what actually runs. Phantom cross-app RPC.
6. `TermijnNotificationService::$router` never read — `BerichtenboxRoutingService` is injected but unused; termijn notifications never reach the berichtenbox.
7. `ZaakdossierService:151` reads `$informatieobject['id']` (the **pre-save** payload, which has no `id`) instead of `$saved`, so `storeRaw()` always receives `uuid: ''`. `AdviceService:669` does the same thing correctly.

## Not addressed here

`phpmd` is still at **1095** findings and remains the reason `composer check:strict` exits non-zero. ~28% of those (308) are the complexity family (CyclomaticComplexity, NPathComplexity, ExcessiveClassComplexity, …) which need real refactoring rather than a lint pass. That work is deliberately not bundled into this PR.
