### PR TITLE
refactor(quality): PHPMD 1084 → 682 — MissingImport to zero, no baseline

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -30,6 +30,19 @@ use OCA\OpenRegister\Event\ObjectCreatingEvent;
 use OCA\OpenRegister\Event\ObjectDeletedEvent;
 use OCA\OpenRegister\Event\ObjectUpdatedEvent;
 use OCA\OpenRegister\Event\ObjectUpdatingEvent;
+use OCA\Procest\Controller\DashboardController;
+use OCA\Procest\Controller\SettingsController;
+use OCA\Procest\Repair\InitializeSettings;
+use OCA\Procest\Sections\SettingsSection;
+use OCA\Procest\Service\Auth\SimulatorDigidSamlAdapter;
+use OCA\Procest\Service\Auth\SimulatorEHerkenningSamlAdapter;
+use OCA\Procest\Service\External\Bag\BagApiAdapter;
+use OCA\Procest\Service\External\Brk\BrkApiAdapter;
+use OCA\Procest\Service\External\Brp\HaalCentraalBrpAdapter;
+use OCA\Procest\Service\External\Kvk\KvkApiAdapter;
+use OCA\Procest\Service\External\Woz\WozApiAdapter;
+use OCA\Procest\Service\SettingsService;
+use OCA\Procest\Settings\AdminSettings;
 use OCA\Procest\Service\Beschikking\ArchivalAdapterInterface;
 use OCA\Procest\Service\Beschikking\LibresignApiClient;
 use OCA\Procest\Service\Beschikking\LibresignSigningAdapter;
