### PR TITLE
fix(quality): clear procest phpmd architectural debt — batch 1 (175 → 161)

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -121,6 +121,39 @@ class Application extends App implements IBootstrap
      */
     public function register(IRegistrationContext $context): void
     {
+        $this->registerAppHostEngine(context: $context);
+        $this->registerBespokeServices(context: $context);
+        $this->registerObjectListeners(context: $context);
+
+        $this->registerBezwaarListeners(context: $context);
+        $this->registerTermijnListeners(context: $context);
+        $this->registerDecisionListeners(context: $context);
+
+        $this->registerSaasStack(context: $context);
+        $this->registerBeschikkingAdapters(context: $context);
+        $this->registerAuthAdapters(context: $context);
+        $this->registerExternalRegisterAdapters(context: $context);
+    }//end register()
+
+    /**
+     * Register the OpenRegister AppHost engine (ADR-040).
+     *
+     * StaticAccess is suppressed rather than decomposed: `Bootstrap::register()`
+     * IS OpenRegister's published AppHost entry point. It is a stateless
+     * registration façade with no instance to inject, and wrapping it in a local
+     * collaborator would have to make the very same static call — moving the
+     * finding instead of removing it.
+     *
+     * @param IRegistrationContext $context The registration context
+     *
+     * @return void
+     *
+     * @SuppressWarnings(PHPMD.StaticAccess) Bootstrap::register() is OpenRegister's published AppHost entry point; see the note above.
+     *
+     * @spec openspec/specs/beschikking-generatie/spec.md
+     */
+    private function registerAppHostEngine(IRegistrationContext $context): void
+    {
         // OpenRegister AppHost engine (ADR-040). Aliases the mechanical
         // plumbing classes to the shared generics and registers the
         // manifest-driven deep-link listener + the observability (health /
@@ -155,7 +188,19 @@ class Application extends App implements IBootstrap
                 'mcpProvider'      => ProcestToolProvider::class,
             ]
         );
+    }//end registerAppHostEngine()
 
+    /**
+     * Re-register the procest-bespoke plumbing the AppHost engine aliased to generics.
+     *
+     * @param IRegistrationContext $context The registration context
+     *
+     * @return void
+     *
+     * @spec openspec/specs/beschikking-generatie/spec.md
+     */
+    private function registerBespokeServices(IRegistrationContext $context): void
+    {
         // Re-assert the procest-bespoke plumbing classes the engine just
         // registered to generics. A concrete-to-self alias
         // (registerServiceAlias(X, X)) infinitely recurses on NC's container
@@ -222,7 +267,21 @@ class Application extends App implements IBootstrap
                 );
             }
         );
+    }//end registerBespokeServices()
 
+    /**
+     * Register the notifier plus the object-lifecycle listeners that are not
+     * scoped to a single subsystem (KPI cache, role routing, DSO intake, BAG
+     * location validation).
+     *
+     * @param IRegistrationContext $context The registration context
+     *
+     * @return void
+     *
+     * @spec openspec/specs/beschikking-generatie/spec.md
+     */
+    private function registerObjectListeners(IRegistrationContext $context): void
+    {
         // Note @mention notifications (nc-vue #207, ncvue-w2-leaves-adoption):
         // MentionNotificationService raises `note_mention` notifications;
         // this Notifier renders them for the bell menu.
@@ -274,16 +333,25 @@ class Application extends App implements IBootstrap
             listener: LocationBagValidationListener::class
         );
 
-        $this->registerBezwaarListeners(context: $context);
-        $this->registerTermijnListeners(context: $context);
-        $this->registerDecisionListeners(context: $context);
-
         // DSO Omgevingsloket: create Procest zaak when a vergunningaanvraag is written.
         $context->registerEventListener(
             event: ObjectCreatedEvent::class,
             listener: VergunningaanvraagCreatedListener::class
         );
+    }//end registerObjectListeners()
 
+    /**
+     * Register the SaaS middleware chain and the two services it factories from
+     * app config (tenant JWT signing, Shillinq invoicing).
+     *
+     * @param IRegistrationContext $context The registration context
+     *
+     * @return void
+     *
+     * @spec openspec/specs/beschikking-generatie/spec.md
+     */
+    private function registerSaasStack(IRegistrationContext $context): void
+    {
         $context->registerMiddleware(class: ZgwAuthMiddleware::class);
         $context->registerMiddleware(class: TenantMiddleware::class);
         // SaaS chain (member 04): resolve tenant binding then set Postgres
@@ -336,7 +404,20 @@ class Application extends App implements IBootstrap
                     );
                 }
                 );
+    }//end registerSaasStack()
 
+    /**
+     * Register the beschikking cross-app integration adapters (template render,
+     * digital signing, archival ingest).
+     *
+     * @param IRegistrationContext $context The registration context
+     *
+     * @return void
+     *
+     * @spec openspec/specs/beschikking-generatie/spec.md
+     */
+    private function registerBeschikkingAdapters(IRegistrationContext $context): void
+    {
         // Background jobs are declared in appinfo/info.xml under
         // <background-jobs>; Nextcloud auto-registers them with the IJobList.
         // IRegistrationContext has no registerJob() method.
@@ -391,7 +472,19 @@ class Application extends App implements IBootstrap
         // schema; this adapter records the archival marker + Archiefwet
         // vernietigingsdatum. The former app-local MockArchivalAdapter is retired.
         $context->registerServiceAlias(ArchivalAdapterInterface::class, OpenRegisterArchivalAdapter::class);
+    }//end registerBeschikkingAdapters()
 
+    /**
+     * Register the external auth-broker adapters (DigiD / eHerkenning).
+     *
+     * @param IRegistrationContext $context The registration context
+     *
+     * @return void
+     *
+     * @spec openspec/specs/beschikking-generatie/spec.md
+     */
+    private function registerAuthAdapters(IRegistrationContext $context): void
+    {
         // External auth-broker adapters (lib/Service/Auth/), selected by the
         // `integration.digid.mode` config tier (external-integrations-test-environments).
         // DEFAULT `log` = the dormant Log* implementations which throw + log
@@ -426,7 +519,20 @@ class Application extends App implements IBootstrap
                 return $c->get(\OCA\Procest\Service\Auth\LogEHerkenningSamlAdapter::class);
             }
         );
+    }//end registerAuthAdapters()
 
+    /**
+     * Register the wave-4 external base-register ports (KvK, BRP, BAG, BRK, WOZ)
+     * plus the dormant external-ZGW / ZTC client aliases.
+     *
+     * @param IRegistrationContext $context The registration context
+     *
+     * @return void
+     *
+     * @spec openspec/specs/beschikking-generatie/spec.md
+     */
+    private function registerExternalRegisterAdapters(IRegistrationContext $context): void
+    {
         // Wave-4 external-API ports (low-volume families). All dormant
         // log-only by default; flip the matching openconnector
         // source-slug feature flag and override the alias in a
@@ -453,6 +559,22 @@ class Application extends App implements IBootstrap
         // (test tier = api.kvk.nl/test, public key). BRP `mock`/`test` binds
         // the HaalCentraalBrpAdapter (mock = ghcr.io/brp-api/personen-mock
         // offline; test = proefomgeving once the X-API-KEY is granted).
+        $this->registerKvkBrpAdapters(context: $context);
+        $this->registerGeoRegisterAdapters(context: $context);
+        $this->registerExternalZgwAdapters(context: $context);
+    }//end registerExternalRegisterAdapters()
+
+    /**
+     * Register the KvK Handelsregister and BRP / Haal Centraal ports.
+     *
+     * @param IRegistrationContext $context The registration context
+     *
+     * @return void
+     *
+     * @spec openspec/specs/beschikking-generatie/spec.md
+     */
+    private function registerKvkBrpAdapters(IRegistrationContext $context): void
+    {
         $context->registerService(
             \OCA\Procest\Service\External\Kvk\KvkHandelsregisterAdapterInterface::class,
             static function (\Psr\Container\ContainerInterface $c): \OCA\Procest\Service\External\Kvk\KvkHandelsregisterAdapterInterface {
@@ -497,6 +619,19 @@ class Application extends App implements IBootstrap
                 return $c->get(\OCA\Procest\Service\External\Brp\LogBrpHaalCentraalAdapter::class);
             }
         );
+    }//end registerKvkBrpAdapters()
+
+    /**
+     * Register the geo/property base-register ports (BAG, BRK, WOZ).
+     *
+     * @param IRegistrationContext $context The registration context
+     *
+     * @return void
+     *
+     * @spec openspec/specs/beschikking-generatie/spec.md
+     */
+    private function registerGeoRegisterAdapters(IRegistrationContext $context): void
+    {
         // BAG (Basisregistratie Adressen en Gebouwen) — authoritative address +
         // pand/verblijfsobject lookup (bag-register-adapter). Selected by
         // `integration.bag.mode` (external-integrations-test-environments config-tier
@@ -586,6 +721,19 @@ class Application extends App implements IBootstrap
                 return $c->get(\OCA\Procest\Service\External\Woz\LogWozAdapter::class);
             }
         );
+    }//end registerGeoRegisterAdapters()
+
+    /**
+     * Register the dormant external-ZGW and ZTC / Catalogi-API client aliases.
+     *
+     * @param IRegistrationContext $context The registration context
+     *
+     * @return void
+     *
+     * @spec openspec/specs/beschikking-generatie/spec.md
+     */
+    private function registerExternalZgwAdapters(IRegistrationContext $context): void
+    {
         // TMLO metadata building + e-Depot submission adapter seams retired
         // (migrate-archival-to-or, ADR-022): OpenRegister's TmloService builds
         // TMLO/MDTO metadata from schema config and its Edepot/Transport seam owns
@@ -598,7 +746,7 @@ class Application extends App implements IBootstrap
             \OCA\Procest\Service\External\Ztc\ZtcCatalogiAdapterInterface::class,
             \OCA\Procest\Service\External\Ztc\LogZtcCatalogiAdapter::class
         );
-    }//end register()
+    }//end registerExternalZgwAdapters()
 
     /**
      * Register an object-lifecycle listener that declares its interest up front.

--- a/lib/BackgroundJob/ShareMaintenanceJob.php
+++ b/lib/BackgroundJob/ShareMaintenanceJob.php
@@ -112,31 +112,8 @@ class ShareMaintenanceJob extends TimedJob
             $reminderDate = new DateTime('+'.self::REMINDER_DAYS.' days');
 
             foreach ($shares as $share) {
-                $shareData = $share;
-                if (is_object($share) === true) {
-                    $shareData = $share->jsonSerialize();
-                }
-
-                // Skip revoked shares.
-                if (empty($shareData['revokedAt']) === false) {
-                    continue;
-                }
-
-                // Check if share expires within reminder window.
-                if (empty($shareData['expiresAt']) === false) {
-                    $expiresAt = new DateTime($shareData['expiresAt']);
-                    if ($expiresAt <= $reminderDate && $expiresAt > new DateTime()) {
-                        $this->logger->info(
-                            'Procest: Share expiring soon',
-                            [
-                                'shareId'   => ($shareData['id'] ?? 'unknown'),
-                                'expiresAt' => $shareData['expiresAt'],
-                                'createdBy' => ($shareData['createdBy'] ?? 'unknown'),
-                            ]
-                        );
-                    }
-                }
-            }//end foreach
+                $this->reportExpiringShare(share: $share, reminderDate: $reminderDate);
+            }
         } catch (\Exception $e) {
             $this->logger->error(
                 'Procest: ShareMaintenanceJob failed',
@@ -144,4 +121,46 @@ class ShareMaintenanceJob extends TimedJob
             );
         }//end try
     }//end run()
+
+    /**
+     * Log a reminder when a single share expires within the reminder window.
+     *
+     * Revoked shares are skipped, as are shares without an expiry date and
+     * shares whose expiry lies outside the window (already lapsed, or further
+     * away than self::REMINDER_DAYS).
+     *
+     * @param mixed    $share        One share entry, either an array or an object exposing jsonSerialize()
+     * @param DateTime $reminderDate The upper bound of the reminder window
+     *
+     * @return void
+     */
+    private function reportExpiringShare(mixed $share, DateTime $reminderDate): void
+    {
+        $shareData = $share;
+        if (is_object($share) === true) {
+            $shareData = $share->jsonSerialize();
+        }
+
+        // Skip revoked shares.
+        if (empty($shareData['revokedAt']) === false) {
+            return;
+        }
+
+        // Check if share expires within reminder window.
+        if (empty($shareData['expiresAt']) === true) {
+            return;
+        }
+
+        $expiresAt = new DateTime($shareData['expiresAt']);
+        if ($expiresAt <= $reminderDate && $expiresAt > new DateTime()) {
+            $this->logger->info(
+                'Procest: Share expiring soon',
+                [
+                    'shareId'   => ($shareData['id'] ?? 'unknown'),
+                    'expiresAt' => $shareData['expiresAt'],
+                    'createdBy' => ($shareData['createdBy'] ?? 'unknown'),
+                ]
+            );
+        }
+    }//end reportExpiringShare()
 }//end class

--- a/lib/Controller/DsoController.php
+++ b/lib/Controller/DsoController.php
@@ -337,7 +337,7 @@ class DsoController extends Controller
 
             $samenwerkverzoek = $this->samenwerkService->initiateSamenwerking(
                 zaakId: $caseId,
-                aangezochtBevoegdGezag: $bevoegdGezag,
+                aangezochtGezag: $bevoegdGezag,
                 rationale: $rationale
             );
 

--- a/lib/Controller/ProcessMiningController.php
+++ b/lib/Controller/ProcessMiningController.php
@@ -100,6 +100,35 @@ class ProcessMiningController extends Controller
         $to       = $this->request->getParam('to');
         $caseType = $this->request->getParam('caseType');
 
+        $invalid = $this->validateFilters(from: $from, to: $to, caseType: $caseType);
+        if ($invalid !== null) {
+            return $invalid;
+        }
+
+        $params = $this->buildFilters(from: $from, to: $to, caseType: $caseType);
+
+        try {
+            return new JSONResponse($this->processMiningService->getReport(params: $params));
+        } catch (Throwable $e) {
+            $this->logger->error('Procest: process-mining report generation failed', ['exception' => $e->getMessage()]);
+            return new JSONResponse(['message' => 'Report generation failed'], Http::STATUS_INTERNAL_SERVER_ERROR);
+        }
+    }//end report()
+
+    /**
+     * Validate the optional report filter parameters.
+     *
+     * Each filter may be absent (null); when present it must carry the right
+     * shape — `from`/`to` a calendar-valid `Y-m-d` string, `caseType` a string.
+     *
+     * @param mixed $from     Raw `from` request parameter.
+     * @param mixed $to       Raw `to` request parameter.
+     * @param mixed $caseType Raw `caseType` request parameter.
+     *
+     * @return JSONResponse|null A 400 response for the first offending filter, or null when all are acceptable.
+     */
+    private function validateFilters(mixed $from, mixed $to, mixed $caseType): ?JSONResponse
+    {
         if ($from !== null && (is_string($from) === false || $this->isValidDate(value: $from) === false)) {
             return new JSONResponse(['message' => 'from must be a Y-m-d date'], Http::STATUS_BAD_REQUEST);
         }
@@ -112,6 +141,23 @@ class ProcessMiningController extends Controller
             return new JSONResponse(['message' => 'caseType must be a string'], Http::STATUS_BAD_REQUEST);
         }
 
+        return null;
+    }//end validateFilters()
+
+    /**
+     * Assemble the service filter map from the validated request parameters.
+     *
+     * Absent and empty-string filters are omitted so the service sees only the
+     * filters the caller actually supplied.
+     *
+     * @param mixed $from     Validated `from` request parameter.
+     * @param mixed $to       Validated `to` request parameter.
+     * @param mixed $caseType Validated `caseType` request parameter.
+     *
+     * @return array<string, string> The filter map passed to the report service.
+     */
+    private function buildFilters(mixed $from, mixed $to, mixed $caseType): array
+    {
         $params = [];
         if (is_string($from) === true && $from !== '') {
             $params['from'] = $from;
@@ -125,13 +171,8 @@ class ProcessMiningController extends Controller
             $params['caseType'] = $caseType;
         }
 
-        try {
-            return new JSONResponse($this->processMiningService->getReport(params: $params));
-        } catch (Throwable $e) {
-            $this->logger->error('Procest: process-mining report generation failed', ['exception' => $e->getMessage()]);
-            return new JSONResponse(['message' => 'Report generation failed'], Http::STATUS_INTERNAL_SERVER_ERROR);
-        }
-    }//end report()
+        return $params;
+    }//end buildFilters()
 
     /**
      * Authentication + RBAC guard for {@see self::report()}.

--- a/lib/Controller/StufController.php
+++ b/lib/Controller/StufController.php
@@ -320,6 +320,43 @@ class StufController extends Controller
             return $this->soapResponse(xml: $response, statusCode: Http::STATUS_REQUEST_ENTITY_TOO_LARGE);
         }
 
+        $parsed = $this->parseSoapDocument(rawBody: $rawBody, service: $service);
+        if ($parsed instanceof DataDisplayResponse) {
+            return $parsed;
+        }
+
+        $messageElement = $this->extractStufMessageElement(dom: $parsed);
+        if ($messageElement instanceof DataDisplayResponse) {
+            return $messageElement;
+        }
+
+        // Dispatch based on message type.
+        $messageType = $messageElement->localName;
+
+        $this->logger->info(
+            'Received StUF message: {type} at {service}',
+            ['type' => $messageType, 'service' => $service]
+        );
+
+        return match ($messageType) {
+            'zakLk01' => $this->handleZakLk01(message: $messageElement),
+            'zakLv01' => $this->handleZakLv01(message: $messageElement),
+            'npsLv01' => $this->handleNpsLv01(message: $messageElement),
+            'edcLk01' => $this->handleEdcLk01(message: $messageElement),
+            default => $this->handleUnknownMessage(messageType: $messageType),
+        };
+    }//end handleSoapMessage()
+
+    /**
+     * Parse an inbound SOAP envelope with XXE/DTD protections.
+     *
+     * @param string $rawBody The raw request body.
+     * @param string $service The service type ('zaken' or 'personen').
+     *
+     * @return DOMDocument|DataDisplayResponse The parsed document, or a SOAP fault response.
+     */
+    private function parseSoapDocument(string $rawBody, string $service): DOMDocument|DataDisplayResponse
+    {
         // Parse the XML with XXE/DTD protections.
         $dom = new DOMDocument();
         libxml_use_internal_errors(true);
@@ -336,6 +373,18 @@ class StufController extends Controller
             return $this->soapResponse(xml: $response, statusCode: Http::STATUS_BAD_REQUEST);
         }
 
+        return $dom;
+    }//end parseSoapDocument()
+
+    /**
+     * Locate the StUF message element inside a parsed SOAP envelope.
+     *
+     * @param DOMDocument $dom The parsed SOAP envelope.
+     *
+     * @return \DOMElement|DataDisplayResponse The StUF message element, or a SOAP fault response.
+     */
+    private function extractStufMessageElement(DOMDocument $dom): \DOMElement|DataDisplayResponse
+    {
         // Extract the SOAP Body content.
         $bodyElements = $dom->getElementsByTagNameNS(
             StufMessageBuilder::NS_SOAP,
@@ -367,22 +416,8 @@ class StufController extends Controller
             return $this->soapResponse(xml: $response, statusCode: Http::STATUS_BAD_REQUEST);
         }
 
-        // Dispatch based on message type.
-        $messageType = $messageElement->localName;
-
-        $this->logger->info(
-            'Received StUF message: {type} at {service}',
-            ['type' => $messageType, 'service' => $service]
-        );
-
-        return match ($messageType) {
-            'zakLk01' => $this->handleZakLk01(message: $messageElement),
-            'zakLv01' => $this->handleZakLv01(message: $messageElement),
-            'npsLv01' => $this->handleNpsLv01(message: $messageElement),
-            'edcLk01' => $this->handleEdcLk01(message: $messageElement),
-            default => $this->handleUnknownMessage(messageType: $messageType),
-        };
-    }//end handleSoapMessage()
+        return $messageElement;
+    }//end extractStufMessageElement()
 
     /**
      * Handle zakLk01 (case create/update) message.

--- a/lib/Event/VergunningStatusChangedEvent.php
+++ b/lib/Event/VergunningStatusChangedEvent.php
@@ -35,17 +35,17 @@ class VergunningStatusChangedEvent extends Event
     /**
      * Constructor.
      *
-     * @param string      $vergunningaanvraagRef The vergunningaanvraag UUID reference
-     * @param string      $oldStatus             The previous status value
-     * @param string      $newStatus             The new status value
-     * @param string|null $besluitdatum          Optional decision date (ISO 8601)
-     * @param string|null $toelichting           Optional explanation text
-     * @param string      $userId                The Nextcloud user UID who triggered the transition
+     * @param string      $aanvraagRef  The vergunningaanvraag UUID reference
+     * @param string      $oldStatus    The previous status value
+     * @param string      $newStatus    The new status value
+     * @param string|null $besluitdatum Optional decision date (ISO 8601)
+     * @param string|null $toelichting  Optional explanation text
+     * @param string      $userId       The Nextcloud user UID who triggered the transition
      *
      * @spec openspec/changes/dso-omgevingsloket/tasks.md#T01
      */
     public function __construct(
-        private readonly string $vergunningaanvraagRef,
+        private readonly string $aanvraagRef,
         private readonly string $oldStatus,
         private readonly string $newStatus,
         private readonly ?string $besluitdatum,
@@ -64,7 +64,7 @@ class VergunningStatusChangedEvent extends Event
      */
     public function getVergunningaanvraagRef(): string
     {
-        return $this->vergunningaanvraagRef;
+        return $this->aanvraagRef;
     }//end getVergunningaanvraagRef()
 
     /**

--- a/lib/Http/RangeStreamResponse.php
+++ b/lib/Http/RangeStreamResponse.php
@@ -106,7 +106,46 @@ class RangeStreamResponse extends Response
      */
     private function parseRange(string $rangeHeader, int $total): ?array
     {
-        if ($rangeHeader === '' || $total === 0) {
+        if ($total === 0) {
+            return null;
+        }
+
+        $parts = $this->matchRangeHeader(rangeHeader: $rangeHeader);
+        if ($parts === null) {
+            return null;
+        }
+
+        [$startRaw, $endRaw] = $parts;
+
+        $bounds = $this->resolveBounds(startRaw: $startRaw, endRaw: $endRaw, total: $total);
+        if ($bounds === null) {
+            return null;
+        }
+
+        [$start, $end] = $bounds;
+
+        if ($start > $end || $start >= $total) {
+            return null;
+        }
+
+        $end = min($end, ($total - 1));
+
+        return [$start, $end];
+    }//end parseRange()
+
+    /**
+     * Match the raw `Range` header against the single-range byte syntax.
+     *
+     * Returns null when no range is requested, the header does not match the
+     * `bytes=start-end` grammar, or both bounds are absent (`bytes=-`).
+     *
+     * @param string $rangeHeader The raw Range header.
+     *
+     * @return array{0:string,1:string}|null The raw [start, end] capture pair, or null.
+     */
+    private function matchRangeHeader(string $rangeHeader): ?array
+    {
+        if ($rangeHeader === '') {
             return null;
         }
 
@@ -121,13 +160,23 @@ class RangeStreamResponse extends Response
             return null;
         }
 
-        // Explicit "bytes=start-[end]" range; an absent end means "until EOF".
-        $start = (int) $startRaw;
-        $end   = ($total - 1);
-        if ($endRaw !== '') {
-            $end = (int) $endRaw;
-        }
+        return [$startRaw, $endRaw];
+    }//end matchRangeHeader()
 
+    /**
+     * Resolve the raw capture pair into unclamped [start, end] byte offsets.
+     *
+     * An absent end means "until EOF"; an absent start makes it a suffix range
+     * ("the last N bytes"), which is unsatisfiable when N is not positive.
+     *
+     * @param string $startRaw The raw start capture (may be empty).
+     * @param string $endRaw   The raw end capture (may be empty).
+     * @param int    $total    The total content length.
+     *
+     * @return array{0:int,1:int}|null The [start, end] pair, or null when unsatisfiable.
+     */
+    private function resolveBounds(string $startRaw, string $endRaw, int $total): ?array
+    {
         if ($startRaw === '') {
             // Suffix range: last N bytes.
             $suffix = (int) $endRaw;
@@ -135,16 +184,15 @@ class RangeStreamResponse extends Response
                 return null;
             }
 
-            $start = max(0, ($total - $suffix));
-            $end   = ($total - 1);
+            return [max(0, ($total - $suffix)), ($total - 1)];
         }
 
-        if ($start > $end || $start >= $total) {
-            return null;
+        // Explicit "bytes=start-[end]" range; an absent end means "until EOF".
+        $end = ($total - 1);
+        if ($endRaw !== '') {
+            $end = (int) $endRaw;
         }
 
-        $end = min($end, ($total - 1));
-
-        return [$start, $end];
-    }//end parseRange()
+        return [(int) $startRaw, $end];
+    }//end resolveBounds()
 }//end class

--- a/lib/Lifecycle/BezwaarDeadlineGuard.php
+++ b/lib/Lifecycle/BezwaarDeadlineGuard.php
@@ -45,6 +45,12 @@ class BezwaarDeadlineGuard implements LifecycleGuardInterface
     /**
      * Authorise (or deny) the transition.
      *
+     * StaticAccess is suppressed below rather than decomposed: OpenRegister's
+     * GuardResult is an immutable value object whose constructor is private,
+     * so allow()/deny() are its only construction path. A local factory
+     * collaborator would have to make the very same static call, which would
+     * move the finding instead of removing it.
+     *
      * @param array<string, mixed> $object The loaded bezwaar payload at its current state.
      * @param string               $action The transition action being applied.
      * @param string               $userId The uid of the caller.
@@ -52,6 +58,7 @@ class BezwaarDeadlineGuard implements LifecycleGuardInterface
      * @return GuardResult Allow when the deadline is unset or not yet passed, deny otherwise.
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter) $action/$userId are mandated by the interface; this guard reads only the payload.
+     * @SuppressWarnings(PHPMD.StaticAccess)          GuardResult has a private constructor upstream; see the note above.
      *
      * @spec openspec/changes/migrate-status-engine-to-or-lifecycle/tasks.md#P-3.3
      */

--- a/lib/Lifecycle/HoorzittingAfzienGuard.php
+++ b/lib/Lifecycle/HoorzittingAfzienGuard.php
@@ -43,6 +43,12 @@ class HoorzittingAfzienGuard implements LifecycleGuardInterface
     /**
      * Authorise (or deny) the transition.
      *
+     * StaticAccess is suppressed below rather than decomposed: OpenRegister's
+     * GuardResult is an immutable value object whose constructor is private,
+     * so allow()/deny() are its only construction path. A local factory
+     * collaborator would have to make the very same static call, which would
+     * move the finding instead of removing it.
+     *
      * @param array<string, mixed> $object The loaded bezwaar payload at its current state.
      * @param string               $action The transition action being applied.
      * @param string               $userId The uid of the caller.
@@ -50,6 +56,7 @@ class HoorzittingAfzienGuard implements LifecycleGuardInterface
      * @return GuardResult Allow when hearingWaived is true, deny otherwise.
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter) $action/$userId are mandated by the interface; this guard reads only the payload.
+     * @SuppressWarnings(PHPMD.StaticAccess)          GuardResult has a private constructor upstream; see the note above.
      *
      * @spec openspec/changes/migrate-status-engine-to-or-lifecycle/tasks.md#P-3.2
      */

--- a/lib/Lifecycle/VoorstelSubmitGuard.php
+++ b/lib/Lifecycle/VoorstelSubmitGuard.php
@@ -44,6 +44,12 @@ class VoorstelSubmitGuard implements LifecycleGuardInterface
     /**
      * Authorise (or deny) the transition.
      *
+     * StaticAccess is suppressed below rather than decomposed: OpenRegister's
+     * GuardResult is an immutable value object whose constructor is private,
+     * so allow()/deny() are its only construction path. A local factory
+     * collaborator would have to make the very same static call, which would
+     * move the finding instead of removing it.
+     *
      * @param array<string, mixed> $object The loaded voorstel payload at its current state.
      * @param string               $action The transition action being applied.
      * @param string               $userId The uid of the caller.
@@ -51,6 +57,7 @@ class VoorstelSubmitGuard implements LifecycleGuardInterface
      * @return GuardResult Allow when both required fields are filled, deny otherwise.
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter) $action/$userId are mandated by the interface; this guard reads only the payload.
+     * @SuppressWarnings(PHPMD.StaticAccess)          GuardResult has a private constructor upstream; see the note above.
      *
      * @spec openspec/changes/migrate-status-engine-to-or-lifecycle/tasks.md#P-1.2
      */

--- a/lib/Repair/SeedVthWorkflowTemplates.php
+++ b/lib/Repair/SeedVthWorkflowTemplates.php
@@ -200,33 +200,13 @@ class SeedVthWorkflowTemplates implements IRepairStep
      */
     private function processCatalogFile(string $file, IOutput $output): string
     {
-        $raw = file_get_contents($file);
-        if ($raw === false) {
-            $this->logger->error(
-                'Procest: VTH workflow template — unable to read catalog file',
-                ['app' => Application::APP_ID, 'file' => basename($file)]
-            );
-            return 'failed';
-        }
-
-        $data = json_decode($raw, true);
-        if (json_last_error() !== JSON_ERROR_NONE || is_array($data) === false) {
-            $this->logger->error(
-                'Procest: VTH workflow template — invalid JSON in catalog file',
-                ['app' => Application::APP_ID, 'file' => basename($file)]
-            );
+        $data = $this->loadCatalogEntry(file: $file);
+        if ($data === null) {
             return 'failed';
         }
 
         $slug  = (string) ($data['slug'] ?? '');
         $title = (string) ($data['title'] ?? '');
-        if ($slug === '' || $title === '') {
-            $this->logger->warning(
-                'Procest: VTH workflow template — missing slug or title',
-                ['app' => Application::APP_ID, 'file' => basename($file)]
-            );
-            return 'failed';
-        }
 
         // Cross-link entries (e.g. bezwaar) do not create a new
         // workflowTemplate; they only document VTH-specific guards that
@@ -246,14 +226,104 @@ class SeedVthWorkflowTemplates implements IRepairStep
             return 'crossLink';
         }
 
-        // Resolve caseType slug → UUID (soft-fail).
+        // Resolve caseType slug → UUID and the statusType map (soft-fail).
+        $context = $this->resolveTemplateContext(
+            data: $data,
+            slug: $slug,
+            title: $title,
+            output: $output,
+        );
+        if ($context === null) {
+            return 'skipped';
+        }
+
+        // Resolve steps and transitions. On any unresolved status, skip
+        // the entire template (no partial seed).
+        $graph = $this->resolveWorkflowGraph(
+            data: $data,
+            slug: $slug,
+            statusMap: (array) $context['statusMap'],
+        );
+        if ($graph === null) {
+            return 'skipped';
+        }
+
+        return $this->createAndPublishTemplate(
+            data: $data,
+            slug: $slug,
+            title: $title,
+            caseTypeId: (string) $context['caseTypeId'],
+            graph: $graph,
+            output: $output,
+        );
+    }//end processCatalogFile()
+
+    /**
+     * Read and validate one catalog file, returning its decoded entry.
+     *
+     * Returns null on any condition that makes the file unusable (unreadable,
+     * invalid JSON, or missing slug/title) — the caller reports those as failed.
+     *
+     * @param string $file Absolute path to the JSON catalog file
+     *
+     * @return array<string, mixed>|null The decoded catalog entry, or null when unusable
+     */
+    private function loadCatalogEntry(string $file): ?array
+    {
+        $raw = file_get_contents($file);
+        if ($raw === false) {
+            $this->logger->error(
+                'Procest: VTH workflow template — unable to read catalog file',
+                ['app' => Application::APP_ID, 'file' => basename($file)]
+            );
+            return null;
+        }
+
+        $data = json_decode($raw, true);
+        if (json_last_error() !== JSON_ERROR_NONE || is_array($data) === false) {
+            $this->logger->error(
+                'Procest: VTH workflow template — invalid JSON in catalog file',
+                ['app' => Application::APP_ID, 'file' => basename($file)]
+            );
+            return null;
+        }
+
+        $slug  = (string) ($data['slug'] ?? '');
+        $title = (string) ($data['title'] ?? '');
+        if ($slug === '' || $title === '') {
+            $this->logger->warning(
+                'Procest: VTH workflow template — missing slug or title',
+                ['app' => Application::APP_ID, 'file' => basename($file)]
+            );
+            return null;
+        }
+
+        return $data;
+    }//end loadCatalogEntry()
+
+    /**
+     * Resolve the caseType UUID and statusType map a template needs, applying
+     * the idempotency check.
+     *
+     * Returns null for every soft-fail precondition — the caller reports those
+     * as skipped.
+     *
+     * @param array<string, mixed> $data   The decoded catalog entry
+     * @param string               $slug   The template slug
+     * @param string               $title  The template title
+     * @param IOutput              $output The output interface
+     *
+     * @return array<string, mixed>|null {caseTypeId, statusMap}, or null when the template must be skipped
+     */
+    private function resolveTemplateContext(array $data, string $slug, string $title, IOutput $output): ?array
+    {
         $caseTypeSlug = (string) ($data['caseTypeSlug'] ?? '');
         if ($caseTypeSlug === '') {
             $this->logger->warning(
                 'Procest: VTH workflow template — missing caseTypeSlug',
                 ['app' => Application::APP_ID, 'slug' => $slug]
             );
-            return 'skipped';
+            return null;
         }
 
         $caseTypeId = $this->resolveCaseTypeId(slug: $caseTypeSlug);
@@ -273,7 +343,7 @@ class SeedVthWorkflowTemplates implements IRepairStep
                 'VTH catalog: caseType "'.$caseTypeSlug.'" not found for template "'
                 .$slug.'" — skipping (run base-register-seed-data first).'
             );
-            return 'skipped';
+            return null;
         }
 
         // Idempotency: skip if a workflow template with the same title +
@@ -287,7 +357,7 @@ class SeedVthWorkflowTemplates implements IRepairStep
                     'caseType' => $caseTypeId,
                 ]
             );
-            return 'skipped';
+            return null;
         }
 
         // Build the name → UUID map for statusTypes belonging to this caseType.
@@ -301,11 +371,29 @@ class SeedVthWorkflowTemplates implements IRepairStep
                     'caseType' => $caseTypeId,
                 ]
             );
-            return 'skipped';
+            return null;
         }
 
-        // Resolve steps and transitions. On any unresolved status, skip
-        // the entire template (no partial seed).
+        return [
+            'caseTypeId' => $caseTypeId,
+            'statusMap'  => $statusMap,
+        ];
+    }//end resolveTemplateContext()
+
+    /**
+     * Resolve the steps[] and transitions[] blocks against the status map.
+     *
+     * Returns null when any status name does not resolve — the caller reports
+     * that as skipped (no partial seed).
+     *
+     * @param array<string, mixed>  $data      The decoded catalog entry
+     * @param string                $slug      The template slug
+     * @param array<string, string> $statusMap Status name → UUID map
+     *
+     * @return array<string, mixed>|null {steps, transitions}, or null when unresolved
+     */
+    private function resolveWorkflowGraph(array $data, string $slug, array $statusMap): ?array
+    {
         $resolvedSteps = $this->resolveSteps(
             slug: $slug,
             rawSteps: ($data['steps'] ?? []),
@@ -316,7 +404,7 @@ class SeedVthWorkflowTemplates implements IRepairStep
                 'Procest: VTH workflow template — unresolved status in steps, skipping',
                 ['app' => Application::APP_ID, 'slug' => $slug]
             );
-            return 'skipped';
+            return null;
         }
 
         $resolvedTransitions = $this->resolveTransitions(
@@ -329,9 +417,35 @@ class SeedVthWorkflowTemplates implements IRepairStep
                 'Procest: VTH workflow template — unresolved status in transitions, skipping',
                 ['app' => Application::APP_ID, 'slug' => $slug]
             );
-            return 'skipped';
+            return null;
         }
 
