### PR TITLE
fix(quality): phpmd DevelopmentCodeFragment could never fire on namespaced code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
 		"phpcs": "./vendor/bin/phpcs --standard=phpcs.xml",
 		"phpcs:fix": "./vendor/bin/phpcbf --standard=phpcs.xml",
 		"phpcs:output": "./vendor/bin/phpcs --standard=phpcs.xml --report=json lib/ 2>/dev/null | tail -1 > phpcs-output.json",
-		"phpmd": "if [ -f vendor/bin/phpmd ]; then ./vendor/bin/phpmd lib text phpmd.xml; else echo 'PHPMD not installed, skipping...'; fi",
+		"phpmd": "./vendor/bin/phpmd lib text phpmd.xml",
 		"phpmetrics": "./vendor/bin/phpmetrics --report-html=phpmetrics lib/",
 		"phpmetrics:violations": "./vendor/bin/phpmetrics --violations-xml=phpmetrics/violations.xml lib/",
 		"psalm": "if [ -f vendor/bin/psalm ]; then ./vendor/bin/psalm --threads=1 --no-cache; else echo 'Psalm not installed, skipping...'; fi",

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -48,7 +48,32 @@
     <rule ref="rulesets/design.xml/NumberOfChildren"/>
     <rule ref="rulesets/design.xml/DepthOfInheritance"/>
     <rule ref="rulesets/design.xml/CouplingBetweenObjects"/>
-    <rule ref="rulesets/design.xml/DevelopmentCodeFragment"/>
+    <!-- DevelopmentCodeFragment MUST carry ignore-namespaces=true, or it is dead
+         code in this ruleset. See ConductionNL/openregister#2286.
+
+         PDepend resolves an unqualified call inside a namespaced file to the
+         CURRENT-NAMESPACE-qualified image, so `var_dump($x)` in
+         `namespace OCA\MyApp\Service;` reaches the rule as
+         `OCA\MyApp\Service\var_dump`, which never matches the
+         `unwanted-functions` list. All of our production PHP is namespaced, so
+         with the default (false) the rule catches nothing anywhere.
+
+         Measured on phpmd 2.15.0 / PHP 8.3.32: byte-identical probe class,
+         namespaced -> exit 0, non-namespaced -> exit 2. With
+         ignore-namespaces=true the rule strips the enclosing namespace before
+         matching, the namespaced probe is reported (exit 2), and a clean
+         namespaced file stays exit 0.
+
+         Note: hydra gate 2 (forbidden-patterns) independently greps lib/ for
+         var_dump / die / error_log / print_r / dd / dump and is the broader
+         control - it also catches calls outside methods, which this rule (a
+         MethodAware/FunctionAware rule) cannot see. This rule is the
+         `composer check:strict` half of the same guard; keep both. -->
+    <rule ref="rulesets/design.xml/DevelopmentCodeFragment">
+        <properties>
+            <property name="ignore-namespaces" value="true"/>
+        </properties>
+    </rule>
     <rule ref="rulesets/design.xml/EmptyCatchBlock"/>
     <rule ref="rulesets/design.xml/CountInLoopExpression"/>
 


### PR DESCRIPTION
## The hole

Every Conduction repo enables `rulesets/design.xml/DevelopmentCodeFragment` — the
rule that is supposed to stop `var_dump()` / `print_r()` / `var_export()` shipping
in production code. **It has never reported anything, in any repo.**

The cause is a config gap, not a phpmd bug. PDepend resolves an *unqualified*
call inside a namespaced file to the current-namespace-qualified image, so:

```php
namespace OCA\MyApp\Service;
...
var_dump($x);          // reaches the rule as OCA\MyApp\Service\var_dump
```

…which never matches the rule's `unwanted-functions` list. All of our production
PHP is namespaced, so with the default (`ignore-namespaces=false`) the rule is
dead everywhere. The fleet has had **no `composer check:strict` protection
against shipped debug helpers**.

The rule's own `ignore-namespaces` property is the switch. This PR copies the
configuration already merged in openregister (`ConductionNL/openregister#2286`).

## Proof it now fires

phpmd 2.15.0 / PHP 8.3.32, run against **this repo's own `phpmd.xml`**, using a
byte-identical pair of namespaced probe classes:

| probe | before | after |
|---|---|---|
| namespaced class calling `var_dump()` | exit 0, **no finding** | **exit 2, `DevelopmentCodeFragment`** |
| same class, call removed | exit 0 | exit 0, no finding |

Both directions are checked deliberately: a repair that only shows "something
failed" cannot distinguish a working rule from a noisy one.

## Blast radius: 0 new findings

**Measured, not assumed.** The rule was run in isolation over this repo's scanned
path at the base branch before the flip: **0 findings.**

The zero carries a **per-run positive control** — the namespaced probe was dropped
into the same extracted tree and did produce `exit 2`, so this is a true zero and
not a harness that silently analysed nothing. An independent `git grep` for
`var_dump|print_r|dd|dump` across `lib/` agrees. **Nothing is baselined or
suppressed by this PR.**

## Note on overlap with hydra gate 2

`hydra-gate-forbidden-patterns` independently greps `lib/` for
`var_dump / die / error_log / print_r / dd / dump`, and is the broader control —
it also catches calls made outside a method body, which `DevelopmentCodeFragment`
(a MethodAware/FunctionAware rule) structurally cannot see. That gate is why the
measured count is 0: **it has been holding this line alone.** This rule is the
`composer check:strict` half of the same guard. Keep both.

## Also: the composer script guard

This PR also drops the `if [ -f vendor/bin/phpmd ]` wrapper from the `phpmd`
script. A file-presence guard that echoes and returns 0 is the same silent-pass
defect as the `|| echo '... skipping'` it replaced — a phpmd that failed to
install reads as a phpmd that found nothing.

`phpmd/phpmd` is a declared `require-dev` and the shared quality workflow runs
`composer install` before the gate, so this is a **no-op whenever the tool is
present** and a loud failure when it is not. The shared workflow already states
this rule for its own `require_script` check (`ConductionNL/.github#121`).

`psalm` / `phpstan` / `test:*` in the same file still carry the guard. Left
alone deliberately — not measured in this pass.