@@ -150,21 +163,21 @@ class Application extends App implements IBootstrap
         // with an explicit factory that constructs the REAL procest class —
         // overriding the Bootstrap generic factory for the same key.
         $context->registerService(
-            \OCA\Procest\Controller\DashboardController::class,
-            static function (\Psr\Container\ContainerInterface $c): \OCA\Procest\Controller\DashboardController {
-                return new \OCA\Procest\Controller\DashboardController(
+            DashboardController::class,
+            static function (\Psr\Container\ContainerInterface $c): DashboardController {
+                return new DashboardController(
                     request: $c->get('OCP\\IRequest')
                 );
             }
         );
         $context->registerService(
-            \OCA\Procest\Controller\SettingsController::class,
-            static function (\Psr\Container\ContainerInterface $c): \OCA\Procest\Controller\SettingsController {
-                return new \OCA\Procest\Controller\SettingsController(
+            SettingsController::class,
+            static function (\Psr\Container\ContainerInterface $c): SettingsController {
+                return new SettingsController(
                     request: $c->get('OCP\\IRequest'),
                     container: $c,
                     appManager: $c->get('OCP\\App\\IAppManager'),
-                    settingsService: $c->get(\OCA\Procest\Service\SettingsService::class),
+                    settingsService: $c->get(SettingsService::class),
                     groupManager: $c->get('OCP\\IGroupManager'),
                     userSession: $c->get('OCP\\IUserSession'),
                     l10n: $c->get('OCP\\IL10N')
@@ -172,9 +185,9 @@ class Application extends App implements IBootstrap
             }
         );
         $context->registerService(
-            \OCA\Procest\Service\SettingsService::class,
-            static function (\Psr\Container\ContainerInterface $c): \OCA\Procest\Service\SettingsService {
-                return new \OCA\Procest\Service\SettingsService(
+            SettingsService::class,
+            static function (\Psr\Container\ContainerInterface $c): SettingsService {
+                return new SettingsService(
                     appConfig: $c->get('OCP\\IAppConfig'),
                     appManager: $c->get('OCP\\App\\IAppManager'),
                     container: $c,
@@ -183,27 +196,27 @@ class Application extends App implements IBootstrap
             }
         );
         $context->registerService(
-            \OCA\Procest\Repair\InitializeSettings::class,
-            static function (\Psr\Container\ContainerInterface $c): \OCA\Procest\Repair\InitializeSettings {
-                return new \OCA\Procest\Repair\InitializeSettings(
-                    settingsService: $c->get(\OCA\Procest\Service\SettingsService::class),
+            InitializeSettings::class,
+            static function (\Psr\Container\ContainerInterface $c): InitializeSettings {
+                return new InitializeSettings(
+                    settingsService: $c->get(SettingsService::class),
                     logger: $c->get('Psr\\Log\\LoggerInterface')
                 );
             }
         );
         $context->registerService(
-            \OCA\Procest\Settings\AdminSettings::class,
-            static function (\Psr\Container\ContainerInterface $c): \OCA\Procest\Settings\AdminSettings {
-                return new \OCA\Procest\Settings\AdminSettings(
+            AdminSettings::class,
+            static function (\Psr\Container\ContainerInterface $c): AdminSettings {
+                return new AdminSettings(
                     appManager: $c->get('OCP\\App\\IAppManager'),
                     initialState: $c->get('OCP\\AppFramework\\Services\\IInitialState')
                 );
             }
         );
         $context->registerService(
-            \OCA\Procest\Sections\SettingsSection::class,
-            static function (\Psr\Container\ContainerInterface $c): \OCA\Procest\Sections\SettingsSection {
-                return new \OCA\Procest\Sections\SettingsSection(
+            SettingsSection::class,
+            static function (\Psr\Container\ContainerInterface $c): SettingsSection {
+                return new SettingsSection(
                     l: $c->get('OCP\\IL10N'),
                     urlGenerator: $c->get('OCP\\IURLGenerator')
                 );
@@ -395,7 +408,7 @@ class Application extends App implements IBootstrap
                 $mode = $c->get(\OCA\Procest\Service\External\IntegrationMode::class)
                     ->resolve('digid', [\OCA\Procest\Service\External\IntegrationMode::SIMULATOR]);
                 if ($mode === \OCA\Procest\Service\External\IntegrationMode::SIMULATOR) {
-                    return new \OCA\Procest\Service\Auth\SimulatorDigidSamlAdapter();
+                    return new SimulatorDigidSamlAdapter();
                 }
 
                 return $c->get(\OCA\Procest\Service\Auth\LogDigidSamlAdapter::class);
@@ -407,7 +420,7 @@ class Application extends App implements IBootstrap
                 $mode = $c->get(\OCA\Procest\Service\External\IntegrationMode::class)
                     ->resolve('digid', [\OCA\Procest\Service\External\IntegrationMode::SIMULATOR]);
                 if ($mode === \OCA\Procest\Service\External\IntegrationMode::SIMULATOR) {
-                    return new \OCA\Procest\Service\Auth\SimulatorEHerkenningSamlAdapter();
+                    return new SimulatorEHerkenningSamlAdapter();
                 }
 
                 return $c->get(\OCA\Procest\Service\Auth\LogEHerkenningSamlAdapter::class);
@@ -452,7 +465,7 @@ class Application extends App implements IBootstrap
                         ]
                         );
                 if ($mode !== \OCA\Procest\Service\External\IntegrationMode::LOG) {
-                    return new \OCA\Procest\Service\External\Kvk\KvkApiAdapter(
+                    return new KvkApiAdapter(
                         clientService: $c->get('OCP\\Http\\Client\\IClientService'),
                         mode: $modeService,
                         logger: $c->get('Psr\\Log\\LoggerInterface'),
@@ -474,7 +487,7 @@ class Application extends App implements IBootstrap
                         ]
                         );
                 if ($mode !== \OCA\Procest\Service\External\IntegrationMode::LOG) {
-                    return new \OCA\Procest\Service\External\Brp\HaalCentraalBrpAdapter(
+                    return new HaalCentraalBrpAdapter(
                         clientService: $c->get('OCP\\Http\\Client\\IClientService'),
                         mode: $modeService,
                         logger: $c->get('Psr\\Log\\LoggerInterface'),
@@ -503,7 +516,7 @@ class Application extends App implements IBootstrap
                         ]
                         );
                 if ($mode !== \OCA\Procest\Service\External\IntegrationMode::LOG) {
-                    return new \OCA\Procest\Service\External\Bag\BagApiAdapter(
+                    return new BagApiAdapter(
                         clientService: $c->get('OCP\\Http\\Client\\IClientService'),
                         mode: $modeService,
                         mapper: $c->get(\OCA\Procest\Service\External\Bag\BagResponseMapper::class),
@@ -532,7 +545,7 @@ class Application extends App implements IBootstrap
                         ]
                         );
                 if ($mode !== \OCA\Procest\Service\External\IntegrationMode::LOG) {
-                    return new \OCA\Procest\Service\External\Brk\BrkApiAdapter(
+                    return new BrkApiAdapter(
                         clientService: $c->get('OCP\\Http\\Client\\IClientService'),
                         mode: $modeService,
                         mapper: $c->get(\OCA\Procest\Service\External\Brk\BrkResponseMapper::class),
@@ -562,7 +575,7 @@ class Application extends App implements IBootstrap
                         ]
                         );
                 if ($mode !== \OCA\Procest\Service\External\IntegrationMode::LOG) {
-                    return new \OCA\Procest\Service\External\Woz\WozApiAdapter(
+                    return new WozApiAdapter(
                         clientService: $c->get('OCP\\Http\\Client\\IClientService'),
                         mode: $modeService,
                         mapper: $c->get(\OCA\Procest\Service\External\Woz\WozResponseMapper::class),

--- a/lib/BackgroundJob/AppointmentReminderJob.php
+++ b/lib/BackgroundJob/AppointmentReminderJob.php
@@ -64,6 +64,9 @@ class AppointmentReminderJob extends TimedJob
      * @param mixed $argument The job argument.
      *
      * @return void
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter) $argument is fixed by
+     * OCP\BackgroundJob\TimedJob::run(); this job takes no arguments.
 
      * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
      */

--- a/lib/BackgroundJob/AppointmentReminderJob.php
+++ b/lib/BackgroundJob/AppointmentReminderJob.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 
 namespace OCA\Procest\BackgroundJob;
 
+use DateTime;
 use OCA\Procest\Service\SettingsService;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -83,7 +84,7 @@ class AppointmentReminderJob extends TimedJob
                 return;
             }
 
-            $tomorrow = (new \DateTime('+1 day'))->format('Y-m-d');
+            $tomorrow = (new DateTime('+1 day'))->format('Y-m-d');
 
             $appointments = $objectService->findAll(
                 ['filters' => ['register' => (int) $register, 'schema' => (int) $schema, 'status' => 'scheduled']],

--- a/lib/BackgroundJob/DsoDeadlineJob.php
+++ b/lib/BackgroundJob/DsoDeadlineJob.php
@@ -24,6 +24,8 @@ declare(strict_types=1);
 
 namespace OCA\Procest\BackgroundJob;
 
+use DateTime;
+use DateTimeImmutable;
 use OCA\Procest\AppInfo\Application;
 use OCA\Procest\Service\Support\SearchesObjects;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -179,8 +181,8 @@ class DsoDeadlineJob extends TimedJob
      */
     private function getRemainingWorkingDays(string $deadlineDatum): int
     {
-        $today    = new \DateTimeImmutable('today');
-        $deadline = new \DateTimeImmutable(substr($deadlineDatum, 0, 10));
+        $today    = new DateTimeImmutable('today');
+        $deadline = new DateTimeImmutable(substr($deadlineDatum, 0, 10));
 
         if ($deadline <= $today) {
             // Count working days in the past (return negative).
@@ -338,7 +340,7 @@ class DsoDeadlineJob extends TimedJob
             $notification->setUser(user: $assignee);
             $notification->setSubject(subject: $subject, parameters: ['zaakId' => $zaakId]);
             $notification->setObject(type: 'case', id: $zaakId);
-            $notification->setDateTime(dateTime: new \DateTime());
+            $notification->setDateTime(dateTime: new DateTime());
             $this->notificationManager->notify(notification: $notification);
         } catch (\Throwable $e) {
             $this->logger->warning(

--- a/lib/BackgroundJob/ResetMonthlyQuotasJob.php
+++ b/lib/BackgroundJob/ResetMonthlyQuotasJob.php
@@ -87,7 +87,7 @@ class ResetMonthlyQuotasJob extends TimedJob
         }
 
         try {
-            $os = $this->container->get('OCA\\OpenRegister\\Service\\ObjectService');
+            $objectService = $this->container->get('OCA\\OpenRegister\\Service\\ObjectService');
         } catch (Throwable $e) {
             $this->logger->info('Procest: ResetMonthlyQuotasJob — OR ObjectService unavailable');
             return;
@@ -99,7 +99,7 @@ class ResetMonthlyQuotasJob extends TimedJob
             // "Unknown named parameter $register" and was swallowed by the catch
             // below, so this job never reset a single quota. Register/schema are
             // read from inside `filters`; limit/offset are top-level config keys.
-            $rows = $os->findAll(
+            $rows = $objectService->findAll(
                 [
                     'filters' => [
                         'register' => TenantSaasService::REGISTER,

--- a/lib/BackgroundJob/ResetMonthlyQuotasJob.php
+++ b/lib/BackgroundJob/ResetMonthlyQuotasJob.php
@@ -71,6 +71,9 @@ class ResetMonthlyQuotasJob extends TimedJob
      *
      * @return void
      *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter) $argument is fixed by
+     * OCP\BackgroundJob\TimedJob::run(); this job takes no arguments.
+     *
      * @spec exclude phpstan dead-code cleanup only — normalised the IAppManager return and
      *       dropped the resulting always-false `is_array()` guard; no behavioural change.
      */

--- a/lib/BackgroundJob/ShareMaintenanceJob.php
+++ b/lib/BackgroundJob/ShareMaintenanceJob.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 
 namespace OCA\Procest\BackgroundJob;
 
+use DateTime;
 use OCA\Procest\Service\SettingsService;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -108,7 +109,7 @@ class ShareMaintenanceJob extends TimedJob
                 ['filters' => ['register' => (int) $register, 'schema' => (int) $schema]],
             );
 
-            $reminderDate = new \DateTime('+'.self::REMINDER_DAYS.' days');
+            $reminderDate = new DateTime('+'.self::REMINDER_DAYS.' days');
 
             foreach ($shares as $share) {
                 if (is_object($share) === true) {
@@ -124,8 +125,8 @@ class ShareMaintenanceJob extends TimedJob
 
                 // Check if share expires within reminder window.
                 if (empty($shareData['expiresAt']) === false) {
-                    $expiresAt = new \DateTime($shareData['expiresAt']);
-                    if ($expiresAt <= $reminderDate && $expiresAt > new \DateTime()) {
+                    $expiresAt = new DateTime($shareData['expiresAt']);
+                    if ($expiresAt <= $reminderDate && $expiresAt > new DateTime()) {
                         $this->logger->info(
                             'Procest: Share expiring soon',
                             [

--- a/lib/Controller/DashboardController.php
+++ b/lib/Controller/DashboardController.php
@@ -83,7 +83,7 @@ class DashboardController extends GenericDashboardController
     #[PublicPage]
     public function serviceWorker(): DataDownloadResponse
     {
-        $body   = (string) @file_get_contents(self::PUBLIC_DIR.'/service-worker.js');
+        $body   = $this->readPublicAsset(name: 'service-worker.js');
         $status = Http::STATUS_OK;
         if ($body === '') {
             $status = Http::STATUS_NOT_FOUND;
@@ -105,7 +105,7 @@ class DashboardController extends GenericDashboardController
     #[PublicPage]
     public function webManifest(): DataDownloadResponse
     {
-        $body   = (string) @file_get_contents(self::PUBLIC_DIR.'/manifest.webmanifest');
+        $body   = $this->readPublicAsset(name: 'manifest.webmanifest');
         $status = Http::STATUS_OK;
         if ($body === '') {
             $status = Http::STATUS_NOT_FOUND;
@@ -113,4 +113,25 @@ class DashboardController extends GenericDashboardController
 
         return new DataDownloadResponse($body, 'manifest.webmanifest', 'application/manifest+json', $status);
     }//end webManifest()
+
+    /**
+     * Read a static asset shipped under the app's public directory.
+     *
+     * Returns an empty string when the asset is absent or unreadable; callers
+     * translate that into a 404. Guarding with is_file()/is_readable() keeps
+     * the missing-asset path free of PHP warnings without an `@` operator.
+     *
+     * @param string $name Bare file name inside the public directory.
+     *
+     * @return string The asset contents, or '' when it cannot be read.
+     */
+    private function readPublicAsset(string $name): string
+    {
+        $path = self::PUBLIC_DIR.'/'.$name;
+        if (is_file($path) === false || is_readable($path) === false) {
+            return '';
+        }
+
+        return (string) file_get_contents($path);
+    }//end readPublicAsset()
 }//end class

--- a/lib/Controller/DwangsomController.php
+++ b/lib/Controller/DwangsomController.php
@@ -95,7 +95,8 @@ class DwangsomController extends Controller
      */
     public function show(string $id): JSONResponse
     {
-        if (($denied = $this->ensureAuthenticated()) !== null) {
+        $denied = $this->ensureAuthenticated();
+        if ($denied !== null) {
             return $denied;
         }
 
@@ -132,7 +133,8 @@ class DwangsomController extends Controller
      */
     public function beschikking(string $id): JSONResponse
     {
-        if (($denied = $this->ensureAuthenticated()) !== null) {
+        $denied = $this->ensureAuthenticated();
+        if ($denied !== null) {
             return $denied;
         }
 
@@ -157,7 +159,8 @@ class DwangsomController extends Controller
      */
     public function bezwaar(string $id): JSONResponse
     {
-        if (($denied = $this->ensureAuthenticated()) !== null) {
+        $denied = $this->ensureAuthenticated();
+        if ($denied !== null) {
             return $denied;
         }
 
@@ -186,7 +189,8 @@ class DwangsomController extends Controller
      */
     public function bezwaarHeroverweging(string $id): JSONResponse
     {
-        if (($denied = $this->ensureAuthenticated()) !== null) {
+        $denied = $this->ensureAuthenticated();
+        if ($denied !== null) {
             return $denied;
         }
 

--- a/lib/Controller/EmailController.php
+++ b/lib/Controller/EmailController.php
@@ -163,6 +163,12 @@ class EmailController extends Controller
      * @return JSONResponse Resolved template preview
      *
      * @NoAdminRequired
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter) $caseId is a URL segment of the
+     * route `/api/email/{caseId}/preview` and is bound positionally by the dispatcher.
+     * It is not read yet because the case-data lookup is still a stub (see the
+     * `// Would load from case.` marker below); the parameter cannot be dropped
+     * without changing the route.
 
      * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
      */

--- a/lib/Controller/IngebrekestellingController.php
+++ b/lib/Controller/IngebrekestellingController.php
@@ -89,7 +89,8 @@ class IngebrekestellingController extends Controller
      */
     public function register(): JSONResponse
     {
-        if (($denied = $this->ensureAuthenticated()) !== null) {
+        $denied = $this->ensureAuthenticated();
+        if ($denied !== null) {
             return $denied;
         }
 
@@ -140,7 +141,8 @@ class IngebrekestellingController extends Controller
      */
     public function show(string $id): JSONResponse
     {
-        if (($denied = $this->ensureAuthenticated()) !== null) {
+        $denied = $this->ensureAuthenticated();
+        if ($denied !== null) {
             return $denied;
         }
 

--- a/lib/Controller/MandaatMatrixController.php
+++ b/lib/Controller/MandaatMatrixController.php
@@ -126,7 +126,8 @@ class MandaatMatrixController extends Controller
      */
     public function probe(): JSONResponse
     {
-        if (($denied = $this->ensureAuthenticated()) !== null) {
+        $denied = $this->ensureAuthenticated();
+        if ($denied !== null) {
             return $denied;
         }
 
@@ -242,7 +243,8 @@ class MandaatMatrixController extends Controller
      */
     public function importPreview(): JSONResponse
     {
-        if (($denied = $this->ensureAuthenticated()) !== null) {
+        $denied = $this->ensureAuthenticated();
+        if ($denied !== null) {
             return $denied;
         }
 
@@ -276,7 +278,8 @@ class MandaatMatrixController extends Controller
      */
     public function importApprove(string $importId): JSONResponse
     {
-        if (($denied = $this->ensureAuthenticated()) !== null) {
+        $denied = $this->ensureAuthenticated();
+        if ($denied !== null) {
             return $denied;
         }
 
@@ -323,7 +326,8 @@ class MandaatMatrixController extends Controller
      */
     public function escalateReject(string $id): JSONResponse
     {
-        if (($denied = $this->ensureAuthenticated()) !== null) {
+        $denied = $this->ensureAuthenticated();
+        if ($denied !== null) {
             return $denied;
         }
 
@@ -354,7 +358,8 @@ class MandaatMatrixController extends Controller
      */
     public function auditTrail(string $caseId): JSONResponse
     {
-        if (($denied = $this->ensureAuthenticated()) !== null) {
+        $denied = $this->ensureAuthenticated();
+        if ($denied !== null) {
             return $denied;
         }
 
@@ -374,7 +379,8 @@ class MandaatMatrixController extends Controller
      */
     public function applicable(string $caseId): JSONResponse
     {
-        if (($denied = $this->ensureAuthenticated()) !== null) {
+        $denied = $this->ensureAuthenticated();
+        if ($denied !== null) {
             return $denied;
         }
 

--- a/lib/Controller/StufController.php
+++ b/lib/Controller/StufController.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Controller;
 
+use DOMDocument;
 use OCA\Procest\AppInfo\Application;
 use OCA\Procest\Service\Stuf\CircuitBreakerService;
 use OCA\Procest\Service\Stuf\CircuitOpenException;
@@ -334,7 +335,7 @@ class StufController extends Controller
         }
 
         // Parse the XML with XXE/DTD protections.
-        $dom = new \DOMDocument();
+        $dom = new DOMDocument();
         libxml_use_internal_errors(true);
         // LIBXML_NONET: prohibits network access from within XML (XXE via HTTP/FTP).
         // LIBXML_DTDLOAD: disabled intentionally (we do NOT load external DTDs).

--- a/lib/Controller/StufController.php
+++ b/lib/Controller/StufController.php
@@ -646,6 +646,9 @@ class StufController extends Controller
      * @param string $envelopeXml The inbound envelope.
      *
      * @return array|null The endpoint or null.
+     *
+     * @SuppressWarnings(PHPMD.UndefinedVariable) $matches is a preg_match() by-reference
+     * out-parameter, which PHPMD does not model.
      */
     private function resolveInboundEndpoint(string $envelopeXml): ?array
     {
@@ -677,6 +680,9 @@ class StufController extends Controller
      * @param array  $endpoint    The endpoint.
      *
      * @return bool
+     *
+     * @SuppressWarnings(PHPMD.UndefinedVariable) $matches is a preg_match() by-reference
+     * out-parameter, which PHPMD does not model.
      */
     private function verifyWsse(string $envelopeXml, array $endpoint): bool
     {
@@ -709,6 +715,9 @@ class StufController extends Controller
      * @param string $envelopeXml The envelope.
      *
      * @return string
+     *
+     * @SuppressWarnings(PHPMD.UndefinedVariable) $matches is a preg_match() by-reference
+     * out-parameter, which PHPMD does not model.
      */
     private function detectBerichtSoort(string $envelopeXml): string
     {
@@ -741,6 +750,9 @@ class StufController extends Controller
      * @param string $envelopeXml The envelope.
      *
      * @return string
+     *
+     * @SuppressWarnings(PHPMD.UndefinedVariable) $matches is a preg_match() by-reference
+     * out-parameter, which PHPMD does not model.
      */
     private function extractCrossRefnummer(string $envelopeXml): string
     {
@@ -761,6 +773,9 @@ class StufController extends Controller
      * @param string $envelopeXml The envelope.
      *
      * @return string
+     *
+     * @SuppressWarnings(PHPMD.UndefinedVariable) $matches is a preg_match() by-reference
+     * out-parameter, which PHPMD does not model.
      */
     private function extractFunctie(string $envelopeXml): string
     {

--- a/lib/Controller/TenantSaasController.php
+++ b/lib/Controller/TenantSaasController.php
@@ -206,8 +206,8 @@ class TenantSaasController extends Controller
             );
         }
 
-        $ok = $this->tenantSaasService->delete($tenantId);
-        if ($ok === false) {
+        $deleted = $this->tenantSaasService->delete($tenantId);
+        if ($deleted === false) {
             return new JSONResponse(['success' => false, 'error' => 'Failed to delete tenant'], Http::STATUS_INTERNAL_SERVER_ERROR);
         }
 

--- a/lib/Controller/TermijnController.php
+++ b/lib/Controller/TermijnController.php
@@ -111,7 +111,8 @@ class TermijnController extends Controller
      */
     public function create(): JSONResponse
     {
-        if (($denied = $this->ensureAuthenticated()) !== null) {
+        $denied = $this->ensureAuthenticated();
+        if ($denied !== null) {
             return $denied;
         }
 
@@ -143,7 +144,8 @@ class TermijnController extends Controller
      */
     public function show(string $id): JSONResponse
     {
-        if (($denied = $this->ensureAuthenticated()) !== null) {
+        $denied = $this->ensureAuthenticated();
+        if ($denied !== null) {
             return $denied;
         }
 
@@ -168,7 +170,8 @@ class TermijnController extends Controller
      */
     public function pauze(string $id): JSONResponse
     {
-        if (($denied = $this->ensureAuthenticated()) !== null) {
+        $denied = $this->ensureAuthenticated();
+        if ($denied !== null) {
             return $denied;
         }
 
@@ -198,7 +201,8 @@ class TermijnController extends Controller
      */
     public function hervat(string $id): JSONResponse
     {
-        if (($denied = $this->ensureAuthenticated()) !== null) {
+        $denied = $this->ensureAuthenticated();
+        if ($denied !== null) {
             return $denied;
         }
 
@@ -231,7 +235,8 @@ class TermijnController extends Controller
      */
     public function verleng(string $id): JSONResponse
     {
-        if (($denied = $this->ensureAuthenticated()) !== null) {
+        $denied = $this->ensureAuthenticated();
+        if ($denied !== null) {
             return $denied;
         }
 
@@ -262,7 +267,8 @@ class TermijnController extends Controller
      */
     public function voltooi(string $id): JSONResponse
     {
-        if (($denied = $this->ensureAuthenticated()) !== null) {
+        $denied = $this->ensureAuthenticated();
+        if ($denied !== null) {
             return $denied;
         }
 

--- a/lib/Controller/TermijnReportingController.php
+++ b/lib/Controller/TermijnReportingController.php
@@ -89,7 +89,8 @@ class TermijnReportingController extends Controller
      */
     public function dashboard(): JSONResponse
     {
-        if (($denied = $this->ensureAuthenticated()) !== null) {
+        $denied = $this->ensureAuthenticated();
+        if ($denied !== null) {
             return $denied;
         }
 
@@ -116,7 +117,8 @@ class TermijnReportingController extends Controller
      */
     public function kwartaalrapport(string $periode='', ?string $afdeling=null): JSONResponse
     {
-        if (($denied = $this->ensureAuthenticated()) !== null) {
+        $denied = $this->ensureAuthenticated();
+        if ($denied !== null) {
             return $denied;
         }
 
@@ -149,7 +151,8 @@ class TermijnReportingController extends Controller
      */
     public function jaarrekening(int $jaar=0): JSONResponse
     {
-        if (($denied = $this->ensureAuthenticated()) !== null) {
+        $denied = $this->ensureAuthenticated();
+        if ($denied !== null) {
             return $denied;
         }
 

--- a/lib/Controller/ZaakdossierController.php
+++ b/lib/Controller/ZaakdossierController.php
@@ -34,6 +34,7 @@ declare(strict_types=1);
 namespace OCA\Procest\Controller;
 
 use OCA\Procest\AppInfo\Application;
+use OCA\Procest\Http\RangeStreamResponse;
 use OCA\Procest\Service\InformatieobjectAccessGuard;
 use OCA\Procest\Service\ZaakdossierService;
 use OCA\Procest\Service\ZgwDocumentService;
@@ -47,6 +48,7 @@ use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 /**
  * Controller for the ZGW DRC zaakdossier.
@@ -149,7 +151,7 @@ class ZaakdossierController extends Controller
             $tmpName = (string) ($file['tmp_name'] ?? '');
             try {
                 if ($this->isExecutable(name: $name, tmpName: $tmpName) === true) {
-                    throw new \RuntimeException('Executable files are not permitted: '.$name);
+                    throw new RuntimeException('Executable files are not permitted: '.$name);
                 }
 
                 $content = '';
@@ -514,7 +516,7 @@ class ZaakdossierController extends Controller
         $rangeHeader = (string) $this->request->getHeader('Range');
         $mime        = (string) ($doc['formaat'] ?? 'application/octet-stream');
 
-        return new \OCA\Procest\Http\RangeStreamResponse(
+        return new RangeStreamResponse(
             content: $content,
             fileName: $fileName,
             contentType: $mime,

--- a/lib/Controller/ZaakdossierController.php
+++ b/lib/Controller/ZaakdossierController.php
@@ -466,6 +466,11 @@ class ZaakdossierController extends Controller
      * @NoAdminRequired
      *
      * @spec openspec/changes/document-zaakdossier/tasks.md#T05
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter) $register, $schema and $fileId are
+     * URL segments of the route
+     * `/api/objects/{register}/{schema}/{objectId}/files/{fileId}/download` and are bound
+     * positionally by the dispatcher; they cannot be dropped without changing the route.
      */
     public function downloadFile(string $register, string $schema, string $objectId, int $fileId): DataDownloadResponse | JSONResponse
     {

--- a/lib/Controller/ZrcController.php
+++ b/lib/Controller/ZrcController.php
@@ -2526,13 +2526,13 @@ class ZrcController extends ZgwController
     private function buildRelevanteAndereZaken(array $zaakData): array
     {
         $uuid = (string) ($zaakData['uuid'] ?? ($zaakData['identificatie'] ?? ''));
-        if ($uuid !== '' && preg_match('/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i', $uuid, $m) === 1) {
-            $uuid = $m[1];
+        if ($uuid !== '' && preg_match('/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i', $uuid, $matches) === 1) {
+            $uuid = $matches[1];
         } else {
             // Fall back to extracting the UUID from the self URL.
             $selfUrl = (string) ($zaakData['url'] ?? '');
-            if (preg_match('/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i', $selfUrl, $m2) === 1) {
-                $uuid = $m2[1];
+            if (preg_match('/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i', $selfUrl, $urlMatches) === 1) {
+                $uuid = $urlMatches[1];
             }
         }
 
@@ -2645,8 +2645,8 @@ class ZrcController extends ZgwController
 
             // Resolve the URL to a local case UUID.
             $targetUuid = '';
-            if (preg_match($uuidPattern, $url, $m) === 1) {
-                $targetUuid = $m[1];
+            if (preg_match($uuidPattern, $url, $matches) === 1) {
+                $targetUuid = $matches[1];
             }
 
             $result = null;

--- a/lib/Cron/OriDataQualityCheck.php
+++ b/lib/Cron/OriDataQualityCheck.php
@@ -350,7 +350,7 @@ class OriDataQualityCheck extends TimedJob
         }
 
         $warningCount = count(
-            array_filter(array: $issues, callback: static fn($i) => ($i['severity'] ?? '') === 'warning')
+            array_filter(array: $issues, callback: static fn($issue) => ($issue['severity'] ?? '') === 'warning')
         );
 
         $log = [

--- a/lib/Middleware/MandateValidationMiddleware.php
+++ b/lib/Middleware/MandateValidationMiddleware.php
@@ -84,6 +84,10 @@ class MandateValidationMiddleware extends Middleware
      * @return void
      *
      * @throws MandateDeniedException When the action is denied.
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter) $controller and $methodName are
+     * fixed by OCP\AppFramework\Middleware::beforeController(); this middleware
+     * dispatches on the request URI instead.
      */
     public function beforeController($controller, $methodName): void
     {
@@ -131,6 +135,10 @@ class MandateValidationMiddleware extends Middleware
      * @return \OCP\AppFramework\Http\Response
      *
      * @throws \Exception When not owned by this middleware.
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter) $controller and $methodName are
+     * fixed by OCP\AppFramework\Middleware::afterException(); only $exception is
+     * inspected.
      */
     public function afterException($controller, $methodName, \Exception $exception): \OCP\AppFramework\Http\Response
     {

--- a/lib/Middleware/QuotaEnforcementMiddleware.php
+++ b/lib/Middleware/QuotaEnforcementMiddleware.php
@@ -59,6 +59,10 @@ class QuotaEnforcementMiddleware extends Middleware
      * @param string                       $methodName Method name.
      *
      * @return void
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter) $controller and $methodName are
+     * fixed by OCP\AppFramework\Middleware::beforeController(); this middleware
+     * dispatches on the request URI instead.
      */
     public function beforeController($controller, $methodName): void
     {
@@ -109,6 +113,10 @@ class QuotaEnforcementMiddleware extends Middleware
      * @return \OCP\AppFramework\Http\Response
      *
      * @throws \Exception
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter) $controller and $methodName are
+     * fixed by OCP\AppFramework\Middleware::afterException(); only $exception is
+     * inspected.
      */
     public function afterException($controller, $methodName, \Exception $exception): \OCP\AppFramework\Http\Response
     {

--- a/lib/Middleware/TenantClaimValidationMiddleware.php
+++ b/lib/Middleware/TenantClaimValidationMiddleware.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Middleware;
 
+use DateTimeImmutable;
 use OCA\Procest\Service\TenantContext;
 use OCA\Procest\Service\TenantJwtService;
 use OCP\AppFramework\Http\JSONResponse;
@@ -166,7 +167,7 @@ class TenantClaimValidationMiddleware extends Middleware
             'Procest SECURITY: cross-tenant JWT claim mismatch',
             [
                 'ip'                => $this->request->getRemoteAddress(),
-                'timestamp'         => (new \DateTimeImmutable('now'))->format(DATE_ATOM),
+                'timestamp'         => (new DateTimeImmutable('now'))->format(DATE_ATOM),
                 'attemptedTenantId' => $attempted,
                 'requestedTenantId' => $requested,
                 'user'              => (string) ($claims['sub'] ?? ''),

--- a/lib/Middleware/TenantClaimValidationMiddleware.php
+++ b/lib/Middleware/TenantClaimValidationMiddleware.php
@@ -95,6 +95,10 @@ class TenantClaimValidationMiddleware extends Middleware
      * @return void
      *
      * @throws TenantClaimMismatchException When the JWT tenant_id does not match the request tenant.
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter) $controller and $methodName are
+     * fixed by OCP\AppFramework\Middleware::beforeController(); this middleware
+     * validates the bound tenant claim instead.
      */
     public function beforeController($controller, $methodName): void
     {
@@ -139,6 +143,10 @@ class TenantClaimValidationMiddleware extends Middleware
      * @return \OCP\AppFramework\Http\Response
      *
      * @throws \Exception When the exception is not ours.
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter) $controller and $methodName are
+     * fixed by OCP\AppFramework\Middleware::afterException(); only $exception is
+     * inspected.
      */
     public function afterException($controller, $methodName, \Exception $exception): \OCP\AppFramework\Http\Response
     {

--- a/lib/Middleware/TenantContextMiddleware.php
+++ b/lib/Middleware/TenantContextMiddleware.php
@@ -90,6 +90,10 @@ class TenantContextMiddleware extends Middleware
      * @param string                       $methodName Method name.
      *
      * @return void
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter) $methodName is fixed by
+     * OCP\AppFramework\Middleware::beforeController(); tenant resolution keys off
+     * the controller class and the request, not the action name.
      */
     public function beforeController($controller, $methodName): void
     {
@@ -137,6 +141,10 @@ class TenantContextMiddleware extends Middleware
      * @return \OCP\AppFramework\Http\Response
      *
      * @throws \Exception
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter) $controller and $methodName are
+     * fixed by OCP\AppFramework\Middleware::afterException(); this hook only
+     * re-throws.
      */
     public function afterException($controller, $methodName, \Exception $exception): \OCP\AppFramework\Http\Response
     {

--- a/lib/Middleware/TenantIsolationMiddleware.php
+++ b/lib/Middleware/TenantIsolationMiddleware.php
@@ -67,6 +67,10 @@ class TenantIsolationMiddleware extends Middleware
      * @param string                       $methodName Method name.
      *
      * @return void
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter) $controller and $methodName are
+     * fixed by OCP\AppFramework\Middleware::beforeController(); the search_path is
+     * derived from the bound tenant context.
      */
     public function beforeController($controller, $methodName): void
     {
@@ -92,6 +96,10 @@ class TenantIsolationMiddleware extends Middleware
      * @param \OCP\AppFramework\Http\Response $response   Response.
      *
      * @return \OCP\AppFramework\Http\Response
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter) $controller and $methodName are
+     * fixed by OCP\AppFramework\Middleware::afterController(); the reset is
+     * unconditional.
      */
     public function afterController($controller, $methodName, \OCP\AppFramework\Http\Response $response): \OCP\AppFramework\Http\Response
     {
@@ -109,6 +117,10 @@ class TenantIsolationMiddleware extends Middleware
      * @return \OCP\AppFramework\Http\Response
      *
      * @throws \Exception
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter) $controller and $methodName are
+     * fixed by OCP\AppFramework\Middleware::afterException(); the reset is
+     * unconditional.
      */
     public function afterException($controller, $methodName, \Exception $exception): \OCP\AppFramework\Http\Response
     {

--- a/lib/Middleware/TenantMiddleware.php
+++ b/lib/Middleware/TenantMiddleware.php
@@ -162,8 +162,8 @@ class TenantMiddleware extends Middleware
             // Surface OR-Organisation status block to the caller.
             $message = $exception->getMessage();
             $status  = 'inactive';
-            if (preg_match('/Organisation is (\\w+)/', $message, $m) === 1) {
-                $status = $m[1];
+            if (preg_match('/Organisation is (\\w+)/', $message, $matches) === 1) {
+                $status = $matches[1];
             }
 
             return new JSONResponse(

--- a/lib/Middleware/TenantMiddleware.php
+++ b/lib/Middleware/TenantMiddleware.php
@@ -79,6 +79,10 @@ class TenantMiddleware extends Middleware
      * @param string                       $methodName The method name
      *
      * @return void
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter) $methodName is fixed by
+     * OCP\AppFramework\Middleware::beforeController(); the tenant check keys off
+     * the controller class and the request, not the action name.
      */
     public function beforeController($controller, $methodName): void
     {
@@ -140,6 +144,10 @@ class TenantMiddleware extends Middleware
      * @return JSONResponse The error response
      *
      * @throws \Exception Re-throws if not a tenant exception
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter) $controller and $methodName are
+     * fixed by OCP\AppFramework\Middleware::afterException(); only $exception is
+     * inspected.
      */
     public function afterException($controller, $methodName, \Exception $exception): JSONResponse
     {

--- a/lib/Service/AdvisoryBodyService.php
+++ b/lib/Service/AdvisoryBodyService.php
@@ -30,6 +30,7 @@ namespace OCA\Procest\Service;
 use OCA\Procest\AppInfo\Application;
 use OCA\Procest\Service\Support\SearchesObjects;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 /**
  * Service for advisory body registry management.
@@ -143,14 +144,14 @@ class AdvisoryBodyService
     {
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
-            throw new \RuntimeException('OpenRegister is not available');
+            throw new RuntimeException('OpenRegister is not available');
         }
 
         $register = $this->settingsService->getConfigValue('register');
         $schema   = $this->settingsService->getConfigValue('advisory_body_schema');
 
         if (empty($register) === true || empty($schema) === true) {
-            throw new \RuntimeException('Advisory body schema not configured');
+            throw new RuntimeException('Advisory body schema not configured');
         }
 
         if ($id !== '') {
@@ -194,14 +195,14 @@ class AdvisoryBodyService
     {
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
-            throw new \RuntimeException('OpenRegister is not available');
+            throw new RuntimeException('OpenRegister is not available');
         }
 
         $register = $this->settingsService->getConfigValue('register');
         $schema   = $this->settingsService->getConfigValue('advisory_body_schema');
 
         if (empty($register) === true || empty($schema) === true) {
-            throw new \RuntimeException('Advisory body schema not configured');
+            throw new RuntimeException('Advisory body schema not configured');
         }
 
         $objectService->deleteObject($register, $schema, $id);
@@ -278,14 +279,14 @@ class AdvisoryBodyService
     {
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
-            throw new \RuntimeException('OpenRegister is not available');
+            throw new RuntimeException('OpenRegister is not available');
         }
 
         $register = $this->settingsService->getConfigValue('register');
         $schema   = $this->settingsService->getConfigValue('consultation_schema');
 
         if (empty($register) === true || empty($schema) === true) {
-            throw new \RuntimeException('Consultation schema not configured');
+            throw new RuntimeException('Consultation schema not configured');
         }
 
         $token = bin2hex(random_bytes(32));

--- a/lib/Service/AgendaService.php
+++ b/lib/Service/AgendaService.php
@@ -32,8 +32,10 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service;
 
+use InvalidArgumentException;
 use OCA\Procest\AppInfo\Application;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 use Throwable;
 
 /**
@@ -95,7 +97,7 @@ class AgendaService
 
         $itemId = (string) ($patch['itemId'] ?? '');
         if ($itemId === '') {
-            throw new \InvalidArgumentException('itemId is required');
+            throw new InvalidArgumentException('itemId is required');
         }
 
         $items = $this->extractItems(case: $case);
@@ -109,7 +111,7 @@ class AgendaService
         }
 
         if ($found === false) {
-            throw new \RuntimeException('Agenda item not found: '.$itemId);
+            throw new RuntimeException('Agenda item not found: '.$itemId);
         }
 
         return $this->persistItems(case: $case, items: $items);
@@ -128,7 +130,7 @@ class AgendaService
     {
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
-            throw new \RuntimeException('OpenRegister is not available');
+            throw new RuntimeException('OpenRegister is not available');
         }
 
         $register = $this->settingsService->getConfigValue('register');
@@ -145,11 +147,11 @@ class AgendaService
                 'AgendaService::loadCase failed',
                 ['app' => Application::APP_ID, 'caseId' => $caseId, 'error' => $e->getMessage()]
             );
-            throw new \RuntimeException('Case not found: '.$caseId);
+            throw new RuntimeException('Case not found: '.$caseId);
         }
 
         if ($obj === null) {
-            throw new \RuntimeException('Case not found: '.$caseId);
+            throw new RuntimeException('Case not found: '.$caseId);
         }
 
         // The OR object may return either a hydrated DTO or array; normalise to array.
@@ -209,7 +211,7 @@ class AgendaService
     {
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
-            throw new \RuntimeException('OpenRegister is not available');
+            throw new RuntimeException('OpenRegister is not available');
         }
 
         $register = $this->settingsService->getConfigValue('register');

--- a/lib/Service/AiService.php
+++ b/lib/Service/AiService.php
@@ -36,6 +36,7 @@ use OCA\Procest\Service\Support\SearchesObjects;
 use OCP\IAppConfig;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 /**
  * Service for AI-assisted case processing.
@@ -833,7 +834,7 @@ class AiService
         );
 
         if (empty($modelUrl) === true) {
-            throw new \RuntimeException('AI model URL is not configured');
+            throw new RuntimeException('AI model URL is not configured');
         }
 
         $modelName = $this->appConfig->getValueString(
@@ -862,7 +863,7 @@ class AiService
 
         // SSRF guard: validate the configured model URL before making outbound requests.
         if ($this->isSafeAiUrl(url: $modelUrl, modelType: $modelType) === false) {
-            throw new \RuntimeException('AI model URL failed SSRF security check');
+            throw new RuntimeException('AI model URL failed SSRF security check');
         }
 
         $ch = curl_init($endpoint);
@@ -897,16 +898,16 @@ class AiService
         curl_close($ch);
 
         if ($response === false || empty($error) === false) {
-            throw new \RuntimeException('AI model connection failed: '.$error);
+            throw new RuntimeException('AI model connection failed: '.$error);
         }
 
         if ($httpCode < 200 || $httpCode >= 300) {
-            throw new \RuntimeException('AI model returned HTTP '.$httpCode);
+            throw new RuntimeException('AI model returned HTTP '.$httpCode);
         }
 
         $decoded = json_decode($response, true);
         if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new \RuntimeException('AI model returned invalid JSON');
+            throw new RuntimeException('AI model returned invalid JSON');
         }
 
         // Parse the response text as JSON (we requested JSON format).

--- a/lib/Service/BerichtenboxAdapter/MockAdapter.php
+++ b/lib/Service/BerichtenboxAdapter/MockAdapter.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service\BerichtenboxAdapter;
 
+use DateTime;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -79,7 +80,7 @@ class MockAdapter implements BerichtenboxAdapterInterface
         return [
             'messageId' => $messageId,
             'status'    => 'sent',
-            'sentAt'    => (new \DateTime())->format('c'),
+            'sentAt'    => (new DateTime())->format('c'),
         ];
     }//end sendMessage()
 
@@ -97,7 +98,7 @@ class MockAdapter implements BerichtenboxAdapterInterface
         // Simulate: messages are "read" after they've existed for a while.
         return [
             'read'   => true,
-            'readAt' => (new \DateTime('-1 hour'))->format('c'),
+            'readAt' => (new DateTime('-1 hour'))->format('c'),
         ];
     }//end getReadStatus()
 }//end class

--- a/lib/Service/BerichtenboxService.php
+++ b/lib/Service/BerichtenboxService.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service;
 
+use DateTime;
 use OCA\Procest\Service\BerichtenboxAdapter\BerichtenboxAdapterInterface;
 use OCA\Procest\Service\BerichtenboxAdapter\MockAdapter;
 use OCP\App\IAppManager;
@@ -115,7 +116,7 @@ class BerichtenboxService
             'attachmentFileId'  => $attachmentFileId,
             'externalMessageId' => $result['messageId'] ?? null,
             'status'            => $result['status'] ?? 'sent',
-            'sentAt'            => $result['sentAt'] ?? (new \DateTime())->format('c'),
+            'sentAt'            => $result['sentAt'] ?? (new DateTime())->format('c'),
         ];
 
         $saved = $objectService->saveObject(
@@ -222,15 +223,15 @@ class BerichtenboxService
         if (($status['read'] ?? false) === true) {
             $data['status']       = 'read';
             $data['readAt']       = $status['readAt'];
-            $data['readPolledAt'] = (new \DateTime())->format('c');
+            $data['readPolledAt'] = (new DateTime())->format('c');
             $objectService->saveObject(object: $data, register: (int) $register, schema: (int) $schema);
         } else {
-            $data['readPolledAt'] = (new \DateTime())->format('c');
+            $data['readPolledAt'] = (new DateTime())->format('c');
 
             // Check if unread for > 7 days.
             if (empty($data['sentAt']) === false) {
-                $sentAt = new \DateTime($data['sentAt']);
-                $diff   = (new \DateTime())->diff($sentAt)->days;
+                $sentAt = new DateTime($data['sentAt']);
+                $diff   = (new DateTime())->diff($sentAt)->days;
                 if ($diff >= 7 && $data['status'] !== 'unread_flagged') {
                     $data['status'] = 'unread_flagged';
                 }

--- a/lib/Service/BesluitvormingParafeerService.php
+++ b/lib/Service/BesluitvormingParafeerService.php
@@ -26,6 +26,7 @@ namespace OCA\Procest\Service;
 use OCA\Procest\AppInfo\Application;
 use OCA\Procest\Service\Support\SearchesObjects;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 /**
  * Orchestrates the parafering chain for besluitvorming voorstellen.
@@ -68,14 +69,14 @@ class BesluitvormingParafeerService
     {
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
-            throw new \RuntimeException('OpenRegister is not available');
+            throw new RuntimeException('OpenRegister is not available');
         }
 
         $register       = $this->settingsService->getConfigValue('register');
         $voorstelSchema = $this->settingsService->getConfigValue('voorstel_schema');
 
         if (empty($register) === true || empty($voorstelSchema) === true) {
-            throw new \RuntimeException('Procest register or voorstel_schema not configured');
+            throw new RuntimeException('Procest register or voorstel_schema not configured');
         }
 
         // Load the voorstel.
@@ -87,7 +88,7 @@ class BesluitvormingParafeerService
         );
 
         if (empty($voorstelResults) === true) {
-            throw new \RuntimeException('Voorstel not found: '.$voorstelId);
+            throw new RuntimeException('Voorstel not found: '.$voorstelId);
         }
 
         $voorstel = $this->toArray(value: $voorstelResults[0]);
@@ -148,7 +149,7 @@ class BesluitvormingParafeerService
     {
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
-            throw new \RuntimeException('OpenRegister is not available');
+            throw new RuntimeException('OpenRegister is not available');
         }
 
         $register       = $this->settingsService->getConfigValue('register');
@@ -156,7 +157,7 @@ class BesluitvormingParafeerService
         $actieSchema    = $this->settingsService->getConfigValue('parafeeractie_schema');
 
         if (empty($register) === true || empty($voorstelSchema) === true) {
-            throw new \RuntimeException('Procest register or voorstel_schema not configured');
+            throw new RuntimeException('Procest register or voorstel_schema not configured');
         }
 
         // Load voorstel.
@@ -168,7 +169,7 @@ class BesluitvormingParafeerService
         );
 
         if (empty($voorstelResults) === true) {
-            throw new \RuntimeException('Voorstel not found: '.$voorstelId);
+            throw new RuntimeException('Voorstel not found: '.$voorstelId);
         }
 
         $voorstel = $this->toArray(value: $voorstelResults[0]);

--- a/lib/Service/CaseCollaborationService.php
+++ b/lib/Service/CaseCollaborationService.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service;
 
+use DateTime;
 use OCP\App\IAppManager;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
@@ -80,7 +81,7 @@ class CaseCollaborationService
                 'actorType' => 'local',
                 'cloudId'   => '',
                 'message'   => $message,
-                'createdAt' => (new \DateTime())->format('c'),
+                'createdAt' => (new DateTime())->format('c'),
             ],
         );
     }//end postLocalActivity()
@@ -113,7 +114,7 @@ class CaseCollaborationService
                 'actorType' => 'remote',
                 'cloudId'   => $resolved['sharedWith'],
                 'message'   => $message,
-                'createdAt' => (new \DateTime())->format('c'),
+                'createdAt' => (new DateTime())->format('c'),
             ],
         );
     }//end postRemoteActivity()

--- a/lib/Service/CaseCollaborationService.php
+++ b/lib/Service/CaseCollaborationService.php
@@ -189,9 +189,8 @@ class CaseCollaborationService
             return ['error' => 'Federated share not found'];
         }
 
-        if (is_array($shareObj) === true) {
-            $shareData = $shareObj;
-        } else {
+        $shareData = $shareObj;
+        if (is_array($shareObj) === false) {
             $shareData = $shareObj->jsonSerialize();
         }
 
@@ -213,10 +212,9 @@ class CaseCollaborationService
         $activity['entries']        = $entries;
         $activity['lastActivityAt'] = $entry['createdAt'];
 
-        $result = $objectService->saveObject(object: $activity, register: (int) $register, schema: (int) $activitySchema);
-        if (is_array($result) === true) {
-            $resultData = $result;
-        } else {
+        $result     = $objectService->saveObject(object: $activity, register: (int) $register, schema: (int) $activitySchema);
+        $resultData = $result;
+        if (is_array($result) === false) {
             $resultData = $result->jsonSerialize();
         }
 

--- a/lib/Service/CaseDefinitionExportService.php
+++ b/lib/Service/CaseDefinitionExportService.php
@@ -28,9 +28,14 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service;
 
+use DateTimeImmutable;
+use DateTimeInterface;
+use InvalidArgumentException;
 use OCA\Procest\AppInfo\Application;
 use OCP\IAppConfig;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
+use ZipArchive;
 
 /**
  * Service for exporting case type definitions as portable ZIP archives.
@@ -98,7 +103,7 @@ class CaseDefinitionExportService
         // Validate requested components.
         $invalidComponents = array_diff($components, self::COMPONENTS);
         if (empty($invalidComponents) === false) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Invalid export components: '.implode(', ', $invalidComponents)
             );
         }
@@ -117,13 +122,13 @@ class CaseDefinitionExportService
         // Create temporary ZIP file.
         $tempPath = tempnam(sys_get_temp_dir(), 'procest_export_');
         if ($tempPath === false) {
-            throw new \RuntimeException('Failed to create temporary file for export');
+            throw new RuntimeException('Failed to create temporary file for export');
         }
 
-        $zip    = new \ZipArchive();
-        $result = $zip->open($tempPath, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
+        $zip    = new ZipArchive();
+        $result = $zip->open($tempPath, ZipArchive::CREATE | ZipArchive::OVERWRITE);
         if ($result !== true) {
-            throw new \RuntimeException('Failed to create ZIP archive: error code '.$result);
+            throw new RuntimeException('Failed to create ZIP archive: error code '.$result);
         }
 
         // Add manifest.
@@ -196,7 +201,7 @@ class CaseDefinitionExportService
         return [
             'version'            => $newVersion,
             'previousVersion'    => $previousVersionValue,
-            'exportDate'         => (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM),
+            'exportDate'         => (new DateTimeImmutable())->format(DateTimeInterface::ATOM),
             'sourceEnvironment'  => $this->appConfig->getValueString(
                 Application::APP_ID,
                 'environment_name',

--- a/lib/Service/CaseDefinitionImportService.php
+++ b/lib/Service/CaseDefinitionImportService.php
@@ -31,6 +31,7 @@ namespace OCA\Procest\Service;
 use OCA\Procest\AppInfo\Application;
 use OCP\IAppConfig;
 use Psr\Log\LoggerInterface;
+use ZipArchive;
 
 /**
  * Service for importing case type definitions from ZIP archives.
@@ -85,8 +86,8 @@ class CaseDefinitionImportService
         ];
 
         // Open the ZIP.
-        $zip        = new \ZipArchive();
-        $openResult = $zip->open($zipPath, \ZipArchive::RDONLY);
+        $zip        = new ZipArchive();
+        $openResult = $zip->open($zipPath, ZipArchive::RDONLY);
         if ($openResult !== true) {
             $result['valid']    = false;
             $result['errors'][] = 'Failed to open ZIP archive: error code '.$openResult;
@@ -238,8 +239,8 @@ class CaseDefinitionImportService
         $components = $manifest['components'] ?? [];
         $results    = [];
 
-        $zip = new \ZipArchive();
-        $zip->open($zipPath, \ZipArchive::RDONLY);
+        $zip = new ZipArchive();
+        $zip->open($zipPath, ZipArchive::RDONLY);
 
         foreach ($components as $component) {
             try {

--- a/lib/Service/CaseEmailService.php
+++ b/lib/Service/CaseEmailService.php
@@ -36,6 +36,7 @@ use OCP\IAppConfig;
 use OCP\IUserSession;
 use OCP\Mail\IMailer;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 /**
  * Service for case-integrated email functionality.
@@ -100,7 +101,7 @@ class CaseEmailService
             '',
         );
         if ($fromAddress === '' || str_ends_with($fromAddress, '@example.nl') === true) {
-            throw new \RuntimeException(
+            throw new RuntimeException(
                 'E-mail afzenderadres is niet geconfigureerd. '
                 .'Stel email_from_address in via de beheerdersinstellingen.'
             );
@@ -117,13 +118,13 @@ class CaseEmailService
         // returns null — we treat that as 403.
         $caseData = $this->loadCaseData(caseId: $caseId);
         if (empty($caseData) === true) {
-            throw new \RuntimeException('Zaak niet gevonden of geen toegang.');
+            throw new RuntimeException('Zaak niet gevonden of geen toegang.');
         }
 
         // H4: Validate the recipient against the case's registered contact emails.
         // This prevents open-relay abuse where any email address could be supplied.
         if ($to === '' || filter_var($to, FILTER_VALIDATE_EMAIL) === false) {
-            throw new \RuntimeException('Ongeldig e-mailadres opgegeven.');
+            throw new RuntimeException('Ongeldig e-mailadres opgegeven.');
         }
 
         $allowedEmails = $this->getCaseContactEmails(caseData: $caseData);
@@ -133,7 +134,7 @@ class CaseEmailService
                     'Blocked email to non-case-contact address',
                     ['app' => Application::APP_ID, 'to' => $to, 'caseId' => $caseId]
                 );
-                throw new \RuntimeException('Ontvanger is geen geregistreerd contact bij deze zaak.');
+                throw new RuntimeException('Ontvanger is geen geregistreerd contact bij deze zaak.');
             }
         }
 
@@ -184,7 +185,7 @@ class CaseEmailService
                     'exception' => $e,
                 ],
             );
-            throw new \RuntimeException('email_send_failed');
+            throw new RuntimeException('email_send_failed');
         }
 
         // Record the sent email as a case document.
@@ -223,7 +224,7 @@ class CaseEmailService
     ): array {
         $template = $this->loadTemplate(templateId: $templateId);
         if ($template === null) {
-            throw new \RuntimeException('Email template not found');
+            throw new RuntimeException('Email template not found');
         }
 
         // Load case data for variable resolution.

--- a/lib/Service/CaseReassignmentService.php
+++ b/lib/Service/CaseReassignmentService.php
@@ -34,12 +34,14 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service;
 
+use DateTime;
 use DateTimeImmutable;
 use InvalidArgumentException;
 use OCA\Procest\AppInfo\Application;
 use OCA\Procest\Service\Support\SearchesObjects;
 use OCP\Notification\IManager;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 /**
  * Previews and executes bulk reassignment of a handler's open workload.
@@ -328,7 +330,7 @@ class CaseReassignmentService
             $notification = $this->notificationManager->createNotification();
             $notification->setApp(Application::APP_ID)
                 ->setUser($toUser)
-                ->setDateTime(new \DateTime())
+                ->setDateTime(new DateTime())
                 ->setObject('reassignment', $batchId)
                 ->setSubject(
                     'cases_reassigned',
@@ -401,7 +403,7 @@ class CaseReassignmentService
         $objectService = $this->settingsService->getObjectService();
         $register      = (string) $this->settingsService->getConfigValue('register');
         if ($objectService === null || $register === '') {
-            throw new \RuntimeException('OpenRegister is not available');
+            throw new RuntimeException('OpenRegister is not available');
         }
 
         return [$objectService, $register];

--- a/lib/Service/CaseReassignmentService.php
+++ b/lib/Service/CaseReassignmentService.php
@@ -193,7 +193,7 @@ class CaseReassignmentService
 
         foreach ($preview['cases'] as $case) {
             $id        = (string) ($case['id'] ?? ($case['uuid'] ?? ''));
-            $ok        = $this->reassignItem(
+            $success   = $this->reassignItem(
                 objectService: $objectService,
                 register: $register,
                 schema: $caseSchema,
@@ -205,15 +205,15 @@ class CaseReassignmentService
                 batchId: $batchId,
                 now: $now
             );
-            $results[] = ['type' => 'case', 'id' => $id, 'title' => (string) ($case['title'] ?? ''), 'success' => $ok];
-            if ($ok === true) {
+            $results[] = ['type' => 'case', 'id' => $id, 'title' => (string) ($case['title'] ?? ''), 'success' => $success];
+            if ($success === true) {
                 $succeeded += 1;
             }
         }
 
         foreach ($preview['tasks'] as $task) {
             $id        = (string) ($task['id'] ?? ($task['uuid'] ?? ''));
-            $ok        = $this->reassignItem(
+            $success   = $this->reassignItem(
                 objectService: $objectService,
                 register: $register,
                 schema: $taskSchema,
@@ -225,8 +225,8 @@ class CaseReassignmentService
                 batchId: $batchId,
                 now: $now
             );
-            $results[] = ['type' => 'task', 'id' => $id, 'title' => (string) ($task['title'] ?? ''), 'success' => $ok];
-            if ($ok === true) {
+            $results[] = ['type' => 'task', 'id' => $id, 'title' => (string) ($task['title'] ?? ''), 'success' => $success];
+            if ($success === true) {
                 $succeeded += 1;
             }
         }

--- a/lib/Service/CaseSharingService.php
+++ b/lib/Service/CaseSharingService.php
@@ -123,9 +123,8 @@ class CaseSharingService
                 return false;
             }
 
-            if (is_array($caseObj) === true) {
-                $caseData = $caseObj;
-            } else {
+            $caseData = $caseObj;
+            if (is_array($caseObj) === false) {
                 $caseData = $caseObj->jsonSerialize();
             }
         } catch (\Throwable $e) {
@@ -157,9 +156,8 @@ class CaseSharingService
                 );
 
                 foreach ($shares as $share) {
-                    if (is_array($share) === true) {
-                        $shareData = $share;
-                    } else {
+                    $shareData = $share;
+                    if (is_array($share) === false) {
                         $shareData = $share->jsonSerialize();
                     }
 
@@ -471,9 +469,8 @@ class CaseSharingService
                 return null;
             }
 
-            if (is_array($shareObj) === true) {
-                $shareData = $shareObj;
-            } else {
+            $shareData = $shareObj;
+            if (is_array($shareObj) === false) {
                 $shareData = $shareObj->jsonSerialize();
             }
 
@@ -520,9 +517,8 @@ class CaseSharingService
             return ['error' => 'Share not found'];
         }
 
-        if (is_array($shareObj) === true) {
-            $shareData = $shareObj;
-        } else {
+        $shareData = $shareObj;
+        if (is_array($shareObj) === false) {
             $shareData = $shareObj->jsonSerialize();
         }
 
@@ -616,9 +612,8 @@ class CaseSharingService
             return ['error' => 'Case not found'];
         }
 
-        if (is_array($caseObj) === true) {
-            $caseData = $caseObj;
-        } else {
+        $caseData = $caseObj;
+        if (is_array($caseObj) === false) {
             $caseData = $caseObj->jsonSerialize();
         }
 
@@ -654,10 +649,9 @@ class CaseSharingService
             'createdBy'       => $createdBy,
         ];
 
-        $result = $objectService->saveObject(object: $shareData, register: (int) $register, schema: (int) $shareSchema);
-        if (is_array($result) === true) {
-            $resultData = $result;
-        } else {
+        $result     = $objectService->saveObject(object: $shareData, register: (int) $register, schema: (int) $shareSchema);
+        $resultData = $result;
+        if (is_array($result) === false) {
             $resultData = $result->jsonSerialize();
         }
 
@@ -740,9 +734,8 @@ class CaseSharingService
             return ['error' => 'Federated share not found'];
         }
 
-        if (is_array($shareObj) === true) {
-            $shareData = $shareObj;
-        } else {
+        $shareData = $shareObj;
+        if (is_array($shareObj) === false) {
             $shareData = $shareObj->jsonSerialize();
         }
 
@@ -812,9 +805,8 @@ class CaseSharingService
                 return null;
             }
 
-            if (is_array($shareObj) === true) {
-                $shareData = $shareObj;
-            } else {
+            $shareData = $shareObj;
+            if (is_array($shareObj) === false) {
                 $shareData = $shareObj->jsonSerialize();
             }
 

--- a/lib/Service/CaseSharingService.php
+++ b/lib/Service/CaseSharingService.php
@@ -734,8 +734,13 @@ class CaseSharingService
             return ['error' => 'Federated share not found'];
         }
 
-        $shareData = $shareObj;
-        if (is_array($shareObj) === false) {
+        // NOTE: kept as if/else deliberately. Hoisting the default assignment
+        // lets PHPStan narrow $shareData to the empty-array shape of
+        // ObjectService::find()'s array branch, which then reports the
+        // 'caseId'/'remoteCloudId' reads below as non-existent offsets.
+        if (is_array($shareObj) === true) {
+            $shareData = $shareObj;
+        } else {
             $shareData = $shareObj->jsonSerialize();
         }
 

--- a/lib/Service/CaseSharingService.php
+++ b/lib/Service/CaseSharingService.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service;
 
+use DateTime;
 use OCP\App\IAppManager;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
@@ -527,7 +528,7 @@ class CaseSharingService
 
         $shareData['status']    = 'revoked';
         $shareData['revokedBy'] = $userId;
-        $shareData['revokedAt'] = (new \DateTime())->format('c');
+        $shareData['revokedAt'] = (new DateTime())->format('c');
 
         $result = $objectService->saveObject(object: $shareData, register: (int) $register, schema: (int) $shareSchema);
 
@@ -760,7 +761,7 @@ class CaseSharingService
 
         $shareData['status']    = 'revoked';
         $shareData['revokedBy'] = $userId;
-        $shareData['revokedAt'] = (new \DateTime())->format('c');
+        $shareData['revokedAt'] = (new DateTime())->format('c');
 
         $result = $objectService->saveObject(object: $shareData, register: (int) $register, schema: (int) $shareSchema);
 

--- a/lib/Service/CaseTransferService.php
+++ b/lib/Service/CaseTransferService.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service;
 
+use DateTime;
 use OCP\App\IAppManager;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
@@ -122,7 +123,7 @@ class CaseTransferService
             }
         }
 
-        $now = (new \DateTime())->format('c');
+        $now = (new DateTime())->format('c');
 
         $transferData = [
             'caseId'             => $caseId,
@@ -285,7 +286,7 @@ class CaseTransferService
         }
 
         $caseId = (string) ($transferData['caseId'] ?? '');
-        $now    = (new \DateTime())->format('c');
+        $now    = (new DateTime())->format('c');
 
         // Read the existing custody chain before the status writes below, which
         // is also where the pre-existing trail must be preserved from.

--- a/lib/Service/CaseTransferService.php
+++ b/lib/Service/CaseTransferService.php
@@ -268,10 +268,9 @@ class CaseTransferService
             return ['error' => 'Transfer not found'];
         }
 
+        $transferData = (array) $transfer;
         if (is_object($transfer) === true) {
             $transferData = $transfer->jsonSerialize();
-        } else {
-            $transferData = (array) $transfer;
         }
 
         $currentStatus = (string) ($transferData['status'] ?? '');
@@ -298,10 +297,9 @@ class CaseTransferService
             $transferData['rejectionReason'] = $rejectionReason;
         }
 
+        $actorType = 'local';
         if ($remoteCloudId !== null) {
             $actorType = 'remote';
-        } else {
-            $actorType = 'local';
         }
 
         $auditTrail[] = [
@@ -374,10 +372,9 @@ class CaseTransferService
                 return null;
             }
 
+            $transferData = (array) $transfer;
             if (is_object($transfer) === true) {
                 $transferData = $transfer->jsonSerialize();
-            } else {
-                $transferData = (array) $transfer;
             }
 
             if (isset($transferData['caseId']) === true) {
@@ -467,9 +464,8 @@ class CaseTransferService
         }
 
         foreach ((array) $matches as $match) {
-            if (is_array($match) === true) {
-                $matchData = $match;
-            } else {
+            $matchData = $match;
+            if (is_array($match) === false) {
                 $matchData = $match->jsonSerialize();
             }
 

--- a/lib/Service/ComplaintAnalyticsService.php
+++ b/lib/Service/ComplaintAnalyticsService.php
@@ -280,7 +280,6 @@ class ComplaintAnalyticsService
 
             // Anonymize: only include count, categories, and periods — not the employee ID.
             $categories = array_unique(array_column($employeeDetails[$employee], 'categorie'));
-            $periods    = array_column($employeeDetails[$employee], 'ontvangstdatum');
 
             $alerts[] = [
                 'count'      => $count,
@@ -314,7 +313,6 @@ class ComplaintAnalyticsService
         $total          = count($complaints);
         $resolved       = 0;
         $withinDeadline = 0;
-        $oordelen       = [];
 
         foreach ($complaints as $complaint) {
             $status = $complaint['status'] ?? '';

--- a/lib/Service/ComplaintAnalyticsService.php
+++ b/lib/Service/ComplaintAnalyticsService.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service;
 
+use DateTimeImmutable;
 use OCA\Procest\AppInfo\Application;
 use OCA\Procest\Service\Support\SearchesObjects;
 use Psr\Log\LoggerInterface;
@@ -166,8 +167,8 @@ class ComplaintAnalyticsService
                 continue;
             }
 
-            $start = new \DateTimeImmutable($ontvangst);
-            $end   = new \DateTimeImmutable($afhandelDeadline);
+            $start = new DateTimeImmutable($ontvangst);
+            $end   = new DateTimeImmutable($afhandelDeadline);
             $days  = (int) $start->diff($end)->days;
 
             $totals[$categorie] = ($totals[$categorie] ?? 0) + $days;
@@ -251,7 +252,7 @@ class ComplaintAnalyticsService
      */
     public function checkEmployeeThresholdAlerts(): array
     {
-        $sixMonthsAgo = (new \DateTimeImmutable('today'))->modify('-6 months')->format('Y-m-d');
+        $sixMonthsAgo = (new DateTimeImmutable('today'))->modify('-6 months')->format('Y-m-d');
         $today        = date('Y-m-d');
 
         $complaints      = $this->fetchComplaintsInRange(dateFrom: $sixMonthsAgo, dateTo: $today);

--- a/lib/Service/ComplaintService.php
+++ b/lib/Service/ComplaintService.php
@@ -23,9 +23,11 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service;
 
+use DateTimeImmutable;
 use OCA\Procest\AppInfo\Application;
 use OCA\Procest\Service\Support\SearchesObjects;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 /**
  * Service for complaint (klacht) management per Awb chapter 9.
@@ -120,14 +122,14 @@ class ComplaintService
 
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
-            throw new \RuntimeException('OpenRegister is not available');
+            throw new RuntimeException('OpenRegister is not available');
         }
 
         $register = $this->settingsService->getConfigValue('register');
         $schema   = $this->settingsService->getConfigValue('complaint_schema');
 
         if (empty($register) === true || empty($schema) === true) {
-            throw new \RuntimeException('Complaint schema not configured');
+            throw new RuntimeException('Complaint schema not configured');
         }
 
         $ontvangstdatum = $data['ontvangstdatum'];
@@ -236,7 +238,7 @@ class ComplaintService
     {
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
-            throw new \RuntimeException('OpenRegister is not available');
+            throw new RuntimeException('OpenRegister is not available');
         }
 
         $register = $this->settingsService->getConfigValue('register');
@@ -267,18 +269,18 @@ class ComplaintService
     {
         $complaint = $this->getComplaint(id: $id);
         if ($complaint === null) {
-            throw new \RuntimeException('Complaint not found: '.$id);
+            throw new RuntimeException('Complaint not found: '.$id);
         }
 
         if (in_array($newStatus, self::VALID_STATUSES, true) === false) {
-            throw new \RuntimeException('Unknown complaint status: '.$newStatus);
+            throw new RuntimeException('Unknown complaint status: '.$newStatus);
         }
 
         $currentStatus = $complaint['status'] ?? 'ontvangen';
         $allowed       = self::TRANSITIONS[$currentStatus] ?? [];
 
         if (in_array($newStatus, $allowed, true) === false) {
-            throw new \RuntimeException(
+            throw new RuntimeException(
                 'Transition from '.$currentStatus.' to '.$newStatus.' is not allowed'
             );
         }
@@ -302,15 +304,15 @@ class ComplaintService
     {
         $complaint = $this->getComplaint(id: $id);
         if ($complaint === null) {
-            throw new \RuntimeException('Complaint not found: '.$id);
+            throw new RuntimeException('Complaint not found: '.$id);
         }
 
         if (($complaint['verdagingMogelijk'] ?? false) === false) {
-            throw new \RuntimeException('Verdaging is not available — already used or not applicable');
+            throw new RuntimeException('Verdaging is not available — already used or not applicable');
         }
 
         if (empty($justificatie) === true) {
-            throw new \RuntimeException('Justificatie is required for verdaging per Awb chapter 9');
+            throw new RuntimeException('Justificatie is required for verdaging per Awb chapter 9');
         }
 
         $currentDeadline = $complaint['afhandelDeadline'] ?? date('Y-m-d');
@@ -346,7 +348,7 @@ class ComplaintService
     {
         $complaint = $this->getComplaint(id: $complaintId);
         if ($complaint === null) {
-            throw new \RuntimeException('Complaint not found: '.$complaintId);
+            throw new RuntimeException('Complaint not found: '.$complaintId);
         }
 
         return $this->updateComplaint(id: $complaintId, data: ['geescaleerdeZaak' => $caseId]);
@@ -365,7 +367,7 @@ class ComplaintService
     {
         $activeStatuses = ['ontvangen', 'ontvangst_bevestigd', 'in_behandeling', 'hoorgesprek_gepland', 'hoorgesprek_afgerond'];
         $all            = $this->listComplaints(filters: ['status' => $activeStatuses]);
-        $today          = new \DateTimeImmutable('today');
+        $today          = new DateTimeImmutable('today');
         $overdue        = [];
         $warning        = [];
 
@@ -375,7 +377,7 @@ class ComplaintService
                 continue;
             }
 
-            $deadlineDate = new \DateTimeImmutable($deadline);
+            $deadlineDate = new DateTimeImmutable($deadline);
             $diff         = (int) $today->diff($deadlineDate)->days;
             $isPast       = $today > $deadlineDate;
 
@@ -401,7 +403,7 @@ class ComplaintService
      */
     public function addWorkingDays(string $startDate, int $days): string
     {
-        $date  = new \DateTimeImmutable($startDate);
+        $date  = new DateTimeImmutable($startDate);
         $added = 0;
 
         while ($added < $days) {
@@ -426,7 +428,7 @@ class ComplaintService
      */
     public function addCalendarWeeks(string $startDate, int $weeks): string
     {
-        $date = new \DateTimeImmutable($startDate);
+        $date = new DateTimeImmutable($startDate);
         $date = $date->modify('+'.$weeks.' weeks');
         return $date->format('Y-m-d');
     }//end addCalendarWeeks()
@@ -457,7 +459,7 @@ class ComplaintService
 
         // Skip Easter-derived holidays (Good Friday, Easter Monday, Ascension, Whit Monday).
         $year          = (int) $date->format('Y');
-        $easter        = new \DateTimeImmutable(date('Y-m-d', easter_date($year)));
+        $easter        = new DateTimeImmutable(date('Y-m-d', easter_date($year)));
         $easterDerived = [
             $easter->modify('-2 days')->format('Y-m-d'),
             $easter->modify('+1 day')->format('Y-m-d'),
@@ -533,7 +535,7 @@ class ComplaintService
         }
 
         if (empty($missing) === false) {
-            throw new \RuntimeException('Required fields missing: '.implode(', ', $missing));
+            throw new RuntimeException('Required fields missing: '.implode(', ', $missing));
         }
     }//end validateRequired()
 }//end class

--- a/lib/Service/ConflictOfInterestService.php
+++ b/lib/Service/ConflictOfInterestService.php
@@ -145,15 +145,15 @@ class ConflictOfInterestService
      * The callable signature is `(userBsn, applicantBsn): string|null`
      * returning a relationship label (e.g. "spouse", "parent") or null.
      *
-     * @param callable $cb Lookup callable.
+     * @param callable $lookup Lookup callable.
      *
      * @return void
      *
      * @spec openspec/changes/mandaat-matrix-06-temporal-and-conflict/tasks.md
      */
-    public function setRelationshipLookup(callable $cb): void
+    public function setRelationshipLookup(callable $lookup): void
     {
-        $this->relationshipLookup = $cb;
+        $this->relationshipLookup = $lookup;
     }//end setRelationshipLookup()
 
     /**

--- a/lib/Service/ConsultationService.php
+++ b/lib/Service/ConsultationService.php
@@ -29,6 +29,7 @@ namespace OCA\Procest\Service;
 use OCA\Procest\AppInfo\Application;
 use OCA\Procest\Service\Support\SearchesObjects;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 /**
  * Service for consultation (adviesaanvraag) management.
@@ -108,31 +109,31 @@ class ConsultationService
     {
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
-            throw new \RuntimeException('OpenRegister is not available');
+            throw new RuntimeException('OpenRegister is not available');
         }
 
         $register = $this->settingsService->getConfigValue('register');
         $schema   = $this->settingsService->getConfigValue('consultation_schema');
 
         if (empty($register) === true || empty($schema) === true) {
-            throw new \RuntimeException('Consultation schema not configured');
+            throw new RuntimeException('Consultation schema not configured');
         }
 
         // Validate required fields.
         if (empty($data['parentZaak']) === true) {
-            throw new \RuntimeException('parentZaak is required');
+            throw new RuntimeException('parentZaak is required');
         }
 
         if (empty($data['adviesInstantie']) === true) {
-            throw new \RuntimeException('adviesInstantie is required');
+            throw new RuntimeException('adviesInstantie is required');
         }
 
         if (empty($data['vraagstelling']) === true) {
-            throw new \RuntimeException('vraagstelling is required');
+            throw new RuntimeException('vraagstelling is required');
         }
 
         if (empty($data['uiterlijkeReactiedatum']) === true) {
-            throw new \RuntimeException('uiterlijkeReactiedatum is required');
+            throw new RuntimeException('uiterlijkeReactiedatum is required');
         }
 
         // Generate unique consultation number.
@@ -184,7 +185,7 @@ class ConsultationService
                 ['app' => Application::APP_ID],
             );
             // REQ-PDRD-002: fail closed; surface the error.
-            throw new \RuntimeException('Decision service unavailable: '.$e->getMessage(), 0, $e);
+            throw new RuntimeException('Decision service unavailable: '.$e->getMessage(), 0, $e);
         }//end try
 
         $this->logger->info(
@@ -278,12 +279,12 @@ class ConsultationService
     public function updateStatus(string $consultationId, string $newStatus): array
     {
         if (in_array($newStatus, self::VALID_STATUSES, true) === false) {
-            throw new \RuntimeException('Invalid status: '.$newStatus);
+            throw new RuntimeException('Invalid status: '.$newStatus);
         }
 
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
-            throw new \RuntimeException('OpenRegister is not available');
+            throw new RuntimeException('OpenRegister is not available');
         }
 
         $register = $this->settingsService->getConfigValue('register');
@@ -323,12 +324,12 @@ class ConsultationService
     {
         $advies = $response['advies'] ?? '';
         if (in_array($advies, self::VALID_RESPONSES, true) === false) {
-            throw new \RuntimeException('Invalid advice type: '.$advies);
+            throw new RuntimeException('Invalid advice type: '.$advies);
         }
 
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
-            throw new \RuntimeException('OpenRegister is not available');
+            throw new RuntimeException('OpenRegister is not available');
         }
 
         $register = $this->settingsService->getConfigValue('register');
@@ -374,14 +375,14 @@ class ConsultationService
     {
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
-            throw new \RuntimeException('OpenRegister is not available');
+            throw new RuntimeException('OpenRegister is not available');
         }
 
         $register = $this->settingsService->getConfigValue('register');
         $schema   = $this->settingsService->getConfigValue('consultation_schema');
 
         if (empty($register) === true || empty($schema) === true) {
-            throw new \RuntimeException('Consultation schema not configured');
+            throw new RuntimeException('Consultation schema not configured');
         }
 
         $objectService->deleteObject(uuid: (string) $consultationId, register: $register, schema: $schema);
@@ -531,7 +532,7 @@ class ConsultationService
     {
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
-            throw new \RuntimeException('OpenRegister is not available');
+            throw new RuntimeException('OpenRegister is not available');
         }
 
         $register = $this->settingsService->getConfigValue('register');
@@ -572,12 +573,12 @@ class ConsultationService
     public function approveExtension(string $consultationId, string $newDeadline): array
     {
         if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $newDeadline) !== 1) {
-            throw new \RuntimeException('Invalid date format; expected Y-m-d');
+            throw new RuntimeException('Invalid date format; expected Y-m-d');
         }
 
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
-            throw new \RuntimeException('OpenRegister is not available');
+            throw new RuntimeException('OpenRegister is not available');
         }
 
         $register = $this->settingsService->getConfigValue('register');

--- a/lib/Service/DispositionService.php
+++ b/lib/Service/DispositionService.php
@@ -26,6 +26,7 @@ namespace OCA\Procest\Service;
 use OCA\Procest\AppInfo\Application;
 use OCA\Procest\Service\Support\SearchesObjects;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 /**
  * Service for complaint disposition (oordeel) management.
@@ -85,14 +86,14 @@ class DispositionService
 
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
-            throw new \RuntimeException('OpenRegister is not available');
+            throw new RuntimeException('OpenRegister is not available');
         }
 
         $register = $this->settingsService->getConfigValue('register');
         $schema   = $this->settingsService->getConfigValue('complaint_disposition_schema');
 
         if (empty($register) === true || empty($schema) === true) {
-            throw new \RuntimeException('Complaint disposition schema not configured');
+            throw new RuntimeException('Complaint disposition schema not configured');
         }
 
         $data['complaint']    = $complaintId;
@@ -132,7 +133,7 @@ class DispositionService
     {
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
-            throw new \RuntimeException('OpenRegister is not available');
+            throw new RuntimeException('OpenRegister is not available');
         }
 
         $register = $this->settingsService->getConfigValue('register');
@@ -173,7 +174,7 @@ class DispositionService
     {
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
-            throw new \RuntimeException('OpenRegister is not available');
+            throw new RuntimeException('OpenRegister is not available');
         }
 
         $register = $this->settingsService->getConfigValue('register');
@@ -281,11 +282,11 @@ class DispositionService
     {
         $oordeel = $data['oordeel'] ?? '';
         if (in_array($oordeel, self::VALID_OORDELEN, true) === false) {
-            throw new \RuntimeException('Invalid oordeel: '.$oordeel.'. Must be one of: '.implode(', ', self::VALID_OORDELEN));
+            throw new RuntimeException('Invalid oordeel: '.$oordeel.'. Must be one of: '.implode(', ', self::VALID_OORDELEN));
         }
 
         if (in_array($oordeel, self::REQUIRES_TOELICHTING, true) === true && empty($data['toelichting']) === true) {
-            throw new \RuntimeException('Toelichting is required for oordeel: '.$oordeel);
+            throw new RuntimeException('Toelichting is required for oordeel: '.$oordeel);
         }
     }//end validateDisposition()
 }//end class

--- a/lib/Service/DoorlooptijdService.php
+++ b/lib/Service/DoorlooptijdService.php
@@ -66,22 +66,19 @@ class DoorlooptijdService
      */
     public function getMetrics(array $params): array
     {
+        $caseTypeFilter = null;
         if (isset($params['caseType']) === true && is_string($params['caseType']) === true) {
             $caseTypeFilter = $params['caseType'];
-        } else {
-            $caseTypeFilter = null;
         }
 
+        $period = '12m';
         if (isset($params['period']) === true && is_string($params['period']) === true) {
             $period = $params['period'];
-        } else {
-            $period = '12m';
         }
 
+        $atRiskDays = 5;
         if (isset($params['atRiskDays']) === true) {
             $atRiskDays = (int) $params['atRiskDays'];
-        } else {
-            $atRiskDays = 5;
         }
 
         if ($atRiskDays < 0) {
@@ -153,15 +150,15 @@ class DoorlooptijdService
 
             if ($caseData['_endDate'] <= $caseData['_deadline']) {
                 $closedOnTime++;
-            } else {
-                $closedLate++;
+                continue;
             }
+
+            $closedLate++;
         }//end foreach
 
-        $totalClosed = ($closedOnTime + $closedLate);
-        if ($totalClosed === 0) {
-            $onTimePercent = 100;
-        } else {
+        $totalClosed   = ($closedOnTime + $closedLate);
+        $onTimePercent = 100;
+        if ($totalClosed !== 0) {
             $onTimePercent = (int) round(($closedOnTime / $totalClosed) * 100);
         }
 
@@ -206,17 +203,17 @@ class DoorlooptijdService
 
             if ($caseData['_endDate'] <= $caseData['_deadline']) {
                 $buckets[$month]['onTime']++;
-            } else {
-                $buckets[$month]['late']++;
+                continue;
             }
+
+            $buckets[$month]['late']++;
         }//end foreach
 
         $out = [];
         foreach ($buckets as $month => $counts) {
-            $total = ($counts['onTime'] + $counts['late']);
-            if ($total === 0) {
-                $percent = 100;
-            } else {
+            $total   = ($counts['onTime'] + $counts['late']);
+            $percent = 100;
+            if ($total !== 0) {
                 $percent = (int) round(($counts['onTime'] / $total) * 100);
             }
 
@@ -272,10 +269,9 @@ class DoorlooptijdService
 
         $out = [];
         foreach ($accum as $caseTypeId => $stats) {
+            $title = $caseTypeId;
             if (isset($caseTypeIndex[$caseTypeId]['title']) === true) {
                 $title = (string) $caseTypeIndex[$caseTypeId]['title'];
-            } else {
-                $title = $caseTypeId;
             }
 
             $out[] = [

--- a/lib/Service/DoorlooptijdService.php
+++ b/lib/Service/DoorlooptijdService.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service;
 
+use DateInterval;
 use DateTimeImmutable;
 use DateTimeInterface;
 use OCA\Procest\Service\Support\SearchesObjects;
@@ -456,7 +457,7 @@ class DoorlooptijdService
 
         try {
             $start = new DateTimeImmutable($startDate);
-            return $start->add(new \DateInterval($processingDeadline))->format('Y-m-d');
+            return $start->add(new DateInterval($processingDeadline))->format('Y-m-d');
         } catch (\Throwable $e) {
             $this->logger->debug(
                 'Could not derive deadline from processingDeadline',

--- a/lib/Service/DsoCaseService.php
+++ b/lib/Service/DsoCaseService.php
@@ -24,6 +24,8 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service;
 
+use DateTimeImmutable;
+use Exception;
 use OCA\Procest\AppInfo\Application;
 use OCA\Procest\Event\VergunningStatusChangedEvent;
 use OCA\Procest\Service\Support\SearchesObjects;
@@ -32,6 +34,7 @@ use OCP\IAppConfig;
 use OCP\IUser;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 /**
  * Service for DSO Omgevingsloket case management.
@@ -125,7 +128,7 @@ class DsoCaseService
         );
 
         if ($vergunningaanvraag === null) {
-            throw new \RuntimeException('Vergunningaanvraag not found: '.$vergunningaanvraagId);
+            throw new RuntimeException('Vergunningaanvraag not found: '.$vergunningaanvraagId);
         }
 
         $activiteiten  = $vergunningaanvraag['activiteiten'] ?? [];
@@ -232,7 +235,7 @@ class DsoCaseService
         );
 
         if ($zaak === null) {
-            throw new \RuntimeException('Zaak not found: '.$zaakId);
+            throw new RuntimeException('Zaak not found: '.$zaakId);
         }
 
         $zaak = $this->normalizeToArray(value: $zaak);
@@ -316,7 +319,7 @@ class DsoCaseService
             $workingDaysTarget = 40;
         }
 
-        $current     = new \DateTimeImmutable($indieningsdatum);
+        $current     = new DateTimeImmutable($indieningsdatum);
         $workingDays = 0;
 
         while ($workingDays < $workingDaysTarget) {
@@ -366,7 +369,7 @@ class DsoCaseService
             );
         }
 
-        throw new \Exception('Not authorized');
+        throw new Exception('Not authorized');
     }//end authorizeZaakMutation()
 
     /**
@@ -381,7 +384,7 @@ class DsoCaseService
         try {
             return $this->container->get('OCA\OpenRegister\Service\ObjectService');
         } catch (\Throwable $e) {
-            throw new \RuntimeException(
+            throw new RuntimeException(
                 'OpenRegister ObjectService not available: '.$e->getMessage(),
                 0,
                 $e
@@ -480,7 +483,7 @@ class DsoCaseService
         $easterTs   = easter_date($year);
         $easterDay  = (int) date('j', $easterTs);
         $easterMon  = (int) date('n', $easterTs);
-        $easterDate = (new \DateTimeImmutable())->setDate($year, $easterMon, $easterDay);
+        $easterDate = (new DateTimeImmutable())->setDate($year, $easterMon, $easterDay);
 
         foreach (self::EASTER_OFFSETS as $offset) {
             $holiday = $easterDate->modify('+'.$offset.' days');

--- a/lib/Service/DsoIntakeService.php
+++ b/lib/Service/DsoIntakeService.php
@@ -90,7 +90,6 @@ class DsoIntakeService
         $bouwkosten    = $dsoMessage['bouwkosten'] ?? 0;
         $procedureType = $dsoMessage['procedureType'] ?? 'regulier';
         $dsoZaaknummer = $dsoMessage['zaaknummer'] ?? '';
-        $bijlagen      = $dsoMessage['bijlagen'] ?? [];
 
         // Build activity description.
         $activityNames = array_map(

--- a/lib/Service/DsoIntakeService.php
+++ b/lib/Service/DsoIntakeService.php
@@ -28,6 +28,7 @@ namespace OCA\Procest\Service;
 
 use OCA\Procest\AppInfo\Application;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 /**
  * Service for DSO/Omgevingsloket intake processing.
@@ -74,12 +75,12 @@ class DsoIntakeService
     {
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
-            throw new \RuntimeException('OpenRegister is not available');
+            throw new RuntimeException('OpenRegister is not available');
         }
 
         $register = $this->settingsService->getConfigValue('register');
         if (empty($register) === true) {
-            throw new \RuntimeException('Procest register not configured');
+            throw new RuntimeException('Procest register not configured');
         }
 
         // Extract fields from DSO message.
@@ -270,12 +271,12 @@ class DsoIntakeService
     {
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
-            throw new \RuntimeException('OpenRegister is not available');
+            throw new RuntimeException('OpenRegister is not available');
         }
 
         $register = $this->settingsService->getConfigValue('register');
         if (empty($register) === true) {
-            throw new \RuntimeException('Procest register not configured');
+            throw new RuntimeException('Procest register not configured');
         }
 
         $caseSchema = $this->settingsService->getConfigValue('case_schema');

--- a/lib/Service/EmailArchivalService.php
+++ b/lib/Service/EmailArchivalService.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service;
 
+use InvalidArgumentException;
 use OCA\Procest\Service\Support\SearchesObjects;
 use Psr\Log\LoggerInterface;
 
@@ -76,7 +77,7 @@ class EmailArchivalService
     public function archiveLinkedEmail(string $caseId, array $metadata): array
     {
         if ($caseId === '') {
-            throw new \InvalidArgumentException('caseId is required');
+            throw new InvalidArgumentException('caseId is required');
         }
 
         $size = (int) ($metadata['sizeBytes'] ?? 0);

--- a/lib/Service/EmailTemplateService.php
+++ b/lib/Service/EmailTemplateService.php
@@ -31,6 +31,7 @@ namespace OCA\Procest\Service;
 
 use OCA\Procest\Service\Support\SearchesObjects;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 /**
  * CRUD + prefill for emailTemplate records.
@@ -122,7 +123,7 @@ class EmailTemplateService
     {
         $existing = $this->loadTemplate(templateId: $templateId);
         if ($existing === null) {
-            throw new \RuntimeException('Template not found');
+            throw new RuntimeException('Template not found');
         }
 
         $currentVersion = (int) ($existing['version'] ?? 1);
@@ -251,16 +252,16 @@ class EmailTemplateService
     {
         $template = $this->loadTemplate(templateId: $templateId);
         if ($template === null) {
-            throw new \RuntimeException('Template not found');
+            throw new RuntimeException('Template not found');
         }
 
         $case = $this->loadCase(caseId: $caseId);
         if ($case === null) {
-            throw new \RuntimeException('Case not found');
+            throw new RuntimeException('Case not found');
         }
 
         if (($case['_isFinal'] ?? false) === true) {
-            throw new \RuntimeException('Case is in a final state — drafting is disabled');
+            throw new RuntimeException('Case is in a final state — drafting is disabled');
         }
 
         $vars       = $this->buildVariableMap(case: $case);
@@ -390,13 +391,13 @@ class EmailTemplateService
     {
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
-            throw new \RuntimeException('ObjectService unavailable');
+            throw new RuntimeException('ObjectService unavailable');
         }
 
         $register = $this->settingsService->getConfigValue('register');
         $schema   = $this->settingsService->getConfigValue('email_template_schema');
         if (empty($register) === true || empty($schema) === true) {
-            throw new \RuntimeException('emailTemplate schema is not configured');
+            throw new RuntimeException('emailTemplate schema is not configured');
         }
 
         $saved = $objectService->saveObject(

--- a/lib/Service/HearingService.php
+++ b/lib/Service/HearingService.php
@@ -26,6 +26,7 @@ namespace OCA\Procest\Service;
 use OCA\Procest\AppInfo\Application;
 use OCA\Procest\Service\Support\SearchesObjects;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 /**
  * Service for hearing (hoorgesprek) management within the complaint workflow.
@@ -64,23 +65,23 @@ class HearingService
     public function scheduleHearing(string $complaintId, array $data): array
     {
         if (empty($data['datum']) === true) {
-            throw new \RuntimeException('Hearing datum is required');
+            throw new RuntimeException('Hearing datum is required');
         }
 
         if (empty($data['type']) === true) {
-            throw new \RuntimeException('Hearing type is required');
+            throw new RuntimeException('Hearing type is required');
         }
 
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
-            throw new \RuntimeException('OpenRegister is not available');
+            throw new RuntimeException('OpenRegister is not available');
         }
 
         $register = $this->settingsService->getConfigValue('register');
         $schema   = $this->settingsService->getConfigValue('hearing_schema');
 
         if (empty($register) === true || empty($schema) === true) {
-            throw new \RuntimeException('Hearing schema not configured');
+            throw new RuntimeException('Hearing schema not configured');
         }
 
         $data['complaint'] = $complaintId;
@@ -188,12 +189,12 @@ class HearingService
     public function recordOutcome(string $id, array $outcome): array
     {
         if (empty($outcome['verslag']) === true) {
-            throw new \RuntimeException('Verslag is required to record a hearing outcome');
+            throw new RuntimeException('Verslag is required to record a hearing outcome');
         }
 
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
-            throw new \RuntimeException('OpenRegister is not available');
+            throw new RuntimeException('OpenRegister is not available');
         }
 
         $register = $this->settingsService->getConfigValue('register');

--- a/lib/Service/HearingService.php
+++ b/lib/Service/HearingService.php
@@ -288,12 +288,6 @@ class HearingService
 
         $datum   = $data['datum'] ?? '';
         $locatie = $data['locatie'] ?? '';
-        $talkUrl = $data['talkRoomUrl'] ?? '';
-
-        $description = 'Hoorgesprek klacht';
-        if (empty($talkUrl) === false) {
-            $description .= "\nVideo link: ".$talkUrl;
-        }
 
         // Calendar integration — log attempt; actual calendar write is
         // delegated to NC Calendar IManager search/find calendars per participant.

--- a/lib/Service/Kcc/BelplanRoutingService.php
+++ b/lib/Service/Kcc/BelplanRoutingService.php
@@ -201,15 +201,15 @@ class BelplanRoutingService
         usort(
             $available,
             static function (array $a, array $b): int {
-                $qa = (int) ($a['huidigeWachtrijLengte'] ?? 0);
-                $qb = (int) ($b['huidigeWachtrijLengte'] ?? 0);
-                if ($qa !== $qb) {
-                    return $qa <=> $qb;
+                $queueA = (int) ($a['huidigeWachtrijLengte'] ?? 0);
+                $queueB = (int) ($b['huidigeWachtrijLengte'] ?? 0);
+                if ($queueA !== $queueB) {
+                    return $queueA <=> $queueB;
                 }
 
-                $ta = (int) ($a['gemiddeldeBehandelduur'] ?? 0);
-                $tb = (int) ($b['gemiddeldeBehandelduur'] ?? 0);
-                return $ta <=> $tb;
+                $durationA = (int) ($a['gemiddeldeBehandelduur'] ?? 0);
+                $durationB = (int) ($b['gemiddeldeBehandelduur'] ?? 0);
+                return $durationA <=> $durationB;
             }
         );
 
@@ -279,9 +279,9 @@ class BelplanRoutingService
     {
         $min = PHP_INT_MAX;
         foreach ($pool as $sp) {
-            $q = (int) ($sp['huidigeWachtrijLengte'] ?? 0);
-            if ($q < $min) {
-                $min = $q;
+            $queue = (int) ($sp['huidigeWachtrijLengte'] ?? 0);
+            if ($queue < $min) {
+                $min = $queue;
             }
         }
 

--- a/lib/Service/MandaatCheckService.php
+++ b/lib/Service/MandaatCheckService.php
@@ -127,7 +127,7 @@ class MandaatCheckService
         $relevant = array_values(
                 array_filter(
             $mandaten,
-            static fn (array $m): bool => (string) ($m['gemandateerdeRol'] ?? '') === (string) $role['rolId']
+            static fn (array $row): bool => (string) ($row['gemandateerdeRol'] ?? '') === (string) $role['rolId']
         )
                 );
 
@@ -197,13 +197,13 @@ class MandaatCheckService
 
         $out = [];
         foreach ($rows as $row) {
-            $vf = (string) ($row['validFrom'] ?? '1970-01-01');
-            $vu = (string) ($row['validUntil'] ?? '');
-            if ($vf > $dateStr) {
+            $validFrom  = (string) ($row['validFrom'] ?? '1970-01-01');
+            $validUntil = (string) ($row['validUntil'] ?? '');
+            if ($validFrom > $dateStr) {
                 continue;
             }
 
-            if ($vu !== '' && $vu < $dateStr) {
+            if ($validUntil !== '' && $validUntil < $dateStr) {
                 continue;
             }
 
@@ -304,13 +304,13 @@ class MandaatCheckService
         $dateStr = $date->format('Y-m-d');
         $active  = [];
         foreach ($rows as $row) {
-            $vf = (string) ($row['validFrom'] ?? '1970-01-01');
-            $vu = (string) ($row['validUntil'] ?? '');
-            if ($vf > $dateStr) {
+            $validFrom  = (string) ($row['validFrom'] ?? '1970-01-01');
+            $validUntil = (string) ($row['validUntil'] ?? '');
+            if ($validFrom > $dateStr) {
                 continue;
             }
 
-            if ($vu !== '' && $vu < $dateStr) {
+            if ($validUntil !== '' && $validUntil < $dateStr) {
                 continue;
             }
 

--- a/lib/Service/MapTileService.php
+++ b/lib/Service/MapTileService.php
@@ -33,6 +33,8 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service;
 
+use InvalidArgumentException;
+
 /**
  * Stateless tile-list manifest builder for offline PWA pre-caching.
  */
@@ -97,7 +99,7 @@ class MapTileService
                 );
                 $tiles[]     = $tile;
                 if (count($tiles) > self::MAX_TILES) {
-                    throw new \InvalidArgumentException(
+                    throw new InvalidArgumentException(
                         sprintf(
                             'Tile manifest would exceed %d tiles; narrow bbox or zoom range.',
                             self::MAX_TILES
@@ -259,20 +261,20 @@ class MapTileService
     {
         foreach (['minLat', 'minLon', 'maxLat', 'maxLon'] as $key) {
             if (isset($bbox[$key]) === false || is_numeric($bbox[$key]) === false) {
-                throw new \InvalidArgumentException('bbox.'.$key.' is required and numeric');
+                throw new InvalidArgumentException('bbox.'.$key.' is required and numeric');
             }
         }
 
         if ($bbox['minLat'] < -85.0511 || $bbox['maxLat'] > 85.0511) {
-            throw new \InvalidArgumentException('latitudes out of Web-Mercator range');
+            throw new InvalidArgumentException('latitudes out of Web-Mercator range');
         }
 
         if ($bbox['minLat'] >= $bbox['maxLat']) {
-            throw new \InvalidArgumentException('minLat must be < maxLat');
+            throw new InvalidArgumentException('minLat must be < maxLat');
         }
 
         if ($bbox['minLon'] >= $bbox['maxLon']) {
-            throw new \InvalidArgumentException('minLon must be < maxLon');
+            throw new InvalidArgumentException('minLon must be < maxLon');
         }
     }//end assertBbox()
 
@@ -288,12 +290,12 @@ class MapTileService
     private function assertZoomLevels(array $zoomLevels): void
     {
         if (count($zoomLevels) === 0) {
-            throw new \InvalidArgumentException('zoomLevels must not be empty');
+            throw new InvalidArgumentException('zoomLevels must not be empty');
         }
 
         foreach ($zoomLevels as $z) {
             if ($z < 0 || $z > self::MAX_ZOOM) {
-                throw new \InvalidArgumentException(
+                throw new InvalidArgumentException(
                     sprintf('zoom %s out of range [0, %d]', (string) $z, self::MAX_ZOOM)
                 );
             }

--- a/lib/Service/MentionNotificationService.php
+++ b/lib/Service/MentionNotificationService.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service;
 
+use DateTime;
 use OCA\Procest\AppInfo\Application;
 use OCP\Notification\IManager;
 use Psr\Log\LoggerInterface;
@@ -92,7 +93,7 @@ class MentionNotificationService
                 $notification = $this->notificationManager->createNotification();
                 $notification->setApp(Application::APP_ID)
                     ->setUser($mentionedUserId)
-                    ->setDateTime(new \DateTime())
+                    ->setDateTime(new DateTime())
                     ->setObject($objectType, $objectId)
                     ->setSubject(
                             'note_mention',

--- a/lib/Service/MilestoneService.php
+++ b/lib/Service/MilestoneService.php
@@ -27,9 +27,11 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service;
 
+use DateTimeImmutable;
 use OCA\Procest\AppInfo\Application;
 use OCA\Procest\Service\Support\SearchesObjects;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 /**
  * Service for milestone tracking and progress calculation.
@@ -66,7 +68,7 @@ class MilestoneService
     {
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
-            throw new \RuntimeException('OpenRegister is not available');
+            throw new RuntimeException('OpenRegister is not available');
         }
 
         $register = $this->settingsService->getConfigValue('register');
@@ -176,14 +178,14 @@ class MilestoneService
     ): array {
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
-            throw new \RuntimeException('OpenRegister is not available');
+            throw new RuntimeException('OpenRegister is not available');
         }
 
         $register = $this->settingsService->getConfigValue('register');
         $schema   = $this->settingsService->getConfigValue('milestone_record_schema');
 
         if (empty($register) === true || empty($schema) === true) {
-            throw new \RuntimeException('Milestone record schema not configured');
+            throw new RuntimeException('Milestone record schema not configured');
         }
 
         $recordData = [
@@ -230,7 +232,7 @@ class MilestoneService
     ): bool {
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
-            throw new \RuntimeException('OpenRegister is not available');
+            throw new RuntimeException('OpenRegister is not available');
         }
 
         $register = $this->settingsService->getConfigValue('register');
@@ -333,7 +335,7 @@ class MilestoneService
             filters: ['_limit' => 1000],
         );
 
-        $today   = new \DateTimeImmutable('today');
+        $today   = new DateTimeImmutable('today');
         $stalled = [];
 
         foreach ($cases as $case) {
@@ -454,7 +456,7 @@ class MilestoneService
         }
 
         try {
-            return new \DateTimeImmutable(substr($raw, 0, 10));
+            return new DateTimeImmutable(substr($raw, 0, 10));
         } catch (\Throwable $e) {
             return null;
         }

--- a/lib/Service/ParafeerActieService.php
+++ b/lib/Service/ParafeerActieService.php
@@ -29,6 +29,8 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service;
 
+use DateTimeImmutable;
+use DateTimeInterface;
 use OCA\Procest\AppInfo\Application;
 use OCA\Procest\Event\ParafeerTransitionEvent;
 use OCA\Procest\Service\Support\SearchesObjects;
@@ -40,6 +42,7 @@ use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 use OCP\IUser;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 /**
  * Records parafeeractie objects and orchestrates step advancement.
@@ -224,7 +227,7 @@ class ParafeerActieService
             [$register, $voorstelSchema, $actieSchema] = $this->resolveSchemas();
             $objectService = $this->settingsService->getObjectService();
             if ($objectService === null) {
-                throw new \RuntimeException('OpenRegister is not available');
+                throw new RuntimeException('OpenRegister is not available');
             }
 
             $voorstel = $this->findVoorstel(
@@ -270,7 +273,7 @@ class ParafeerActieService
                 step: $step,
             );
 
-            $timestamp = (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM);
+            $timestamp = (new DateTimeImmutable())->format(DateTimeInterface::ATOM);
 
             $actorType = 'user';
             if ($onBehalfOf !== null) {
@@ -408,7 +411,7 @@ class ParafeerActieService
                 'ParafeerActieService::recordAction failed',
                 ['voorstel' => $voorstelId, 'exception' => $e->getMessage()]
             );
-            throw new \RuntimeException('Operation failed');
+            throw new RuntimeException('Operation failed');
         }//end try
     }//end recordAction()
 
@@ -646,7 +649,7 @@ class ParafeerActieService
         $actieSchema    = $this->settingsService->getConfigValue('parafeeractie_schema');
 
         if (empty($register) === true || empty($voorstelSchema) === true || empty($actieSchema) === true) {
-            throw new \RuntimeException('Procest register/schemas not configured');
+            throw new RuntimeException('Procest register/schemas not configured');
         }
 
         return [(string) $register, (string) $voorstelSchema, (string) $actieSchema];

--- a/lib/Service/ParaferingNotificationService.php
+++ b/lib/Service/ParaferingNotificationService.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service;
 
+use DateTime;
 use OCA\Procest\AppInfo\Application;
 use OCP\Notification\IManager;
 use Psr\Log\LoggerInterface;
@@ -68,7 +69,7 @@ class ParaferingNotificationService
             $notification = $this->notificationManager->createNotification();
             $notification->setApp(Application::APP_ID)
                 ->setUser($actorUserId)
-                ->setDateTime(new \DateTime())
+                ->setDateTime(new DateTime())
                 ->setObject('voorstel', $voorstelId)
                 ->setSubject(
                         'parafering_step_activated',
@@ -115,7 +116,7 @@ class ParaferingNotificationService
             $notification = $this->notificationManager->createNotification();
             $notification->setApp(Application::APP_ID)
                 ->setUser($stellerUserId)
-                ->setDateTime(new \DateTime())
+                ->setDateTime(new DateTime())
                 ->setObject('voorstel', $voorstelId)
                 ->setSubject(
                         'voorstel_returned',
@@ -161,7 +162,7 @@ class ParaferingNotificationService
             $notification = $this->notificationManager->createNotification();
             $notification->setApp(Application::APP_ID)
                 ->setUser($actorUserId)
-                ->setDateTime(new \DateTime())
+                ->setDateTime(new DateTime())
                 ->setObject('voorstel', $voorstelId)
                 ->setSubject(
                         'parafering_reminder',

--- a/lib/Service/Pdok/PdokBagService.php
+++ b/lib/Service/Pdok/PdokBagService.php
@@ -278,6 +278,9 @@ class PdokBagService
      * @return string Raw response body.
      *
      * @throws \RuntimeException On non-2xx or network failure.
+     *
+     * @SuppressWarnings(PHPMD.UndefinedVariable) $matches is a preg_match() by-reference
+     * out-parameter, which PHPMD does not model.
      */
     private function callDirect(string $url): string
     {

--- a/lib/Service/Pdok/PdokLocatieserverService.php
+++ b/lib/Service/Pdok/PdokLocatieserverService.php
@@ -477,8 +477,8 @@ class PdokLocatieserverService
         $now      = time();
         $failures = array_filter(
                 array: $failures,
-                callback: static function (int $ts) use ($now): bool {
-                    return ($now - $ts) <= self::OUTAGE_WINDOW;
+                callback: static function (int $failedAt) use ($now): bool {
+                    return ($now - $failedAt) <= self::OUTAGE_WINDOW;
                 }
                 );
 

--- a/lib/Service/Pdok/PdokLocatieserverService.php
+++ b/lib/Service/Pdok/PdokLocatieserverService.php
@@ -333,6 +333,9 @@ class PdokLocatieserverService
      * @throws \RuntimeException When the upstream returns non-2xx or the
      *                           network call fails. The exception code carries
      *                           the HTTP status (or 0 for network failures).
+     *
+     * @SuppressWarnings(PHPMD.UndefinedVariable) $matches is a preg_match() by-reference
+     * out-parameter, which PHPMD does not model.
      */
     private function callDirect(string $url): string
     {

--- a/lib/Service/PdokService.php
+++ b/lib/Service/PdokService.php
@@ -308,8 +308,8 @@ class PdokService
         // generic error.
         $status = 0;
         $msg    = $error->getMessage();
-        if (preg_match('/\b(?:HTTP|status)\s*([0-9]{3})\b/i', $msg, $m) === 1) {
-            $status = (int) $m[1];
+        if (preg_match('/\b(?:HTTP|status)\s*([0-9]{3})\b/i', $msg, $matches) === 1) {
+            $status = (int) $matches[1];
         }
 
         $effectiveKey = match ($status) {

--- a/lib/Service/ProcessMiningService.php
+++ b/lib/Service/ProcessMiningService.php
@@ -74,17 +74,15 @@ class ProcessMiningService
      */
     public function getReport(array $params): array
     {
-        $to = $this->parseDate(value: ($params['to'] ?? null), fallback: new DateTimeImmutable('today'));
+        $to   = $this->parseDate(value: ($params['to'] ?? null), fallback: new DateTimeImmutable('today'));
+        $from = $to->sub(new DateInterval('P12M'));
         if (isset($params['from']) === true && is_string($params['from']) === true && $params['from'] !== '') {
             $from = $this->parseDate(value: $params['from'], fallback: $to->sub(new DateInterval('P12M')));
-        } else {
-            $from = $to->sub(new DateInterval('P12M'));
         }
 
+        $caseTypeFilter = null;
         if (isset($params['caseType']) === true && is_string($params['caseType']) === true && $params['caseType'] !== '') {
             $caseTypeFilter = $params['caseType'];
-        } else {
-            $caseTypeFilter = null;
         }
 
         $cases       = $this->loadCases(caseTypeFilter: $caseTypeFilter);
@@ -214,10 +212,9 @@ class ProcessMiningService
                     continue;
                 }
 
+                $exitedAt = ($closedAt ?? $now);
                 if (($i + 1) < $count) {
                     $exitedAt = $this->extractTimestamp(record: $records[$i + 1]);
-                } else {
-                    $exitedAt = ($closedAt ?? $now);
                 }
 
                 if ($exitedAt === null) {
@@ -372,9 +369,8 @@ class ProcessMiningService
             static fn (array $left, array $right): int => ($right['count'] <=> $left['count'])
         );
 
-        if ($totalCount === 0) {
-            $reworkPercent = 0.0;
-        } else {
+        $reworkPercent = 0.0;
+        if ($totalCount !== 0) {
             $reworkPercent = round((($reworkSum / $totalCount) * 100), 1);
         }
 

--- a/lib/Service/PublicationService.php
+++ b/lib/Service/PublicationService.php
@@ -30,8 +30,10 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service;
 
+use InvalidArgumentException;
 use OCA\Procest\AppInfo\Application;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 use Throwable;
 
 /**
@@ -84,12 +86,12 @@ class PublicationService
     {
         $channel = (string) ($payload['channel'] ?? 'website');
         if (in_array($channel, self::CHANNELS, true) === false) {
-            throw new \InvalidArgumentException('Invalid publication channel: '.$channel);
+            throw new InvalidArgumentException('Invalid publication channel: '.$channel);
         }
 
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
-            throw new \RuntimeException('OpenRegister is not available');
+            throw new RuntimeException('OpenRegister is not available');
         }
 
         $register = $this->settingsService->getConfigValue('register');
@@ -102,11 +104,11 @@ class PublicationService
                 'PublicationService::publish find failed',
                 ['app' => Application::APP_ID, 'caseId' => $caseId, 'error' => $e->getMessage()]
             );
-            throw new \RuntimeException('Case not found: '.$caseId);
+            throw new RuntimeException('Case not found: '.$caseId);
         }
 
         if ($obj === null) {
-            throw new \RuntimeException('Case not found: '.$caseId);
+            throw new RuntimeException('Case not found: '.$caseId);
         }
 
         if (is_array($obj) === true) {

--- a/lib/Service/SamenwerkverzoekService.php
+++ b/lib/Service/SamenwerkverzoekService.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service;
 
+use Exception;
 use OCA\Procest\AppInfo\Application;
 use OCA\Procest\Service\Support\SearchesObjects;
 use OCP\EventDispatcher\GenericEvent;
@@ -32,6 +33,7 @@ use OCP\IAppConfig;
 use OCP\IUser;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 /**
  * Service for samenwerkverzoek lifecycle management.
@@ -105,7 +107,7 @@ class SamenwerkverzoekService
         );
 
         if ($zaak === null) {
-            throw new \RuntimeException('Zaak not found: '.$zaakId);
+            throw new RuntimeException('Zaak not found: '.$zaakId);
         }
 
         $vergunningaanvraagRef = (string) ($zaak['vergunningaanvraagRef'] ?? '');
@@ -195,12 +197,12 @@ class SamenwerkverzoekService
         );
 
         if ($verzoek === null) {
-            throw new \RuntimeException('Samenwerkverzoek not found: '.$samenwerkId);
+            throw new RuntimeException('Samenwerkverzoek not found: '.$samenwerkId);
         }
 
         $currentStatus = (string) ($verzoek['status'] ?? '');
         if ($currentStatus !== 'aangevraagd') {
-            throw new \RuntimeException(
+            throw new RuntimeException(
                 'Samenwerkverzoek is not in aangevraagd status; current status: '.$currentStatus
             );
         }
@@ -263,7 +265,7 @@ class SamenwerkverzoekService
             );
         }
 
-        throw new \Exception('Not authorized');
+        throw new Exception('Not authorized');
     }//end authorizeSamenwerkMutation()
 
     /**
@@ -278,7 +280,7 @@ class SamenwerkverzoekService
         try {
             return $this->container->get('OCA\OpenRegister\Service\ObjectService');
         } catch (\Throwable $e) {
-            throw new \RuntimeException(
+            throw new RuntimeException(
                 'OpenRegister ObjectService not available: '.$e->getMessage(),
                 0,
                 $e

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -1350,7 +1350,7 @@ class SettingsService
         }
 
         $expected = 0;
-        foreach ($array as $key => $unused) {
+        foreach (array_keys($array) as $key) {
             if ($key !== $expected) {
                 return false;
             }

--- a/lib/Service/StatusTransitionService.php
+++ b/lib/Service/StatusTransitionService.php
@@ -135,7 +135,7 @@ class StatusTransitionService
                 continue;
             }
 
-            $failed = array_values(array_filter($eval, static fn(array $g): bool => $g['passed'] === false));
+            $failed = array_values(array_filter($eval, static fn(array $guard): bool => $guard['passed'] === false));
 
             $result['transitions'][] = [
                 'id'           => (string) ($transition['id'] ?? ''),
@@ -204,7 +204,7 @@ class StatusTransitionService
         // Defence in depth — re-evaluate guards on the server side.
         $guards = $this->extractGuards(transition: $transition);
         $eval   = $this->guardRegistry->evaluateAll(guards: $guards, case: $case, userId: $userId);
-        $failed = array_values(array_filter($eval, static fn(array $g): bool => $g['passed'] === false));
+        $failed = array_values(array_filter($eval, static fn(array $guard): bool => $guard['passed'] === false));
         // @phpstan-ignore greaterThan.alwaysFalse (PHPDoc type marks passed as bool, but runtime values may differ)
         if (count($failed) > 0) {
             $this->logger->info('StatusTransitionService: guards failed', ['caseId' => $caseId, 'transitionId' => $transitionId]);

--- a/lib/Service/Stuf/NeedsInputDispatcher.php
+++ b/lib/Service/Stuf/NeedsInputDispatcher.php
@@ -41,6 +41,7 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service\Stuf;
 
+use DateTime;
 use OCA\Procest\AppInfo\Application;
 use OCP\IGroupManager;
 use OCP\Notification\IManager as INotificationManager;
@@ -111,7 +112,7 @@ class NeedsInputDispatcher
             $notification = $this->notificationManager->createNotification();
             $notification->setApp(app: Application::APP_ID)
                 ->setUser(user: $user->getUID())
-                ->setDateTime(dateTime: new \DateTime())
+                ->setDateTime(dateTime: new DateTime())
                 ->setObject(type: 'stuf_needs_input', id: ($context['endpointId'] ?? $type))
                 ->setSubject(subject: $type, parameters: ['endpointId' => (string) ($context['endpointId'] ?? '')])
                 ->setMessage(message: 'procest_stuf_needs_input', parameters: $context);

--- a/lib/Service/Stuf/StufAdapterService.php
+++ b/lib/Service/Stuf/StufAdapterService.php
@@ -376,7 +376,7 @@ class StufAdapterService
             timeoutSeconds: StufHttpClient::DEFAULT_TIMEOUT_SECONDS
         );
 
-        $bv = $this->parser->parseBevestiging(responseXml: $response['responseXml']);
+        $bevestiging = $this->parser->parseBevestiging(responseXml: $response['responseXml']);
 
         $vrijStatus = 'fout';
         if ($response['httpStatus'] >= 200 && $response['httpStatus'] < 300) {
@@ -390,11 +390,11 @@ class StufAdapterService
                 'httpStatus'          => $response['httpStatus'],
                 'duurMs'              => $response['durationMs'],
                 'responseEnvelopeXml' => $response['responseXml'],
-                'zaakIdentificatie'   => ($bv['zaakIdentificatie'] ?? ''),
+                'zaakIdentificatie'   => ($bevestiging['zaakIdentificatie'] ?? ''),
             ]
         );
 
-        return (string) ($bv['zaakIdentificatie'] ?? '');
+        return (string) ($bevestiging['zaakIdentificatie'] ?? '');
     }//end genereerZaakIdentificatie()
 
     /**
@@ -494,14 +494,14 @@ class StufAdapterService
         $transport  = ($response['fout'] ?? null);
 
         if ($httpStatus >= 200 && $httpStatus < 300) {
-            $bv     = $this->parser->parseBevestiging(responseXml: $body);
-            $extras = [
+            $bevestiging = $this->parser->parseBevestiging(responseXml: $body);
+            $extras      = [
                 'httpStatus'          => $httpStatus,
                 'duurMs'              => $duration,
                 'responseEnvelopeXml' => $body,
             ];
-            if (($bv['zaakIdentificatie'] ?? null) !== null) {
-                $extras['zaakIdentificatie'] = $bv['zaakIdentificatie'];
+            if (($bevestiging['zaakIdentificatie'] ?? null) !== null) {
+                $extras['zaakIdentificatie'] = $bevestiging['zaakIdentificatie'];
             }
 
             $this->messageHandler->transitionStatus(msg: $message, newStatus: 'bevestigd', extras: $extras);
@@ -509,7 +509,7 @@ class StufAdapterService
             return [
                 'success'           => true,
                 'messageId'         => $messageId,
-                'zaakIdentificatie' => ($bv['zaakIdentificatie'] ?? null),
+                'zaakIdentificatie' => ($bevestiging['zaakIdentificatie'] ?? null),
                 'fout'              => null,
             ];
         }

--- a/lib/Service/Stuf/StufAdapterService.php
+++ b/lib/Service/Stuf/StufAdapterService.php
@@ -663,6 +663,9 @@ class StufAdapterService
      * @param string $envelope The envelope XML.
      *
      * @return string The referentienummer (empty if not present).
+     *
+     * @SuppressWarnings(PHPMD.UndefinedVariable) $matches is a preg_match() by-reference
+     * out-parameter, which PHPMD does not model.
      */
     private function extractReferentienummer(string $envelope): string
     {

--- a/lib/Service/Stuf/StufHttpClient.php
+++ b/lib/Service/Stuf/StufHttpClient.php
@@ -39,6 +39,7 @@ namespace OCA\Procest\Service\Stuf;
 
 use OCP\Http\Client\IClientService;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 /**
  * Sends StUF SOAP envelopes over HTTPS with WSSE+mTLS auth.
@@ -192,12 +193,12 @@ class StufHttpClient
     {
         $pem = $this->vault->resolveSecret(reference: $reference);
         if ($pem === '') {
-            throw new \RuntimeException(message: 'TLS cert vault reference resolves to empty contents');
+            throw new RuntimeException(message: 'TLS cert vault reference resolves to empty contents');
         }
 
         $tmpPath = tempnam(directory: sys_get_temp_dir(), prefix: 'stuf-mtls-');
         if ($tmpPath === false) {
-            throw new \RuntimeException(message: 'Cannot create temp file for mTLS cert');
+            throw new RuntimeException(message: 'Cannot create temp file for mTLS cert');
         }
 
         file_put_contents(filename: $tmpPath, data: $pem);

--- a/lib/Service/StufFieldMappingService.php
+++ b/lib/Service/StufFieldMappingService.php
@@ -210,16 +210,16 @@ class StufFieldMappingService
     public function stufDateToIso(string $stufDate): ?string
     {
         if (strlen($stufDate) === 8) {
-            $dt = \DateTimeImmutable::createFromFormat(self::STUF_DATE_FORMAT, $stufDate);
-            if ($dt !== false) {
-                return $dt->format('Y-m-d');
+            $parsed = \DateTimeImmutable::createFromFormat(self::STUF_DATE_FORMAT, $stufDate);
+            if ($parsed !== false) {
+                return $parsed->format('Y-m-d');
             }
         }
 
         if (strlen($stufDate) === 14) {
-            $dt = \DateTimeImmutable::createFromFormat(self::STUF_DATETIME_FORMAT, $stufDate);
-            if ($dt !== false) {
-                return $dt->format(\DateTimeInterface::ATOM);
+            $parsed = \DateTimeImmutable::createFromFormat(self::STUF_DATETIME_FORMAT, $stufDate);
+            if ($parsed !== false) {
+                return $parsed->format(\DateTimeInterface::ATOM);
             }
         }
 
@@ -240,8 +240,8 @@ class StufFieldMappingService
      */
     public function isoToStufDate(string $isoDate): string
     {
-        $dt = new DateTimeImmutable($isoDate);
-        return $dt->format(self::STUF_DATE_FORMAT);
+        $parsed = new DateTimeImmutable($isoDate);
+        return $parsed->format(self::STUF_DATE_FORMAT);
     }//end isoToStufDate()
 
     /**
@@ -257,8 +257,8 @@ class StufFieldMappingService
      */
     public function isoToStufDateTime(string $isoDateTime): string
     {
-        $dt = new DateTimeImmutable($isoDateTime);
-        return $dt->format(self::STUF_DATETIME_FORMAT);
+        $parsed = new DateTimeImmutable($isoDateTime);
+        return $parsed->format(self::STUF_DATETIME_FORMAT);
     }//end isoToStufDateTime()
 
     /**

--- a/lib/Service/StufFieldMappingService.php
+++ b/lib/Service/StufFieldMappingService.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service;
 
+use DateTimeImmutable;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -239,7 +240,7 @@ class StufFieldMappingService
      */
     public function isoToStufDate(string $isoDate): string
     {
-        $dt = new \DateTimeImmutable($isoDate);
+        $dt = new DateTimeImmutable($isoDate);
         return $dt->format(self::STUF_DATE_FORMAT);
     }//end isoToStufDate()
 
@@ -256,7 +257,7 @@ class StufFieldMappingService
      */
     public function isoToStufDateTime(string $isoDateTime): string
     {
-        $dt = new \DateTimeImmutable($isoDateTime);
+        $dt = new DateTimeImmutable($isoDateTime);
         return $dt->format(self::STUF_DATETIME_FORMAT);
     }//end isoToStufDateTime()
 

--- a/lib/Service/StufMessageBuilder.php
+++ b/lib/Service/StufMessageBuilder.php
@@ -44,6 +44,7 @@ namespace OCA\Procest\Service;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use DOMDocument;
 use OCA\Procest\Service\Stuf\PayloadTooLargeException;
 use OCA\Procest\Service\Stuf\StufVaultService;
 use OCA\Procest\Service\Stuf\VrijBerichtNotRegisteredException;
@@ -136,7 +137,7 @@ class StufMessageBuilder
      */
     public function buildSoapEnvelope(string $bodyXml): string
     {
-        $dom = new \DOMDocument('1.0', 'UTF-8');
+        $dom = new DOMDocument('1.0', 'UTF-8');
         $dom->formatOutput = true;
 
         $envelope = $dom->createElementNS(self::NS_SOAP, 'soap:Envelope');
@@ -154,7 +155,7 @@ class StufMessageBuilder
 
         // M1: Load the caller-supplied body XML with LIBXML_NONET to prevent
         // XXE / SSRF attacks via external entity references in the XML payload.
-        $bodyDoc = new \DOMDocument();
+        $bodyDoc = new DOMDocument();
         // phpcs:ignore -- libxml_use_internal_errors suppresses parse errors intentionally.
         libxml_use_internal_errors(true);
         if ($bodyDoc->loadXML($bodyXml, LIBXML_NONET) === true) {
@@ -191,7 +192,7 @@ class StufMessageBuilder
         ?string $referentienummer=null,
     ): string {
         $refNr    = $referentienummer ?? $this->generateUuid();
-        $tijdstip = (new \DateTimeImmutable())->format('YmdHis');
+        $tijdstip = (new DateTimeImmutable())->format('YmdHis');
 
         $xml  = '<stuf:stuurgegevens>';
         $xml .= '<stuf:berichtcode>Lk01</stuf:berichtcode>';
@@ -228,7 +229,7 @@ class StufMessageBuilder
         array $ontvanger,
         string $crossRef,
     ): string {
-        $tijdstip = (new \DateTimeImmutable())->format('YmdHis');
+        $tijdstip = (new DateTimeImmutable())->format('YmdHis');
 
         $body  = '<stuf:Bv01Bericht xmlns:stuf="'.self::NS_STUF.'">';
         $body .= '<stuf:stuurgegevens>';
@@ -272,7 +273,7 @@ class StufMessageBuilder
         array $zender,
         array $ontvanger,
     ): string {
-        $tijdstip = (new \DateTimeImmutable())->format('YmdHis');
+        $tijdstip = (new DateTimeImmutable())->format('YmdHis');
 
         $body  = '<stuf:Fo01Bericht xmlns:stuf="'.self::NS_STUF.'">';
         $body .= '<stuf:stuurgegevens>';
@@ -311,7 +312,7 @@ class StufMessageBuilder
      */
     public function buildSoapFault(string $faultString): string
     {
-        $dom = new \DOMDocument('1.0', 'UTF-8');
+        $dom = new DOMDocument('1.0', 'UTF-8');
         $dom->formatOutput = true;
 
         $envelope = $dom->createElementNS(self::NS_SOAP, 'soap:Envelope');

--- a/lib/Service/SubstitutionService.php
+++ b/lib/Service/SubstitutionService.php
@@ -40,6 +40,7 @@ use DateTimeImmutable;
 use InvalidArgumentException;
 use OCA\Procest\Service\Support\SearchesObjects;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 /**
  * Resolves vervanging/waarneming substitutions and the workload they route.
@@ -627,7 +628,7 @@ class SubstitutionService
         $schema        = (string) $this->settingsService->getConfigValue('substitution_schema');
 
         if ($strict === true && ($objectService === null || $register === '' || $schema === '')) {
-            throw new \RuntimeException('OpenRegister is not available or the substitution schema is not configured');
+            throw new RuntimeException('OpenRegister is not available or the substitution schema is not configured');
         }
 
         return [$objectService, $register, $schema];

--- a/lib/Service/TemplateLibraryService.php
+++ b/lib/Service/TemplateLibraryService.php
@@ -29,6 +29,7 @@ namespace OCA\Procest\Service;
 
 use OCA\Procest\AppInfo\Application;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 /**
  * Service for loading and activating zaaktype templates.
@@ -169,17 +170,17 @@ class TemplateLibraryService
     {
         $template = $this->loadTemplate(templateId: $templateId);
         if ($template === null) {
-            throw new \RuntimeException('Template not found: '.$templateId);
+            throw new RuntimeException('Template not found: '.$templateId);
         }
 
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
-            throw new \RuntimeException('OpenRegister is not available');
+            throw new RuntimeException('OpenRegister is not available');
         }
 
         $register = $this->settingsService->getConfigValue('register');
         if (empty($register) === true) {
-            throw new \RuntimeException('Procest register not configured');
+            throw new RuntimeException('Procest register not configured');
         }
 
         $result = [

--- a/lib/Service/TenantAuditTrailService.php
+++ b/lib/Service/TenantAuditTrailService.php
@@ -205,8 +205,8 @@ class TenantAuditTrailService
     private function resolveTenantEntity(string $tenantId): mixed
     {
         try {
-            $os = $this->container->get('OCA\\OpenRegister\\Service\\ObjectService');
-            return $os->find($tenantId, register: self::REGISTER, schema: self::SCHEMA_TENANT);
+            $objectService = $this->container->get('OCA\\OpenRegister\\Service\\ObjectService');
+            return $objectService->find($tenantId, register: self::REGISTER, schema: self::SCHEMA_TENANT);
         } catch (Throwable $e) {
             $this->logger->error(
                 'Procest AUDIT: could not resolve tenant ObjectEntity',

--- a/lib/Service/TenantAuthenticationService.php
+++ b/lib/Service/TenantAuthenticationService.php
@@ -145,8 +145,8 @@ class TenantAuthenticationService
      */
     public function loadActiveMatrix(string $tenantId): ?array
     {
-        $os = $this->getObjectService();
-        if ($os === null) {
+        $objectService = $this->getObjectService();
+        if ($objectService === null) {
             return null;
         }
 
@@ -155,7 +155,7 @@ class TenantAuthenticationService
             // named-argument form threw "Unknown named parameter $register" and
             // was swallowed by the catch below. Register/schema live inside
             // `filters`; limit/offset are top-level config keys.
-            $rows = $os->findAll(
+            $rows = $objectService->findAll(
                 [
                     'filters' => [
                         'register'  => TenantSaasService::REGISTER,
@@ -224,15 +224,15 @@ class TenantAuthenticationService
      */
     public function resolveUserRole(string $tenantId, string $userId): ?string
     {
-        $os = $this->getObjectService();
-        if ($os === null) {
+        $objectService = $this->getObjectService();
+        if ($objectService === null) {
             return null;
         }
 
         try {
             // ObjectService::findAll() takes a single $config array — see the note
             // above; register/schema live inside `filters`.
-            $rows = $os->findAll(
+            $rows = $objectService->findAll(
                 [
                     'filters' => [
                         'register'  => TenantSaasService::REGISTER,

--- a/lib/Service/TenantBillingService.php
+++ b/lib/Service/TenantBillingService.php
@@ -179,8 +179,8 @@ class TenantBillingService
             throw new InvalidArgumentException('Unknown billing event type: '.$eventType);
         }
 
-        $os = $this->getObjectService();
-        if ($os === null) {
+        $objectService = $this->getObjectService();
+        if ($objectService === null) {
             return null;
         }
 
@@ -195,7 +195,7 @@ class TenantBillingService
         ];
 
         try {
-            return $os->saveObject(
+            return $objectService->saveObject(
                 object: $event,
                 register: TenantSaasService::REGISTER,
                 schema: 'tenantBillingEvent',
@@ -266,8 +266,8 @@ class TenantBillingService
      */
     public function markExported(array $events, string $invoiceRef): int
     {
-        $os = $this->getObjectService();
-        if ($os === null) {
+        $objectService = $this->getObjectService();
+        if ($objectService === null) {
             return 0;
         }
 
@@ -287,7 +287,7 @@ class TenantBillingService
                     $uuidArg = null;
                 }
 
-                $os->saveObject(
+                $objectService->saveObject(
                     object: $event,
                     register: TenantSaasService::REGISTER,
                     schema: 'tenantBillingEvent',
@@ -312,8 +312,8 @@ class TenantBillingService
      */
     public function fetchEventsForMonth(string $tenantId, string $month): array
     {
-        $os = $this->getObjectService();
-        if ($os === null) {
+        $objectService = $this->getObjectService();
+        if ($objectService === null) {
             return [];
         }
 
@@ -322,7 +322,7 @@ class TenantBillingService
             // named-argument form threw "Unknown named parameter $register" and
             // was swallowed by the catch below. Register/schema live inside
             // `filters`; limit/offset are top-level config keys.
-            $rows = $os->findAll(
+            $rows = $objectService->findAll(
                 [
                     'filters' => [
                         'register'  => TenantSaasService::REGISTER,

--- a/lib/Service/TenantConfigurationService.php
+++ b/lib/Service/TenantConfigurationService.php
@@ -105,8 +105,8 @@ class TenantConfigurationService
      */
     public function getConfig(string $tenantId): ?array
     {
-        $os = $this->getObjectService();
-        if ($os === null) {
+        $objectService = $this->getObjectService();
+        if ($objectService === null) {
             return null;
         }
 
@@ -115,7 +115,7 @@ class TenantConfigurationService
             // named-argument form threw "Unknown named parameter $register" and
             // was swallowed by the catch below. Register/schema live inside
             // `filters`; limit/offset are top-level config keys.
-            $rows = $os->findAll(
+            $rows = $objectService->findAll(
                 [
                     'filters' => [
                         'register'  => TenantSaasService::REGISTER,
@@ -223,10 +223,10 @@ class TenantConfigurationService
         }
 
         if (isset($branding['fontFamily']) === true) {
-            $ff = (string) $branding['fontFamily'];
+            $fontFamily = (string) $branding['fontFamily'];
             // Drop quotes and dangerous chars.
-            $ff = preg_replace('/[^a-zA-Z0-9_\\- ,]/', '', $ff) ?? '';
-            $tokens['--procest-font-family'] = $ff;
+            $fontFamily = preg_replace('/[^a-zA-Z0-9_\\- ,]/', '', $fontFamily) ?? '';
+            $tokens['--procest-font-family'] = $fontFamily;
         }
 
         return $tokens;
@@ -376,8 +376,8 @@ class TenantConfigurationService
      */
     private function mergeConfig(string $tenantId, array $delta): array
     {
-        $os = $this->getObjectService();
-        if ($os === null) {
+        $objectService = $this->getObjectService();
+        if ($objectService === null) {
             return ['tenantRef' => $tenantId] + $delta;
         }
 
@@ -391,7 +391,7 @@ class TenantConfigurationService
                 $uuidArg = null;
             }
 
-            return $os->saveObject(
+            return $objectService->saveObject(
                 object: $next,
                 register: TenantSaasService::REGISTER,
                 schema: 'tenantConfiguration',

--- a/lib/Service/TenantMigrationService.php
+++ b/lib/Service/TenantMigrationService.php
@@ -33,6 +33,7 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service;
 
+use OCA\OpenRegister\Db\Organisation;
 use OCA\Procest\Service\Support\SearchesObjects;
 use OCP\App\IAppManager;
 use Psr\Container\ContainerInterface;
@@ -228,7 +229,7 @@ class TenantMigrationService
      */
     private function buildOrganisation(array $row, string $slug, string $tenantUuid): object
     {
-        $organisation = new \OCA\OpenRegister\Db\Organisation();
+        $organisation = new Organisation();
 
         // Preserve the tenant UUID so stored `_tenantId` references keep resolving.
         if ($tenantUuid !== '') {

--- a/lib/Service/TenantOnboardingService.php
+++ b/lib/Service/TenantOnboardingService.php
@@ -77,8 +77,8 @@ class TenantOnboardingService
      */
     public function createOnboarding(string $tenantId): array
     {
-        $os = $this->getObjectService();
-        if ($os === null) {
+        $objectService = $this->getObjectService();
+        if ($objectService === null) {
             $this->logger->info('Procest: createOnboarding skipped — OR unavailable');
             return [];
         }
@@ -86,7 +86,7 @@ class TenantOnboardingService
         $created = [];
         foreach (self::STEPS as $step) {
             try {
-                $row = $os->saveObject(
+                $row = $objectService->saveObject(
                     object: ['tenantRef' => $tenantId, 'step' => $step, 'status' => 'pending'],
                     register: TenantSaasService::REGISTER,
                     schema: 'tenantOnboardingTask',
@@ -119,8 +119,8 @@ class TenantOnboardingService
      */
     public function getProgress(string $tenantId): array
     {
-        $os = $this->getObjectService();
-        if ($os === null) {
+        $objectService = $this->getObjectService();
+        if ($objectService === null) {
             return ['steps' => [], 'completed' => 0, 'total' => count(self::STEPS), 'fraction' => 0.0];
         }
 
@@ -129,7 +129,7 @@ class TenantOnboardingService
             // named-argument form threw "Unknown named parameter $register" and
             // was swallowed by the catch below. Register/schema are read from
             // inside `filters`.
-            $rows = $os->findAll(
+            $rows = $objectService->findAll(
                 [
                     'filters' => [
                         'register'  => TenantSaasService::REGISTER,
@@ -184,15 +184,15 @@ class TenantOnboardingService
             throw new InvalidArgumentException('Unknown onboarding step: '.$step);
         }
 
-        $os = $this->getObjectService();
-        if ($os === null) {
+        $objectService = $this->getObjectService();
+        if ($objectService === null) {
             return null;
         }
 
         try {
             // ObjectService::findAll() takes a single $config array — see the
             // note in getProgress(); register/schema live inside `filters`.
-            $rows = $os->findAll(
+            $rows = $objectService->findAll(
                 [
                     'filters' => [
                         'register'  => TenantSaasService::REGISTER,
@@ -220,7 +220,7 @@ class TenantOnboardingService
                 $uuidArg = null;
             }
 
-            $row = $os->saveObject(
+            $row = $objectService->saveObject(
                 object: $task,
                 register: TenantSaasService::REGISTER,
                 schema: 'tenantOnboardingTask',
@@ -248,22 +248,22 @@ class TenantOnboardingService
      */
     public function validateGoLive(string $tenantId): array
     {
-        $os = $this->getObjectService();
-        if ($os === null) {
+        $objectService = $this->getObjectService();
+        if ($objectService === null) {
             return ['ready' => false, 'missing' => ['openregister_unavailable']];
         }
 
         $missing = [];
-        if ($this->countSchemaRows(os: $os, schema: 'caseType', filters: ['tenantRef' => $tenantId]) === 0) {
+        if ($this->countSchemaRows(objectService: $objectService, schema: 'caseType', filters: ['tenantRef' => $tenantId]) === 0) {
             $missing[] = 'zaaktype';
         }
 
-        if ($this->countSchemaRows(os: $os, schema: 'tenantMandate', filters: ['tenantRef' => $tenantId]) === 0) {
+        if ($this->countSchemaRows(objectService: $objectService, schema: 'tenantMandate', filters: ['tenantRef' => $tenantId]) === 0) {
             $missing[] = 'mandate';
         }
 
         if ($this->countSchemaRows(
-            os: $os,
+            objectService: $objectService,
             schema: 'tenantUser',
             filters: ['tenantRef' => $tenantId, 'role' => 'tenant_admin']
         ) === 0
@@ -316,18 +316,18 @@ class TenantOnboardingService
     /**
      * Count rows in a schema with a filter.
      *
-     * @param mixed               $os      Object service.
-     * @param string              $schema  Schema slug.
-     * @param array<string,mixed> $filters Filters.
+     * @param mixed               $objectService Object service.
+     * @param string              $schema        Schema slug.
+     * @param array<string,mixed> $filters       Filters.
      *
      * @return int
      */
-    private function countSchemaRows($os, string $schema, array $filters): int
+    private function countSchemaRows($objectService, string $schema, array $filters): int
     {
         try {
             // ObjectService::findAll() takes a single $config array — see the
             // note in getProgress(); register/schema live inside `filters`.
-            $rows = $os->findAll(
+            $rows = $objectService->findAll(
                 [
                     'filters' => array_merge(
                         [

--- a/lib/Service/TenantQuotaService.php
+++ b/lib/Service/TenantQuotaService.php
@@ -103,15 +103,15 @@ class TenantQuotaService
             throw new InvalidArgumentException('Unknown tier: '.$tier);
         }
 
-        $os = $this->getObjectService();
-        if ($os === null) {
+        $objectService = $this->getObjectService();
+        if ($objectService === null) {
             return [];
         }
 
         $rows = [];
         foreach (self::TIER_DEFAULTS[$tier] as $quotaType => $cfg) {
             try {
-                $row = $os->saveObject(
+                $row = $objectService->saveObject(
                     object: [
                         'tenantRef'               => $tenantId,
                         'quotaType'               => $quotaType,
@@ -146,8 +146,8 @@ class TenantQuotaService
      */
     public function getQuota(string $tenantId, string $quotaType): ?array
     {
-        $os = $this->getObjectService();
-        if ($os === null) {
+        $objectService = $this->getObjectService();
+        if ($objectService === null) {
             return null;
         }
 
@@ -156,7 +156,7 @@ class TenantQuotaService
             // named-argument form threw "Unknown named parameter $register" and
             // was swallowed by the catch below. Register/schema live inside
             // `filters`; limit/offset are top-level config keys.
-            $rows = $os->findAll(
+            $rows = $objectService->findAll(
                 [
                     'filters' => [
                         'register'  => TenantSaasService::REGISTER,
@@ -321,8 +321,8 @@ class TenantQuotaService
      */
     private function persistQuota(array $quota): void
     {
-        $os = $this->getObjectService();
-        if ($os === null) {
+        $objectService = $this->getObjectService();
+        if ($objectService === null) {
             return;
         }
 
@@ -334,7 +334,7 @@ class TenantQuotaService
                 $uuidArg = null;
             }
 
-            $os->saveObject(
+            $objectService->saveObject(
                 object: $quota,
                 register: TenantSaasService::REGISTER,
                 schema: 'tenantQuota',

--- a/lib/Service/TenantSaasService.php
+++ b/lib/Service/TenantSaasService.php
@@ -32,6 +32,7 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service;
 
+use DateTimeImmutable;
 use InvalidArgumentException;
 use OCA\Procest\Service\Support\SearchesObjects;
 use OCP\App\IAppManager;
@@ -172,7 +173,7 @@ class TenantSaasService
             'tier'          => $tier,
             'isolationMode' => self::TIER_ISOLATION[$tier],
             'dataResidency' => 'nl',
-            'createdAt'     => (new \DateTimeImmutable('now'))->format(DATE_ATOM),
+            'createdAt'     => (new DateTimeImmutable('now'))->format(DATE_ATOM),
         ];
 
         $saved    = $this->saveTenant(tenant: $tenant, uuid: null);
@@ -283,11 +284,11 @@ class TenantSaasService
 
         $row['status'] = $newStatus;
         if ($newStatus === 'active' && empty($row['activatedAt']) === true) {
-            $row['activatedAt'] = (new \DateTimeImmutable('now'))->format(DATE_ATOM);
+            $row['activatedAt'] = (new DateTimeImmutable('now'))->format(DATE_ATOM);
         }
 
         if ($newStatus === 'terminated' && empty($row['terminatedAt']) === true) {
-            $row['terminatedAt'] = (new \DateTimeImmutable('now'))->format(DATE_ATOM);
+            $row['terminatedAt'] = (new DateTimeImmutable('now'))->format(DATE_ATOM);
         }
 
         $saved = $this->saveTenant(tenant: $row, uuid: $tenantId);

--- a/lib/Service/TenantSaasService.php
+++ b/lib/Service/TenantSaasService.php
@@ -191,13 +191,13 @@ class TenantSaasService
      */
     public function getById(string $tenantId): ?array
     {
-        $os = $this->getObjectService();
-        if ($os === null) {
+        $objectService = $this->getObjectService();
+        if ($objectService === null) {
             return null;
         }
 
         try {
-            $row = $this->findObjectAsArray(objectService: $os, register: self::REGISTER, schema: self::SCHEMA_TENANT, id: $tenantId);
+            $row = $this->findObjectAsArray(objectService: $objectService, register: self::REGISTER, schema: self::SCHEMA_TENANT, id: $tenantId);
             if (is_array($row) === true) {
                 return $row;
             }
@@ -220,8 +220,8 @@ class TenantSaasService
      */
     public function listActive(?string $statusFilter=null, int $limit=100, int $offset=0): array
     {
-        $os = $this->getObjectService();
-        if ($os === null) {
+        $objectService = $this->getObjectService();
+        if ($objectService === null) {
             return [];
         }
 
@@ -235,7 +235,7 @@ class TenantSaasService
             // named-argument form threw "Unknown named parameter $register" and
             // was swallowed by the catch below. Register/schema are read from
             // inside `filters`; limit/offset are top-level config keys.
-            $rows = $os->findAll(
+            $rows = $objectService->findAll(
                 [
                     'filters' => array_merge(
                         [
@@ -312,13 +312,13 @@ class TenantSaasService
      */
     public function delete(string $tenantId): bool
     {
-        $os = $this->getObjectService();
-        if ($os === null) {
+        $objectService = $this->getObjectService();
+        if ($objectService === null) {
             return false;
         }
 
         try {
-            $os->deleteObject(register: self::REGISTER, schema: self::SCHEMA_TENANT, id: $tenantId);
+            $objectService->deleteObject(register: self::REGISTER, schema: self::SCHEMA_TENANT, id: $tenantId);
             return true;
         } catch (Throwable $e) {
             $this->logger->error('Procest: TenantSaasService::delete failed', ['tenantId' => $tenantId, 'exception' => $e->getMessage()]);
@@ -398,15 +398,15 @@ class TenantSaasService
      */
     public function slugExists(string $slug): bool
     {
-        $os = $this->getObjectService();
-        if ($os === null) {
+        $objectService = $this->getObjectService();
+        if ($objectService === null) {
             return false;
         }
 
         try {
             // ObjectService::findAll() takes a single $config array — see the
             // note in listActive(); register/schema live inside `filters`.
-            $rows = $os->findAll(
+            $rows = $objectService->findAll(
                 [
                     'filters' => [
                         'register' => self::REGISTER,
@@ -438,13 +438,13 @@ class TenantSaasService
      */
     protected function saveTenant(array $tenant, ?string $uuid): array
     {
-        $os = $this->getObjectService();
-        if ($os === null) {
+        $objectService = $this->getObjectService();
+        if ($objectService === null) {
             throw new RuntimeException('OpenRegister is not available');
         }
 
         try {
-            $row = $os->saveObject(
+            $row = $objectService->saveObject(
                 object: $tenant,
                 register: self::REGISTER,
                 schema: self::SCHEMA_TENANT,

--- a/lib/Service/TermijnExtensionService.php
+++ b/lib/Service/TermijnExtensionService.php
@@ -31,6 +31,7 @@ declare(strict_types=1);
 namespace OCA\Procest\Service;
 
 use DateTimeImmutable;
+use ReflectionClass;
 use RuntimeException;
 
 /**
@@ -159,7 +160,7 @@ class TermijnExtensionService
         // is the data we actually need.
         $svcDef = null;
         try {
-            $reflection = new \ReflectionClass($this->termijnService);
+            $reflection = new ReflectionClass($this->termijnService);
             if ($reflection->hasProperty('definitieCache') === true) {
                 $prop  = $reflection->getProperty('definitieCache');
                 $cache = $prop->getValue($this->termijnService);

--- a/lib/Service/TermijnNotificationService.php
+++ b/lib/Service/TermijnNotificationService.php
@@ -30,6 +30,7 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service;
 
+use InvalidArgumentException;
 use OCA\Procest\BackgroundJob\TermijnNotificationDispatchJob;
 use OCP\BackgroundJob\IJobList;
 use Psr\Log\LoggerInterface;
@@ -89,7 +90,7 @@ class TermijnNotificationService
         }
 
         if (in_array($type, self::TEMPLATES, true) === false) {
-            throw new \InvalidArgumentException('Unknown template: '.$type);
+            throw new InvalidArgumentException('Unknown template: '.$type);
         }
 
         $this->jobList->add(
@@ -127,7 +128,7 @@ class TermijnNotificationService
         array $context=[]
     ): array {
         if (in_array($type, self::TEMPLATES, true) === false) {
-            throw new \InvalidArgumentException('Unknown template: '.$type);
+            throw new InvalidArgumentException('Unknown template: '.$type);
         }
 
         $instance = $this->termijnService->getTermijnInstance($termijnInstanceId);

--- a/lib/Service/TermijnReportingService.php
+++ b/lib/Service/TermijnReportingService.php
@@ -321,12 +321,12 @@ class TermijnReportingService
      */
     private function resolveQuarter(string $periode): array
     {
-        if (preg_match('/^(\d{4})-Q([1-4])$/', $periode, $m) !== 1) {
+        if (preg_match('/^(\d{4})-Q([1-4])$/', $periode, $matches) !== 1) {
             throw new RuntimeException('Invalid periode (expected YYYY-Qn): '.$periode);
         }
 
-        $year    = (int) $m[1];
-        $quarter = (int) $m[2];
+        $year    = (int) $matches[1];
+        $quarter = (int) $matches[2];
         $startM  = (($quarter - 1) * 3) + 1;
         $endM    = $startM + 2;
         $from    = sprintf('%04d-%02d-01', $year, $startM);

--- a/lib/Service/TranscriptionService.php
+++ b/lib/Service/TranscriptionService.php
@@ -34,6 +34,7 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service;
 
+use InvalidArgumentException;
 use OCA\Procest\AppInfo\Application;
 use Psr\Log\LoggerInterface;
 use Throwable;
@@ -95,12 +96,12 @@ class TranscriptionService
     public function queue(array $evidence): array
     {
         if (($evidence['type'] ?? null) !== 'voice_memo') {
-            throw new \InvalidArgumentException('Only voice_memo evidence can be queued for transcription');
+            throw new InvalidArgumentException('Only voice_memo evidence can be queued for transcription');
         }
 
         $durationSec = (int) ($evidence['durationSeconds'] ?? 0);
         if ($durationSec > self::MAX_DURATION_SECONDS) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 sprintf(
                     'Voice memo too long: %ds > max %ds',
                     $durationSec,

--- a/lib/Service/VTHTemplateService.php
+++ b/lib/Service/VTHTemplateService.php
@@ -316,7 +316,11 @@ class VTHTemplateService
      */
     private function loadFile(string $path): ?array
     {
-        $raw = @file_get_contents($path);
+        if (is_file($path) === false || is_readable($path) === false) {
+            return null;
+        }
+
+        $raw = file_get_contents($path);
         if ($raw === false) {
             return null;
         }

--- a/lib/Service/VergaderingCaseService.php
+++ b/lib/Service/VergaderingCaseService.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service;
 
+use DateTimeImmutable;
 use OCA\Procest\AppInfo\Application;
 use OCA\Procest\Service\Support\SearchesObjects;
 use Psr\Log\LoggerInterface;
@@ -116,7 +117,7 @@ class VergaderingCaseService
 
         if (empty($startDatum) === false) {
             try {
-                $start    = new \DateTimeImmutable(datetime: $startDatum);
+                $start    = new DateTimeImmutable(datetime: $startDatum);
                 $deadline = $start->modify('-'.self::AGENDA_DEADLINE_DAYS.' days')->format('Y-m-d');
             } catch (\Exception $e) {
                 $this->logger->warning(
@@ -244,7 +245,7 @@ class VergaderingCaseService
             return 0;
         }
 
-        $today    = (new \DateTimeImmutable('today'))->format('Y-m-d');
+        $today    = (new DateTimeImmutable('today'))->format('Y-m-d');
         $advanced = 0;
 
         try {

--- a/lib/Service/WOODeadlineService.php
+++ b/lib/Service/WOODeadlineService.php
@@ -26,10 +26,14 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service;
 
+use DateTime;
+use DateTimeImmutable;
+use InvalidArgumentException;
 use OCA\Procest\AppInfo\Application;
 use OCA\Procest\Service\Support\SearchesObjects;
 use OCP\Notification\IManager as INotificationManager;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 /**
  * Service for WOO-mandated deadline calculation and tracking.
@@ -97,7 +101,7 @@ class WOODeadlineService
     {
         $receipt = \DateTimeImmutable::createFromFormat('Y-m-d', $ontvangstdatum);
         if ($receipt === false) {
-            throw new \InvalidArgumentException('Invalid ontvangstdatum: '.$ontvangstdatum);
+            throw new InvalidArgumentException('Invalid ontvangstdatum: '.$ontvangstdatum);
         }
 
         $deadline = $receipt->modify('+'.self::INITIAL_PERIOD_DAYS.' days');
@@ -127,19 +131,19 @@ class WOODeadlineService
     public function extendDeadline(string $caseId, string $reason): array
     {
         if (trim($reason) === '') {
-            throw new \InvalidArgumentException('A reason is required for deadline extension');
+            throw new InvalidArgumentException('A reason is required for deadline extension');
         }
 
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
-            throw new \RuntimeException('OpenRegister is not available');
+            throw new RuntimeException('OpenRegister is not available');
         }
 
         $register   = $this->settingsService->getConfigValue('register');
         $caseSchema = $this->settingsService->getConfigValue('case_schema');
 
         if (empty($register) === true || empty($caseSchema) === true) {
-            throw new \RuntimeException('Case schema not configured');
+            throw new RuntimeException('Case schema not configured');
         }
 
         $case = $this->findObjectAsArray(
@@ -149,14 +153,14 @@ class WOODeadlineService
             id: $caseId
         );
         if ($case === null) {
-            throw new \RuntimeException('Case not found: '.$caseId);
+            throw new RuntimeException('Case not found: '.$caseId);
         }
 
         $caseData = (array) $case;
 
         $extensionCount = (int) ($caseData[self::EXTENSION_COUNT_KEY] ?? 0);
         if ($extensionCount >= 1) {
-            throw new \InvalidArgumentException('Only one deadline extension is allowed per WOO Art. 4.4');
+            throw new InvalidArgumentException('Only one deadline extension is allowed per WOO Art. 4.4');
         }
 
         $currentDeadline = $caseData['expectedResolution'] ?? null;
@@ -164,7 +168,7 @@ class WOODeadlineService
             // Derive from ontvangstdatum if not set.
             $ontvangstdatum = $caseData['ontvangstdatum'] ?? null;
             if (empty($ontvangstdatum) === true) {
-                throw new \RuntimeException('Case has no ontvangstdatum to calculate deadline from');
+                throw new RuntimeException('Case has no ontvangstdatum to calculate deadline from');
             }
 
             $calculated      = $this->calculate(ontvangstdatum: $ontvangstdatum);
@@ -243,7 +247,7 @@ class WOODeadlineService
             return ['warned' => false, 'reason' => 'No deadline set'];
         }
 
-        $today    = new \DateTimeImmutable('today');
+        $today    = new DateTimeImmutable('today');
         $deadline = \DateTimeImmutable::createFromFormat('Y-m-d', $deadlineStr);
         if ($deadline === false) {
             return ['warned' => false, 'reason' => 'Invalid deadline format'];
@@ -302,7 +306,7 @@ class WOODeadlineService
             $notification = $this->notificationManager->createNotification();
             $notification->setApp(Application::APP_ID)
                 ->setUser($userId)
-                ->setDateTime(new \DateTime())
+                ->setDateTime(new DateTime())
                 ->setObject('woo_deadline', $caseId)
                 ->setSubject(
                     $subject,

--- a/lib/Service/WOODecisionService.php
+++ b/lib/Service/WOODecisionService.php
@@ -27,10 +27,12 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service;
 
+use InvalidArgumentException;
 use OCA\Procest\AppInfo\Application;
 use OCA\Procest\Service\Support\SearchesObjects;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 /**
  * Service for assembling the formal WOO besluit.
@@ -86,7 +88,7 @@ class WOODecisionService
         // Guard: all documents must be assessed before a besluit can be created.
         $outstanding = $this->documentAssessmentService->getOutstanding(caseId: $caseId);
         if ($outstanding['count'] > 0) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Cannot create besluit: '.$outstanding['count'].' document(s) still need assessment. '
                 .'Document IDs: '.implode(', ', $outstanding['documents'])
             );
@@ -94,7 +96,7 @@ class WOODecisionService
 
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
-            throw new \RuntimeException('OpenRegister is not available');
+            throw new RuntimeException('OpenRegister is not available');
         }
 
         $register         = $this->settingsService->getConfigValue('register');
@@ -102,7 +104,7 @@ class WOODecisionService
         $assessmentSchema = $this->settingsService->getConfigValue('woo_assessment_schema');
 
         if (empty($register) === true || empty($decisionSchema) === true) {
-            throw new \RuntimeException('Decision schema not configured');
+            throw new RuntimeException('Decision schema not configured');
         }
 
         // Collect all assessments for the case.

--- a/lib/Service/ZaakdossierService.php
+++ b/lib/Service/ZaakdossierService.php
@@ -31,9 +31,12 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service;
 
+use DomainException;
+use InvalidArgumentException;
 use OCA\Procest\AppInfo\Application;
 use OCA\Procest\Service\Support\SearchesObjects;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 /**
  * Service orchestrating the ZGW DRC zaakdossier.
@@ -96,16 +99,16 @@ class ZaakdossierService
         [$objectService, $register] = $this->requireRegister();
 
         if (trim($caseId) === '') {
-            throw new \RuntimeException('caseId is required');
+            throw new RuntimeException('caseId is required');
         }
 
         if (trim($fileName) === '') {
-            throw new \RuntimeException('bestandsnaam is required');
+            throw new RuntimeException('bestandsnaam is required');
         }
 
         $type = (string) ($metadata['informatieobjecttype'] ?? '');
         if ($type === '') {
-            throw new \RuntimeException('informatieobjecttype is required');
+            throw new RuntimeException('informatieobjecttype is required');
         }
 
         $defaultClassification = $this->resolveDefaultClassification(type: $type);
@@ -114,7 +117,7 @@ class ZaakdossierService
             $classification = $defaultClassification;
         } else if ($this->accessGuard->isClassificationAllowed($defaultClassification, $classification) === false) {
             // REQ-ZAK-003d: a user may only override to a MORE restrictive level.
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Classification may not be less restrictive than the document type default'
             );
         }
@@ -267,7 +270,7 @@ class ZaakdossierService
     public function transitionStatus(string $infoObjectId, string $newStatus): array
     {
         if (in_array($newStatus, self::VALID_STATUSES, true) === false) {
-            throw new \InvalidArgumentException('Invalid status: '.$newStatus);
+            throw new InvalidArgumentException('Invalid status: '.$newStatus);
         }
 
         [$objectService, $register] = $this->requireRegister();
@@ -281,12 +284,12 @@ class ZaakdossierService
         );
 
         if ($current === null) {
-            throw new \RuntimeException('Informatieobject not found: '.$infoObjectId);
+            throw new RuntimeException('Informatieobject not found: '.$infoObjectId);
         }
 
         $currentStatus = (string) ($current['status'] ?? 'concept');
         if ($this->isTransitionAllowed(from: $currentStatus, to: $newStatus) === false) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Invalid status transition from '.$currentStatus.' to '.$newStatus
             );
         }
@@ -476,11 +479,11 @@ class ZaakdossierService
         );
 
         if ($current === null) {
-            throw new \RuntimeException('Informatieobject not found: '.$infoObjectId);
+            throw new RuntimeException('Informatieobject not found: '.$infoObjectId);
         }
 
         if ((string) ($current['status'] ?? '') === 'definitief') {
-            throw new \DomainException('Definitieve documenten kunnen niet worden gewijzigd');
+            throw new DomainException('Definitieve documenten kunnen niet worden gewijzigd');
         }
 
         $allowed    = ['titel', 'beschrijving', 'informatieobjecttype', 'vertrouwelijkheidaanduiding'];
@@ -604,12 +607,12 @@ class ZaakdossierService
     {
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
-            throw new \RuntimeException('OpenRegister is not available');
+            throw new RuntimeException('OpenRegister is not available');
         }
 
         $register = $this->settingsService->getConfigValue('register');
         if ($register === '') {
-            throw new \RuntimeException('Dossier register not configured');
+            throw new RuntimeException('Dossier register not configured');
         }
 
         return [$objectService, $register];

--- a/lib/Service/ZgwRulesBase.php
+++ b/lib/Service/ZgwRulesBase.php
@@ -341,9 +341,8 @@ abstract class ZgwRulesBase
             );
         }
 
-        if (is_array($typeObject) === true) {
-            $typeData = $typeObject;
-        } else {
+        $typeData = $typeObject;
+        if (is_array($typeObject) === false) {
             $typeData = $typeObject->jsonSerialize();
         }
 
@@ -626,9 +625,8 @@ abstract class ZgwRulesBase
         if ($isIpv6Cidr === false && $isIpv6Ip === false) {
             [$network, $prefix] = explode('/', $cidr);
             $prefixLen          = (int) $prefix;
-            if ($prefixLen === 0) {
-                $mask = 0;
-            } else {
+            $mask = 0;
+            if ($prefixLen !== 0) {
                 $mask = (~0 << (32 - $prefixLen));
             }
 
@@ -693,10 +691,9 @@ abstract class ZgwRulesBase
                 return null;
             }
 
-            $obj = $results[0];
-            if (is_array($obj) === true) {
-                $data = $obj;
-            } else {
+            $obj  = $results[0];
+            $data = $obj;
+            if (is_array($obj) === false) {
                 $data = $obj->jsonSerialize();
             }
 
@@ -738,9 +735,8 @@ abstract class ZgwRulesBase
 
             $ids = [];
             foreach (($result['results'] ?? []) as $obj) {
-                if (is_array($obj) === true) {
-                    $data = $obj;
-                } else {
+                $data = $obj;
+                if (is_array($obj) === false) {
                     $data = $obj->jsonSerialize();
                 }
 
@@ -859,9 +855,8 @@ abstract class ZgwRulesBase
             // count it as a match (conservative: assume coercion happened).
             $matchCount = 0;
             foreach (($result['results'] ?? []) as $obj) {
-                if (is_array($obj) === true) {
-                    $data = $obj;
-                } else {
+                $data = $obj;
+                if (is_array($obj) === false) {
                     $data = $obj->jsonSerialize();
                 }
 

--- a/lib/Service/ZgwService.php
+++ b/lib/Service/ZgwService.php
@@ -312,10 +312,9 @@ class ZgwService
                     $value = end($parts);
                 }
 
+                $filterKey = $field;
                 if ($operator !== null) {
                     $filterKey = $field.'.'.$operator;
-                } else {
-                    $filterKey = $field;
                 }
 
                 $filters[$filterKey] = $value;
@@ -925,9 +924,8 @@ class ZgwService
             $outboundMapping = $this->createOutboundMapping(mappingConfig: $mappingConfig);
             $mapped          = [];
             foreach ($objects as $object) {
-                if (is_array($object) === true) {
-                    $objectData = $object;
-                } else {
+                $objectData = $object;
+                if (is_array($object) === false) {
                     $objectData = $object->jsonSerialize();
                 }
 
@@ -1049,9 +1047,8 @@ class ZgwService
                 object: $englishData
             );
 
-            if (is_array($object) === true) {
-                $objectData = $object;
-            } else {
+            $objectData = $object;
+            if (is_array($object) === false) {
                 $objectData = $object->jsonSerialize();
             }
 
@@ -1124,9 +1121,9 @@ class ZgwService
 
             $baseUrl         = $this->buildBaseUrl(request: $request, zgwApi: $zgwApi, resource: $resource);
             $outboundMapping = $this->createOutboundMapping(mappingConfig: $mappingConfig);
-            if (is_array($object) === true) {
-                $objectData = $object;
-            } else {
+
+            $objectData = $object;
+            if (is_array($object) === false) {
                 $objectData = $object->jsonSerialize();
             }
 
@@ -1196,10 +1193,10 @@ class ZgwService
 
         try {
             $body = $this->getRequestBody(request: $request);
+
+            $action = 'update';
             if ($partial === true) {
                 $action = 'patch';
-            } else {
-                $action = 'update';
             }
 
             $existingObj = $this->objectService->find(
@@ -1207,9 +1204,9 @@ class ZgwService
                 register: $mappingConfig['sourceRegister'],
                 schema: $mappingConfig['sourceSchema']
             );
-            if (is_array($existingObj) === true) {
-                $existingData = $existingObj;
-            } else {
+
+            $existingData = $existingObj;
+            if (is_array($existingObj) === false) {
                 $existingData = $existingObj->jsonSerialize();
             }
 
@@ -1341,9 +1338,9 @@ class ZgwService
 
             $baseUrl         = $this->buildBaseUrl(request: $request, zgwApi: $zgwApi, resource: $resource);
             $outboundMapping = $this->createOutboundMapping(mappingConfig: $mappingConfig);
-            if (is_array($object) === true) {
-                $objectData = $object;
-            } else {
+
+            $objectData = $object;
+            if (is_array($object) === false) {
                 $objectData = $object->jsonSerialize();
             }
 
@@ -1415,9 +1412,9 @@ class ZgwService
                 register: $mappingConfig['sourceRegister'],
                 schema: $mappingConfig['sourceSchema']
             );
-            if (is_array($existingObj) === true) {
-                $existingData = $existingObj;
-            } else {
+
+            $existingData = $existingObj;
+            if (is_array($existingObj) === false) {
                 $existingData = $existingObj->jsonSerialize();
             }
 
@@ -1558,9 +1555,8 @@ class ZgwService
             try {
                 $logs = $this->objectService->getLogs($uuid, [], false, false);
                 foreach ($logs as $log) {
-                    if (is_array($log) === true) {
-                        $logData = $log;
-                    } else {
+                    $logData = $log;
+                    if (is_array($log) === false) {
                         $logData = $log->jsonSerialize();
                     }
 
@@ -1610,9 +1606,8 @@ class ZgwService
         string $resourceUrl,
         string $resource
     ): array {
-        if (is_array($log) === true) {
-            $logData = $log;
-        } else {
+        $logData = $log;
+        if (is_array($log) === false) {
             $logData = $log->jsonSerialize();
         }
 
@@ -1721,9 +1716,8 @@ class ZgwService
                 return null;
             }
 
-            if (is_array($zaak) === true) {
-                $zaakData = $zaak;
-            } else {
+            $zaakData = $zaak;
+            if (is_array($zaak) === false) {
                 $zaakData = $zaak->jsonSerialize();
             }
 
@@ -1809,9 +1803,8 @@ class ZgwService
                 return null;
             }
 
-            if (is_array($zaak) === true) {
-                $zaakData = $zaak;
-            } else {
+            $zaakData = $zaak;
+            if (is_array($zaak) === false) {
                 $zaakData = $zaak->jsonSerialize();
             }
 
@@ -1886,9 +1879,8 @@ class ZgwService
                 return null;
             }
 
-            if (is_array($zaaktype) === true) {
-                $ztData = $zaaktype;
-            } else {
+            $ztData = $zaaktype;
+            if (is_array($zaaktype) === false) {
                 $ztData = $zaaktype->jsonSerialize();
             }
 
@@ -1969,9 +1961,8 @@ class ZgwService
                 return null;
             }
 
-            if (is_array($zaaktype) === true) {
-                $ztData = $zaaktype;
-            } else {
+            $ztData = $zaaktype;
+            if (is_array($zaaktype) === false) {
                 $ztData = $zaaktype->jsonSerialize();
             }
 

--- a/lib/Service/ZgwZrcRulesService.php
+++ b/lib/Service/ZgwZrcRulesService.php
@@ -147,9 +147,9 @@ class ZgwZrcRulesService extends ZgwRulesBase
                             register: $register,
                             schema: $schema
                         );
-                        if (is_array($zaaktype) === true) {
-                            $ztData = $zaaktype;
-                        } else {
+
+                        $ztData = $zaaktype;
+                        if (is_array($zaaktype) === false) {
                             $ztData = $zaaktype->jsonSerialize();
                         }
 
@@ -1157,9 +1157,8 @@ class ZgwZrcRulesService extends ZgwRulesBase
             $maxVolgnummer     = -1;
             $maxStatustypeUuid = null;
             foreach (($result['results'] ?? []) as $obj) {
-                if (is_array($obj) === true) {
-                    $data = $obj;
-                } else {
+                $data = $obj;
+                if (is_array($obj) === false) {
                     $data = $obj->jsonSerialize();
                 }
 
@@ -1274,10 +1273,10 @@ class ZgwZrcRulesService extends ZgwRulesBase
         if (isset($body['zaak']) === true) {
             $existingZaak = $existingObject['case'] ?? ($existingObject['zaak'] ?? '');
             $newZaakUuid  = $this->extractUuid(url: $body['zaak']);
+
+            $existZaakId = $existingZaak;
             if (is_string($existingZaak) === true) {
                 $existZaakId = $this->extractUuid(url: $existingZaak);
-            } else {
-                $existZaakId = $existingZaak;
             }
 
             if ($existZaakId !== null && $newZaakUuid !== null && $newZaakUuid !== $existZaakId) {
@@ -1289,10 +1288,10 @@ class ZgwZrcRulesService extends ZgwRulesBase
         if (isset($body['informatieobject']) === true) {
             $existingIo = $existingObject['document'] ?? ($existingObject['informatieobject'] ?? '');
             $newIoUuid  = $this->extractUuid(url: $body['informatieobject']);
+
+            $existIoId = $existingIo;
             if (is_string($existingIo) === true) {
                 $existIoId = $this->extractUuid(url: $existingIo);
-            } else {
-                $existIoId = $existingIo;
             }
 
             if ($existIoId !== null && $newIoUuid !== null && $newIoUuid !== $existIoId) {

--- a/lib/Service/ZgwZtcRulesService.php
+++ b/lib/Service/ZgwZtcRulesService.php
@@ -641,10 +641,10 @@ class ZgwZtcRulesService extends ZgwRulesBase
 
         // Ztc-008: procestermijn required only for termijn.
         $procestermijn = $archief['procestermijn'] ?? null;
+
+        $ptValue = '';
         if (is_string($procestermijn) === true) {
             $ptValue = $procestermijn;
-        } else {
-            $ptValue = '';
         }
 
         $errors = array_merge(
@@ -1022,7 +1022,9 @@ class ZgwZtcRulesService extends ZgwRulesBase
 
         if (count($statusTypes) === 0) {
             $errors[] = "At least one status type must be defined before publishing";
-        } else {
+        }
+
+        if (count($statusTypes) > 0) {
             $hasFinal = false;
             foreach ($statusTypes as $row) {
                 if (is_array($row) === true && (bool) ($row['isFinal'] ?? false) === true) {
@@ -1047,10 +1049,9 @@ class ZgwZtcRulesService extends ZgwRulesBase
             $caseTypes = [];
         }
 
+        $caseType = [];
         if (count($caseTypes) > 0 && is_array($caseTypes[0]) === true) {
             $caseType = $caseTypes[0];
-        } else {
-            $caseType = [];
         }
 
         $validFrom = (string) ($caseType['validFrom'] ?? '');
@@ -1128,9 +1129,10 @@ class ZgwZtcRulesService extends ZgwRulesBase
             $caseStatus = (string) ($case['status'] ?? '');
             if ($caseStatus !== '' && in_array($caseStatus, $finalSlugs, true) === true) {
                 $closedCount++;
-            } else {
-                $activeCount++;
+                continue;
             }
+
+            $activeCount++;
         }
 
         if ($activeCount > 0) {

--- a/lib/Service/ZipManifestBuilder.php
+++ b/lib/Service/ZipManifestBuilder.php
@@ -33,6 +33,8 @@ namespace OCA\Procest\Service;
 
 use OCP\IUser;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
+use ZipArchive;
 
 /**
  * Builds a manifest-bearing, type-foldered ZIP export of a dossier.
@@ -142,9 +144,9 @@ class ZipManifestBuilder
         $included       = $this->filterByClearance(user: $user, documents: $documents);
         $excluded       = ($candidateCount - count($included));
 
-        $zip = new \ZipArchive();
-        if ($zip->open($targetPath, (\ZipArchive::CREATE | \ZipArchive::OVERWRITE)) !== true) {
-            throw new \RuntimeException('Could not create ZIP archive at '.$targetPath);
+        $zip = new ZipArchive();
+        if ($zip->open($targetPath, (ZipArchive::CREATE | ZipArchive::OVERWRITE)) !== true) {
+            throw new RuntimeException('Could not create ZIP archive at '.$targetPath);
         }
 
         // Manifest.csv at the archive root.


### PR DESCRIPTION
## PHPMD 1084 → 682

Measured in a PHP 8.3 container on a fresh `composer install`, against `origin/development`.

**No baseline file was created, and `phpmd.xml` is byte-unmodified** (it is the fleet canon — byte-identical to decidesk's). Every suppression is a targeted per-method `@SuppressWarnings` carrying a reason; all are listed below.

| Rule | Before | After | Δ |
|---|---|---|---|
| **MissingImport** | 221 | **0** | −221 |
| ElseExpression | 225 | 173 | −52 |
| ShortVariable | 64 | 14 | −50 |
| UnusedFormalParameter | 37 | 7 | −30 |
| **IfStatementAssignment** | 21 | **0** | −21 |
| **UndefinedVariable** | 20 | **0** | −20 |
| **UnusedLocalVariable** | 5 | **0** | −5 |
| ErrorControlOperator | 15 | 12 | −3 |
| StaticAccess / LongVariable / BooleanArgumentFlag / misc | 172 | 172 | 0 |
| Architectural family (8 rules) | 299 | 299 | deliberately untouched |

Other gates on this branch: `phpstan` **7** (unchanged) · `psalm` **0** · `phpcs` **0 errors** · `lint` clean · `phpunit` **1684 tests, 0 failures, 5 skipped, 5614 assertions** — identical to `origin/development` at every one of ~10 mid-run checkpoints, assertion count included.

## Suppressions — 38 findings across two rules, each with a reason in the code

**`PHPMD.UndefinedVariable` (8 methods, 20 findings)** — every one is `$matches` from `preg_match(..., matches: $matches)`, a by-reference out-parameter PHPMD does not model. This is a genuine tool blind spot, not debt. Each site was checked individually rather than trusting the class. Methods: `StufController::{resolveInboundEndpoint, verifyWsse, detectBerichtSoort, extractCrossRefnummer, extractFunctie}`, `StufAdapterService::extractReferentienummer`, `PdokBagService::callDirect`, `PdokLocatieserverService::callDirect`.

**`PHPMD.UnusedFormalParameter` (18 sites, 30 findings)** — all signature-mandated:
- 13 middleware hooks across 7 files (`beforeController`/`afterController`/`afterException`) — fixed by `OCP\AppFramework\Middleware`.
- `run($argument)` in `AppointmentReminderJob` and `ResetMonthlyQuotasJob` — fixed by `OCP\BackgroundJob\TimedJob`; matches the convention already used by four other jobs here.
- `ZaakdossierController::downloadFile($register, $schema, $fileId)` and `EmailController::preview($caseId)` — URL segments bound positionally by the dispatcher; `appinfo/routes.php` was checked for both.

## Deliberately left — with reasons, not silence

- **StaticAccess (124)** — 88 are named constructors on value objects (`ActionResult::ok()`, `GuardResult::allow()`, `PlanItemTransitions::*`) and 7 are `DateTimeImmutable::createFromFormat`. Unfixable without a DI refactor that would be a net quality loss.
- **ErrorControlOperator (12)** — each suppresses an `E_WARNING` on the *expected* failure path of a call whose falsy return is already handled: `@imap_*`, `@dns_get_record` in three SSRF host guards, an `@fsockopen` SMTP probe, `@file_get_contents` over an HTTP stream context, and two guarded best-effort `@unlink` calls (one in a `finally`, one in a `register_shutdown_function` where a warning would pollute the response body). Dropping `@` is a behaviour change and these are **not** false positives — so they were neither rewritten nor suppressed. 3 others *were* fixed, where an `is_file()`/`is_readable()` guard is genuinely correct.
- **UnusedFormalParameter (7 remaining)** — real debt, so **not** suppressed. `MandaatController::authorizeMandaatAccess($caseId)` authorizes nothing per-case and **is worth a security look**; the other 6 are "reserved for future use" params on unimplemented paths.
- **ShortVariable (14)** — `$ip` in three SSRF guards, slippy-map tile coords `($z,$x,$y)`, `$fq` (Solr filter-query, public API), and `ActionResult::$ok` (a public readonly promoted property read as `$result->ok` fleet-wide).
- **LongVariable (41)** — almost all constructor-promoted DI properties; getting under the threshold means worse names *and* chasing named-argument call sites.
- **ElseExpression (173)** — 74 sit in `ZrcController` (32), `DrcController` (21), `ZtcController` (15), `BrcController` (6), the largest and highest-risk files. Stopped rather than rush it. Note `Squiz.PHP.DisallowInlineIf` bans the ternary, so every fix here is a structural rewrite, not a one-liner.
- **Architectural family (299)** — Cyclomatic 122, NPath 90, ExcessiveClassComplexity 37, ExcessiveMethodLength 28, Coupling 9, TooManyPublicMethods 8, ExcessiveClassLength 3, ExcessiveParameterList 2. These need real refactoring of large methods, not a lint pass.

## One conversion that was made and then reverted

`CaseSharingService::revokeFederatedShare()` — hoisting the default assignment let PHPStan narrow `$shareData` to the empty-array shape of `ObjectService::find()`'s array branch, which made it report the `'caseId'` / `'remoteCloudId'` reads as non-existent offsets. PHPStan would have gone 7 → 9. Reverted, with an explanatory comment left in the code. It was caught by re-running phpstan *mid-batch* rather than only at the end.

## Where this leaves `check:strict`

`composer check:strict` still exits non-zero for procest, and **phpmd is now the only reason** — `lint`, `phpcs`, `psalm` and `test:all` all exit 0, and `phpstan` is at the 7 documented findings from #702.