+        return [
+            'steps'       => $resolvedSteps,
+            'transitions' => $resolvedTransitions,
+        ];
+    }//end resolveWorkflowGraph()
+
+    /**
+     * Create the draft via the lifecycle service and publish it.
+     *
+     * @param array<string, mixed> $data       The decoded catalog entry
+     * @param string               $slug       The template slug
+     * @param string               $title      The template title
+     * @param string               $caseTypeId The resolved caseType UUID
+     * @param array<string, mixed> $graph      The resolved {steps, transitions}
+     * @param IOutput              $output     The output interface
+     *
+     * @return string One of seeded|failed
+     */
+    private function createAndPublishTemplate(
+        array $data,
+        string $slug,
+        string $title,
+        string $caseTypeId,
+        array $graph,
+        IOutput $output
+    ): string {
         // Create draft via the lifecycle service.
         $draft = $this->definitionService->createDraft(
             payload: [
@@ -339,8 +453,8 @@ class SeedVthWorkflowTemplates implements IRepairStep
                 'description' => (string) ($data['description'] ?? ''),
                 'caseType'    => $caseTypeId,
                 'version'     => (int) ($data['version'] ?? 1),
-                'steps'       => $resolvedSteps,
-                'transitions' => $resolvedTransitions,
+                'steps'       => $graph['steps'],
+                'transitions' => $graph['transitions'],
             ]
         );
 
@@ -366,7 +480,7 @@ class SeedVthWorkflowTemplates implements IRepairStep
 
         $output->info('VTH catalog: seeded "'.$title.'" v'.(int) ($data['version'] ?? 1).'.');
         return 'seeded';
-    }//end processCatalogFile()
+    }//end createAndPublishTemplate()
 
     /**
      * Resolve a caseType by its slug — uses the `identifier` field on the
@@ -510,13 +624,25 @@ class SeedVthWorkflowTemplates implements IRepairStep
             return [];
         }
 
-        $map      = [];
         $rowsList = [];
         if (is_array($rows) === true) {
             $rowsList = $rows;
         }
 
-        foreach ($rowsList as $row) {
+        return $this->mapStatusTypeRows(rows: $rowsList);
+    }//end buildStatusMap()
+
+    /**
+     * Reduce statusType rows to a name → UUID map, dropping unusable rows.
+     *
+     * @param array<int, mixed> $rows The raw statusType rows
+     *
+     * @return array<string, string> Map of statusType name to UUID
+     */
+    private function mapStatusTypeRows(array $rows): array
+    {
+        $map = [];
+        foreach ($rows as $row) {
             $normalized = $this->normalizeRow(row: $row);
             if ($normalized === null) {
                 continue;
@@ -530,7 +656,7 @@ class SeedVthWorkflowTemplates implements IRepairStep
         }
 
         return $map;
-    }//end buildStatusMap()
+    }//end mapStatusTypeRows()
 
     /**
      * Resolve the steps[] block against the status name → UUID map.

--- a/lib/Service/Actions/ActionHandlerLocator.php
+++ b/lib/Service/Actions/ActionHandlerLocator.php
@@ -1,0 +1,156 @@
+<?php
+
+/**
+ * Procest ActionHandlerLocator.
+ *
+ * Owns the automatic-action handler table: the list of handler implementations,
+ * their lazy resolution out of the DI container, and the `type` slug index used
+ * to dispatch. Split out of ActionRegistry, which is otherwise a read-only
+ * lookup over OpenRegister objects and has no business also knowing the
+ * concrete handler classes — carrying that list is what pushed ActionRegistry
+ * over the CouplingBetweenObjects threshold.
+ *
+ * Resolution stays lazy and failure-tolerant: a handler that cannot be built is
+ * logged at error level and skipped, so one broken handler never takes the whole
+ * dispatch table down.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Actions
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Actions;
+
+use OCA\Procest\AppInfo\Application;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Resolves automatic-action handlers by their `type` slug.
+ *
+ * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+ */
+class ActionHandlerLocator
+{
+
+    /**
+     * In-memory handler index keyed by handler `type` slug.
+     *
+     * Populated lazily from the DI container the first time a handler is
+     * requested, so the container stays lean until a transition actually
+     * dispatches a side effect.
+     *
+     * @var array<string, ActionHandlerInterface>|null
+     */
+    private ?array $handlerIndex = null;
+
+    /**
+     * Constructor for ActionHandlerLocator.
+     *
+     * @param ContainerInterface $container DI container — used to lazily resolve the handler implementations.
+     * @param LoggerInterface    $logger    PSR-3 logger for handler-resolution failures.
+     *
+     * @return void
+     */
+    public function __construct(
+        private readonly ContainerInterface $container,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Lookup a registered handler by its `type` slug.
+     *
+     * @param string $type Handler `type` slug (matches ActionHandlerInterface::type()).
+     *
+     * @return ActionHandlerInterface|null Null when no handler is registered for the slug.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+     */
+    public function get(string $type): ?ActionHandlerInterface
+    {
+        if ($this->handlerIndex === null) {
+            $this->handlerIndex = $this->buildIndex();
+        }
+
+        return ($this->handlerIndex[$type] ?? null);
+    }//end get()
+
+    /**
+     * Resolve every known handler class and index it by its `type` slug.
+     *
+     * Each handler class is registered as a regular DI service and referenced by
+     * FQCN; they are resolved lazily so the container can stay lean.
+     *
+     * @return array<string, ActionHandlerInterface> The handler index, keyed by type slug.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+     */
+    private function buildIndex(): array
+    {
+        $index      = [];
+        $candidates = [
+            SendEmailHandler::class,
+            CreateDocumentHandler::class,
+            NotifyRoleHandler::class,
+            CallWebhookHandler::class,
+            MergeTemplateHandler::class,
+            ScheduleReminderHandler::class,
+        ];
+
+        foreach ($candidates as $fqcn) {
+            $handler = $this->resolve(fqcn: $fqcn);
+            if ($handler !== null) {
+                $index[$handler->type()] = $handler;
+            }
+        }
+
+        return $index;
+    }//end buildIndex()
+
+    /**
+     * Resolve one handler out of the container, tolerating a broken handler.
+     *
+     * @param string $fqcn Fully-qualified handler class name.
+     *
+     * @return ActionHandlerInterface|null The handler, or null when it cannot be built or is not a handler.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+     */
+    private function resolve(string $fqcn): ?ActionHandlerInterface
+    {
+        try {
+            $handler = $this->container->get($fqcn);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'ActionRegistry: failed to resolve handler',
+                [
+                    'app'       => Application::APP_ID,
+                    'fqcn'      => $fqcn,
+                    'exception' => $e->getMessage(),
+                ]
+            );
+            return null;
+        }
+
+        if ($handler instanceof ActionHandlerInterface) {
+            return $handler;
+        }
+
+        return null;
+    }//end resolve()
+}//end class

--- a/lib/Service/Actions/ActionRegistry.php
+++ b/lib/Service/Actions/ActionRegistry.php
@@ -65,30 +65,24 @@ class ActionRegistry
     private array $cache = [];
 
     /**
-     * In-memory handler index keyed by handler `type` slug.
-     *
-     * Populated lazily from the DI container the first time a handler is
-     * requested. Mirrors the dispatch lookup in SideEffectDispatcher so that
-     * external callers (e.g. a dry-run endpoint) can resolve a handler
-     * without rebuilding the table.
-     *
-     * @var array<string, ActionHandlerInterface>|null
-     */
-    private ?array $handlerIndex = null;
-
-    /**
      * Constructor for ActionRegistry.
      *
-     * @param ContainerInterface $container DI container — used to lazily
-     *                                      resolve OpenRegister's
-     *                                      ObjectService and to discover
-     *                                      handler implementations.
-     * @param IAppConfig         $appConfig Procest app config — provides the
-     *                                      `register` and
-     *                                      `automatic_action_schema` keys.
-     * @param LoggerInterface    $logger    PSR-3 logger for error logging on
-     *                                      unknown slugs, cross-tenant
-     *                                      attempts, and resolution failures.
+     * @param ContainerInterface   $container      DI container — used
+     *                                             to lazily resolve
+     *                                             OpenRegister's
+     *                                             ObjectService and to
+     *                                             discover handler
+     *                                             implementations.
+     * @param IAppConfig           $appConfig      Procest app config —
+     *                                             provides the `register` and
+     *                                             `automatic_action_schema`
+     *                                             keys.
+     * @param LoggerInterface      $logger         PSR-3 logger for error logging on
+     *                                             unknown slugs, cross-tenant
+     *                                             attempts, and resolution
+     *                                             failures.
+     * @param ActionHandlerLocator $handlerLocator Owns the handler table and
+     *                                             resolves handlers by `type` slug.
      *
      * @return void
      */
@@ -96,6 +90,7 @@ class ActionRegistry
         private readonly ContainerInterface $container,
         private readonly IAppConfig $appConfig,
         private readonly LoggerInterface $logger,
+        private readonly ActionHandlerLocator $handlerLocator,
     ) {
     }//end __construct()
 
@@ -277,41 +272,7 @@ class ActionRegistry
      */
     public function getHandler(string $type): ?ActionHandlerInterface
     {
-        if ($this->handlerIndex === null) {
-            $this->handlerIndex = [];
-            // Each handler class is registered as a regular DI service and
-            // referenced by FQCN; we resolve them lazily so the container
-            // can stay lean.
-            $candidates = [
-                \OCA\Procest\Service\Actions\SendEmailHandler::class,
-                \OCA\Procest\Service\Actions\CreateDocumentHandler::class,
-                \OCA\Procest\Service\Actions\NotifyRoleHandler::class,
-                \OCA\Procest\Service\Actions\CallWebhookHandler::class,
-                \OCA\Procest\Service\Actions\MergeTemplateHandler::class,
-                \OCA\Procest\Service\Actions\ScheduleReminderHandler::class,
-            ];
-            foreach ($candidates as $fqcn) {
-                try {
-                    $handler = $this->container->get($fqcn);
-                } catch (\Throwable $e) {
-                    $this->logger->error(
-                        'ActionRegistry: failed to resolve handler',
-                        [
-                            'app'       => Application::APP_ID,
-                            'fqcn'      => $fqcn,
-                            'exception' => $e->getMessage(),
-                        ]
-                    );
-                    continue;
-                }
-
-                if ($handler instanceof ActionHandlerInterface) {
-                    $this->handlerIndex[$handler->type()] = $handler;
-                }
-            }
-        }//end if
-
-        return ($this->handlerIndex[$type] ?? null);
+        return $this->handlerLocator->get(type: $type);
     }//end getHandler()
 
     /**

--- a/lib/Service/AiService.php
+++ b/lib/Service/AiService.php
@@ -907,6 +907,20 @@ class AiService
             throw new RuntimeException('AI model returned HTTP '.$httpCode);
         }
 
+        return $this->decodeAiModelResponse(response: $response);
+    }//end callAiModel()
+
+    /**
+     * Decode the raw AI model HTTP body into the suggestion array.
+     *
+     * @param string $response The raw response body returned by the model
+     *
+     * @return array The parsed model response
+     *
+     * @throws \RuntimeException If the response body is not valid JSON
+     */
+    private function decodeAiModelResponse(string $response): array
+    {
         $decoded = json_decode($response, true);
         if (json_last_error() !== JSON_ERROR_NONE) {
             throw new RuntimeException('AI model returned invalid JSON');
@@ -922,7 +936,7 @@ class AiService
         }
 
         return $parsed;
-    }//end callAiModel()
+    }//end decodeAiModelResponse()
 
     /**
      * Record an audit entry for a case-assistant-via-hermiq conversational
@@ -1121,29 +1135,61 @@ class AiService
         }//end if
 
         if ($modelType === 'local') {
-            // Local models: only http/https to localhost or 127.0.0.1.
-            if (in_array($scheme, ['http', 'https'], true) === false) {
-                return false;
-            }//end if
-
-            if ($host !== 'localhost' && $host !== '127.0.0.1' && $host !== '::1') {
-                // Allow named docker service hostnames (e.g. 'ollama') for local deployments
-                // but still block known public metadata endpoints and RFC1918 IPs.
-                $ipAddress = gethostbyname($host);
-                if ($ipAddress !== $host
-                    && $this->ipInCidr(ipAddress: $ipAddress, cidr: '169.254.0.0/16') === true
-                ) {
-                    $this->logger->warning(
-                        'AI SSRF: local model URL resolves to cloud metadata range',
-                        ['host' => $host, 'ip' => $ipAddress]
-                    );
-                    return false;
-                }//end if
-            }//end if
-
-            return true;
+            return $this->isSafeLocalAiUrl(scheme: $scheme, host: $host);
         }//end if
 
+        return $this->isSafeCloudAiUrl(scheme: $scheme, host: $host);
+    }//end isSafeAiUrl()
+
+    /**
+     * Validate a local-model URL (SSRF guard).
+     *
+     * Only http/https to localhost or 127.0.0.1; named docker service hostnames
+     * are allowed but must not resolve into the cloud metadata range.
+     *
+     * @param string $scheme The lower-cased URL scheme
+     * @param string $host   The lower-cased URL host
+     *
+     * @return bool True if the URL passes the SSRF check
+     */
+    private function isSafeLocalAiUrl(string $scheme, string $host): bool
+    {
+        // Local models: only http/https to localhost or 127.0.0.1.
+        if (in_array($scheme, ['http', 'https'], true) === false) {
+            return false;
+        }//end if
+
+        if ($host !== 'localhost' && $host !== '127.0.0.1' && $host !== '::1') {
+            // Allow named docker service hostnames (e.g. 'ollama') for local deployments
+            // but still block known public metadata endpoints and RFC1918 IPs.
+            $ipAddress = gethostbyname($host);
+            if ($ipAddress !== $host
+                && $this->ipInCidr(ipAddress: $ipAddress, cidr: '169.254.0.0/16') === true
+            ) {
+                $this->logger->warning(
+                    'AI SSRF: local model URL resolves to cloud metadata range',
+                    ['host' => $host, 'ip' => $ipAddress]
+                );
+                return false;
+            }//end if
+        }//end if
+
+        return true;
+    }//end isSafeLocalAiUrl()
+
+    /**
+     * Validate a cloud-model URL (SSRF guard).
+     *
+     * Https only, and the host must resolve to a public (non-RFC1918,
+     * non-loopback) address.
+     *
+     * @param string $scheme The lower-cased URL scheme
+     * @param string $host   The lower-cased URL host
+     *
+     * @return bool True if the URL passes the SSRF check
+     */
+    private function isSafeCloudAiUrl(string $scheme, string $host): bool
+    {
         // Cloud models: https only, must resolve to a public (non-RFC1918) address.
         if ($scheme !== 'https') {
             $this->logger->warning(
@@ -1184,7 +1230,7 @@ class AiService
         }
 
         return true;
-    }//end isSafeAiUrl()
+    }//end isSafeCloudAiUrl()
 
     /**
      * Check if an IP address falls within a CIDR range (IPv4 and IPv6).
@@ -1200,49 +1246,75 @@ class AiService
         $isIpv6Ip   = str_contains($ipAddress, ':');
 
         if ($isIpv6Cidr === true && $isIpv6Ip === true) {
-            [$network, $prefix] = explode('/', $cidr);
-            $prefixLen          = (int) $prefix;
-            $networkBin         = inet_pton($network);
-            $inputBin           = inet_pton($ipAddress);
-            if ($networkBin === false || $inputBin === false) {
-                return false;
-            }//end if
-
-            $fullBytes  = intdiv($prefixLen, 8);
-            $remainBits = $prefixLen % 8;
-            for ($i = 0; $i < $fullBytes; $i++) {
-                if ($networkBin[$i] !== $inputBin[$i]) {
-                    return false;
-                }//end if
-            }
-
-            if ($remainBits > 0 && $fullBytes < 16) {
-                $mask = (0xFF << (8 - $remainBits)) & 0xFF;
-                if ((ord($networkBin[$fullBytes]) & $mask) !== (ord($inputBin[$fullBytes]) & $mask)) {
-                    return false;
-                }//end if
-            }//end if
-
-            return true;
+            return $this->isIpv6InCidr(ipAddress: $ipAddress, cidr: $cidr);
         }//end if
 
         if ($isIpv6Cidr === false && $isIpv6Ip === false) {
-            [$network, $prefix] = explode('/', $cidr);
-            $prefixLen          = (int) $prefix;
-            $networkLong        = ip2long($network);
-            $ipLong = ip2long($ipAddress);
-            if ($networkLong === false || $ipLong === false) {
-                return false;
-            }//end if
-
-            $mask = 0;
-            if ($prefixLen !== 0) {
-                $mask = ~0 << (32 - $prefixLen);
-            }//end if
-
-            return ($ipLong & $mask) === ($networkLong & $mask);
+            return $this->isIpv4InCidr(ipAddress: $ipAddress, cidr: $cidr);
         }//end if
 
         return false;
     }//end ipInCidr()
+
+    /**
+     * Check if an IPv6 address falls within an IPv6 CIDR range.
+     *
+     * @param string $ipAddress The IPv6 address to test
+     * @param string $cidr      The IPv6 CIDR block (e.g. 'fc00::/7')
+     *
+     * @return bool True if the IP is within the range
+     */
+    private function isIpv6InCidr(string $ipAddress, string $cidr): bool
+    {
+        [$network, $prefix] = explode('/', $cidr);
+        $prefixLen          = (int) $prefix;
+        $networkBin         = inet_pton($network);
+        $inputBin           = inet_pton($ipAddress);
+        if ($networkBin === false || $inputBin === false) {
+            return false;
+        }//end if
+
+        $fullBytes  = intdiv($prefixLen, 8);
+        $remainBits = $prefixLen % 8;
+        for ($i = 0; $i < $fullBytes; $i++) {
+            if ($networkBin[$i] !== $inputBin[$i]) {
+                return false;
+            }//end if
+        }
+
+        if ($remainBits > 0 && $fullBytes < 16) {
+            $mask = (0xFF << (8 - $remainBits)) & 0xFF;
+            if ((ord($networkBin[$fullBytes]) & $mask) !== (ord($inputBin[$fullBytes]) & $mask)) {
+                return false;
+            }//end if
+        }//end if
+
+        return true;
+    }//end isIpv6InCidr()
+
+    /**
+     * Check if an IPv4 address falls within an IPv4 CIDR range.
+     *
+     * @param string $ipAddress The IPv4 address to test
+     * @param string $cidr      The IPv4 CIDR block (e.g. '10.0.0.0/8')
+     *
+     * @return bool True if the IP is within the range
+     */
+    private function isIpv4InCidr(string $ipAddress, string $cidr): bool
+    {
+        [$network, $prefix] = explode('/', $cidr);
+        $prefixLen          = (int) $prefix;
+        $networkLong        = ip2long($network);
+        $ipLong = ip2long($ipAddress);
+        if ($networkLong === false || $ipLong === false) {
+            return false;
+        }//end if
+
+        $mask = 0;
+        if ($prefixLen !== 0) {
+            $mask = ~0 << (32 - $prefixLen);
+        }//end if
+
+        return ($ipLong & $mask) === ($networkLong & $mask);
+    }//end isIpv4InCidr()
 }//end class

--- a/lib/Service/CaseCollaborationService.php
+++ b/lib/Service/CaseCollaborationService.php
@@ -189,10 +189,7 @@ class CaseCollaborationService
             return ['error' => 'Federated share not found'];
         }
 
-        $shareData = $shareObj;
-        if (is_array($shareObj) === false) {
-            $shareData = $shareObj->jsonSerialize();
-        }
+        $shareData = $this->asArray(value: $shareObj);
 
         if (($shareData['status'] ?? '') === 'revoked') {
             return ['error' => 'This federated share has been revoked'];
@@ -213,10 +210,7 @@ class CaseCollaborationService
         $activity['lastActivityAt'] = $entry['createdAt'];
 
         $result     = $objectService->saveObject(object: $activity, register: (int) $register, schema: (int) $activitySchema);
-        $resultData = $result;
-        if (is_array($result) === false) {
-            $resultData = $result->jsonSerialize();
-        }
+        $resultData = $this->asArray(value: $result);
 
         $this->tenantAuditTrail->emit(
             [
@@ -230,6 +224,23 @@ class CaseCollaborationService
 
         return $resultData;
     }//end appendEntry()
+
+    /**
+     * Normalise an OpenRegister return value to its array form — OR hands back
+     * either a plain array or a JsonSerializable entity depending on the call.
+     *
+     * @param mixed $value The array or JsonSerializable entity to normalise
+     *
+     * @return array The array form of the value
+     */
+    private function asArray(mixed $value): array
+    {
+        if (is_array($value) === true) {
+            return $value;
+        }
+
+        return $value->jsonSerialize();
+    }//end asArray()
 
     /**
      * Find the caseFederatedActivity object for a share, if any.

--- a/lib/Service/CaseDefinitionExportService.php
+++ b/lib/Service/CaseDefinitionExportService.php
@@ -125,6 +125,36 @@ class CaseDefinitionExportService
             throw new RuntimeException('Failed to create temporary file for export');
         }
 
+        $this->writeArchive(
+            tempPath: $tempPath,
+            caseTypeId: $caseTypeId,
+            manifest: $manifest,
+            components: $components
+        );
+
+        $slug    = $manifest['caseType']['slug'] ?? 'unknown';
+        $version = $manifest['version'] ?? '1.0';
+
+        return [
+            'path'     => $tempPath,
+            'filename' => "case-definition-{$slug}-v{$version}.zip",
+        ];
+    }//end exportCaseDefinition()
+
+    /**
+     * Write the manifest and the selected components into the export archive.
+     *
+     * @param string               $tempPath   Path of the temporary ZIP file to write.
+     * @param string               $caseTypeId The case type ID being exported.
+     * @param array<string, mixed> $manifest   The manifest to store as manifest.json.
+     * @param string[]             $components The components to include.
+     *
+     * @return void
+     *
+     * @throws \RuntimeException If the ZIP archive cannot be created.
+     */
+    private function writeArchive(string $tempPath, string $caseTypeId, array $manifest, array $components): void
+    {
         $zip    = new ZipArchive();
         $result = $zip->open($tempPath, ZipArchive::CREATE | ZipArchive::OVERWRITE);
         if ($result !== true) {
@@ -142,13 +172,7 @@ class CaseDefinitionExportService
             }
 
             if ($component === 'workflows' && is_array($data) === true) {
-                foreach ($data as $workflowName => $workflowData) {
-                    $zip->addFromString(
-                        'workflows/'.$workflowName.'.json',
-                        json_encode($workflowData, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)
-                    );
-                }
-
+                $this->addWorkflowEntries(zip: $zip, workflows: $data);
                 continue;
             }
 
@@ -159,15 +183,25 @@ class CaseDefinitionExportService
         }//end foreach
 
         $zip->close();
+    }//end writeArchive()
 
-        $slug    = $manifest['caseType']['slug'] ?? 'unknown';
-        $version = $manifest['version'] ?? '1.0';
-
-        return [
-            'path'     => $tempPath,
-            'filename' => "case-definition-{$slug}-v{$version}.zip",
-        ];
-    }//end exportCaseDefinition()
+    /**
+     * Add one JSON entry per workflow under the archive's workflows/ directory.
+     *
+     * @param ZipArchive           $zip       The opened ZIP archive.
+     * @param array<string, mixed> $workflows The workflow data keyed by workflow name.
+     *
+     * @return void
+     */
+    private function addWorkflowEntries(ZipArchive $zip, array $workflows): void
+    {
+        foreach ($workflows as $workflowName => $workflowData) {
+            $zip->addFromString(
+                'workflows/'.$workflowName.'.json',
+                json_encode($workflowData, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)
+            );
+        }
+    }//end addWorkflowEntries()
 
     /**
      * Build the manifest for a case definition export.

--- a/lib/Service/CaseDefinitionImportService.php
+++ b/lib/Service/CaseDefinitionImportService.php
@@ -95,99 +95,31 @@ class CaseDefinitionImportService
         }
 
         // Check required files.
-        foreach (self::REQUIRED_FILES as $requiredFile) {
-            if ($zip->locateName($requiredFile) === false) {
-                $result['valid']    = false;
-                $result['errors'][] = "Missing required file: {$requiredFile}";
-            }
-        }
-
-        if ($result['valid'] === false) {
+        $missingFiles = $this->findMissingRequiredFiles(zip: $zip);
+        if ($missingFiles !== []) {
+            $result['valid']  = false;
+            $result['errors'] = $missingFiles;
             $zip->close();
             return $result;
         }
 
         // Parse manifest.
-        $manifestJson = $zip->getFromName('manifest.json');
-        if ($manifestJson === false) {
-            $result['valid']    = false;
-            $result['errors'][] = 'Failed to read manifest.json';
+        $manifestResult = $this->readManifest(zip: $zip);
+        if ($manifestResult['errors'] !== []) {
+            $result['valid']  = false;
+            $result['errors'] = $manifestResult['errors'];
             $zip->close();
             return $result;
         }
 
-        $manifest = json_decode($manifestJson, true);
-        if ($manifest === null) {
-            $result['valid']    = false;
-            $result['errors'][] = 'Invalid JSON in manifest.json: '.json_last_error_msg();
-            $zip->close();
-            return $result;
-        }
+        $result['manifest'] = $manifestResult['manifest'];
 
-        $result['manifest'] = $manifest;
+        // Validate manifest structure, declared components and dependencies.
+        $issues = $this->validateManifestContents(zip: $zip, manifest: (array) $manifestResult['manifest']);
 
-        // Validate manifest structure.
-        $requiredFields = ['version', 'exportDate', 'caseType', 'components'];
-        foreach ($requiredFields as $field) {
-            if (isset($manifest[$field]) === false) {
-                $result['valid']    = false;
-                $result['errors'][] = "Missing required manifest field: {$field}";
-            }
-        }
-
-        // Validate that declared components have matching files.
-        $components = $manifest['components'] ?? [];
-        foreach ($components as $component) {
-            if ($component === 'workflows') {
-                // Workflows are in a subdirectory -- check for at least the directory.
-                $hasWorkflows = false;
-                for ($i = 0; $i < $zip->numFiles; $i++) {
-                    $name = $zip->getNameIndex($i);
-                    if ($name !== false && str_starts_with($name, 'workflows/') === true) {
-                        $hasWorkflows = true;
-                        break;
-                    }
-                }
-
-                if ($hasWorkflows === false) {
-                    $result['warnings'][] = 'Component "workflows" declared but no workflow files found';
-                }
-
-                continue;
-            }
-
-            $componentFile = $component.'.json';
-            if ($zip->locateName($componentFile) === false) {
-                $result['valid']    = false;
-                $result['errors'][] = "Component '{$component}' declared in manifest but file '{$componentFile}' not found";
-            }
-        }//end foreach
-
-        // Validate component JSON.
-        foreach ($components as $component) {
-            if ($component === 'workflows') {
-                continue;
-            }
-
-            $componentFile = $component.'.json';
-            $content       = $zip->getFromName($componentFile);
-            if ($content !== false) {
-                $decoded = json_decode($content, true);
-                if ($decoded === null && json_last_error() !== JSON_ERROR_NONE) {
-                    $result['valid']    = false;
-                    $result['errors'][] = "Invalid JSON in {$componentFile}: ".json_last_error_msg();
-                }
-            }
-        }
-
-        // Check for dependency conflicts.
-        $dependencies = $manifest['dependencies'] ?? [];
-        foreach ($dependencies as $dep) {
-            $depType = $dep['type'] ?? 'unknown';
-            $depName = $dep['name'] ?? 'unknown';
-            // In a full implementation, check if the dependency exists in OpenRegister.
-            $result['warnings'][] = "Dependency '{$depName}' (type: {$depType}) should be verified in target environment";
-        }
+        $result['errors']   = $issues['errors'];
+        $result['warnings'] = $issues['warnings'];
+        $result['valid']    = ($issues['errors'] === []);
 
         $zip->close();
 
@@ -368,4 +300,210 @@ class CaseDefinitionImportService
             'message' => "Imported {$workflowCount} workflow(s)",
         ];
     }//end importWorkflows()
+
+    /**
+     * Collect an error for every required package file missing from the archive.
+     *
+     * @param \ZipArchive $zip The opened ZIP archive.
+     *
+     * @return string[] One error message per missing required file.
+     */
+    private function findMissingRequiredFiles(\ZipArchive $zip): array
+    {
+        $errors = [];
+
+        foreach (self::REQUIRED_FILES as $requiredFile) {
+            if ($zip->locateName($requiredFile) === false) {
+                $errors[] = "Missing required file: {$requiredFile}";
+            }
+        }
+
+        return $errors;
+    }//end findMissingRequiredFiles()
+
+    /**
+     * Read and decode manifest.json from the archive.
+     *
+     * @param \ZipArchive $zip The opened ZIP archive.
+     *
+     * @return array{manifest: mixed, errors: string[]} The decoded manifest, or the read/decode errors.
+     */
+    private function readManifest(\ZipArchive $zip): array
+    {
+        $manifestJson = $zip->getFromName('manifest.json');
+        if ($manifestJson === false) {
+            return [
+                'manifest' => null,
+                'errors'   => ['Failed to read manifest.json'],
+            ];
+        }
+
+        $manifest = json_decode($manifestJson, true);
+        if ($manifest === null) {
+            return [
+                'manifest' => null,
+                'errors'   => ['Invalid JSON in manifest.json: '.json_last_error_msg()],
+            ];
+        }
+
+        return [
+            'manifest' => $manifest,
+            'errors'   => [],
+        ];
+    }//end readManifest()
+
+    /**
+     * Validate the manifest structure, its declared components and its dependencies.
+     *
+     * @param \ZipArchive          $zip      The opened ZIP archive.
+     * @param array<string, mixed> $manifest The decoded manifest.
+     *
+     * @return array{errors: string[], warnings: string[]} The accumulated errors and warnings, in report order.
+     */
+    private function validateManifestContents(\ZipArchive $zip, array $manifest): array
+    {
+        $errors = $this->findMissingManifestFields(manifest: $manifest);
+
+        $components   = (array) ($manifest['components'] ?? []);
+        $dependencies = (array) ($manifest['dependencies'] ?? []);
+
+        $componentIssues = $this->validateComponentFiles(zip: $zip, components: $components);
+        $errors          = array_merge($errors, $componentIssues['errors']);
+        $warnings        = $componentIssues['warnings'];
+
+        $errors = array_merge($errors, $this->validateComponentJson(zip: $zip, components: $components));
+
+        $warnings = array_merge($warnings, $this->buildDependencyWarnings(dependencies: $dependencies));
+
+        return [
+            'errors'   => $errors,
+            'warnings' => $warnings,
+        ];
+    }//end validateManifestContents()
+
+    /**
+     * Collect an error for every mandatory manifest field that is absent.
+     *
+     * @param array<string, mixed> $manifest The decoded manifest.
+     *
+     * @return string[] One error message per missing field.
+     */
+    private function findMissingManifestFields(array $manifest): array
+    {
+        $errors = [];
+
+        $requiredFields = ['version', 'exportDate', 'caseType', 'components'];
+        foreach ($requiredFields as $field) {
+            if (isset($manifest[$field]) === false) {
+                $errors[] = "Missing required manifest field: {$field}";
+            }
+        }
+
+        return $errors;
+    }//end findMissingManifestFields()
+
+    /**
+     * Verify that every declared component has a matching file in the archive.
+     *
+     * @param \ZipArchive  $zip        The opened ZIP archive.
+     * @param array<mixed> $components The components declared in the manifest.
+     *
+     * @return array{errors: string[], warnings: string[]} Missing-file errors and workflow warnings.
+     */
+    private function validateComponentFiles(\ZipArchive $zip, array $components): array
+    {
+        $errors   = [];
+        $warnings = [];
+
+        foreach ($components as $component) {
+            if ($component === 'workflows') {
+                // Workflows are in a subdirectory -- check for at least the directory.
+                if ($this->hasWorkflowEntries(zip: $zip) === false) {
+                    $warnings[] = 'Component "workflows" declared but no workflow files found';
+                }
+
+                continue;
+            }
+
+            $componentFile = $component.'.json';
+            if ($zip->locateName($componentFile) === false) {
+                $errors[] = "Component '{$component}' declared in manifest but file '{$componentFile}' not found";
+            }
+        }//end foreach
+
+        return [
+            'errors'   => $errors,
+            'warnings' => $warnings,
+        ];
+    }//end validateComponentFiles()
+
+    /**
+     * Determine whether the archive contains at least one entry under workflows/.
+     *
+     * @param \ZipArchive $zip The opened ZIP archive.
+     *
+     * @return bool True when a workflows/ entry is present.
+     */
+    private function hasWorkflowEntries(\ZipArchive $zip): bool
+    {
+        for ($i = 0; $i < $zip->numFiles; $i++) {
+            $name = $zip->getNameIndex($i);
+            if ($name !== false && str_starts_with($name, 'workflows/') === true) {
+                return true;
+            }
+        }
+
+        return false;
+    }//end hasWorkflowEntries()
+
+    /**
+     * Verify that each declared component file contains parseable JSON.
+     *
+     * @param \ZipArchive  $zip        The opened ZIP archive.
+     * @param array<mixed> $components The components declared in the manifest.
+     *
+     * @return string[] One error message per component file with invalid JSON.
+     */
+    private function validateComponentJson(\ZipArchive $zip, array $components): array
+    {
+        $errors = [];
+
+        foreach ($components as $component) {
+            if ($component === 'workflows') {
+                continue;
+            }
+
+            $componentFile = $component.'.json';
+            $content       = $zip->getFromName($componentFile);
+            if ($content !== false) {
+                $decoded = json_decode($content, true);
+                if ($decoded === null && json_last_error() !== JSON_ERROR_NONE) {
+                    $errors[] = "Invalid JSON in {$componentFile}: ".json_last_error_msg();
+                }
+            }
+        }
+
+        return $errors;
+    }//end validateComponentJson()
+
+    /**
+     * Build the "verify in target environment" warning for each declared dependency.
+     *
+     * @param array<mixed> $dependencies The dependencies declared in the manifest.
+     *
+     * @return string[] One warning per dependency.
+     */
+    private function buildDependencyWarnings(array $dependencies): array
+    {
+        $warnings = [];
+
+        foreach ($dependencies as $dep) {
+            $depType = $dep['type'] ?? 'unknown';
+            $depName = $dep['name'] ?? 'unknown';
+            // In a full implementation, check if the dependency exists in OpenRegister.
+            $warnings[] = "Dependency '{$depName}' (type: {$depType}) should be verified in target environment";
+        }
+
+        return $warnings;
+    }//end buildDependencyWarnings()
 }//end class

--- a/lib/Service/CaseEmailService.php
+++ b/lib/Service/CaseEmailService.php
@@ -35,6 +35,7 @@ use OCP\Files\NotFoundException;
 use OCP\IAppConfig;
 use OCP\IUserSession;
 use OCP\Mail\IMailer;
+use OCP\Mail\IMessage;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 
@@ -105,17 +106,7 @@ class CaseEmailService
     ): array {
         // H6 / C4: Fail loudly if from-address is not configured — never fall back to
         // the reserved example.nl domain which would cause bounces and expose config errors.
-        $fromAddress = $this->appConfig->getValueString(
-            Application::APP_ID,
-            'email_from_address',
-            '',
-        );
-        if ($fromAddress === '' || str_ends_with($fromAddress, '@example.nl') === true) {
-            throw new RuntimeException(
-                'E-mail afzenderadres is niet geconfigureerd. '
-                .'Stel email_from_address in via de beheerdersinstellingen.'
-            );
-        }
+        $fromAddress = $this->resolveFromAddress();
 
         $fromName = $this->appConfig->getValueString(
             Application::APP_ID,
@@ -133,20 +124,7 @@ class CaseEmailService
 
         // H4: Validate the recipient against the case's registered contact emails.
         // This prevents open-relay abuse where any email address could be supplied.
-        if ($to === '' || filter_var($to, FILTER_VALIDATE_EMAIL) === false) {
-            throw new RuntimeException('Ongeldig e-mailadres opgegeven.');
-        }
-
-        $allowedEmails = $this->getCaseContactEmails(caseData: $caseData);
-        if (count($allowedEmails) > 0) {
-            if (in_array(strtolower($to), $allowedEmails, true) === false) {
-                $this->logger->warning(
-                    'Blocked email to non-case-contact address',
-                    ['app' => Application::APP_ID, 'to' => $to, 'caseId' => $caseId]
-                );
-                throw new RuntimeException('Ontvanger is geen geregistreerd contact bij deze zaak.');
-            }
-        }
+        $this->assertRecipientAllowed(recipient: $to, caseData: $caseData, caseId: $caseId);
 
         $message = $this->mailer->createMessage();
         $message->setFrom([$fromAddress => $fromName]);
@@ -157,6 +135,101 @@ class CaseEmailService
 
         // H5: Resolve attachments via IUserFolder to restrict file access to the
         // calling user's own files and prevent path traversal outside their folder.
+        $this->attachUserFiles(message: $message, attachments: $attachments, caseId: $caseId);
+
+        $this->dispatchMessage(message: $message, caseId: $caseId);
+
+        // Record the sent email as a case document.
+        $messageId = $this->recordSentEmail(caseId: $caseId, to: $to, subject: $subject, body: $body);
+
+        $this->logger->info(
+            'Email sent for case {caseId}',
+            ['app' => Application::APP_ID, 'caseId' => $caseId],
+        );
+
+        return [
+            'messageId' => $messageId,
+            'to'        => $to,
+            'subject'   => $subject,
+            'sentAt'    => date('Y-m-d\TH:i:s'),
+        ];
+    }//end sendEmail()
+
+    /**
+     * Resolve the configured envelope from-address.
+     *
+     * H6 / C4: fails loudly when the address is unset or still points at the
+     * reserved example.nl domain, rather than silently sending mail that bounces.
+     *
+     * @return string The configured from-address
+     *
+     * @throws \RuntimeException If no usable from-address is configured
+     */
+    private function resolveFromAddress(): string
+    {
+        $fromAddress = $this->appConfig->getValueString(
+            Application::APP_ID,
+            'email_from_address',
+            '',
+        );
+        if ($fromAddress === '' || str_ends_with($fromAddress, '@example.nl') === true) {
+            throw new RuntimeException(
+                'E-mail afzenderadres is niet geconfigureerd. '
+                .'Stel email_from_address in via de beheerdersinstellingen.'
+            );
+        }
+
+        return $fromAddress;
+    }//end resolveFromAddress()
+
+    /**
+     * Assert that a recipient address is well-formed and registered on the case.
+     *
+     * H4: prevents open-relay abuse where any address could be supplied. When the
+     * case registers no contacts at all the address list is empty and no
+     * restriction applies.
+     *
+     * @param string               $recipient The recipient email address
+     * @param array<string, mixed> $caseData  The case data array
+     * @param string               $caseId    The case UUID (logging context)
+     *
+     * @return void
+     *
+     * @throws \RuntimeException If the address is invalid or not a case contact
+     */
+    private function assertRecipientAllowed(string $recipient, array $caseData, string $caseId): void
+    {
+        if ($recipient === '' || filter_var($recipient, FILTER_VALIDATE_EMAIL) === false) {
+            throw new RuntimeException('Ongeldig e-mailadres opgegeven.');
+        }
+
+        $allowedEmails = $this->getCaseContactEmails(caseData: $caseData);
+        if (count($allowedEmails) > 0) {
+            if (in_array(strtolower($recipient), $allowedEmails, true) === false) {
+                $this->logger->warning(
+                    'Blocked email to non-case-contact address',
+                    ['app' => Application::APP_ID, 'to' => $recipient, 'caseId' => $caseId]
+                );
+                throw new RuntimeException('Ontvanger is geen geregistreerd contact bij deze zaak.');
+            }
+        }
+    }//end assertRecipientAllowed()
+
+    /**
+     * Attach the requested files to a message, resolved from the caller's own folder.
+     *
+     * H5: resolving via the user folder restricts file access to the calling
+     * user's own files and prevents path traversal outside that folder. A file
+     * that cannot be resolved or attached is logged and skipped.
+     *
+     * @param IMessage      $message     The message under construction
+     * @param array<string> $attachments File references to attach
+     * @param string        $caseId      The case UUID (logging context)
+     *
+     * @return void
+     */
+    private function attachUserFiles(IMessage $message, array $attachments, string $caseId): void
+    {
         $currentUser = $this->userSession->getUser();
         if ($currentUser !== null && count($attachments) > 0) {
             $userFolder = $this->rootFolder->getUserFolder($currentUser->getUID());
@@ -180,12 +253,27 @@ class CaseEmailService
                 }//end try
             }//end foreach
         }//end if
+    }//end attachUserFiles()
 
+    /**
+     * Hand a fully-built message to the mailer.
+     *
+     * M4: the full exception is logged server-side while the caller receives a
+     * generic message, so internal mail-server details (hostnames, credentials)
+     * are never leaked.
+     *
+     * @param IMessage $message The message to send
+     * @param string   $caseId  The case UUID (logging context)
+     *
+     * @return void
+     *
+     * @throws \RuntimeException If the mailer rejects the message
+     */
+    private function dispatchMessage(IMessage $message, string $caseId): void
+    {
         try {
             $this->mailer->send($message);
         } catch (\Exception $e) {
-            // M4: Log full exception server-side; throw a generic message so internal
-            // mail-server errors (hostnames, credentials, etc.) are not leaked to callers.
             $this->logger->error(
                 'Failed to send email for case {caseId}: {error}',
                 [
@@ -197,22 +285,7 @@ class CaseEmailService
             );
             throw new RuntimeException('email_send_failed');
         }
-
-        // Record the sent email as a case document.
-        $messageId = $this->recordSentEmail(caseId: $caseId, to: $to, subject: $subject, body: $body);
-
-        $this->logger->info(
-            'Email sent for case {caseId}',
-            ['app' => Application::APP_ID, 'caseId' => $caseId],
-        );
-
-        return [
-            'messageId' => $messageId,
-            'to'        => $to,
-            'subject'   => $subject,
-            'sentAt'    => date('Y-m-d\TH:i:s'),
-        ];
-    }//end sendEmail()
+    }//end dispatchMessage()
 
     /**
      * Send an email using a template.
@@ -471,24 +544,58 @@ class CaseEmailService
      */
     private function getCaseContactEmails(array $caseData): array
     {
+        $emails = array_merge(
+            $this->collectPrimaryContactEmails(caseData: $caseData),
+            $this->collectContactListEmails(caseData: $caseData),
+        );
+
+        return array_unique($emails);
+    }//end getCaseContactEmails()
+
+    /**
+     * Collect the single-valued contact addresses on a case.
+     *
+     * Covers the top-level `email` field and the `initiator` contact object, in
+     * that order.
+     *
+     * @param array<string, mixed> $caseData The case data array
+     *
+     * @return array<string> Lowercase email addresses
+     */
+    private function collectPrimaryContactEmails(array $caseData): array
+    {
         $emails = [];
 
         // Top-level email field.
-        $topEmail = strtolower(trim((string) ($caseData['email'] ?? '')));
-        if ($topEmail !== '' && filter_var($topEmail, FILTER_VALIDATE_EMAIL) !== false) {
+        $topEmail = $this->normalizeContactEmail(value: (string) ($caseData['email'] ?? ''));
+        if ($topEmail !== null) {
             $emails[] = $topEmail;
         }
 
         // Initiator field (single contact object or email string).
-        $initiator = $caseData['initiator'] ?? null;
+        $initiator = ($caseData['initiator'] ?? null);
         if (is_array($initiator) === true) {
-            $addr = strtolower(trim((string) ($initiator['email'] ?? '')));
-            if ($addr !== '' && filter_var($addr, FILTER_VALIDATE_EMAIL) !== false) {
+            $addr = $this->normalizeContactEmail(value: (string) ($initiator['email'] ?? ''));
+            if ($addr !== null) {
                 $emails[] = $addr;
             }
         }
 
-        // Betrokkenen / contacts arrays.
+        return $emails;
+    }//end collectPrimaryContactEmails()
+
+    /**
+     * Collect the addresses held in a case's contact collections.
+     *
+     * Covers `betrokkenen` and `contacts`, in that order; each entry may carry
+     * either an `email` or an `emailadres` key.
+     *
+     * @param array<string, mixed> $caseData The case data array
+     *
+     * @return array<string> Lowercase email addresses
+     */
+    private function collectContactListEmails(array $caseData): array
+    {
         $contactArrays = [];
         if (is_array($caseData['betrokkenen'] ?? null) === true) {
             $contactArrays[] = $caseData['betrokkenen'];
@@ -498,21 +605,41 @@ class CaseEmailService
             $contactArrays[] = $caseData['contacts'];
         }
 
+        $emails = [];
         foreach ($contactArrays as $contacts) {
             foreach ($contacts as $contact) {
                 if (is_array($contact) === false) {
                     continue;
                 }
 
-                $addr = strtolower(trim((string) ($contact['email'] ?? ($contact['emailadres'] ?? ''))));
-                if ($addr !== '' && filter_var($addr, FILTER_VALIDATE_EMAIL) !== false) {
+                $addr = $this->normalizeContactEmail(
+                    value: (string) ($contact['email'] ?? ($contact['emailadres'] ?? ''))
+                );
+                if ($addr !== null) {
                     $emails[] = $addr;
                 }
             }
         }
 
-        return array_unique($emails);
-    }//end getCaseContactEmails()
+        return $emails;
+    }//end collectContactListEmails()
+
+    /**
+     * Normalise a raw contact value to a lowercase, validated email address.
+     *
+     * @param string $value The raw contact value
+     *
+     * @return string|null The lowercase address, or null when absent/invalid
+     */
+    private function normalizeContactEmail(string $value): ?string
+    {
+        $addr = strtolower(trim($value));
+        if ($addr === '' || filter_var($addr, FILTER_VALIDATE_EMAIL) === false) {
+            return null;
+        }
+
+        return $addr;
+    }//end normalizeContactEmail()
 
     /**
      * Load an email template.

--- a/lib/Service/CaseReassignmentService.php
+++ b/lib/Service/CaseReassignmentService.php
@@ -105,49 +105,87 @@ class CaseReassignmentService
                 schema: $caseSchema,
                 filters: ['assignee' => $fromUser]
             );
-            foreach ($caseResults as $case) {
-                if (in_array((string) ($case['status'] ?? ''), $finalIds, true) === true) {
-                    continue;
-                }
 
-                if ($caseType !== '' && (string) ($case['caseType'] ?? '') !== $caseType) {
-                    continue;
-                }
-
-                $cases[] = $case;
-            }
+            $cases = $this->filterOpenCases(caseResults: $caseResults, finalIds: $finalIds, caseType: $caseType);
         }
 
         $tasks = [];
         if ($taskSchema !== '') {
-            $caseIds = [];
-            foreach ($cases as $c) {
-                $caseIds[(string) ($c['id'] ?? ($c['uuid'] ?? ''))] = true;
-            }
-
             $taskResults = $this->searchObjectsAsArrays(
                 objectService: $objectService,
                 register: $register,
                 schema: $taskSchema,
                 filters: ['assignee' => $fromUser]
             );
-            foreach ($taskResults as $task) {
-                if (in_array((string) ($task['status'] ?? ''), ['completed', 'terminated', 'disabled'], true) === true) {
-                    continue;
-                }
 
-                // When narrowed by caseType, only tasks belonging to a previewed
-                // case are in scope.
-                if ($caseType !== '' && isset($caseIds[(string) ($task['case'] ?? '')]) === false) {
-                    continue;
-                }
-
-                $tasks[] = $task;
-            }
-        }//end if
+            $tasks = $this->filterOpenTasks(taskResults: $taskResults, cases: $cases, caseType: $caseType);
+        }
 
         return ['cases' => $cases, 'tasks' => $tasks];
     }//end preview()
+
+    /**
+     * Keep only the non-final cases, optionally narrowed to one case type.
+     *
+     * @param array<int, array<string, mixed>> $caseResults The raw case search results.
+     * @param array<int, string>               $finalIds    Status ids marking a case as closed/archived.
+     * @param string                           $caseType    Optional caseType uuid to narrow by ('' = all).
+     *
+     * @return array<int, array<string, mixed>> The open cases, in search order.
+     */
+    private function filterOpenCases(array $caseResults, array $finalIds, string $caseType): array
+    {
+        $cases = [];
+
+        foreach ($caseResults as $case) {
+            if (in_array((string) ($case['status'] ?? ''), $finalIds, true) === true) {
+                continue;
+            }
+
+            if ($caseType !== '' && (string) ($case['caseType'] ?? '') !== $caseType) {
+                continue;
+            }
+
+            $cases[] = $case;
+        }
+
+        return $cases;
+    }//end filterOpenCases()
+
+    /**
+     * Keep only the open tasks, optionally narrowed to the previewed cases.
+     *
+     * @param array<int, array<string, mixed>> $taskResults The raw task search results.
+     * @param array<int, array<string, mixed>> $cases       The previewed cases the tasks may belong to.
+     * @param string                           $caseType    Optional caseType uuid to narrow by ('' = all).
+     *
+     * @return array<int, array<string, mixed>> The open tasks, in search order.
+     */
+    private function filterOpenTasks(array $taskResults, array $cases, string $caseType): array
+    {
+        $caseIds = [];
+        foreach ($cases as $c) {
+            $caseIds[(string) ($c['id'] ?? ($c['uuid'] ?? ''))] = true;
+        }
+
+        $tasks = [];
+
+        foreach ($taskResults as $task) {
+            if (in_array((string) ($task['status'] ?? ''), ['completed', 'terminated', 'disabled'], true) === true) {
+                continue;
+            }
+
+            // When narrowed by caseType, only tasks belonging to a previewed
+            // case are in scope.
+            if ($caseType !== '' && isset($caseIds[(string) ($task['case'] ?? '')]) === false) {
+                continue;
+            }
+
+            $tasks[] = $task;
+        }
+
+        return $tasks;
+    }//end filterOpenTasks()
 
     /**
      * Execute a bulk reassignment from one handler to another.
@@ -275,16 +313,7 @@ class CaseReassignmentService
 
             // Append a batch audit entry onto the activity log when present
             // (cases carry an activity property; tasks may not).
-            $activity = [];
-            $raw      = ($item['activity'] ?? null);
-            if (is_array($raw) === true) {
-                $activity = $raw;
-            } else if (is_string($raw) === true && $raw !== '') {
-                $decoded = json_decode($raw, true);
-                if (is_array($decoded) === true) {
-                    $activity = $decoded;
-                }
-            }
+            $activity = $this->extractActivityLog(item: $item);
 
             $activity[] = [
                 'type'           => 'reassignment',
@@ -308,6 +337,33 @@ class CaseReassignmentService
             return false;
         }//end try
     }//end reassignItem()
+
+    /**
+     * Read an item's existing activity log, accepting both the array and the
+     * JSON-string storage shapes and falling back to an empty log.
+     *
+     * @param array<string, mixed> $item The object payload.
+     *
+     * @return array<int, mixed> The decoded activity log.
+     */
+    private function extractActivityLog(array $item): array
+    {
+        $raw = ($item['activity'] ?? null);
+        if (is_array($raw) === true) {
+            return $raw;
+        }
+
+        if (is_string($raw) === true) {
+            // An empty string decodes to null, so it falls through to the
+            // empty log below without a separate guard.
+            $decoded = json_decode($raw, true);
+            if (is_array($decoded) === true) {
+                return $decoded;
+            }
+        }
+
+        return [];
+    }//end extractActivityLog()
 
     /**
      * Send a single digest notification to the receiving handler.
@@ -364,7 +420,7 @@ class CaseReassignmentService
         $ids = [];
         foreach ($rows as $row) {
             $isFinal = ($row['isFinal'] ?? false);
-            if ($isFinal === true || $isFinal === 'true' || $isFinal === 1) {
+            if (in_array($isFinal, [true, 'true', 1], true) === true) {
                 $ids[] = (string) ($row['id'] ?? ($row['uuid'] ?? ''));
             }
         }

--- a/lib/Service/CaseRelationService.php
+++ b/lib/Service/CaseRelationService.php
@@ -119,16 +119,13 @@ class CaseRelationService
         string $aardRelatie,
         ?string $toelichting=null
     ): array {
-        if (in_array($aardRelatie, self::RELATION_TYPES, true) === false) {
-            return ['ok' => false, 'reason' => 'invalid_aard_relatie'];
-        }
-
-        if ($caseId === '' || $targetId === '') {
-            return ['ok' => false, 'reason' => 'missing_case_id'];
-        }
-
-        if ($caseId === $targetId) {
-            return ['ok' => false, 'reason' => 'self_relation'];
+        $rejection = $this->rejectInvalidRelationInput(
+            caseId: $caseId,
+            targetId: $targetId,
+            aardRelatie: $aardRelatie
+        );
+        if ($rejection !== null) {
+            return $rejection;
         }
 
         // OR-RBAC read access to BOTH cases (fail closed on either miss).
@@ -153,29 +150,100 @@ class CaseRelationService
             return ['ok' => false, 'reason' => 'duplicate'];
         }
 
-        $entry = ['caseId' => $targetId, 'aardRelatie' => $aardRelatie];
-        if ($toelichting !== null && $toelichting !== '') {
-            $entry['toelichting'] = $toelichting;
-        }
-
-        $originRelations[] = $entry;
+        $originRelations[] = $this->buildRelationEntry(
+            caseId: $targetId,
+            aardRelatie: $aardRelatie,
+            toelichting: $toelichting
+        );
         $this->persistRelations(case: $origin, relations: $originRelations);
 
         // Symmetric counterpart — same type names the link, the UI renders
         // direction-aware labels.
-        $targetRelations = $this->decodeRelations(case: $target);
-        if ($this->hasPair(relations: $targetRelations, caseId: $caseId, aardRelatie: $aardRelatie) === false) {
-            $inverse = ['caseId' => $caseId, 'aardRelatie' => $aardRelatie];
-            if ($toelichting !== null && $toelichting !== '') {
-                $inverse['toelichting'] = $toelichting;
-            }
-
-            $targetRelations[] = $inverse;
-            $this->persistRelations(case: $target, relations: $targetRelations);
-        }
+        $this->addInverseRelation(
+            target: $target,
+            caseId: $caseId,
+            aardRelatie: $aardRelatie,
+            toelichting: $toelichting
+        );
 
         return ['ok' => true];
     }//end addRelation()
+
+    /**
+     * Reject a relation request whose inputs cannot form a valid peer relation.
+     *
+     * Returns the failure array to hand straight back to the caller, or null
+     * when the inputs pass every input-only guard.
+     *
+     * @param string $caseId      Origin case UUID.
+     * @param string $targetId    Target case UUID.
+     * @param string $aardRelatie Relation type.
+     *
+     * @return array{ok: bool, reason?: string}|null
+     */
+    private function rejectInvalidRelationInput(string $caseId, string $targetId, string $aardRelatie): ?array
+    {
+        if (in_array($aardRelatie, self::RELATION_TYPES, true) === false) {
+            return ['ok' => false, 'reason' => 'invalid_aard_relatie'];
+        }
+
+        if ($caseId === '' || $targetId === '') {
+            return ['ok' => false, 'reason' => 'missing_case_id'];
+        }
+
+        if ($caseId === $targetId) {
+            return ['ok' => false, 'reason' => 'self_relation'];
+        }
+
+        return null;
+    }//end rejectInvalidRelationInput()
+
+    /**
+     * Build a single relation entry, carrying the optional clarification.
+     *
+     * @param string      $caseId      Referenced case UUID.
+     * @param string      $aardRelatie Relation type.
+     * @param string|null $toelichting Optional free-text clarification.
+     *
+     * @return array<string, string>
+     */
+    private function buildRelationEntry(string $caseId, string $aardRelatie, ?string $toelichting): array
+    {
+        $entry = ['caseId' => $caseId, 'aardRelatie' => $aardRelatie];
+        if ($toelichting !== null && $toelichting !== '') {
+            $entry['toelichting'] = $toelichting;
+        }
+
+        return $entry;
+    }//end buildRelationEntry()
+
+    /**
+     * Persist the symmetric counterpart entry on the target case, unless it is
+     * already present.
+     *
+     * @param array<string, mixed> $target      Target case object.
+     * @param string               $caseId      Origin case UUID (the entry's reference).
+     * @param string               $aardRelatie Relation type.
+     * @param string|null          $toelichting Optional free-text clarification.
+     *
+     * @return void
+     */
+    private function addInverseRelation(
+        array $target,
+        string $caseId,
+        string $aardRelatie,
+        ?string $toelichting
+    ): void {
+        $targetRelations = $this->decodeRelations(case: $target);
+        if ($this->hasPair(relations: $targetRelations, caseId: $caseId, aardRelatie: $aardRelatie) === false) {
+            $targetRelations[] = $this->buildRelationEntry(
+                caseId: $caseId,
+                aardRelatie: $aardRelatie,
+                toelichting: $toelichting
+            );
+            $this->persistRelations(case: $target, relations: $targetRelations);
+        }
+    }//end addInverseRelation()
 
     /**
      * Remove a typed peer relation from BOTH cases.
@@ -385,6 +453,33 @@ class CaseRelationService
      */
     private function decodeRelations(array $case): array
     {
+        $entries = [];
+        foreach ($this->rawRelationList(case: $case) as $item) {
+            if (is_array($item) === false) {
+                continue;
+            }
+
+            $entry = $this->decodeRelationEntry(item: $item);
+            if ($entry === null) {
+                continue;
+            }
+
+            $entries[] = $entry;
+        }//end foreach
+
+        return $entries;
+    }//end decodeRelations()
+
+    /**
+     * Read the raw `relatedCases` payload as a list, accepting either the
+     * JSON-encoded string shape or an already-decoded array.
+     *
+     * @param array<string, mixed> $case Case object.
+     *
+     * @return array<mixed> The raw relation list, or [] when unusable.
+     */
+    private function rawRelationList(array $case): array
+    {
         $raw  = ($case['relatedCases'] ?? null);
         $list = [];
         if (is_array($raw) === true) {
@@ -398,30 +493,33 @@ class CaseRelationService
             }
         }
 
-        $entries = [];
-        foreach ($list as $item) {
-            if (is_array($item) === false) {
-                continue;
-            }
+        return $list;
+    }//end rawRelationList()
 
-            $targetId = (string) ($item['caseId'] ?? '');
-            if ($targetId === '') {
-                continue;
-            }
+    /**
+     * Normalise one raw relation item into a relation entry.
+     *
+     * @param array<string, mixed> $item Raw relation item.
+     *
+     * @return array<string, string>|null The entry, or null when it names no case.
+     */
+    private function decodeRelationEntry(array $item): ?array
+    {
+        $targetId = (string) ($item['caseId'] ?? '');
+        if ($targetId === '') {
+            return null;
+        }
 
-            $entry = [
-                'caseId'      => $targetId,
-                'aardRelatie' => (string) ($item['aardRelatie'] ?? ''),
-            ];
-            if (isset($item['toelichting']) === true && (string) $item['toelichting'] !== '') {
-                $entry['toelichting'] = (string) $item['toelichting'];
-            }
+        $entry = [
+            'caseId'      => $targetId,
+            'aardRelatie' => (string) ($item['aardRelatie'] ?? ''),
+        ];
+        if (isset($item['toelichting']) === true && (string) $item['toelichting'] !== '') {
+            $entry['toelichting'] = (string) $item['toelichting'];
+        }
 
-            $entries[] = $entry;
-        }//end foreach
-
-        return $entries;
-    }//end decodeRelations()
+        return $entry;
+    }//end decodeRelationEntry()
 
     /**
      * Whether a `{caseId, aardRelatie}` pair already exists in a relation list.
@@ -504,20 +602,32 @@ class CaseRelationService
             return null;
         }
 
-        if ($obj === null) {
+        return $this->normalizeCaseObject(object: $obj);
+    }//end fetchCase()
+
+    /**
+     * Normalise an OpenRegister lookup result to a plain case array.
+     *
+     * @param mixed $object The value returned by the ObjectService.
+     *
+     * @return array<string, mixed>|null The case as an array, or null when unusable.
+     */
+    private function normalizeCaseObject(mixed $object): ?array
+    {
+        if ($object === null) {
             return null;
         }
 
-        if (is_object($obj) === true && method_exists($obj, 'jsonSerialize') === true) {
-            $obj = $obj->jsonSerialize();
+        if (is_object($object) === true && method_exists($object, 'jsonSerialize') === true) {
+            $object = $object->jsonSerialize();
         }
 
-        if (is_array($obj) === true) {
-            return $obj;
+        if (is_array($object) === true) {
+            return $object;
         }
 
         return null;
-    }//end fetchCase()
+    }//end normalizeCaseObject()
 
     /**
      * Persist a relation list back onto a case, JSON-encoding the field

--- a/lib/Service/CaseSharingService.php
+++ b/lib/Service/CaseSharingService.php
@@ -123,10 +123,7 @@ class CaseSharingService
                 return false;
             }
 
-            $caseData = $caseObj;
-            if (is_array($caseObj) === false) {
-                $caseData = $caseObj->jsonSerialize();
-            }
+            $caseData = $this->normalizeToArray(value: $caseObj);
         } catch (\Throwable $e) {
             $this->logger->warning(
                 'CaseSharingService: canUserAccessCase load failed',
@@ -135,46 +132,99 @@ class CaseSharingService
             return true;
         }
 
+        // Direct assignee field, then the assignees array.
+        if ($this->isCaseAssignee(caseData: $caseData, userId: $userId) === true) {
+            return true;
+        }
+
+        // Check existing caseShares: if this user created any share for this case they
+        // already had access at that time.
+        if ($this->hasCreatedShareForCase(
+            objectService: $objectService,
+            caseId: $caseId,
+            userId: $userId,
+            register: (int) $register
+        ) === true
+        ) {
+            return true;
+        }
+
+        return false;
+    }//end canUserAccessCase()
+
+    /**
+     * Whether a case names the given user as assignee.
+     *
+     * Accepts both the single-valued `assignee` field and membership of the
+     * `assignees` array; either one grants access.
+     *
+     * @param array<string, mixed> $caseData The case data
+     * @param string               $userId   The caller's user ID
+     *
+     * @return bool True when the user is an assignee of the case
+     */
+    private function isCaseAssignee(array $caseData, string $userId): bool
+    {
         // Direct assignee field (single user ID string).
         if (isset($caseData['assignee']) === true && (string) $caseData['assignee'] === $userId) {
             return true;
         }
 
         // Assignees array.
-        $assignees = $caseData['assignees'] ?? [];
+        $assignees = ($caseData['assignees'] ?? []);
         if (is_array($assignees) === true && in_array($userId, $assignees, true) === true) {
             return true;
         }
 
-        // Check existing caseShares: if this user created any share for this case they
-        // already had access at that time.
+        return false;
+    }//end isCaseAssignee()
+
+    /**
+     * Whether the given user created any caseShare for the given case.
+     *
+     * A user who once minted a share for the case already had access at that
+     * time, so the share record is treated as standing evidence of access.
+     * A failed lookup is logged and treated as "no share found" (deny), never
+     * as a grant.
+     *
+     * @param object $objectService The OpenRegister ObjectService
+     * @param string $caseId        The case UUID
+     * @param string $userId        The caller's user ID
+     * @param int    $register      The configured register id
+     *
+     * @return bool True when a share created by this user exists
+     */
+    private function hasCreatedShareForCase(
+        object $objectService,
+        string $caseId,
+        string $userId,
+        int $register,
+    ): bool {
         $shareSchema = $this->settingsService->getConfigValue('case_share_schema');
-        if (empty($shareSchema) === false) {
-            try {
-                $shares = $objectService->findAll(
-                    ['filters' => ['register' => (int) $register, 'schema' => (int) $shareSchema, 'caseId' => $caseId]],
-                );
+        if (empty($shareSchema) === true) {
+            return false;
+        }
 
-                foreach ($shares as $share) {
-                    $shareData = $share;
-                    if (is_array($share) === false) {
-                        $shareData = $share->jsonSerialize();
-                    }
+        try {
+            $shares = $objectService->findAll(
+                ['filters' => ['register' => $register, 'schema' => (int) $shareSchema, 'caseId' => $caseId]],
+            );
 
-                    if (isset($shareData['createdBy']) === true && (string) $shareData['createdBy'] === $userId) {
-                        return true;
-                    }
+            foreach ($shares as $share) {
+                $shareData = $this->normalizeToArray(value: $share);
+                if (isset($shareData['createdBy']) === true && (string) $shareData['createdBy'] === $userId) {
+                    return true;
                 }
-            } catch (\Throwable $e) {
-                $this->logger->debug(
-                    'CaseSharingService: share lookup in canUserAccessCase failed',
-                    ['caseId' => $caseId, 'exception' => $e->getMessage()]
-                );
-            }//end try
-        }//end if
+            }
+        } catch (\Throwable $e) {
+            $this->logger->debug(
+                'CaseSharingService: share lookup in canUserAccessCase failed',
+                ['caseId' => $caseId, 'exception' => $e->getMessage()]
+            );
+        }//end try
 
         return false;
-    }//end canUserAccessCase()
+    }//end hasCreatedShareForCase()
 
     /**
      * Resolve OpenRegister's CaseTokenService — the public "track your
@@ -585,57 +635,36 @@ class CaseSharingService
 
         $invalidFields = array_diff($sharedFields, self::FEDERATION_ALLOWED_FIELDS);
         if (count($invalidFields) > 0) {
-            return [
-                'error' => 'Field(s) not shareable across a federation boundary: '.implode(', ', $invalidFields),
-            ];
+            return ['error' => 'Field(s) not shareable across a federation boundary: '.implode(', ', $invalidFields)];
         }
 
         $register    = $this->settingsService->getConfigValue('register');
         $caseSchema  = $this->settingsService->getConfigValue('case_schema');
         $shareSchema = $this->settingsService->getConfigValue('case_federated_share_schema');
 
-        if (empty($register) === true || empty($caseSchema) === true || empty($shareSchema) === true) {
+        if ($this->isFederatedShareConfigured(register: $register, caseSchema: $caseSchema, shareSchema: $shareSchema) === false) {
             return ['error' => 'Federated case sharing is not configured'];
         }
 
-        try {
-            $caseObj = $objectService->find($caseId, register: (int) $register, schema: (int) $caseSchema);
-        } catch (\Throwable $e) {
-            $this->logger->warning(
-                'CaseSharingService: createFederatedShare case load failed',
-                ['caseId' => $caseId, 'exception' => $e->getMessage()]
-            );
+        $caseData = $this->loadCaseForFederatedShare(
+            objectService: $objectService,
+            caseId: $caseId,
+            register: (int) $register,
+            caseSchema: (int) $caseSchema
+        );
+        if ($caseData === null) {
             return ['error' => 'Case not found'];
         }
 
-        if ($caseObj === null) {
-            return ['error' => 'Case not found'];
-        }
-
-        $caseData = $caseObj;
-        if (is_array($caseObj) === false) {
-            $caseData = $caseObj->jsonSerialize();
-        }
-
-        // Build the redacted snapshot — allow-listed fields present on the
-        // case only. @self/relations are excluded by construction: they are
-        // never in FEDERATION_ALLOWED_FIELDS, so they can never appear here
-        // even if requested.
-        $fieldSnapshot = [];
-        foreach ($sharedFields as $field) {
-            if (array_key_exists($field, $caseData) === true) {
-                $fieldSnapshot[$field] = $caseData[$field];
-            }
-        }
+        // Build the redacted snapshot — allow-listed fields present on the case only.
+        $fieldSnapshot = $this->buildFieldSnapshot(caseData: $caseData, sharedFields: $sharedFields);
 
         // Only document references already attached to the case may cross.
         $caseDocuments    = (array) ($caseData['documents'] ?? []);
         $validDocuments   = array_values(array_intersect($sharedDocuments, $caseDocuments));
         $invalidDocuments = array_diff($sharedDocuments, $caseDocuments);
         if (count($invalidDocuments) > 0) {
-            return [
-                'error' => 'Document(s) not attached to this case: '.implode(', ', $invalidDocuments),
-            ];
+            return ['error' => 'Document(s) not attached to this case: '.implode(', ', $invalidDocuments)];
         }
 
         $shareData = [
@@ -650,40 +679,26 @@ class CaseSharingService
         ];
 
         $result     = $objectService->saveObject(object: $shareData, register: (int) $register, schema: (int) $shareSchema);
-        $resultData = $result;
-        if (is_array($result) === false) {
-            $resultData = $result->jsonSerialize();
-        }
+        $resultData = $this->normalizeToArray(value: $result);
 
         $shareUuid = (string) ($resultData['id'] ?? $resultData['uuid'] ?? '');
 
-        try {
-            $federatedShare = $federationService->createOutgoingShare(
-                params: [
-                    'scope'       => 'object',
-                    'register'    => (string) $register,
-                    'schema'      => (string) $shareSchema,
-                    'objectUri'   => $shareUuid,
-                    'sharedWith'  => $remoteCloudId,
-                    // Always 'read' — the case-summary share never grants
-                    // the remote org write access to the case.
-                    'permissions' => 'read',
-                ]
-            );
-        } catch (\Throwable $e) {
-            $this->logger->error(
-                'CaseSharingService: OR createOutgoingShare failed',
-                ['caseId' => $caseId, 'exception' => $e->getMessage()]
-            );
+        $federatedShare = $this->mintOutgoingShare(
+            federationService: $federationService,
+            caseId: $caseId,
+            shareUuid: $shareUuid,
+            remoteCloudId: $remoteCloudId,
+            register: (string) $register,
+            shareSchema: (string) $shareSchema
+        );
+        if ($federatedShare === null) {
             return ['error' => 'Could not mint the federated share token'];
         }
 
         $resultData['federationShareId'] = $federatedShare->getId();
         $resultData['status']            = 'active';
-        $resultData = $objectService->saveObject(object: $resultData, register: (int) $register, schema: (int) $shareSchema);
-        if (is_array($resultData) === false) {
-            $resultData = $resultData->jsonSerialize();
-        }
+        $activated  = $objectService->saveObject(object: $resultData, register: (int) $register, schema: (int) $shareSchema);
+        $resultData = $this->normalizeToArray(value: $activated);
 
         $this->auditTrailService->emit(
             [
@@ -701,6 +716,127 @@ class CaseSharingService
 
         return $resultData;
     }//end createFederatedShare()
+
+    /**
+     * Whether every configuration value a federated share needs is present.
+     *
+     * @param string $register    The configured register id
+     * @param string $caseSchema  The configured case schema id
+     * @param string $shareSchema The configured federated-share schema id
+     *
+     * @return bool True when all three are configured
+     */
+    private function isFederatedShareConfigured(string $register, string $caseSchema, string $shareSchema): bool
+    {
+        return (empty($register) === false && empty($caseSchema) === false && empty($shareSchema) === false);
+    }//end isFederatedShareConfigured()
+
+    /**
+     * Load the case a federated share is being built from.
+     *
+     * Returns null both when the case cannot be loaded and when it does not
+     * exist — the caller reports 'Case not found' either way; the load failure
+     * is additionally logged here.
+     *
+     * @param object $objectService The OpenRegister ObjectService
+     * @param string $caseId        The UUID of the case to share
+     * @param int    $register      The configured register id
+     * @param int    $caseSchema    The configured case schema id
+     *
+     * @return array<string, mixed>|null The case data, or null when unavailable
+     */
+    private function loadCaseForFederatedShare(
+        object $objectService,
+        string $caseId,
+        int $register,
+        int $caseSchema,
+    ): ?array {
+        try {
+            $caseObj = $objectService->find($caseId, register: $register, schema: $caseSchema);
+        } catch (\Throwable $e) {
+            $this->logger->warning(
+                'CaseSharingService: createFederatedShare case load failed',
+                ['caseId' => $caseId, 'exception' => $e->getMessage()]
+            );
+            return null;
+        }
+
+        if ($caseObj === null) {
+            return null;
+        }
+
+        return $this->normalizeToArray(value: $caseObj);
+    }//end loadCaseForFederatedShare()
+
+    /**
+     * Project the requested fields that are actually present on the case.
+     *
+     * The caller has already rejected any field outside
+     * {@see FEDERATION_ALLOWED_FIELDS}, so this only drops fields the case does
+     * not carry.
+     *
+     * @param array<string, mixed> $caseData     The case data
+     * @param array<string>        $sharedFields Requested case field names
+     *
+     * @return array<string, mixed> The redacted snapshot
+     */
+    private function buildFieldSnapshot(array $caseData, array $sharedFields): array
+    {
+        $fieldSnapshot = [];
+        foreach ($sharedFields as $field) {
+            if (array_key_exists($field, $caseData) === true) {
+                $fieldSnapshot[$field] = $caseData[$field];
+            }
+        }
+
+        return $fieldSnapshot;
+    }//end buildFieldSnapshot()
+
+    /**
+     * Mint the outgoing OCM share for a persisted snapshot through the OR leaf.
+     *
+     * The grant is always 'read' — the case-summary share never gives the
+     * remote org write access to the case. Returns null (and logs) when the
+     * leaf refuses, so the caller can fail closed.
+     *
+     * @param object $federationService The OR FederationShareService
+     * @param string $caseId            The UUID of the case being shared (logging context)
+     * @param string $shareUuid         The UUID of the persisted snapshot object
+     * @param string $remoteCloudId     The federated target (slug@host)
+     * @param string $register          The configured register id
+     * @param string $shareSchema       The configured federated-share schema id
+     *
+     * @return object|null The minted OR federated share, or null on failure
+     */
+    private function mintOutgoingShare(
+        object $federationService,
+        string $caseId,
+        string $shareUuid,
+        string $remoteCloudId,
+        string $register,
+        string $shareSchema,
+    ): ?object {
+        try {
+            return $federationService->createOutgoingShare(
+                params: [
+                    'scope'       => 'object',
+                    'register'    => $register,
+                    'schema'      => $shareSchema,
+                    'objectUri'   => $shareUuid,
+                    'sharedWith'  => $remoteCloudId,
+                    // Always 'read' — the case-summary share never grants
+                    // the remote org write access to the case.
+                    'permissions' => 'read',
+                ]
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'CaseSharingService: OR createOutgoingShare failed',
+                ['caseId' => $caseId, 'exception' => $e->getMessage()]
+            );
+            return null;
+        }
+    }//end mintOutgoingShare()
 
     /**
      * Revoke a federated case share. Sets the OR `FederatedShare.status` to

--- a/lib/Service/CaseTransferService.php
+++ b/lib/Service/CaseTransferService.php
@@ -125,26 +125,17 @@ class CaseTransferService
 
         $now = (new DateTime())->format('c');
 
-        $transferData = [
-            'caseId'             => $caseId,
-            'sourceOrganization' => $sourceOrganization,
-            'targetOrganization' => $targetOrganization,
-            'reason'             => $reason,
-            'requestedDate'      => $requestedDate,
-            'status'             => 'pending',
-            'initiatedBy'        => $initiatedBy,
-            'remoteCloudId'      => $remoteCloudId,
-            'idempotencyKey'     => $idempotencyKey,
-            'custodyAuditTrail'  => [
-                [
-                    'event'     => 'initiated',
-                    'actor'     => $initiatedBy,
-                    'actorType' => 'local',
-                    'cloudId'   => '',
-                    'timestamp' => $now,
-                ],
-            ],
-        ];
+        $transferData = $this->buildInitialTransferData(
+            caseId: $caseId,
+            sourceOrganization: $sourceOrganization,
+            targetOrganization: $targetOrganization,
+            reason: $reason,
+            requestedDate: $requestedDate,
+            initiatedBy: $initiatedBy,
+            remoteCloudId: $remoteCloudId,
+            idempotencyKey: $idempotencyKey,
+            now: $now,
+        );
 
         $result     = $objectService->saveObject(
             object: $transferData,
@@ -170,6 +161,84 @@ class CaseTransferService
             $resultData = $result->jsonSerialize();
         }
 
+        $this->recordTransferInitiated(
+            result: $result,
+            caseId: $caseId,
+            targetOrganization: $targetOrganization,
+            initiatedBy: $initiatedBy,
+            remoteCloudId: $remoteCloudId,
+        );
+
+        return $resultData;
+    }//end initiateTransfer()
+
+    /**
+     * Build the initial (pending) transfer object payload with its first
+     * custody-audit entry.
+     *
+     * @param string      $caseId             The UUID of the case to transfer
+     * @param string      $sourceOrganization The source organization identifier
+     * @param string      $targetOrganization The UUID of the target partner organization
+     * @param string      $reason             The reason for transfer
+     * @param string      $requestedDate      The requested transfer date (ISO 8601)
+     * @param string      $initiatedBy        User ID of the initiator (custody audit trail)
+     * @param string|null $remoteCloudId      The federated target (slug@host), or null for a local-only transfer
+     * @param string|null $idempotencyKey     The federated idempotency key, or null for a local-only transfer
+     * @param string      $now                The ISO 8601 timestamp used for the custody entry
+     *
+     * @return array The transfer object payload ready to be saved
+     */
+    private function buildInitialTransferData(
+        string $caseId,
+        string $sourceOrganization,
+        string $targetOrganization,
+        string $reason,
+        string $requestedDate,
+        string $initiatedBy,
+        ?string $remoteCloudId,
+        ?string $idempotencyKey,
+        string $now,
+    ): array {
+        return [
+            'caseId'             => $caseId,
+            'sourceOrganization' => $sourceOrganization,
+            'targetOrganization' => $targetOrganization,
+            'reason'             => $reason,
+            'requestedDate'      => $requestedDate,
+            'status'             => 'pending',
+            'initiatedBy'        => $initiatedBy,
+            'remoteCloudId'      => $remoteCloudId,
+            'idempotencyKey'     => $idempotencyKey,
+            'custodyAuditTrail'  => [
+                [
+                    'event'     => 'initiated',
+                    'actor'     => $initiatedBy,
+                    'actorType' => 'local',
+                    'cloudId'   => '',
+                    'timestamp' => $now,
+                ],
+            ],
+        ];
+    }//end buildInitialTransferData()
+
+    /**
+     * Emit the tenant audit event and log line for a freshly initiated transfer.
+     *
+     * @param object      $result             The saved transfer object
+     * @param string      $caseId             The UUID of the transferred case
+     * @param string      $targetOrganization The UUID of the target partner organization
+     * @param string      $initiatedBy        User ID of the initiator
+     * @param string|null $remoteCloudId      The federated target (slug@host), or null for a local-only transfer
+     *
+     * @return void
+     */
+    private function recordTransferInitiated(
+        object $result,
+        string $caseId,
+        string $targetOrganization,
+        string $initiatedBy,
+        ?string $remoteCloudId,
+    ): void {
         $this->auditTrail->emit(
             [
                 'action'   => 'case_transfer_initiated',
@@ -188,9 +257,7 @@ class CaseTransferService
                 'federated'  => ($remoteCloudId !== null),
             ]
         );
-
-        return $resultData;
-    }//end initiateTransfer()
+    }//end recordTransferInitiated()
 
     /**
      * Accept a pending case transfer request. Idempotent when called again
@@ -290,26 +357,17 @@ class CaseTransferService
         // Read the existing custody chain before the status writes below, which
         // is also where the pre-existing trail must be preserved from.
         $auditTrail = (array) ($transferData['custodyAuditTrail'] ?? []);
+        $actorType  = $this->resolveCustodyActorType(remoteCloudId: $remoteCloudId);
 
-        $transferData['status']      = $targetStatus;
-        $transferData['completedAt'] = $now;
-        if ($targetStatus === 'rejected') {
-            $transferData['rejectionReason'] = $rejectionReason;
-        }
-
-        $actorType = 'local';
-        if ($remoteCloudId !== null) {
-            $actorType = 'remote';
-        }
-
-        $auditTrail[] = [
-            'event'     => $targetStatus,
-            'actor'     => ($remoteCloudId ?? ''),
-            'actorType' => $actorType,
-            'cloudId'   => ($remoteCloudId ?? ''),
-            'timestamp' => $now,
-        ];
-        $transferData['custodyAuditTrail'] = $auditTrail;
+        $transferData = $this->applyTransferCompletion(
+            transferData: $transferData,
+            auditTrail: $auditTrail,
+            targetStatus: $targetStatus,
+            rejectionReason: $rejectionReason,
+            actorType: $actorType,
+            remoteCloudId: $remoteCloudId,
+            now: $now,
+        );
 
         $result = $objectService->saveObject(
             object: $transferData,
@@ -342,6 +400,63 @@ class CaseTransferService
 
         return $result->jsonSerialize();
     }//end completeTransfer()
+
+    /**
+     * Resolve the custody-audit actor type for a completion event.
+     *
+     * @param string|null $remoteCloudId Set when the call was authenticated via a federated token
+     *
+     * @return string 'remote' for a federated call, 'local' otherwise
+     */
+    private function resolveCustodyActorType(?string $remoteCloudId): string
+    {
+        if ($remoteCloudId !== null) {
+            return 'remote';
+        }
+
+        return 'local';
+    }//end resolveCustodyActorType()
+
+    /**
+     * Apply the completion status, optional rejection reason and custody entry
+     * to a transfer payload.
+     *
+     * @param array       $transferData    The transfer payload being completed
+     * @param array       $auditTrail      The pre-existing custody chain, read before the status writes
+     * @param string      $targetStatus    'accepted' or 'rejected'
+     * @param string      $rejectionReason Reason text (rejected only)
+     * @param string      $actorType       'local' or 'remote'
+     * @param string|null $remoteCloudId   Set for a federated (remote-authenticated) call
+     * @param string      $now             The ISO 8601 completion timestamp
+     *
+     * @return array The completed transfer payload
+     */
+    private function applyTransferCompletion(
+        array $transferData,
+        array $auditTrail,
+        string $targetStatus,
+        string $rejectionReason,
+        string $actorType,
+        ?string $remoteCloudId,
+        string $now,
+    ): array {
+        $transferData['status']      = $targetStatus;
+        $transferData['completedAt'] = $now;
+        if ($targetStatus === 'rejected') {
+            $transferData['rejectionReason'] = $rejectionReason;
+        }
+
+        $auditTrail[] = [
+            'event'     => $targetStatus,
+            'actor'     => ($remoteCloudId ?? ''),
+            'actorType' => $actorType,
+            'cloudId'   => ($remoteCloudId ?? ''),
+            'timestamp' => $now,
+        ];
+        $transferData['custodyAuditTrail'] = $auditTrail;
+
+        return $transferData;
+    }//end applyTransferCompletion()
 
     /**
      * Look up the caseId for a given transfer UUID (for the controller's

--- a/lib/Service/Cmmn/CaseModelEngine.php
+++ b/lib/Service/Cmmn/CaseModelEngine.php
@@ -657,33 +657,24 @@ class CaseModelEngine
             throw new RuntimeException('cmmn_not_configured');
         }
 
-        try {
-            $case = $this->toArray(value: $objectService->find($caseId, register: $register, schema: $caseSchema));
-        } catch (Throwable $e) {
-            $this->logger->error('CaseModelEngine: loadCase failed', ['exception' => $e->getMessage(), 'caseId' => $caseId]);
-            throw new RuntimeException('case_not_found');
-        }
-
-        if ($case === []) {
-            throw new RuntimeException('case_not_found');
-        }
+        $case = $this->getCaseObject(
+            objectService: $objectService,
+            register: $register,
+            caseSchema: $caseSchema,
+            caseId: $caseId
+        );
 
         $caseTypeId = (string) ($case['caseType'] ?? '');
         if ($caseTypeId === '') {
             throw new RuntimeException('case_type_not_configured');
         }
 
-        try {
-            $caseType = $this->toArray(value: $objectService->find($caseTypeId, register: $register, schema: $caseTypeSchema));
-        } catch (Throwable $e) {
-            $this->logger->error('CaseModelEngine: loadCaseType failed', ['exception' => $e->getMessage(), 'caseTypeId' => $caseTypeId]);
-            throw new RuntimeException('case_type_not_found');
-        }
-
-        $handlingModel = (string) ($caseType['handlingModel'] ?? 'bpmn');
-        if ($handlingModel !== 'cmmn') {
-            throw new RuntimeException('case_not_cmmn_managed');
-        }
+        $caseType = $this->getCmmnCaseType(
+            objectService: $objectService,
+            register: $register,
+            caseTypeSchema: $caseTypeSchema,
+            caseTypeId: $caseTypeId
+        );
 
         $itemsById = $this->loadItemsById(caseTypeId: $caseTypeId);
         $state     = $this->decodeState(case: $case);
@@ -698,6 +689,63 @@ class CaseModelEngine
             'caseSchema'    => $caseSchema,
         ];
     }//end loadContext()
+
+    /**
+     * Load the case object from OpenRegister.
+     *
+     * @param object $objectService The OpenRegister object service.
+     * @param string $register      The register slug.
+     * @param string $caseSchema    The case schema slug.
+     * @param string $caseId        Case UUID.
+     *
+     * @return array<string, mixed> The case object.
+     *
+     * @throws RuntimeException When the case cannot be loaded or is empty.
+     */
+    private function getCaseObject(object $objectService, string $register, string $caseSchema, string $caseId): array
+    {
+        try {
+            $case = $this->toArray(value: $objectService->find($caseId, register: $register, schema: $caseSchema));
+        } catch (Throwable $e) {
+            $this->logger->error('CaseModelEngine: loadCase failed', ['exception' => $e->getMessage(), 'caseId' => $caseId]);
+            throw new RuntimeException('case_not_found');
+        }
+
+        if ($case === []) {
+            throw new RuntimeException('case_not_found');
+        }
+
+        return $case;
+    }//end getCaseObject()
+
+    /**
+     * Load the caseType object and assert it is CMMN-managed.
+     *
+     * @param object $objectService  The OpenRegister object service.
+     * @param string $register       The register slug.
+     * @param string $caseTypeSchema The caseType schema slug.
+     * @param string $caseTypeId     The caseType UUID.
+     *
+     * @return array<string, mixed> The caseType object.
+     *
+     * @throws RuntimeException When the caseType cannot be loaded or is not CMMN-managed.
+     */
+    private function getCmmnCaseType(object $objectService, string $register, string $caseTypeSchema, string $caseTypeId): array
+    {
+        try {
+            $caseType = $this->toArray(value: $objectService->find($caseTypeId, register: $register, schema: $caseTypeSchema));
+        } catch (Throwable $e) {
+            $this->logger->error('CaseModelEngine: loadCaseType failed', ['exception' => $e->getMessage(), 'caseTypeId' => $caseTypeId]);
+            throw new RuntimeException('case_type_not_found');
+        }
+
+        $handlingModel = (string) ($caseType['handlingModel'] ?? 'bpmn');
+        if ($handlingModel !== 'cmmn') {
+            throw new RuntimeException('case_not_cmmn_managed');
+        }
+
+        return $caseType;
+    }//end getCmmnCaseType()
 
     /**
      * Load and validate the active caseModel's plan items for a caseType.

--- a/lib/Service/ConsultationService.php
+++ b/lib/Service/ConsultationService.php
@@ -120,21 +120,7 @@ class ConsultationService
         }
 
         // Validate required fields.
-        if (empty($data['parentZaak']) === true) {
-            throw new RuntimeException('parentZaak is required');
-        }
-
-        if (empty($data['adviesInstantie']) === true) {
-            throw new RuntimeException('adviesInstantie is required');
-        }
-
-        if (empty($data['vraagstelling']) === true) {
-            throw new RuntimeException('vraagstelling is required');
-        }
-
-        if (empty($data['uiterlijkeReactiedatum']) === true) {
-            throw new RuntimeException('uiterlijkeReactiedatum is required');
-        }
+        $this->assertRequiredConsultationFields(data: $data);
 
         // Generate unique consultation number.
         $data['consultationNumber'] = $this->generateConsultationNumber(
@@ -158,34 +144,13 @@ class ConsultationService
         // is *decided* in decidesk. Raise a decidesk `advice` Decision and
         // persist its ref. Fail CLOSED — never author the consultation advice
         // outcome locally as a fallback.
-        try {
-            $decisionRef = $this->adviceDelegation->raiseAdviceDecision(
-                subjectSchema: 'consultation',
-                subjectId: (string) $consultationId,
-                payload: [
-                    'subjectRegister'   => $register,
-                    'externalReference' => (string) $data['parentZaak'],
-                    'subjectLabel'      => (string) $data['consultationNumber'],
-                    'question'          => (string) $data['vraagstelling'],
-                ],
-            );
-
-            if ((string) $consultationId !== '') {
-                $objectService->saveObject(
-                    object: ['decisionRef' => $decisionRef],
-                    register: $register,
-                    schema: $schema,
-                    uuid: (string) $consultationId,
-                );
-            }
-        } catch (\RuntimeException $e) {
-            $this->logger->error(
-                'Procest: createConsultation: decidesk advice Decision raise failed — failing closed: '.$e->getMessage(),
-                ['app' => Application::APP_ID],
-            );
-            // REQ-PDRD-002: fail closed; surface the error.
-            throw new RuntimeException('Decision service unavailable: '.$e->getMessage(), 0, $e);
-        }//end try
+        $decisionRef = $this->raiseAndPersistAdviceDecision(
+            objectService: $objectService,
+            register: $register,
+            schema: $schema,
+            consultationId: (string) $consultationId,
+            data: $data,
+        );
 
         $this->logger->info(
             'Consultation created: '.$consultationId
@@ -613,6 +578,88 @@ class ConsultationService
             'extensionApproved'      => true,
         ];
     }//end approveExtension()
+
+    /**
+     * Assert that every field required to create a consultation is present.
+     *
+     * @param array<string, mixed> $data Consultation data to validate
+     *
+     * @return void
+     *
+     * @throws \RuntimeException If any required field is missing or empty
+     */
+    private function assertRequiredConsultationFields(array $data): void
+    {
+        if (empty($data['parentZaak']) === true) {
+            throw new RuntimeException('parentZaak is required');
+        }
+
+        if (empty($data['adviesInstantie']) === true) {
+            throw new RuntimeException('adviesInstantie is required');
+        }
+
+        if (empty($data['vraagstelling']) === true) {
+            throw new RuntimeException('vraagstelling is required');
+        }
+
+        if (empty($data['uiterlijkeReactiedatum']) === true) {
+            throw new RuntimeException('uiterlijkeReactiedatum is required');
+        }
+    }//end assertRequiredConsultationFields()
+
+    /**
+     * Raise the decidesk advice Decision for a consultation and persist its ref.
+     *
+     * Fails CLOSED — never authors the consultation advice outcome locally.
+     *
+     * @param object               $objectService  The OpenRegister object service
+     * @param string               $register       The register slug
+     * @param string               $schema         The schema slug
+     * @param string               $consultationId The freshly created consultation UUID
+     * @param array<string, mixed> $data           Consultation data used to build the decision payload
+     *
+     * @return string The decidesk decision reference
+     *
+     * @throws \RuntimeException If decidesk is unavailable (REQ-PDRD-002)
+     */
+    private function raiseAndPersistAdviceDecision(
+        object $objectService,
+        string $register,
+        string $schema,
+        string $consultationId,
+        array $data,
+    ): string {
+        try {
+            $decisionRef = $this->adviceDelegation->raiseAdviceDecision(
+                subjectSchema: 'consultation',
+                subjectId: $consultationId,
+                payload: [
+                    'subjectRegister'   => $register,
+                    'externalReference' => (string) $data['parentZaak'],
+                    'subjectLabel'      => (string) $data['consultationNumber'],
+                    'question'          => (string) $data['vraagstelling'],
+                ],
+            );
+
+            if ($consultationId !== '') {
+                $objectService->saveObject(
+                    object: ['decisionRef' => $decisionRef],
+                    register: $register,
+                    schema: $schema,
+                    uuid: $consultationId,
+                );
+            }
+        } catch (\RuntimeException $e) {
+            $this->logger->error(
+                'Procest: createConsultation: decidesk advice Decision raise failed — failing closed: '.$e->getMessage(),
+                ['app' => Application::APP_ID],
+            );
+            // REQ-PDRD-002: fail closed; surface the error.
+            throw new RuntimeException('Decision service unavailable: '.$e->getMessage(), 0, $e);
+        }//end try
+
+        return $decisionRef;
+    }//end raiseAndPersistAdviceDecision()
 
     /**
      * Generate a unique consultation number in ADV-{year}-{seq} format.

--- a/lib/Service/DsoCaseService.php
+++ b/lib/Service/DsoCaseService.php
@@ -284,7 +284,7 @@ class DsoCaseService
         }
 
         $event = new VergunningStatusChangedEvent(
-            vergunningaanvraagRef: $aanvraagRef,
+            aanvraagRef: $aanvraagRef,
             oldStatus: $oldStatus,
             newStatus: $newStatus,
             besluitdatum: $besluitdatum,

--- a/lib/Service/DsoIntakeService.php
+++ b/lib/Service/DsoIntakeService.php
@@ -92,16 +92,7 @@ class DsoIntakeService
         $dsoZaaknummer = $dsoMessage['zaaknummer'] ?? '';
 
         // Build activity description.
-        $activityNames = array_map(
-            static function ($act) {
-                if (is_array($act) === true) {
-                    return $act['naam'] ?? '';
-                }
-
-                return (string) $act;
-            },
-            $activiteiten,
-        );
+        $activityNames = $this->extractActivityNames(activiteiten: $activiteiten);
         $activityStr   = implode(', ', array_filter($activityNames));
 
         // Determine processing deadline.
@@ -137,30 +128,20 @@ class DsoIntakeService
             $locatieValue = json_encode($locatie);
         }
 
-        $properties = [
-            'dsoZaaknummer' => $dsoZaaknummer,
-            'activiteiten'  => $activityStr,
-            'locatie'       => $locatieValue,
-            'bouwkosten'    => (string) $bouwkosten,
-            'procedureType' => $procedureType,
-            'aanvragerNaam' => $aanvrager['naam'] ?? '',
-        ];
-
-        foreach ($properties as $name => $value) {
-            if ($value === '') {
-                continue;
-            }
-
-            $objectService->saveObject(
-                object: [
-                    'case'  => $caseId,
-                    'name'  => $name,
-                    'value' => $value,
-                ],
-                register: $register,
-                schema: $propertySchema
-            );
-        }
+        $this->storeCaseProperties(
+            objectService: $objectService,
+            register: $register,
+            schema: $propertySchema,
+            caseId: $caseId,
+            properties: [
+                'dsoZaaknummer' => $dsoZaaknummer,
+                'activiteiten'  => $activityStr,
+                'locatie'       => $locatieValue,
+                'bouwkosten'    => (string) $bouwkosten,
+                'procedureType' => $procedureType,
+                'aanvragerNaam' => $aanvrager['naam'] ?? '',
+            ],
+        );
 
         $this->logger->info(
             'DSO intake processed: case '.$caseId.' (DSO: '.$dsoZaaknummer.')',
@@ -175,6 +156,66 @@ class DsoIntakeService
             'deadline'      => $deadline,
         ];
     }//end processAanvraag()
+
+    /**
+     * Reduce the DSO activiteiten list to a flat list of activity names.
+     *
+     * A structured activity contributes its `naam`; a scalar one is used as-is.
+     *
+     * @param mixed $activiteiten The raw activiteiten entry from the DSO payload
+     *
+     * @return array<int|string, mixed> The activity names, in payload order
+     */
+    private function extractActivityNames(mixed $activiteiten): array
+    {
+        return array_map(
+            static function ($act) {
+                if (is_array($act) === true) {
+                    return $act['naam'] ?? '';
+                }
+
+                return (string) $act;
+            },
+            $activiteiten,
+        );
+    }//end extractActivityNames()
+
+    /**
+     * Persist the DSO-specific case properties as case property objects.
+     *
+     * Properties with an empty value are skipped rather than written as blanks.
+     *
+     * @param object               $objectService The OpenRegister object service
+     * @param string               $register      Register slug
+     * @param string               $schema        Case property schema slug
+     * @param string               $caseId        UUID of the case the properties belong to
+     * @param array<string, mixed> $properties    Property name to value map
+     *
+     * @return void
+     */
+    private function storeCaseProperties(
+        object $objectService,
+        string $register,
+        string $schema,
+        string $caseId,
+        array $properties
+    ): void {
+        foreach ($properties as $name => $value) {
+            if ($value === '') {
+                continue;
+            }
+
+            $objectService->saveObject(
+                object: [
+                    'case'  => $caseId,
+                    'name'  => $name,
+                    'value' => $value,
+                ],
+                register: $register,
+                schema: $schema
+            );
+        }
+    }//end storeCaseProperties()
 
     /**
      * Get the processing deadline duration for a procedure type.
@@ -207,16 +248,7 @@ class DsoIntakeService
         $dsoZaaknummer = $dsoMessage['zaaknummer'] ?? '';
         $bijlagen      = $dsoMessage['bijlagen'] ?? [];
 
-        $activityNames = array_map(
-            static function ($act) {
-                if (is_array($act) === true) {
-                    return $act['naam'] ?? '';
-                }
-
-                return (string) $act;
-            },
-            $activiteiten,
-        );
+        $activityNames = $this->extractActivityNames(activiteiten: $activiteiten);
         $activityStr   = implode(', ', array_filter($activityNames));
 
         $deadline = self::DEADLINE_DURATIONS[$procedureType] ?? self::DEADLINE_DURATIONS['regulier'];

--- a/lib/Service/DwangsomCalculationService.php
+++ b/lib/Service/DwangsomCalculationService.php
@@ -120,6 +120,47 @@ class DwangsomCalculationService
             return null;
         }
 
+        $row = $this->fetchBerekeningRow(
+            objectService: $objectService,
+            register: $register,
+            schema: $schema,
+            berekeningId: $berekeningId
+        );
+        if ($row === null) {
+            return null;
+        }
+
+        if (($row['status'] ?? '') !== 'lopend' || ($row['plafondBereikt'] ?? false) === true) {
+            return $row;
+        }
+
+        $row = $this->applyDailyAccrual(row: $row);
+
+        return $this->persistBerekening(
+            objectService: $objectService,
+            register: $register,
+            schema: $schema,
+            row: $row,
+            berekeningId: $berekeningId
+        );
+    }//end calculateDaily()
+
+    /**
+     * Fetch a DwangsomBerekening row, logging and swallowing lookup failures.
+     *
+     * @param object $objectService OpenRegister object service.
+     * @param string $register      Register identifier.
+     * @param string $schema        Schema identifier.
+     * @param string $berekeningId  Berekening id.
+     *
+     * @return array<string, mixed>|null The row, or null when unavailable.
+     */
+    private function fetchBerekeningRow(
+        object $objectService,
+        string $register,
+        string $schema,
+        string $berekeningId
+    ): ?array {
         try {
             $row = $objectService->find($berekeningId, register: $register, schema: $schema);
         } catch (\Throwable $e) {
@@ -134,10 +175,18 @@ class DwangsomCalculationService
             return null;
         }
 
-        if (($row['status'] ?? '') !== 'lopend' || ($row['plafondBereikt'] ?? false) === true) {
-            return $row;
-        }
+        return $row;
+    }//end fetchBerekeningRow()
 
+    /**
+     * Accrue one calculation day onto a berekening row (capped at the plafond).
+     *
+     * @param array<string, mixed> $row Berekening row.
+     *
+     * @return array<string, mixed> The row with the new day, tariff and cumulative amount.
+     */
+    private function applyDailyAccrual(array $row): array
+    {
         $currentDay = (int) ($row['huidigeDag'] ?? 0);
         $cumulative = (int) ($row['cumulatievBedrag'] ?? 0);
         $plafond    = (int) ($row['plafondBerekend'] ?? self::AWB_PLAFOND_CENTS);
@@ -161,6 +210,27 @@ class DwangsomCalculationService
         $row['cumulatievBedrag'] = $newCumul;
         $row['plafondBereikt']   = $plafondHit;
 
+        return $row;
+    }//end applyDailyAccrual()
+
+    /**
+     * Persist a berekening row, falling back to the in-memory row on failure.
+     *
+     * @param object               $objectService OpenRegister object service.
+     * @param string               $register      Register identifier.
+     * @param string               $schema        Schema identifier.
+     * @param array<string, mixed> $row           Berekening row to persist.
+     * @param string               $berekeningId  Berekening id (for logging).
+     *
+     * @return array<string, mixed> The saved row, or the supplied row.
+     */
+    private function persistBerekening(
+        object $objectService,
+        string $register,
+        string $schema,
+        array $row,
+        string $berekeningId
+    ): array {
         try {
             $saved = $objectService->saveObject($register, $schema, $row);
             if (is_array($saved) === true) {
@@ -175,7 +245,7 @@ class DwangsomCalculationService
             );
             return $row;
         }
-    }//end calculateDaily()
+    }//end persistBerekening()
 
     /**
      * Stop a DwangsomBerekening because the beschikking was filed.
@@ -244,23 +314,71 @@ class DwangsomCalculationService
             return self::AWB_TIER_1_CENTS;
         }
 
-        try {
-            $instance = $objectService->find($instanceId, register: $register, schema: $instSchema);
-        } catch (\Throwable $e) {
-            return self::AWB_TIER_1_CENTS;
-        }
-
-        if (is_array($instance) === false) {
-            return self::AWB_TIER_1_CENTS;
-        }
-
-        $defId = (string) ($instance['termijnDefinitie'] ?? '');
+        $defId = $this->resolveTermijnDefinitieId(
+            objectService: $objectService,
+            register: $register,
+            schema: $instSchema,
+            instanceId: $instanceId
+        );
         if ($defId === '') {
             return self::AWB_TIER_1_CENTS;
         }
 
+        return $this->resolveRegimeDailyTariff(
+            objectService: $objectService,
+            register: $register,
+            schema: $defSchema,
+            definitieId: $defId
+        );
+    }//end resolveCustomDailyTariff()
+
+    /**
+     * Resolve the TermijnDefinitie id linked to a TermijnInstance.
+     *
+     * @param object $objectService OpenRegister object service.
+     * @param string $register      Register identifier.
+     * @param string $schema        TermijnInstance schema identifier.
+     * @param string $instanceId    TermijnInstance id.
+     *
+     * @return string The definitie id, or an empty string when unresolvable.
+     */
+    private function resolveTermijnDefinitieId(
+        object $objectService,
+        string $register,
+        string $schema,
+        string $instanceId
+    ): string {
         try {
-            $def = $objectService->find($defId, register: $register, schema: $defSchema);
+            $instance = $objectService->find($instanceId, register: $register, schema: $schema);
+        } catch (\Throwable $e) {
+            return '';
+        }
+
+        if (is_array($instance) === false) {
+            return '';
+        }
+
+        return (string) ($instance['termijnDefinitie'] ?? '');
+    }//end resolveTermijnDefinitieId()
+
+    /**
+     * Read the afwijkend regime daily tariff from a TermijnDefinitie.
+     *
+     * @param object $objectService OpenRegister object service.
+     * @param string $register      Register identifier.
+     * @param string $schema        TermijnDefinitie schema identifier.
+     * @param string $definitieId   TermijnDefinitie id.
+     *
+     * @return int Cents, falling back to the AWB tier 1 tariff.
+     */
+    private function resolveRegimeDailyTariff(
+        object $objectService,
+        string $register,
+        string $schema,
+        string $definitieId
+    ): int {
+        try {
+            $def = $objectService->find($definitieId, register: $register, schema: $schema);
         } catch (\Throwable $e) {
             return self::AWB_TIER_1_CENTS;
         }
@@ -275,5 +393,5 @@ class DwangsomCalculationService
         }
 
         return self::AWB_TIER_1_CENTS;
-    }//end resolveCustomDailyTariff()
+    }//end resolveRegimeDailyTariff()
 }//end class

--- a/lib/Service/DwangsomUitbetalingService.php
+++ b/lib/Service/DwangsomUitbetalingService.php
@@ -79,13 +79,7 @@ class DwangsomUitbetalingService
         string $iban,
         ?DateTimeImmutable $ontvangstDatum=null
     ): array {
-        if ($this->isValidIban(iban: $iban) === false) {
-            throw new RuntimeException('Invalid IBAN provided for dwangsom uitbetaling');
-        }
-
-        if (trim($rekeninghouderNaam) === '') {
-            throw new RuntimeException('rekeninghouderNaam is required');
-        }
+        $this->assertBetalingInput(iban: $iban, rekeninghouderNaam: $rekeninghouderNaam);
 
         $objectService = $this->settingsService->getObjectService();
         $register      = (string) $this->settingsService->getConfigValue('register');
@@ -95,20 +89,12 @@ class DwangsomUitbetalingService
             throw new RuntimeException('Dwangsom services not configured');
         }
 
-        try {
-            $berekening = $objectService->find($berekeningId, register: $register, schema: $bSchema);
-        } catch (\Throwable $e) {
-            throw new RuntimeException('DwangsomBerekening lookup failed: '.$e->getMessage());
-        }
-
-        if (is_array($berekening) === false) {
-            throw new RuntimeException('DwangsomBerekening not found: '.$berekeningId);
-        }
-
-        $definitief = (int) ($berekening['definitievBedrag'] ?? $berekening['cumulatievBedrag'] ?? 0);
-        if ($definitief <= 0) {
-            throw new RuntimeException('DwangsomBerekening has no payable amount');
-        }
+        $definitief = $this->resolvePayableAmount(
+            objectService: $objectService,
+            register: $register,
+            schema: $bSchema,
+            berekeningId: $berekeningId
+        );
 
         $ontvangstDatum = ($ontvangstDatum ?? new DateTimeImmutable());
         $uiterlijk      = $ontvangstDatum->modify('+'.self::BETALING_UITERLIJK_OFFSET_DAYS.' days')->format('Y-m-d');
@@ -124,8 +110,91 @@ class DwangsomUitbetalingService
             'status'               => 'voorbereid',
         ];
 
+        return $this->persistUitbetaling(
+            objectService: $objectService,
+            register: $register,
+            schema: $uSchema,
+            row: $row
+        );
+    }//end prepareBetaling()
+
+    /**
+     * Validate the caller-supplied payment input.
+     *
+     * @param string $iban               IBAN.
+     * @param string $rekeninghouderNaam Account holder name.
+     *
+     * @return void
+     *
+     * @throws RuntimeException When the IBAN or the account holder name is invalid.
+     */
+    private function assertBetalingInput(string $iban, string $rekeninghouderNaam): void
+    {
+        if ($this->isValidIban(iban: $iban) === false) {
+            throw new RuntimeException('Invalid IBAN provided for dwangsom uitbetaling');
+        }
+
+        if (trim($rekeninghouderNaam) === '') {
+            throw new RuntimeException('rekeninghouderNaam is required');
+        }
+    }//end assertBetalingInput()
+
+    /**
+     * Resolve the payable amount locked on a DwangsomBerekening.
+     *
+     * @param object $objectService OpenRegister object service.
+     * @param string $register      Register identifier.
+     * @param string $schema        DwangsomBerekening schema identifier.
+     * @param string $berekeningId  Berekening id.
+     *
+     * @return int Payable amount in EUR cents.
+     *
+     * @throws RuntimeException When the berekening is missing or has nothing payable.
+     */
+    private function resolvePayableAmount(
+        object $objectService,
+        string $register,
+        string $schema,
+        string $berekeningId
+    ): int {
         try {
-            $saved = $objectService->saveObject($register, $uSchema, $row);
+            $berekening = $objectService->find($berekeningId, register: $register, schema: $schema);
+        } catch (\Throwable $e) {
+            throw new RuntimeException('DwangsomBerekening lookup failed: '.$e->getMessage());
+        }
+
+        if (is_array($berekening) === false) {
+            throw new RuntimeException('DwangsomBerekening not found: '.$berekeningId);
+        }
+
+        $definitief = (int) ($berekening['definitievBedrag'] ?? $berekening['cumulatievBedrag'] ?? 0);
+        if ($definitief <= 0) {
+            throw new RuntimeException('DwangsomBerekening has no payable amount');
+        }
+
+        return $definitief;
+    }//end resolvePayableAmount()
+
+    /**
+     * Persist a DwangsomUitbetaling row.
+     *
+     * @param object               $objectService OpenRegister object service.
+     * @param string               $register      Register identifier.
+     * @param string               $schema        DwangsomUitbetaling schema identifier.
+     * @param array<string, mixed> $row           Row to persist.
+     *
+     * @return array<string, mixed> The saved row, or the supplied row.
+     *
+     * @throws RuntimeException When persisting fails.
+     */
+    private function persistUitbetaling(
+        object $objectService,
+        string $register,
+        string $schema,
+        array $row
+    ): array {
+        try {
+            $saved = $objectService->saveObject($register, $schema, $row);
             if (is_array($saved) === true) {
                 return $saved;
             }
@@ -134,7 +203,7 @@ class DwangsomUitbetalingService
         } catch (\Throwable $e) {
             throw new RuntimeException('DwangsomUitbetaling persist failed: '.$e->getMessage());
         }
-    }//end prepareBetaling()
+    }//end persistUitbetaling()
 
     /**
      * Handle an ERP callback updating the uitbetaling state.
@@ -163,11 +232,51 @@ class DwangsomUitbetalingService
             throw new RuntimeException('Dwangsom services not configured');
         }
 
+        $row = $this->findUitbetalingByReferentie(
+            objectService: $objectService,
+            register: $register,
+            schema: $uSchema,
+            referentie: $referentie
+        );
+
+        $row = $this->applyCallbackFields(
+            row: $row,
+            status: $status,
+            betaaldatum: $betaaldatum,
+            betalingsreferentie: $betalingsreferentie
+        );
+
+        return $this->persistUitbetaling(
+            objectService: $objectService,
+            register: $register,
+            schema: $uSchema,
+            row: $row
+        );
+    }//end handleCallback()
+
+    /**
+     * Look up the single DwangsomUitbetaling row carrying a referentie.
+     *
+     * @param object $objectService OpenRegister object service.
+     * @param string $register      Register identifier.
+     * @param string $schema        DwangsomUitbetaling schema identifier.
+     * @param string $referentie    Payment reference.
+     *
+     * @return array<string, mixed> The matching row.
+     *
+     * @throws RuntimeException When the lookup fails or the referentie is unknown.
+     */
+    private function findUitbetalingByReferentie(
+        object $objectService,
+        string $register,
+        string $schema,
+        string $referentie
+    ): array {
         try {
             $rows = $this->searchObjectsAsArrays(
                 objectService: $objectService,
                 register: $register,
-                schema: $uSchema,
+                schema: $schema,
                 filters: ['referentie' => $referentie],
             );
         } catch (\Throwable $e) {
@@ -183,6 +292,25 @@ class DwangsomUitbetalingService
             throw new RuntimeException('No DwangsomUitbetaling found for referentie '.$referentie);
         }
 
+        return $row;
+    }//end findUitbetalingByReferentie()
+
+    /**
+     * Apply the ERP callback fields onto an uitbetaling row.
+     *
+     * @param array<string, mixed>   $row                 Uitbetaling row.
+     * @param string                 $status              New status.
+     * @param DateTimeImmutable|null $betaaldatum         Actual payment date.
+     * @param string                 $betalingsreferentie ERP/bank reference.
+     *
+     * @return array<string, mixed> The updated row.
+     */
+    private function applyCallbackFields(
+        array $row,
+        string $status,
+        ?DateTimeImmutable $betaaldatum,
+        string $betalingsreferentie
+    ): array {
         $row['status'] = $status;
         if ($betalingsreferentie !== '') {
             $row['betalingsreferentie'] = $betalingsreferentie;
@@ -192,17 +320,8 @@ class DwangsomUitbetalingService
             $row['werkelijkeBetaaldatum'] = $betaaldatum->format('Y-m-d');
         }
 
-        try {
-            $saved = $objectService->saveObject($register, $uSchema, $row);
-            if (is_array($saved) === true) {
-                return $saved;
-            }
-
-            return $row;
-        } catch (\Throwable $e) {
-            throw new RuntimeException('DwangsomUitbetaling persist failed: '.$e->getMessage());
-        }
-    }//end handleCallback()
+        return $row;
+    }//end applyCallbackFields()
 
     /**
      * Conservative IBAN check (length + mod-97).

--- a/lib/Service/IngebrekestellingService.php
+++ b/lib/Service/IngebrekestellingService.php
@@ -126,9 +126,41 @@ class IngebrekestellingService
         }
 
         // First valid notice: link it and start a DwangsomBerekening.
+        $row['dwangsomBerekening'] = $this->startDwangsomBerekening(
+            termijnInstanceId: $termijnInstanceId,
+            instance: $instance,
+            ingebrekestellingId: (string) $row['id'],
+            ontvangstDatum: $ontvangstDatum,
+            kanaal: $kanaal,
+            documentLink: $documentLink,
+        );
+
+        return $row;
+    }//end registerIngebrekestelling()
+
+    /**
+     * Link the first valid notice to its instance and open the DwangsomBerekening.
+     *
+     * @param string               $termijnInstanceId   TermijnInstance id.
+     * @param array<string, mixed> $instance            TermijnInstance row.
+     * @param string               $ingebrekestellingId Id of the saved ingebrekestelling.
+     * @param DateTimeImmutable    $ontvangstDatum      Receipt date.
+     * @param string               $kanaal              Receipt channel.
+     * @param string               $documentLink        Document link.
+     *
+     * @return array<string, mixed> The created DwangsomBerekening row.
+     */
+    private function startDwangsomBerekening(
+        string $termijnInstanceId,
+        array $instance,
+        string $ingebrekestellingId,
+        DateTimeImmutable $ontvangstDatum,
+        string $kanaal,
+        string $documentLink
+    ): array {
         $this->termijnService->updateTermijnInstance(
             $termijnInstanceId,
-            ['relevantIngbrekes' => (string) $row['id']]
+            ['relevantIngbrekes' => $ingebrekestellingId]
         );
 
         $regime  = $this->resolveRegime(instance: $instance);
@@ -140,20 +172,20 @@ class IngebrekestellingService
         }
 
         $berekening = $this->saveSchema(
-                schemaConfigKey: 'dwangsom_berekening_schema',
-                object: [
-                    'ingebrekestelling' => (string) $row['id'],
-                    'termijnInstance'   => $termijnInstanceId,
-                    'startDatum'        => $startAt,
-                    'huidigeDag'        => 0,
-                    'dagtarief'         => 0,
-                    'cumulatievBedrag'  => 0,
-                    'plafondBerekend'   => (int) $regime['plafond'],
-                    'plafondBereikt'    => false,
-                    'status'            => 'lopend',
-                    'regime'            => $regimeLabel,
-                ]
-                );
+            schemaConfigKey: 'dwangsom_berekening_schema',
+            object: [
+                'ingebrekestelling' => $ingebrekestellingId,
+                'termijnInstance'   => $termijnInstanceId,
+                'startDatum'        => $startAt,
+                'huidigeDag'        => 0,
+                'dagtarief'         => 0,
+                'cumulatievBedrag'  => 0,
+                'plafondBerekend'   => (int) $regime['plafond'],
+                'plafondBereikt'    => false,
+                'status'            => 'lopend',
+                'regime'            => $regimeLabel,
+            ]
+        );
 
         $this->termijnService->recordEvent(
             termijnInstanceId: $termijnInstanceId,
@@ -174,10 +206,8 @@ class IngebrekestellingService
             tijdstip: $ontvangstDatum,
         );
 
-        $row['dwangsomBerekening'] = $berekening;
-
-        return $row;
-    }//end registerIngebrekestelling()
+        return $berekening;
+    }//end startDwangsomBerekening()
 
     /**
      * Resolve the dwangsom regime (AWB-default or custom from definition).

--- a/lib/Service/MandaatCheckService.php
+++ b/lib/Service/MandaatCheckService.php
@@ -197,32 +197,70 @@ class MandaatCheckService
 
         $out = [];
         foreach ($rows as $row) {
-            $validFrom  = (string) ($row['validFrom'] ?? '1970-01-01');
-            $validUntil = (string) ($row['validUntil'] ?? '');
-            if ($validFrom > $dateStr) {
+            if ($this->isRowTemporallyValid(row: $row, dateStr: $dateStr) === false) {
                 continue;
             }
 
-            if ($validUntil !== '' && $validUntil < $dateStr) {
-                continue;
-            }
-
-            $voorw    = (array) ($row['voorwaarden'] ?? []);
-            $decTypes = (array) ($voorw['decisionTypes'] ?? []);
-            if (count($decTypes) > 0 && in_array($decisionType, $decTypes, true) === false) {
-                continue;
-            }
-
-            $caseTypes = (array) ($voorw['caseTypes'] ?? []);
-            if ($caseType !== '' && count($caseTypes) > 0 && in_array($caseType, $caseTypes, true) === false) {
+            if ($this->matchesTypeVoorwaarden(row: $row, decisionType: $decisionType, caseType: $caseType) === false) {
                 continue;
             }
 
             $out[] = $row;
-        }//end foreach
+        }
 
         return $out;
     }//end getApplicableMandaten()
+
+    /**
+     * Check whether a row's validFrom/validUntil window covers the given date.
+     *
+     * @param array<string, mixed> $row     Row carrying validFrom/validUntil.
+     * @param string               $dateStr Date in Y-m-d form.
+     *
+     * @return bool True when the row is temporally valid on that date.
+     */
+    private function isRowTemporallyValid(array $row, string $dateStr): bool
+    {
+        $validFrom  = (string) ($row['validFrom'] ?? '1970-01-01');
+        $validUntil = (string) ($row['validUntil'] ?? '');
+        if ($validFrom > $dateStr) {
+            return false;
+        }
+
+        if ($validUntil !== '' && $validUntil < $dateStr) {
+            return false;
+        }
+
+        return true;
+    }//end isRowTemporallyValid()
+
+    /**
+     * Check a mandaat's decisionTypes/caseTypes voorwaarden against the request.
+     *
+     * An empty list means "no restriction"; an empty case type skips the
+     * case-type filter entirely.
+     *
+     * @param array<string, mixed> $row          Mandaat row.
+     * @param string               $decisionType Decision type slug.
+     * @param string               $caseType     Case type slug (may be empty).
+     *
+     * @return bool True when the mandaat applies to the pair.
+     */
+    private function matchesTypeVoorwaarden(array $row, string $decisionType, string $caseType): bool
+    {
+        $voorw    = (array) ($row['voorwaarden'] ?? []);
+        $decTypes = (array) ($voorw['decisionTypes'] ?? []);
+        if (count($decTypes) > 0 && in_array($decisionType, $decTypes, true) === false) {
+            return false;
+        }
+
+        $caseTypes = (array) ($voorw['caseTypes'] ?? []);
+        if ($caseType !== '' && count($caseTypes) > 0 && in_array($caseType, $caseTypes, true) === false) {
+            return false;
+        }
+
+        return true;
+    }//end matchesTypeVoorwaarden()
 
     /**
      * Applicable mandates for the given user (filtered to their active role).
@@ -304,13 +342,7 @@ class MandaatCheckService
         $dateStr = $date->format('Y-m-d');
         $active  = [];
         foreach ($rows as $row) {
-            $validFrom  = (string) ($row['validFrom'] ?? '1970-01-01');
-            $validUntil = (string) ($row['validUntil'] ?? '');
-            if ($validFrom > $dateStr) {
-                continue;
-            }
-
-            if ($validUntil !== '' && $validUntil < $dateStr) {
+            if ($this->isRowTemporallyValid(row: $row, dateStr: $dateStr) === false) {
                 continue;
             }
 
@@ -344,40 +376,72 @@ class MandaatCheckService
      */
     public function evaluateConditions(array $mandaat, array $caseProperties): array
     {
-        $voorw  = (array) ($mandaat['voorwaarden'] ?? []);
-        $failed = [];
-        $reden  = '';
+        $voorw   = (array) ($mandaat['voorwaarden'] ?? []);
+        $failed  = [];
+        $redenen = [];
 
         // Plafond check (cents).
-        if (isset($voorw['plafondCents']) === true && isset($caseProperties['bedragCents']) === true) {
-            $plafond = (int) $voorw['plafondCents'];
-            $bedrag  = (int) $caseProperties['bedragCents'];
-            if ($bedrag > $plafond) {
-                $failed[] = 'plafond';
-                $reden    = self::REDEN_PLAFOND_OVERSCHREDEN;
-            }
+        if ($this->plafondExceeded(voorwaarden: $voorw, caseProperties: $caseProperties) === true) {
+            $failed[]  = 'plafond';
+            $redenen[] = self::REDEN_PLAFOND_OVERSCHREDEN;
         }
 
         // Subdelegation check.
-        if (isset($caseProperties['subdelegatieRequested']) === true && $caseProperties['subdelegatieRequested'] === true) {
-            $allowed = (bool) ($voorw['subdelegatie'] ?? false);
-            if ($allowed === false) {
-                $failed[] = 'subdelegatie';
-                if ($reden === '') {
-                    $reden = self::REDEN_SUBDELEGATIE_NIET_TOEGESTAAN;
-                }
-            }
+        if ($this->subdelegatieDenied(voorwaarden: $voorw, caseProperties: $caseProperties) === true) {
+            $failed[]  = 'subdelegatie';
+            $redenen[] = self::REDEN_SUBDELEGATIE_NIET_TOEGESTAAN;
         }
 
-        if (count($failed) > 0) {
-            $effectiveReden = self::REDEN_NIET_BEVOEGD;
-            if ($reden !== '') {
-                $effectiveReden = $reden;
-            }
-
-            return ['passed' => false, 'reden' => $effectiveReden, 'failedConditions' => $failed];
+        if (count($failed) === 0) {
+            return ['passed' => true, 'reden' => '', 'failedConditions' => []];
         }
 
-        return ['passed' => true, 'reden' => '', 'failedConditions' => []];
+        // The most-specific failure wins; plafond is evaluated first and so
+        // takes precedence over subdelegatie.
+        $effectiveReden = ($redenen[0] ?? self::REDEN_NIET_BEVOEGD);
+
+        return ['passed' => false, 'reden' => $effectiveReden, 'failedConditions' => $failed];
     }//end evaluateConditions()
+
+    /**
+     * Check whether the case amount exceeds the mandaat plafond.
+     *
+     * Both the plafond and the case amount must be present; when either is
+     * absent the plafond is not applicable and the check passes.
+     *
+     * @param array<string, mixed> $voorwaarden    Mandaat voorwaarden.
+     * @param array<string, mixed> $caseProperties Case properties.
+     *
+     * @return bool True when the plafond is exceeded.
+     */
+    private function plafondExceeded(array $voorwaarden, array $caseProperties): bool
+    {
+        if (isset($voorwaarden['plafondCents'], $caseProperties['bedragCents']) === false) {
+            return false;
+        }
+
+        $plafond = (int) $voorwaarden['plafondCents'];
+        $bedrag  = (int) $caseProperties['bedragCents'];
+
+        return ($bedrag > $plafond);
+    }//end plafondExceeded()
+
+    /**
+     * Check whether a requested subdelegation is denied by the voorwaarden.
+     *
+     * Only evaluated when the case explicitly requests subdelegation.
+     *
+     * @param array<string, mixed> $voorwaarden    Mandaat voorwaarden.
+     * @param array<string, mixed> $caseProperties Case properties.
+     *
+     * @return bool True when subdelegation was requested but is not allowed.
+     */
+    private function subdelegatieDenied(array $voorwaarden, array $caseProperties): bool
+    {
+        if (($caseProperties['subdelegatieRequested'] ?? false) !== true) {
+            return false;
+        }
+
+        return ((bool) ($voorwaarden['subdelegatie'] ?? false) === false);
+    }//end subdelegatieDenied()
 }//end class

--- a/lib/Service/MandaatImportService.php
+++ b/lib/Service/MandaatImportService.php
@@ -86,20 +86,7 @@ class MandaatImportService
         }
 
         // Resolve rol-name → rolId.
-        $roleIndex = $this->loadRoleIndex();
-        $resolved  = [];
-        foreach ($rows as $idx => $row) {
-            $rolNaam = (string) ($row['rolNaam'] ?? '');
-            if ($rolNaam === '') {
-                throw new RuntimeException('Row '.($idx + 1).' missing rolNaam');
-            }
-
-            if (isset($roleIndex[$rolNaam]) === false) {
-                throw new RuntimeException('Unknown OrganisatieRol "'.$rolNaam.'" at row '.($idx + 1));
-            }
-
-            $resolved[] = $row + ['gemandateerdeRol' => $roleIndex[$rolNaam]];
-        }
+        $resolved = $this->resolveRolReferences(rows: $rows);
 
         // Create the besluit (concept).
         $besluit = $this->save(
@@ -125,29 +112,14 @@ class MandaatImportService
         $unchangedCount = 0;
         $diff           = [];
         foreach ($resolved as $row) {
-            $payload = [
-                'mandaatNummer'       => (string) $row['mandaatNummer'],
-                'mandateringsBesluit' => (string) $besluit['id'],
-                'omschrijving'        => (string) ($row['omschrijving'] ?? ''),
-                'gemandateerdeRol'    => (string) $row['gemandateerdeRol'],
-                'wettelijkeGrondslag' => (string) ($row['wettelijkeGrondslag'] ?? ''),
-                'voorwaarden'         => [
-                    'plafondCents'  => (int) ($row['plafondCents'] ?? 0),
-                    'subdelegatie'  => $this->parseBool(value: (string) ($row['subdelegatie'] ?? 'false')),
-                    'decisionTypes' => $this->parseList(value: (string) ($row['decisionTypes'] ?? '')),
-                ],
-                'status'              => 'concept',
-            ];
+            $payload = $this->buildMandaatPayload(row: $row, besluitId: (string) $besluit['id']);
 
             $this->save(schemaConfigKey: 'mandaat_schema', object: $payload);
 
-            $existing = null;
-            foreach ($priorMandaten as $pm) {
-                if ((string) ($pm['mandaatNummer'] ?? '') === (string) $row['mandaatNummer']) {
-                    $existing = $pm;
-                    break;
-                }
-            }
+            $existing = $this->findPriorMandaat(
+                priorMandaten: $priorMandaten,
+                mandaatNummer: (string) $row['mandaatNummer']
+            );
 
             if ($existing === null) {
                 $newCount++;
@@ -155,22 +127,9 @@ class MandaatImportService
                 continue;
             }
 
-            $changed       = false;
-            $changedFields = [];
-            foreach (['omschrijving', 'gemandateerdeRol', 'wettelijkeGrondslag'] as $f) {
-                if ((string) ($existing[$f] ?? '') !== (string) $payload[$f]) {
-                    $changed         = true;
-                    $changedFields[] = $f;
-                }
-            }
+            $changedFields = $this->collectChangedFields(existing: $existing, payload: $payload);
 
-            $exPlafond = (int) (($existing['voorwaarden'] ?? [])['plafondCents'] ?? 0);
-            if ($exPlafond !== (int) $payload['voorwaarden']['plafondCents']) {
-                $changed         = true;
-                $changedFields[] = 'plafondCents';
-            }
-
-            if ($changed === true) {
+            if (count($changedFields) > 0) {
                 $changedCount++;
                 $diff[] = [
                     'mandaatNummer' => (string) $row['mandaatNummer'],
@@ -185,15 +144,9 @@ class MandaatImportService
         }//end foreach
 
         // REMOVED = in prior, not in new.
-        $newNumbers   = array_map(static fn (array $r): string => (string) ($r['mandaatNummer'] ?? ''), $resolved);
-        $removedCount = 0;
-        foreach ($priorMandaten as $pm) {
-            $num = (string) ($pm['mandaatNummer'] ?? '');
-            if ($num !== '' && in_array($num, $newNumbers, true) === false) {
-                $removedCount++;
-                $diff[] = ['mandaatNummer' => $num, 'change' => 'REMOVED'];
-            }
-        }
+        $removed      = $this->collectRemovedMandaten(priorMandaten: $priorMandaten, resolved: $resolved);
+        $removedCount = count($removed);
+        $diff         = array_merge($diff, $removed);
 
         return [
             'mandateringsBesluitId' => (string) $besluit['id'],
@@ -207,6 +160,127 @@ class MandaatImportService
     }//end importFromCsv()
 
     /**
+     * Resolve every CSV row's rolNaam to a gemandateerdeRol id.
+     *
+     * @param array<int, array<string, string>> $rows Parsed CSV data rows.
+     *
+     * @return array<int, array<string, mixed>> Rows enriched with gemandateerdeRol.
+     *
+     * @throws RuntimeException When a row has no rolNaam or names an unknown OrganisatieRol.
+     */
+    private function resolveRolReferences(array $rows): array
+    {
+        $roleIndex = $this->loadRoleIndex();
+        $resolved  = [];
+        foreach ($rows as $idx => $row) {
+            $rolNaam = (string) ($row['rolNaam'] ?? '');
+            if ($rolNaam === '') {
+                throw new RuntimeException('Row '.($idx + 1).' missing rolNaam');
+            }
+
+            if (isset($roleIndex[$rolNaam]) === false) {
+                throw new RuntimeException('Unknown OrganisatieRol "'.$rolNaam.'" at row '.($idx + 1));
+            }
+
+            $resolved[] = $row + ['gemandateerdeRol' => $roleIndex[$rolNaam]];
+        }
+
+        return $resolved;
+    }//end resolveRolReferences()
+
+    /**
+     * Build the concept mandaat payload for a single resolved CSV row.
+     *
+     * @param array<string, mixed> $row       A resolved CSV row.
+     * @param string               $besluitId The owning MandateringsBesluit id.
+     *
+     * @return array<string, mixed> The mandaat object payload.
+     */
+    private function buildMandaatPayload(array $row, string $besluitId): array
+    {
+        return [
+            'mandaatNummer'       => (string) $row['mandaatNummer'],
+            'mandateringsBesluit' => $besluitId,
+            'omschrijving'        => (string) ($row['omschrijving'] ?? ''),
+            'gemandateerdeRol'    => (string) $row['gemandateerdeRol'],
+            'wettelijkeGrondslag' => (string) ($row['wettelijkeGrondslag'] ?? ''),
+            'voorwaarden'         => [
+                'plafondCents'  => (int) ($row['plafondCents'] ?? 0),
+                'subdelegatie'  => $this->parseBool(value: (string) ($row['subdelegatie'] ?? 'false')),
+                'decisionTypes' => $this->parseList(value: (string) ($row['decisionTypes'] ?? '')),
+            ],
+            'status'              => 'concept',
+        ];
+    }//end buildMandaatPayload()
+
+    /**
+     * Find the prior-version mandaat carrying a given mandaatNummer.
+     *
+     * @param array<int, array<string, mixed>> $priorMandaten Mandaten of the prior besluit version.
+     * @param string                           $mandaatNummer The mandaat number to look for.
+     *
+     * @return array<string, mixed>|null The matching prior mandaat, or null when it is new.
+     */
+    private function findPriorMandaat(array $priorMandaten, string $mandaatNummer): ?array
+    {
+        foreach ($priorMandaten as $pm) {
+            if ((string) ($pm['mandaatNummer'] ?? '') === $mandaatNummer) {
+                return $pm;
+            }
+        }
+
+        return null;
+    }//end findPriorMandaat()
+
+    /**
+     * Collect the field names that differ between a prior mandaat and its new payload.
+     *
+     * @param array<string, mixed> $existing The prior-version mandaat.
+     * @param array<string, mixed> $payload  The freshly built mandaat payload.
+     *
+     * @return array<int, string> Changed field names; empty when unchanged.
+     */
+    private function collectChangedFields(array $existing, array $payload): array
+    {
+        $changedFields = [];
+        foreach (['omschrijving', 'gemandateerdeRol', 'wettelijkeGrondslag'] as $f) {
+            if ((string) ($existing[$f] ?? '') !== (string) $payload[$f]) {
+                $changedFields[] = $f;
+            }
+        }
+
+        $exPlafond = (int) (($existing['voorwaarden'] ?? [])['plafondCents'] ?? 0);
+        if ($exPlafond !== (int) $payload['voorwaarden']['plafondCents']) {
+            $changedFields[] = 'plafondCents';
+        }
+
+        return $changedFields;
+    }//end collectChangedFields()
+
+    /**
+     * Build the REMOVED diff entries — mandaten present in the prior besluit but
+     * absent from the new import.
+     *
+     * @param array<int, array<string, mixed>> $priorMandaten Mandaten of the prior besluit version.
+     * @param array<int, array<string, mixed>> $resolved      The resolved CSV rows of the new import.
+     *
+     * @return array<int, array<string, string>> REMOVED diff entries.
+     */
+    private function collectRemovedMandaten(array $priorMandaten, array $resolved): array
+    {
+        $newNumbers = array_map(static fn (array $r): string => (string) ($r['mandaatNummer'] ?? ''), $resolved);
+        $removed    = [];
+        foreach ($priorMandaten as $pm) {
+            $num = (string) ($pm['mandaatNummer'] ?? '');
+            if ($num !== '' && in_array($num, $newNumbers, true) === false) {
+                $removed[] = ['mandaatNummer' => $num, 'change' => 'REMOVED'];
+            }
+        }
+
+        return $removed;
+    }//end collectRemovedMandaten()
+
+    /**
      * Approve a concept besluit: flip besluit → vastgesteld + every mandaat → active,
      * and mark the prior besluit (if any) → vervallen.
      *
@@ -218,13 +292,11 @@ class MandaatImportService
      */
     public function approveImport(string $besluitId): array
     {
-        $objectService = $this->settingsService->getObjectService();
-        $register      = (string) $this->settingsService->getConfigValue('register');
-        $bSchema       = (string) $this->settingsService->getConfigValue('mandaterings_besluit_schema');
-        $mSchema       = (string) $this->settingsService->getConfigValue('mandaat_schema');
-        if ($objectService === null || $register === '' || $bSchema === '' || $mSchema === '') {
-            throw new RuntimeException('Mandaat services not configured');
-        }
+        $context       = $this->resolveApprovalContext();
+        $objectService = $context['objectService'];
+        $register      = $context['register'];
+        $bSchema       = $context['bSchema'];
+        $mSchema       = $context['mSchema'];
 
         $besluit = $objectService->find($besluitId, register: $register, schema: $bSchema);
         if (is_array($besluit) === false) {
@@ -241,6 +313,68 @@ class MandaatImportService
         $besluit = $objectService->saveObject($register, $bSchema, $besluit);
 
         // Flip mandaten to active.
+        $this->activateMandatenForBesluit(
+            objectService: $objectService,
+            register: $register,
+            mSchema: $mSchema,
+            besluitId: $besluitId,
+            now: $now
+        );
+
+        // Expire prior besluit.
+        $prior = $this->findPriorBesluit(besluitNummer: (string) $besluit['besluitNummer'], excludeId: $besluitId);
+        if ($prior !== null) {
+            $prior['status']      = 'vervallen';
+            $prior['vervalDatum'] = $now;
+            $objectService->saveObject($register, $bSchema, $prior);
+        }
+
+        return $besluit;
+    }//end approveImport()
+
+    /**
+     * Resolve the object service, register and schemas needed to approve an import.
+     *
+     * @return array<string, mixed> {objectService, register, bSchema, mSchema}
+     *
+     * @throws RuntimeException When the mandaat services are not configured.
+     */
+    private function resolveApprovalContext(): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        $register      = (string) $this->settingsService->getConfigValue('register');
+        $bSchema       = (string) $this->settingsService->getConfigValue('mandaterings_besluit_schema');
+        $mSchema       = (string) $this->settingsService->getConfigValue('mandaat_schema');
+        if ($objectService === null || $register === '' || $bSchema === '' || $mSchema === '') {
+            throw new RuntimeException('Mandaat services not configured');
+        }
+
+        return [
+            'objectService' => $objectService,
+            'register'      => $register,
+            'bSchema'       => $bSchema,
+            'mSchema'       => $mSchema,
+        ];
+    }//end resolveApprovalContext()
+
+    /**
+     * Flip every mandaat of a besluit to active, defaulting a missing validFrom.
+     *
+     * @param object $objectService The OpenRegister object service.
+     * @param string $register      The register id.
+     * @param string $mSchema       The mandaat schema id.
+     * @param string $besluitId     The owning MandateringsBesluit id.
+     * @param string $now           The activation date (Y-m-d).
+     *
+     * @return void
+     */
+    private function activateMandatenForBesluit(
+        object $objectService,
+        string $register,
+        string $mSchema,
+        string $besluitId,
+        string $now
+    ): void {
         try {
             $mandaten = $this->searchObjectsAsArrays(
                 objectService: $objectService,
@@ -260,17 +394,7 @@ class MandaatImportService
 
             $objectService->saveObject($register, $mSchema, $m);
         }
-
-        // Expire prior besluit.
-        $prior = $this->findPriorBesluit(besluitNummer: (string) $besluit['besluitNummer'], excludeId: $besluitId);
-        if ($prior !== null) {
-            $prior['status']      = 'vervallen';
-            $prior['vervalDatum'] = $now;
-            $objectService->saveObject($register, $bSchema, $prior);
-        }
-
-        return $besluit;
-    }//end approveImport()
+    }//end activateMandatenForBesluit()
 
     /**
      * Parse RFC-4180-ish CSV with first row = header.

--- a/lib/Service/MilestoneService.php
+++ b/lib/Service/MilestoneService.php
@@ -335,40 +335,63 @@ class MilestoneService
         $stalled = [];
 
         foreach ($cases as $case) {
-            $caseId = (string) ($case['id'] ?? ($case['uuid'] ?? ''));
-            $status = strtolower((string) ($case['status'] ?? ''));
-            if ($caseId === '' || $this->isClosedStatus(status: $status) === true) {
-                continue;
-            }
-
-            $caseTypeId = (string) ($case['caseType'] ?? '');
-            if ($caseTypeId === '') {
-                continue;
-            }
-
-            $startDate = $this->parseCaseStart(case: $case);
-            if ($startDate === null) {
-                continue;
-            }
-
-            $stall = $this->evaluateStall(
-                caseId: $caseId,
-                caseTypeId: $caseTypeId,
-                startDate: $startDate,
-                today: $today,
-                thresholdDays: $thresholdDays,
-            );
-
+            $stall = $this->getStallRow(case: $case, today: $today, thresholdDays: $thresholdDays);
             if ($stall !== null) {
-                $stall['caseTitle'] = (string) ($case['title'] ?? '');
-                $stall['caseType']  = $caseTypeId;
-                $stall['assignee']  = (string) ($case['assignee'] ?? '');
-                $stalled[]          = $stall;
+                $stalled[] = $stall;
             }
         }//end foreach
 
         return $stalled;
     }//end findStalledCases()
+
+    /**
+     * Build the stall report row for a single case, or null when it is not stalled.
+     *
+     * Cases without an id, closed cases, cases without a case type and cases
+     * without a parsable start date are skipped (null).
+     *
+     * @param array<string, mixed> $case          The case object.
+     * @param \DateTimeImmutable   $today         Today (date only).
+     * @param int                  $thresholdDays Grace days past the deadline.
+     *
+     * @return array<string, mixed>|null Stall row, or null when on track or skipped.
+     */
+    private function getStallRow(array $case, \DateTimeImmutable $today, int $thresholdDays): ?array
+    {
+        $caseId = (string) ($case['id'] ?? ($case['uuid'] ?? ''));
+        $status = strtolower((string) ($case['status'] ?? ''));
+        if ($caseId === '' || $this->isClosedStatus(status: $status) === true) {
+            return null;
+        }
+
+        $caseTypeId = (string) ($case['caseType'] ?? '');
+        if ($caseTypeId === '') {
+            return null;
+        }
+
+        $startDate = $this->parseCaseStart(case: $case);
+        if ($startDate === null) {
+            return null;
+        }
+
+        $stall = $this->evaluateStall(
+            caseId: $caseId,
+            caseTypeId: $caseTypeId,
+            startDate: $startDate,
+            today: $today,
+            thresholdDays: $thresholdDays,
+        );
+
+        if ($stall === null) {
+            return null;
+        }
+
+        $stall['caseTitle'] = (string) ($case['title'] ?? '');
+        $stall['caseType']  = $caseTypeId;
+        $stall['assignee']  = (string) ($case['assignee'] ?? '');
+
+        return $stall;
+    }//end getStallRow()
 
     /**
      * Evaluate whether a single case has stalled on its earliest unreached

--- a/lib/Service/NotificatieService.php
+++ b/lib/Service/NotificatieService.php
@@ -341,49 +341,80 @@ class NotificatieService
         $isIpv6Ip   = str_contains($ipAddress, ':');
 
         if ($isIpv6Cidr === true && $isIpv6Ip === true) {
-            [$network, $prefix] = explode('/', $cidr);
-            $prefixLen          = (int) $prefix;
-            $networkBin         = inet_pton($network);
-            $inputBin           = inet_pton($ipAddress);
-            if ($networkBin === false || $inputBin === false) {
-                return false;
-            }//end if
-
-            $fullBytes  = intdiv($prefixLen, 8);
-            $remainBits = $prefixLen % 8;
-            for ($i = 0; $i < $fullBytes; $i++) {
-                if ($networkBin[$i] !== $inputBin[$i]) {
-                    return false;
-                }//end if
-            }
-
-            if ($remainBits > 0 && $fullBytes < 16) {
-                $mask = (0xFF << (8 - $remainBits)) & 0xFF;
-                if ((ord($networkBin[$fullBytes]) & $mask) !== (ord($inputBin[$fullBytes]) & $mask)) {
-                    return false;
-                }//end if
-            }//end if
-
-            return true;
+            return $this->ipv6InCidr(ipAddress: $ipAddress, cidr: $cidr);
         }//end if
 
         if ($isIpv6Cidr === false && $isIpv6Ip === false) {
-            [$network, $prefix] = explode('/', $cidr);
-            $prefixLen          = (int) $prefix;
-            $networkLong        = ip2long($network);
-            $ipLong = ip2long($ipAddress);
-            if ($networkLong === false || $ipLong === false) {
-                return false;
-            }//end if
-
-            $mask = 0;
-            if ($prefixLen > 0) {
-                $mask = ~0 << (32 - $prefixLen);
-            }//end if
-
-            return ($ipLong & $mask) === ($networkLong & $mask);
+            return $this->ipv4InCidr(ipAddress: $ipAddress, cidr: $cidr);
         }//end if
 
+        // Address family mismatch: an IPv4 address never falls inside an IPv6
+        // block and vice versa, so the CIDR simply does not apply.
         return false;
     }//end ipInCidr()
+
+    /**
+     * Check if an IPv6 address falls within an IPv6 CIDR range.
+     *
+     * Compares the packed 16-byte representations byte by byte for the whole
+     * bytes of the prefix, then masks the single partial byte (if any).
+     *
+     * @param string $ipAddress The IPv6 address to test
+     * @param string $cidr      The IPv6 CIDR block (e.g. 'fc00::/7')
+     *
+     * @return bool True if the address is within the range
+     */
+    private function ipv6InCidr(string $ipAddress, string $cidr): bool
+    {
+        [$network, $prefix] = explode('/', $cidr);
+        $prefixLen          = (int) $prefix;
+        $networkBin         = inet_pton($network);
+        $inputBin           = inet_pton($ipAddress);
+        if ($networkBin === false || $inputBin === false) {
+            return false;
+        }//end if
+
+        $fullBytes  = intdiv($prefixLen, 8);
+        $remainBits = $prefixLen % 8;
+        for ($i = 0; $i < $fullBytes; $i++) {
+            if ($networkBin[$i] !== $inputBin[$i]) {
+                return false;
+            }//end if
+        }
+
+        if ($remainBits > 0 && $fullBytes < 16) {
+            $mask = (0xFF << (8 - $remainBits)) & 0xFF;
+            if ((ord($networkBin[$fullBytes]) & $mask) !== (ord($inputBin[$fullBytes]) & $mask)) {
+                return false;
+            }//end if
+        }//end if
+
+        return true;
+    }//end ipv6InCidr()
+
+    /**
+     * Check if an IPv4 address falls within an IPv4 CIDR range.
+     *
+     * @param string $ipAddress The IPv4 address to test
+     * @param string $cidr      The IPv4 CIDR block (e.g. '10.0.0.0/8')
+     *
+     * @return bool True if the address is within the range
+     */
+    private function ipv4InCidr(string $ipAddress, string $cidr): bool
+    {
+        [$network, $prefix] = explode('/', $cidr);
+        $prefixLen          = (int) $prefix;
+        $networkLong        = ip2long($network);
+        $ipLong = ip2long($ipAddress);
+        if ($networkLong === false || $ipLong === false) {
+            return false;
+        }//end if
+
+        $mask = 0;
+        if ($prefixLen > 0) {
+            $mask = ~0 << (32 - $prefixLen);
+        }//end if
+
+        return ($ipLong & $mask) === ($networkLong & $mask);
+    }//end ipv4InCidr()
 }//end class

--- a/lib/Service/Parafeer/ParaferingActionMapper.php
+++ b/lib/Service/Parafeer/ParaferingActionMapper.php
@@ -1,0 +1,165 @@
+<?php
+
+/**
+ * Procest ParaferingActionMapper.
+ *
+ * Pure shaping of parafering action data. Split out of ParafeerActieService so
+ * that service keeps only the orchestration (authorize, persist, propagate,
+ * advance): normalizing the untrusted request payload into the five action
+ * inputs, assembling the parafeeractie object payload, and locating the next
+ * step in a voorstel's route snapshot live here and nowhere else. Every method
+ * is side-effect free — no ObjectService, no logging, no events.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Parafeer
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/specs/parafering-actions/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Parafeer;
+
+/**
+ * Shapes parafering action input, payloads and route navigation.
+ *
+ * Per ADR-005 the request body is NEVER trusted for actor identity: this
+ * mapper normalizes the payload only, the acting user id is supplied by the
+ * caller from IUserSession.
+ *
+ * @spec openspec/specs/parafering-actions/spec.md
+ *
+ * @psalm-suppress UnusedClass
+ */
+class ParaferingActionMapper
+{
+    /**
+     * Normalize the request payload into the five action inputs.
+     *
+     * @param array<string, mixed> $data Request payload (action, comment, advice, onBehalfOf, mandate).
+     *
+     * @return array<string, mixed> {action, comment, advice, onBehalfOf, mandate}
+     *
+     * @spec openspec/specs/parafering-actions/spec.md
+     */
+    public function parseActionInput(array $data): array
+    {
+        $onBehalfOf = null;
+        if (isset($data['onBehalfOf']) === true && $data['onBehalfOf'] !== '') {
+            $onBehalfOf = (string) $data['onBehalfOf'];
+        }
+
+        $mandate = null;
+        if (isset($data['mandate']) === true && $data['mandate'] !== '') {
+            $mandate = (string) $data['mandate'];
+        }
+
+        return [
+            'action'     => (string) ($data['action'] ?? ''),
+            'comment'    => trim((string) ($data['comment'] ?? '')),
+            'advice'     => trim((string) ($data['advice'] ?? '')),
+            'onBehalfOf' => $onBehalfOf,
+            'mandate'    => $mandate,
+        ];
+    }//end parseActionInput()
+
+    /**
+     * Build the parafeeractie payload, omitting the optional fields that are unset.
+     *
+     * @param string               $voorstelId The voorstel UUID.
+     * @param int                  $stepOrder  The step order this action applies to.
+     * @param string               $actor      The acting user id (from IUserSession, never the body).
+     * @param array<string, mixed> $input      The parsed action inputs.
+     *
+     * @return array<string, mixed> The parafeeractie object payload.
+     *
+     * @spec openspec/specs/parafering-actions/spec.md
+     */
+    public function buildActieData(string $voorstelId, int $stepOrder, string $actor, array $input): array
+    {
+        $actieData = [
+            'voorstel'  => $voorstelId,
+            'step'      => $stepOrder,
+            'actor'     => $actor,
+            'actorType' => 'user',
+            'action'    => (string) $input['action'],
+        ];
+
+        if ($input['onBehalfOf'] !== null) {
+            $actieData['actorType']  = 'delegate';
+            $actieData['onBehalfOf'] = $input['onBehalfOf'];
+        }
+
+        if ($input['mandate'] !== null) {
+            $actieData['mandate'] = $input['mandate'];
+        }
+
+        if ($input['comment'] !== '') {
+            $actieData['comment'] = $input['comment'];
+        }
+
+        if ($input['advice'] !== '') {
+            $actieData['advice'] = $input['advice'];
+        }
+
+        return $actieData;
+    }//end buildActieData()
+
+    /**
+     * Find the lowest-ordered route step after the current one.
+     *
+     * Accepts the raw routeSnapshot (JSON string or array) and normalizes it.
+     *
+     * @param mixed $snapshotRaw The raw routeSnapshot value.
+     * @param int   $currentStep The current step order.
+     *
+     * @return array<string, mixed>|null {order, type}, or null when the route is finished.
+     *
+     * @spec openspec/specs/parafering-actions/spec.md
+     */
+    public function findNextRouteStep(mixed $snapshotRaw, int $currentStep): ?array
+    {
+        $steps = $snapshotRaw;
+        if (is_string($snapshotRaw) === true) {
+            $steps = json_decode($snapshotRaw, true);
+        }
+
+        if (is_array($steps) === false) {
+            $steps = [];
+        }
+
+        $nextStep     = null;
+        $nextStepType = null;
+        foreach ($steps as $step) {
+            if (is_array($step) === false) {
+                continue;
+            }
+
+            $order = (int) ($step['order'] ?? 0);
+            if ($order > $currentStep && ($nextStep === null || $order < $nextStep)) {
+                $nextStep     = $order;
+                $nextStepType = (string) ($step['type'] ?? '');
+            }
+        }
+
+        if ($nextStep === null) {
+            return null;
+        }
+
+        return [
+            'order' => $nextStep,
+            'type'  => $nextStepType,
+        ];
+    }//end findNextRouteStep()
+}//end class

--- a/lib/Service/ParafeerActieService.php
+++ b/lib/Service/ParafeerActieService.php
@@ -33,6 +33,7 @@ use DateTimeImmutable;
 use DateTimeInterface;
 use OCA\Procest\AppInfo\Application;
 use OCA\Procest\Event\ParafeerTransitionEvent;
+use OCA\Procest\Service\Parafeer\ParaferingActionMapper;
 use OCA\Procest\Service\Support\SearchesObjects;
 use OCP\AppFramework\OCS\OCSBadRequestException;
 use OCP\AppFramework\OCS\OCSForbiddenException;
@@ -130,6 +131,7 @@ class ParafeerActieService
      * @param LoggerInterface               $logger              The logger.
      * @param IEventDispatcher              $eventDispatcher     The event dispatcher (parafering transition events).
      * @param ParaferingApprovalBridge      $approvalBridge      Bridge to OpenRegister approval-workflow (ADR-022).
+     * @param ParaferingActionMapper        $actionMapper        Pure shaping of action input, payload and route steps.
      */
     public function __construct(
         private readonly SettingsService $settingsService,
@@ -138,6 +140,7 @@ class ParafeerActieService
         private readonly LoggerInterface $logger,
         private readonly IEventDispatcher $eventDispatcher,
         private readonly ParaferingApprovalBridge $approvalBridge,
+        private readonly ParaferingActionMapper $actionMapper,
     ) {
     }//end __construct()
 
@@ -224,184 +227,11 @@ class ParafeerActieService
     public function recordAction(string $voorstelId, array $data, IUser $currentUser): array
     {
         try {
-            [$register, $voorstelSchema, $actieSchema] = $this->resolveSchemas();
-            $objectService = $this->settingsService->getObjectService();
-            if ($objectService === null) {
-                throw new RuntimeException('OpenRegister is not available');
-            }
-
-            $voorstel = $this->findVoorstel(
-                objectService: $objectService,
-                register: $register,
-                schema: $voorstelSchema,
+            return $this->performRecordAction(
                 voorstelId: $voorstelId,
-            );
-            $step     = $this->resolveCurrentStep(voorstel: $voorstel);
-
-            $action  = (string) ($data['action'] ?? '');
-            $comment = '';
-            if (isset($data['comment']) === true) {
-                $comment = trim((string) $data['comment']);
-            }
-
-            $advice = '';
-            if (isset($data['advice']) === true) {
-                $advice = trim((string) $data['advice']);
-            }
-
-            $onBehalfOf = null;
-            if (isset($data['onBehalfOf']) === true && $data['onBehalfOf'] !== '') {
-                $onBehalfOf = (string) $data['onBehalfOf'];
-            }
-
-            $mandate = null;
-            if (isset($data['mandate']) === true && $data['mandate'] !== '') {
-                $mandate = (string) $data['mandate'];
-            }
-
-            $this->authorize(
-                step: $step,
-                currentUser: $currentUser,
-                onBehalfOf: $onBehalfOf,
-                mandate: $mandate,
-            );
-            $this->validateActionForStepType(step: $step, action: $action);
-            $this->validateRequiredFields(
-                action: $action,
-                comment: $comment,
-                advice: $advice,
-            );
-
-            $timestamp = (new DateTimeImmutable())->format(DateTimeInterface::ATOM);
-
-            $actorType = 'user';
-            if ($onBehalfOf !== null) {
-                $actorType = 'delegate';
-            }
-
-            $actieData = [
-                'voorstel'  => $voorstelId,
-                'step'      => (int) ($step['order'] ?? ($voorstel['currentStep'] ?? 0)),
-                'actor'     => $currentUser->getUID(),
-                'actorType' => $actorType,
-                'action'    => $action,
-            ];
-
-            if ($onBehalfOf !== null) {
-                $actieData['onBehalfOf'] = $onBehalfOf;
-            }
-
-            if ($mandate !== null) {
-                $actieData['mandate'] = $mandate;
-            }
-
-            if ($comment !== '') {
-                $actieData['comment'] = $comment;
-            }
-
-            if ($advice !== '') {
-                $actieData['advice'] = $advice;
-            }
-
-            // Persist the parafeeractie.
-            $savedActie = $objectService->saveObject(object: $actieData, register: $register, schema: $actieSchema);
-
-            // Per ADR-022: delegate the step transition to OpenRegister's
-            // approval-workflow when this voorstel is backed by an OR
-            // ApprovalChain. OpenRegister enforces the step role, advances the
-            // next step, records the decision, and dispatches the approval
-            // events that ParaferingNotificationService observes. The legacy
-            // in-array currentStep/status update below remains the
-            // consumer-facing projection during the migration window.
-            $this->delegateToApprovalWorkflow(
-                voorstel: $voorstel,
-                voorstelId: $voorstelId,
-                action: $action,
-                comment: $comment,
-                advice: $advice,
-                onBehalfOf: $onBehalfOf,
-                mandate: $mandate,
+                data: $data,
                 currentUser: $currentUser,
             );
-
-            // Emit the parafering transition event for the audit listener.
-            [$transitionType, $actorRoleForAudit] = $this->transitionForAction(action: $action);
-            $dispatchReason = null;
-            if ($action === self::ACTION_RETURNED || $action === self::ACTION_SKIPPED) {
-                $dispatchReason = $comment;
-            }
-
-            $this->dispatchTransition(
-                voorstelId: $voorstelId,
-                action: $transitionType,
-                step: (string) ((int) ($step['order'] ?? ($voorstel['currentStep'] ?? 0))),
-                actor: $currentUser->getUID(),
-                actorRole: $actorRoleForAudit,
-                reason: $dispatchReason,
-            );
-
-            // Handle terugsturen: set voorstel status + notify steller, no route advance.
-            if ($action === self::ACTION_RETURNED) {
-                $this->handleReturn(
-                    objectService: $objectService,
-                    register: $register,
-                    voorstelSchema: $voorstelSchema,
-                    voorstel: $voorstel,
-                    voorstelId: $voorstelId,
-                    currentUser: $currentUser,
-                    reason: $comment,
-                );
-
-                return [
-                    'parafeeractie' => $this->toArray(value: $savedActie),
-                    'voorstel'      => ['id' => $voorstelId, 'status' => self::STATUS_TERUGGESTUURD],
-                ];
-            }
-
-            // Advance the route on success.
-            $updatedVoorstel = $this->advanceVoorstel(
-                objectService: $objectService,
-                register: $register,
-                voorstelSchema: $voorstelSchema,
-                voorstel: $voorstel,
-                voorstelId: $voorstelId,
-            );
-
-            // PDF signature on completed accordering step (only when document attached).
-            $accorderingDone = ($step['type'] ?? null) === self::STEP_TYPE_ACCORDERING
-                && $action === self::ACTION_ACCORDED;
-            if ($accorderingDone === true && empty($voorstel['document']) === false) {
-                $this->applyPdfSignature(
-                    voorstelId: $voorstelId,
-                    fileId: (string) $voorstel['document'],
-                    actor: $currentUser,
-                    step: (int) ($step['order'] ?? 0),
-                    timestamp: $timestamp,
-                );
-            }
-
-            // Notify steller on full accordering.
-            if ($accorderingDone === true && empty($voorstel['steller']) === false) {
-                try {
-                    $this->notificationService->notifyVoorstelReturned(
-                        (string) $voorstel['steller'],
-                        (string) ($voorstel['onderwerp'] ?? ''),
-                        $voorstelId,
-                        $currentUser->getDisplayName(),
-                        'Voorstel volledig geaccordeerd'
-                    );
-                } catch (\Throwable $e) {
-                    $this->logger->warning(
-                        'Failed to send accordering notification to steller',
-                        ['voorstel' => $voorstelId, 'exception' => $e->getMessage()]
-                    );
-                }
-            }
-
-            return [
-                'parafeeractie' => $this->toArray(value: $savedActie),
-                'voorstel'      => $this->toArray(value: $updatedVoorstel),
-            ];
         } catch (OCSForbiddenException | OCSBadRequestException $e) {
             // Re-throw intentional exceptions for the controller to map to HTTP codes.
             throw $e;
@@ -413,6 +243,227 @@ class ParafeerActieService
             throw new RuntimeException('Operation failed');
         }//end try
     }//end recordAction()
+
+    /**
+     * Run the parafering action pipeline: validate, persist, propagate, advance.
+     *
+     * @param string               $voorstelId  The voorstel UUID.
+     * @param array<string, mixed> $data        Request payload (action, comment, advice, onBehalfOf, mandate).
+     * @param IUser                $currentUser The authenticated user from IUserSession.
+     *
+     * @return array<string, mixed> Result envelope with parafeeractie and updated voorstel.
+     *
+     * @throws OCSForbiddenException  When the current user is not authorized for this step.
+     * @throws OCSBadRequestException When request data is invalid (e.g. missing reason on returned).
+     */
+    private function performRecordAction(string $voorstelId, array $data, IUser $currentUser): array
+    {
+        [$register, $voorstelSchema, $actieSchema] = $this->resolveSchemas();
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            throw new RuntimeException('OpenRegister is not available');
+        }
+
+        $voorstel = $this->findVoorstel(
+            objectService: $objectService,
+            register: $register,
+            schema: $voorstelSchema,
+            voorstelId: $voorstelId,
+        );
+        $step     = $this->resolveCurrentStep(voorstel: $voorstel);
+
+        $input   = $this->actionMapper->parseActionInput(data: $data);
+        $action  = (string) $input['action'];
+        $comment = (string) $input['comment'];
+
+        $this->authorize(
+            step: $step,
+            currentUser: $currentUser,
+            onBehalfOf: $input['onBehalfOf'],
+            mandate: $input['mandate'],
+        );
+        $this->validateActionForStepType(step: $step, action: $action);
+        $this->validateRequiredFields(
+            action: $action,
+            comment: $comment,
+            advice: (string) $input['advice'],
+        );
+
+        $timestamp = (new DateTimeImmutable())->format(DateTimeInterface::ATOM);
+        $stepOrder = (int) ($step['order'] ?? ($voorstel['currentStep'] ?? 0));
+
+        $actieData = $this->actionMapper->buildActieData(
+            voorstelId: $voorstelId,
+            stepOrder: $stepOrder,
+            actor: $currentUser->getUID(),
+            input: $input,
+        );
+
+        // Persist the parafeeractie.
+        $savedActie = $objectService->saveObject(object: $actieData, register: $register, schema: $actieSchema);
+
+        $this->propagateDecision(
+            voorstel: $voorstel,
+            voorstelId: $voorstelId,
+            input: $input,
+            stepOrder: $stepOrder,
+            currentUser: $currentUser,
+        );
+
+        // Handle terugsturen: set voorstel status + notify steller, no route advance.
+        if ($action === self::ACTION_RETURNED) {
+            $this->handleReturn(
+                objectService: $objectService,
+                register: $register,
+                voorstelSchema: $voorstelSchema,
+                voorstel: $voorstel,
+                voorstelId: $voorstelId,
+                currentUser: $currentUser,
+                reason: $comment,
+            );
+
+            return [
+                'parafeeractie' => $this->toArray(value: $savedActie),
+                'voorstel'      => ['id' => $voorstelId, 'status' => self::STATUS_TERUGGESTUURD],
+            ];
+        }
+
+        // Advance the route on success.
+        $updatedVoorstel = $this->advanceVoorstel(
+            objectService: $objectService,
+            register: $register,
+            voorstelSchema: $voorstelSchema,
+            voorstel: $voorstel,
+            voorstelId: $voorstelId,
+        );
+
+        $this->applyAccorderingEffects(
+            step: $step,
+            action: $action,
+            voorstel: $voorstel,
+            voorstelId: $voorstelId,
+            currentUser: $currentUser,
+            timestamp: $timestamp,
+        );
+
+        return [
+            'parafeeractie' => $this->toArray(value: $savedActie),
+            'voorstel'      => $this->toArray(value: $updatedVoorstel),
+        ];
+    }//end performRecordAction()
+
+    /**
+     * Propagate the step decision to OpenRegister and emit the audit transition.
+     *
+     * @param array<string, mixed> $voorstel    The voorstel array (provides approvalChainUuid).
+     * @param string               $voorstelId  The voorstel UUID.
+     * @param array<string, mixed> $input       The parsed action inputs.
+     * @param int                  $stepOrder   The step order this action applies to.
+     * @param IUser                $currentUser The authenticated user from IUserSession.
+     *
+     * @return void
+     */
+    private function propagateDecision(
+        array $voorstel,
+        string $voorstelId,
+        array $input,
+        int $stepOrder,
+        IUser $currentUser,
+    ): void {
+        $action  = (string) $input['action'];
+        $comment = (string) $input['comment'];
+
+        // Per ADR-022: delegate the step transition to OpenRegister's
+        // approval-workflow when this voorstel is backed by an OR
+        // ApprovalChain. OpenRegister enforces the step role, advances the
+        // next step, records the decision, and dispatches the approval
+        // events that ParaferingNotificationService observes. The legacy
+        // in-array currentStep/status update below remains the
+        // consumer-facing projection during the migration window.
+        $this->delegateToApprovalWorkflow(
+            voorstel: $voorstel,
+            voorstelId: $voorstelId,
+            action: $action,
+            comment: $comment,
+            advice: (string) $input['advice'],
+            onBehalfOf: $input['onBehalfOf'],
+            mandate: $input['mandate'],
+            currentUser: $currentUser,
+        );
+
+        // Emit the parafering transition event for the audit listener.
+        [$transitionType, $actorRoleForAudit] = $this->transitionForAction(action: $action);
+        $dispatchReason = null;
+        if ($action === self::ACTION_RETURNED || $action === self::ACTION_SKIPPED) {
+            $dispatchReason = $comment;
+        }
+
+        $this->dispatchTransition(
+            voorstelId: $voorstelId,
+            action: $transitionType,
+            step: (string) $stepOrder,
+            actor: $currentUser->getUID(),
+            actorRole: $actorRoleForAudit,
+            reason: $dispatchReason,
+        );
+    }//end propagateDecision()
+
+    /**
+     * Apply the side effects of a completed accordering step: PDF signature and
+     * steller notification. A no-op for any other step type or action.
+     *
+     * @param array<string, mixed> $step        The current route step.
+     * @param string               $action      The recorded action.
+     * @param array<string, mixed> $voorstel    The voorstel array (current state).
+     * @param string               $voorstelId  The voorstel UUID.
+     * @param IUser                $currentUser The authenticated user from IUserSession.
+     * @param string               $timestamp   The ATOM timestamp of this action.
+     *
+     * @return void
+     */
+    private function applyAccorderingEffects(
+        array $step,
+        string $action,
+        array $voorstel,
+        string $voorstelId,
+        IUser $currentUser,
+        string $timestamp,
+    ): void {
+        $accorderingDone = ($step['type'] ?? null) === self::STEP_TYPE_ACCORDERING
+            && $action === self::ACTION_ACCORDED;
+        if ($accorderingDone === false) {
+            return;
+        }
+
+        // PDF signature on completed accordering step (only when document attached).
+        if (empty($voorstel['document']) === false) {
+            $this->applyPdfSignature(
+                voorstelId: $voorstelId,
+                fileId: (string) $voorstel['document'],
+                actor: $currentUser,
+                step: (int) ($step['order'] ?? 0),
+                timestamp: $timestamp,
+            );
+        }
+
+        // Notify steller on full accordering.
+        if (empty($voorstel['steller']) === false) {
+            try {
+                $this->notificationService->notifyVoorstelReturned(
+                    (string) $voorstel['steller'],
+                    (string) ($voorstel['onderwerp'] ?? ''),
+                    $voorstelId,
+                    $currentUser->getDisplayName(),
+                    'Voorstel volledig geaccordeerd'
+                );
+            } catch (\Throwable $e) {
+                $this->logger->warning(
+                    'Failed to send accordering notification to steller',
+                    ['voorstel' => $voorstelId, 'exception' => $e->getMessage()]
+                );
+            }
+        }
+    }//end applyAccorderingEffects()
 
     /**
      * Delegate a parafering step decision to OpenRegister's approval-workflow.
@@ -870,40 +921,21 @@ class ParafeerActieService
         array $voorstel,
         string $voorstelId
     ): array {
-        $snapshotRaw = $voorstel['routeSnapshot'] ?? null;
-        $steps       = $snapshotRaw;
-        if (is_string($snapshotRaw) === true) {
-            $steps = json_decode($snapshotRaw, true);
-        }
-
-        if (is_array($steps) === false) {
-            $steps = [];
-        }
-
-        $currentStep  = (int) ($voorstel['currentStep'] ?? 0);
-        $nextStep     = null;
-        $nextStepType = null;
-        foreach ($steps as $step) {
-            if (is_array($step) === false) {
-                continue;
-            }
-
-            $order = (int) ($step['order'] ?? 0);
-            if ($order > $currentStep && ($nextStep === null || $order < $nextStep)) {
-                $nextStep     = $order;
-                $nextStepType = (string) ($step['type'] ?? '');
-            }
-        }
+        $currentStep = (int) ($voorstel['currentStep'] ?? 0);
+        $next        = $this->actionMapper->findNextRouteStep(
+            snapshotRaw: ($voorstel['routeSnapshot'] ?? null),
+            currentStep: $currentStep,
+        );
 
         $updateData = ['status' => self::STATUS_GEACCORDEERD];
-        if ($nextStep !== null) {
+        if ($next !== null) {
             $status = self::STATUS_IN_PARAFERING;
-            if ($nextStepType === self::STEP_TYPE_ACCORDERING) {
+            if ($next['type'] === self::STEP_TYPE_ACCORDERING) {
                 $status = self::STATUS_TER_ACCORDERING;
             }
 
             $updateData = [
-                'currentStep' => $nextStep,
+                'currentStep' => $next['order'],
                 'status'      => $status,
             ];
         }

--- a/lib/Service/PublicationService.php
+++ b/lib/Service/PublicationService.php
@@ -97,6 +97,60 @@ class PublicationService
         $register = $this->settingsService->getConfigValue('register');
         $schema   = $this->settingsService->getConfigValue('case_schema');
 
+        $case = $this->loadCase(
+            objectService: $objectService,
+            caseId: $caseId,
+            register: $register,
+            schema: $schema
+        );
+
+        $publications = $this->extractPublications(case: $case);
+
+        $publishedAt = (string) ($payload['publishedAt'] ?? date(format: 'c'));
+        $notes       = null;
+        if (isset($payload['notes']) === true) {
+            $notes = (string) $payload['notes'];
+        }
+
+        // Upsert by channel — same channel publishing twice updates the timestamp.
+        $publications = $this->upsertPublication(
+            publications: $publications,
+            channel: $channel,
+            publishedAt: $publishedAt,
+            notes: $notes
+        );
+
+        $case['publications'] = $publications;
+        $case['publishedAt']  = $publishedAt;
+
+        $objectService->saveObject(
+            object: $case,
+            register: $register,
+            schema: $schema,
+        );
+
+        return [
+            'caseId'       => $caseId,
+            'channel'      => $channel,
+            'publishedAt'  => $publishedAt,
+            'publications' => $publications,
+        ];
+    }//end publish()
+
+    /**
+     * Load a case from OpenRegister and normalise it to its array form.
+     *
+     * @param object $objectService The OpenRegister ObjectService.
+     * @param string $caseId        The case id.
+     * @param mixed  $register      The configured register id.
+     * @param mixed  $schema        The configured case schema id.
+     *
+     * @return array<string, mixed> The case data.
+     *
+     * @throws \RuntimeException When the case cannot be loaded or does not exist.
+     */
+    private function loadCase(object $objectService, string $caseId, mixed $register, mixed $schema): array
+    {
         try {
             $obj = $objectService->find(id: $caseId, register: $register, schema: $schema);
         } catch (Throwable $e) {
@@ -117,15 +171,22 @@ class PublicationService
             $case = $obj->jsonSerialize();
         }
 
-        $publications = $this->extractPublications(case: $case);
+        return $case;
+    }//end loadCase()
 
-        $publishedAt = (string) ($payload['publishedAt'] ?? date(format: 'c'));
-        $notes       = null;
-        if (isset($payload['notes']) === true) {
-            $notes = (string) $payload['notes'];
-        }
-
-        // Upsert by channel — same channel publishing twice updates the timestamp.
+    /**
+     * Upsert a publication record by channel — an existing record for the same
+     * channel has its timestamp and notes replaced rather than being duplicated.
+     *
+     * @param array<int, array<string, mixed>> $publications The existing publications list.
+     * @param string                           $channel      The publication channel.
+     * @param string                           $publishedAt  The publication timestamp.
+     * @param string|null                      $notes        Optional publication notes.
+     *
+     * @return array<int, array<string, mixed>> The updated publications list.
+     */
+    private function upsertPublication(array $publications, string $channel, string $publishedAt, ?string $notes): array
+    {
         $upserted = false;
         foreach ($publications as $i => $pub) {
             if ((string) ($pub['channel'] ?? '') === $channel) {
@@ -147,22 +208,8 @@ class PublicationService
             ];
         }
 
-        $case['publications'] = $publications;
-        $case['publishedAt']  = $publishedAt;
-
-        $objectService->saveObject(
-            object: $case,
-            register: $register,
-            schema: $schema,
-        );
-
-        return [
-            'caseId'       => $caseId,
-            'channel'      => $channel,
-            'publishedAt'  => $publishedAt,
-            'publications' => $publications,
-        ];
-    }//end publish()
+        return $publications;
+    }//end upsertPublication()
 
     /**
      * Pull the existing publications list from a case.

--- a/lib/Service/SamenwerkverzoekService.php
+++ b/lib/Service/SamenwerkverzoekService.php
@@ -71,9 +71,9 @@ class SamenwerkverzoekService
      * Creates a samenwerkverzoek object with status 'aangevraagd' and
      * dispatches a SamenwerkverzoekInitiated event for downstream listeners.
      *
-     * @param string $zaakId                 The UUID of the zaak
-     * @param string $aangezochtBevoegdGezag The requested authority identifier
-     * @param string $rationale              The reason for requesting cooperation
+     * @param string $zaakId          The UUID of the zaak
+     * @param string $aangezochtGezag The requested authority identifier
+     * @param string $rationale       The reason for requesting cooperation
      *
      * @return array<string,mixed> The created samenwerkverzoek object
      *
@@ -83,7 +83,7 @@ class SamenwerkverzoekService
      */
     public function initiateSamenwerking(
         string $zaakId,
-        string $aangezochtBevoegdGezag,
+        string $aangezochtGezag,
         string $rationale,
     ): array {
         $objectService = $this->getObjectService();
@@ -121,7 +121,7 @@ class SamenwerkverzoekService
         $samenwerkverzoek = [
             'zaakId'                 => $zaakId,
             'vergunningaanvraagRef'  => $aanvraagRef,
-            'aangezochtBevoegdGezag' => $aangezochtBevoegdGezag,
+            'aangezochtBevoegdGezag' => $aangezochtGezag,
             'rationale'              => $rationale,
             'status'                 => 'aangevraagd',
             'aangevraagdOp'          => date('c'),
@@ -138,7 +138,7 @@ class SamenwerkverzoekService
             arguments: [
                 'zaakId'                 => $zaakId,
                 'vergunningaanvraagRef'  => $aanvraagRef,
-                'aangezochtBevoegdGezag' => $aangezochtBevoegdGezag,
+                'aangezochtBevoegdGezag' => $aangezochtGezag,
             ]
         );
         $this->eventDispatcher->dispatch(
@@ -151,7 +151,7 @@ class SamenwerkverzoekService
             [
                 'app'                    => Application::APP_ID,
                 'zaakId'                 => $zaakId,
-                'aangezochtBevoegdGezag' => $aangezochtBevoegdGezag,
+                'aangezochtBevoegdGezag' => $aangezochtGezag,
             ]
         );
 

--- a/lib/Service/SeedDataService.php
+++ b/lib/Service/SeedDataService.php
@@ -163,18 +163,14 @@ class SeedDataService
         $identifier = ($caseTypeData['identifier'] ?? '');
 
         // Check if case type already exists by identifier.
-        $existing = $this->findByFilter(
+        $alreadySeeded = $this->caseTypeAlreadySeeded(
             objectService: $objectService,
             registerId: $registerId,
-            schemaId: $caseTypeSchema,
-            filters: ['identifier' => $identifier],
+            caseTypeSchema: $caseTypeSchema,
+            identifier: $identifier,
         );
 
-        if ($existing !== null) {
-            $this->logger->info(
-                'Procest: Case type already exists, skipping seed',
-                ['identifier' => $identifier]
-            );
+        if ($alreadySeeded === true) {
             $counts['skipped']++;
             return $counts;
         }
@@ -190,7 +186,121 @@ class SeedDataService
             $caseTypeData['workflowTemplate']
         );
 
-        // Create the case type.
+        // Create the case type and resolve the id its children must point at.
+        $caseTypeId = $this->createCaseType(
+            objectService: $objectService,
+            caseTypeData: $caseTypeData,
+            registerId: $registerId,
+            caseTypeSchema: $caseTypeSchema,
+            identifier: $identifier,
+        );
+
+        if ($caseTypeId === null) {
+            return $counts;
+        }
+
+        $counts['caseTypes']++;
+
+        // Create status types and build a name-to-ID map.
+        $statuses = $this->seedChildTypes(
+            objectService: $objectService,
+            childrenData: $statusTypesData,
+            registerId: $registerId,
+            schemaId: $statusTypeSchema,
+            caseTypeId: $caseTypeId,
+        );
+
+        $statusNameToId         = $statuses['map'];
+        $counts['statusTypes'] += $statuses['created'];
+
+        // Create role types and build a name-to-ID map.
+        $roleNameToId = [];
+        if ($roleTypeSchema !== '') {
+            $roles = $this->seedChildTypes(
+                objectService: $objectService,
+                childrenData: $roleTypesData,
+                registerId: $registerId,
+                schemaId: $roleTypeSchema,
+                caseTypeId: $caseTypeId,
+            );
+
+            $roleNameToId         = $roles['map'];
+            $counts['roleTypes'] += $roles['created'];
+        }
+
+        // Create workflow template with resolved status/role references.
+        $counts['workflows'] += $this->seedWorkflowTemplate(
+            objectService: $objectService,
+            workflowData: $workflowData,
+            registerId: $registerId,
+            workflowSchema: $workflowSchema,
+            statusNameMap: $statusNameToId,
+            roleNameMap: $roleNameToId,
+            caseTypeId: $caseTypeId,
+        );
+
+        return $counts;
+    }//end seedCaseType()
+
+    /**
+     * Determine whether a case type with this identifier was already seeded.
+     *
+     * @param object $objectService  The OpenRegister ObjectService
+     * @param string $registerId     The register UUID
+     * @param string $caseTypeSchema The case type schema UUID
+     * @param mixed  $identifier     The case type identifier from the seed data
+     *
+     * @return bool True when a matching case type already exists
+     */
+    private function caseTypeAlreadySeeded(
+        object $objectService,
+        string $registerId,
+        string $caseTypeSchema,
+        mixed $identifier,
+    ): bool {
+        $existing = $this->findByFilter(
+            objectService: $objectService,
+            registerId: $registerId,
+            schemaId: $caseTypeSchema,
+            filters: ['identifier' => $identifier],
+        );
+
+        if ($existing === null) {
+            return false;
+        }
+
+        $this->logger->info(
+            'Procest: Case type already exists, skipping seed',
+            ['identifier' => $identifier]
+        );
+
+        return true;
+    }//end caseTypeAlreadySeeded()
+
+    /**
+     * Create the case type object and resolve the id its children must point at.
+     *
+     * Prefers the deterministic id from the seed data: OpenRegister's
+     * saveObject() return is not always hydrated with the new id (getId() and
+     * getUuid() can both be empty), which left child status/role types with an
+     * empty caseType and failed their uuid-format validation. The seed assigns
+     * fixed UUIDs to the case types, so use those.
+     *
+     * @param object $objectService  The OpenRegister ObjectService
+     * @param array  $caseTypeData   The case type seed data, nested children removed
+     * @param string $registerId     The register UUID
+     * @param string $caseTypeSchema The case type schema UUID
+     * @param mixed  $identifier     The case type identifier from the seed data
+     *
+     * @return string|null The case type UUID, or null when creation failed
+     */
+    private function createCaseType(
+        object $objectService,
+        array $caseTypeData,
+        string $registerId,
+        string $caseTypeSchema,
+        mixed $identifier,
+    ): ?string {
         $caseType = $this->createObject(
             objectService: $objectService,
             registerId: $registerId,
@@ -203,91 +313,110 @@ class SeedDataService
                 'Procest: Failed to create case type',
                 ['identifier' => $identifier]
             );
-            return $counts;
+            return null;
         }
 
-        // Prefer the deterministic id from the seed data: OpenRegister's
-        // saveObject() return is not always hydrated with the new id (getId()
-        // and getUuid() can both be empty), which left child status/role types
-        // with an empty caseType and failed their uuid-format validation. The
-        // seed assigns fixed UUIDs to the case types, so use those.
         $caseTypeId = (string) ($caseTypeData['id'] ?? $caseTypeData['uuid'] ?? '');
         if ($caseTypeId === '') {
             $caseTypeId = $this->getObjectId(object: $caseType);
         }
-
-        $counts['caseTypes']++;
 
         $this->logger->info(
             'Procest: Created case type',
             ['identifier' => $identifier, 'id' => $caseTypeId]
         );
 
-        // Create status types and build a name-to-ID map. Assign a fixed UUID
-        // up front so the id is known regardless of saveObject's return shape
-        // (used for the workflow step references below).
-        $statusNameToId = [];
-        foreach ($statusTypesData as $statusData) {
-            $statusData['caseType'] = $caseTypeId;
-            $statusId         = (string) ($statusData['id'] ?? $this->generateUUID());
-            $statusData['id'] = $statusId;
-            $statusObj        = $this->createObject(
+        return $caseTypeId;
+    }//end createCaseType()
+
+    /**
+     * Create the named children of a case type (status types, role types) and
+     * map their names to their ids.
+     *
+     * A fixed UUID is assigned up front so the id is known regardless of
+     * saveObject()'s return shape — the workflow step/transition references
+     * below are resolved from this map.
+     *
+     * @param object $objectService The OpenRegister ObjectService
+     * @param array  $childrenData  The child seed data
+     * @param string $registerId    The register UUID
+     * @param string $schemaId      The child schema UUID
+     * @param string $caseTypeId    The owning case type UUID
+     *
+     * @return array{map: array<string, string>, created: int} The name-to-id map and the created count
+     */
+    private function seedChildTypes(
+        object $objectService,
+        array $childrenData,
+        string $registerId,
+        string $schemaId,
+        string $caseTypeId,
+    ): array {
+        $map     = [];
+        $created = 0;
+
+        foreach ($childrenData as $childData) {
+            $childData['caseType'] = $caseTypeId;
+            $childId         = (string) ($childData['id'] ?? $this->generateUUID());
+            $childData['id'] = $childId;
+            $childObj        = $this->createObject(
                 objectService: $objectService,
                 registerId: $registerId,
-                schemaId: $statusTypeSchema,
-                data: $statusData,
+                schemaId: $schemaId,
+                data: $childData,
             );
 
-            if ($statusObj !== null) {
-                $statusNameToId[$statusData['name']] = $statusId;
-                $counts['statusTypes']++;
+            if ($childObj !== null) {
+                $map[$childData['name']] = $childId;
+                $created++;
             }
         }
 
-        // Create role types and build a name-to-ID map.
-        $roleNameToId = [];
-        if ($roleTypeSchema !== '') {
-            foreach ($roleTypesData as $roleData) {
-                $roleData['caseType'] = $caseTypeId;
-                $roleId         = (string) ($roleData['id'] ?? $this->generateUUID());
-                $roleData['id'] = $roleId;
-                $roleObj        = $this->createObject(
-                    objectService: $objectService,
-                    registerId: $registerId,
-                    schemaId: $roleTypeSchema,
-                    data: $roleData,
-                );
+        return ['map' => $map, 'created' => $created];
+    }//end seedChildTypes()
 
-                if ($roleObj !== null) {
-                    $roleNameToId[$roleData['name']] = $roleId;
-                    $counts['roleTypes']++;
-                }
-            }
+    /**
+     * Create the workflow template of a case type with resolved status/role references.
+     *
+     * @param object     $objectService  The OpenRegister ObjectService
+     * @param array|null $workflowData   The raw workflow template seed data, or null when absent
+     * @param string     $registerId     The register UUID
+     * @param string     $workflowSchema The workflow template schema UUID (empty disables seeding)
+     * @param array      $statusNameMap  Status name to UUID mapping
+     * @param array      $roleNameMap    Role name to UUID mapping
+     * @param string     $caseTypeId     The owning case type UUID
+     *
+     * @return int The number of workflow templates created (0 or 1)
+     */
+    private function seedWorkflowTemplate(
+        object $objectService,
+        ?array $workflowData,
+        string $registerId,
+        string $workflowSchema,
+        array $statusNameMap,
+        array $roleNameMap,
+        string $caseTypeId,
+    ): int {
+        if ($workflowData === null || $workflowSchema === '') {
+            return 0;
         }
 
-        // Create workflow template with resolved status/role references.
-        if ($workflowData !== null && $workflowSchema !== '') {
-            $resolvedWorkflow = $this->resolveWorkflowReferences(
-                workflowData: $workflowData,
-                statusNameMap: $statusNameToId,
-                roleNameMap: $roleNameToId,
-                caseTypeId: $caseTypeId,
-            );
+        $resolvedWorkflow = $this->resolveWorkflowReferences(
+            workflowData: $workflowData,
+            statusNameMap: $statusNameMap,
+            roleNameMap: $roleNameMap,
+            caseTypeId: $caseTypeId,
+        );
 
-            $workflowObj = $this->createObject(
-                objectService: $objectService,
-                registerId: $registerId,
-                schemaId: $workflowSchema,
-                data: $resolvedWorkflow,
-            );
+        $workflowObj = $this->createObject(
+            objectService: $objectService,
+            registerId: $registerId,
+            schemaId: $workflowSchema,
+            data: $resolvedWorkflow,
+        );
 
-            if ($workflowObj !== null) {
-                $counts['workflows']++;
-            }
-        }
-
-        return $counts;
-    }//end seedCaseType()
+        return (int) ($workflowObj !== null);
+    }//end seedWorkflowTemplate()
 
     /**
      * Resolve workflow step and transition references from names to UUIDs.

--- a/lib/Service/Substitution/SubstitutedWorkResolver.php
+++ b/lib/Service/Substitution/SubstitutedWorkResolver.php
@@ -1,0 +1,304 @@
+<?php
+
+/**
+ * Procest SubstitutedWorkResolver.
+ *
+ * Gathers the open cases and tasks that a set of active substitutions routes to
+ * a waarnemer. Split out of SubstitutionService, which now only decides WHICH
+ * substitutions are active; this collaborator decides WHAT work those
+ * substitutions surface.
+ *
+ * Because the OpenRegister ObjectService search runs in the calling user's (the
+ * substitute's) RBAC context, items the substitute cannot read are already
+ * excluded — this resolver never elevates.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Substitution
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/specs/handler-vervanging-waarneming/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Substitution;
+
+use OCA\Procest\Service\SettingsService;
+use OCA\Procest\Service\Support\SearchesObjects;
+
+/**
+ * Resolves the workload a set of active substitutions routes to a waarnemer.
+ *
+ * @spec openspec/specs/handler-vervanging-waarneming/spec.md
+ */
+class SubstitutedWorkResolver
+{
+    use SearchesObjects;
+
+    /**
+     * Constructor.
+     *
+     * @param SettingsService $settingsService The settings/config + ObjectService bridge.
+     *
+     * @return void
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+    ) {
+    }//end __construct()
+
+    /**
+     * Resolve the substituted open cases and tasks for a set of active substitutions.
+     *
+     * Each returned item is annotated with `_substituted` so the UI can render
+     * the "waargenomen voor {naam}" badge.
+     *
+     * @param array<int, array<string, mixed>> $subs The active substitution records.
+     *
+     * @return array{cases: array<int, array<string, mixed>>, tasks: array<int, array<string, mixed>>}
+     *
+     * @spec openspec/specs/handler-vervanging-waarneming/spec.md
+     */
+    public function resolve(array $subs): array
+    {
+        $result = ['cases' => [], 'tasks' => []];
+        if (count($subs) === 0) {
+            return $result;
+        }
+
+        $objectService = $this->settingsService->getObjectService();
+        $register      = (string) $this->settingsService->getConfigValue('register');
+        if ($objectService === null) {
+            return $result;
+        }
+
+        $caseSchema = (string) $this->settingsService->getConfigValue('case_schema');
+        $taskSchema = (string) $this->settingsService->getConfigValue('task_schema');
+        $finalIds   = $this->finalStatusIds(objectService: $objectService, register: $register);
+
+        $seenCases = [];
+        $seenTasks = [];
+
+        foreach ($subs as $sub) {
+            $absentee = (string) ($sub['absentee'] ?? '');
+            if ($absentee === '') {
+                continue;
+            }
+
+            if ($caseSchema !== '') {
+                $result['cases'] = array_merge(
+                    $result['cases'],
+                    $this->collectCases(
+                        objectService: $objectService,
+                        register: $register,
+                        caseSchema: $caseSchema,
+                        sub: $sub,
+                        finalIds: $finalIds,
+                        seen: $seenCases
+                    )
+                );
+            }
+
+            if ($taskSchema !== '') {
+                $result['tasks'] = array_merge(
+                    $result['tasks'],
+                    $this->collectTasks(
+                        objectService: $objectService,
+                        register: $register,
+                        taskSchema: $taskSchema,
+                        sub: $sub,
+                        seen: $seenTasks
+                    )
+                );
+            }
+        }//end foreach
+
+        return $result;
+    }//end resolve()
+
+    /**
+     * Collect the absentee's in-scope, non-final cases for one substitution.
+     *
+     * @param object               $objectService The ObjectService.
+     * @param string               $register      Register id.
+     * @param string               $caseSchema    Case schema id.
+     * @param array<string, mixed> $sub           The substitution record.
+     * @param array<int, string>   $finalIds      Final statusType ids to exclude.
+     * @param array<string, bool>  $seen          Dedup map, mutated in place.
+     *
+     * @return array<int, array<string, mixed>> The newly collected cases.
+     *
+     * @spec openspec/specs/handler-vervanging-waarneming/spec.md
+     */
+    private function collectCases(
+        object $objectService,
+        string $register,
+        string $caseSchema,
+        array $sub,
+        array $finalIds,
+        array &$seen
+    ): array {
+        $absentee  = (string) ($sub['absentee'] ?? '');
+        $subId     = (string) ($sub['id'] ?? ($sub['uuid'] ?? ''));
+        $scope     = (string) ($sub['scope'] ?? 'all');
+        $scopeRefs = array_map('strval', (array) ($sub['scopeRefs'] ?? []));
+
+        $cases = $this->searchObjectsAsArrays(
+            objectService: $objectService,
+            register: $register,
+            schema: $caseSchema,
+            filters: ['assignee' => $absentee]
+        );
+
+        $collected = [];
+        foreach ($cases as $case) {
+            if ($this->caseInScope(case: $case, scope: $scope, scopeRefs: $scopeRefs) === false) {
+                continue;
+            }
+
+            if (in_array((string) ($case['status'] ?? ''), $finalIds, true) === true) {
+                continue;
+            }
+
+            $id = (string) ($case['id'] ?? ($case['uuid'] ?? ''));
+            if ($id === '' || isset($seen[$id]) === true) {
+                continue;
+            }
+
+            $seen[$id]            = true;
+            $case['_substituted'] = ['absentee' => $absentee, 'substitutionId' => $subId];
+            $collected[]          = $case;
+        }//end foreach
+
+        return $collected;
+    }//end collectCases()
+
+    /**
+     * Collect the absentee's open tasks for one substitution.
+     *
+     * @param object               $objectService The ObjectService.
+     * @param string               $register      Register id.
+     * @param string               $taskSchema    Task schema id.
+     * @param array<string, mixed> $sub           The substitution record.
+     * @param array<string, bool>  $seen          Dedup map, mutated in place.
+     *
+     * @return array<int, array<string, mixed>> The newly collected tasks.
+     *
+     * @spec openspec/specs/handler-vervanging-waarneming/spec.md
+     */
+    private function collectTasks(
+        object $objectService,
+        string $register,
+        string $taskSchema,
+        array $sub,
+        array &$seen
+    ): array {
+        $absentee  = (string) ($sub['absentee'] ?? '');
+        $subId     = (string) ($sub['id'] ?? ($sub['uuid'] ?? ''));
+        $scope     = (string) ($sub['scope'] ?? 'all');
+        $scopeRefs = array_map('strval', (array) ($sub['scopeRefs'] ?? []));
+
+        $tasks = $this->searchObjectsAsArrays(
+            objectService: $objectService,
+            register: $register,
+            schema: $taskSchema,
+            filters: ['assignee' => $absentee]
+        );
+
+        $collected = [];
+        foreach ($tasks as $task) {
+            $tStatus = (string) ($task['status'] ?? '');
+            if (in_array($tStatus, ['completed', 'terminated', 'disabled'], true) === true) {
+                continue;
+            }
+
+            if ($scope === 'cases' && in_array((string) ($task['case'] ?? ''), $scopeRefs, true) === false) {
+                continue;
+            }
+
+            $id = (string) ($task['id'] ?? ($task['uuid'] ?? ''));
+            if ($id === '' || isset($seen[$id]) === true) {
+                continue;
+            }
+
+            $seen[$id]            = true;
+            $task['_substituted'] = ['absentee' => $absentee, 'substitutionId' => $subId];
+            $collected[]          = $task;
+        }//end foreach
+
+        return $collected;
+    }//end collectTasks()
+
+    /**
+     * Whether a case falls within a substitution scope.
+     *
+     * @param array<string, mixed> $case      The case object.
+     * @param string               $scope     all|caseTypes|cases.
+     * @param array<int, string>   $scopeRefs The narrowed refs.
+     *
+     * @return bool True when the case is covered by the scope.
+     *
+     * @spec openspec/specs/handler-vervanging-waarneming/spec.md
+     */
+    public function caseInScope(array $case, string $scope, array $scopeRefs): bool
+    {
+        if ($scope === 'all') {
+            return true;
+        }
+
+        if ($scope === 'caseTypes') {
+            return in_array((string) ($case['caseType'] ?? ''), $scopeRefs, true);
+        }
+
+        if ($scope === 'cases') {
+            $id = (string) ($case['id'] ?? ($case['uuid'] ?? ''));
+            return in_array($id, $scopeRefs, true);
+        }
+
+        return false;
+    }//end caseInScope()
+
+    /**
+     * Resolve the set of final statusType ids (closed/archived cases).
+     *
+     * @param object $objectService The ObjectService.
+     * @param string $register      Register id.
+     *
+     * @return array<int, string> The final statusType ids.
+     *
+     * @spec openspec/specs/handler-vervanging-waarneming/spec.md
+     */
+    private function finalStatusIds(object $objectService, string $register): array
+    {
+        $statusTypeSchema = (string) $this->settingsService->getConfigValue('status_type_schema');
+        if ($statusTypeSchema === '') {
+            return [];
+        }
+
+        try {
+            $rows = $this->searchObjectsAsArrays(objectService: $objectService, register: $register, schema: $statusTypeSchema);
+        } catch (\Throwable $e) {
+            return [];
+        }
+
+        $ids = [];
+        foreach ($rows as $row) {
+            $isFinal = ($row['isFinal'] ?? false);
+            if ($isFinal === true || $isFinal === 'true' || $isFinal === 1) {
+                $ids[] = (string) ($row['id'] ?? ($row['uuid'] ?? ''));
+            }
+        }
+
+        return array_values(array_filter($ids));
+    }//end finalStatusIds()
+}//end class

--- a/lib/Service/Substitution/SubstitutionValidator.php
+++ b/lib/Service/Substitution/SubstitutionValidator.php
@@ -1,0 +1,302 @@
+<?php
+
+/**
+ * Procest SubstitutionValidator.
+ *
+ * Input validation and conflict detection for vervanging/waarneming
+ * (handler absence/substitution) records. Split out of SubstitutionService so
+ * that service keeps only the create/resolve orchestration: the rules for what
+ * makes a substitution acceptable — identity, enum membership, a well-formed
+ * closed period, scope refs, and the "no two overlapping full-scope
+ * substitutions for one absentee" invariant — live here and nowhere else.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Substitution
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/specs/handler-vervanging-waarneming/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Substitution;
+
+use DateTimeImmutable;
+use InvalidArgumentException;
+use OCA\Procest\Service\SettingsService;
+use OCA\Procest\Service\Support\SearchesObjects;
+
+/**
+ * Validates substitution input and rejects conflicting full-scope overlaps.
+ *
+ * @spec openspec/specs/handler-vervanging-waarneming/spec.md
+ */
+class SubstitutionValidator
+{
+    use SearchesObjects;
+
+    /**
+     * Constructor.
+     *
+     * @param SettingsService $settingsService The settings/config + ObjectService bridge.
+     *
+     * @return void
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+    ) {
+    }//end __construct()
+
+    /**
+     * Validate every create() argument and resolve the substitution period.
+     *
+     * @param string             $absentee   Handler being covered (user id), pre-trimmed.
+     * @param string             $substitute Waarnemer (user id), pre-trimmed.
+     * @param string             $startDate  Inclusive start (Y-m-d).
+     * @param string             $endDate    Inclusive end (Y-m-d), required.
+     * @param string             $scope      One of all|caseTypes|cases.
+     * @param array<int, string> $scopeRefs  caseType/case UUIDs when narrowed.
+     * @param string             $reason     One of verlof|ziekte|anders.
+     *
+     * @return array{0: DateTimeImmutable, 1: DateTimeImmutable} The resolved [start, end] period.
+     *
+     * @throws InvalidArgumentException On any validation failure.
+     *
+     * @spec openspec/specs/handler-vervanging-waarneming/spec.md
+     */
+    public function validateCreate(
+        string $absentee,
+        string $substitute,
+        string $startDate,
+        string $endDate,
+        string $scope,
+        array $scopeRefs,
+        string $reason
+    ): array {
+        $this->assertIdentities(absentee: $absentee, substitute: $substitute);
+        $this->assertEnums(scope: $scope, reason: $reason);
+
+        $period = $this->resolvePeriod(startDate: $startDate, endDate: $endDate);
+
+        $this->assertScopeRefs(scope: $scope, scopeRefs: $scopeRefs);
+
+        return $period;
+    }//end validateCreate()
+
+    /**
+     * Reject a missing or self-referential handler pair.
+     *
+     * @param string $absentee   Handler being covered (user id).
+     * @param string $substitute Waarnemer (user id).
+     *
+     * @return void
+     *
+     * @throws InvalidArgumentException When either id is empty or they are equal.
+     *
+     * @spec openspec/specs/handler-vervanging-waarneming/spec.md
+     */
+    private function assertIdentities(string $absentee, string $substitute): void
+    {
+        if ($absentee === '' || $substitute === '') {
+            throw new InvalidArgumentException('Both absentee and substitute are required');
+        }
+
+        if ($absentee === $substitute) {
+            throw new InvalidArgumentException('A handler cannot be their own waarnemer (self-substitution is not allowed)');
+        }
+    }//end assertIdentities()
+
+    /**
+     * Reject an unknown scope or reason.
+     *
+     * @param string $scope  One of all|caseTypes|cases.
+     * @param string $reason One of verlof|ziekte|anders.
+     *
+     * @return void
+     *
+     * @throws InvalidArgumentException When either value is outside its enum.
+     *
+     * @spec openspec/specs/handler-vervanging-waarneming/spec.md
+     */
+    private function assertEnums(string $scope, string $reason): void
+    {
+        if (in_array($scope, ['all', 'caseTypes', 'cases'], true) === false) {
+            throw new InvalidArgumentException('Invalid scope; expected all, caseTypes or cases');
+        }
+
+        if (in_array($reason, ['verlof', 'ziekte', 'anders'], true) === false) {
+            throw new InvalidArgumentException('Invalid reason; expected verlof, ziekte or anders');
+        }
+    }//end assertEnums()
+
+    /**
+     * Parse and order the substitution period. Open-ended absences are rejected.
+     *
+     * @param string $startDate Inclusive start (Y-m-d).
+     * @param string $endDate   Inclusive end (Y-m-d).
+     *
+     * @return array{0: DateTimeImmutable, 1: DateTimeImmutable} The resolved [start, end] period.
+     *
+     * @throws InvalidArgumentException When either date is unparseable or the range is inverted.
+     *
+     * @spec openspec/specs/handler-vervanging-waarneming/spec.md
+     */
+    private function resolvePeriod(string $startDate, string $endDate): array
+    {
+        $start = $this->parseDate(value: $startDate);
+        $end   = $this->parseDate(value: $endDate);
+        if ($start === null) {
+            throw new InvalidArgumentException('A valid startDate (YYYY-MM-DD) is required');
+        }
+
+        if ($end === null) {
+            throw new InvalidArgumentException(
+                'A valid endDate (YYYY-MM-DD) is required; open-ended absences must be re-issued or converted to a bulk reassignment'
+            );
+        }
+
+        if ($end < $start) {
+            throw new InvalidArgumentException('endDate must not be before startDate');
+        }
+
+        return [$start, $end];
+    }//end resolvePeriod()
+
+    /**
+     * Require scope refs whenever the scope is narrowed.
+     *
+     * @param string             $scope     One of all|caseTypes|cases.
+     * @param array<int, string> $scopeRefs caseType/case UUIDs when narrowed.
+     *
+     * @return void
+     *
+     * @throws InvalidArgumentException When a narrowed scope carries no refs.
+     *
+     * @spec openspec/specs/handler-vervanging-waarneming/spec.md
+     */
+    private function assertScopeRefs(string $scope, array $scopeRefs): void
+    {
+        if (($scope === 'caseTypes' || $scope === 'cases') && count($scopeRefs) === 0) {
+            throw new InvalidArgumentException('scopeRefs is required when scope is caseTypes or cases');
+        }
+    }//end assertScopeRefs()
+
+    /**
+     * Reject a new substitution that overlaps an existing active full-scope one.
+     *
+     * Only `all`+`all` overlaps for the same absentee and period are rejected;
+     * disjoint scopes are allowed to coexist.
+     *
+     * @param string            $absentee The covered handler.
+     * @param string            $scope    The new substitution scope.
+     * @param DateTimeImmutable $start    New start.
+     * @param DateTimeImmutable $end      New end.
+     *
+     * @return void
+     *
+     * @throws InvalidArgumentException When a conflicting full-scope substitution exists.
+     *
+     * @spec openspec/specs/handler-vervanging-waarneming/spec.md
+     */
+    public function assertNoOverlappingFullScope(string $absentee, string $scope, DateTimeImmutable $start, DateTimeImmutable $end): void
+    {
+        if ($scope !== 'all') {
+            return;
+        }
+
+        $objectService = $this->settingsService->getObjectService();
+        $register      = (string) $this->settingsService->getConfigValue('register');
+        $schema        = (string) $this->settingsService->getConfigValue('substitution_schema');
+        if ($objectService === null) {
+            return;
+        }
+
+        $rows = $this->searchObjectsAsArrays(
+            objectService: $objectService,
+            register: $register,
+            schema: $schema,
+            filters: ['absentee' => $absentee]
+        );
+
+        foreach ($rows as $row) {
+            if ($this->rowOverlapsFullScope(row: $row, start: $start, end: $end) === false) {
+                continue;
+            }
+
+            $conflictId = (string) ($row['id'] ?? ($row['uuid'] ?? '?'));
+            throw new InvalidArgumentException(
+                'An active full-scope substitution already covers this handler for an '
+                .'overlapping period (conflicting substitution: '.$conflictId.')'
+            );
+        }
+    }//end assertNoOverlappingFullScope()
+
+    /**
+     * Whether one existing row is an active full-scope substitution whose period
+     * overlaps the candidate period.
+     *
+     * @param array<string, mixed> $row   An existing substitution row.
+     * @param DateTimeImmutable    $start Candidate start.
+     * @param DateTimeImmutable    $end   Candidate end.
+     *
+     * @return bool True when the row conflicts with the candidate period.
+     *
+     * @spec openspec/specs/handler-vervanging-waarneming/spec.md
+     */
+    private function rowOverlapsFullScope(array $row, DateTimeImmutable $start, DateTimeImmutable $end): bool
+    {
+        if ((string) ($row['status'] ?? '') !== 'active') {
+            return false;
+        }
+
+        if ((string) ($row['scope'] ?? '') !== 'all') {
+            return false;
+        }
+
+        $existingStart = $this->parseDate(value: (string) ($row['startDate'] ?? ''));
+        $existingEnd   = $this->parseDate(value: (string) ($row['endDate'] ?? ''));
+        if ($existingStart === null || $existingEnd === null) {
+            return false;
+        }
+
+        // Overlap when neither range is entirely before the other.
+        return ($start <= $existingEnd && $existingStart <= $end);
+    }//end rowOverlapsFullScope()
+
+    /**
+     * Parse a YYYY-MM-DD date string into an immutable date (midnight).
+     *
+     * @param string $value The date string.
+     *
+     * @return DateTimeImmutable|null The parsed date, or null when unparseable.
+     *
+     * @spec openspec/specs/handler-vervanging-waarneming/spec.md
+     */
+    public function parseDate(string $value): ?DateTimeImmutable
+    {
+        // An empty/garbage value simply fails the pattern, so no separate
+        // empty check is needed. checkdate() then rejects out-of-range
+        // components, which is what makes the constructor call below safe
+        // (it can no longer throw) — a plain `new` keeps this free of a
+        // static factory call.
+        if (preg_match('/^(\d{4})-(\d{1,2})-(\d{1,2})/', trim($value), $parts) !== 1) {
+            return null;
+        }
+
+        if (checkdate((int) $parts[2], (int) $parts[3], (int) $parts[1]) === false) {
+            return null;
+        }
+
+        return new DateTimeImmutable($parts[0].' 00:00:00');
+    }//end parseDate()
+}//end class

--- a/lib/Service/SubstitutionService.php
+++ b/lib/Service/SubstitutionService.php
@@ -37,7 +37,8 @@ declare(strict_types=1);
 namespace OCA\Procest\Service;
 
 use DateTimeImmutable;
-use InvalidArgumentException;
+use OCA\Procest\Service\Substitution\SubstitutedWorkResolver;
+use OCA\Procest\Service\Substitution\SubstitutionValidator;
 use OCA\Procest\Service\Support\SearchesObjects;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
@@ -61,14 +62,18 @@ class SubstitutionService
     /**
      * Constructor.
      *
-     * @param SettingsService $settingsService The settings/config + ObjectService bridge.
-     * @param LoggerInterface $logger          The logger.
+     * @param SettingsService         $settingsService The settings/config + ObjectService bridge.
+     * @param LoggerInterface         $logger          The logger.
+     * @param SubstitutionValidator   $validator       Create-input validation + overlap detection.
+     * @param SubstitutedWorkResolver $workResolver    Resolver for the work a substitution routes.
      *
      * @return void
      */
     public function __construct(
         private readonly SettingsService $settingsService,
         private readonly LoggerInterface $logger,
+        private readonly SubstitutionValidator $validator,
+        private readonly SubstitutedWorkResolver $workResolver,
     ) {
     }//end __construct()
 
@@ -110,43 +115,17 @@ class SubstitutionService
         $absentee   = trim($absentee);
         $substitute = trim($substitute);
 
-        if ($absentee === '' || $substitute === '') {
-            throw new InvalidArgumentException('Both absentee and substitute are required');
-        }
+        [$start, $end] = $this->validator->validateCreate(
+            absentee: $absentee,
+            substitute: $substitute,
+            startDate: $startDate,
+            endDate: $endDate,
+            scope: $scope,
+            scopeRefs: $scopeRefs,
+            reason: $reason
+        );
 
-        if ($absentee === $substitute) {
-            throw new InvalidArgumentException('A handler cannot be their own waarnemer (self-substitution is not allowed)');
-        }
-
-        if (in_array($scope, ['all', 'caseTypes', 'cases'], true) === false) {
-            throw new InvalidArgumentException('Invalid scope; expected all, caseTypes or cases');
-        }
-
-        if (in_array($reason, ['verlof', 'ziekte', 'anders'], true) === false) {
-            throw new InvalidArgumentException('Invalid reason; expected verlof, ziekte or anders');
-        }
-
-        $start = $this->parseDate(value: $startDate);
-        $end   = $this->parseDate(value: $endDate);
-        if ($start === null) {
-            throw new InvalidArgumentException('A valid startDate (YYYY-MM-DD) is required');
-        }
-
-        if ($end === null) {
-            throw new InvalidArgumentException(
-                'A valid endDate (YYYY-MM-DD) is required; open-ended absences must be re-issued or converted to a bulk reassignment'
-            );
-        }
-
-        if ($end < $start) {
-            throw new InvalidArgumentException('endDate must not be before startDate');
-        }
-
-        if (($scope === 'caseTypes' || $scope === 'cases') && count($scopeRefs) === 0) {
-            throw new InvalidArgumentException('scopeRefs is required when scope is caseTypes or cases');
-        }
-
-        $this->assertNoOverlappingFullScope(
+        $this->validator->assertNoOverlappingFullScope(
             absentee: $absentee,
             scope: $scope,
             start: $start,
@@ -252,43 +231,78 @@ class SubstitutionService
 
         $active = [];
         foreach ($rows as $row) {
-            $status = (string) ($row['status'] ?? '');
-            if ($status === 'revoked') {
-                continue;
+            $isActive = $this->isRowActiveOn(
+                row: $row,
+                refDay: $refDay,
+                objectService: $objectService,
+                register: $register,
+                schema: $schema
+            );
+            if ($isActive === true) {
+                $active[] = $row;
             }
-
-            $start = (string) ($row['startDate'] ?? '');
-            $end   = (string) ($row['endDate'] ?? '');
-
-            // Lazy expiry: past endDate -> ended, excluded.
-            if ($end !== '' && $refDay > $end) {
-                if ($status === 'active') {
-                    $this->markEnded(
-                        objectService: $objectService,
-                        register: $register,
-                        schema: $schema,
-                        row: $row
-                    );
-                }
-
-                continue;
-            }
-
-            if ($status !== 'active') {
-                continue;
-            }
-
-            if ($start !== '' && $refDay < $start) {
-                continue;
-            }
-
-            $active[] = $row;
-        }//end foreach
+        }
 
         $this->activeCache[$cacheKey] = $active;
 
         return $active;
     }//end getActiveSubstitutionsFor()
+
+    /**
+     * Whether one substitution row is active on the reference day.
+     *
+     * Applies the lazy-expiry side effect: a row whose endDate has passed while
+     * still marked `active` is best-effort persisted as `ended` and excluded.
+     *
+     * @param array<string, mixed> $row           The substitution row.
+     * @param string               $refDay        Reference day (Y-m-d).
+     * @param object               $objectService The ObjectService.
+     * @param string               $register      Register id.
+     * @param string               $schema        Substitution schema id.
+     *
+     * @return bool True when the row is active on the reference day.
+     *
+     * @spec openspec/specs/handler-vervanging-waarneming/spec.md
+     */
+    private function isRowActiveOn(
+        array $row,
+        string $refDay,
+        object $objectService,
+        string $register,
+        string $schema
+    ): bool {
+        $status = (string) ($row['status'] ?? '');
+        if ($status === 'revoked') {
+            return false;
+        }
+
+        $start = (string) ($row['startDate'] ?? '');
+        $end   = (string) ($row['endDate'] ?? '');
+
+        // Lazy expiry: past endDate -> ended, excluded.
+        if ($end !== '' && $refDay > $end) {
+            if ($status === 'active') {
+                $this->markEnded(
+                    objectService: $objectService,
+                    register: $register,
+                    schema: $schema,
+                    row: $row
+                );
+            }
+
+            return false;
+        }
+
+        if ($status !== 'active') {
+            return false;
+        }
+
+        if ($start !== '' && $refDay < $start) {
+            return false;
+        }
+
+        return true;
+    }//end isRowActiveOn()
 
     /**
      * Resolve the substituted open cases and tasks routed to a waarnemer.
@@ -309,92 +323,9 @@ class SubstitutionService
      */
     public function getSubstitutedWorkFor(string $userId, ?DateTimeImmutable $date=null): array
     {
-        $result = ['cases' => [], 'tasks' => []];
-        $subs   = $this->getActiveSubstitutionsFor(userId: $userId, date: $date);
-        if (count($subs) === 0) {
-            return $result;
-        }
-
-        [$objectService, $register] = $this->resolveContext();
-        if ($objectService === null) {
-            return $result;
-        }
-
-        $caseSchema = (string) $this->settingsService->getConfigValue('case_schema');
-        $taskSchema = (string) $this->settingsService->getConfigValue('task_schema');
-        $finalIds   = $this->finalStatusIds(objectService: $objectService, register: $register);
-
-        $seenCases = [];
-        $seenTasks = [];
-
-        foreach ($subs as $sub) {
-            $absentee  = (string) ($sub['absentee'] ?? '');
-            $subId     = (string) ($sub['id'] ?? ($sub['uuid'] ?? ''));
-            $scope     = (string) ($sub['scope'] ?? 'all');
-            $scopeRefs = array_map('strval', (array) ($sub['scopeRefs'] ?? []));
-            if ($absentee === '') {
-                continue;
-            }
-
-            // Cases the absentee handles.
-            if ($caseSchema !== '') {
-                $cases = $this->searchObjectsAsArrays(
-                    objectService: $objectService,
-                    register: $register,
-                    schema: $caseSchema,
-                    filters: ['assignee' => $absentee]
-                );
-                foreach ($cases as $case) {
-                    if ($this->caseInScope(case: $case, scope: $scope, scopeRefs: $scopeRefs) === false) {
-                        continue;
-                    }
-
-                    if (in_array((string) ($case['status'] ?? ''), $finalIds, true) === true) {
-                        continue;
-                    }
-
-                    $id = (string) ($case['id'] ?? ($case['uuid'] ?? ''));
-                    if ($id === '' || isset($seenCases[$id]) === true) {
-                        continue;
-                    }
-
-                    $seenCases[$id]       = true;
-                    $case['_substituted'] = ['absentee' => $absentee, 'substitutionId' => $subId];
-                    $result['cases'][]    = $case;
-                }//end foreach
-            }//end if
-
-            // Tasks the absentee is assigned (open = not completed/terminated).
-            if ($taskSchema !== '') {
-                $tasks = $this->searchObjectsAsArrays(
-                    objectService: $objectService,
-                    register: $register,
-                    schema: $taskSchema,
-                    filters: ['assignee' => $absentee]
-                );
-                foreach ($tasks as $task) {
-                    $tStatus = (string) ($task['status'] ?? '');
-                    if (in_array($tStatus, ['completed', 'terminated', 'disabled'], true) === true) {
-                        continue;
-                    }
-
-                    if ($scope === 'cases' && in_array((string) ($task['case'] ?? ''), $scopeRefs, true) === false) {
-                        continue;
-                    }
-
-                    $id = (string) ($task['id'] ?? ($task['uuid'] ?? ''));
-                    if ($id === '' || isset($seenTasks[$id]) === true) {
-                        continue;
-                    }
-
-                    $seenTasks[$id]       = true;
-                    $task['_substituted'] = ['absentee' => $absentee, 'substitutionId' => $subId];
-                    $result['tasks'][]    = $task;
-                }//end foreach
-            }//end if
-        }//end foreach
-
-        return $result;
+        return $this->workResolver->resolve(
+            subs: $this->getActiveSubstitutionsFor(userId: $userId, date: $date)
+        );
     }//end getSubstitutedWorkFor()
 
     /**
@@ -434,103 +365,13 @@ class SubstitutionService
             $scope     = (string) ($sub['scope'] ?? 'all');
             $scopeRefs = array_map('strval', (array) ($sub['scopeRefs'] ?? []));
             $probe     = ['caseType' => $caseType, 'id' => $caseId];
-            if ($this->caseInScope(case: $probe, scope: $scope, scopeRefs: $scopeRefs) === true) {
+            if ($this->workResolver->caseInScope(case: $probe, scope: $scope, scopeRefs: $scopeRefs) === true) {
                 return $sub;
             }
         }
 
         return null;
     }//end resolveActingCapacity()
-
-    /**
-     * Whether a case falls within a substitution scope.
-     *
-     * @param array<string, mixed> $case      The case object.
-     * @param string               $scope     all|caseTypes|cases.
-     * @param array<int, string>   $scopeRefs The narrowed refs.
-     *
-     * @return bool
-     *
-     * @spec openspec/specs/handler-vervanging-waarneming/spec.md
-     */
-    private function caseInScope(array $case, string $scope, array $scopeRefs): bool
-    {
-        if ($scope === 'all') {
-            return true;
-        }
-
-        if ($scope === 'caseTypes') {
-            return in_array((string) ($case['caseType'] ?? ''), $scopeRefs, true);
-        }
-
-        if ($scope === 'cases') {
-            $id = (string) ($case['id'] ?? ($case['uuid'] ?? ''));
-            return in_array($id, $scopeRefs, true);
-        }
-
-        return false;
-    }//end caseInScope()
-
-    /**
-     * Reject a new substitution that overlaps an existing active full-scope one.
-     *
-     * Only `all`+`all` overlaps for the same absentee and period are rejected;
-     * disjoint scopes are allowed to coexist.
-     *
-     * @param string            $absentee The covered handler.
-     * @param string            $scope    The new substitution scope.
-     * @param DateTimeImmutable $start    New start.
-     * @param DateTimeImmutable $end      New end.
-     *
-     * @return void
-     *
-     * @throws InvalidArgumentException When a conflicting full-scope substitution exists.
-     *
-     * @spec openspec/specs/handler-vervanging-waarneming/spec.md
-     */
-    private function assertNoOverlappingFullScope(string $absentee, string $scope, DateTimeImmutable $start, DateTimeImmutable $end): void
-    {
-        if ($scope !== 'all') {
-            return;
-        }
-
-        [$objectService, $register, $schema] = $this->resolveContext();
-        if ($objectService === null) {
-            return;
-        }
-
-        $rows = $this->searchObjectsAsArrays(
-            objectService: $objectService,
-            register: $register,
-            schema: $schema,
-            filters: ['absentee' => $absentee]
-        );
-
-        foreach ($rows as $row) {
-            if ((string) ($row['status'] ?? '') !== 'active') {
-                continue;
-            }
-
-            if ((string) ($row['scope'] ?? '') !== 'all') {
-                continue;
-            }
-
-            $existingStart = $this->parseDate(value: (string) ($row['startDate'] ?? ''));
-            $existingEnd   = $this->parseDate(value: (string) ($row['endDate'] ?? ''));
-            if ($existingStart === null || $existingEnd === null) {
-                continue;
-            }
-
-            // Overlap when neither range is entirely before the other.
-            if ($start <= $existingEnd && $existingStart <= $end) {
-                $conflictId = (string) ($row['id'] ?? ($row['uuid'] ?? '?'));
-                throw new InvalidArgumentException(
-                    'An active full-scope substitution already covers this handler for an '
-                    .'overlapping period (conflicting substitution: '.$conflictId.')'
-                );
-            }
-        }//end foreach
-    }//end assertNoOverlappingFullScope()
 
     /**
      * Best-effort lazy persistence of the `ended` status.
@@ -556,63 +397,6 @@ class SubstitutionService
             $this->logger->warning('Substitution lazy-ended persistence failed', ['id' => $id, 'error' => $e->getMessage()]);
         }
     }//end markEnded()
-
-    /**
-     * Resolve the set of final statusType ids (closed/archived cases).
-     *
-     * @param object $objectService The ObjectService.
-     * @param string $register      Register id.
-     *
-     * @return array<int, string>
-     */
-    private function finalStatusIds(object $objectService, string $register): array
-    {
-        $statusTypeSchema = (string) $this->settingsService->getConfigValue('status_type_schema');
-        if ($statusTypeSchema === '') {
-            return [];
-        }
-
-        try {
-            $rows = $this->searchObjectsAsArrays(objectService: $objectService, register: $register, schema: $statusTypeSchema);
-        } catch (\Throwable $e) {
-            return [];
-        }
-
-        $ids = [];
-        foreach ($rows as $row) {
-            $isFinal = ($row['isFinal'] ?? false);
-            if ($isFinal === true || $isFinal === 'true' || $isFinal === 1) {
-                $ids[] = (string) ($row['id'] ?? ($row['uuid'] ?? ''));
-            }
-        }
-
-        return array_values(array_filter($ids));
-    }//end finalStatusIds()
-
-    /**
-     * Parse a YYYY-MM-DD date string into an immutable date (midnight).
-     *
-     * @param string $value The date string.
-     *
-     * @return DateTimeImmutable|null
-     */
-    private function parseDate(string $value): ?DateTimeImmutable
-    {
-        // An empty/garbage value simply fails the pattern, so no separate
-        // empty check is needed. checkdate() then rejects out-of-range
-        // components, which is what makes the constructor call below safe
-        // (it can no longer throw) — a plain `new` keeps this free of a
-        // static factory call.
-        if (preg_match('/^(\d{4})-(\d{1,2})-(\d{1,2})/', trim($value), $parts) !== 1) {
-            return null;
-        }
-
-        if (checkdate((int) $parts[2], (int) $parts[3], (int) $parts[1]) === false) {
-            return null;
-        }
-
-        return new DateTimeImmutable($parts[0].' 00:00:00');
-    }//end parseDate()
 
     /**
      * Resolve the ObjectService + register + substitution schema context,

--- a/lib/Service/SubstitutionService.php
+++ b/lib/Service/SubstitutionService.php
@@ -96,8 +96,8 @@ class SubstitutionService
      *
      * @return array<string, mixed> The created substitution object.
      *
-     * @throws InvalidArgumentException On any validation failure.
-     * @throws \RuntimeException        When OpenRegister is unavailable.
+     * @throws \InvalidArgumentException On any validation failure.
+     * @throws \RuntimeException         When OpenRegister is unavailable.
      *
      * @spec openspec/specs/handler-vervanging-waarneming/spec.md
      */

--- a/lib/Service/TermijnDailyScanService.php
+++ b/lib/Service/TermijnDailyScanService.php
@@ -190,19 +190,7 @@ class TermijnDailyScanService
 
         // Pause-expiry detection.
         if ($status === 'gepauzeerd') {
-            $pauseEnd = (string) ($row['pauzeDeadline'] ?? '');
-            if ($pauseEnd !== '' && $pauseEnd < $now->format('Y-m-d')) {
-                $counts['pauseExpired']++;
-                $this->termijnService->recordEvent(
-                    termijnInstanceId: $rowId,
-                    type: 'pauze-verlopen',
-                    grondslag: 'AWB 4:5',
-                    motivering: 'Pauzetermijn verlopen zonder aanvulling',
-                    dagenImpact: 0,
-                    tijdstip: $now,
-                );
-            }
-
+            $this->handlePauseExpiry(row: $row, rowId: $rowId, now: $now, counts: $counts);
             return;
         }
 
@@ -211,39 +199,111 @@ class TermijnDailyScanService
             return;
         }
 
-        $deadlineDate = new DateTimeImmutable($deadline);
-        $today        = new DateTimeImmutable($now->format('Y-m-d'));
-        $diff         = (int) $today->diff($deadlineDate)->days;
-        $daysLeft     = $diff;
-        if ($today > $deadlineDate) {
-            $daysLeft = (-1 * $diff);
-        }
+        $daysLeft = $this->calculateDaysLeft(deadline: $deadline, now: $now);
 
         // Overschrijding.
         if ($daysLeft <= 0 && $status !== 'overschreden') {
-            $counts['overschreden']++;
-            $this->termijnService->updateTermijnInstance($rowId, ['status' => 'overschreden']);
-            $this->termijnService->recordEvent(
-                termijnInstanceId: $rowId,
-                type: 'overschreden',
-                grondslag: 'AWB 4:13',
-                motivering: 'Termijn overschreden zonder beschikking',
-                dagenImpact: 0,
-                tijdstip: $now,
-            );
+            $this->recordOverschrijding(rowId: $rowId, now: $now, counts: $counts);
             $row['status'] = 'overschreden';
         }
 
         // Threshold escalation.
-        $bucket = $this->escalationService->bucketFor($daysLeft);
-        if ($bucket !== null) {
-            // Re-read instance to pick up the just-updated status/notificatiesVerstuurd.
-            $latest = $this->termijnService->getTermijnInstance($rowId);
-            if ($latest !== null) {
-                if ($this->escalationService->notifyThreshold($latest, $bucket) === true) {
-                    $counts['escalated']++;
-                }
-            }
-        }
+        $this->escalateThreshold(rowId: $rowId, daysLeft: $daysLeft, counts: $counts);
     }//end processInstance()
+
+    /**
+     * Emit a `pauze-verlopen` event when a paused instance ran past its pause deadline.
+     *
+     * @param array<string, mixed> $row    Instance row.
+     * @param string               $rowId  Instance identifier.
+     * @param DateTimeImmutable    $now    Now.
+     * @param array<string, int>   $counts Running counts (by reference).
+     *
+     * @return void
+     */
+    private function handlePauseExpiry(array $row, string $rowId, DateTimeImmutable $now, array &$counts): void
+    {
+        $pauseEnd = (string) ($row['pauzeDeadline'] ?? '');
+        if ($pauseEnd !== '' && $pauseEnd < $now->format('Y-m-d')) {
+            $counts['pauseExpired']++;
+            $this->termijnService->recordEvent(
+                termijnInstanceId: $rowId,
+                type: 'pauze-verlopen',
+                grondslag: 'AWB 4:5',
+                motivering: 'Pauzetermijn verlopen zonder aanvulling',
+                dagenImpact: 0,
+                tijdstip: $now,
+            );
+        }
+    }//end handlePauseExpiry()
+
+    /**
+     * Compute the signed number of days left until a deadline.
+     *
+     * @param string            $deadline Deadline date string.
+     * @param DateTimeImmutable $now      Now.
+     *
+     * @return int Positive when the deadline lies ahead, negative when it has passed.
+     */
+    private function calculateDaysLeft(string $deadline, DateTimeImmutable $now): int
+    {
+        $deadlineDate = new DateTimeImmutable($deadline);
+        $today        = new DateTimeImmutable($now->format('Y-m-d'));
+        $diff         = (int) $today->diff($deadlineDate)->days;
+        if ($today > $deadlineDate) {
+            return (-1 * $diff);
+        }
+
+        return $diff;
+    }//end calculateDaysLeft()
+
+    /**
+     * Flip an instance to `overschreden` and record the accompanying event.
+     *
+     * @param string             $rowId  Instance identifier.
+     * @param DateTimeImmutable  $now    Now.
+     * @param array<string, int> $counts Running counts (by reference).
+     *
+     * @return void
+     */
+    private function recordOverschrijding(string $rowId, DateTimeImmutable $now, array &$counts): void
+    {
+        $counts['overschreden']++;
+        $this->termijnService->updateTermijnInstance($rowId, ['status' => 'overschreden']);
+        $this->termijnService->recordEvent(
+            termijnInstanceId: $rowId,
+            type: 'overschreden',
+            grondslag: 'AWB 4:13',
+            motivering: 'Termijn overschreden zonder beschikking',
+            dagenImpact: 0,
+            tijdstip: $now,
+        );
+    }//end recordOverschrijding()
+
+    /**
+     * Dispatch threshold escalation for an instance when its days-left falls in a bucket.
+     *
+     * @param string             $rowId    Instance identifier.
+     * @param int                $daysLeft Signed days left until the deadline.
+     * @param array<string, int> $counts   Running counts (by reference).
+     *
+     * @return void
+     */
+    private function escalateThreshold(string $rowId, int $daysLeft, array &$counts): void
+    {
+        $bucket = $this->escalationService->bucketFor($daysLeft);
+        if ($bucket === null) {
+            return;
+        }
+
+        // Re-read instance to pick up the just-updated status/notificatiesVerstuurd.
+        $latest = $this->termijnService->getTermijnInstance($rowId);
+        if ($latest === null) {
+            return;
+        }
+
+        if ($this->escalationService->notifyThreshold($latest, $bucket) === true) {
+            $counts['escalated']++;
+        }
+    }//end escalateThreshold()
 }//end class

--- a/lib/Service/TermijnExtensionService.php
+++ b/lib/Service/TermijnExtensionService.php
@@ -150,38 +150,18 @@ class TermijnExtensionService
         string $documentLink,
         string $mode
     ): array {
-        if (trim($motivering) === '') {
-            throw new RuntimeException('Motivering is required for AWB 4:14 verlenging');
-        }
-
-        if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $newEinddatum) !== 1) {
-            throw new RuntimeException('newEinddatum must be in YYYY-MM-DD format');
-        }
+        $this->assertExtensionInput(motivering: $motivering, newEinddatum: $newEinddatum);
 
         $instance = $this->termijnService->getTermijnInstance($termijnInstanceId);
         if ($instance === null) {
             throw new RuntimeException('TermijnInstance not found: '.$termijnInstanceId);
         }
 
-        $current = (string) ($instance['einddatumActueel'] ?? '');
-        if ($current !== '' && $newEinddatum <= $current) {
-            throw new RuntimeException('newEinddatum must be later than current einddatumActueel');
-        }
+        $this->assertExtensionPermitted(instance: $instance, newEinddatum: $newEinddatum, mode: $mode);
 
-        $consumed = (int) ($instance['aantalVerlengingen'] ?? 0);
-        $maxExt   = $this->resolveMaxExtensions(instance: $instance);
-        if ($mode !== self::MODE_SUPERVISOR && $consumed >= $maxExt) {
-            throw new RuntimeException('AWB 4:14 lid 3: maximum aantal verlengingen al verbruikt ('.$maxExt.')');
-        }
-
-        $currentInput = 'now';
-        if ($current !== '') {
-            $currentInput = $current;
-        }
-
-        $currentDate = new DateTimeImmutable($currentInput);
-        $newDate     = new DateTimeImmutable($newEinddatum);
-        $dagenImpact = (int) $currentDate->diff($newDate)->days;
+        $current     = (string) ($instance['einddatumActueel'] ?? '');
+        $consumed    = (int) ($instance['aantalVerlengingen'] ?? 0);
+        $dagenImpact = $this->calculateDagenImpact(current: $current, newEinddatum: $newEinddatum);
 
         $updated = $this->termijnService->updateTermijnInstance(
             $termijnInstanceId,
@@ -192,25 +172,109 @@ class TermijnExtensionService
             ]
         );
 
-        $grondslag = 'AWB 4:14 lid 1';
-        $actor     = 'system';
-        if ($mode === self::MODE_SUPERVISOR) {
-            $grondslag = 'AWB 4:14 lid 3 (supervisor)';
-            $actor     = 'supervisor';
-        }
+        $context = $this->resolveExtensionContext(mode: $mode);
 
         $this->termijnService->recordEvent(
             termijnInstanceId: $termijnInstanceId,
             type: 'verleng',
-            grondslag: $grondslag,
+            grondslag: $context['grondslag'],
             motivering: $motivering,
             dagenImpact: $dagenImpact,
             documentLink: $documentLink,
-            actor: $actor,
+            actor: $context['actor'],
         );
 
         return $updated ?? $instance;
     }//end applyExtension()
+
+    /**
+     * Validate the raw verlenging input before any lookup is performed.
+     *
+     * @param string $motivering   Non-empty reason.
+     * @param string $newEinddatum New deadline (YYYY-MM-DD).
+     *
+     * @return void
+     *
+     * @throws RuntimeException When the motivering is empty or the date is malformed.
+     */
+    private function assertExtensionInput(string $motivering, string $newEinddatum): void
+    {
+        if (trim($motivering) === '') {
+            throw new RuntimeException('Motivering is required for AWB 4:14 verlenging');
+        }
+
+        if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $newEinddatum) !== 1) {
+            throw new RuntimeException('newEinddatum must be in YYYY-MM-DD format');
+        }
+    }//end assertExtensionInput()
+
+    /**
+     * Validate the verlenging against the instance state and the AWB 4:14 ceiling.
+     *
+     * @param array<string, mixed> $instance     Instance row.
+     * @param string               $newEinddatum New deadline (YYYY-MM-DD).
+     * @param string               $mode         One of self::MODE_STANDARD or self::MODE_SUPERVISOR.
+     *
+     * @return void
+     *
+     * @throws RuntimeException When the deadline does not move forward or the ceiling is exhausted.
+     */
+    private function assertExtensionPermitted(array $instance, string $newEinddatum, string $mode): void
+    {
+        $current = (string) ($instance['einddatumActueel'] ?? '');
+        if ($current !== '' && $newEinddatum <= $current) {
+            throw new RuntimeException('newEinddatum must be later than current einddatumActueel');
+        }
+
+        $consumed = (int) ($instance['aantalVerlengingen'] ?? 0);
+        $maxExt   = $this->resolveMaxExtensions(instance: $instance);
+        if ($mode !== self::MODE_SUPERVISOR && $consumed >= $maxExt) {
+            throw new RuntimeException('AWB 4:14 lid 3: maximum aantal verlengingen al verbruikt ('.$maxExt.')');
+        }
+    }//end assertExtensionPermitted()
+
+    /**
+     * Compute the number of days the deadline moves by.
+     *
+     * @param string $current      Current einddatumActueel, empty when unset.
+     * @param string $newEinddatum New deadline (YYYY-MM-DD).
+     *
+     * @return int Absolute number of days between the current and the new deadline.
+     */
+    private function calculateDagenImpact(string $current, string $newEinddatum): int
+    {
+        $currentInput = 'now';
+        if ($current !== '') {
+            $currentInput = $current;
+        }
+
+        $currentDate = new DateTimeImmutable($currentInput);
+        $newDate     = new DateTimeImmutable($newEinddatum);
+
+        return (int) $currentDate->diff($newDate)->days;
+    }//end calculateDagenImpact()
+
+    /**
+     * Resolve the grondslag and actor recorded with the verlenging event.
+     *
+     * @param string $mode One of self::MODE_STANDARD or self::MODE_SUPERVISOR.
+     *
+     * @return array{grondslag: string, actor: string} Event grondslag and actor for the mode.
+     */
+    private function resolveExtensionContext(string $mode): array
+    {
+        if ($mode === self::MODE_SUPERVISOR) {
+            return [
+                'grondslag' => 'AWB 4:14 lid 3 (supervisor)',
+                'actor'     => 'supervisor',
+            ];
+        }
+
+        return [
+            'grondslag' => 'AWB 4:14 lid 1',
+            'actor'     => 'system',
+        ];
+    }//end resolveExtensionContext()
 
     /**
      * Resolve the maximum number of extensions allowed for this instance.

--- a/lib/Service/TermijnReportingService.php
+++ b/lib/Service/TermijnReportingService.php
@@ -70,6 +70,34 @@ class TermijnReportingService
         $bounds = $this->resolveQuarter(periode: $periode);
         $rows   = $this->listInstances(from: $bounds['from'], until: $bounds['until']);
 
+        $byType = $this->aggregateByType(rows: $rows, afdeling: $afdeling);
+
+        // Reduce per-type aggregates.
+        $perType = $this->reducePerType(byType: $byType);
+
+        return [
+            'periode'  => $periode,
+            'afdeling' => $afdeling,
+            'from'     => $bounds['from'],
+            'until'    => $bounds['until'],
+            'perType'  => $perType,
+            'metadata' => [
+                'generatedAt' => (new DateTimeImmutable())->format('Y-m-d\TH:i:sP'),
+                'rowsScanned' => count($rows),
+            ],
+        ];
+    }//end generateQuarterlyReport()
+
+    /**
+     * Bucket instance rows per zaaktype, skipping rows outside the department filter.
+     *
+     * @param array<int, array<string, mixed>> $rows     Instance rows.
+     * @param string|null                      $afdeling Optional department filter.
+     *
+     * @return array<string, array<string, mixed>> Raw per-zaaktype tallies.
+     */
+    private function aggregateByType(array $rows, ?string $afdeling): array
+    {
         $byType = [];
         foreach ($rows as $row) {
             $type = (string) ($row['zaaktype'] ?? 'onbekend');
@@ -87,30 +115,54 @@ class TermijnReportingService
                 'dwangsomTotalCents'  => 0,
             ];
 
-            $byType[$type]['totaal']++;
-            $status = (string) ($row['status'] ?? '');
-            if ($status === 'voltooid') {
-                $byType[$type]['binnenTermijn']++;
-            }
+            $this->accumulateRow(row: $row, bucket: $byType[$type]);
+        }
 
-            if ($status === 'overschreden') {
-                $byType[$type]['overschrijdingen']++;
-            }
+        return $byType;
+    }//end aggregateByType()
 
-            if ((int) ($row['aantalVerlengingen'] ?? 0) > 0) {
-                $byType[$type]['verlengingen']++;
-            }
+    /**
+     * Fold a single instance row into its zaaktype bucket.
+     *
+     * @param array<string, mixed> $row    Instance row.
+     * @param array<string, mixed> $bucket Bucket for the row's zaaktype (by reference).
+     *
+     * @return void
+     */
+    private function accumulateRow(array $row, array &$bucket): void
+    {
+        $bucket['totaal']++;
+        $status = (string) ($row['status'] ?? '');
+        if ($status === 'voltooid') {
+            $bucket['binnenTermijn']++;
+        }
 
-            $start = (string) ($row['startDatum'] ?? '');
-            $eind  = (string) ($row['einddatumActueel'] ?? '');
-            if ($start !== '' && $eind !== '') {
-                $startD = new DateTimeImmutable(substr($start, 0, 10));
-                $eindD  = new DateTimeImmutable($eind);
-                $byType[$type]['doorlooptijdenDagen'][] = (int) $startD->diff($eindD)->days;
-            }
-        }//end foreach
+        if ($status === 'overschreden') {
+            $bucket['overschrijdingen']++;
+        }
 
-        // Reduce per-type aggregates.
+        if ((int) ($row['aantalVerlengingen'] ?? 0) > 0) {
+            $bucket['verlengingen']++;
+        }
+
+        $start = (string) ($row['startDatum'] ?? '');
+        $eind  = (string) ($row['einddatumActueel'] ?? '');
+        if ($start !== '' && $eind !== '') {
+            $startD = new DateTimeImmutable(substr($start, 0, 10));
+            $eindD  = new DateTimeImmutable($eind);
+            $bucket['doorlooptijdenDagen'][] = (int) $startD->diff($eindD)->days;
+        }
+    }//end accumulateRow()
+
+    /**
+     * Reduce the raw per-zaaktype tallies into the reported percentages and averages.
+     *
+     * @param array<string, array<string, mixed>> $byType Raw per-zaaktype tallies.
+     *
+     * @return array<string, array<string, mixed>> Reported per-zaaktype aggregates.
+     */
+    private function reducePerType(array $byType): array
+    {
         $perType = [];
         foreach ($byType as $type => $b) {
             // $byType entries are only created when a row is counted, so
@@ -136,18 +188,8 @@ class TermijnReportingService
             ];
         }//end foreach
 
-        return [
-            'periode'  => $periode,
-            'afdeling' => $afdeling,
-            'from'     => $bounds['from'],
-            'until'    => $bounds['until'],
-            'perType'  => $perType,
-            'metadata' => [
-                'generatedAt' => (new DateTimeImmutable())->format('Y-m-d\TH:i:sP'),
-                'rowsScanned' => count($rows),
-            ],
-        ];
-    }//end generateQuarterlyReport()
+        return $perType;
+    }//end reducePerType()
 
     /**
      * Generate an annual dwangsom audit report.
@@ -223,11 +265,49 @@ class TermijnReportingService
     {
         $rows = $this->listInstances(from: '1970-01-01', until: '2999-12-31');
 
+        $dwTotal = 0;
+        $totals  = $this->collectKpiTotals(rows: $rows, filters: $filters);
+
+        $total     = $totals['total'];
+        $within    = $totals['within'];
+        $overrun   = $totals['overrun'];
+        $durations = $totals['durations'];
+
+        $withinTermijnPercent = 0.0;
+        if ($total > 0) {
+            $withinTermijnPercent = round(($within / $total) * 100, 1);
+        }
+
+        $aantalDuraties  = count($durations);
+        $avgDurationDays = 0.0;
+        if ($aantalDuraties > 0) {
+            $avgDurationDays = round(array_sum($durations) / $aantalDuraties, 1);
+        }
+
+        return [
+            'totalZaken'           => $total,
+            'withinTermijnPercent' => $withinTermijnPercent,
+            'avgDurationDays'      => $avgDurationDays,
+            'overrunCount'         => $overrun,
+            'dwangsomTotalCents'   => $dwTotal,
+            'lastUpdated'          => (new DateTimeImmutable())->format('Y-m-d\TH:i:sP'),
+        ];
+    }//end getTermijnKpi()
+
+    /**
+     * Tally the dashboard KPI counters over the instance rows.
+     *
+     * @param array<int, array<string, mixed>> $rows    Instance rows.
+     * @param array<string, mixed>             $filters Optional filters (afdeling, zaaktype).
+     *
+     * @return array{total:int,within:int,overrun:int,durations:array<int,int>} Counters plus the collected doorlooptijden.
+     */
+    private function collectKpiTotals(array $rows, array $filters): array
+    {
         $total     = 0;
         $within    = 0;
         $overrun   = 0;
         $durations = [];
-        $dwTotal   = 0;
         foreach ($rows as $row) {
             if (isset($filters['zaaktype']) === true && (string) ($row['zaaktype'] ?? '') !== $filters['zaaktype']) {
                 continue;
@@ -250,26 +330,13 @@ class TermijnReportingService
             }
         }//end foreach
 
-        $withinTermijnPercent = 0.0;
-        if ($total > 0) {
-            $withinTermijnPercent = round(($within / $total) * 100, 1);
-        }
-
-        $aantalDuraties  = count($durations);
-        $avgDurationDays = 0.0;
-        if ($aantalDuraties > 0) {
-            $avgDurationDays = round(array_sum($durations) / $aantalDuraties, 1);
-        }
-
         return [
-            'totalZaken'           => $total,
-            'withinTermijnPercent' => $withinTermijnPercent,
-            'avgDurationDays'      => $avgDurationDays,
-            'overrunCount'         => $overrun,
-            'dwangsomTotalCents'   => $dwTotal,
-            'lastUpdated'          => (new DateTimeImmutable())->format('Y-m-d\TH:i:sP'),
+            'total'     => $total,
+            'within'    => $within,
+            'overrun'   => $overrun,
+            'durations' => $durations,
         ];
-    }//end getTermijnKpi()
+    }//end collectKpiTotals()
 
     /**
      * Generate a CSV for a quarterly report.

--- a/lib/Service/VTHTemplateService.php
+++ b/lib/Service/VTHTemplateService.php
@@ -130,6 +130,55 @@ class VTHTemplateService
      */
     public function activateTemplate(string $slug): array
     {
+        $template = $this->loadTemplateOrFail(slug: $slug);
+
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            throw new RuntimeException('OpenRegister is not available');
+        }
+
+        $config = $this->resolveSchemaConfig();
+
+        $caseTypeData = array_merge(
+            $template['caseType'] ?? [],
+            ['slug' => $template['id']]
+        );
+
+        $caseTypeObj = $this->upsertCaseType(
+            objectService: $objectService,
+            config: $config,
+            caseTypeData: $caseTypeData,
+            slug: $template['id']
+        );
+
+        $caseTypeId = $this->extractCaseTypeId(caseTypeObj: $caseTypeObj);
+
+        $counts = $this->seedTemplateSections(
+            objectService: $objectService,
+            config: $config,
+            template: $template,
+            caseTypeId: $caseTypeId
+        );
+
+        $this->logger->info(
+            'VTH template activated: '.$slug.' (caseType='.$caseTypeId.')',
+            ['app' => 'procest']
+        );
+
+        return ['caseTypeId' => $caseTypeId, 'template' => $slug, 'counts' => $counts];
+    }//end activateTemplate()
+
+    /**
+     * Resolve a template slug to its decoded JSON body.
+     *
+     * @param string $slug Template slug (e.g. 'vth-omgevingsvergunning')
+     *
+     * @return array<string, mixed> The decoded template body
+     *
+     * @throws RuntimeException If the template file is missing or cannot be parsed
+     */
+    private function loadTemplateOrFail(string $slug): array
+    {
         $file = self::TEMPLATES_DIR.'/'.ltrim(string: $slug, characters: '/').'.json';
         if (file_exists($file) === false) {
             throw new RuntimeException('VTH template not found: '.$slug);
@@ -140,33 +189,54 @@ class VTHTemplateService
             throw new RuntimeException('Failed to parse VTH template: '.$slug);
         }
 
-        $objectService = $this->settingsService->getObjectService();
-        if ($objectService === null) {
-            throw new RuntimeException('OpenRegister is not available');
-        }
+        return $template;
+    }//end loadTemplateOrFail()
 
-        $register         = $this->settingsService->getConfigValue('register');
-        $caseTypeSchema   = $this->settingsService->getConfigValue('case_type_schema');
-        $statusTypeSchema = $this->settingsService->getConfigValue('status_type_schema');
-        $roleTypeSchema   = $this->settingsService->getConfigValue('role_type_schema');
-        $docTypeSchema    = $this->settingsService->getConfigValue('document_type_schema');
-        $propDefSchema    = $this->settingsService->getConfigValue('property_definition_schema');
+    /**
+     * Read the register and schema references that activation writes into.
+     *
+     * @return array<string, string> Map with the register plus the caseType, statusType, roleType, docType and propDef schema refs
+     *
+     * @throws RuntimeException If the register or case type schema is not configured
+     */
+    private function resolveSchemaConfig(): array
+    {
+        $config = [
+            'register'         => $this->settingsService->getConfigValue('register'),
+            'caseTypeSchema'   => $this->settingsService->getConfigValue('case_type_schema'),
+            'statusTypeSchema' => $this->settingsService->getConfigValue('status_type_schema'),
+            'roleTypeSchema'   => $this->settingsService->getConfigValue('role_type_schema'),
+            'docTypeSchema'    => $this->settingsService->getConfigValue('document_type_schema'),
+            'propDefSchema'    => $this->settingsService->getConfigValue('property_definition_schema'),
+        ];
 
-        if ($register === '' || $caseTypeSchema === '') {
+        if ($config['register'] === '' || $config['caseTypeSchema'] === '') {
             throw new RuntimeException('Procest register or case type schema not configured');
         }
 
-        $caseTypeData = array_merge(
-            $template['caseType'] ?? [],
-            ['slug' => $template['id']]
-        );
+        return $config;
+    }//end resolveSchemaConfig()
 
-        // Create or update the case type (idempotent by slug).
+    /**
+     * Create or update the case type for a template (idempotent by slug).
+     *
+     * An existing case type carrying the template slug is updated in-place;
+     * otherwise a new one is created.
+     *
+     * @param object                $objectService The OpenRegister object service
+     * @param array<string, string> $config        Register and schema references from resolveSchemaConfig()
+     * @param array<string, mixed>  $caseTypeData  The case type payload to write
+     * @param mixed                 $slug          The template identifier used as the idempotency key
+     *
+     * @return mixed The saved case type, as returned by OpenRegister
+     */
+    private function upsertCaseType(object $objectService, array $config, array $caseTypeData, mixed $slug): mixed
+    {
         $existing = $this->searchObjectsAsArrays(
             objectService: $objectService,
-            register: $register,
-            schema: $caseTypeSchema,
-            filters: ['slug' => $template['id'], '_limit' => 1]
+            register: $config['register'],
+            schema: $config['caseTypeSchema'],
+            filters: ['slug' => $slug, '_limit' => 1]
         );
 
         $caseTypeObj = null;
@@ -180,8 +250,8 @@ class VTHTemplateService
             if (isset($row['id']) === true) {
                 $caseTypeData['id'] = $row['id'];
                 $caseTypeObj        = $objectService->saveObject(
-                    register: $register,
-                    schema: $caseTypeSchema,
+                    register: $config['register'],
+                    schema: $config['caseTypeSchema'],
                     object: $caseTypeData
                 );
             }
@@ -189,12 +259,24 @@ class VTHTemplateService
 
         if ($caseTypeObj === null) {
             $caseTypeObj = $objectService->saveObject(
-                register: $register,
-                schema: $caseTypeSchema,
+                register: $config['register'],
+                schema: $config['caseTypeSchema'],
                 object: $caseTypeData
             );
         }
 
+        return $caseTypeObj;
+    }//end upsertCaseType()
+
+    /**
+     * Read the case type identifier out of whatever OpenRegister returned.
+     *
+     * @param mixed $caseTypeObj The saved case type, either an array row or an entity object
+     *
+     * @return string The case type UUID, or an empty string when it cannot be determined
+     */
+    private function extractCaseTypeId(mixed $caseTypeObj): string
+    {
         $caseTypeId = '';
         if (is_array($caseTypeObj) === true) {
             $caseTypeId = $caseTypeObj['id'] ?? '';
@@ -204,60 +286,72 @@ class VTHTemplateService
             $caseTypeId = $caseTypeObj->getUuid();
         }
 
+        return $caseTypeId;
+    }//end extractCaseTypeId()
+
+    /**
+     * Seed the template's sub-object sections onto the activated case type.
+     *
+     * A section is skipped when its schema is not configured or the template
+     * does not declare it.
+     *
+     * @param object                $objectService The OpenRegister object service
+     * @param array<string, string> $config        Register and schema references from resolveSchemaConfig()
+     * @param array<string, mixed>  $template      The decoded template body
+     * @param string                $caseTypeId    UUID of the activated case type
+     *
+     * @return array<string, int> Per-section counts of seeded items
+     */
+    private function seedTemplateSections(object $objectService, array $config, array $template, string $caseTypeId): array
+    {
         $counts = ['statusTypes' => 0, 'roleTypes' => 0, 'documentTypes' => 0, 'propertyDefinitions' => 0];
 
-        // Seed sub-objects if schemas are configured.
-        if ($statusTypeSchema !== '' && isset($template['statusTypes']) === true) {
+        if ($config['statusTypeSchema'] !== '' && isset($template['statusTypes']) === true) {
             $counts['statusTypes'] = $this->seedSubObjects(
                 objectService: $objectService,
-                register: $register,
-                schema: $statusTypeSchema,
+                register: $config['register'],
+                schema: $config['statusTypeSchema'],
                 items: $template['statusTypes'],
                 caseTypeId: $caseTypeId,
                 caseTypeField: 'caseType'
             );
         }
 
-        if ($roleTypeSchema !== '' && isset($template['roleTypes']) === true) {
+        if ($config['roleTypeSchema'] !== '' && isset($template['roleTypes']) === true) {
             $counts['roleTypes'] = $this->seedSubObjects(
                 objectService: $objectService,
-                register: $register,
-                schema: $roleTypeSchema,
+                register: $config['register'],
+                schema: $config['roleTypeSchema'],
                 items: $template['roleTypes'],
                 caseTypeId: $caseTypeId,
                 caseTypeField: 'caseType'
             );
         }
 
-        if ($docTypeSchema !== '' && isset($template['documentTypes']) === true) {
+        if ($config['docTypeSchema'] !== '' && isset($template['documentTypes']) === true) {
             $counts['documentTypes'] = $this->seedSubObjects(
                 objectService: $objectService,
-                register: $register,
-                schema: $docTypeSchema,
+                register: $config['register'],
+                schema: $config['docTypeSchema'],
                 items: $template['documentTypes'],
                 caseTypeId: $caseTypeId,
                 caseTypeField: 'caseType'
             );
         }
 
-        if ($propDefSchema !== '' && isset($template['propertyDefinitions']) === true) {
+        if ($config['propDefSchema'] !== '' && isset($template['propertyDefinitions']) === true) {
             $counts['propertyDefinitions'] = $this->seedSubObjects(
                 objectService: $objectService,
-                register: $register,
-                schema: $propDefSchema,
+                register: $config['register'],
+                schema: $config['propDefSchema'],
                 items: $template['propertyDefinitions'],
                 caseTypeId: $caseTypeId,
                 caseTypeField: 'caseType'
             );
         }
 
-        $this->logger->info(
-            'VTH template activated: '.$slug.' (caseType='.$caseTypeId.')',
-            ['app' => 'procest']
-        );
-
-        return ['caseTypeId' => $caseTypeId, 'template' => $slug, 'counts' => $counts];
-    }//end activateTemplate()
+        return $counts;
+    }//end seedTemplateSections()
 
     /**
      * Seed sub-objects (statusTypes, roleTypes, etc.) for a case type.

--- a/lib/Service/WOODeadlineService.php
+++ b/lib/Service/WOODeadlineService.php
@@ -214,45 +214,12 @@ class WOODeadlineService
      */
     public function checkAndWarn(string $caseId, string $behandelaar): array
     {
-        $objectService = $this->settingsService->getObjectService();
-        if ($objectService === null) {
-            return ['warned' => false, 'reason' => 'OpenRegister unavailable'];
+        $resolved = $this->resolveWarningDeadline(caseId: $caseId);
+        if ($resolved['deadline'] === null) {
+            return ['warned' => false, 'reason' => $resolved['reason']];
         }
 
-        $register   = $this->settingsService->getConfigValue('register');
-        $caseSchema = $this->settingsService->getConfigValue('case_schema');
-
-        if (empty($register) === true || empty($caseSchema) === true) {
-            return ['warned' => false, 'reason' => 'Case schema not configured'];
-        }
-
-        $case = $this->findObjectAsArray(
-            objectService: $objectService,
-            register: $register,
-            schema: $caseSchema,
-            id: $caseId
-        );
-        if ($case === null) {
-            return ['warned' => false, 'reason' => 'Case not found'];
-        }
-
-        $caseData = (array) $case;
-
-        $deadlineStr = $caseData['expectedResolution'] ?? null;
-        if (empty($deadlineStr) === true) {
-            return ['warned' => false, 'reason' => 'No deadline set'];
-        }
-
-        $today    = new DateTimeImmutable('today');
-        $deadline = $this->parseIsoDate(value: (string) $deadlineStr);
-        if ($deadline === null) {
-            return ['warned' => false, 'reason' => 'Invalid deadline format'];
-        }
-
-        $daysRemaining = (int) $today->diff($deadline)->days;
-        if ($today > $deadline) {
-            $daysRemaining = -$daysRemaining;
-        }
+        $daysRemaining = $this->signedDaysUntil(deadline: $resolved['deadline']);
 
         $isOverdue = ($daysRemaining < 0);
         $warned    = false;
@@ -274,6 +241,70 @@ class WOODeadlineService
             'warned'        => $warned,
         ];
     }//end checkAndWarn()
+
+    /**
+     * Load the case and resolve the deadline that the warning check operates on.
+     *
+     * @param string $caseId The case UUID
+     *
+     * @return array{deadline: \DateTimeImmutable|null, reason: string} The parsed deadline, or null with the blocking reason
+     */
+    private function resolveWarningDeadline(string $caseId): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return ['deadline' => null, 'reason' => 'OpenRegister unavailable'];
+        }
+
+        $register   = $this->settingsService->getConfigValue('register');
+        $caseSchema = $this->settingsService->getConfigValue('case_schema');
+
+        if (empty($register) === true || empty($caseSchema) === true) {
+            return ['deadline' => null, 'reason' => 'Case schema not configured'];
+        }
+
+        $case = $this->findObjectAsArray(
+            objectService: $objectService,
+            register: $register,
+            schema: $caseSchema,
+            id: $caseId
+        );
+        if ($case === null) {
+            return ['deadline' => null, 'reason' => 'Case not found'];
+        }
+
+        $caseData = (array) $case;
+
+        $deadlineStr = $caseData['expectedResolution'] ?? null;
+        if (empty($deadlineStr) === true) {
+            return ['deadline' => null, 'reason' => 'No deadline set'];
+        }
+
+        $deadline = $this->parseIsoDate(value: (string) $deadlineStr);
+        if ($deadline === null) {
+            return ['deadline' => null, 'reason' => 'Invalid deadline format'];
+        }
+
+        return ['deadline' => $deadline, 'reason' => ''];
+    }//end resolveWarningDeadline()
+
+    /**
+     * Count the days between today and a deadline, negative once the deadline has passed.
+     *
+     * @param DateTimeImmutable $deadline The deadline to measure against
+     *
+     * @return int Days remaining, negative when overdue
+     */
+    private function signedDaysUntil(DateTimeImmutable $deadline): int
+    {
+        $today         = new DateTimeImmutable('today');
+        $daysRemaining = (int) $today->diff($deadline)->days;
+        if ($today > $deadline) {
+            return -$daysRemaining;
+        }
+
+        return $daysRemaining;
+    }//end signedDaysUntil()
 
     /**
      * Send a deadline notification to the behandelaar.

--- a/lib/Service/WOODecisionService.php
+++ b/lib/Service/WOODecisionService.php
@@ -86,13 +86,7 @@ class WOODecisionService
     public function assembleDecision(string $caseId, array $decisionData=[]): array
     {
         // Guard: all documents must be assessed before a besluit can be created.
-        $outstanding = $this->assessmentService->getOutstanding(caseId: $caseId);
-        if ($outstanding['count'] > 0) {
-            throw new InvalidArgumentException(
-                'Cannot create besluit: '.$outstanding['count'].' document(s) still need assessment. '
-                .'Document IDs: '.implode(', ', $outstanding['documents'])
-            );
-        }
+        $this->assertAllDocumentsAssessed(caseId: $caseId);
 
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {
@@ -108,46 +102,19 @@ class WOODecisionService
         }
 
         // Collect all assessments for the case.
-        $assessments = [];
-        if (empty($assessmentSchema) === false) {
-            $result = $this->searchObjectsAsArrays(
-                objectService: $objectService,
-                register: $register,
-                schema: $assessmentSchema,
-                filters: ['caseRef' => $caseId, '_limit' => 500],
-            );
-
-            if (is_array($result) === true) {
-                $assessments = $result;
-            }
-        }
+        $assessments = $this->collectAssessments(
+            objectService: $objectService,
+            register: $register,
+            assessmentSchema: $assessmentSchema,
+            caseId: $caseId,
+        );
 
         // Summarise assessments by classification.
-        $summary = [
-            'openbaar'       => 0,
-            'deels_openbaar' => 0,
-            'niet_openbaar'  => 0,
-        ];
+        $summarised        = $this->summariseAssessments(assessments: $assessments);
+        $summary           = $summarised['summary'];
+        $weigeringsgronden = $summarised['weigeringsgronden'];
 
-        $weigeringsgronden = [];
-        foreach ($assessments as $assessment) {
-            $classification = $assessment['classification'] ?? null;
-            if ($classification !== null && isset($summary[$classification]) === true) {
-                $summary[$classification]++;
-            }
-
-            foreach (($assessment['weigeringsgronden'] ?? []) as $code) {
-                if (in_array($code, $weigeringsgronden, true) === false) {
-                    $weigeringsgronden[] = $code;
-                }
-            }
-        }
-
-        $user   = $this->userSession->getUser();
-        $userId = 'system';
-        if ($user !== null) {
-            $userId = $user->getUID();
-        }
+        $userId = $this->resolveDecidedBy();
 
         $besluitData = array_merge(
             [
@@ -178,4 +145,104 @@ class WOODecisionService
             'assessmentCount'   => count($assessments),
         ];
     }//end assembleDecision()
+
+    /**
+     * Guard that every document of a case carries an assessment.
+     *
+     * @param string $caseId The case UUID
+     *
+     * @return void
+     *
+     * @throws \InvalidArgumentException If any document has not been assessed
+     */
+    private function assertAllDocumentsAssessed(string $caseId): void
+    {
+        $outstanding = $this->assessmentService->getOutstanding(caseId: $caseId);
+        if ($outstanding['count'] > 0) {
+            throw new InvalidArgumentException(
+                'Cannot create besluit: '.$outstanding['count'].' document(s) still need assessment. '
+                .'Document IDs: '.implode(', ', $outstanding['documents'])
+            );
+        }
+    }//end assertAllDocumentsAssessed()
+
+    /**
+     * Fetch all assessment objects belonging to a case.
+     *
+     * @param object $objectService    OpenRegister object service
+     * @param mixed  $register         Configured register identifier
+     * @param mixed  $assessmentSchema Configured assessment schema identifier
+     * @param string $caseId           The case UUID
+     *
+     * @return array<int, array<string, mixed>> Assessment rows, empty when the schema is not configured
+     */
+    private function collectAssessments(object $objectService, mixed $register, mixed $assessmentSchema, string $caseId): array
+    {
+        if (empty($assessmentSchema) === true) {
+            return [];
+        }
+
+        $result = $this->searchObjectsAsArrays(
+            objectService: $objectService,
+            register: $register,
+            schema: $assessmentSchema,
+            filters: ['caseRef' => $caseId, '_limit' => 500],
+        );
+
+        if (is_array($result) === false) {
+            return [];
+        }
+
+        return $result;
+    }//end collectAssessments()
+
+    /**
+     * Tally assessments by classification and collect the distinct weigeringsgronden.
+     *
+     * @param array<int, array<string, mixed>> $assessments Assessment rows
+     *
+     * @return array{summary: array<string, int>, weigeringsgronden: array<int, mixed>} Counts per classification plus distinct grounds
+     */
+    private function summariseAssessments(array $assessments): array
+    {
+        $summary = [
+            'openbaar'       => 0,
+            'deels_openbaar' => 0,
+            'niet_openbaar'  => 0,
+        ];
+
+        $weigeringsgronden = [];
+        foreach ($assessments as $assessment) {
+            $classification = $assessment['classification'] ?? null;
+            if ($classification !== null && isset($summary[$classification]) === true) {
+                $summary[$classification]++;
+            }
+
+            foreach (($assessment['weigeringsgronden'] ?? []) as $code) {
+                if (in_array($code, $weigeringsgronden, true) === false) {
+                    $weigeringsgronden[] = $code;
+                }
+            }
+        }
+
+        return [
+            'summary'           => $summary,
+            'weigeringsgronden' => $weigeringsgronden,
+        ];
+    }//end summariseAssessments()
+
+    /**
+     * Resolve the user id credited with the besluit.
+     *
+     * @return string The current user id, or `system` when there is no session user
+     */
+    private function resolveDecidedBy(): string
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return 'system';
+        }
+
+        return $user->getUID();
+    }//end resolveDecidedBy()
 }//end class

--- a/lib/Service/WOODecisionService.php
+++ b/lib/Service/WOODecisionService.php
@@ -182,18 +182,15 @@ class WOODecisionService
             return [];
         }
 
-        $result = $this->searchObjectsAsArrays(
+        // The is_array() guard the inline version carried here is dead code:
+        // searchObjectsAsArrays() is declared `: array`. Dropped rather than
+        // inverted, because phpstan rejects it in either direction.
+        return $this->searchObjectsAsArrays(
             objectService: $objectService,
             register: $register,
             schema: $assessmentSchema,
             filters: ['caseRef' => $caseId, '_limit' => 500],
         );
-
-        if (is_array($result) === false) {
-            return [];
-        }
-
-        return $result;
     }//end collectAssessments()
 
     /**

--- a/lib/Service/WOODocumentAssessmentService.php
+++ b/lib/Service/WOODocumentAssessmentService.php
@@ -305,15 +305,13 @@ class WOODocumentAssessmentService
             filters: ['case' => $caseId, '_limit' => 500],
         );
 
-        if (is_array($docs) === false) {
-            return [];
-        }
-
         $allDocs = [];
-        foreach ($docs as $doc) {
-            $docId = $doc['id'] ?? $doc['uuid'] ?? null;
-            if ($docId !== null) {
-                $allDocs[$docId] = true;
+        if (is_array($docs) === true) {
+            foreach ($docs as $doc) {
+                $docId = $doc['id'] ?? $doc['uuid'] ?? null;
+                if ($docId !== null) {
+                    $allDocs[$docId] = true;
+                }
             }
         }
 
@@ -343,15 +341,13 @@ class WOODocumentAssessmentService
             filters: ['caseRef' => $caseId, '_limit' => 500],
         );
 
-        if (is_array($assessed) === false) {
-            return [];
-        }
-
         $assessedDocIds = [];
-        foreach ($assessed as $item) {
-            $docRef = $item['documentRef'] ?? null;
-            if ($docRef !== null) {
-                $assessedDocIds[$docRef] = true;
+        if (is_array($assessed) === true) {
+            foreach ($assessed as $item) {
+                $docRef = $item['documentRef'] ?? null;
+                if ($docRef !== null) {
+                    $assessedDocIds[$docRef] = true;
+                }
             }
         }
 

--- a/lib/Service/WOODocumentAssessmentService.php
+++ b/lib/Service/WOODocumentAssessmentService.php
@@ -255,48 +255,24 @@ class WOODocumentAssessmentService
         }
 
         // Collect all documents for this case.
-        $allDocs = [];
-        if (empty($docSchema) === false) {
-            $docs = $this->searchObjectsAsArrays(
-                objectService: $objectService,
-                register: $register,
-                schema: $docSchema,
-                filters: ['case' => $caseId, '_limit' => 500],
-            );
-
-            if (is_array($docs) === true) {
-                foreach ($docs as $doc) {
-                    $docId = $doc['id'] ?? $doc['uuid'] ?? null;
-                    if ($docId !== null) {
-                        $allDocs[$docId] = true;
-                    }
-                }
-            }
-        }
+        $allDocs = $this->collectCaseDocumentIds(
+            objectService: $objectService,
+            register: $register,
+            docSchema: $docSchema,
+            caseId: $caseId,
+        );
 
         if (empty($allDocs) === true) {
             return ['count' => 0, 'documents' => []];
         }
 
         // Collect all assessed document IDs.
-        $assessedDocIds = [];
-        if (empty($assessmentSchema) === false) {
-            $assessed = $this->searchObjectsAsArrays(
-                objectService: $objectService,
-                register: $register,
-                schema: $assessmentSchema,
-                filters: ['caseRef' => $caseId, '_limit' => 500],
-            );
-
-            if (is_array($assessed) === true) {
-                foreach ($assessed as $item) {
-                    $docRef = $item['documentRef'] ?? null;
-                    if ($docRef !== null) {
-                        $assessedDocIds[$docRef] = true;
-                    }
-                }
-            }
-        }
+        $assessedDocIds = $this->collectAssessedDocumentIds(
+            objectService: $objectService,
+            register: $register,
+            assessmentSchema: $assessmentSchema,
+            caseId: $caseId,
+        );
 
         $outstanding = array_keys(array_diff_key($allDocs, $assessedDocIds));
 
@@ -305,6 +281,82 @@ class WOODocumentAssessmentService
             'documents' => $outstanding,
         ];
     }//end getOutstanding()
+
+    /**
+     * Collect the identifiers of every document attached to a case.
+     *
+     * @param object $objectService OpenRegister object service
+     * @param mixed  $register      Configured register identifier
+     * @param mixed  $docSchema     Configured document schema identifier
+     * @param string $caseId        The case UUID
+     *
+     * @return array<string, bool> Document identifiers as keys, empty when the schema is not configured
+     */
+    private function collectCaseDocumentIds(object $objectService, mixed $register, mixed $docSchema, string $caseId): array
+    {
+        if (empty($docSchema) === true) {
+            return [];
+        }
+
+        $docs = $this->searchObjectsAsArrays(
+            objectService: $objectService,
+            register: $register,
+            schema: $docSchema,
+            filters: ['case' => $caseId, '_limit' => 500],
+        );
+
+        if (is_array($docs) === false) {
+            return [];
+        }
+
+        $allDocs = [];
+        foreach ($docs as $doc) {
+            $docId = $doc['id'] ?? $doc['uuid'] ?? null;
+            if ($docId !== null) {
+                $allDocs[$docId] = true;
+            }
+        }
+
+        return $allDocs;
+    }//end collectCaseDocumentIds()
+
+    /**
+     * Collect the identifiers of every document of a case that already carries an assessment.
+     *
+     * @param object $objectService    OpenRegister object service
+     * @param mixed  $register         Configured register identifier
+     * @param mixed  $assessmentSchema Configured assessment schema identifier
+     * @param string $caseId           The case UUID
+     *
+     * @return array<string, bool> Assessed document identifiers as keys, empty when the schema is not configured
+     */
+    private function collectAssessedDocumentIds(object $objectService, mixed $register, mixed $assessmentSchema, string $caseId): array
+    {
+        if (empty($assessmentSchema) === true) {
+            return [];
+        }
+
+        $assessed = $this->searchObjectsAsArrays(
+            objectService: $objectService,
+            register: $register,
+            schema: $assessmentSchema,
+            filters: ['caseRef' => $caseId, '_limit' => 500],
+        );
+
+        if (is_array($assessed) === false) {
+            return [];
+        }
+
+        $assessedDocIds = [];
+        foreach ($assessed as $item) {
+            $docRef = $item['documentRef'] ?? null;
+            if ($docRef !== null) {
+                $assessedDocIds[$docRef] = true;
+            }
+        }
+
+        return $assessedDocIds;
+    }//end collectAssessedDocumentIds()
 
     /**
      * Check whether all documents in a case have been assessed.

--- a/tests/Unit/Event/VergunningStatusChangedEventTest.php
+++ b/tests/Unit/Event/VergunningStatusChangedEventTest.php
@@ -43,7 +43,7 @@ class VergunningStatusChangedEventTest extends TestCase
     public function testEventExtendsOcpEvent(): void
     {
         $event = new VergunningStatusChangedEvent(
-            vergunningaanvraagRef: 'ref-001',
+            aanvraagRef: 'ref-001',
             oldStatus: 'ingediend',
             newStatus: 'in_behandeling',
             besluitdatum: null,
@@ -64,7 +64,7 @@ class VergunningStatusChangedEventTest extends TestCase
     public function testGettersReturnConstructorValues(): void
     {
         $event = new VergunningStatusChangedEvent(
-            vergunningaanvraagRef: 'aanvraag-abc-123',
+            aanvraagRef: 'aanvraag-abc-123',
             oldStatus: 'ingediend',
             newStatus: 'verleend',
             besluitdatum: '2026-06-01',
@@ -92,7 +92,7 @@ class VergunningStatusChangedEventTest extends TestCase
     public function testNullableFieldsAcceptNull(): void
     {
         $event = new VergunningStatusChangedEvent(
-            vergunningaanvraagRef: 'ref-002',
+            aanvraagRef: 'ref-002',
             oldStatus: 'in_behandeling',
             newStatus: 'geweigerd',
             besluitdatum: null,

--- a/tests/Unit/Service/SamenwerkverzoekServiceTest.php
+++ b/tests/Unit/Service/SamenwerkverzoekServiceTest.php
@@ -202,7 +202,7 @@ class SamenwerkverzoekServiceTest extends TestCase
 
         $result = $this->service->initiateSamenwerking(
             zaakId: 'zaak-uuid-1',
-            aangezochtBevoegdGezag: 'gemeente-haarlem',
+            aangezochtGezag: 'gemeente-haarlem',
             rationale: 'Bevoegdheidsgrens.'
         );
 

--- a/tests/Unit/Service/SubstitutionServiceTest.php
+++ b/tests/Unit/Service/SubstitutionServiceTest.php
@@ -26,6 +26,8 @@ namespace OCA\Procest\Tests\Unit\Service;
 use DateTimeImmutable;
 use InvalidArgumentException;
 use OCA\Procest\Service\SettingsService;
+use OCA\Procest\Service\Substitution\SubstitutedWorkResolver;
+use OCA\Procest\Service\Substitution\SubstitutionValidator;
 use OCA\Procest\Service\SubstitutionService;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -113,7 +115,12 @@ class SubstitutionServiceTest extends TestCase
             }
         );
 
-        return new SubstitutionService($this->settingsService, $this->logger);
+        return new SubstitutionService(
+            $this->settingsService,
+            $this->logger,
+            new SubstitutionValidator($this->settingsService),
+            new SubstitutedWorkResolver($this->settingsService)
+        );
     }//end makeService()
 
     /**


### PR DESCRIPTION
First batch of the PHPMD architectural-debt clearance on procest. No suppression
of rules wholesale, no baseline, no threshold loosening.

## phpmd: 175 → 161

| rule | before | after |
|---|---|---|
| CyclomaticComplexity | 51 | 50 |
| NPathComplexity | 42 | 41 |
| ExcessiveClassComplexity | 39 | 39 |
| ExcessiveMethodLength | 12 | 11 |
| StaticAccess | 9 | **0** |
| CouplingBetweenObjects | 9 | 9 |
| TooManyPublicMethods | 8 | 8 |
| ExcessiveClassLength | 3 | 3 |
| LongVariable | 2 | **0** |

## What changed

**LongVariable (2 → 0)** — `$vergunningaanvraagRef` → `$aanvraagRef` on
`VergunningStatusChangedEvent`, `$aangezochtBevoegdGezag` → `$aangezochtGezag` on
`SamenwerkverzoekService::initiateSamenwerking()`. Named-argument call sites updated
in `DsoCaseService`, `DsoController` and the unit tests. The **persisted payload keys
are untouched** — only the PHP parameter names change.

**StaticAccess (9 → 0)** — two individually-justified inline suppressions, not a bulk
tactic:

* The three `lib/Lifecycle/*Guard` classes build OpenRegister's `GuardResult`, whose
  constructor is **private upstream** — `allow()`/`deny()` are the only construction
  path there is. A local factory collaborator would have to make the very same static
  call, so decomposition moves the finding instead of removing it.
* `Application::registerAppHostEngine()` calls `Bootstrap::register()`, which *is*
  OpenRegister's published AppHost entry point (ADR-040) — a stateless registration
  façade with no instance to inject.

Each carries the reasoning as prose in the method docblock, not just a tag.

**`Application::register()` (480 lines, CC 11, NPath 768 → all clear)** — split into
`registerAppHostEngine` / `registerBespokeServices` / `registerObjectListeners` /
`registerSaasStack` / `registerBeschikkingAdapters` / `registerAuthAdapters` /
`registerExternalRegisterAdapters`, with the last delegating to
`registerKvkBrpAdapters` / `registerGeoRegisterAdapters` / `registerExternalZgwAdapters`.
**Registration order is preserved exactly** — the SaaS middleware chain still runs
Context → Isolation → ClaimValidation → MandateValidation → QuotaEnforcement, and the
bespoke plumbing is still re-asserted after the AppHost engine aliases it to generics.

## Verified

Measured in the PHP 8.3 container, not inferred:

* `phpmd lib text phpmd.xml` — 175 → 161 findings
* `composer lint` — 0
* `composer phpcs` — 0 errors (warnings unchanged from `development`)
* `composer psalm` — 0
* `composer phpstan` — 0
* `phpunit` — **1684 tests, 5614 assertions, 0 failures** (5 skipped, same as before)

## Noted, not fixed here

`Application` still carries `CouplingBetweenObjects` 92. It is a DI composition root;
getting it under 13 needs the registration blocks moved into a package of ~10 registrar
collaborators. That is a separate, reviewable change — flagged rather than papered over.

`VergunningaanvraagCreatedListener` is registered **twice** for `ObjectCreatedEvent`
(pre-existing on `development`, now visible in `registerObjectListeners()`). Preserved
verbatim here so this PR stays behaviour-neutral; worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)