### PR TITLE
fix(quality): decompose the Case/Consultation service cluster (6 phpmd findings)

### DIFF
--- a/lib/Service/CaseEmailService.php
+++ b/lib/Service/CaseEmailService.php
@@ -29,11 +29,10 @@ declare(strict_types=1);
 namespace OCA\Procest\Service;
 
 use OCA\Procest\AppInfo\Application;
-use OCA\Procest\Service\Support\SearchesObjects;
-use OCP\Files\IRootFolder;
-use OCP\Files\NotFoundException;
+use OCA\Procest\Service\Email\CaseContactDirectory;
+use OCA\Procest\Service\Email\CaseEmailAttachmentResolver;
+use OCA\Procest\Service\Email\CaseEmailRepository;
 use OCP\IAppConfig;
-use OCP\IUserSession;
 use OCP\Mail\IMailer;
 use OCP\Mail\IMessage;
 use Psr\Log\LoggerInterface;
@@ -44,8 +43,6 @@ use RuntimeException;
  */
 class CaseEmailService
 {
-
-    use SearchesObjects;
 
     /**
      * Regex pattern for extracting case number from email subject.
@@ -65,20 +62,20 @@ class CaseEmailService
     /**
      * Constructor.
      *
-     * @param SettingsService $settingsService Settings service
-     * @param IMailer         $mailer          Nextcloud mailer
-     * @param IAppConfig      $appConfig       Nextcloud app config
-     * @param LoggerInterface $logger          Logger
-     * @param IRootFolder     $rootFolder      Root folder for user-file access
-     * @param IUserSession    $userSession     Current user session
+     * @param IMailer                     $mailer             Nextcloud mailer
+     * @param IAppConfig                  $appConfig          Nextcloud app config
+     * @param LoggerInterface             $logger             Logger
+     * @param CaseEmailRepository         $repository         OpenRegister reads/writes for case email
+     * @param CaseContactDirectory        $contactDirectory   Contact addresses registered on a case
+     * @param CaseEmailAttachmentResolver $attachmentResolver User-folder-scoped attachment resolution
      */
     public function __construct(
-        private readonly SettingsService $settingsService,
         private readonly IMailer $mailer,
         private readonly IAppConfig $appConfig,
         private readonly LoggerInterface $logger,
-        private readonly IRootFolder $rootFolder,
-        private readonly IUserSession $userSession,
+        private readonly CaseEmailRepository $repository,
+        private readonly CaseContactDirectory $contactDirectory,
+        private readonly CaseEmailAttachmentResolver $attachmentResolver,
     ) {
     }//end __construct()
 
@@ -117,7 +114,7 @@ class CaseEmailService
         // C4 IDOR: Load the case via OR with RBAC enabled to verify the current user
         // has read access. If the case is not found (or the user has no access), OR
         // returns null — we treat that as 403.
-        $caseData = $this->loadCaseData(caseId: $caseId);
+        $caseData = $this->repository->loadCaseVariables(caseId: $caseId);
         if (empty($caseData) === true) {
             throw new RuntimeException('Zaak niet gevonden of geen toegang.');
         }
@@ -135,12 +132,18 @@ class CaseEmailService
 
         // H5: Resolve attachments via IUserFolder to restrict file access to the
         // calling user's own files and prevent path traversal outside their folder.
-        $this->attachUserFiles(message: $message, attachments: $attachments, caseId: $caseId);
+        $this->attachmentResolver->attach(message: $message, attachments: $attachments, caseId: $caseId);
 
         $this->dispatchMessage(message: $message, caseId: $caseId);
 
         // Record the sent email as a case document.
-        $messageId = $this->recordSentEmail(caseId: $caseId, to: $to, subject: $subject, body: $body);
+        $messageId = $this->repository->recordSentEmail(
+            caseId: $caseId,
+            fromAddress: $fromAddress,
+            to: $to,
+            subject: $subject,
+            body: $body,
+        );
 
         $this->logger->info(
             'Email sent for case {caseId}',
@@ -203,7 +206,7 @@ class CaseEmailService
             throw new RuntimeException('Ongeldig e-mailadres opgegeven.');
         }
 
-        $allowedEmails = $this->getCaseContactEmails(caseData: $caseData);
+        $allowedEmails = $this->contactDirectory->collectAddresses(caseData: $caseData);
         if (count($allowedEmails) > 0) {
             if (in_array(strtolower($recipient), $allowedEmails, true) === false) {
                 $this->logger->warning(
@@ -214,46 +217,6 @@ class CaseEmailService
             }
         }
     }//end assertRecipientAllowed()
-
-    /**
-     * Attach the requested files to a message, resolved from the caller's own folder.
-     *
-     * H5: resolving via the user folder restricts file access to the calling
-     * user's own files and prevents path traversal outside that folder. A file
-     * that cannot be resolved or attached is logged and skipped.
-     *
-     * @param IMessage      $message     The message under construction
-     * @param array<string> $attachments File references to attach
-     * @param string        $caseId      The case UUID (logging context)
-     *
-     * @return void
-     */
-    private function attachUserFiles(IMessage $message, array $attachments, string $caseId): void
-    {
-        $currentUser = $this->userSession->getUser();
-        if ($currentUser !== null && count($attachments) > 0) {
-            $userFolder = $this->rootFolder->getUserFolder($currentUser->getUID());
-            foreach ($attachments as $fileRef) {
-                try {
-                    $file      = $userFolder->get((string) $fileRef);
-                    $localPath = $file->getStorage()->getLocalFile($file->getInternalPath());
-                    if ($localPath !== null && $localPath !== false) {
-                        $message->attachFile($localPath);
-                    }
-                } catch (NotFoundException $e) {
-                    $this->logger->warning(
-                        'Attachment file not found in user folder',
-                        ['app' => Application::APP_ID, 'fileRef' => $fileRef, 'caseId' => $caseId]
-                    );
-                } catch (\Throwable $e) {
-                    $this->logger->warning(
-                        'Failed to attach file',
-                        ['app' => Application::APP_ID, 'fileRef' => $fileRef, 'error' => $e->getMessage()]
-                    );
-                }//end try
-            }//end foreach
-        }//end if
-    }//end attachUserFiles()
 
     /**
      * Hand a fully-built message to the mailer.
@@ -305,13 +268,13 @@ class CaseEmailService
         string $templateId,
         string $to,
     ): array {
-        $template = $this->loadTemplate(templateId: $templateId);
+        $template = $this->repository->findTemplate(templateId: $templateId);
         if ($template === null) {
             throw new RuntimeException('Email template not found');
         }
 
         // Load case data for variable resolution.
-        $caseData = $this->loadCaseData(caseId: $caseId);
+        $caseData = $this->repository->loadCaseVariables(caseId: $caseId);
 
         // Resolve template variables.
         $subject = $this->resolveVariables(template: $template['subjectPattern'] ?? '', data: $caseData);
@@ -465,9 +428,9 @@ class CaseEmailService
 
         if ($caseNumber !== null) {
             // Auto-link to case.
-            $caseId = $this->findCaseByIdentifier(identifier: $caseNumber);
+            $caseId = $this->repository->findCaseIdByIdentifier(identifier: $caseNumber);
             if ($caseId !== null) {
-                $messageId = $this->recordReceivedEmail(
+                $messageId = $this->repository->recordReceivedEmail(
                     caseId: $caseId,
                     from: $from,
                     recipient: $to,
@@ -511,332 +474,6 @@ class CaseEmailService
      */
     public function getTemplatesForCaseType(string $caseTypeId): array
     {
-        $objectService = $this->settingsService->getObjectService();
-        if ($objectService === null) {
-            return [];
-        }
-
-        $register = $this->settingsService->getConfigValue('register');
-        $schema   = $this->settingsService->getConfigValue('email_template_schema');
-
-        if (empty($register) === true || empty($schema) === true) {
-            return [];
-        }
-
-        return $this->searchObjectsAsArrays(
-            objectService: $objectService,
-            register: $register,
-            schema: $schema,
-            filters: ['caseType' => $caseTypeId, '_limit' => 100],
-        );
+        return $this->repository->findTemplatesForCaseType(caseTypeId: $caseTypeId);
     }//end getTemplatesForCaseType()
-
-    /**
-     * Collect the normalised (lowercased) email addresses of all contacts on a case.
-     *
-     * Inspects the following fields (all optional): `betrokkenen`, `contacts`,
-     * `initiator`, and the top-level `email` field. Returns an empty array when
-     * no contacts are registered; the caller treats an empty array as "no restriction".
-     *
-     * @param array<string, mixed> $caseData The case data array
-     *
-     * @return array<string> Lowercase email addresses
-     */
-    private function getCaseContactEmails(array $caseData): array
-    {
-        $emails = array_merge(
-            $this->collectPrimaryContactEmails(caseData: $caseData),
-            $this->collectContactListEmails(caseData: $caseData),
-        );
-
-        return array_unique($emails);
-    }//end getCaseContactEmails()
-
-    /**
-     * Collect the single-valued contact addresses on a case.
-     *
-     * Covers the top-level `email` field and the `initiator` contact object, in
-     * that order.
-     *
-     * @param array<string, mixed> $caseData The case data array
-     *
-     * @return array<string> Lowercase email addresses
-     */
-    private function collectPrimaryContactEmails(array $caseData): array
-    {
-        $emails = [];
-
-        // Top-level email field.
-        $topEmail = $this->normalizeContactEmail(value: (string) ($caseData['email'] ?? ''));
-        if ($topEmail !== null) {
-            $emails[] = $topEmail;
-        }
-
-        // Initiator field (single contact object or email string).
-        $initiator = ($caseData['initiator'] ?? null);
-        if (is_array($initiator) === true) {
-            $addr = $this->normalizeContactEmail(value: (string) ($initiator['email'] ?? ''));
-            if ($addr !== null) {
-                $emails[] = $addr;
-            }
-        }
-
-        return $emails;
-    }//end collectPrimaryContactEmails()
-
-    /**
-     * Collect the addresses held in a case's contact collections.
-     *
-     * Covers `betrokkenen` and `contacts`, in that order; each entry may carry
-     * either an `email` or an `emailadres` key.
-     *
-     * @param array<string, mixed> $caseData The case data array
-     *
-     * @return array<string> Lowercase email addresses
-     */
-    private function collectContactListEmails(array $caseData): array
-    {
-        $contactArrays = [];
-        if (is_array($caseData['betrokkenen'] ?? null) === true) {
-            $contactArrays[] = $caseData['betrokkenen'];
-        }
-
-        if (is_array($caseData['contacts'] ?? null) === true) {
-            $contactArrays[] = $caseData['contacts'];
-        }
-
-        $emails = [];
-        foreach ($contactArrays as $contacts) {
-            foreach ($contacts as $contact) {
-                if (is_array($contact) === false) {
-                    continue;
-                }
-
-                $addr = $this->normalizeContactEmail(
-                    value: (string) ($contact['email'] ?? ($contact['emailadres'] ?? ''))
-                );
-                if ($addr !== null) {
-                    $emails[] = $addr;
-                }
-            }
-        }
-
-        return $emails;
-    }//end collectContactListEmails()
-
-    /**
-     * Normalise a raw contact value to a lowercase, validated email address.
-     *
-     * @param string $value The raw contact value
-     *
-     * @return string|null The lowercase address, or null when absent/invalid
-     */
-    private function normalizeContactEmail(string $value): ?string
-    {
-        $addr = strtolower(trim($value));
-        if ($addr === '' || filter_var($addr, FILTER_VALIDATE_EMAIL) === false) {
-            return null;
-        }
-
-        return $addr;
-    }//end normalizeContactEmail()
-
-    /**
-     * Load an email template.
-     *
-     * @param string $templateId The template UUID
-     *
-     * @return array<string, mixed>|null The template data
-     */
-    private function loadTemplate(string $templateId): ?array
-    {
-        $objectService = $this->settingsService->getObjectService();
-        if ($objectService === null) {
-            return null;
-        }
-
-        $register = $this->settingsService->getConfigValue('register');
-        $schema   = $this->settingsService->getConfigValue('email_template_schema');
-
-        if (empty($register) === true || empty($schema) === true) {
-            return null;
-        }
-
-        $result = $objectService->find($templateId, register: $register, schema: $schema);
-        if (is_array($result) === true) {
-            return $result;
-        }
-
-        return null;
-    }//end loadTemplate()
-
-    /**
-     * Load case data for template variable resolution.
-     *
-     * @param string $caseId The case UUID
-     *
-     * @return array<string, mixed> Case data flattened for variable resolution
-     */
-    private function loadCaseData(string $caseId): array
-    {
-        $objectService = $this->settingsService->getObjectService();
-        if ($objectService === null) {
-            return [];
-        }
-
-        $register = $this->settingsService->getConfigValue('register');
-        $schema   = $this->settingsService->getConfigValue('case_schema');
-
-        $caseObj = $objectService->find($caseId, register: $register, schema: $schema);
-        if ($caseObj === null) {
-            return [];
-        }
-
-        if (is_object($caseObj) === true && method_exists($caseObj, 'jsonSerialize') === true) {
-            $caseObj = $caseObj->jsonSerialize();
-        }
-
-        if (is_array($caseObj) === false) {
-            return [];
-        }
-
-        // Flatten for variable resolution.
-        return [
-            'zaakNummer'  => $caseObj['identifier'] ?? '',
-            'titel'       => $caseObj['title'] ?? '',
-            'startdatum'  => $caseObj['startDate'] ?? '',
-            'deadline'    => $caseObj['deadline'] ?? '',
-            'status'      => $caseObj['status'] ?? '',
-            'behandelaar' => $caseObj['assignee'] ?? '',
-        ];
-    }//end loadCaseData()
-
-    /**
-     * Record a sent email as a case document.
-     *
-     * @param string $caseId  Case UUID
-     * @param string $to      Recipient
-     * @param string $subject Subject
-     * @param string $body    Body
-     *
-     * @return string The recorded message ID
-     */
-    private function recordSentEmail(
-        string $caseId,
-        string $to,
-        string $subject,
-        string $body,
-    ): string {
-        // Store as activity on the case.
-        $messageId = 'msg-'.uniqid();
-
-        $objectService = $this->settingsService->getObjectService();
-        if ($objectService === null) {
-            return $messageId;
-        }
-
-        $register = $this->settingsService->getConfigValue('register');
-        $schema   = $this->settingsService->getConfigValue('email_message_schema');
-
-        if (empty($register) === false && empty($schema) === false) {
-            $objectService->saveObject(
-                    object: [
-                        'case'      => $caseId,
-                        'direction' => 'outbound',
-                        'from'      => $this->appConfig->getValueString(Application::APP_ID, 'email_from_address', ''),
-                        'to'        => $to,
-                        'subject'   => $subject,
-                        'body'      => $body,
-                        'messageId' => $messageId,
-                        'sentAt'    => date('Y-m-d\TH:i:s'),
-                    ],
-                    register: $register,
-                    schema: $schema,
-                    );
-        }
-
-        return $messageId;
-    }//end recordSentEmail()
-
-    /**
-     * Record a received email.
-     *
-     * @param string $caseId    Case UUID
-     * @param string $from      Sender
-     * @param string $recipient Recipient (the mailbox the message arrived on)
-     * @param string $subject   Subject
-     * @param string $body      Body
-     * @param string $inReplyTo Threading header
-     *
-     * @return string The recorded message ID
-     */
-    private function recordReceivedEmail(
-        string $caseId,
-        string $from,
-        string $recipient,
-        string $subject,
-        string $body,
-        string $inReplyTo,
-    ): string {
-        $messageId = 'msg-'.uniqid();
-
-        $objectService = $this->settingsService->getObjectService();
-        if ($objectService === null) {
-            return $messageId;
-        }
-
-        $register = $this->settingsService->getConfigValue('register');
-        $schema   = $this->settingsService->getConfigValue('email_message_schema');
-
-        if (empty($register) === false && empty($schema) === false) {
-            $objectService->saveObject(
-                    object: [
-                        'case'       => $caseId,
-                        'direction'  => 'inbound',
-                        'from'       => $from,
-                        'to'         => $recipient,
-                        'subject'    => $subject,
-                        'body'       => $body,
-                        'messageId'  => $messageId,
-                        'inReplyTo'  => $inReplyTo,
-                        'receivedAt' => date('Y-m-d\TH:i:s'),
-                    ],
-                    register: $register,
-                    schema: $schema,
-                    );
-        }
-
-        return $messageId;
-    }//end recordReceivedEmail()
-
-    /**
-     * Find a case by its identifier.
-     *
-     * @param string $identifier The case identifier (e.g., 2026-0042)
-     *
-     * @return string|null The case UUID or null
-     */
-    private function findCaseByIdentifier(string $identifier): ?string
-    {
-        $objectService = $this->settingsService->getObjectService();
-        if ($objectService === null) {
-            return null;
-        }
-
-        $register = $this->settingsService->getConfigValue('register');
-        $schema   = $this->settingsService->getConfigValue('case_schema');
-
-        $results = $this->searchObjectsAsArrays(
-            objectService: $objectService,
-            register: $register,
-            schema: $schema,
-            filters: ['identifier' => $identifier, '_limit' => 1],
-        );
-
-        if (is_array($results) === true && count($results) > 0) {
-            return $results[0]['id'] ?? $results[0]['uuid'] ?? null;
-        }
-
-        return null;
-    }//end findCaseByIdentifier()
 }//end class

--- a/lib/Service/CaseRelationService.php
+++ b/lib/Service/CaseRelationService.php
@@ -37,8 +37,9 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service;
 
-use OCA\Procest\Service\Support\SearchesObjects;
-use Psr\Log\LoggerInterface;
+use OCA\Procest\Service\Relation\CaseHierarchyOverlapGuard;
+use OCA\Procest\Service\Relation\CaseRelationCodec;
+use OCA\Procest\Service\Relation\CaseRelationStore;
 
 /**
  * Service for typed peer relations between cases.
@@ -47,8 +48,6 @@ use Psr\Log\LoggerInterface;
  */
 class CaseRelationService
 {
-
-    use SearchesObjects;
 
     /**
      * Allowed ZRC relation types (`aardRelatie`).
@@ -60,12 +59,14 @@ class CaseRelationService
     /**
      * Constructor.
      *
-     * @param SettingsService $settingsService Shared OR/settings resolver.
-     * @param LoggerInterface $logger          Logger.
+     * @param CaseRelationStore         $store          OpenRegister reads/writes for case objects.
+     * @param CaseRelationCodec         $codec          Relation-list encoding and pair operations.
+     * @param CaseHierarchyOverlapGuard $hierarchyGuard Hoofdzaak/deelzaak overlap detection.
      */
     public function __construct(
-        private readonly SettingsService $settingsService,
-        private readonly LoggerInterface $logger,
+        private readonly CaseRelationStore $store,
+        private readonly CaseRelationCodec $codec,
+        private readonly CaseHierarchyOverlapGuard $hierarchyGuard,
     ) {
     }//end __construct()
 
@@ -84,12 +85,12 @@ class CaseRelationService
      */
     public function listRelations(string $caseId): array
     {
-        $case = $this->fetchCase(caseUuid: $caseId);
+        $case = $this->store->fetchCase(caseUuid: $caseId);
         if ($case === null) {
             return [];
         }
 
-        return $this->decodeRelations(case: $case);
+        return $this->codec->decode(case: $case);
     }//end listRelations()
 
     /**
@@ -129,15 +130,15 @@ class CaseRelationService
         }
 
         // OR-RBAC read access to BOTH cases (fail closed on either miss).
-        $origin = $this->fetchCase(caseUuid: $caseId);
-        $target = $this->fetchCase(caseUuid: $targetId);
+        $origin = $this->store->fetchCase(caseUuid: $caseId);
+        $target = $this->store->fetchCase(caseUuid: $targetId);
         if ($origin === null || $target === null) {
             return ['ok' => false, 'reason' => 'access_denied'];
         }
 
         // Hierarchy-overlap guard — the parent/sub-case link already expresses
         // the relation, so refuse to also peer-link the same pair.
-        if ($this->isHierarchyLinked(caseA: $origin, caseB: $target) === true) {
+        if ($this->hierarchyGuard->areLinked(caseA: $origin, caseB: $target) === true) {
             return [
                 'ok'     => false,
                 'reason' => 'hierarchy_overlap',
@@ -145,17 +146,17 @@ class CaseRelationService
             ];
         }
 
-        $originRelations = $this->decodeRelations(case: $origin);
-        if ($this->hasPair(relations: $originRelations, caseId: $targetId, aardRelatie: $aardRelatie) === true) {
+        $originRelations = $this->codec->decode(case: $origin);
+        if ($this->codec->hasPair(relations: $originRelations, caseId: $targetId, aardRelatie: $aardRelatie) === true) {
             return ['ok' => false, 'reason' => 'duplicate'];
         }
 
-        $originRelations[] = $this->buildRelationEntry(
+        $originRelations[] = $this->codec->buildEntry(
             caseId: $targetId,
             aardRelatie: $aardRelatie,
             toelichting: $toelichting
         );
-        $this->persistRelations(case: $origin, relations: $originRelations);
+        $this->store->persistRelations(case: $origin, relations: $originRelations);
 
         // Symmetric counterpart — same type names the link, the UI renders
         // direction-aware labels.
@@ -199,25 +200,6 @@ class CaseRelationService
     }//end rejectInvalidRelationInput()
 
     /**
-     * Build a single relation entry, carrying the optional clarification.
-     *
-     * @param string      $caseId      Referenced case UUID.
-     * @param string      $aardRelatie Relation type.
-     * @param string|null $toelichting Optional free-text clarification.
-     *
-     * @return array<string, string>
-     */
-    private function buildRelationEntry(string $caseId, string $aardRelatie, ?string $toelichting): array
-    {
-        $entry = ['caseId' => $caseId, 'aardRelatie' => $aardRelatie];
-        if ($toelichting !== null && $toelichting !== '') {
-            $entry['toelichting'] = $toelichting;
-        }
-
-        return $entry;
-    }//end buildRelationEntry()
-
-    /**
      * Persist the symmetric counterpart entry on the target case, unless it is
      * already present.
      *
@@ -234,14 +216,14 @@ class CaseRelationService
         string $aardRelatie,
         ?string $toelichting
     ): void {
-        $targetRelations = $this->decodeRelations(case: $target);
-        if ($this->hasPair(relations: $targetRelations, caseId: $caseId, aardRelatie: $aardRelatie) === false) {
-            $targetRelations[] = $this->buildRelationEntry(
+        $targetRelations = $this->codec->decode(case: $target);
+        if ($this->codec->hasPair(relations: $targetRelations, caseId: $caseId, aardRelatie: $aardRelatie) === false) {
+            $targetRelations[] = $this->codec->buildEntry(
                 caseId: $caseId,
                 aardRelatie: $aardRelatie,
                 toelichting: $toelichting
             );
-            $this->persistRelations(case: $target, relations: $targetRelations);
+            $this->store->persistRelations(case: $target, relations: $targetRelations);
         }
     }//end addInverseRelation()
 
@@ -262,25 +244,25 @@ class CaseRelationService
             return ['ok' => false, 'reason' => 'missing_case_id'];
         }
 
-        $origin = $this->fetchCase(caseUuid: $caseId);
-        $target = $this->fetchCase(caseUuid: $targetId);
+        $origin = $this->store->fetchCase(caseUuid: $caseId);
+        $target = $this->store->fetchCase(caseUuid: $targetId);
         if ($origin === null || $target === null) {
             return ['ok' => false, 'reason' => 'access_denied'];
         }
 
-        $originRelations = $this->removePair(
-            relations: $this->decodeRelations(case: $origin),
+        $originRelations = $this->codec->removePair(
+            relations: $this->codec->decode(case: $origin),
             caseId: $targetId,
             aardRelatie: $aardRelatie
         );
-        $this->persistRelations(case: $origin, relations: $originRelations);
+        $this->store->persistRelations(case: $origin, relations: $originRelations);
 
-        $targetRelations = $this->removePair(
-            relations: $this->decodeRelations(case: $target),
+        $targetRelations = $this->codec->removePair(
+            relations: $this->codec->decode(case: $target),
             caseId: $caseId,
             aardRelatie: $aardRelatie
         );
-        $this->persistRelations(case: $target, relations: $targetRelations);
+        $this->store->persistRelations(case: $target, relations: $targetRelations);
 
         return ['ok' => true];
     }//end removeRelation()
@@ -304,12 +286,12 @@ class CaseRelationService
             return 0;
         }
 
-        $deleted = $this->fetchCase(caseUuid: $caseId);
+        $deleted = $this->store->fetchCase(caseUuid: $caseId);
         // Even when the case is already gone we still scan counterparts: the
         // relation entries on OTHER cases are what must be cleaned up.
         $counterpartIds = [];
         if ($deleted !== null) {
-            foreach ($this->decodeRelations(case: $deleted) as $relation) {
+            foreach ($this->codec->decode(case: $deleted) as $relation) {
                 $ref = (string) ($relation['caseId'] ?? '');
                 if ($ref !== '' && in_array($ref, $counterpartIds, true) === false) {
                     $counterpartIds[] = $ref;
@@ -319,21 +301,16 @@ class CaseRelationService
 
         $updated = 0;
         foreach ($counterpartIds as $counterpartId) {
-            $counterpart = $this->fetchCase(caseUuid: $counterpartId);
+            $counterpart = $this->store->fetchCase(caseUuid: $counterpartId);
             if ($counterpart === null) {
                 continue;
             }
 
-            $relations = $this->decodeRelations(case: $counterpart);
-            $stripped  = array_values(
-                array_filter(
-                    $relations,
-                    static fn (array $relation): bool => (string) ($relation['caseId'] ?? '') !== $caseId
-                )
-            );
+            $relations = $this->codec->decode(case: $counterpart);
+            $stripped  = $this->codec->removeAllForCase(relations: $relations, caseId: $caseId);
 
             if (count($stripped) !== count($relations)) {
-                $this->persistRelations(case: $counterpart, relations: $stripped);
+                $this->store->persistRelations(case: $counterpart, relations: $stripped);
                 $updated++;
             }
         }//end foreach
@@ -361,12 +338,12 @@ class CaseRelationService
             return;
         }
 
-        $case = $this->fetchCase(caseUuid: $caseId);
+        $case = $this->store->fetchCase(caseUuid: $caseId);
         if ($case === null) {
             return;
         }
 
-        foreach ($this->decodeRelations(case: $case) as $relation) {
+        foreach ($this->codec->decode(case: $case) as $relation) {
             $targetId    = (string) ($relation['caseId'] ?? '');
             $aardRelatie = (string) ($relation['aardRelatie'] ?? '');
             if ($targetId === '' || $targetId === $caseId
@@ -375,296 +352,16 @@ class CaseRelationService
                 continue;
             }
 
-            $target = $this->fetchCase(caseUuid: $targetId);
+            $target = $this->store->fetchCase(caseUuid: $targetId);
             if ($target === null) {
                 continue;
             }
 
-            $targetRelations = $this->decodeRelations(case: $target);
-            if ($this->hasPair(relations: $targetRelations, caseId: $caseId, aardRelatie: $aardRelatie) === false) {
+            $targetRelations = $this->codec->decode(case: $target);
+            if ($this->codec->hasPair(relations: $targetRelations, caseId: $caseId, aardRelatie: $aardRelatie) === false) {
                 $targetRelations[] = ['caseId' => $caseId, 'aardRelatie' => $aardRelatie];
-                $this->persistRelations(case: $target, relations: $targetRelations);
+                $this->store->persistRelations(case: $target, relations: $targetRelations);
             }
         }//end foreach
     }//end normalise()
-
-    /**
-     * Determine whether two cases are already linked through the deelzaak
-     * (parent/child) hierarchy in either direction.
-     *
-     * @param array<string, mixed> $caseA First case object.
-     * @param array<string, mixed> $caseB Second case object.
-     *
-     * @return bool
-     */
-    private function isHierarchyLinked(array $caseA, array $caseB): bool
-    {
-        $idA = (string) ($caseA['id'] ?? ($caseA['@self']['id'] ?? ''));
-        $idB = (string) ($caseB['id'] ?? ($caseB['@self']['id'] ?? ''));
-
-        $parentA = $this->parentRef(case: $caseA);
-        $parentB = $this->parentRef(case: $caseB);
-
-        if ($idB !== '' && $parentA === $idB) {
-            return true;
-        }
-
-        if ($idA !== '' && $parentB === $idA) {
-            return true;
-        }
-
-        return false;
-    }//end isHierarchyLinked()
-
-    /**
-     * Read the `parentCase` reference UUID out of a case array (scalar or
-     * expanded-object shape).
-     *
-     * @param array<string, mixed> $case Case object.
-     *
-     * @return string Parent UUID or '' when absent.
-     */
-    private function parentRef(array $case): string
-    {
-        $parent = ($case['parentCase'] ?? null);
-        if (is_string($parent) === true) {
-            return $parent;
-        }
-
-        if (is_array($parent) === true) {
-            $ref = ($parent['id'] ?? ($parent['uuid'] ?? ''));
-            if (is_string($ref) === true) {
-                return $ref;
-            }
-
-            return '';
-        }
-
-        return '';
-    }//end parentRef()
-
-    /**
-     * Decode the JSON-encoded `relatedCases` field into a list of relation
-     * entries, tolerating an already-array shape.
-     *
-     * @param array<string, mixed> $case Case object.
-     *
-     * @return array<int, array<string, mixed>>
-     */
-    private function decodeRelations(array $case): array
-    {
-        $entries = [];
-        foreach ($this->rawRelationList(case: $case) as $item) {
-            if (is_array($item) === false) {
-                continue;
-            }
-
-            $entry = $this->decodeRelationEntry(item: $item);
-            if ($entry === null) {
-                continue;
-            }
-
-            $entries[] = $entry;
-        }//end foreach
-
-        return $entries;
-    }//end decodeRelations()
-
-    /**
-     * Read the raw `relatedCases` payload as a list, accepting either the
-     * JSON-encoded string shape or an already-decoded array.
-     *
-     * @param array<string, mixed> $case Case object.
-     *
-     * @return array<mixed> The raw relation list, or [] when unusable.
-     */
-    private function rawRelationList(array $case): array
-    {
-        $raw  = ($case['relatedCases'] ?? null);
-        $list = [];
-        if (is_array($raw) === true) {
-            $list = $raw;
-        }
-
-        if (is_string($raw) === true && $raw !== '') {
-            $decoded = json_decode($raw, true);
-            if (is_array($decoded) === true) {
-                $list = $decoded;
-            }
-        }
-
-        return $list;
-    }//end rawRelationList()
-
-    /**
-     * Normalise one raw relation item into a relation entry.
-     *
-     * @param array<string, mixed> $item Raw relation item.
-     *
-     * @return array<string, string>|null The entry, or null when it names no case.
-     */
-    private function decodeRelationEntry(array $item): ?array
-    {
-        $targetId = (string) ($item['caseId'] ?? '');
-        if ($targetId === '') {
-            return null;
-        }
-
-        $entry = [
-            'caseId'      => $targetId,
-            'aardRelatie' => (string) ($item['aardRelatie'] ?? ''),
-        ];
-        if (isset($item['toelichting']) === true && (string) $item['toelichting'] !== '') {
-            $entry['toelichting'] = (string) $item['toelichting'];
-        }
-
-        return $entry;
-    }//end decodeRelationEntry()
-
-    /**
-     * Whether a `{caseId, aardRelatie}` pair already exists in a relation list.
-     *
-     * @param array<int, array<string, mixed>> $relations   Relation entries.
-     * @param string                           $caseId      Target case UUID.
-     * @param string                           $aardRelatie Relation type.
-     *
-     * @return bool
-     */
-    private function hasPair(array $relations, string $caseId, string $aardRelatie): bool
-    {
-        foreach ($relations as $relation) {
-            if ((string) ($relation['caseId'] ?? '') === $caseId
-                && (string) ($relation['aardRelatie'] ?? '') === $aardRelatie
-            ) {
-                return true;
-            }
-        }
-
-        return false;
-    }//end hasPair()
-
-    /**
-     * Return a copy of the relation list with the given pair removed.
-     *
-     * @param array<int, array<string, mixed>> $relations   Relation entries.
-     * @param string                           $caseId      Target case UUID.
-     * @param string                           $aardRelatie Relation type.
-     *
-     * @return array<int, array<string, mixed>>
-     */
-    private function removePair(array $relations, string $caseId, string $aardRelatie): array
-    {
-        return array_values(
-            array_filter(
-                $relations,
-                static fn (array $relation): bool => (
-                    (string) ($relation['caseId'] ?? '') !== $caseId
-                    || (string) ($relation['aardRelatie'] ?? '') !== $aardRelatie
-                )
-            )
-        );
-    }//end removePair()
-
-    /**
-     * Fetch a single case object by UUID through the session's ObjectService.
-     *
-     * Resolving via OpenRegister applies its per-object RBAC for the current
-     * user, so an unreadable case resolves to null — this is the access guard.
-     *
-     * @param string $caseUuid Case UUID.
-     *
-     * @return array<string, mixed>|null
-     */
-    private function fetchCase(string $caseUuid): ?array
-    {
-        if ($caseUuid === '') {
-            return null;
-        }
-
-        $objectService = $this->settingsService->getObjectService();
-        if ($objectService === null) {
-            return null;
-        }
-
-        $register = $this->settingsService->getConfigValue('register');
-        $schema   = $this->settingsService->getConfigValue('case_schema');
-        if ($register === '' || $schema === '') {
-            return null;
-        }
-
-        try {
-            $obj = $objectService->find($caseUuid, register: $register, schema: $schema);
-        } catch (\Throwable $e) {
-            $this->logger->debug(
-                'CaseRelationService: case lookup failed',
-                ['uuid' => $caseUuid, 'error' => $e->getMessage()]
-            );
-            return null;
-        }
-
-        return $this->normalizeCaseObject(object: $obj);
-    }//end fetchCase()
-
-    /**
-     * Normalise an OpenRegister lookup result to a plain case array.
-     *
-     * @param mixed $object The value returned by the ObjectService.
-     *
-     * @return array<string, mixed>|null The case as an array, or null when unusable.
-     */
-    private function normalizeCaseObject(mixed $object): ?array
-    {
-        if ($object === null) {
-            return null;
-        }
-
-        if (is_object($object) === true && method_exists($object, 'jsonSerialize') === true) {
-            $object = $object->jsonSerialize();
-        }
-
-        if (is_array($object) === true) {
-            return $object;
-        }
-
-        return null;
-    }//end normalizeCaseObject()
-
-    /**
-     * Persist a relation list back onto a case, JSON-encoding the field
-     * (the `relatedCases` field is a JSON-encoded string).
-     *
-     * @param array<string, mixed>             $case      Case object to update.
-     * @param array<int, array<string, mixed>> $relations Relation entries.
-     *
-     * @return void
-     */
-    private function persistRelations(array $case, array $relations): void
-    {
-        $objectService = $this->settingsService->getObjectService();
-        if ($objectService === null) {
-            return;
-        }
-
-        $register = $this->settingsService->getConfigValue('register');
-        $schema   = $this->settingsService->getConfigValue('case_schema');
-        if ($register === '' || $schema === '') {
-            return;
-        }
-
-        $payload = $case;
-        $payload['relatedCases'] = json_encode(array_values($relations));
-
-        try {
-            $objectService->saveObject(
-                object: $payload,
-                register: $register,
-                schema: $schema,
-            );
-        } catch (\Throwable $e) {
-            $this->logger->warning(
-                'CaseRelationService: failed to persist relatedCases',
-                ['error' => $e->getMessage()]
-            );
-        }
-    }//end persistRelations()
 }//end class

--- a/lib/Service/CaseSharingService.php
+++ b/lib/Service/CaseSharingService.php
@@ -27,15 +27,29 @@ declare(strict_types=1);
 namespace OCA\Procest\Service;
 
 use DateTime;
-use OCP\App\IAppManager;
-use Psr\Container\ContainerInterface;
+use OCA\Procest\Service\Sharing\CaseAccessPolicy;
+use OCA\Procest\Service\Sharing\CaseTokenShareService;
+use OCA\Procest\Service\Sharing\FederatedCaseShareService;
+use OCA\Procest\Service\Sharing\OpenRegisterSharingGateway;
 use Psr\Log\LoggerInterface;
 
 /**
- * Service for managing case sharing with external parties.
+ * Entry point for case sharing, and the owner of the in-app partner hand-off.
  *
- * Handles token-based sharing, partner organization sharing,
- * permission enforcement, and field-level data filtering.
+ * Procest shares a case in three distinct ways, each with its own trust model,
+ * and this class is the seam between them:
+ *
+ *  - a PUBLIC token link, delegated to {@see CaseTokenShareService}, which
+ *    mints nothing itself and defers entirely to OpenRegister's shares leaf;
+ *  - a PARTNER-organisation hand-off, owned here, because org-to-org case
+ *    hand-off inside one instance is zaak-domain logic and carries no public
+ *    token (ADR-022);
+ *  - a FEDERATED (OCM) share, delegated to {@see FederatedCaseShareService},
+ *    which crosses an org boundary and therefore shares a redacted snapshot
+ *    rather than the live case.
+ *
+ * Access decisions for all three live in {@see CaseAccessPolicy}, and every
+ * reach into OpenRegister goes through {@see OpenRegisterSharingGateway}.
  *
  * @spec openspec/specs/federated-case-collaboration/spec.md
  */
@@ -48,6 +62,9 @@ class CaseSharingService
      * `relations` are deliberately never included: the fleet lesson is that
      * a relations mirror can leak writeOnly fields, so it is excluded by
      * construction rather than filtered after the fact.
+     *
+     * This constant stays on CaseSharingService: it is the documented source
+     * of truth that `src/utils/federatedShareHelpers.js` mirrors by name.
      *
      * @var string[]
      */
@@ -64,35 +81,27 @@ class CaseSharingService
     /**
      * Constructor for the CaseSharingService.
      *
-     * @param SettingsService         $settingsService   The settings service
-     * @param IAppManager             $appManager        The app manager
-     * @param ContainerInterface      $container         The DI container
-     * @param LoggerInterface         $logger            The logger
-     * @param TenantAuditTrailService $auditTrailService Audit-trail emitter for cross-org actions
+     * @param SettingsService            $settingsService The settings service
+     * @param OpenRegisterSharingGateway $gateway         OpenRegister resolution for the sharing surface
+     * @param CaseAccessPolicy           $accessPolicy    Per-case access decisions
+     * @param CaseTokenShareService      $tokenShares     Public "track your case" token links
+     * @param FederatedCaseShareService  $federatedShares Cross-org (OCM) case shares
+     * @param LoggerInterface            $logger          The logger
      *
      * @return void
      */
     public function __construct(
         private SettingsService $settingsService,
-        private IAppManager $appManager,
-        private ContainerInterface $container,
+        private OpenRegisterSharingGateway $gateway,
+        private CaseAccessPolicy $accessPolicy,
+        private CaseTokenShareService $tokenShares,
+        private FederatedCaseShareService $federatedShares,
         private LoggerInterface $logger,
-        private TenantAuditTrailService $auditTrailService,
     ) {
     }//end __construct()
 
     /**
      * Check whether a given user may access a case for sharing purposes.
-     *
-     * A user is permitted when any of the following holds:
-     *  - the case's `assignee` field equals the user ID
-     *  - the user ID appears in `assignees` (array)
-     *  - the user ID appears as a `createdBy` on any caseShare linked to the case
-     *  - the caller is an NC admin (checked via group membership `admin`)
-     *
-     * Returns true when the case cannot be loaded (fail-safe for missing OR
-     * config) to avoid breaking installations that have not configured the
-     * case schema. The caller must still authenticate via IUserSession.
      *
      * @param string $caseId The case UUID
      * @param string $userId The caller's user ID
@@ -103,175 +112,12 @@ class CaseSharingService
      */
     public function canUserAccessCase(string $caseId, string $userId): bool
     {
-        $objectService = $this->getObjectService();
-        if ($objectService === null) {
-            // OR not available — fail-open so the feature still works on basic setups.
-            return true;
-        }
-
-        $register   = $this->settingsService->getConfigValue('register');
-        $caseSchema = $this->settingsService->getConfigValue('case_schema');
-
-        if (empty($register) === true || empty($caseSchema) === true) {
-            return true;
-        }
-
-        try {
-            $caseObj = $objectService->find($caseId, register: (int) $register, schema: (int) $caseSchema);
-            if ($caseObj === null) {
-                // Case not found — deny (treated as 404 by callers).
-                return false;
-            }
-
-            $caseData = $this->normalizeToArray(value: $caseObj);
-        } catch (\Throwable $e) {
-            $this->logger->warning(
-                'CaseSharingService: canUserAccessCase load failed',
-                ['caseId' => $caseId, 'exception' => $e->getMessage()]
-            );
-            return true;
-        }
-
-        // Direct assignee field, then the assignees array.
-        if ($this->isCaseAssignee(caseData: $caseData, userId: $userId) === true) {
-            return true;
-        }
-
-        // Check existing caseShares: if this user created any share for this case they
-        // already had access at that time.
-        if ($this->hasCreatedShareForCase(
-            objectService: $objectService,
-            caseId: $caseId,
-            userId: $userId,
-            register: (int) $register
-        ) === true
-        ) {
-            return true;
-        }
-
-        return false;
+        return $this->accessPolicy->canUserAccessCase(caseId: $caseId, userId: $userId);
     }//end canUserAccessCase()
-
-    /**
-     * Whether a case names the given user as assignee.
-     *
-     * Accepts both the single-valued `assignee` field and membership of the
-     * `assignees` array; either one grants access.
-     *
-     * @param array<string, mixed> $caseData The case data
-     * @param string               $userId   The caller's user ID
-     *
-     * @return bool True when the user is an assignee of the case
-     */
-    private function isCaseAssignee(array $caseData, string $userId): bool
-    {
-        // Direct assignee field (single user ID string).
-        if (isset($caseData['assignee']) === true && (string) $caseData['assignee'] === $userId) {
-            return true;
-        }
-
-        // Assignees array.
-        $assignees = ($caseData['assignees'] ?? []);
-        if (is_array($assignees) === true && in_array($userId, $assignees, true) === true) {
-            return true;
-        }
-
-        return false;
-    }//end isCaseAssignee()
-
-    /**
-     * Whether the given user created any caseShare for the given case.
-     *
-     * A user who once minted a share for the case already had access at that
-     * time, so the share record is treated as standing evidence of access.
-     * A failed lookup is logged and treated as "no share found" (deny), never
-     * as a grant.
-     *
-     * @param object $objectService The OpenRegister ObjectService
-     * @param string $caseId        The case UUID
-     * @param string $userId        The caller's user ID
-     * @param int    $register      The configured register id
-     *
-     * @return bool True when a share created by this user exists
-     */
-    private function hasCreatedShareForCase(
-        object $objectService,
-        string $caseId,
-        string $userId,
-        int $register,
-    ): bool {
-        $shareSchema = $this->settingsService->getConfigValue('case_share_schema');
-        if (empty($shareSchema) === true) {
-            return false;
-        }
-
-        try {
-            $shares = $objectService->findAll(
-                ['filters' => ['register' => $register, 'schema' => (int) $shareSchema, 'caseId' => $caseId]],
-            );
-
-            foreach ($shares as $share) {
-                $shareData = $this->normalizeToArray(value: $share);
-                if (isset($shareData['createdBy']) === true && (string) $shareData['createdBy'] === $userId) {
-                    return true;
-                }
-            }
-        } catch (\Throwable $e) {
-            $this->logger->debug(
-                'CaseSharingService: share lookup in canUserAccessCase failed',
-                ['caseId' => $caseId, 'exception' => $e->getMessage()]
-            );
-        }//end try
-
-        return false;
-    }//end hasCreatedShareForCase()
-
-    /**
-     * Resolve OpenRegister's CaseTokenService — the public "track your
-     * case" token-link surface of the shares integration leaf (ADR-022).
-     *
-     * The leaf owns token generation (256-bit non-guessable handle),
-     * expiry, revocation, and the RBAC-respecting public resolve path;
-     * procest mints no share tokens of its own.
-     *
-     * @return object|null The OR CaseTokenService, or null when OR is
-     *                     unavailable / pre-foundation build.
-     *
-     * @spec openspec/changes/migrate-public-share-to-shares-leaf/tasks.md#P1.2
-     */
-    private function getCaseTokenService(): ?object
-    {
-        if ($this->appManager->isInstalled('openregister') === false) {
-            return null;
-        }
-
-        try {
-            $service = $this->container->get('OCA\OpenRegister\Service\CaseTokenService');
-            if (method_exists($service, 'mint') === false) {
-                return null;
-            }
-
-            return $service;
-        } catch (\Throwable $e) {
-            $this->logger->warning(
-                'CaseSharingService: OR CaseTokenService unavailable (shares leaf not present)',
-                ['exception' => $e->getMessage()]
-            );
-            return null;
-        }
-    }//end getCaseTokenService()
 
     /**
      * Create a public "track your case" token link through OpenRegister's
      * shares integration leaf.
-     *
-     * The leaf mints a 256-bit token bound to the case object. The token
-     * resolves anonymously to a PUBLIC-SAFE view of the case via OR's
-     * `#[PublicPage]` resolve endpoint — only the fields the public group
-     * may read are returned (the `publicatiedatum<=$now` + public-group
-     * predicate), so procest no longer hand-maintains a token store,
-     * field-exclusion list, password gate, or brute-force lockout. RBAC
-     * is enforced by the OR public read path, not by procest.
      *
      * @param string      $caseId    The UUID of the case to share
      * @param string      $label     Human-readable label for the link
@@ -290,76 +136,16 @@ class CaseSharingService
         string $createdBy,
         ?string $expiresAt=null,
     ): array {
-        $tokenService = $this->getCaseTokenService();
-        if ($tokenService === null) {
-            return ['error' => 'OpenRegister shares leaf is not available'];
-        }
-
-        $register = $this->settingsService->getConfigValue('register');
-        $schema   = $this->settingsService->getConfigValue('case_schema');
-
-        $ttlSeconds = null;
-        if ($expiresAt !== null) {
-            $expiryTs = strtotime((string) $expiresAt);
-            if ($expiryTs !== false) {
-                $ttlSeconds = max(1, ($expiryTs - time()));
-            }
-        }
-
-        $registerId = null;
-        if (empty($register) === false) {
-            $registerId = (int) $register;
-        }
-
-        $schemaId = null;
-        if (empty($schema) === false) {
-            $schemaId = (int) $schema;
-        }
-
-        $mintLabel = null;
-        if ($label !== '') {
-            $mintLabel = $label;
-        }
-
-        try {
-            // Mint through the leaf — it owns token generation, expiry and
-            // the public resolve URL. The minter (createdBy) is recorded by
-            // the leaf via the current user session.
-            $minted = $tokenService->mint(
-                objectUuid: $caseId,
-                registerId: $registerId,
-                schemaId: $schemaId,
-                label: $mintLabel,
-                ttlSeconds: $ttlSeconds
-            );
-        } catch (\Throwable $e) {
-            $this->logger->error(
-                'CaseSharingService: leaf mint failed',
-                ['caseId' => $caseId, 'exception' => $e->getMessage()]
-            );
-            return ['error' => 'Could not create share link'];
-        }
-
-        $this->logger->info(
-            'Procest: Public case-token link minted via OR shares leaf',
-            [
-                'caseId'    => $caseId,
-                'createdBy' => $createdBy,
-                'label'     => $label,
-            ]
+        return $this->tokenShares->createTokenShare(
+            caseId: $caseId,
+            label: $label,
+            createdBy: $createdBy,
+            expiresAt: $expiresAt
         );
-
-        return $minted;
     }//end createTokenShare()
 
     /**
-     * Resolve the case (object) a leaf-minted token belongs to.
-     *
-     * Used by the controller to enforce the per-case owner/handler guard
-     * before revoking a public token (ADR-005): the controller looks up
-     * which case the token addresses, then checks the caller may access
-     * that case. Returns null when the token cannot be matched to any
-     * case the candidate caseId owns.
+     * Resolve whether a leaf-minted token belongs to the given case.
      *
      * @param string $tokenId The leaf token id (numeric) or opaque token.
      * @param string $caseId  The candidate case UUID.
@@ -370,36 +156,14 @@ class CaseSharingService
      */
     public function tokenBelongsToCase(string $tokenId, string $caseId): bool
     {
-        $tokenService = $this->getCaseTokenService();
-        if ($tokenService === null || method_exists($tokenService, 'listForObject') === false) {
-            return false;
-        }
-
-        try {
-            $tokens = $tokenService->listForObject($caseId);
-        } catch (\Throwable $e) {
-            $this->logger->warning(
-                'CaseSharingService: listForObject failed',
-                ['caseId' => $caseId, 'exception' => $e->getMessage()]
-            );
-            return false;
-        }
-
-        foreach ((array) $tokens as $token) {
-            $candidateId    = (string) ($token['id'] ?? '');
-            $candidateToken = (string) ($token['token'] ?? '');
-            if ($tokenId !== '' && ($tokenId === $candidateId || $tokenId === $candidateToken)) {
-                return true;
-            }
-        }
-
-        return false;
+        return $this->tokenShares->tokenBelongsToCase(tokenId: $tokenId, caseId: $caseId);
     }//end tokenBelongsToCase()
 
     /**
-     * Revoke a public "track your case" token link through the OR shares
-     * leaf. The caller MUST have already authorised the revoke against the
-     * owning case (see {@see tokenBelongsToCase()} + canUserAccessCase()).
+     * Revoke a public "track your case" token link through the OR shares leaf.
+     *
+     * The caller MUST have already authorised the revoke against the owning
+     * case (see {@see tokenBelongsToCase()} + {@see canUserAccessCase()}).
      *
      * @param string $tokenId The token id (or the opaque token) minted by
      *                        the leaf.
@@ -410,25 +174,7 @@ class CaseSharingService
      */
     public function revokeTokenShare(string $tokenId): bool
     {
-        $tokenService = $this->getCaseTokenService();
-        if ($tokenService === null || method_exists($tokenService, 'revoke') === false) {
-            return false;
-        }
-
-        try {
-            $tokenService->revoke($tokenId);
-            $this->logger->info(
-                'Procest: Public case-token link revoked via OR shares leaf',
-                ['tokenId' => $tokenId]
-            );
-            return true;
-        } catch (\Throwable $e) {
-            $this->logger->error(
-                'CaseSharingService: leaf revoke failed',
-                ['tokenId' => $tokenId, 'exception' => $e->getMessage()]
-            );
-            return false;
-        }
+        return $this->tokenShares->revokeTokenShare(tokenId: $tokenId);
     }//end revokeTokenShare()
 
     /**
@@ -449,7 +195,7 @@ class CaseSharingService
         string $permissionLevel,
         string $createdBy,
     ): array {
-        $objectService = $this->getObjectService();
+        $objectService = $this->gateway->objectService();
         if ($objectService === null) {
             return ['error' => 'OpenRegister is not available'];
         }
@@ -501,7 +247,7 @@ class CaseSharingService
      */
     public function getCaseIdForShare(string $shareId): ?string
     {
-        $objectService = $this->getObjectService();
+        $objectService = $this->gateway->objectService();
         if ($objectService === null) {
             return null;
         }
@@ -550,7 +296,7 @@ class CaseSharingService
      */
     public function revokeShare(string $shareId, string $userId): array
     {
-        $objectService = $this->getObjectService();
+        $objectService = $this->gateway->objectService();
         if ($objectService === null) {
             return ['error' => 'OpenRegister is not available'];
         }
@@ -593,20 +339,7 @@ class CaseSharingService
     /**
      * Create a federated case share: a purpose-built, field-scoped snapshot
      * of the case shared with a remote org over OpenRegister's OCM
-     * federation leaf (`FederationShareService`).
-     *
-     * OpenRegister's `scope: object` federated share serves exactly the
-     * object it is pointed at — the whole object, no field projection. So
-     * rather than sharing the live case, this builds a `caseFederatedShare`
-     * object containing only {@see FEDERATION_ALLOWED_FIELDS} fields (and
-     * document references actually attached to the case), and shares THAT
-     * object with `permissions: 'read'`. The live case is never shared and
-     * never mutable by the remote org (see design.md §3 authority model).
-     *
-     * Fails closed (returns an error, writes nothing) when the OR
-     * federation leaf is unavailable — unlike {@see canUserAccessCase()},
-     * which fails open for same-instance convenience, there is nothing safe
-     * to fall back to once a request is about to cross an org boundary.
+     * federation leaf.
      *
      * @param string        $caseId          The UUID of the case to share
      * @param string        $remoteCloudId   The federated target (slug@host)
@@ -627,222 +360,18 @@ class CaseSharingService
         string $permissionLevel,
         string $createdBy,
     ): array {
-        $federationService = $this->getFederationShareService();
-        $objectService     = $this->getObjectService();
-        if ($federationService === null || $objectService === null) {
-            return ['error' => 'Federated case sharing requires the OpenRegister federation leaf'];
-        }
-
-        $invalidFields = array_diff($sharedFields, self::FEDERATION_ALLOWED_FIELDS);
-        if (count($invalidFields) > 0) {
-            return ['error' => 'Field(s) not shareable across a federation boundary: '.implode(', ', $invalidFields)];
-        }
-
-        $register    = $this->settingsService->getConfigValue('register');
-        $caseSchema  = $this->settingsService->getConfigValue('case_schema');
-        $shareSchema = $this->settingsService->getConfigValue('case_federated_share_schema');
-
-        if ($this->isFederatedShareConfigured(register: $register, caseSchema: $caseSchema, shareSchema: $shareSchema) === false) {
-            return ['error' => 'Federated case sharing is not configured'];
-        }
-
-        $caseData = $this->loadCaseForFederatedShare(
-            objectService: $objectService,
+        return $this->federatedShares->createFederatedShare(
             caseId: $caseId,
-            register: (int) $register,
-            caseSchema: (int) $caseSchema
-        );
-        if ($caseData === null) {
-            return ['error' => 'Case not found'];
-        }
-
-        // Build the redacted snapshot — allow-listed fields present on the case only.
-        $fieldSnapshot = $this->buildFieldSnapshot(caseData: $caseData, sharedFields: $sharedFields);
-
-        // Only document references already attached to the case may cross.
-        $caseDocuments    = (array) ($caseData['documents'] ?? []);
-        $validDocuments   = array_values(array_intersect($sharedDocuments, $caseDocuments));
-        $invalidDocuments = array_diff($sharedDocuments, $caseDocuments);
-        if (count($invalidDocuments) > 0) {
-            return ['error' => 'Document(s) not attached to this case: '.implode(', ', $invalidDocuments)];
-        }
-
-        $shareData = [
-            'caseId'          => $caseId,
-            'remoteCloudId'   => $remoteCloudId,
-            'sharedFields'    => array_values($sharedFields),
-            'sharedDocuments' => $validDocuments,
-            'fieldSnapshot'   => $fieldSnapshot,
-            'permissionLevel' => $permissionLevel,
-            'status'          => 'pending',
-            'createdBy'       => $createdBy,
-        ];
-
-        $result     = $objectService->saveObject(object: $shareData, register: (int) $register, schema: (int) $shareSchema);
-        $resultData = $this->normalizeToArray(value: $result);
-
-        $shareUuid = (string) ($resultData['id'] ?? $resultData['uuid'] ?? '');
-
-        $federatedShare = $this->mintOutgoingShare(
-            federationService: $federationService,
-            caseId: $caseId,
-            shareUuid: $shareUuid,
             remoteCloudId: $remoteCloudId,
-            register: (string) $register,
-            shareSchema: (string) $shareSchema
+            sharedFields: $sharedFields,
+            sharedDocuments: $sharedDocuments,
+            permissionLevel: $permissionLevel,
+            createdBy: $createdBy
         );
-        if ($federatedShare === null) {
-            return ['error' => 'Could not mint the federated share token'];
-        }
-
-        $resultData['federationShareId'] = $federatedShare->getId();
-        $resultData['status']            = 'active';
-        $activated  = $objectService->saveObject(object: $resultData, register: (int) $register, schema: (int) $shareSchema);
-        $resultData = $this->normalizeToArray(value: $activated);
-
-        $this->auditTrailService->emit(
-            [
-                'action'   => 'federated_case_share_created',
-                'actor'    => $createdBy,
-                'resource' => $caseId,
-                'tenantId' => $remoteCloudId,
-            ]
-        );
-
-        $this->logger->info(
-            'Procest: Federated case share created',
-            ['caseId' => $caseId, 'remoteCloudId' => $remoteCloudId, 'shareId' => $shareUuid]
-        );
-
-        return $resultData;
     }//end createFederatedShare()
 
     /**
-     * Whether every configuration value a federated share needs is present.
-     *
-     * @param string $register    The configured register id
-     * @param string $caseSchema  The configured case schema id
-     * @param string $shareSchema The configured federated-share schema id
-     *
-     * @return bool True when all three are configured
-     */
-    private function isFederatedShareConfigured(string $register, string $caseSchema, string $shareSchema): bool
-    {
-        return (empty($register) === false && empty($caseSchema) === false && empty($shareSchema) === false);
-    }//end isFederatedShareConfigured()
-
-    /**
-     * Load the case a federated share is being built from.
-     *
-     * Returns null both when the case cannot be loaded and when it does not
-     * exist — the caller reports 'Case not found' either way; the load failure
-     * is additionally logged here.
-     *
-     * @param object $objectService The OpenRegister ObjectService
-     * @param string $caseId        The UUID of the case to share
-     * @param int    $register      The configured register id
-     * @param int    $caseSchema    The configured case schema id
-     *
-     * @return array<string, mixed>|null The case data, or null when unavailable
-     */
-    private function loadCaseForFederatedShare(
-        object $objectService,
-        string $caseId,
-        int $register,
-        int $caseSchema,
-    ): ?array {
-        try {
-            $caseObj = $objectService->find($caseId, register: $register, schema: $caseSchema);
-        } catch (\Throwable $e) {
-            $this->logger->warning(
-                'CaseSharingService: createFederatedShare case load failed',
-                ['caseId' => $caseId, 'exception' => $e->getMessage()]
-            );
-            return null;
-        }
-
-        if ($caseObj === null) {
-            return null;
-        }
-
-        return $this->normalizeToArray(value: $caseObj);
-    }//end loadCaseForFederatedShare()
-
-    /**
-     * Project the requested fields that are actually present on the case.
-     *
-     * The caller has already rejected any field outside
-     * {@see FEDERATION_ALLOWED_FIELDS}, so this only drops fields the case does
-     * not carry.
-     *
-     * @param array<string, mixed> $caseData     The case data
-     * @param array<string>        $sharedFields Requested case field names
-     *
-     * @return array<string, mixed> The redacted snapshot
-     */
-    private function buildFieldSnapshot(array $caseData, array $sharedFields): array
-    {
-        $fieldSnapshot = [];
-        foreach ($sharedFields as $field) {
-            if (array_key_exists($field, $caseData) === true) {
-                $fieldSnapshot[$field] = $caseData[$field];
-            }
-        }
-
-        return $fieldSnapshot;
-    }//end buildFieldSnapshot()
-
-    /**
-     * Mint the outgoing OCM share for a persisted snapshot through the OR leaf.
-     *
-     * The grant is always 'read' — the case-summary share never gives the
-     * remote org write access to the case. Returns null (and logs) when the
-     * leaf refuses, so the caller can fail closed.
-     *
-     * @param object $federationService The OR FederationShareService
-     * @param string $caseId            The UUID of the case being shared (logging context)
-     * @param string $shareUuid         The UUID of the persisted snapshot object
-     * @param string $remoteCloudId     The federated target (slug@host)
-     * @param string $register          The configured register id
-     * @param string $shareSchema       The configured federated-share schema id
-     *
-     * @return object|null The minted OR federated share, or null on failure
-     */
-    private function mintOutgoingShare(
-        object $federationService,
-        string $caseId,
-        string $shareUuid,
-        string $remoteCloudId,
-        string $register,
-        string $shareSchema,
-    ): ?object {
-        try {
-            return $federationService->createOutgoingShare(
-                params: [
-                    'scope'       => 'object',
-                    'register'    => $register,
-                    'schema'      => $shareSchema,
-                    'objectUri'   => $shareUuid,
-                    'sharedWith'  => $remoteCloudId,
-                    // Always 'read' — the case-summary share never grants
-                    // the remote org write access to the case.
-                    'permissions' => 'read',
-                ]
-            );
-        } catch (\Throwable $e) {
-            $this->logger->error(
-                'CaseSharingService: OR createOutgoingShare failed',
-                ['caseId' => $caseId, 'exception' => $e->getMessage()]
-            );
-            return null;
-        }
-    }//end mintOutgoingShare()
-
-    /**
-     * Revoke a federated case share. Sets the OR `FederatedShare.status` to
-     * 'revoked' — the single source of truth every downstream check
-     * (OR's own serving endpoint, procest's own token checks) consults, so
-     * revocation is immediate everywhere.
+     * Revoke a federated case share.
      *
      * @param string $shareId The UUID of the caseFederatedShare to revoke
      * @param string $userId  The user ID performing the revocation
@@ -853,64 +382,7 @@ class CaseSharingService
      */
     public function revokeFederatedShare(string $shareId, string $userId): array
     {
-        $federationService = $this->getFederationShareService();
-        $objectService     = $this->getObjectService();
-        if ($federationService === null || $objectService === null) {
-            return ['error' => 'Federated case sharing requires the OpenRegister federation leaf'];
-        }
-
-        $register    = $this->settingsService->getConfigValue('register');
-        $shareSchema = $this->settingsService->getConfigValue('case_federated_share_schema');
-        if (empty($register) === true || empty($shareSchema) === true) {
-            return ['error' => 'Federated case sharing is not configured'];
-        }
-
-        $shareObj = $objectService->find($shareId, register: (int) $register, schema: (int) $shareSchema);
-        if ($shareObj === null) {
-            return ['error' => 'Federated share not found'];
-        }
-
-        // NOTE: normalised through a helper deliberately. Hoisting a default
-        // assignment inline lets PHPStan narrow $shareData to the empty-array
-        // shape of ObjectService::find()'s array branch, which then reports
-        // the 'caseId'/'remoteCloudId' reads below as non-existent offsets.
-        $shareData = $this->normalizeToArray(value: $shareObj);
-
-        $federationShareId = $shareData['federationShareId'] ?? null;
-        if ($federationShareId !== null) {
-            try {
-                $federationService->setStatus(id: (int) $federationShareId, status: 'revoked');
-            } catch (\Throwable $e) {
-                $this->logger->error(
-                    'CaseSharingService: OR federated-share revoke failed',
-                    ['shareId' => $shareId, 'exception' => $e->getMessage()]
-                );
-                return ['error' => 'Could not revoke the federated share token'];
-            }
-        }
-
-        $shareData['status']    = 'revoked';
-        $shareData['revokedBy'] = $userId;
-        $shareData['revokedAt'] = (new DateTime())->format('c');
-
-        $result = $objectService->saveObject(object: $shareData, register: (int) $register, schema: (int) $shareSchema);
-
-        $this->auditTrailService->emit(
-            [
-                'action'   => 'federated_case_share_revoked',
-                'actor'    => $userId,
-                'resource' => (string) ($shareData['caseId'] ?? ''),
-                'tenantId' => (string) ($shareData['remoteCloudId'] ?? ''),
-            ]
-        );
-
-        $this->logger->info('Procest: Federated case share revoked', ['shareId' => $shareId, 'revokedBy' => $userId]);
-
-        if (is_array($result) === true) {
-            return $result;
-        }
-
-        return $result->jsonSerialize();
+        return $this->federatedShares->revokeFederatedShare(shareId: $shareId, userId: $userId);
     }//end revokeFederatedShare()
 
     /**
@@ -925,111 +397,6 @@ class CaseSharingService
      */
     public function getCaseIdForFederatedShare(string $shareId): ?string
     {
-        $objectService = $this->getObjectService();
-        if ($objectService === null) {
-            return null;
-        }
-
-        $register    = $this->settingsService->getConfigValue('register');
-        $shareSchema = $this->settingsService->getConfigValue('case_federated_share_schema');
-        if (empty($register) === true || empty($shareSchema) === true) {
-            return null;
-        }
-
-        try {
-            $shareObj = $objectService->find($shareId, register: (int) $register, schema: (int) $shareSchema);
-            if ($shareObj === null) {
-                return null;
-            }
-
-            $shareData = $shareObj;
-            if (is_array($shareObj) === false) {
-                $shareData = $shareObj->jsonSerialize();
-            }
-
-            if (isset($shareData['caseId']) === true) {
-                return (string) $shareData['caseId'];
-            }
-
-            return null;
-        } catch (\Throwable $e) {
-            $this->logger->debug(
-                'CaseSharingService: getCaseIdForFederatedShare failed',
-                ['shareId' => $shareId, 'exception' => $e->getMessage()]
-            );
-            return null;
-        }//end try
+        return $this->federatedShares->getCaseIdForFederatedShare(shareId: $shareId);
     }//end getCaseIdForFederatedShare()
-
-    /**
-     * Resolve OpenRegister's FederationShareService — the leaf that owns
-     * OCM token minting, transport and lifecycle status. Returns null (fail
-     * closed for federation callers) when OR or its federation classes are
-     * unavailable.
-     *
-     * @return object|null The OR FederationShareService, or null
-     */
-    private function getFederationShareService(): ?object
-    {
-        if ($this->appManager->isInstalled('openregister') === false) {
-            return null;
-        }
-
-        try {
-            $service = $this->container->get('OCA\OpenRegister\Service\FederationShareService');
-            if (method_exists($service, 'createOutgoingShare') === false || method_exists($service, 'setStatus') === false) {
-                return null;
-            }
-
-            return $service;
-        } catch (\Throwable $e) {
-            $this->logger->warning(
-                'CaseSharingService: OR FederationShareService unavailable (federation leaf not present)',
-                ['exception' => $e->getMessage()]
-            );
-            return null;
-        }
-    }//end getFederationShareService()
-
-    /**
-     * Normalize an OpenRegister return value (array or ObjectEntity) to an array.
-     *
-     * @param mixed $value The value returned by the ObjectService
-     *
-     * @return array<string, mixed> The value as a plain array
-     */
-    private function normalizeToArray(mixed $value): array
-    {
-        if (is_array($value) === true) {
-            return $value;
-        }
-
-        if (is_object($value) === true && method_exists($value, 'jsonSerialize') === true) {
-            return (array) $value->jsonSerialize();
-        }
-
-        return [];
-    }//end normalizeToArray()
-
-    /**
-     * Resolve the ObjectService from the DI container.
-     *
-     * @return object|null The ObjectService, or null when OpenRegister is unavailable
-     */
-    private function getObjectService(): ?object
-    {
-        if ($this->appManager->isInstalled('openregister') === false) {
-            return null;
-        }
-
-        try {
-            return $this->container->get('OCA\OpenRegister\Service\ObjectService');
-        } catch (\Throwable $e) {
-            $this->logger->warning(
-                'CaseSharingService: ObjectService unavailable',
-                ['exception' => $e->getMessage()]
-            );
-            return null;
-        }
-    }//end getObjectService()
 }//end class

--- a/lib/Service/CaseTransferService.php
+++ b/lib/Service/CaseTransferService.php
@@ -27,8 +27,8 @@ declare(strict_types=1);
 namespace OCA\Procest\Service;
 
 use DateTime;
-use OCP\App\IAppManager;
-use Psr\Container\ContainerInterface;
+use OCA\Procest\Service\Transfer\TransferRegisterGateway;
+use OCA\Procest\Service\Transfer\TransferShareBroker;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -45,8 +45,8 @@ class CaseTransferService
      * Constructor for the CaseTransferService.
      *
      * @param SettingsService         $settingsService The settings service
-     * @param IAppManager             $appManager      The app manager
-     * @param ContainerInterface      $container       The DI container
+     * @param TransferRegisterGateway $gateway         OpenRegister resolution for the transfer surface
+     * @param TransferShareBroker     $shareBroker     Transfer-scoped OCM token minting and resolution
      * @param LoggerInterface         $logger          The logger
      * @param TenantAuditTrailService $auditTrail      Audit-trail emitter for custody-change actions
      *
@@ -54,8 +54,8 @@ class CaseTransferService
      */
     public function __construct(
         private SettingsService $settingsService,
-        private IAppManager $appManager,
-        private ContainerInterface $container,
+        private TransferRegisterGateway $gateway,
+        private TransferShareBroker $shareBroker,
         private LoggerInterface $logger,
         private TenantAuditTrailService $auditTrail,
     ) {
@@ -95,7 +95,7 @@ class CaseTransferService
         string $initiatedBy='',
         ?string $remoteCloudId=null,
     ): array {
-        $objectService = $this->getObjectService();
+        $objectService = $this->gateway->objectService();
         if ($objectService === null) {
             return ['error' => 'OpenRegister is not available'];
         }
@@ -105,7 +105,7 @@ class CaseTransferService
 
         $idempotencyKey = null;
         if ($remoteCloudId !== null && $remoteCloudId !== '') {
-            $shareService = $this->getFederationShareService();
+            $shareService = $this->gateway->federationShareService();
             if ($shareService === null) {
                 return ['error' => 'Federated case transfer requires the OpenRegister federation leaf'];
             }
@@ -146,7 +146,7 @@ class CaseTransferService
 
         if ($remoteCloudId !== null && $remoteCloudId !== '') {
             $transferUuid = (string) ($resultData['id'] ?? $resultData['uuid'] ?? '');
-            $mintedShare  = $this->mintFederatedTransferShare(
+            $mintedShare  = $this->shareBroker->mintTransferShare(
                 transferUuid: $transferUuid,
                 remoteCloudId: $remoteCloudId,
                 register: (string) $register,
@@ -322,7 +322,7 @@ class CaseTransferService
         ?string $remoteCloudId=null,
         string $rejectionReason='',
     ): array {
-        $objectService = $this->getObjectService();
+        $objectService = $this->gateway->objectService();
         if ($objectService === null) {
             return ['error' => 'OpenRegister is not available'];
         }
@@ -470,7 +470,7 @@ class CaseTransferService
      */
     public function getCaseIdForTransfer(string $transferId): ?string
     {
-        $objectService = $this->getObjectService();
+        $objectService = $this->gateway->objectService();
         if ($objectService === null) {
             return null;
         }
@@ -523,38 +523,7 @@ class CaseTransferService
      */
     public function resolveFederatedTransferShare(string $shareToken, string $transferId): ?array
     {
-        $shareMapper = $this->getFederatedShareMapper();
-        if ($shareMapper === null || $shareToken === '' || $transferId === '') {
-            return null;
-        }
-
-        try {
-            $share = $shareMapper->findByToken($shareToken);
-        } catch (\Throwable $e) {
-            return null;
-        }
-
-        if ($share->getDirection() !== 'outgoing') {
-            return null;
-        }
-
-        if (in_array($share->getStatus(), ['revoked', 'declined'], true) === true) {
-            return null;
-        }
-
-        if ($share->getPermissions() !== 'read-write') {
-            return null;
-        }
-
-        $objectUri = (string) $share->getObjectUri();
-        if ($this->uuidFromUri(uri: $objectUri) !== $transferId) {
-            return null;
-        }
-
-        return [
-            'sharedWith'   => (string) $share->getSharedWith(),
-            'organisation' => $share->getOrganisation(),
-        ];
+        return $this->shareBroker->resolveTransferShare(shareToken: $shareToken, transferId: $transferId);
     }//end resolveFederatedTransferShare()
 
     /**
@@ -592,149 +561,4 @@ class CaseTransferService
 
         return null;
     }//end findTransferByIdempotencyKey()
-
-    /**
-     * Mint a transfer-scoped OR federated share (read-write, pointed only
-     * at the transfer object) so the remote org can later authenticate its
-     * accept/reject call. Distinct from the case-summary share's token —
-     * this one grants no access to the case itself, only to this one
-     * transfer's status field via procest's own state machine.
-     *
-     * @param string $transferUuid  The transfer object's uuid
-     * @param string $remoteCloudId The federated target (slug@host)
-     * @param string $register      The register id/slug
-     * @param string $schema        The case_transfer_schema id/slug
-     *
-     * @return object|null The minted OR FederatedShare, or null on failure
-     */
-    private function mintFederatedTransferShare(string $transferUuid, string $remoteCloudId, string $register, string $schema): ?object
-    {
-        $shareService = $this->getFederationShareService();
-        if ($shareService === null) {
-            return null;
-        }
-
-        try {
-            return $shareService->createOutgoingShare(
-                params: [
-                    'scope'       => 'object',
-                    'register'    => $register,
-                    'schema'      => $schema,
-                    'objectUri'   => $transferUuid,
-                    'sharedWith'  => $remoteCloudId,
-                    'permissions' => 'read-write',
-                ]
-            );
-        } catch (\Throwable $e) {
-            $this->logger->error(
-                'CaseTransferService: OR createOutgoingShare failed',
-                ['transferUuid' => $transferUuid, 'exception' => $e->getMessage()]
-            );
-            return null;
-        }
-    }//end mintFederatedTransferShare()
-
-    /**
-     * Extract the trailing uuid from a canonical object uri (or return it
-     * as-is when it is already a bare uuid).
-     *
-     * @param string $uri The object uri or uuid
-     *
-     * @return string The uuid
-     */
-    private function uuidFromUri(string $uri): string
-    {
-        $parts = explode('/', rtrim($uri, '/'));
-        return (string) end($parts);
-    }//end uuidFromUri()
-
-    /**
-     * Resolve OpenRegister's FederationShareService. Returns null (fail
-     * closed) when OR or its federation classes are unavailable.
-     *
-     * @return object|null The OR FederationShareService, or null
-     */
-    private function getFederationShareService(): ?object
-    {
-        if (in_array('openregister', $this->appManager->getInstalledApps()) === false) {
-            return null;
-        }
-
-        try {
-            $service = $this->container->get('OCA\OpenRegister\Service\FederationShareService');
-            if (method_exists($service, 'createOutgoingShare') === false) {
-                return null;
-            }
-
-            return $service;
-        } catch (\Throwable $e) {
-            $this->logger->error(
-                'Procest: Could not get OR FederationShareService',
-                ['exception' => $e->getMessage()]
-            );
-            return null;
-        }
-    }//end getFederationShareService()
-
-    /**
-     * Resolve OpenRegister's FederatedShareMapper — used only to resolve a
-     * scoped bearer token to its share (`findByToken`), for the remote
-     * accept/reject endpoint. Returns null (fail closed) when unavailable.
-     *
-     * @return object|null The OR FederatedShareMapper, or null
-     */
-    private function getFederatedShareMapper(): ?object
-    {
-        if (in_array('openregister', $this->appManager->getInstalledApps()) === false) {
-            return null;
-        }
-
-        try {
-            $mapper = $this->container->get('OCA\OpenRegister\Db\FederatedShareMapper');
-            if (method_exists($mapper, 'findByToken') === false) {
-                return null;
-            }
-
-            return $mapper;
-        } catch (\Throwable $e) {
-            $this->logger->error(
-                'Procest: Could not get OR FederatedShareMapper',
-                ['exception' => $e->getMessage()]
-            );
-            return null;
-        }
-    }//end getFederatedShareMapper()
-
-    /**
-     * Get the OpenRegister ObjectService.
-     *
-     * Pre-existing gap fixed alongside the federation extension: this
-     * previously declared a concrete `?\OCA\OpenRegister\Service\ObjectService`
-     * return type. That class is not part of this app's autoload map (OR is
-     * a separate app, resolved only through the DI container at runtime), so
-     * the type declaration was unenforceable and would TypeError the moment
-     * any test exercised this method with a test double — which none did
-     * before this change, since CaseTransferService had zero prior test
-     * coverage. `?object` matches the pattern already used everywhere else
-     * in this file (getFederationShareService/getFederatedShareMapper) and
-     * in CaseSharingService's own getObjectService().
-     *
-     * @return object|null The service or null
-     */
-    private function getObjectService(): ?object
-    {
-        if (in_array('openregister', $this->appManager->getInstalledApps()) === false) {
-            return null;
-        }
-
-        try {
-            return $this->container->get('OCA\OpenRegister\Service\ObjectService');
-        } catch (\Exception $e) {
-            $this->logger->error(
-                'Procest: Could not get ObjectService',
-                ['exception' => $e->getMessage()]
-            );
-            return null;
-        }
-    }//end getObjectService()
 }//end class

--- a/lib/Service/Cmmn/CaseModelEngine.php
+++ b/lib/Service/Cmmn/CaseModelEngine.php
@@ -16,6 +16,18 @@
  * `handlingModel: cmmn`, and never touches `case.status`/`statusHistory` —
  * `StatusTransitionService`'s write surface is untouched by this class.
  *
+ * This class is the REST-facing orchestrator; the four pieces it drives each
+ * own one concern:
+ *   - {@see CasePlanRepository}   loads the case/caseType/plan items and
+ *                                 performs the single persist per mutation;
+ *   - {@see PlanItemCascade}      drives the plan to a fixed point;
+ *   - {@see PlanItemStateMachine} applies one validated transition;
+ *   - {@see PlanItemTree}         answers structural queries over the hierarchy.
+ *
+ * Every mutating method follows the same shape — load, initialise, cascade,
+ * act, cascade again, persist — so a worker action and its knock-on effects
+ * settle within one request and reach storage in one write.
+ *
  * @category Service
  * @package  OCA\Procest\Service\Cmmn
  *
@@ -31,19 +43,13 @@
  * @link https://procest.nl
  *
  * @spec openspec/specs/cmmn-adaptive-case/spec.md
- *
- * @SuppressWarnings(PHPMD.ExcessiveClassComplexity) — one cohesive state-machine engine by design
  */
 
 declare(strict_types=1);
 
 namespace OCA\Procest\Service\Cmmn;
 
-use DateTimeImmutable;
-use OCA\Procest\Service\SettingsService;
-use Psr\Log\LoggerInterface;
 use RuntimeException;
-use Throwable;
 
 /**
  * The CMMN plan-item lifecycle + sentry evaluation engine.
@@ -52,35 +58,21 @@ use Throwable;
  */
 class CaseModelEngine
 {
-
-    /**
-     * Bound on cascade fixed-point iterations per mutation — protects against
-     * an authoring cycle in the case model (e.g. two plan items whose entry
-     * sentries reference each other's completion) looping forever. Reaching
-     * the bound is a defensive stop, not expected in a well-formed model.
-     */
-    private const MAX_CASCADE_DEPTH = 50;
-
-    /**
-     * Bound on the number of retained event-log entries in casePlanState.
-     */
-    private const MAX_EVENT_LOG = 100;
-
     /**
      * Constructor.
      *
-     * @param SettingsService     $settingsService Bridge to OpenRegister + config.
-     * @param CaseModelLoader     $modelLoader     Active-caseModel-by-caseType loader.
-     * @param LoggerInterface     $logger          Logger.
-     * @param PlanItemTransitions $transitions     Legal plan-item transition table.
-     * @param SentryEvaluator     $sentries        Pure sentry-firing evaluator.
+     * @param CasePlanRepository   $repository   Case/caseType/plan-item loading and persistence.
+     * @param PlanItemCascade      $cascade      Fixed-point sentry evaluation.
+     * @param PlanItemStateMachine $stateMachine Single validated transition application.
+     * @param PlanItemTree         $tree         Structural queries over the plan-item hierarchy.
+     * @param PlanItemTransitions  $transitions  Legal plan-item transition table.
      */
     public function __construct(
-        private readonly SettingsService $settingsService,
-        private readonly CaseModelLoader $modelLoader,
-        private readonly LoggerInterface $logger,
+        private readonly CasePlanRepository $repository,
+        private readonly PlanItemCascade $cascade,
+        private readonly PlanItemStateMachine $stateMachine,
+        private readonly PlanItemTree $tree,
         private readonly PlanItemTransitions $transitions,
-        private readonly SentryEvaluator $sentries,
     ) {
     }//end __construct()
 
@@ -100,11 +92,11 @@ class CaseModelEngine
      */
     public function getCasePlan(string $caseId): array
     {
-        $ctx      = $this->loadContext(caseId: $caseId);
+        $ctx      = $this->repository->loadContext(caseId: $caseId);
         $newInit  = $this->ensureInitialized(state: $ctx['state'], itemsById: $ctx['itemsById']);
-        $cascaded = $this->cascade(itemsById: $ctx['itemsById'], state: $ctx['state'], touchedKeys: [], changedKeys: []);
+        $cascaded = $this->cascade->run(itemsById: $ctx['itemsById'], state: $ctx['state'], touchedKeys: [], changedKeys: []);
         if ($newInit === true || $cascaded === true) {
-            $this->persist(ctx: $ctx);
+            $this->repository->persist(ctx: $ctx);
         }
 
         return $this->buildPlanView(ctx: $ctx);
@@ -127,9 +119,9 @@ class CaseModelEngine
      */
     public function enableDiscretionaryItem(string $caseId, string $itemId): array
     {
-        $ctx = $this->loadContext(caseId: $caseId);
+        $ctx = $this->repository->loadContext(caseId: $caseId);
         $this->ensureInitialized(state: $ctx['state'], itemsById: $ctx['itemsById']);
-        $this->cascade(itemsById: $ctx['itemsById'], state: $ctx['state'], touchedKeys: [], changedKeys: []);
+        $this->cascade->run(itemsById: $ctx['itemsById'], state: $ctx['state'], touchedKeys: [], changedKeys: []);
 
         $item = $ctx['itemsById'][$itemId] ?? null;
         if ($item === null) {
@@ -150,9 +142,15 @@ class CaseModelEngine
             );
         }
 
-        $this->transition(item: $item, from: $current, to: PlanItemTransitions::STATE_ACTIVE, itemsById: $ctx['itemsById'], state: $ctx['state']);
-        $this->cascade(itemsById: $ctx['itemsById'], state: $ctx['state'], touchedKeys: [], changedKeys: []);
-        $this->persist(ctx: $ctx);
+        $this->stateMachine->transition(
+            item: $item,
+            from: $current,
+            to: PlanItemTransitions::STATE_ACTIVE,
+            itemsById: $ctx['itemsById'],
+            state: $ctx['state'],
+        );
+        $this->cascade->run(itemsById: $ctx['itemsById'], state: $ctx['state'], touchedKeys: [], changedKeys: []);
+        $this->repository->persist(ctx: $ctx);
 
         return $this->buildPlanView(ctx: $ctx);
     }//end enableDiscretionaryItem()
@@ -209,9 +207,9 @@ class CaseModelEngine
      */
     public function signalCaseFileEvent(string $caseId, array $updates): array
     {
-        $ctx = $this->loadContext(caseId: $caseId);
+        $ctx = $this->repository->loadContext(caseId: $caseId);
         $this->ensureInitialized(state: $ctx['state'], itemsById: $ctx['itemsById']);
-        $this->cascade(itemsById: $ctx['itemsById'], state: $ctx['state'], touchedKeys: [], changedKeys: []);
+        $this->cascade->run(itemsById: $ctx['itemsById'], state: $ctx['state'], touchedKeys: [], changedKeys: []);
 
         $oldCaseFile = $ctx['state']['caseFile'];
         $touchedKeys = [];
@@ -226,10 +224,10 @@ class CaseModelEngine
             $ctx['state']['caseFile'][$key] = $value;
         }
 
-        $this->cascade(itemsById: $ctx['itemsById'], state: $ctx['state'], touchedKeys: $touchedKeys, changedKeys: $changedKeys);
+        $this->cascade->run(itemsById: $ctx['itemsById'], state: $ctx['state'], touchedKeys: $touchedKeys, changedKeys: $changedKeys);
         // Always persist — the case-file mutation itself must be saved even
         // when no plan-item state changed as a result.
-        $this->persist(ctx: $ctx);
+        $this->repository->persist(ctx: $ctx);
 
         return $this->buildPlanView(ctx: $ctx);
     }//end signalCaseFileEvent()
@@ -251,7 +249,7 @@ class CaseModelEngine
      */
     public function getPlanItemAuthorization(string $caseId, string $itemId): array
     {
-        $ctx  = $this->loadContext(caseId: $caseId);
+        $ctx  = $this->repository->loadContext(caseId: $caseId);
         $item = $ctx['itemsById'][$itemId] ?? null;
         if ($item === null) {
             throw new RuntimeException('plan_item_not_found');
@@ -277,9 +275,9 @@ class CaseModelEngine
      */
     public function getEnableableDiscretionaryItems(string $caseId): array
     {
-        $ctx = $this->loadContext(caseId: $caseId);
+        $ctx = $this->repository->loadContext(caseId: $caseId);
         $this->ensureInitialized(state: $ctx['state'], itemsById: $ctx['itemsById']);
-        $this->cascade(itemsById: $ctx['itemsById'], state: $ctx['state'], touchedKeys: [], changedKeys: []);
+        $this->cascade->run(itemsById: $ctx['itemsById'], state: $ctx['state'], touchedKeys: [], changedKeys: []);
 
         return $this->enableableDiscretionaryIds(ctx: $ctx);
     }//end getEnableableDiscretionaryItems()
@@ -299,9 +297,9 @@ class CaseModelEngine
      */
     private function transitionHumanTask(string $caseId, string $itemId, string $to): array
     {
-        $ctx = $this->loadContext(caseId: $caseId);
+        $ctx = $this->repository->loadContext(caseId: $caseId);
         $this->ensureInitialized(state: $ctx['state'], itemsById: $ctx['itemsById']);
-        $this->cascade(itemsById: $ctx['itemsById'], state: $ctx['state'], touchedKeys: [], changedKeys: []);
+        $this->cascade->run(itemsById: $ctx['itemsById'], state: $ctx['state'], touchedKeys: [], changedKeys: []);
 
         $item = $ctx['itemsById'][$itemId] ?? null;
         if ($item === null) {
@@ -313,571 +311,16 @@ class CaseModelEngine
         }
 
         $current = $ctx['state']['planItemStates'][$itemId] ?? $this->transitions->initialState();
-        $this->transition(item: $item, from: $current, to: $to, itemsById: $ctx['itemsById'], state: $ctx['state']);
-        $this->cascade(itemsById: $ctx['itemsById'], state: $ctx['state'], touchedKeys: [], changedKeys: []);
-        $this->persist(ctx: $ctx);
+        $this->stateMachine->transition(item: $item, from: $current, to: $to, itemsById: $ctx['itemsById'], state: $ctx['state']);
+        $this->cascade->run(itemsById: $ctx['itemsById'], state: $ctx['state'], touchedKeys: [], changedKeys: []);
+        $this->repository->persist(ctx: $ctx);
 
         return $this->buildPlanView(ctx: $ctx);
     }//end transitionHumanTask()
 
     // ------------------------------------------------------------------
-    // Cascade / sentry evaluation
+    // Runtime-state initialisation / view
     // ------------------------------------------------------------------
-
-    /**
-     * Run cascade passes to a fixed point (or MAX_CASCADE_DEPTH).
-     *
-     * @param array<string, array<string, mixed>> $itemsById   Plan items by id.
-     * @param array<string, mixed>                $state       Runtime state, mutated in place.
-     * @param array<int, string>                  $touchedKeys Case-file keys touched this call.
-     * @param array<int, string>                  $changedKeys Subset of touchedKeys whose value changed.
-     *
-     * @return bool Whether any transition occurred across all passes.
-     */
-    private function cascade(array &$itemsById, array &$state, array $touchedKeys, array $changedKeys): bool
-    {
-        $anyChanged = false;
-        for ($depth = 0; $depth < self::MAX_CASCADE_DEPTH; $depth++) {
-            $passChanged = $this->cascadePass(itemsById: $itemsById, state: $state, touchedKeys: $touchedKeys, changedKeys: $changedKeys);
-            if ($passChanged === false) {
-                break;
-            }
-
-            $anyChanged = true;
-        }
-
-        return $anyChanged;
-    }//end cascade()
-
-    /**
-     * One evaluation pass over every non-terminal item, against a snapshot
-     * taken at the start of the pass (so results are independent of item
-     * iteration order — a later pass picks up anything this pass changed).
-     *
-     * @param array<string, array<string, mixed>> $itemsById   Plan items by id.
-     * @param array<string, mixed>                $state       Runtime state, mutated in place.
-     * @param array<int, string>                  $touchedKeys Case-file keys touched this call.
-     * @param array<int, string>                  $changedKeys Subset of touchedKeys whose value changed.
-     *
-     * @return bool Whether this pass changed any item's state.
-     *
-     * @SuppressWarnings(PHPMD.CyclomaticComplexity) — one evaluation pass over the state machine's
-     *   own branches (exit sentry, entry sentry, mandatory-cascade, stage auto-complete); splitting
-     *   it would scatter one pass across several methods that all need the same $context snapshot.
-     */
-    private function cascadePass(array &$itemsById, array &$state, array $touchedKeys, array $changedKeys): bool
-    {
-        $changed = false;
-        $context = [
-            'planItemStates' => $state['planItemStates'],
-            'caseFile'       => $state['caseFile'],
-            'touchedKeys'    => $touchedKeys,
-            'changedKeys'    => $changedKeys,
-        ];
-
-        foreach ($itemsById as $id => $item) {
-            $current = $state['planItemStates'][$id] ?? $this->transitions->initialState();
-            if ($this->transitions->isTerminal(state: $current) === true) {
-                continue;
-            }
-
-            if ($this->isParentActive(item: $item, state: $state) === false) {
-                continue;
-            }
-
-            $exitCriteria = $item['exitCriteria'] ?? [];
-            if (is_array($exitCriteria) === true && count($exitCriteria) > 0
-                && $this->sentries->anyFires(sentries: $exitCriteria, context: $context) === true
-            ) {
-                $this->transition(item: $item, from: $current, to: PlanItemTransitions::STATE_TERMINATED, itemsById: $itemsById, state: $state);
-                $changed = true;
-                continue;
-            }
-
-            if ($current === PlanItemTransitions::STATE_AVAILABLE) {
-                $entryCriteria = $item['entryCriteria'] ?? [];
-                $hasNoCriteria = (is_array($entryCriteria) === false || count($entryCriteria) === 0);
-                $satisfied     = $hasNoCriteria || $this->sentries->anyFires(sentries: $entryCriteria, context: $context);
-
-                if ($satisfied === true) {
-                    $this->advanceFromAvailable(item: $item, current: $current, itemsById: $itemsById, state: $state);
-                    $changed = true;
-                }
-
-                continue;
-            }
-
-            if ($current === PlanItemTransitions::STATE_ACTIVE && $item['type'] === PlanItemTransitions::TYPE_STAGE) {
-                if ($this->stageMandatoryChildrenAllTerminal(stageId: $id, itemsById: $itemsById, state: $state) === true) {
-                    $this->transition(item: $item, from: $current, to: PlanItemTransitions::STATE_COMPLETED, itemsById: $itemsById, state: $state);
-                    $changed = true;
-                }
-            }//end if
-        }//end foreach
-
-        return $changed;
-    }//end cascadePass()
-
-    /**
-     * Advance a plan item whose entry criteria just became satisfied: a
-     * milestone completes directly; a stage/humanTask enables, then
-     * auto-cascades straight to `active` unless it is discretionary (which
-     * stops at `enabled`, pending the worker's opt-in).
-     *
-     * @param array<string, mixed>                $item      The plan item (state `available`).
-     * @param string                              $current   Current state (`available`).
-     * @param array<string, array<string, mixed>> $itemsById Plan items by id.
-     * @param array<string, mixed>                $state     Runtime state, mutated in place.
-     *
-     * @return void
-     */
-    private function advanceFromAvailable(array $item, string $current, array &$itemsById, array &$state): void
-    {
-        if ($item['type'] === PlanItemTransitions::TYPE_MILESTONE) {
-            $this->transition(item: $item, from: $current, to: PlanItemTransitions::STATE_COMPLETED, itemsById: $itemsById, state: $state);
-            return;
-        }
-
-        $this->transition(item: $item, from: $current, to: PlanItemTransitions::STATE_ENABLED, itemsById: $itemsById, state: $state);
-        if (($item['discretionary'] ?? false) !== true) {
-            $this->transition(
-                item: $item,
-                from: PlanItemTransitions::STATE_ENABLED,
-                to: PlanItemTransitions::STATE_ACTIVE,
-                itemsById: $itemsById,
-                state: $state,
-            );
-        }
-    }//end advanceFromAvailable()
-
-    /**
-     * Whether an item's containing stage is active (root items — no parent —
-     * are always considered active).
-     *
-     * @param array<string, mixed> $item  The plan item.
-     * @param array<string, mixed> $state Runtime state.
-     *
-     * @return bool
-     */
-    private function isParentActive(array $item, array $state): bool
-    {
-        $parentId = $item['parentId'] ?? null;
-        if ($parentId === null || $parentId === '') {
-            return true;
-        }
-
-        return ($state['planItemStates'][$parentId] ?? $this->transitions->initialState()) === PlanItemTransitions::STATE_ACTIVE;
-    }//end isParentActive()
-
-    /**
-     * Whether every mandatory (non-discretionary) direct child of a stage is
-     * in a terminal state. A stage with no mandatory children never
-     * auto-completes from this rule (it stays active until an exit sentry
-     * fires or is otherwise driven, since "all zero of zero children are
-     * terminal" would trivially auto-complete it on activation).
-     *
-     * @param string                              $stageId   Stage plan-item id.
-     * @param array<string, array<string, mixed>> $itemsById Plan items by id.
-     * @param array<string, mixed>                $state     Runtime state.
-     *
-     * @return bool
-     */
-    private function stageMandatoryChildrenAllTerminal(string $stageId, array $itemsById, array $state): bool
-    {
-        $mandatoryFound = false;
-        foreach ($itemsById as $id => $item) {
-            if (($item['parentId'] ?? null) !== $stageId) {
-                continue;
-            }
-
-            if (($item['discretionary'] ?? false) === true) {
-                continue;
-            }
-
-            $mandatoryFound = true;
-            $childState     = $state['planItemStates'][$id] ?? $this->transitions->initialState();
-            if ($this->transitions->isTerminal(state: $childState) === false) {
-                return false;
-            }
-        }
-
-        return $mandatoryFound;
-    }//end stageMandatoryChildrenAllTerminal()
-
-    /**
-     * Apply a single validated transition, recording it and cascading its
-     * structural side effects: a stage reaching `completed` disables any
-     * still-unplanned discretionary children; a stage (or any item) reaching
-     * `terminated` force-terminates every non-terminal descendant.
-     *
-     * @param array<string, mixed>                $item      The plan item.
-     * @param string                              $from      Current state.
-     * @param string                              $to        Target state.
-     * @param array<string, array<string, mixed>> $itemsById Plan items by id.
-     * @param array<string, mixed>                $state     Runtime state, mutated in place.
-     *
-     * @return void
-     *
-     * @throws IllegalPlanItemTransitionException When the transition is not legal.
-     */
-    private function transition(array $item, string $from, string $to, array &$itemsById, array &$state): void
-    {
-        $this->transitions->assertLegal(itemId: (string) $item['id'], itemType: (string) $item['type'], fromState: $from, toState: $to);
-
-        $state['planItemStates'][$item['id']] = $to;
-        $this->appendEvent(state: $state, itemId: (string) $item['id'], itemType: (string) $item['type'], from: $from, to: $to);
-
-        if ($to === PlanItemTransitions::STATE_COMPLETED && $item['type'] === PlanItemTransitions::TYPE_MILESTONE) {
-            $state['milestones'][$item['id']] = [
-                'achieved'   => true,
-                'achievedAt' => $this->now(),
-            ];
-        }
-
-        if ($item['type'] === PlanItemTransitions::TYPE_STAGE) {
-            if ($to === PlanItemTransitions::STATE_COMPLETED) {
-                $this->disableUnplannedDiscretionaryChildren(stageId: (string) $item['id'], itemsById: $itemsById, state: $state);
-            } else if ($to === PlanItemTransitions::STATE_TERMINATED) {
-                $this->forceTerminateChildren(stageId: (string) $item['id'], itemsById: $itemsById, state: $state);
-            }
-        }
-    }//end transition()
-
-    /**
-     * When a stage completes naturally, any discretionary child that was
-     * never enabled (still `available`/`enabled`) is disabled — it will
-     * never be worked on now the stage is done.
-     *
-     * @param string                              $stageId   Stage plan-item id.
-     * @param array<string, array<string, mixed>> $itemsById Plan items by id.
-     * @param array<string, mixed>                $state     Runtime state, mutated in place.
-     *
-     * @return void
-     */
-    private function disableUnplannedDiscretionaryChildren(string $stageId, array &$itemsById, array &$state): void
-    {
-        foreach ($itemsById as $id => $item) {
-            if (($item['parentId'] ?? null) !== $stageId || ($item['discretionary'] ?? false) !== true) {
-                continue;
-            }
-
-            $current = $state['planItemStates'][$id] ?? $this->transitions->initialState();
-            if ($current === PlanItemTransitions::STATE_AVAILABLE || $current === PlanItemTransitions::STATE_ENABLED) {
-                $this->transition(item: $item, from: $current, to: PlanItemTransitions::STATE_DISABLED, itemsById: $itemsById, state: $state);
-            }
-        }
-    }//end disableUnplannedDiscretionaryChildren()
-
-    /**
-     * When a stage (or any item) is force-terminated, every non-terminal
-     * direct child is force-terminated too — recursively, since `transition()`
-     * re-invokes this for any child that is itself a stage reaching `terminated`.
-     *
-     * @param string                              $stageId   Stage plan-item id.
-     * @param array<string, array<string, mixed>> $itemsById Plan items by id.
-     * @param array<string, mixed>                $state     Runtime state, mutated in place.
-     *
-     * @return void
-     */
-    private function forceTerminateChildren(string $stageId, array &$itemsById, array &$state): void
-    {
-        foreach ($itemsById as $id => $item) {
-            if (($item['parentId'] ?? null) !== $stageId) {
-                continue;
-            }
-
-            $current = $state['planItemStates'][$id] ?? $this->transitions->initialState();
-            if ($this->transitions->isTerminal(state: $current) === true) {
-                continue;
-            }
-
-            $this->transition(item: $item, from: $current, to: PlanItemTransitions::STATE_TERMINATED, itemsById: $itemsById, state: $state);
-        }
-    }//end forceTerminateChildren()
-
-    /**
-     * Append a bounded event-log entry.
-     *
-     * @param array<string, mixed> $state    Runtime state, mutated in place.
-     * @param string               $itemId   Plan-item id.
-     * @param string               $itemType Plan-item type.
-     * @param string               $from     Prior state.
-     * @param string               $to       New state.
-     *
-     * @return void
-     */
-    private function appendEvent(array &$state, string $itemId, string $itemType, string $from, string $to): void
-    {
-        $state['eventLog'][] = [
-            'at'       => $this->now(),
-            'itemId'   => $itemId,
-            'itemType' => $itemType,
-            'from'     => $from,
-            'to'       => $to,
-        ];
-
-        if (count($state['eventLog']) > self::MAX_EVENT_LOG) {
-            $state['eventLog'] = array_slice($state['eventLog'], -self::MAX_EVENT_LOG);
-        }
-    }//end appendEvent()
-
-    // ------------------------------------------------------------------
-    // Load / persist / view
-    // ------------------------------------------------------------------
-
-    /**
-     * Load the case, its caseType (enforcing `handlingModel: cmmn`), the
-     * active caseModel's plan items, and the decoded runtime state.
-     *
-     * @param string $caseId Case UUID.
-     *
-     * @return array{
-     *     case: array<string, mixed>,
-     *     caseType: array<string, mixed>,
-     *     itemsById: array<string, array<string, mixed>>,
-     *     state: array<string, mixed>,
-     *     objectService: mixed,
-     *     register: string,
-     *     caseSchema: string,
-     * }
-     *
-     * @throws RuntimeException When the case/caseType cannot be loaded or is not CMMN-managed.
-     */
-    private function loadContext(string $caseId): array
-    {
-        $objectService = $this->settingsService->getObjectService();
-        if ($objectService === null) {
-            throw new RuntimeException('storage_unavailable');
-        }
-
-        $register       = $this->settingsService->getConfigValue(key: 'register');
-        $caseSchema     = $this->settingsService->getConfigValue(key: 'case_schema');
-        $caseTypeSchema = $this->settingsService->getConfigValue(key: 'case_type_schema');
-        if ($register === '' || $caseSchema === '' || $caseTypeSchema === '') {
-            throw new RuntimeException('cmmn_not_configured');
-        }
-
-        $case = $this->getCaseObject(
-            objectService: $objectService,
-            register: $register,
-            caseSchema: $caseSchema,
-            caseId: $caseId
-        );
-
-        $caseTypeId = (string) ($case['caseType'] ?? '');
-        if ($caseTypeId === '') {
-            throw new RuntimeException('case_type_not_configured');
-        }
-
-        $caseType = $this->getCmmnCaseType(
-            objectService: $objectService,
-            register: $register,
-            caseTypeSchema: $caseTypeSchema,
-            caseTypeId: $caseTypeId
-        );
-
-        $itemsById = $this->loadItemsById(caseTypeId: $caseTypeId);
-        $state     = $this->decodeState(case: $case);
-
-        return [
-            'case'          => $case,
-            'caseType'      => $caseType,
-            'itemsById'     => $itemsById,
-            'state'         => $state,
-            'objectService' => $objectService,
-            'register'      => $register,
-            'caseSchema'    => $caseSchema,
-        ];
-    }//end loadContext()
-
-    /**
-     * Load the case object from OpenRegister.
-     *
-     * @param object $objectService The OpenRegister object service.
-     * @param string $register      The register slug.
-     * @param string $caseSchema    The case schema slug.
-     * @param string $caseId        Case UUID.
-     *
-     * @return array<string, mixed> The case object.
-     *
-     * @throws RuntimeException When the case cannot be loaded or is empty.
-     */
-    private function getCaseObject(object $objectService, string $register, string $caseSchema, string $caseId): array
-    {
-        try {
-            $case = $this->toArray(value: $objectService->find($caseId, register: $register, schema: $caseSchema));
-        } catch (Throwable $e) {
-            $this->logger->error('CaseModelEngine: loadCase failed', ['exception' => $e->getMessage(), 'caseId' => $caseId]);
-            throw new RuntimeException('case_not_found');
-        }
-
-        if ($case === []) {
-            throw new RuntimeException('case_not_found');
-        }
-
-        return $case;
-    }//end getCaseObject()
-
-    /**
-     * Load the caseType object and assert it is CMMN-managed.
-     *
-     * @param object $objectService  The OpenRegister object service.
-     * @param string $register       The register slug.
-     * @param string $caseTypeSchema The caseType schema slug.
-     * @param string $caseTypeId     The caseType UUID.
-     *
-     * @return array<string, mixed> The caseType object.
-     *
-     * @throws RuntimeException When the caseType cannot be loaded or is not CMMN-managed.
-     */
-    private function getCmmnCaseType(object $objectService, string $register, string $caseTypeSchema, string $caseTypeId): array
-    {
-        try {
-            $caseType = $this->toArray(value: $objectService->find($caseTypeId, register: $register, schema: $caseTypeSchema));
-        } catch (Throwable $e) {
-            $this->logger->error('CaseModelEngine: loadCaseType failed', ['exception' => $e->getMessage(), 'caseTypeId' => $caseTypeId]);
-            throw new RuntimeException('case_type_not_found');
-        }
-
-        $handlingModel = (string) ($caseType['handlingModel'] ?? 'bpmn');
-        if ($handlingModel !== 'cmmn') {
-            throw new RuntimeException('case_not_cmmn_managed');
-        }
-
-        return $caseType;
-    }//end getCmmnCaseType()
-
-    /**
-     * Load and validate the active caseModel's plan items for a caseType.
-     *
-     * @param string $caseTypeId The caseType UUID.
-     *
-     * @return array<string, array<string, mixed>> Plan items keyed by id.
-     *
-     * @throws RuntimeException When a `children`/`parentId` mismatch is found.
-     */
-    private function loadItemsById(string $caseTypeId): array
-    {
-        $model = $this->modelLoader->getActiveModel(caseTypeId: $caseTypeId);
-        if ($model === null) {
-            return [];
-        }
-
-        $planItems = $model['planItems'] ?? [];
-        if (is_array($planItems) === false) {
-            return [];
-        }
-
-        $itemsById = [];
-        foreach ($planItems as $item) {
-            if (is_array($item) === true && isset($item['id']) === true && $item['id'] !== '') {
-                $itemsById[(string) $item['id']] = $this->normaliseItem(item: $item);
-            }
-        }
-
-        $this->assertModelStructureValid(itemsById: $itemsById);
-
-        return $itemsById;
-    }//end loadItemsById()
-
-    /**
-     * Fill in default keys on a plan-item definition.
-     *
-     * @param array<string, mixed> $item Raw plan-item definition.
-     *
-     * @return array<string, mixed>
-     */
-    private function normaliseItem(array $item): array
-    {
-        $entryCriteria = $item['entryCriteria'] ?? [];
-        if (is_array($entryCriteria) === false) {
-            $entryCriteria = [];
-        }
-
-        $exitCriteria = $item['exitCriteria'] ?? [];
-        if (is_array($exitCriteria) === false) {
-            $exitCriteria = [];
-        }
-
-        $authorization = $item['authorization'] ?? [];
-        if (is_array($authorization) === false) {
-            $authorization = [];
-        }
-
-        $parentId = null;
-        if (isset($item['parentId']) === true && $item['parentId'] !== '') {
-            $parentId = (string) $item['parentId'];
-        }
-
-        return [
-            'id'            => (string) $item['id'],
-            'type'          => (string) ($item['type'] ?? ''),
-            'name'          => (string) ($item['name'] ?? ''),
-            'discretionary' => (($item['discretionary'] ?? false) === true),
-            'parentId'      => $parentId,
-            'entryCriteria' => $entryCriteria,
-            'exitCriteria'  => $exitCriteria,
-            'authorization' => $authorization,
-        ];
-    }//end normaliseItem()
-
-    /**
-     * Validate `parentId` references resolve and any redundant `children`
-     * list is consistent with them — a mismatch is a case-model authoring
-     * error, rejected rather than silently reconciled (`design.md` §2).
-     *
-     * @param array<string, array<string, mixed>> $itemsById Plan items by id.
-     *
-     * @return void
-     *
-     * @throws RuntimeException When a reference is invalid.
-     */
-    private function assertModelStructureValid(array $itemsById): void
-    {
-        foreach ($itemsById as $id => $item) {
-            $parentId = $item['parentId'];
-            if ($parentId !== null && isset($itemsById[$parentId]) === false) {
-                throw new RuntimeException('case_model_invalid');
-            }
-
-            // Note: the schema's optional `children` array on the raw
-            // definition is documentation-only in this engine — parentId is
-            // the single source of truth for the tree, so an inconsistent
-            // `children` list (a stale hand-edit) cannot desync runtime
-            // behaviour from what actually drives it.
-            unset($id);
-        }
-    }//end assertModelStructureValid()
-
-    /**
-     * Decode `case.casePlanState`, defaulting missing/invalid JSON to an
-     * empty state skeleton.
-     *
-     * @param array<string, mixed> $case The case payload.
-     *
-     * @return array<string, mixed>
-     */
-    private function decodeState(array $case): array
-    {
-        $empty = [
-            'planItemStates' => [],
-            'milestones'     => [],
-            'caseFile'       => [],
-            'eventLog'       => [],
-        ];
-
-        $raw = $case['casePlanState'] ?? null;
-        if (is_string($raw) === true && $raw !== '') {
-            $decoded = json_decode($raw, true);
-            if (is_array($decoded) === true) {
-                return array_merge($empty, $decoded);
-            }
-        } else if (is_array($raw) === true) {
-            return array_merge($empty, $raw);
-        }
-
-        return $empty;
-    }//end decodeState()
 
     /**
      * Set every plan item not yet present in runtime state to `available`.
@@ -900,21 +343,6 @@ class CaseModelEngine
 
         return $changed;
     }//end ensureInitialized()
-
-    /**
-     * Persist the runtime state onto the case via a single `saveObject()` call.
-     *
-     * @param array<string, mixed> $ctx Context from {@see loadContext()}, mutated in place (`case` key refreshed with the saved payload).
-     *
-     * @return void
-     */
-    private function persist(array &$ctx): void
-    {
-        $ctx['case']['casePlanState'] = json_encode($ctx['state']);
-        $ctx['case'] = $this->toArray(
-            value: $ctx['objectService']->saveObject(object: $ctx['case'], register: $ctx['register'], schema: $ctx['caseSchema']),
-        );
-    }//end persist()
 
     /**
      * Build the REST-facing plan view from the current context.
@@ -965,44 +393,11 @@ class CaseModelEngine
                 continue;
             }
 
-            if ($this->isParentActive(item: $item, state: $ctx['state']) === true) {
+            if ($this->tree->isParentActive(item: $item, state: $ctx['state']) === true) {
                 $ids[] = $id;
             }
         }
 
         return $ids;
     }//end enableableDiscretionaryIds()
-
-    /**
-     * Current UTC timestamp in ATOM format.
-     *
-     * @return string
-     */
-    private function now(): string
-    {
-        return (new DateTimeImmutable())->format(DATE_ATOM);
-    }//end now()
-
-    /**
-     * Coerce ObjectService results to an array.
-     *
-     * @param mixed $value Raw result.
-     *
-     * @return array<string, mixed>
-     */
-    private function toArray(mixed $value): array
-    {
-        if (is_array($value) === true) {
-            return $value;
-        }
-
-        if (is_object($value) === true && method_exists($value, 'jsonSerialize') === true) {
-            $serialized = $value->jsonSerialize();
-            if (is_array($serialized) === true) {
-                return $serialized;
-            }
-        }
-
-        return [];
-    }//end toArray()
 }//end class

--- a/lib/Service/Cmmn/CasePlanRepository.php
+++ b/lib/Service/Cmmn/CasePlanRepository.php
@@ -1,0 +1,372 @@
+<?php
+
+/**
+ * Procest CMMN case-plan repository.
+ *
+ * Everything the CMMN engine needs from storage: loading the case, asserting
+ * its caseType is CMMN-managed, loading and validating the active caseModel's
+ * plan items, decoding the runtime state out of `case.casePlanState`, and
+ * writing it back.
+ *
+ * Split out of CaseModelEngine so the engine is left with the plan-item
+ * lifecycle alone. Three invariants live here rather than there:
+ *
+ *   - ENGINE SELECTION. {@see getCmmnCaseType()} refuses a caseType whose
+ *     `handlingModel` is not `cmmn` (defaulting to `bpmn` when unset). BPMN and
+ *     CMMN are sibling engines chosen per caseType, and this refusal is what
+ *     keeps this one off a case the other owns.
+ *   - SINGLE WRITE. {@see persist()} performs exactly ONE `saveObject()` per
+ *     mutation, storing the whole runtime state in the single
+ *     `case.casePlanState` field (REQ-CMMN-006) — never one OR object per plan
+ *     item. It never touches `case.status`/`statusHistory`, which belong to
+ *     StatusTransitionService.
+ *   - AUTHORING ERRORS FAIL LOUDLY. A `parentId` that resolves to no item is a
+ *     case-model authoring error and is rejected, not silently reconciled;
+ *     `parentId` is the single source of truth for the tree, so a stale
+ *     `children` list cannot desync runtime behaviour from what drives it.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Cmmn
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/specs/cmmn-adaptive-case/spec.md#REQ-CMMN-006
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Cmmn;
+
+use OCA\Procest\Service\SettingsService;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Loads and persists the CMMN case plan and its runtime state.
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/specs/cmmn-adaptive-case/spec.md#REQ-CMMN-006
+ */
+class CasePlanRepository
+{
+    /**
+     * Constructor.
+     *
+     * @param SettingsService $settingsService Bridge to OpenRegister + config.
+     * @param CaseModelLoader $modelLoader     Active-caseModel-by-caseType loader.
+     * @param LoggerInterface $logger          Logger.
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+        private readonly CaseModelLoader $modelLoader,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Load the case, its caseType (enforcing `handlingModel: cmmn`), the
+     * active caseModel's plan items, and the decoded runtime state.
+     *
+     * @param string $caseId Case UUID.
+     *
+     * @return array{
+     *     case: array<string, mixed>,
+     *     caseType: array<string, mixed>,
+     *     itemsById: array<string, array<string, mixed>>,
+     *     state: array<string, mixed>,
+     *     objectService: mixed,
+     *     register: string,
+     *     caseSchema: string,
+     * }
+     *
+     * @throws RuntimeException When the case/caseType cannot be loaded or is not CMMN-managed.
+     *
+     * @spec openspec/specs/cmmn-adaptive-case/spec.md#REQ-CMMN-006
+     */
+    public function loadContext(string $caseId): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            throw new RuntimeException('storage_unavailable');
+        }
+
+        $register       = $this->settingsService->getConfigValue(key: 'register');
+        $caseSchema     = $this->settingsService->getConfigValue(key: 'case_schema');
+        $caseTypeSchema = $this->settingsService->getConfigValue(key: 'case_type_schema');
+        if ($register === '' || $caseSchema === '' || $caseTypeSchema === '') {
+            throw new RuntimeException('cmmn_not_configured');
+        }
+
+        $case = $this->getCaseObject(
+            objectService: $objectService,
+            register: $register,
+            caseSchema: $caseSchema,
+            caseId: $caseId
+        );
+
+        $caseTypeId = (string) ($case['caseType'] ?? '');
+        if ($caseTypeId === '') {
+            throw new RuntimeException('case_type_not_configured');
+        }
+
+        $caseType = $this->getCmmnCaseType(
+            objectService: $objectService,
+            register: $register,
+            caseTypeSchema: $caseTypeSchema,
+            caseTypeId: $caseTypeId
+        );
+
+        $itemsById = $this->loadItemsById(caseTypeId: $caseTypeId);
+        $state     = $this->decodeState(case: $case);
+
+        return [
+            'case'          => $case,
+            'caseType'      => $caseType,
+            'itemsById'     => $itemsById,
+            'state'         => $state,
+            'objectService' => $objectService,
+            'register'      => $register,
+            'caseSchema'    => $caseSchema,
+        ];
+    }//end loadContext()
+
+    /**
+     * Persist the runtime state onto the case via a single `saveObject()` call.
+     *
+     * @param array<string, mixed> $ctx Context from {@see loadContext()}, mutated in place (`case` key refreshed with the saved payload).
+     *
+     * @return void
+     *
+     * @spec openspec/specs/cmmn-adaptive-case/spec.md#REQ-CMMN-006
+     */
+    public function persist(array &$ctx): void
+    {
+        $ctx['case']['casePlanState'] = json_encode($ctx['state']);
+        $ctx['case'] = $this->toArray(
+            value: $ctx['objectService']->saveObject(object: $ctx['case'], register: $ctx['register'], schema: $ctx['caseSchema']),
+        );
+    }//end persist()
+
+    /**
+     * Load the case object from OpenRegister.
+     *
+     * @param object $objectService The OpenRegister object service.
+     * @param string $register      The register slug.
+     * @param string $caseSchema    The case schema slug.
+     * @param string $caseId        Case UUID.
+     *
+     * @return array<string, mixed> The case object.
+     *
+     * @throws RuntimeException When the case cannot be loaded or is empty.
+     */
+    private function getCaseObject(object $objectService, string $register, string $caseSchema, string $caseId): array
+    {
+        try {
+            $case = $this->toArray(value: $objectService->find($caseId, register: $register, schema: $caseSchema));
+        } catch (Throwable $e) {
+            $this->logger->error('CaseModelEngine: loadCase failed', ['exception' => $e->getMessage(), 'caseId' => $caseId]);
+            throw new RuntimeException('case_not_found');
+        }
+
+        if ($case === []) {
+            throw new RuntimeException('case_not_found');
+        }
+
+        return $case;
+    }//end getCaseObject()
+
+    /**
+     * Load the caseType object and assert it is CMMN-managed.
+     *
+     * @param object $objectService  The OpenRegister object service.
+     * @param string $register       The register slug.
+     * @param string $caseTypeSchema The caseType schema slug.
+     * @param string $caseTypeId     The caseType UUID.
+     *
+     * @return array<string, mixed> The caseType object.
+     *
+     * @throws RuntimeException When the caseType cannot be loaded or is not CMMN-managed.
+     */
+    private function getCmmnCaseType(object $objectService, string $register, string $caseTypeSchema, string $caseTypeId): array
+    {
+        try {
+            $caseType = $this->toArray(value: $objectService->find($caseTypeId, register: $register, schema: $caseTypeSchema));
+        } catch (Throwable $e) {
+            $this->logger->error('CaseModelEngine: loadCaseType failed', ['exception' => $e->getMessage(), 'caseTypeId' => $caseTypeId]);
+            throw new RuntimeException('case_type_not_found');
+        }
+
+        $handlingModel = (string) ($caseType['handlingModel'] ?? 'bpmn');
+        if ($handlingModel !== 'cmmn') {
+            throw new RuntimeException('case_not_cmmn_managed');
+        }
+
+        return $caseType;
+    }//end getCmmnCaseType()
+
+    /**
+     * Load and validate the active caseModel's plan items for a caseType.
+     *
+     * @param string $caseTypeId The caseType UUID.
+     *
+     * @return array<string, array<string, mixed>> Plan items keyed by id.
+     *
+     * @throws RuntimeException When a `children`/`parentId` mismatch is found.
+     */
+    private function loadItemsById(string $caseTypeId): array
+    {
+        $model = $this->modelLoader->getActiveModel(caseTypeId: $caseTypeId);
+        if ($model === null) {
+            return [];
+        }
+
+        $planItems = $model['planItems'] ?? [];
+        if (is_array($planItems) === false) {
+            return [];
+        }
+
+        $itemsById = [];
+        foreach ($planItems as $item) {
+            if (is_array($item) === true && isset($item['id']) === true && $item['id'] !== '') {
+                $itemsById[(string) $item['id']] = $this->normaliseItem(item: $item);
+            }
+        }
+
+        $this->assertModelStructureValid(itemsById: $itemsById);
+
+        return $itemsById;
+    }//end loadItemsById()
+
+    /**
+     * Fill in default keys on a plan-item definition.
+     *
+     * @param array<string, mixed> $item Raw plan-item definition.
+     *
+     * @return array<string, mixed>
+     */
+    private function normaliseItem(array $item): array
+    {
+        $entryCriteria = $item['entryCriteria'] ?? [];
+        if (is_array($entryCriteria) === false) {
+            $entryCriteria = [];
+        }
+
+        $exitCriteria = $item['exitCriteria'] ?? [];
+        if (is_array($exitCriteria) === false) {
+            $exitCriteria = [];
+        }
+
+        $authorization = $item['authorization'] ?? [];
+        if (is_array($authorization) === false) {
+            $authorization = [];
+        }
+
+        $parentId = null;
+        if (isset($item['parentId']) === true && $item['parentId'] !== '') {
+            $parentId = (string) $item['parentId'];
+        }
+
+        return [
+            'id'            => (string) $item['id'],
+            'type'          => (string) ($item['type'] ?? ''),
+            'name'          => (string) ($item['name'] ?? ''),
+            'discretionary' => (($item['discretionary'] ?? false) === true),
+            'parentId'      => $parentId,
+            'entryCriteria' => $entryCriteria,
+            'exitCriteria'  => $exitCriteria,
+            'authorization' => $authorization,
+        ];
+    }//end normaliseItem()
+
+    /**
+     * Validate `parentId` references resolve and any redundant `children`
+     * list is consistent with them — a mismatch is a case-model authoring
+     * error, rejected rather than silently reconciled (`design.md` §2).
+     *
+     * @param array<string, array<string, mixed>> $itemsById Plan items by id.
+     *
+     * @return void
+     *
+     * @throws RuntimeException When a reference is invalid.
+     */
+    private function assertModelStructureValid(array $itemsById): void
+    {
+        foreach ($itemsById as $id => $item) {
+            $parentId = $item['parentId'];
+            if ($parentId !== null && isset($itemsById[$parentId]) === false) {
+                throw new RuntimeException('case_model_invalid');
+            }
+
+            // Note: the schema's optional `children` array on the raw
+            // definition is documentation-only in this engine — parentId is
+            // the single source of truth for the tree, so an inconsistent
+            // `children` list (a stale hand-edit) cannot desync runtime
+            // behaviour from what actually drives it.
+            unset($id);
+        }
+    }//end assertModelStructureValid()
+
+    /**
+     * Decode `case.casePlanState`, defaulting missing/invalid JSON to an
+     * empty state skeleton.
+     *
+     * @param array<string, mixed> $case The case payload.
+     *
+     * @return array<string, mixed>
+     */
+    private function decodeState(array $case): array
+    {
+        $empty = [
+            'planItemStates' => [],
+            'milestones'     => [],
+            'caseFile'       => [],
+            'eventLog'       => [],
+        ];
+
+        $raw = $case['casePlanState'] ?? null;
+        if (is_string($raw) === true && $raw !== '') {
+            $decoded = json_decode($raw, true);
+            if (is_array($decoded) === true) {
+                return array_merge($empty, $decoded);
+            }
+        } else if (is_array($raw) === true) {
+            return array_merge($empty, $raw);
+        }
+
+        return $empty;
+    }//end decodeState()
+
+    /**
+     * Coerce ObjectService results to an array.
+     *
+     * @param mixed $value Raw result.
+     *
+     * @return array<string, mixed>
+     */
+    private function toArray(mixed $value): array
+    {
+        if (is_array($value) === true) {
+            return $value;
+        }
+
+        if (is_object($value) === true && method_exists($value, 'jsonSerialize') === true) {
+            $serialized = $value->jsonSerialize();
+            if (is_array($serialized) === true) {
+                return $serialized;
+            }
+        }
+
+        return [];
+    }//end toArray()
+}//end class

--- a/lib/Service/Cmmn/PlanItemCascade.php
+++ b/lib/Service/Cmmn/PlanItemCascade.php
@@ -1,0 +1,234 @@
+<?php
+
+/**
+ * Procest CMMN cascade evaluator.
+ *
+ * Drives the plan to a fixed point after any mutation: repeatedly evaluates
+ * every non-terminal plan item's exit and entry sentries until a pass changes
+ * nothing, so one worker action or case-file write settles the whole plan in a
+ * single call rather than leaving it to the next request.
+ *
+ * Two properties are what this class exists to hold:
+ *
+ *   - ORDER INDEPENDENCE. Each pass evaluates against a `$context` snapshot
+ *     taken at the START of the pass, so an item's result never depends on
+ *     where it happens to sit in the iteration order; anything a pass changes
+ *     is picked up by the NEXT pass instead.
+ *   - TERMINATION. The loop is bounded by MAX_CASCADE_DEPTH. A well-formed
+ *     model reaches its fixed point long before that; hitting the bound means
+ *     the model has an authoring cycle (e.g. two items whose entry sentries
+ *     reference each other's completion) and the bound is what stops it
+ *     looping forever.
+ *
+ * Split out of CaseModelEngine so the fixed-point loop sits next to the single
+ * pass it repeats, and apart from both the transition semantics
+ * ({@see PlanItemStateMachine}) and the persistence
+ * ({@see CasePlanRepository}).
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Cmmn
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/specs/cmmn-adaptive-case/spec.md#REQ-CMMN-003
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Cmmn;
+
+/**
+ * Evaluates entry/exit sentries to a fixed point after a plan mutation.
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/specs/cmmn-adaptive-case/spec.md#REQ-CMMN-003
+ */
+class PlanItemCascade
+{
+
+    /**
+     * Bound on cascade fixed-point iterations per mutation — protects against
+     * an authoring cycle in the case model (e.g. two plan items whose entry
+     * sentries reference each other's completion) looping forever. Reaching
+     * the bound is a defensive stop, not expected in a well-formed model.
+     */
+    private const MAX_CASCADE_DEPTH = 50;
+
+    /**
+     * Constructor.
+     *
+     * @param PlanItemTransitions  $transitions  Legal plan-item transition table.
+     * @param SentryEvaluator      $sentries     Pure sentry-firing evaluator.
+     * @param PlanItemTree         $tree         Structural queries over the plan-item hierarchy.
+     * @param PlanItemStateMachine $stateMachine Single-transition application.
+     */
+    public function __construct(
+        private readonly PlanItemTransitions $transitions,
+        private readonly SentryEvaluator $sentries,
+        private readonly PlanItemTree $tree,
+        private readonly PlanItemStateMachine $stateMachine,
+    ) {
+    }//end __construct()
+
+    /**
+     * Run cascade passes to a fixed point (or MAX_CASCADE_DEPTH).
+     *
+     * @param array<string, array<string, mixed>> $itemsById   Plan items by id.
+     * @param array<string, mixed>                $state       Runtime state, mutated in place.
+     * @param array<int, string>                  $touchedKeys Case-file keys touched this call.
+     * @param array<int, string>                  $changedKeys Subset of touchedKeys whose value changed.
+     *
+     * @return bool Whether any transition occurred across all passes.
+     *
+     * @spec openspec/specs/cmmn-adaptive-case/spec.md#REQ-CMMN-003
+     */
+    public function run(array &$itemsById, array &$state, array $touchedKeys, array $changedKeys): bool
+    {
+        $anyChanged = false;
+        for ($depth = 0; $depth < self::MAX_CASCADE_DEPTH; $depth++) {
+            $passChanged = $this->cascadePass(itemsById: $itemsById, state: $state, touchedKeys: $touchedKeys, changedKeys: $changedKeys);
+            if ($passChanged === false) {
+                break;
+            }
+
+            $anyChanged = true;
+        }
+
+        return $anyChanged;
+    }//end run()
+
+    /**
+     * One evaluation pass over every non-terminal item, against a snapshot
+     * taken at the start of the pass (so results are independent of item
+     * iteration order — a later pass picks up anything this pass changed).
+     *
+     * @param array<string, array<string, mixed>> $itemsById   Plan items by id.
+     * @param array<string, mixed>                $state       Runtime state, mutated in place.
+     * @param array<int, string>                  $touchedKeys Case-file keys touched this call.
+     * @param array<int, string>                  $changedKeys Subset of touchedKeys whose value changed.
+     *
+     * @return bool Whether this pass changed any item's state.
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity) — one evaluation pass over the state machine's
+     *   own branches (exit sentry, entry sentry, mandatory-cascade, stage auto-complete); splitting
+     *   it would scatter one pass across several methods that all need the same $context snapshot.
+     */
+    private function cascadePass(array &$itemsById, array &$state, array $touchedKeys, array $changedKeys): bool
+    {
+        $changed = false;
+        $context = [
+            'planItemStates' => $state['planItemStates'],
+            'caseFile'       => $state['caseFile'],
+            'touchedKeys'    => $touchedKeys,
+            'changedKeys'    => $changedKeys,
+        ];
+
+        foreach ($itemsById as $id => $item) {
+            $current = $state['planItemStates'][$id] ?? $this->transitions->initialState();
+            if ($this->transitions->isTerminal(state: $current) === true) {
+                continue;
+            }
+
+            if ($this->tree->isParentActive(item: $item, state: $state) === false) {
+                continue;
+            }
+
+            $exitCriteria = $item['exitCriteria'] ?? [];
+            if (is_array($exitCriteria) === true && count($exitCriteria) > 0
+                && $this->sentries->anyFires(sentries: $exitCriteria, context: $context) === true
+            ) {
+                $this->stateMachine->transition(
+                    item: $item,
+                    from: $current,
+                    to: PlanItemTransitions::STATE_TERMINATED,
+                    itemsById: $itemsById,
+                    state: $state,
+                );
+                $changed = true;
+                continue;
+            }
+
+            if ($current === PlanItemTransitions::STATE_AVAILABLE) {
+                $entryCriteria = $item['entryCriteria'] ?? [];
+                $hasNoCriteria = (is_array($entryCriteria) === false || count($entryCriteria) === 0);
+                $satisfied     = $hasNoCriteria || $this->sentries->anyFires(sentries: $entryCriteria, context: $context);
+
+                if ($satisfied === true) {
+                    $this->advanceFromAvailable(item: $item, current: $current, itemsById: $itemsById, state: $state);
+                    $changed = true;
+                }
+
+                continue;
+            }
+
+            if ($current === PlanItemTransitions::STATE_ACTIVE && $item['type'] === PlanItemTransitions::TYPE_STAGE) {
+                if ($this->tree->stageMandatoryChildrenAllTerminal(stageId: $id, itemsById: $itemsById, state: $state) === true) {
+                    $this->stateMachine->transition(
+                        item: $item,
+                        from: $current,
+                        to: PlanItemTransitions::STATE_COMPLETED,
+                        itemsById: $itemsById,
+                        state: $state,
+                    );
+                    $changed = true;
+                }
+            }//end if
+        }//end foreach
+
+        return $changed;
+    }//end cascadePass()
+
+    /**
+     * Advance a plan item whose entry criteria just became satisfied: a
+     * milestone completes directly; a stage/humanTask enables, then
+     * auto-cascades straight to `active` unless it is discretionary (which
+     * stops at `enabled`, pending the worker's opt-in).
+     *
+     * @param array<string, mixed>                $item      The plan item (state `available`).
+     * @param string                              $current   Current state (`available`).
+     * @param array<string, array<string, mixed>> $itemsById Plan items by id.
+     * @param array<string, mixed>                $state     Runtime state, mutated in place.
+     *
+     * @return void
+     */
+    private function advanceFromAvailable(array $item, string $current, array &$itemsById, array &$state): void
+    {
+        if ($item['type'] === PlanItemTransitions::TYPE_MILESTONE) {
+            $this->stateMachine->transition(
+                item: $item,
+                from: $current,
+                to: PlanItemTransitions::STATE_COMPLETED,
+                itemsById: $itemsById,
+                state: $state,
+            );
+            return;
+        }
+
+        $this->stateMachine->transition(
+            item: $item,
+            from: $current,
+            to: PlanItemTransitions::STATE_ENABLED,
+            itemsById: $itemsById,
+            state: $state,
+        );
+        if (($item['discretionary'] ?? false) !== true) {
+            $this->stateMachine->transition(
+                item: $item,
+                from: PlanItemTransitions::STATE_ENABLED,
+                to: PlanItemTransitions::STATE_ACTIVE,
+                itemsById: $itemsById,
+                state: $state,
+            );
+        }
+    }//end advanceFromAvailable()
+}//end class

--- a/lib/Service/Cmmn/PlanItemStateMachine.php
+++ b/lib/Service/Cmmn/PlanItemStateMachine.php
@@ -1,0 +1,199 @@
+<?php
+
+/**
+ * Procest CMMN plan-item state machine.
+ *
+ * Applies ONE validated plan-item transition and everything that structurally
+ * follows from it. Every state change in the CMMN engine — worker-driven,
+ * sentry-driven or cascade-driven — funnels through {@see transition()}, so
+ * the legality check, the event-log entry, milestone achievement and the
+ * parent/child side effects can never be bypassed by a caller that writes
+ * `planItemStates` directly.
+ *
+ * Two structural side effects are owned here:
+ *   - a STAGE reaching `completed` disables any discretionary child that was
+ *     never enabled — it will never be worked on now the stage is done;
+ *   - a STAGE reaching `terminated` force-terminates every non-terminal
+ *     child, and recursively their children, because {@see transition()}
+ *     re-enters for any child that is itself a stage.
+ *
+ * Split out of CaseModelEngine so that "what a single transition means" is
+ * separable from "which transitions the cascade decides to make".
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Cmmn
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/specs/cmmn-adaptive-case/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Cmmn;
+
+use DateTimeImmutable;
+
+/**
+ * Applies a single validated plan-item transition and its side effects.
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/specs/cmmn-adaptive-case/spec.md
+ */
+class PlanItemStateMachine
+{
+
+    /**
+     * Bound on the number of retained event-log entries in casePlanState.
+     */
+    private const MAX_EVENT_LOG = 100;
+
+    /**
+     * Constructor.
+     *
+     * @param PlanItemTransitions $transitions Legal plan-item transition table.
+     */
+    public function __construct(
+        private readonly PlanItemTransitions $transitions,
+    ) {
+    }//end __construct()
+
+    /**
+     * Apply a single validated transition, recording it and cascading its
+     * structural side effects: a stage reaching `completed` disables any
+     * still-unplanned discretionary children; a stage (or any item) reaching
+     * `terminated` force-terminates every non-terminal descendant.
+     *
+     * @param array<string, mixed>                $item      The plan item.
+     * @param string                              $from      Current state.
+     * @param string                              $to        Target state.
+     * @param array<string, array<string, mixed>> $itemsById Plan items by id.
+     * @param array<string, mixed>                $state     Runtime state, mutated in place.
+     *
+     * @return void
+     *
+     * @throws IllegalPlanItemTransitionException When the transition is not legal.
+     *
+     * @spec openspec/specs/cmmn-adaptive-case/spec.md
+     */
+    public function transition(array $item, string $from, string $to, array &$itemsById, array &$state): void
+    {
+        $this->transitions->assertLegal(itemId: (string) $item['id'], itemType: (string) $item['type'], fromState: $from, toState: $to);
+
+        $state['planItemStates'][$item['id']] = $to;
+        $this->appendEvent(state: $state, itemId: (string) $item['id'], itemType: (string) $item['type'], from: $from, to: $to);
+
+        if ($to === PlanItemTransitions::STATE_COMPLETED && $item['type'] === PlanItemTransitions::TYPE_MILESTONE) {
+            $state['milestones'][$item['id']] = [
+                'achieved'   => true,
+                'achievedAt' => $this->now(),
+            ];
+        }
+
+        if ($item['type'] === PlanItemTransitions::TYPE_STAGE) {
+            if ($to === PlanItemTransitions::STATE_COMPLETED) {
+                $this->disableUnplannedDiscretionaryChildren(stageId: (string) $item['id'], itemsById: $itemsById, state: $state);
+            } else if ($to === PlanItemTransitions::STATE_TERMINATED) {
+                $this->forceTerminateChildren(stageId: (string) $item['id'], itemsById: $itemsById, state: $state);
+            }
+        }
+    }//end transition()
+
+    /**
+     * When a stage completes naturally, any discretionary child that was
+     * never enabled (still `available`/`enabled`) is disabled — it will
+     * never be worked on now the stage is done.
+     *
+     * @param string                              $stageId   Stage plan-item id.
+     * @param array<string, array<string, mixed>> $itemsById Plan items by id.
+     * @param array<string, mixed>                $state     Runtime state, mutated in place.
+     *
+     * @return void
+     */
+    private function disableUnplannedDiscretionaryChildren(string $stageId, array &$itemsById, array &$state): void
+    {
+        foreach ($itemsById as $id => $item) {
+            if (($item['parentId'] ?? null) !== $stageId || ($item['discretionary'] ?? false) !== true) {
+                continue;
+            }
+
+            $current = $state['planItemStates'][$id] ?? $this->transitions->initialState();
+            if ($current === PlanItemTransitions::STATE_AVAILABLE || $current === PlanItemTransitions::STATE_ENABLED) {
+                $this->transition(item: $item, from: $current, to: PlanItemTransitions::STATE_DISABLED, itemsById: $itemsById, state: $state);
+            }
+        }
+    }//end disableUnplannedDiscretionaryChildren()
+
+    /**
+     * When a stage (or any item) is force-terminated, every non-terminal
+     * direct child is force-terminated too — recursively, since `transition()`
+     * re-invokes this for any child that is itself a stage reaching `terminated`.
+     *
+     * @param string                              $stageId   Stage plan-item id.
+     * @param array<string, array<string, mixed>> $itemsById Plan items by id.
+     * @param array<string, mixed>                $state     Runtime state, mutated in place.
+     *
+     * @return void
+     */
+    private function forceTerminateChildren(string $stageId, array &$itemsById, array &$state): void
+    {
+        foreach ($itemsById as $id => $item) {
+            if (($item['parentId'] ?? null) !== $stageId) {
+                continue;
+            }
+
+            $current = $state['planItemStates'][$id] ?? $this->transitions->initialState();
+            if ($this->transitions->isTerminal(state: $current) === true) {
+                continue;
+            }
+
+            $this->transition(item: $item, from: $current, to: PlanItemTransitions::STATE_TERMINATED, itemsById: $itemsById, state: $state);
+        }
+    }//end forceTerminateChildren()
+
+    /**
+     * Append a bounded event-log entry.
+     *
+     * @param array<string, mixed> $state    Runtime state, mutated in place.
+     * @param string               $itemId   Plan-item id.
+     * @param string               $itemType Plan-item type.
+     * @param string               $from     Prior state.
+     * @param string               $to       New state.
+     *
+     * @return void
+     */
+    private function appendEvent(array &$state, string $itemId, string $itemType, string $from, string $to): void
+    {
+        $state['eventLog'][] = [
+            'at'       => $this->now(),
+            'itemId'   => $itemId,
+            'itemType' => $itemType,
+            'from'     => $from,
+            'to'       => $to,
+        ];
+
+        if (count($state['eventLog']) > self::MAX_EVENT_LOG) {
+            $state['eventLog'] = array_slice($state['eventLog'], -self::MAX_EVENT_LOG);
+        }
+    }//end appendEvent()
+
+    /**
+     * Current UTC timestamp in ATOM format.
+     *
+     * @return string
+     */
+    private function now(): string
+    {
+        return (new DateTimeImmutable())->format(DATE_ATOM);
+    }//end now()
+}//end class

--- a/lib/Service/Cmmn/PlanItemTree.php
+++ b/lib/Service/Cmmn/PlanItemTree.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * Procest CMMN plan-item tree queries.
+ *
+ * Pure structural questions about the plan-item hierarchy, asked by both the
+ * cascade evaluator and the engine's REST-facing views: is an item's
+ * containing stage active, and has every mandatory child of a stage reached a
+ * terminal state?
+ *
+ * Split out of CaseModelEngine because these are read-only queries over
+ * (itemsById, state) with no side effects at all — no transition, no event, no
+ * persistence — which makes them the one part of the engine that can be
+ * reasoned about, and reused, without the state machine in scope.
+ *
+ * Two conventions here are load-bearing and deliberate:
+ *   - a ROOT item (no parentId) is always "parent-active", so top-level items
+ *     are never gated on a stage that does not exist;
+ *   - a stage with NO mandatory children never auto-completes from
+ *     {@see stageMandatoryChildrenAllTerminal()}. "All zero of zero children
+ *     are terminal" is vacuously true, and returning true would complete such
+ *     a stage the instant it activated.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Cmmn
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/specs/cmmn-adaptive-case/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Cmmn;
+
+/**
+ * Read-only structural queries over the CMMN plan-item hierarchy.
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/specs/cmmn-adaptive-case/spec.md
+ */
+class PlanItemTree
+{
+    /**
+     * Constructor.
+     *
+     * @param PlanItemTransitions $transitions Legal plan-item transition table.
+     */
+    public function __construct(
+        private readonly PlanItemTransitions $transitions,
+    ) {
+    }//end __construct()
+
+    /**
+     * Whether an item's containing stage is active (root items — no parent —
+     * are always considered active).
+     *
+     * @param array<string, mixed> $item  The plan item.
+     * @param array<string, mixed> $state Runtime state.
+     *
+     * @return bool
+     *
+     * @spec openspec/specs/cmmn-adaptive-case/spec.md
+     */
+    public function isParentActive(array $item, array $state): bool
+    {
+        $parentId = $item['parentId'] ?? null;
+        if ($parentId === null || $parentId === '') {
+            return true;
+        }
+
+        return ($state['planItemStates'][$parentId] ?? $this->transitions->initialState()) === PlanItemTransitions::STATE_ACTIVE;
+    }//end isParentActive()
+
+    /**
+     * Whether every mandatory (non-discretionary) direct child of a stage is
+     * in a terminal state. A stage with no mandatory children never
+     * auto-completes from this rule (it stays active until an exit sentry
+     * fires or is otherwise driven, since "all zero of zero children are
+     * terminal" would trivially auto-complete it on activation).
+     *
+     * @param string                              $stageId   Stage plan-item id.
+     * @param array<string, array<string, mixed>> $itemsById Plan items by id.
+     * @param array<string, mixed>                $state     Runtime state.
+     *
+     * @return bool
+     *
+     * @spec openspec/specs/cmmn-adaptive-case/spec.md
+     */
+    public function stageMandatoryChildrenAllTerminal(string $stageId, array $itemsById, array $state): bool
+    {
+        $mandatoryFound = false;
+        foreach ($itemsById as $id => $item) {
+            if (($item['parentId'] ?? null) !== $stageId) {
+                continue;
+            }
+
+            if (($item['discretionary'] ?? false) === true) {
+                continue;
+            }
+
+            $mandatoryFound = true;
+            $childState     = $state['planItemStates'][$id] ?? $this->transitions->initialState();
+            if ($this->transitions->isTerminal(state: $childState) === false) {
+                return false;
+            }
+        }
+
+        return $mandatoryFound;
+    }//end stageMandatoryChildrenAllTerminal()
+}//end class

--- a/lib/Service/Consultation/ConsultationDependencyGraph.php
+++ b/lib/Service/Consultation/ConsultationDependencyGraph.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * Procest consultation dependency graph.
+ *
+ * Guards the `dependsOn` edges between consultations against cycles. A cycle
+ * would make a chain of adviesaanvragen unsatisfiable — each waiting on the
+ * next, none ever becoming actionable — so the edge is refused before it is
+ * written rather than detected later at the blocked case.
+ *
+ * Split out of ConsultationService because graph traversal is a different kind
+ * of reasoning from the Awb lifecycle rules that service owns, and because the
+ * traversal needs only one thing from the rest of the system: the ability to
+ * read a consultation's dependency list.
+ *
+ * The walk is depth-first with a visited set carried by reference, so a node
+ * reachable by several paths is expanded once and the traversal terminates on
+ * any finite graph — including one that already contains a cycle not involving
+ * the node under test.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Consultation
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/changes/consultation-management/tasks.md#TASK-CN-02
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Consultation;
+
+/**
+ * Detects cycles in the consultation `dependsOn` graph.
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/changes/consultation-management/tasks.md#TASK-CN-02
+ */
+class ConsultationDependencyGraph
+{
+    /**
+     * Constructor.
+     *
+     * @param ConsultationRepository $repository Consultation reads (dependency lists)
+     */
+    public function __construct(
+        private readonly ConsultationRepository $repository,
+    ) {
+    }//end __construct()
+
+    /**
+     * Validate that adding the given dependsOn list would not create a dependency cycle.
+     *
+     * Uses depth-first traversal to detect cycles. Returns true if a cycle is
+     * detected, false if the dependency graph remains acyclic.
+     *
+     * @param string   $consultationId The consultation being updated
+     * @param string[] $dependsOn      The proposed dependency IDs
+     *
+     * @return bool True if a cycle would be created
+     *
+     * @spec openspec/changes/consultation-management/tasks.md#TASK-CN-02
+     */
+    public function wouldCreateCycle(string $consultationId, array $dependsOn): bool
+    {
+        // Quick self-reference check.
+        if (in_array($consultationId, $dependsOn, true) === true) {
+            return true;
+        }
+
+        $visited = [];
+        foreach ($dependsOn as $depId) {
+            if ($this->hasCycleDfs(
+                startId: $consultationId,
+                currentId: $depId,
+                visited: $visited,
+            ) === true
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+    }//end wouldCreateCycle()
+
+    /**
+     * Depth-first search helper for cycle detection in dependency graph.
+     *
+     * @param string   $startId   The original consultation ID (cycle target)
+     * @param string   $currentId The current node being visited
+     * @param string[] $visited   Already-visited node IDs (prevents re-traversal)
+     *
+     * @return bool True if startId is reachable from currentId (cycle detected)
+     */
+    private function hasCycleDfs(string $startId, string $currentId, array &$visited): bool
+    {
+        if ($currentId === $startId) {
+            return true;
+        }
+
+        if (in_array($currentId, $visited, true) === true) {
+            return false;
+        }
+
+        $visited[] = $currentId;
+
+        $consultation = $this->repository->getConsultation(consultationId: $currentId);
+        if ($consultation === null) {
+            return false;
+        }
+
+        $deps = $consultation['dependsOn'] ?? [];
+        if (is_array($deps) === false) {
+            return false;
+        }
+
+        foreach ($deps as $depId) {
+            if ($this->hasCycleDfs(startId: $startId, currentId: $depId, visited: $visited) === true) {
+                return true;
+            }
+        }
+
+        return false;
+    }//end hasCycleDfs()
+}//end class

--- a/lib/Service/Consultation/ConsultationRepository.php
+++ b/lib/Service/Consultation/ConsultationRepository.php
@@ -1,0 +1,329 @@
+<?php
+
+/**
+ * Procest consultation repository.
+ *
+ * Every OpenRegister read, delete and query the consultation surface performs:
+ * listing a case's consultations, fetching one, resolving the public secure
+ * token, finding overdue ones, allocating the next ADV-{year}-{seq} number,
+ * and deleting.
+ *
+ * Split out of ConsultationService so that service keeps only the Awb 3:5-3:9
+ * lifecycle — the status graph, the advice-response rules, the deadline
+ * extension rules and the fail-closed decidesk delegation — while the
+ * register/schema resolution and query shapes live here.
+ *
+ * The two return conventions are deliberate and differ by caller expectation:
+ * a *query* degrades to an empty array / null when OpenRegister or the schema
+ * is unconfigured, while {@see deleteConsultation()} throws — a delete that
+ * silently did nothing would read as success to its caller.
+ *
+ * {@see findBySecureToken()} additionally refuses terminal consultations
+ * (afgesloten / ingetrokken): the token is a public, unauthenticated surface,
+ * so a closed consultation must stop resolving rather than stay readable.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Consultation
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/changes/consultation-management/tasks.md#TASK-CN-02
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Consultation;
+
+use OCA\Procest\AppInfo\Application;
+use OCA\Procest\Service\SettingsService;
+use OCA\Procest\Service\Support\SearchesObjects;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * OpenRegister persistence and lookup for consultations (adviesaanvragen).
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/changes/consultation-management/tasks.md#TASK-CN-02
+ */
+class ConsultationRepository
+{
+
+    use SearchesObjects;
+
+    /**
+     * Constructor.
+     *
+     * @param SettingsService $settingsService Settings service
+     * @param LoggerInterface $logger          Logger
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Get all consultations for a case.
+     *
+     * @param string $caseId The parent case UUID
+     *
+     * @return array<int, array<string, mixed>> List of consultations
+     *
+     * @spec openspec/changes/consultation-management/tasks.md#TASK-CN-02
+     */
+    public function getConsultationsForCase(string $caseId): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return [];
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('consultation_schema');
+
+        if (empty($register) === true || empty($schema) === true) {
+            return [];
+        }
+
+        return $this->searchObjectsAsArrays(
+            objectService: $objectService,
+            register: $register,
+            schema: $schema,
+            filters: ['parentZaak' => $caseId, '_limit' => 100],
+        );
+    }//end getConsultationsForCase()
+
+    /**
+     * Get a single consultation by ID.
+     *
+     * @param string $consultationId The consultation UUID
+     *
+     * @return array<string, mixed>|null The consultation data or null if not found
+     *
+     * @spec openspec/changes/consultation-management/tasks.md#TASK-CN-02
+     */
+    public function getConsultation(string $consultationId): ?array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return null;
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('consultation_schema');
+
+        if (empty($register) === true || empty($schema) === true) {
+            return null;
+        }
+
+        return $this->findObjectAsArray(
+            objectService: $objectService,
+            register: $register,
+            schema: $schema,
+            id: $consultationId,
+        );
+    }//end getConsultation()
+
+    /**
+     * Delete a consultation by ID.
+     *
+     * @param string $consultationId The consultation UUID
+     *
+     * @return bool True on success
+     *
+     * @throws \RuntimeException If OpenRegister is unavailable
+     *
+     * @spec openspec/changes/consultation-management/tasks.md#TASK-CN-02
+     */
+    public function deleteConsultation(string $consultationId): bool
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            throw new RuntimeException('OpenRegister is not available');
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('consultation_schema');
+
+        if (empty($register) === true || empty($schema) === true) {
+            throw new RuntimeException('Consultation schema not configured');
+        }
+
+        $objectService->deleteObject(uuid: (string) $consultationId, register: $register, schema: $schema);
+
+        $this->logger->info(
+            'Consultation deleted: '.$consultationId,
+            ['app' => Application::APP_ID],
+        );
+
+        return true;
+    }//end deleteConsultation()
+
+    /**
+     * Get overdue consultations (past deadline with open/in_behandeling status).
+     *
+     * @return array<int, array<string, mixed>> List of overdue consultations
+     *
+     * @spec openspec/changes/consultation-management/tasks.md#TASK-CN-02
+     */
+    public function getOverdueConsultations(): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return [];
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('consultation_schema');
+
+        if (empty($register) === true || empty($schema) === true) {
+            return [];
+        }
+
+        $openList = $this->searchObjectsAsArrays(
+            objectService: $objectService,
+            register: $register,
+            schema: $schema,
+            filters: ['status' => 'open', '_limit' => 200],
+        );
+
+        $inProgressList = $this->searchObjectsAsArrays(
+            objectService: $objectService,
+            register: $register,
+            schema: $schema,
+            filters: ['status' => 'in_behandeling', '_limit' => 200],
+        );
+
+        $all     = array_merge($openList, $inProgressList);
+        $today   = date('Y-m-d');
+        $overdue = [];
+
+        foreach ($all as $consultation) {
+            $deadline = $consultation['uiterlijkeReactiedatum'] ?? '';
+            if ($deadline !== '' && $deadline < $today) {
+                $overdue[] = $consultation;
+            }
+        }
+
+        return $overdue;
+    }//end getOverdueConsultations()
+
+    /**
+     * Find a consultation by its secure token (for external body public access).
+     *
+     * Returns null when the token is invalid, the consultation is not found,
+     * or the consultation is in a terminal status (afgesloten / ingetrokken).
+     *
+     * @param string $token The 64-character hex secure token
+     *
+     * @return array<string, mixed>|null Consultation data or null
+     *
+     * @spec openspec/changes/consultation-management/tasks.md#TASK-CN-02
+     */
+    public function findBySecureToken(string $token): ?array
+    {
+        if (strlen($token) < 32) {
+            return null;
+        }
+
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return null;
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('consultation_schema');
+
+        if (empty($register) === true || empty($schema) === true) {
+            return null;
+        }
+
+        try {
+            $results = $this->searchObjectsAsArrays(
+                objectService: $objectService,
+                register: $register,
+                schema: $schema,
+                filters: ['secureToken' => $token, '_limit' => 1],
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Procest: failed to find consultation by token: '.$e->getMessage(),
+                ['app' => Application::APP_ID],
+            );
+            return null;
+        }
+
+        if (empty($results) === true) {
+            return null;
+        }
+
+        $consultation = $results[0];
+        $status       = $consultation['status'] ?? '';
+
+        if ($status === 'afgesloten' || $status === 'ingetrokken') {
+            return null;
+        }
+
+        return $consultation;
+    }//end findBySecureToken()
+
+    /**
+     * Generate a unique consultation number in ADV-{year}-{seq} format.
+     *
+     * Queries existing consultations to find the maximum sequence number for
+     * the current year, then increments by one.
+     *
+     * @param object $objectService The OpenRegister object service
+     * @param string $register      The register slug
+     * @param string $schema        The schema slug
+     *
+     * @return string Generated consultation number (e.g. ADV-2026-0001)
+     *
+     * @spec openspec/changes/consultation-management/tasks.md#TASK-CN-02
+     */
+    public function nextConsultationNumber(
+        object $objectService,
+        string $register,
+        string $schema,
+    ): string {
+        $year   = (int) date('Y');
+        $prefix = 'ADV-'.$year.'-';
+
+        $existing = $this->searchObjectsAsArrays(
+            objectService: $objectService,
+            register: $register,
+            schema: $schema,
+            filters: [
+                'consultationNumber' => $prefix.'%',
+                '_order'             => ['consultationNumber' => 'DESC'],
+                '_limit'             => 1,
+            ],
+        );
+
+        $maxSeq = 0;
+        if (empty($existing) === false) {
+            $latest = $existing[0];
+            $number = $latest['consultationNumber'] ?? '';
+            if (str_starts_with($number, $prefix) === true) {
+                $seqPart = substr($number, strlen($prefix));
+                $seq     = (int) $seqPart;
+                if ($seq > $maxSeq) {
+                    $maxSeq = $seq;
+                }
+            }
+        }
+
+        return $prefix.str_pad((string) ($maxSeq + 1), 4, '0', STR_PAD_LEFT);
+    }//end nextConsultationNumber()
+}//end class

--- a/lib/Service/ConsultationService.php
+++ b/lib/Service/ConsultationService.php
@@ -27,7 +27,8 @@ declare(strict_types=1);
 namespace OCA\Procest\Service;
 
 use OCA\Procest\AppInfo\Application;
-use OCA\Procest\Service\Support\SearchesObjects;
+use OCA\Procest\Service\Consultation\ConsultationDependencyGraph;
+use OCA\Procest\Service\Consultation\ConsultationRepository;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 
@@ -40,8 +41,6 @@ use RuntimeException;
  */
 class ConsultationService
 {
-    use SearchesObjects;
-
     /**
      * Valid consultation statuses.
      */
@@ -79,14 +78,18 @@ class ConsultationService
     /**
      * Constructor.
      *
-     * @param SettingsService         $settingsService  Settings service
-     * @param LoggerInterface         $logger           Logger
-     * @param AdviceDelegationService $adviceDelegation Advice delegation to decidesk (ADR-019)
+     * @param SettingsService             $settingsService  Settings service
+     * @param LoggerInterface             $logger           Logger
+     * @param AdviceDelegationService     $adviceDelegation Advice delegation to decidesk (ADR-019)
+     * @param ConsultationRepository      $repository       OpenRegister reads/writes for consultations
+     * @param ConsultationDependencyGraph $dependencyGraph  `dependsOn` cycle detection
      */
     public function __construct(
         private readonly SettingsService $settingsService,
         private readonly LoggerInterface $logger,
         private readonly AdviceDelegationService $adviceDelegation,
+        private readonly ConsultationRepository $repository,
+        private readonly ConsultationDependencyGraph $dependencyGraph,
     ) {
     }//end __construct()
 
@@ -123,7 +126,7 @@ class ConsultationService
         $this->assertRequiredConsultationFields(data: $data);
 
         // Generate unique consultation number.
-        $data['consultationNumber'] = $this->generateConsultationNumber(
+        $data['consultationNumber'] = $this->repository->nextConsultationNumber(
             objectService: $objectService,
             register: $register,
             schema: $schema,
@@ -177,24 +180,7 @@ class ConsultationService
      */
     public function getConsultationsForCase(string $caseId): array
     {
-        $objectService = $this->settingsService->getObjectService();
-        if ($objectService === null) {
-            return [];
-        }
-
-        $register = $this->settingsService->getConfigValue('register');
-        $schema   = $this->settingsService->getConfigValue('consultation_schema');
-
-        if (empty($register) === true || empty($schema) === true) {
-            return [];
-        }
-
-        return $this->searchObjectsAsArrays(
-            objectService: $objectService,
-            register: $register,
-            schema: $schema,
-            filters: ['parentZaak' => $caseId, '_limit' => 100],
-        );
+        return $this->repository->getConsultationsForCase(caseId: $caseId);
     }//end getConsultationsForCase()
 
     /**
@@ -208,24 +194,7 @@ class ConsultationService
      */
     public function getConsultation(string $consultationId): ?array
     {
-        $objectService = $this->settingsService->getObjectService();
-        if ($objectService === null) {
-            return null;
-        }
-
-        $register = $this->settingsService->getConfigValue('register');
-        $schema   = $this->settingsService->getConfigValue('consultation_schema');
-
-        if (empty($register) === true || empty($schema) === true) {
-            return null;
-        }
-
-        return $this->findObjectAsArray(
-            objectService: $objectService,
-            register: $register,
-            schema: $schema,
-            id: $consultationId,
-        );
+        return $this->repository->getConsultation(consultationId: $consultationId);
     }//end getConsultation()
 
     /**
@@ -349,26 +318,7 @@ class ConsultationService
      */
     public function deleteConsultation(string $consultationId): bool
     {
-        $objectService = $this->settingsService->getObjectService();
-        if ($objectService === null) {
-            throw new RuntimeException('OpenRegister is not available');
-        }
-
-        $register = $this->settingsService->getConfigValue('register');
-        $schema   = $this->settingsService->getConfigValue('consultation_schema');
-
-        if (empty($register) === true || empty($schema) === true) {
-            throw new RuntimeException('Consultation schema not configured');
-        }
-
-        $objectService->deleteObject(uuid: (string) $consultationId, register: $register, schema: $schema);
-
-        $this->logger->info(
-            'Consultation deleted: '.$consultationId,
-            ['app' => Application::APP_ID],
-        );
-
-        return true;
+        return $this->repository->deleteConsultation(consultationId: $consultationId);
     }//end deleteConsultation()
 
     /**
@@ -380,44 +330,7 @@ class ConsultationService
      */
     public function getOverdueConsultations(): array
     {
-        $objectService = $this->settingsService->getObjectService();
-        if ($objectService === null) {
-            return [];
-        }
-
-        $register = $this->settingsService->getConfigValue('register');
-        $schema   = $this->settingsService->getConfigValue('consultation_schema');
-
-        if (empty($register) === true || empty($schema) === true) {
-            return [];
-        }
-
-        $openList = $this->searchObjectsAsArrays(
-            objectService: $objectService,
-            register: $register,
-            schema: $schema,
-            filters: ['status' => 'open', '_limit' => 200],
-        );
-
-        $inProgressList = $this->searchObjectsAsArrays(
-            objectService: $objectService,
-            register: $register,
-            schema: $schema,
-            filters: ['status' => 'in_behandeling', '_limit' => 200],
-        );
-
-        $all     = array_merge($openList, $inProgressList);
-        $today   = date('Y-m-d');
-        $overdue = [];
-
-        foreach ($all as $consultation) {
-            $deadline = $consultation['uiterlijkeReactiedatum'] ?? '';
-            if ($deadline !== '' && $deadline < $today) {
-                $overdue[] = $consultation;
-            }
-        }
-
-        return $overdue;
+        return $this->repository->getOverdueConsultations();
     }//end getOverdueConsultations()
 
     /**
@@ -470,24 +383,10 @@ class ConsultationService
      */
     public function validateDependencyCycle(string $consultationId, array $dependsOn): bool
     {
-        // Quick self-reference check.
-        if (in_array($consultationId, $dependsOn, true) === true) {
-            return true;
-        }
-
-        $visited = [];
-        foreach ($dependsOn as $depId) {
-            if ($this->hasCycleDfs(
-                startId: $consultationId,
-                currentId: $depId,
-                visited: $visited,
-            ) === true
-            ) {
-                return true;
-            }
-        }
-
-        return false;
+        return $this->dependencyGraph->wouldCreateCycle(
+            consultationId: $consultationId,
+            dependsOn: $dependsOn
+        );
     }//end validateDependencyCycle()
 
     /**
@@ -662,93 +561,6 @@ class ConsultationService
     }//end raiseAndPersistAdviceDecision()
 
     /**
-     * Generate a unique consultation number in ADV-{year}-{seq} format.
-     *
-     * Queries existing consultations to find the maximum sequence number for
-     * the current year, then increments by one.
-     *
-     * @param object $objectService The OpenRegister object service
-     * @param string $register      The register slug
-     * @param string $schema        The schema slug
-     *
-     * @return string Generated consultation number (e.g. ADV-2026-0001)
-     */
-    private function generateConsultationNumber(
-        object $objectService,
-        string $register,
-        string $schema,
-    ): string {
-        $year   = (int) date('Y');
-        $prefix = 'ADV-'.$year.'-';
-
-        $existing = $this->searchObjectsAsArrays(
-            objectService: $objectService,
-            register: $register,
-            schema: $schema,
-            filters: [
-                'consultationNumber' => $prefix.'%',
-                '_order'             => ['consultationNumber' => 'DESC'],
-                '_limit'             => 1,
-            ],
-        );
-
-        $maxSeq = 0;
-        if (empty($existing) === false) {
-            $latest = $existing[0];
-            $number = $latest['consultationNumber'] ?? '';
-            if (str_starts_with($number, $prefix) === true) {
-                $seqPart = substr($number, strlen($prefix));
-                $seq     = (int) $seqPart;
-                if ($seq > $maxSeq) {
-                    $maxSeq = $seq;
-                }
-            }
-        }
-
-        return $prefix.str_pad((string) ($maxSeq + 1), 4, '0', STR_PAD_LEFT);
-    }//end generateConsultationNumber()
-
-    /**
-     * Depth-first search helper for cycle detection in dependency graph.
-     *
-     * @param string   $startId   The original consultation ID (cycle target)
-     * @param string   $currentId The current node being visited
-     * @param string[] $visited   Already-visited node IDs (prevents re-traversal)
-     *
-     * @return bool True if startId is reachable from currentId (cycle detected)
-     */
-    private function hasCycleDfs(string $startId, string $currentId, array &$visited): bool
-    {
-        if ($currentId === $startId) {
-            return true;
-        }
-
-        if (in_array($currentId, $visited, true) === true) {
-            return false;
-        }
-
-        $visited[] = $currentId;
-
-        $consultation = $this->getConsultation(consultationId: $currentId);
-        if ($consultation === null) {
-            return false;
-        }
-
-        $deps = $consultation['dependsOn'] ?? [];
-        if (is_array($deps) === false) {
-            return false;
-        }
-
-        foreach ($deps as $depId) {
-            if ($this->hasCycleDfs(startId: $startId, currentId: $depId, visited: $visited) === true) {
-                return true;
-            }
-        }
-
-        return false;
-    }//end hasCycleDfs()
-
-    /**
      * Find a consultation by its secure token (for external body public access).
      *
      * Returns null when the token is invalid, the consultation is not found,
@@ -762,48 +574,6 @@ class ConsultationService
      */
     public function findBySecureToken(string $token): ?array
     {
-        if (strlen($token) < 32) {
-            return null;
-        }
-
-        $objectService = $this->settingsService->getObjectService();
-        if ($objectService === null) {
-            return null;
-        }
-
-        $register = $this->settingsService->getConfigValue('register');
-        $schema   = $this->settingsService->getConfigValue('consultation_schema');
-
-        if (empty($register) === true || empty($schema) === true) {
-            return null;
-        }
-
-        try {
-            $results = $this->searchObjectsAsArrays(
-                objectService: $objectService,
-                register: $register,
-                schema: $schema,
-                filters: ['secureToken' => $token, '_limit' => 1],
-            );
-        } catch (\Throwable $e) {
-            $this->logger->error(
-                'Procest: failed to find consultation by token: '.$e->getMessage(),
-                ['app' => Application::APP_ID],
-            );
-            return null;
-        }
-
-        if (empty($results) === true) {
-            return null;
-        }
-
-        $consultation = $results[0];
-        $status       = $consultation['status'] ?? '';
-
-        if ($status === 'afgesloten' || $status === 'ingetrokken') {
-            return null;
-        }
-
-        return $consultation;
+        return $this->repository->findBySecureToken(token: $token);
     }//end findBySecureToken()
 }//end class

--- a/lib/Service/Email/CaseContactDirectory.php
+++ b/lib/Service/Email/CaseContactDirectory.php
@@ -1,0 +1,160 @@
+<?php
+
+/**
+ * Procest case contact directory.
+ *
+ * Knows every shape a contact address can take on a case object and reduces
+ * them to one normalised, validated allow-list. Cases carry contacts in four
+ * different places — the top-level `email` field, a single `initiator` object,
+ * and the `betrokkenen` / `contacts` collections, whose entries may key the
+ * address as either `email` or `emailadres`.
+ *
+ * Split out of CaseEmailService so that service states the *policy* ("the
+ * recipient must be a registered contact") while the knowledge of where
+ * contacts are stored lives here.
+ *
+ * An empty result means the case registers no contacts at all, which callers
+ * read as "no restriction applies" — not as "no contact matched".
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Email
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/specs/case-management/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Email;
+
+/**
+ * Collects the normalised contact addresses registered on a case.
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/specs/case-management/spec.md
+ */
+class CaseContactDirectory
+{
+    /**
+     * Collect the normalised (lowercased) email addresses of all contacts on a case.
+     *
+     * Inspects the following fields (all optional): `betrokkenen`, `contacts`,
+     * `initiator`, and the top-level `email` field. Returns an empty array when
+     * no contacts are registered; the caller treats an empty array as "no restriction".
+     *
+     * @param array<string, mixed> $caseData The case data array
+     *
+     * @return array<string> Lowercase email addresses
+     *
+     * @spec openspec/specs/case-management/spec.md
+     */
+    public function collectAddresses(array $caseData): array
+    {
+        $emails = array_merge(
+            $this->collectPrimaryContactEmails(caseData: $caseData),
+            $this->collectContactListEmails(caseData: $caseData),
+        );
+
+        return array_unique($emails);
+    }//end collectAddresses()
+
+    /**
+     * Collect the single-valued contact addresses on a case.
+     *
+     * Covers the top-level `email` field and the `initiator` contact object, in
+     * that order.
+     *
+     * @param array<string, mixed> $caseData The case data array
+     *
+     * @return array<string> Lowercase email addresses
+     */
+    private function collectPrimaryContactEmails(array $caseData): array
+    {
+        $emails = [];
+
+        // Top-level email field.
+        $topEmail = $this->normalizeContactEmail(value: (string) ($caseData['email'] ?? ''));
+        if ($topEmail !== null) {
+            $emails[] = $topEmail;
+        }
+
+        // Initiator field (single contact object or email string).
+        $initiator = ($caseData['initiator'] ?? null);
+        if (is_array($initiator) === true) {
+            $addr = $this->normalizeContactEmail(value: (string) ($initiator['email'] ?? ''));
+            if ($addr !== null) {
+                $emails[] = $addr;
+            }
+        }
+
+        return $emails;
+    }//end collectPrimaryContactEmails()
+
+    /**
+     * Collect the addresses held in a case's contact collections.
+     *
+     * Covers `betrokkenen` and `contacts`, in that order; each entry may carry
+     * either an `email` or an `emailadres` key.
+     *
+     * @param array<string, mixed> $caseData The case data array
+     *
+     * @return array<string> Lowercase email addresses
+     */
+    private function collectContactListEmails(array $caseData): array
+    {
+        $contactArrays = [];
+        if (is_array($caseData['betrokkenen'] ?? null) === true) {
+            $contactArrays[] = $caseData['betrokkenen'];
+        }
+
+        if (is_array($caseData['contacts'] ?? null) === true) {
+            $contactArrays[] = $caseData['contacts'];
+        }
+
+        $emails = [];
+        foreach ($contactArrays as $contacts) {
+            foreach ($contacts as $contact) {
+                if (is_array($contact) === false) {
+                    continue;
+                }
+
+                $addr = $this->normalizeContactEmail(
+                    value: (string) ($contact['email'] ?? ($contact['emailadres'] ?? ''))
+                );
+                if ($addr !== null) {
+                    $emails[] = $addr;
+                }
+            }
+        }
+
+        return $emails;
+    }//end collectContactListEmails()
+
+    /**
+     * Normalise a raw contact value to a lowercase, validated email address.
+     *
+     * @param string $value The raw contact value
+     *
+     * @return string|null The lowercase address, or null when absent/invalid
+     */
+    private function normalizeContactEmail(string $value): ?string
+    {
+        $addr = strtolower(trim($value));
+        if ($addr === '' || filter_var($addr, FILTER_VALIDATE_EMAIL) === false) {
+            return null;
+        }
+
+        return $addr;
+    }//end normalizeContactEmail()
+}//end class

--- a/lib/Service/Email/CaseEmailAttachmentResolver.php
+++ b/lib/Service/Email/CaseEmailAttachmentResolver.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * Procest case-email attachment resolver.
+ *
+ * Owns the H5 security control for case email: an attachment reference
+ * supplied by the caller is resolved through *that caller's own* user folder,
+ * never through the raw filesystem. Resolving via IRootFolder::getUserFolder()
+ * confines every reference to files the user can already reach and makes path
+ * traversal outside that folder impossible.
+ *
+ * Split out of CaseEmailService so that service states the intent ("attach the
+ * requested files") while the file-resolution and failure policy lives here.
+ *
+ * A reference that cannot be resolved or attached is logged and skipped rather
+ * than aborting the send — a broken attachment must not swallow the message.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Email
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/specs/case-management/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Email;
+
+use OCA\Procest\AppInfo\Application;
+use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
+use OCP\IUserSession;
+use OCP\Mail\IMessage;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Resolves case-email attachments from the calling user's own folder.
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/specs/case-management/spec.md
+ */
+class CaseEmailAttachmentResolver
+{
+    /**
+     * Constructor.
+     *
+     * @param IRootFolder     $rootFolder  Root folder for user-file access
+     * @param IUserSession    $userSession Current user session
+     * @param LoggerInterface $logger      Logger
+     */
+    public function __construct(
+        private readonly IRootFolder $rootFolder,
+        private readonly IUserSession $userSession,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Attach the requested files to a message, resolved from the caller's own folder.
+     *
+     * H5: resolving via the user folder restricts file access to the calling
+     * user's own files and prevents path traversal outside that folder. A file
+     * that cannot be resolved or attached is logged and skipped.
+     *
+     * @param IMessage      $message     The message under construction
+     * @param array<string> $attachments File references to attach
+     * @param string        $caseId      The case UUID (logging context)
+     *
+     * @return void
+     *
+     * @spec openspec/specs/case-management/spec.md
+     */
+    public function attach(IMessage $message, array $attachments, string $caseId): void
+    {
+        $currentUser = $this->userSession->getUser();
+        if ($currentUser !== null && count($attachments) > 0) {
+            $userFolder = $this->rootFolder->getUserFolder($currentUser->getUID());
+            foreach ($attachments as $fileRef) {
+                try {
+                    $file      = $userFolder->get((string) $fileRef);
+                    $localPath = $file->getStorage()->getLocalFile($file->getInternalPath());
+                    if ($localPath !== null && $localPath !== false) {
+                        $message->attachFile($localPath);
+                    }
+                } catch (NotFoundException $e) {
+                    $this->logger->warning(
+                        'Attachment file not found in user folder',
+                        ['app' => Application::APP_ID, 'fileRef' => $fileRef, 'caseId' => $caseId]
+                    );
+                } catch (\Throwable $e) {
+                    $this->logger->warning(
+                        'Failed to attach file',
+                        ['app' => Application::APP_ID, 'fileRef' => $fileRef, 'error' => $e->getMessage()]
+                    );
+                }//end try
+            }//end foreach
+        }//end if
+    }//end attach()
+}//end class

--- a/lib/Service/Email/CaseEmailRepository.php
+++ b/lib/Service/Email/CaseEmailRepository.php
@@ -1,0 +1,313 @@
+<?php
+
+/**
+ * Procest case-email OpenRegister repository.
+ *
+ * Owns every OpenRegister read and write that case-integrated email performs:
+ * loading templates, flattening a case into template variables, resolving a
+ * case identifier back to its UUID, and journalling sent/received messages as
+ * email-message objects.
+ *
+ * Split out of CaseEmailService so that service keeps only the concerns that
+ * are actually about *mail* — from-address policy, recipient policy,
+ * attachment resolution, dispatch and template rendering — while the knowledge
+ * of which register/schema holds which record, and how a raw OpenRegister row
+ * is shaped, lives here.
+ *
+ * A missing ObjectService or an unconfigured register/schema is a
+ * pass-through, not an error: procest runs against instances where the email
+ * registers are simply not provisioned, and callers treat the empty/null
+ * return as "nothing recorded".
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Email
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/specs/case-management/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Email;
+
+use OCA\Procest\Service\SettingsService;
+use OCA\Procest\Service\Support\SearchesObjects;
+
+/**
+ * OpenRegister persistence and lookup for case-integrated email.
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/specs/case-management/spec.md
+ */
+class CaseEmailRepository
+{
+
+    use SearchesObjects;
+
+    /**
+     * Constructor.
+     *
+     * @param SettingsService $settingsService Settings service (register/schema resolution)
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+    ) {
+    }//end __construct()
+
+    /**
+     * Load an email template.
+     *
+     * @param string $templateId The template UUID
+     *
+     * @return array<string, mixed>|null The template data
+     *
+     * @spec openspec/specs/case-management/spec.md
+     */
+    public function findTemplate(string $templateId): ?array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return null;
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('email_template_schema');
+
+        if (empty($register) === true || empty($schema) === true) {
+            return null;
+        }
+
+        $result = $objectService->find($templateId, register: $register, schema: $schema);
+        if (is_array($result) === true) {
+            return $result;
+        }
+
+        return null;
+    }//end findTemplate()
+
+    /**
+     * Get email templates for a case type.
+     *
+     * @param string $caseTypeId The case type UUID
+     *
+     * @return array<int, array<string, mixed>> List of templates
+     *
+     * @spec openspec/specs/case-management/spec.md
+     */
+    public function findTemplatesForCaseType(string $caseTypeId): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return [];
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('email_template_schema');
+
+        if (empty($register) === true || empty($schema) === true) {
+            return [];
+        }
+
+        return $this->searchObjectsAsArrays(
+            objectService: $objectService,
+            register: $register,
+            schema: $schema,
+            filters: ['caseType' => $caseTypeId, '_limit' => 100],
+        );
+    }//end findTemplatesForCaseType()
+
+    /**
+     * Load case data for template variable resolution.
+     *
+     * The case is loaded through OpenRegister with RBAC enabled, so a case the
+     * caller may not read comes back as an empty array — which the caller
+     * treats as 403.
+     *
+     * @param string $caseId The case UUID
+     *
+     * @return array<string, mixed> Case data flattened for variable resolution
+     *
+     * @spec openspec/specs/case-management/spec.md
+     */
+    public function loadCaseVariables(string $caseId): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return [];
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('case_schema');
+
+        $caseObj = $objectService->find($caseId, register: $register, schema: $schema);
+        if ($caseObj === null) {
+            return [];
+        }
+
+        if (is_object($caseObj) === true && method_exists($caseObj, 'jsonSerialize') === true) {
+            $caseObj = $caseObj->jsonSerialize();
+        }
+
+        if (is_array($caseObj) === false) {
+            return [];
+        }
+
+        // Flatten for variable resolution.
+        return [
+            'zaakNummer'  => $caseObj['identifier'] ?? '',
+            'titel'       => $caseObj['title'] ?? '',
+            'startdatum'  => $caseObj['startDate'] ?? '',
+            'deadline'    => $caseObj['deadline'] ?? '',
+            'status'      => $caseObj['status'] ?? '',
+            'behandelaar' => $caseObj['assignee'] ?? '',
+        ];
+    }//end loadCaseVariables()
+
+    /**
+     * Record a sent email as a case document.
+     *
+     * @param string $caseId      Case UUID
+     * @param string $fromAddress The resolved envelope from-address
+     * @param string $to          Recipient
+     * @param string $subject     Subject
+     * @param string $body        Body
+     *
+     * @return string The recorded message ID
+     *
+     * @spec openspec/specs/case-management/spec.md
+     */
+    public function recordSentEmail(
+        string $caseId,
+        string $fromAddress,
+        string $to,
+        string $subject,
+        string $body,
+    ): string {
+        // Store as activity on the case.
+        $messageId = 'msg-'.uniqid();
+
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return $messageId;
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('email_message_schema');
+
+        if (empty($register) === false && empty($schema) === false) {
+            $objectService->saveObject(
+                    object: [
+                        'case'      => $caseId,
+                        'direction' => 'outbound',
+                        'from'      => $fromAddress,
+                        'to'        => $to,
+                        'subject'   => $subject,
+                        'body'      => $body,
+                        'messageId' => $messageId,
+                        'sentAt'    => date('Y-m-d\TH:i:s'),
+                    ],
+                    register: $register,
+                    schema: $schema,
+                    );
+        }
+
+        return $messageId;
+    }//end recordSentEmail()
+
+    /**
+     * Record a received email.
+     *
+     * @param string $caseId    Case UUID
+     * @param string $from      Sender
+     * @param string $recipient Recipient (the mailbox the message arrived on)
+     * @param string $subject   Subject
+     * @param string $body      Body
+     * @param string $inReplyTo Threading header
+     *
+     * @return string The recorded message ID
+     *
+     * @spec openspec/specs/case-management/spec.md
+     */
+    public function recordReceivedEmail(
+        string $caseId,
+        string $from,
+        string $recipient,
+        string $subject,
+        string $body,
+        string $inReplyTo,
+    ): string {
+        $messageId = 'msg-'.uniqid();
+
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return $messageId;
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('email_message_schema');
+
+        if (empty($register) === false && empty($schema) === false) {
+            $objectService->saveObject(
+                    object: [
+                        'case'       => $caseId,
+                        'direction'  => 'inbound',
+                        'from'       => $from,
+                        'to'         => $recipient,
+                        'subject'    => $subject,
+                        'body'       => $body,
+                        'messageId'  => $messageId,
+                        'inReplyTo'  => $inReplyTo,
+                        'receivedAt' => date('Y-m-d\TH:i:s'),
+                    ],
+                    register: $register,
+                    schema: $schema,
+                    );
+        }
+
+        return $messageId;
+    }//end recordReceivedEmail()
+
+    /**
+     * Find a case UUID by its human-readable identifier.
+     *
+     * @param string $identifier The case identifier (e.g., 2026-0042)
+     *
+     * @return string|null The case UUID or null
+     *
+     * @spec openspec/specs/case-management/spec.md
+     */
+    public function findCaseIdByIdentifier(string $identifier): ?string
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return null;
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('case_schema');
+
+        $results = $this->searchObjectsAsArrays(
+            objectService: $objectService,
+            register: $register,
+            schema: $schema,
+            filters: ['identifier' => $identifier, '_limit' => 1],
+        );
+
+        if (is_array($results) === true && count($results) > 0) {
+            return $results[0]['id'] ?? $results[0]['uuid'] ?? null;
+        }
+
+        return null;
+    }//end findCaseIdByIdentifier()
+}//end class

--- a/lib/Service/Relation/CaseHierarchyOverlapGuard.php
+++ b/lib/Service/Relation/CaseHierarchyOverlapGuard.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * Procest case-hierarchy overlap guard.
+ *
+ * Answers one question for the peer-relation surface: are these two cases
+ * already linked through the hoofdzaak/deelzaak hierarchy? When they are, a
+ * typed peer relation would express the same link twice, so CaseRelationService
+ * refuses to create it.
+ *
+ * The hierarchy itself (the `parentCase` field) is DeelzaakService's concern.
+ * This class only *reads* it, and only to decide overlap — it never writes a
+ * parent link. It is split out of CaseRelationService precisely so that
+ * read-only borrowing of another aggregate's field is visible in one place.
+ *
+ * The `parentCase` reference is accepted in both shapes OpenRegister can
+ * return it in: a scalar UUID, or an expanded object carrying `id`/`uuid`.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Relation
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/specs/related-case-linking/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Relation;
+
+/**
+ * Detects an existing hoofdzaak/deelzaak link between two cases.
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/specs/related-case-linking/spec.md
+ */
+class CaseHierarchyOverlapGuard
+{
+    /**
+     * Determine whether two cases are already linked through the deelzaak
+     * (parent/child) hierarchy in either direction.
+     *
+     * @param array<string, mixed> $caseA First case object.
+     * @param array<string, mixed> $caseB Second case object.
+     *
+     * @return bool
+     *
+     * @spec openspec/specs/related-case-linking/spec.md
+     */
+    public function areLinked(array $caseA, array $caseB): bool
+    {
+        $idA = (string) ($caseA['id'] ?? ($caseA['@self']['id'] ?? ''));
+        $idB = (string) ($caseB['id'] ?? ($caseB['@self']['id'] ?? ''));
+
+        $parentA = $this->parentRef(case: $caseA);
+        $parentB = $this->parentRef(case: $caseB);
+
+        if ($idB !== '' && $parentA === $idB) {
+            return true;
+        }
+
+        if ($idA !== '' && $parentB === $idA) {
+            return true;
+        }
+
+        return false;
+    }//end areLinked()
+
+    /**
+     * Read the `parentCase` reference UUID out of a case array (scalar or
+     * expanded-object shape).
+     *
+     * @param array<string, mixed> $case Case object.
+     *
+     * @return string Parent UUID or '' when absent.
+     */
+    private function parentRef(array $case): string
+    {
+        $parent = ($case['parentCase'] ?? null);
+        if (is_string($parent) === true) {
+            return $parent;
+        }
+
+        if (is_array($parent) === true) {
+            $ref = ($parent['id'] ?? ($parent['uuid'] ?? ''));
+            if (is_string($ref) === true) {
+                return $ref;
+            }
+
+            return '';
+        }
+
+        return '';
+    }//end parentRef()
+}//end class

--- a/lib/Service/Relation/CaseRelationCodec.php
+++ b/lib/Service/Relation/CaseRelationCodec.php
@@ -1,0 +1,219 @@
+<?php
+
+/**
+ * Procest case-relation codec.
+ *
+ * Owns the on-disk shape of the `case.relatedCases` field and every pure
+ * operation over a relation list: decoding it (the field is a JSON-encoded
+ * string, but an already-decoded array is tolerated because the ZGW inbound
+ * mapping layer writes it directly), building a single entry, and the
+ * pair-level membership and removal used to keep both sides of a symmetric
+ * relation consistent.
+ *
+ * Split out of CaseRelationService so that service keeps only the policy —
+ * which guards fail closed, and that every add/remove touches both cases —
+ * while the encoding contract lives in one place. Everything here is pure: no
+ * OpenRegister access, no session, no logging.
+ *
+ * An entry that names no case is dropped rather than raising: a partially
+ * written relation must not make the whole list unreadable.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Relation
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/specs/related-case-linking/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Relation;
+
+/**
+ * Encodes, decodes and edits the typed peer-relation list of a case.
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/specs/related-case-linking/spec.md
+ */
+class CaseRelationCodec
+{
+    /**
+     * Build a single relation entry, carrying the optional clarification.
+     *
+     * @param string      $caseId      Referenced case UUID.
+     * @param string      $aardRelatie Relation type.
+     * @param string|null $toelichting Optional free-text clarification.
+     *
+     * @return array<string, string>
+     *
+     * @spec openspec/specs/related-case-linking/spec.md
+     */
+    public function buildEntry(string $caseId, string $aardRelatie, ?string $toelichting): array
+    {
+        $entry = ['caseId' => $caseId, 'aardRelatie' => $aardRelatie];
+        if ($toelichting !== null && $toelichting !== '') {
+            $entry['toelichting'] = $toelichting;
+        }
+
+        return $entry;
+    }//end buildEntry()
+
+    /**
+     * Decode the JSON-encoded `relatedCases` field into a list of relation
+     * entries, tolerating an already-array shape.
+     *
+     * @param array<string, mixed> $case Case object.
+     *
+     * @return array<int, array<string, mixed>>
+     *
+     * @spec openspec/specs/related-case-linking/spec.md
+     */
+    public function decode(array $case): array
+    {
+        $entries = [];
+        foreach ($this->rawRelationList(case: $case) as $item) {
+            if (is_array($item) === false) {
+                continue;
+            }
+
+            $entry = $this->decodeRelationEntry(item: $item);
+            if ($entry === null) {
+                continue;
+            }
+
+            $entries[] = $entry;
+        }//end foreach
+
+        return $entries;
+    }//end decode()
+
+    /**
+     * Whether a `{caseId, aardRelatie}` pair already exists in a relation list.
+     *
+     * @param array<int, array<string, mixed>> $relations   Relation entries.
+     * @param string                           $caseId      Target case UUID.
+     * @param string                           $aardRelatie Relation type.
+     *
+     * @return bool
+     *
+     * @spec openspec/specs/related-case-linking/spec.md
+     */
+    public function hasPair(array $relations, string $caseId, string $aardRelatie): bool
+    {
+        foreach ($relations as $relation) {
+            if ((string) ($relation['caseId'] ?? '') === $caseId
+                && (string) ($relation['aardRelatie'] ?? '') === $aardRelatie
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+    }//end hasPair()
+
+    /**
+     * Return a copy of the relation list with the given pair removed.
+     *
+     * @param array<int, array<string, mixed>> $relations   Relation entries.
+     * @param string                           $caseId      Target case UUID.
+     * @param string                           $aardRelatie Relation type.
+     *
+     * @return array<int, array<string, mixed>>
+     *
+     * @spec openspec/specs/related-case-linking/spec.md
+     */
+    public function removePair(array $relations, string $caseId, string $aardRelatie): array
+    {
+        return array_values(
+            array_filter(
+                $relations,
+                static fn (array $relation): bool => (
+                    (string) ($relation['caseId'] ?? '') !== $caseId
+                    || (string) ($relation['aardRelatie'] ?? '') !== $aardRelatie
+                )
+            )
+        );
+    }//end removePair()
+
+    /**
+     * Return a copy of the relation list with every entry naming a case removed.
+     *
+     * @param array<int, array<string, mixed>> $relations Relation entries.
+     * @param string                           $caseId    Case UUID to strip.
+     *
+     * @return array<int, array<string, mixed>>
+     *
+     * @spec openspec/specs/related-case-linking/spec.md
+     */
+    public function removeAllForCase(array $relations, string $caseId): array
+    {
+        return array_values(
+            array_filter(
+                $relations,
+                static fn (array $relation): bool => (string) ($relation['caseId'] ?? '') !== $caseId
+            )
+        );
+    }//end removeAllForCase()
+
+    /**
+     * Read the raw `relatedCases` payload as a list, accepting either the
+     * JSON-encoded string shape or an already-decoded array.
+     *
+     * @param array<string, mixed> $case Case object.
+     *
+     * @return array<mixed> The raw relation list, or [] when unusable.
+     */
+    private function rawRelationList(array $case): array
+    {
+        $raw  = ($case['relatedCases'] ?? null);
+        $list = [];
+        if (is_array($raw) === true) {
+            $list = $raw;
+        }
+
+        if (is_string($raw) === true && $raw !== '') {
+            $decoded = json_decode($raw, true);
+            if (is_array($decoded) === true) {
+                $list = $decoded;
+            }
+        }
+
+        return $list;
+    }//end rawRelationList()
+
+    /**
+     * Normalise one raw relation item into a relation entry.
+     *
+     * @param array<string, mixed> $item Raw relation item.
+     *
+     * @return array<string, string>|null The entry, or null when it names no case.
+     */
+    private function decodeRelationEntry(array $item): ?array
+    {
+        $targetId = (string) ($item['caseId'] ?? '');
+        if ($targetId === '') {
+            return null;
+        }
+
+        $entry = [
+            'caseId'      => $targetId,
+            'aardRelatie' => (string) ($item['aardRelatie'] ?? ''),
+        ];
+        if (isset($item['toelichting']) === true && (string) $item['toelichting'] !== '') {
+            $entry['toelichting'] = (string) $item['toelichting'];
+        }
+
+        return $entry;
+    }//end decodeRelationEntry()
+}//end class

--- a/lib/Service/Relation/CaseRelationStore.php
+++ b/lib/Service/Relation/CaseRelationStore.php
@@ -1,0 +1,171 @@
+<?php
+
+/**
+ * Procest case-relation OpenRegister store.
+ *
+ * The only place case objects are read and written on behalf of the peer
+ * relation surface. Reads resolve through the session's ObjectService, so
+ * OpenRegister's per-object RBAC applies and a case the actor may not read
+ * comes back as null — that null IS the access guard the callers fail closed
+ * on, not an incidental "not found".
+ *
+ * Split out of CaseRelationService so that service keeps only the relation
+ * policy while the OpenRegister register/schema resolution, the ObjectEntity
+ * normalisation and the failure logging live here.
+ *
+ * A lookup or save that throws is logged and degraded to null / no-op rather
+ * than propagating: a relation write must never take down the case operation
+ * that triggered it.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Relation
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/specs/related-case-linking/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Relation;
+
+use OCA\Procest\Service\SettingsService;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Reads and writes case objects for the peer-relation surface.
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/specs/related-case-linking/spec.md
+ */
+class CaseRelationStore
+{
+    /**
+     * Constructor.
+     *
+     * @param SettingsService $settingsService Shared OR/settings resolver.
+     * @param LoggerInterface $logger          Logger.
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Fetch a single case object by UUID through the session's ObjectService.
+     *
+     * Resolving via OpenRegister applies its per-object RBAC for the current
+     * user, so an unreadable case resolves to null — this is the access guard.
+     *
+     * @param string $caseUuid Case UUID.
+     *
+     * @return array<string, mixed>|null
+     *
+     * @spec openspec/specs/related-case-linking/spec.md
+     */
+    public function fetchCase(string $caseUuid): ?array
+    {
+        if ($caseUuid === '') {
+            return null;
+        }
+
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return null;
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('case_schema');
+        if ($register === '' || $schema === '') {
+            return null;
+        }
+
+        try {
+            $obj = $objectService->find($caseUuid, register: $register, schema: $schema);
+        } catch (\Throwable $e) {
+            $this->logger->debug(
+                'CaseRelationService: case lookup failed',
+                ['uuid' => $caseUuid, 'error' => $e->getMessage()]
+            );
+            return null;
+        }
+
+        return $this->normalizeCaseObject(object: $obj);
+    }//end fetchCase()
+
+    /**
+     * Persist a relation list back onto a case, JSON-encoding the field
+     * (the `relatedCases` field is a JSON-encoded string).
+     *
+     * @param array<string, mixed>             $case      Case object to update.
+     * @param array<int, array<string, mixed>> $relations Relation entries.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/related-case-linking/spec.md
+     */
+    public function persistRelations(array $case, array $relations): void
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return;
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('case_schema');
+        if ($register === '' || $schema === '') {
+            return;
+        }
+
+        $payload = $case;
+        $payload['relatedCases'] = json_encode(array_values($relations));
+
+        try {
+            $objectService->saveObject(
+                object: $payload,
+                register: $register,
+                schema: $schema,
+            );
+        } catch (\Throwable $e) {
+            $this->logger->warning(
+                'CaseRelationService: failed to persist relatedCases',
+                ['error' => $e->getMessage()]
+            );
+        }
+    }//end persistRelations()
+
+    /**
+     * Normalise an OpenRegister lookup result to a plain case array.
+     *
+     * @param mixed $object The value returned by the ObjectService.
+     *
+     * @return array<string, mixed>|null The case as an array, or null when unusable.
+     */
+    private function normalizeCaseObject(mixed $object): ?array
+    {
+        if ($object === null) {
+            return null;
+        }
+
+        if (is_object($object) === true && method_exists($object, 'jsonSerialize') === true) {
+            $object = $object->jsonSerialize();
+        }
+
+        if (is_array($object) === true) {
+            return $object;
+        }
+
+        return null;
+    }//end normalizeCaseObject()
+}//end class

--- a/lib/Service/Sharing/CaseAccessPolicy.php
+++ b/lib/Service/Sharing/CaseAccessPolicy.php
@@ -1,0 +1,213 @@
+<?php
+
+/**
+ * Procest case-access policy for the sharing surface.
+ *
+ * Answers "may this user act on this case?" for every share operation. Three
+ * things grant access: the case names the user as assignee (single-valued or
+ * in the `assignees` array), or the user once minted a share for the case —
+ * which is standing evidence they had access at that time.
+ *
+ * Split out of CaseSharingService so the fail-OPEN decisions this policy makes
+ * are stated in one auditable place. Note the asymmetry, and that it is
+ * deliberate: an unavailable OpenRegister or an unconfigured case schema
+ * returns true, because the same-instance sharing feature must keep working on
+ * basic setups where the caller is already authenticated by IUserSession. The
+ * federation surface makes the opposite choice and fails closed — there is
+ * nothing safe to fall back to once a request crosses an org boundary.
+ *
+ * A share lookup that throws is logged and read as "no share found" (deny),
+ * never as a grant.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Sharing
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/specs/case-management/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Sharing;
+
+use OCA\Procest\Service\SettingsService;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Decides whether a user may act on a case for sharing purposes.
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/specs/case-management/spec.md
+ */
+class CaseAccessPolicy
+{
+    /**
+     * Constructor.
+     *
+     * @param SettingsService            $settingsService The settings service
+     * @param OpenRegisterSharingGateway $gateway         OpenRegister resolution for the sharing surface
+     * @param LoggerInterface            $logger          The logger
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+        private readonly OpenRegisterSharingGateway $gateway,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Check whether a given user may access a case for sharing purposes.
+     *
+     * A user is permitted when any of the following holds:
+     *  - the case's `assignee` field equals the user ID
+     *  - the user ID appears in `assignees` (array)
+     *  - the user ID appears as a `createdBy` on any caseShare linked to the case
+     *  - the caller is an NC admin (checked via group membership `admin`)
+     *
+     * Returns true when the case cannot be loaded (fail-safe for missing OR
+     * config) to avoid breaking installations that have not configured the
+     * case schema. The caller must still authenticate via IUserSession.
+     *
+     * @param string $caseId The case UUID
+     * @param string $userId The caller's user ID
+     *
+     * @return bool True when the user may proceed
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+     */
+    public function canUserAccessCase(string $caseId, string $userId): bool
+    {
+        $objectService = $this->gateway->objectService();
+        if ($objectService === null) {
+            // OR not available — fail-open so the feature still works on basic setups.
+            return true;
+        }
+
+        $register   = $this->settingsService->getConfigValue('register');
+        $caseSchema = $this->settingsService->getConfigValue('case_schema');
+
+        if (empty($register) === true || empty($caseSchema) === true) {
+            return true;
+        }
+
+        try {
+            $caseObj = $objectService->find($caseId, register: (int) $register, schema: (int) $caseSchema);
+            if ($caseObj === null) {
+                // Case not found — deny (treated as 404 by callers).
+                return false;
+            }
+
+            $caseData = $this->gateway->toArray(value: $caseObj);
+        } catch (\Throwable $e) {
+            $this->logger->warning(
+                'CaseSharingService: canUserAccessCase load failed',
+                ['caseId' => $caseId, 'exception' => $e->getMessage()]
+            );
+            return true;
+        }
+
+        // Direct assignee field, then the assignees array.
+        if ($this->isCaseAssignee(caseData: $caseData, userId: $userId) === true) {
+            return true;
+        }
+
+        // Check existing caseShares: if this user created any share for this case they
+        // already had access at that time.
+        if ($this->hasCreatedShareForCase(
+            objectService: $objectService,
+            caseId: $caseId,
+            userId: $userId,
+            register: (int) $register
+        ) === true
+        ) {
+            return true;
+        }
+
+        return false;
+    }//end canUserAccessCase()
+
+    /**
+     * Whether a case names the given user as assignee.
+     *
+     * Accepts both the single-valued `assignee` field and membership of the
+     * `assignees` array; either one grants access.
+     *
+     * @param array<string, mixed> $caseData The case data
+     * @param string               $userId   The caller's user ID
+     *
+     * @return bool True when the user is an assignee of the case
+     */
+    private function isCaseAssignee(array $caseData, string $userId): bool
+    {
+        // Direct assignee field (single user ID string).
+        if (isset($caseData['assignee']) === true && (string) $caseData['assignee'] === $userId) {
+            return true;
+        }
+
+        // Assignees array.
+        $assignees = ($caseData['assignees'] ?? []);
+        if (is_array($assignees) === true && in_array($userId, $assignees, true) === true) {
+            return true;
+        }
+
+        return false;
+    }//end isCaseAssignee()
+
+    /**
+     * Whether the given user created any caseShare for the given case.
+     *
+     * A user who once minted a share for the case already had access at that
+     * time, so the share record is treated as standing evidence of access.
+     * A failed lookup is logged and treated as "no share found" (deny), never
+     * as a grant.
+     *
+     * @param object $objectService The OpenRegister ObjectService
+     * @param string $caseId        The case UUID
+     * @param string $userId        The caller's user ID
+     * @param int    $register      The configured register id
+     *
+     * @return bool True when a share created by this user exists
+     */
+    private function hasCreatedShareForCase(
+        object $objectService,
+        string $caseId,
+        string $userId,
+        int $register,
+    ): bool {
+        $shareSchema = $this->settingsService->getConfigValue('case_share_schema');
+        if (empty($shareSchema) === true) {
+            return false;
+        }
+
+        try {
+            $shares = $objectService->findAll(
+                ['filters' => ['register' => $register, 'schema' => (int) $shareSchema, 'caseId' => $caseId]],
+            );
+
+            foreach ($shares as $share) {
+                $shareData = $this->gateway->toArray(value: $share);
+                if (isset($shareData['createdBy']) === true && (string) $shareData['createdBy'] === $userId) {
+                    return true;
+                }
+            }
+        } catch (\Throwable $e) {
+            $this->logger->debug(
+                'CaseSharingService: share lookup in canUserAccessCase failed',
+                ['caseId' => $caseId, 'exception' => $e->getMessage()]
+            );
+        }//end try
+
+        return false;
+    }//end hasCreatedShareForCase()
+}//end class

--- a/lib/Service/Sharing/CaseTokenShareService.php
+++ b/lib/Service/Sharing/CaseTokenShareService.php
@@ -1,0 +1,236 @@
+<?php
+
+/**
+ * Procest public case-token share service.
+ *
+ * The "track your case" public link surface. Procest mints NO tokens of its
+ * own: every token is minted, listed and revoked through OpenRegister's shares
+ * integration leaf (ADR-022), which owns the 256-bit non-guessable handle,
+ * expiry, revocation, and the `#[PublicPage]` resolve path that returns only
+ * the fields the public group may read. There is no procest-side token store,
+ * field-exclusion list, password gate or brute-force lockout to keep in sync.
+ *
+ * Split out of CaseSharingService so this mode's entire dependency on the leaf
+ * — including the "is the leaf even installed?" degradation — sits behind one
+ * class, separate from partner hand-off and OCM federation.
+ *
+ * When the leaf is absent every operation degrades to an error array or false;
+ * a missing leaf is never reported as a successful share.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Sharing
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/changes/migrate-public-share-to-shares-leaf/tasks.md#P1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Sharing;
+
+use OCA\Procest\Service\SettingsService;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Mints, matches and revokes public case-token links via the OR shares leaf.
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/changes/migrate-public-share-to-shares-leaf/tasks.md#P1.2
+ */
+class CaseTokenShareService
+{
+    /**
+     * Constructor.
+     *
+     * @param SettingsService            $settingsService The settings service
+     * @param OpenRegisterSharingGateway $gateway         OpenRegister resolution for the sharing surface
+     * @param LoggerInterface            $logger          The logger
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+        private readonly OpenRegisterSharingGateway $gateway,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Create a public "track your case" token link through OpenRegister's
+     * shares integration leaf.
+     *
+     * The leaf mints a 256-bit token bound to the case object. The token
+     * resolves anonymously to a PUBLIC-SAFE view of the case via OR's
+     * `#[PublicPage]` resolve endpoint — only the fields the public group
+     * may read are returned (the `publicatiedatum<=$now` + public-group
+     * predicate), so procest no longer hand-maintains a token store,
+     * field-exclusion list, password gate, or brute-force lockout. RBAC
+     * is enforced by the OR public read path, not by procest.
+     *
+     * @param string      $caseId    The UUID of the case to share
+     * @param string      $label     Human-readable label for the link
+     * @param string      $createdBy User ID of the creator (audit log)
+     * @param string|null $expiresAt ISO 8601 expiration datetime, or null
+     *                               for a non-expiring link
+     *
+     * @return array The minted token metadata + public resolve URL, or an
+     *               error array when the leaf is unavailable.
+     *
+     * @spec openspec/changes/migrate-public-share-to-shares-leaf/tasks.md#P1.2
+     */
+    public function createTokenShare(
+        string $caseId,
+        string $label,
+        string $createdBy,
+        ?string $expiresAt=null,
+    ): array {
+        $tokenService = $this->gateway->caseTokenService();
+        if ($tokenService === null) {
+            return ['error' => 'OpenRegister shares leaf is not available'];
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('case_schema');
+
+        $ttlSeconds = null;
+        if ($expiresAt !== null) {
+            $expiryTs = strtotime((string) $expiresAt);
+            if ($expiryTs !== false) {
+                $ttlSeconds = max(1, ($expiryTs - time()));
+            }
+        }
+
+        $registerId = null;
+        if (empty($register) === false) {
+            $registerId = (int) $register;
+        }
+
+        $schemaId = null;
+        if (empty($schema) === false) {
+            $schemaId = (int) $schema;
+        }
+
+        $mintLabel = null;
+        if ($label !== '') {
+            $mintLabel = $label;
+        }
+
+        try {
+            // Mint through the leaf — it owns token generation, expiry and
+            // the public resolve URL. The minter (createdBy) is recorded by
+            // the leaf via the current user session.
+            $minted = $tokenService->mint(
+                objectUuid: $caseId,
+                registerId: $registerId,
+                schemaId: $schemaId,
+                label: $mintLabel,
+                ttlSeconds: $ttlSeconds
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'CaseSharingService: leaf mint failed',
+                ['caseId' => $caseId, 'exception' => $e->getMessage()]
+            );
+            return ['error' => 'Could not create share link'];
+        }
+
+        $this->logger->info(
+            'Procest: Public case-token link minted via OR shares leaf',
+            [
+                'caseId'    => $caseId,
+                'createdBy' => $createdBy,
+                'label'     => $label,
+            ]
+        );
+
+        return $minted;
+    }//end createTokenShare()
+
+    /**
+     * Resolve the case (object) a leaf-minted token belongs to.
+     *
+     * Used by the controller to enforce the per-case owner/handler guard
+     * before revoking a public token (ADR-005): the controller looks up
+     * which case the token addresses, then checks the caller may access
+     * that case. Returns null when the token cannot be matched to any
+     * case the candidate caseId owns.
+     *
+     * @param string $tokenId The leaf token id (numeric) or opaque token.
+     * @param string $caseId  The candidate case UUID.
+     *
+     * @return bool True when the token is one of the case's minted tokens.
+     *
+     * @spec openspec/changes/migrate-public-share-to-shares-leaf/tasks.md#P1.3
+     */
+    public function tokenBelongsToCase(string $tokenId, string $caseId): bool
+    {
+        $tokenService = $this->gateway->caseTokenService();
+        if ($tokenService === null || method_exists($tokenService, 'listForObject') === false) {
+            return false;
+        }
+
+        try {
+            $tokens = $tokenService->listForObject($caseId);
+        } catch (\Throwable $e) {
+            $this->logger->warning(
+                'CaseSharingService: listForObject failed',
+                ['caseId' => $caseId, 'exception' => $e->getMessage()]
+            );
+            return false;
+        }
+
+        foreach ((array) $tokens as $token) {
+            $candidateId    = (string) ($token['id'] ?? '');
+            $candidateToken = (string) ($token['token'] ?? '');
+            if ($tokenId !== '' && ($tokenId === $candidateId || $tokenId === $candidateToken)) {
+                return true;
+            }
+        }
+
+        return false;
+    }//end tokenBelongsToCase()
+
+    /**
+     * Revoke a public "track your case" token link through the OR shares
+     * leaf. The caller MUST have already authorised the revoke against the
+     * owning case (see {@see tokenBelongsToCase()} + canUserAccessCase()).
+     *
+     * @param string $tokenId The token id (or the opaque token) minted by
+     *                        the leaf.
+     *
+     * @return bool True when the leaf accepted the revoke.
+     *
+     * @spec openspec/changes/migrate-public-share-to-shares-leaf/tasks.md#P1.3
+     */
+    public function revokeTokenShare(string $tokenId): bool
+    {
+        $tokenService = $this->gateway->caseTokenService();
+        if ($tokenService === null || method_exists($tokenService, 'revoke') === false) {
+            return false;
+        }
+
+        try {
+            $tokenService->revoke($tokenId);
+            $this->logger->info(
+                'Procest: Public case-token link revoked via OR shares leaf',
+                ['tokenId' => $tokenId]
+            );
+            return true;
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'CaseSharingService: leaf revoke failed',
+                ['tokenId' => $tokenId, 'exception' => $e->getMessage()]
+            );
+            return false;
+        }
+    }//end revokeTokenShare()
+}//end class

--- a/lib/Service/Sharing/FederatedCaseShareService.php
+++ b/lib/Service/Sharing/FederatedCaseShareService.php
@@ -1,0 +1,438 @@
+<?php
+
+/**
+ * Procest federated (OCM) case-share service.
+ *
+ * Shares a purpose-built, field-scoped SNAPSHOT of a case with a remote org
+ * over OpenRegister's OCM federation leaf. OpenRegister's `scope: object`
+ * federated share serves exactly the object it is pointed at — the whole
+ * object, no field projection — so the live case is never the shared object.
+ * Instead a `caseFederatedShare` object carrying only allow-listed fields and
+ * document references already attached to the case is persisted, and THAT is
+ * shared with `permissions: 'read'`. The live case is never shared and never
+ * mutable by the remote org (design.md §3, authority model).
+ *
+ * Split out of CaseSharingService so the org-boundary rules live apart from
+ * same-instance sharing. This service fails CLOSED throughout — an unavailable
+ * federation leaf, an unconfigured schema, an unshareable field or an
+ * unattached document each return an error and write nothing. That is the
+ * opposite of CaseAccessPolicy's deliberate fail-open, because there is
+ * nothing safe to fall back to once a request crosses an org boundary.
+ *
+ * Revocation writes the OR `FederatedShare.status`, which is the single source
+ * of truth every downstream check consults, so a revoke is immediate
+ * everywhere rather than eventually consistent.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Sharing
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/specs/federated-case-collaboration/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Sharing;
+
+use DateTime;
+use OCA\Procest\Service\CaseSharingService;
+use OCA\Procest\Service\SettingsService;
+use OCA\Procest\Service\TenantAuditTrailService;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Creates and revokes redacted, field-scoped federated case-share snapshots.
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/specs/federated-case-collaboration/spec.md
+ */
+class FederatedCaseShareService
+{
+    /**
+     * Constructor.
+     *
+     * @param SettingsService            $settingsService   The settings service
+     * @param OpenRegisterSharingGateway $gateway           OpenRegister resolution for the sharing surface
+     * @param LoggerInterface            $logger            The logger
+     * @param TenantAuditTrailService    $auditTrailService Audit-trail emitter for cross-org actions
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+        private readonly OpenRegisterSharingGateway $gateway,
+        private readonly LoggerInterface $logger,
+        private readonly TenantAuditTrailService $auditTrailService,
+    ) {
+    }//end __construct()
+
+    /**
+     * Create a federated case share: a purpose-built, field-scoped snapshot
+     * of the case shared with a remote org over OpenRegister's OCM
+     * federation leaf (`FederationShareService`).
+     *
+     * Fails closed (returns an error, writes nothing) when the OR
+     * federation leaf is unavailable.
+     *
+     * @param string        $caseId          The UUID of the case to share
+     * @param string        $remoteCloudId   The federated target (slug@host)
+     * @param array<string> $sharedFields    Requested case field names
+     * @param array<string> $sharedDocuments Requested document references
+     * @param string        $permissionLevel Permission level slug (informational; the OR grant is always 'read')
+     * @param string        $createdBy       User ID of the share creator
+     *
+     * @return array The created federated share data, or an error array
+     *
+     * @spec openspec/specs/federated-case-collaboration/spec.md#federated-case-share-is-a-redacted-snapshot-never-the-live-case
+     */
+    public function createFederatedShare(
+        string $caseId,
+        string $remoteCloudId,
+        array $sharedFields,
+        array $sharedDocuments,
+        string $permissionLevel,
+        string $createdBy,
+    ): array {
+        $federationService = $this->gateway->federationShareService();
+        $objectService     = $this->gateway->objectService();
+        if ($federationService === null || $objectService === null) {
+            return ['error' => 'Federated case sharing requires the OpenRegister federation leaf'];
+        }
+
+        $invalidFields = array_diff($sharedFields, CaseSharingService::FEDERATION_ALLOWED_FIELDS);
+        if (count($invalidFields) > 0) {
+            return ['error' => 'Field(s) not shareable across a federation boundary: '.implode(', ', $invalidFields)];
+        }
+
+        $register    = $this->settingsService->getConfigValue('register');
+        $caseSchema  = $this->settingsService->getConfigValue('case_schema');
+        $shareSchema = $this->settingsService->getConfigValue('case_federated_share_schema');
+
+        if ($this->isFederatedShareConfigured(register: $register, caseSchema: $caseSchema, shareSchema: $shareSchema) === false) {
+            return ['error' => 'Federated case sharing is not configured'];
+        }
+
+        $caseData = $this->loadCaseForFederatedShare(
+            objectService: $objectService,
+            caseId: $caseId,
+            register: (int) $register,
+            caseSchema: (int) $caseSchema
+        );
+        if ($caseData === null) {
+            return ['error' => 'Case not found'];
+        }
+
+        // Build the redacted snapshot — allow-listed fields present on the case only.
+        $fieldSnapshot = $this->buildFieldSnapshot(caseData: $caseData, sharedFields: $sharedFields);
+
+        // Only document references already attached to the case may cross.
+        $caseDocuments    = (array) ($caseData['documents'] ?? []);
+        $validDocuments   = array_values(array_intersect($sharedDocuments, $caseDocuments));
+        $invalidDocuments = array_diff($sharedDocuments, $caseDocuments);
+        if (count($invalidDocuments) > 0) {
+            return ['error' => 'Document(s) not attached to this case: '.implode(', ', $invalidDocuments)];
+        }
+
+        $shareData = [
+            'caseId'          => $caseId,
+            'remoteCloudId'   => $remoteCloudId,
+            'sharedFields'    => array_values($sharedFields),
+            'sharedDocuments' => $validDocuments,
+            'fieldSnapshot'   => $fieldSnapshot,
+            'permissionLevel' => $permissionLevel,
+            'status'          => 'pending',
+            'createdBy'       => $createdBy,
+        ];
+
+        $result     = $objectService->saveObject(object: $shareData, register: (int) $register, schema: (int) $shareSchema);
+        $resultData = $this->gateway->toArray(value: $result);
+
+        $shareUuid = (string) ($resultData['id'] ?? $resultData['uuid'] ?? '');
+
+        $federatedShare = $this->mintOutgoingShare(
+            federationService: $federationService,
+            caseId: $caseId,
+            shareUuid: $shareUuid,
+            remoteCloudId: $remoteCloudId,
+            register: (string) $register,
+            shareSchema: (string) $shareSchema
+        );
+        if ($federatedShare === null) {
+            return ['error' => 'Could not mint the federated share token'];
+        }
+
+        $resultData['federationShareId'] = $federatedShare->getId();
+        $resultData['status']            = 'active';
+        $activated  = $objectService->saveObject(object: $resultData, register: (int) $register, schema: (int) $shareSchema);
+        $resultData = $this->gateway->toArray(value: $activated);
+
+        $this->auditTrailService->emit(
+            [
+                'action'   => 'federated_case_share_created',
+                'actor'    => $createdBy,
+                'resource' => $caseId,
+                'tenantId' => $remoteCloudId,
+            ]
+        );
+
+        $this->logger->info(
+            'Procest: Federated case share created',
+            ['caseId' => $caseId, 'remoteCloudId' => $remoteCloudId, 'shareId' => $shareUuid]
+        );
+
+        return $resultData;
+    }//end createFederatedShare()
+
+    /**
+     * Revoke a federated case share. Sets the OR `FederatedShare.status` to
+     * 'revoked' — the single source of truth every downstream check
+     * (OR's own serving endpoint, procest's own token checks) consults, so
+     * revocation is immediate everywhere.
+     *
+     * @param string $shareId The UUID of the caseFederatedShare to revoke
+     * @param string $userId  The user ID performing the revocation
+     *
+     * @return array The updated share data, or an error array
+     *
+     * @spec openspec/specs/federated-case-collaboration/spec.md#federated-share-revocation-is-immediate-and-single-sourced
+     */
+    public function revokeFederatedShare(string $shareId, string $userId): array
+    {
+        $federationService = $this->gateway->federationShareService();
+        $objectService     = $this->gateway->objectService();
+        if ($federationService === null || $objectService === null) {
+            return ['error' => 'Federated case sharing requires the OpenRegister federation leaf'];
+        }
+
+        $register    = $this->settingsService->getConfigValue('register');
+        $shareSchema = $this->settingsService->getConfigValue('case_federated_share_schema');
+        if (empty($register) === true || empty($shareSchema) === true) {
+            return ['error' => 'Federated case sharing is not configured'];
+        }
+
+        $shareObj = $objectService->find($shareId, register: (int) $register, schema: (int) $shareSchema);
+        if ($shareObj === null) {
+            return ['error' => 'Federated share not found'];
+        }
+
+        // NOTE: normalised through a helper deliberately. Hoisting a default
+        // assignment inline lets PHPStan narrow $shareData to the empty-array
+        // shape of ObjectService::find()'s array branch, which then reports
+        // the 'caseId'/'remoteCloudId' reads below as non-existent offsets.
+        $shareData = $this->gateway->toArray(value: $shareObj);
+
+        $federationShareId = $shareData['federationShareId'] ?? null;
+        if ($federationShareId !== null) {
+            try {
+                $federationService->setStatus(id: (int) $federationShareId, status: 'revoked');
+            } catch (\Throwable $e) {
+                $this->logger->error(
+                    'CaseSharingService: OR federated-share revoke failed',
+                    ['shareId' => $shareId, 'exception' => $e->getMessage()]
+                );
+                return ['error' => 'Could not revoke the federated share token'];
+            }
+        }
+
+        $shareData['status']    = 'revoked';
+        $shareData['revokedBy'] = $userId;
+        $shareData['revokedAt'] = (new DateTime())->format('c');
+
+        $result = $objectService->saveObject(object: $shareData, register: (int) $register, schema: (int) $shareSchema);
+
+        $this->auditTrailService->emit(
+            [
+                'action'   => 'federated_case_share_revoked',
+                'actor'    => $userId,
+                'resource' => (string) ($shareData['caseId'] ?? ''),
+                'tenantId' => (string) ($shareData['remoteCloudId'] ?? ''),
+            ]
+        );
+
+        $this->logger->info('Procest: Federated case share revoked', ['shareId' => $shareId, 'revokedBy' => $userId]);
+
+        if (is_array($result) === true) {
+            return $result;
+        }
+
+        return $result->jsonSerialize();
+    }//end revokeFederatedShare()
+
+    /**
+     * Look up the caseId for a given federated share UUID (for the
+     * controller's per-case RBAC check before revocation).
+     *
+     * @param string $shareId The federated share UUID
+     *
+     * @return string|null The caseId, or null when unavailable/not found
+     *
+     * @spec openspec/specs/federated-case-collaboration/spec.md#federated-share-revocation-is-immediate-and-single-sourced
+     */
+    public function getCaseIdForFederatedShare(string $shareId): ?string
+    {
+        $objectService = $this->gateway->objectService();
+        if ($objectService === null) {
+            return null;
+        }
+
+        $register    = $this->settingsService->getConfigValue('register');
+        $shareSchema = $this->settingsService->getConfigValue('case_federated_share_schema');
+        if (empty($register) === true || empty($shareSchema) === true) {
+            return null;
+        }
+
+        try {
+            $shareObj = $objectService->find($shareId, register: (int) $register, schema: (int) $shareSchema);
+            if ($shareObj === null) {
+                return null;
+            }
+
+            $shareData = $shareObj;
+            if (is_array($shareObj) === false) {
+                $shareData = $shareObj->jsonSerialize();
+            }
+
+            if (isset($shareData['caseId']) === true) {
+                return (string) $shareData['caseId'];
+            }
+
+            return null;
+        } catch (\Throwable $e) {
+            $this->logger->debug(
+                'CaseSharingService: getCaseIdForFederatedShare failed',
+                ['shareId' => $shareId, 'exception' => $e->getMessage()]
+            );
+            return null;
+        }//end try
+    }//end getCaseIdForFederatedShare()
+
+    /**
+     * Whether every configuration value a federated share needs is present.
+     *
+     * @param string $register    The configured register id
+     * @param string $caseSchema  The configured case schema id
+     * @param string $shareSchema The configured federated-share schema id
+     *
+     * @return bool True when all three are configured
+     */
+    private function isFederatedShareConfigured(string $register, string $caseSchema, string $shareSchema): bool
+    {
+        return (empty($register) === false && empty($caseSchema) === false && empty($shareSchema) === false);
+    }//end isFederatedShareConfigured()
+
+    /**
+     * Load the case a federated share is being built from.
+     *
+     * Returns null both when the case cannot be loaded and when it does not
+     * exist — the caller reports 'Case not found' either way; the load failure
+     * is additionally logged here.
+     *
+     * @param object $objectService The OpenRegister ObjectService
+     * @param string $caseId        The UUID of the case to share
+     * @param int    $register      The configured register id
+     * @param int    $caseSchema    The configured case schema id
+     *
+     * @return array<string, mixed>|null The case data, or null when unavailable
+     */
+    private function loadCaseForFederatedShare(
+        object $objectService,
+        string $caseId,
+        int $register,
+        int $caseSchema,
+    ): ?array {
+        try {
+            $caseObj = $objectService->find($caseId, register: $register, schema: $caseSchema);
+        } catch (\Throwable $e) {
+            $this->logger->warning(
+                'CaseSharingService: createFederatedShare case load failed',
+                ['caseId' => $caseId, 'exception' => $e->getMessage()]
+            );
+            return null;
+        }
+
+        if ($caseObj === null) {
+            return null;
+        }
+
+        return $this->gateway->toArray(value: $caseObj);
+    }//end loadCaseForFederatedShare()
+
+    /**
+     * Project the requested fields that are actually present on the case.
+     *
+     * The caller has already rejected any field outside
+     * {@see CaseSharingService::FEDERATION_ALLOWED_FIELDS}, so this only drops
+     * fields the case does not carry.
+     *
+     * @param array<string, mixed> $caseData     The case data
+     * @param array<string>        $sharedFields Requested case field names
+     *
+     * @return array<string, mixed> The redacted snapshot
+     */
+    private function buildFieldSnapshot(array $caseData, array $sharedFields): array
+    {
+        $fieldSnapshot = [];
+        foreach ($sharedFields as $field) {
+            if (array_key_exists($field, $caseData) === true) {
+                $fieldSnapshot[$field] = $caseData[$field];
+            }
+        }
+
+        return $fieldSnapshot;
+    }//end buildFieldSnapshot()
+
+    /**
+     * Mint the outgoing OCM share for a persisted snapshot through the OR leaf.
+     *
+     * The grant is always 'read' — the case-summary share never gives the
+     * remote org write access to the case. Returns null (and logs) when the
+     * leaf refuses, so the caller can fail closed.
+     *
+     * @param object $federationService The OR FederationShareService
+     * @param string $caseId            The UUID of the case being shared (logging context)
+     * @param string $shareUuid         The UUID of the persisted snapshot object
+     * @param string $remoteCloudId     The federated target (slug@host)
+     * @param string $register          The configured register id
+     * @param string $shareSchema       The configured federated-share schema id
+     *
+     * @return object|null The minted OR federated share, or null on failure
+     */
+    private function mintOutgoingShare(
+        object $federationService,
+        string $caseId,
+        string $shareUuid,
+        string $remoteCloudId,
+        string $register,
+        string $shareSchema,
+    ): ?object {
+        try {
+            return $federationService->createOutgoingShare(
+                params: [
+                    'scope'       => 'object',
+                    'register'    => $register,
+                    'schema'      => $shareSchema,
+                    'objectUri'   => $shareUuid,
+                    'sharedWith'  => $remoteCloudId,
+                    // Always 'read' — the case-summary share never grants
+                    // the remote org write access to the case.
+                    'permissions' => 'read',
+                ]
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'CaseSharingService: OR createOutgoingShare failed',
+                ['caseId' => $caseId, 'exception' => $e->getMessage()]
+            );
+            return null;
+        }
+    }//end mintOutgoingShare()
+}//end class

--- a/lib/Service/Sharing/OpenRegisterSharingGateway.php
+++ b/lib/Service/Sharing/OpenRegisterSharingGateway.php
@@ -1,0 +1,181 @@
+<?php
+
+/**
+ * Procest OpenRegister gateway for the case-sharing surface.
+ *
+ * The single place the sharing surface reaches into OpenRegister. Every
+ * resolution is guarded twice — the app must be installed, and the resolved
+ * service must actually expose the methods the caller will invoke — because
+ * procest runs against OpenRegister builds that predate the shares and
+ * federation leaves. A missing leaf resolves to null; it never throws.
+ *
+ * Split out of CaseSharingService so the "is the leaf there?" question is
+ * answered in one place for all three sharing modes (token links, partner
+ * hand-off, OCM federation), and so each mode's service can state its own
+ * fail-open/fail-closed policy over a uniform null.
+ *
+ * `toArray()` lives here for the same reason: OpenRegister hands back either a
+ * plain array or an ObjectEntity depending on the call path, and every caller
+ * needs the same normalisation before reading fields.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Sharing
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/specs/federated-case-collaboration/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Sharing;
+
+use OCP\App\IAppManager;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Resolves the OpenRegister services the case-sharing surface depends on.
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/specs/federated-case-collaboration/spec.md
+ */
+class OpenRegisterSharingGateway
+{
+    /**
+     * Constructor.
+     *
+     * @param IAppManager        $appManager The app manager
+     * @param ContainerInterface $container  The DI container
+     * @param LoggerInterface    $logger     The logger
+     */
+    public function __construct(
+        private readonly IAppManager $appManager,
+        private readonly ContainerInterface $container,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Resolve the ObjectService from the DI container.
+     *
+     * @return object|null The ObjectService, or null when OpenRegister is unavailable
+     *
+     * @spec openspec/specs/federated-case-collaboration/spec.md
+     */
+    public function objectService(): ?object
+    {
+        if ($this->appManager->isInstalled('openregister') === false) {
+            return null;
+        }
+
+        try {
+            return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+        } catch (\Throwable $e) {
+            $this->logger->warning(
+                'CaseSharingService: ObjectService unavailable',
+                ['exception' => $e->getMessage()]
+            );
+            return null;
+        }
+    }//end objectService()
+
+    /**
+     * Resolve OpenRegister's CaseTokenService — the public "track your
+     * case" token-link surface of the shares integration leaf (ADR-022).
+     *
+     * The leaf owns token generation (256-bit non-guessable handle),
+     * expiry, revocation, and the RBAC-respecting public resolve path;
+     * procest mints no share tokens of its own.
+     *
+     * @return object|null The OR CaseTokenService, or null when OR is
+     *                     unavailable / pre-foundation build.
+     *
+     * @spec openspec/changes/migrate-public-share-to-shares-leaf/tasks.md#P1.2
+     */
+    public function caseTokenService(): ?object
+    {
+        if ($this->appManager->isInstalled('openregister') === false) {
+            return null;
+        }
+
+        try {
+            $service = $this->container->get('OCA\OpenRegister\Service\CaseTokenService');
+            if (method_exists($service, 'mint') === false) {
+                return null;
+            }
+
+            return $service;
+        } catch (\Throwable $e) {
+            $this->logger->warning(
+                'CaseSharingService: OR CaseTokenService unavailable (shares leaf not present)',
+                ['exception' => $e->getMessage()]
+            );
+            return null;
+        }
+    }//end caseTokenService()
+
+    /**
+     * Resolve OpenRegister's FederationShareService — the leaf that owns
+     * OCM token minting, transport and lifecycle status. Returns null (fail
+     * closed for federation callers) when OR or its federation classes are
+     * unavailable.
+     *
+     * @return object|null The OR FederationShareService, or null
+     *
+     * @spec openspec/specs/federated-case-collaboration/spec.md
+     */
+    public function federationShareService(): ?object
+    {
+        if ($this->appManager->isInstalled('openregister') === false) {
+            return null;
+        }
+
+        try {
+            $service = $this->container->get('OCA\OpenRegister\Service\FederationShareService');
+            if (method_exists($service, 'createOutgoingShare') === false || method_exists($service, 'setStatus') === false) {
+                return null;
+            }
+
+            return $service;
+        } catch (\Throwable $e) {
+            $this->logger->warning(
+                'CaseSharingService: OR FederationShareService unavailable (federation leaf not present)',
+                ['exception' => $e->getMessage()]
+            );
+            return null;
+        }
+    }//end federationShareService()
+
+    /**
+     * Normalize an OpenRegister return value (array or ObjectEntity) to an array.
+     *
+     * @param mixed $value The value returned by the ObjectService
+     *
+     * @return array<string, mixed> The value as a plain array
+     *
+     * @spec openspec/specs/federated-case-collaboration/spec.md
+     */
+    public function toArray(mixed $value): array
+    {
+        if (is_array($value) === true) {
+            return $value;
+        }
+
+        if (is_object($value) === true && method_exists($value, 'jsonSerialize') === true) {
+            return (array) $value->jsonSerialize();
+        }
+
+        return [];
+    }//end toArray()
+}//end class

--- a/lib/Service/Transfer/TransferRegisterGateway.php
+++ b/lib/Service/Transfer/TransferRegisterGateway.php
@@ -1,0 +1,153 @@
+<?php
+
+/**
+ * Procest OpenRegister gateway for the case-transfer surface.
+ *
+ * The single place the transfer surface reaches into OpenRegister. Each
+ * resolution checks that the app is installed and — for the federation
+ * collaborators — that the resolved service actually exposes the method the
+ * caller will invoke, because procest runs against OpenRegister builds that
+ * predate the federation leaf. Every failure resolves to null; nothing throws.
+ *
+ * Split out of CaseTransferService so the leaf-availability question is
+ * answered in one place, leaving that service to state the transfer state
+ * machine and its fail-closed policy over a uniform null.
+ *
+ * Note the deliberately loose `?object` return type: the OpenRegister classes
+ * are NOT in this app's autoload map (OR is a separate app, resolved only
+ * through the DI container at runtime), so a concrete return type here would
+ * be unenforceable and would TypeError the moment a test passed a double.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Transfer
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/specs/federated-case-collaboration/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Transfer;
+
+use OCP\App\IAppManager;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Resolves the OpenRegister services the case-transfer surface depends on.
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/specs/federated-case-collaboration/spec.md
+ */
+class TransferRegisterGateway
+{
+    /**
+     * Constructor.
+     *
+     * @param IAppManager        $appManager The app manager
+     * @param ContainerInterface $container  The DI container
+     * @param LoggerInterface    $logger     The logger
+     */
+    public function __construct(
+        private readonly IAppManager $appManager,
+        private readonly ContainerInterface $container,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Get the OpenRegister ObjectService.
+     *
+     * @return object|null The service or null
+     *
+     * @spec openspec/specs/federated-case-collaboration/spec.md
+     */
+    public function objectService(): ?object
+    {
+        if (in_array('openregister', $this->appManager->getInstalledApps()) === false) {
+            return null;
+        }
+
+        try {
+            return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+        } catch (\Exception $e) {
+            $this->logger->error(
+                'Procest: Could not get ObjectService',
+                ['exception' => $e->getMessage()]
+            );
+            return null;
+        }
+    }//end objectService()
+
+    /**
+     * Resolve OpenRegister's FederationShareService. Returns null (fail
+     * closed) when OR or its federation classes are unavailable.
+     *
+     * @return object|null The OR FederationShareService, or null
+     *
+     * @spec openspec/specs/federated-case-collaboration/spec.md
+     */
+    public function federationShareService(): ?object
+    {
+        if (in_array('openregister', $this->appManager->getInstalledApps()) === false) {
+            return null;
+        }
+
+        try {
+            $service = $this->container->get('OCA\OpenRegister\Service\FederationShareService');
+            if (method_exists($service, 'createOutgoingShare') === false) {
+                return null;
+            }
+
+            return $service;
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Procest: Could not get OR FederationShareService',
+                ['exception' => $e->getMessage()]
+            );
+            return null;
+        }
+    }//end federationShareService()
+
+    /**
+     * Resolve OpenRegister's FederatedShareMapper — used only to resolve a
+     * scoped bearer token to its share (`findByToken`), for the remote
+     * accept/reject endpoint. Returns null (fail closed) when unavailable.
+     *
+     * @return object|null The OR FederatedShareMapper, or null
+     *
+     * @spec openspec/specs/federated-case-collaboration/spec.md
+     */
+    public function federatedShareMapper(): ?object
+    {
+        if (in_array('openregister', $this->appManager->getInstalledApps()) === false) {
+            return null;
+        }
+
+        try {
+            $mapper = $this->container->get('OCA\OpenRegister\Db\FederatedShareMapper');
+            if (method_exists($mapper, 'findByToken') === false) {
+                return null;
+            }
+
+            return $mapper;
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Procest: Could not get OR FederatedShareMapper',
+                ['exception' => $e->getMessage()]
+            );
+            return null;
+        }
+    }//end federatedShareMapper()
+}//end class

--- a/lib/Service/Transfer/TransferShareBroker.php
+++ b/lib/Service/Transfer/TransferShareBroker.php
@@ -1,0 +1,174 @@
+<?php
+
+/**
+ * Procest transfer-scoped federated share broker.
+ *
+ * Owns both ends of the token that lets a remote org accept or reject ONE
+ * zaakoverdracht: minting it when a federated transfer is initiated, and
+ * resolving it back to that transfer when the remote org calls the
+ * `#[PublicPage]` accept/reject endpoint.
+ *
+ * The security property this class exists to hold is scope confinement. A
+ * transfer token is minted `scope: object`, `permissions: read-write`, pointed
+ * at ONLY the transfer object — it grants no access to the case itself. On the
+ * way back in, four independent conditions must all hold before a token is
+ * accepted: the share must be OUTGOING, not revoked/declined, read-write, and
+ * its objectUri tail must equal the exact transfer id being acted on. That
+ * last check is what stops a read-only case-summary token, or a token minted
+ * for a different transfer, from authenticating this one.
+ *
+ * Every failure — unavailable leaf, unknown token, wrong direction, wrong
+ * permissions, wrong object — returns null. There is no partial grant.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Transfer
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/specs/federated-case-collaboration/spec.md#a-read-only-case-share-token-cannot-accept-a-transfer
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Transfer;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * Mints and resolves the transfer-scoped OCM share token.
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/specs/federated-case-collaboration/spec.md#a-read-only-case-share-token-cannot-accept-a-transfer
+ */
+class TransferShareBroker
+{
+    /**
+     * Constructor.
+     *
+     * @param TransferRegisterGateway $gateway OpenRegister resolution for the transfer surface
+     * @param LoggerInterface         $logger  The logger
+     */
+    public function __construct(
+        private readonly TransferRegisterGateway $gateway,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Mint a transfer-scoped OR federated share (read-write, pointed only
+     * at the transfer object) so the remote org can later authenticate its
+     * accept/reject call. Distinct from the case-summary share's token —
+     * this one grants no access to the case itself, only to this one
+     * transfer's status field via procest's own state machine.
+     *
+     * @param string $transferUuid  The transfer object's uuid
+     * @param string $remoteCloudId The federated target (slug@host)
+     * @param string $register      The register id/slug
+     * @param string $schema        The case_transfer_schema id/slug
+     *
+     * @return object|null The minted OR FederatedShare, or null on failure
+     *
+     * @spec openspec/specs/federated-case-collaboration/spec.md
+     */
+    public function mintTransferShare(string $transferUuid, string $remoteCloudId, string $register, string $schema): ?object
+    {
+        $shareService = $this->gateway->federationShareService();
+        if ($shareService === null) {
+            return null;
+        }
+
+        try {
+            return $shareService->createOutgoingShare(
+                params: [
+                    'scope'       => 'object',
+                    'register'    => $register,
+                    'schema'      => $schema,
+                    'objectUri'   => $transferUuid,
+                    'sharedWith'  => $remoteCloudId,
+                    'permissions' => 'read-write',
+                ]
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'CaseTransferService: OR createOutgoingShare failed',
+                ['transferUuid' => $transferUuid, 'exception' => $e->getMessage()]
+            );
+            return null;
+        }
+    }//end mintTransferShare()
+
+    /**
+     * Resolve a scoped bearer token to the transfer it authorises — used
+     * exclusively by the `#[PublicPage]` remote accept/reject endpoint.
+     * Requires an OUTGOING, read-write, non-revoked/declined OR
+     * FederatedShare whose objectUri tail matches this exact transfer id,
+     * so a token minted for one transfer (or for a read-only case-summary
+     * share) can never authenticate a different transfer.
+     *
+     * @param string $shareToken The scoped bearer token
+     * @param string $transferId The candidate transfer UUID
+     *
+     * @return array{sharedWith: string, organisation: ?string}|null The resolved grant, or null when invalid
+     *
+     * @spec openspec/specs/federated-case-collaboration/spec.md#a-read-only-case-share-token-cannot-accept-a-transfer
+     */
+    public function resolveTransferShare(string $shareToken, string $transferId): ?array
+    {
+        $shareMapper = $this->gateway->federatedShareMapper();
+        if ($shareMapper === null || $shareToken === '' || $transferId === '') {
+            return null;
+        }
+
+        try {
+            $share = $shareMapper->findByToken($shareToken);
+        } catch (\Throwable $e) {
+            return null;
+        }
+
+        if ($share->getDirection() !== 'outgoing') {
+            return null;
+        }
+
+        if (in_array($share->getStatus(), ['revoked', 'declined'], true) === true) {
+            return null;
+        }
+
+        if ($share->getPermissions() !== 'read-write') {
+            return null;
+        }
+
+        $objectUri = (string) $share->getObjectUri();
+        if ($this->uuidFromUri(uri: $objectUri) !== $transferId) {
+            return null;
+        }
+
+        return [
+            'sharedWith'   => (string) $share->getSharedWith(),
+            'organisation' => $share->getOrganisation(),
+        ];
+    }//end resolveTransferShare()
+
+    /**
+     * Extract the trailing uuid from a canonical object uri (or return it
+     * as-is when it is already a bare uuid).
+     *
+     * @param string $uri The object uri or uuid
+     *
+     * @return string The uuid
+     */
+    private function uuidFromUri(string $uri): string
+    {
+        $parts = explode('/', rtrim($uri, '/'));
+        return (string) end($parts);
+    }//end uuidFromUri()
+}//end class

--- a/tests/Unit/Service/CaseEmailServiceTest.php
+++ b/tests/Unit/Service/CaseEmailServiceTest.php
@@ -26,6 +26,9 @@ namespace OCA\Procest\Tests\Unit\Service;
 
 use OCA\Procest\AppInfo\Application;
 use OCA\Procest\Service\CaseEmailService;
+use OCA\Procest\Service\Email\CaseContactDirectory;
+use OCA\Procest\Service\Email\CaseEmailAttachmentResolver;
+use OCA\Procest\Service\Email\CaseEmailRepository;
 use OCA\Procest\Service\SettingsService;
 use OCP\Files\IRootFolder;
 use OCP\IAppConfig;
@@ -107,13 +110,17 @@ class CaseEmailServiceTest extends TestCase
         $this->rootFolder      = $this->createMock(IRootFolder::class);
         $this->userSession     = $this->createMock(IUserSession::class);
 
+        // The repository and contact directory are real collaborators, not mocks:
+        // every assertion below is about behaviour they inherited verbatim from
+        // CaseEmailService, and the repository is still driven entirely by the
+        // mocked SettingsService (getObjectService() === null ⇒ no case data).
         $this->service = new CaseEmailService(
-            $this->settingsService,
             $this->mailer,
             $this->appConfig,
             $this->logger,
-            $this->rootFolder,
-            $this->userSession,
+            new CaseEmailRepository($this->settingsService),
+            new CaseContactDirectory(),
+            new CaseEmailAttachmentResolver($this->rootFolder, $this->userSession, $this->logger),
         );
 
     }//end setUp()

--- a/tests/Unit/Service/CaseRelationServiceTest.php
+++ b/tests/Unit/Service/CaseRelationServiceTest.php
@@ -27,6 +27,9 @@ declare(strict_types=1);
 namespace OCA\Procest\Tests\Unit\Service;
 
 use OCA\Procest\Service\CaseRelationService;
+use OCA\Procest\Service\Relation\CaseHierarchyOverlapGuard;
+use OCA\Procest\Service\Relation\CaseRelationCodec;
+use OCA\Procest\Service\Relation\CaseRelationStore;
 use OCA\Procest\Service\SettingsService;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -142,9 +145,14 @@ class CaseRelationServiceTest extends TestCase
         $objectService = $this->makeObjectService($store);
         $this->settingsService->method('getObjectService')->willReturn($objectService);
 
+        // The store, codec and hierarchy guard are real collaborators, not
+        // mocks: every assertion below is about behaviour they inherited
+        // verbatim from CaseRelationService, and the store is still driven
+        // entirely by the mocked SettingsService above.
         return new CaseRelationService(
-            settingsService: $this->settingsService,
-            logger: $this->logger,
+            store: new CaseRelationStore($this->settingsService, $this->logger),
+            codec: new CaseRelationCodec(),
+            hierarchyGuard: new CaseHierarchyOverlapGuard(),
         );
     }//end makeService()
 

--- a/tests/Unit/Service/CaseSharingServiceFederationTest.php
+++ b/tests/Unit/Service/CaseSharingServiceFederationTest.php
@@ -29,6 +29,10 @@ namespace OCA\Procest\Tests\Unit\Service;
 
 use OCA\Procest\Service\CaseSharingService;
 use OCA\Procest\Service\SettingsService;
+use OCA\Procest\Service\Sharing\CaseAccessPolicy;
+use OCA\Procest\Service\Sharing\CaseTokenShareService;
+use OCA\Procest\Service\Sharing\FederatedCaseShareService;
+use OCA\Procest\Service\Sharing\OpenRegisterSharingGateway;
 use OCA\Procest\Service\TenantAuditTrailService;
 use OCP\App\IAppManager;
 use PHPUnit\Framework\TestCase;
@@ -159,6 +163,42 @@ class CaseSharingServiceFederationTest extends TestCase
     private CaseSharingService $service;
 
     /**
+     * Assemble CaseSharingService with real sharing collaborators.
+     *
+     * The gateway, access policy, token-share service and federated-share
+     * service are real objects rather than mocks: every assertion in this
+     * class is about behaviour they inherited verbatim from CaseSharingService,
+     * and they stay driven entirely by the mocked app manager, container and
+     * settings passed in here.
+     *
+     * @param SettingsService         $settings   Settings service (mock).
+     * @param IAppManager             $appManager App manager (mock).
+     * @param ContainerInterface      $container  DI container (mock).
+     * @param LoggerInterface         $logger     Logger (mock).
+     * @param TenantAuditTrailService $audit      Audit trail (mock).
+     *
+     * @return CaseSharingService
+     */
+    private static function makeSharingService(
+        SettingsService $settings,
+        IAppManager $appManager,
+        ContainerInterface $container,
+        LoggerInterface $logger,
+        TenantAuditTrailService $audit,
+    ): CaseSharingService {
+        $gateway = new OpenRegisterSharingGateway($appManager, $container, $logger);
+
+        return new CaseSharingService(
+            settingsService: $settings,
+            gateway: $gateway,
+            accessPolicy: new CaseAccessPolicy($settings, $gateway, $logger),
+            tokenShares: new CaseTokenShareService($settings, $gateway, $logger),
+            federatedShares: new FederatedCaseShareService($settings, $gateway, $logger, $audit),
+            logger: $logger,
+        );
+    }//end makeSharingService()
+
+    /**
      * @return void
      */
     protected function setUp(): void
@@ -194,12 +234,12 @@ class CaseSharingServiceFederationTest extends TestCase
 
         $this->audit = $this->createMock(TenantAuditTrailService::class);
 
-        $this->service = new CaseSharingService(
-            settingsService: $settings,
-            appManager: $appManager,
-            container: $this->container,
-            logger: $this->createMock(LoggerInterface::class),
-            auditTrailService: $this->audit,
+        $this->service = self::makeSharingService(
+            $settings,
+            $appManager,
+            $this->container,
+            $this->createMock(LoggerInterface::class),
+            $this->audit,
         );
 
         $this->objects->objects['case-1'] = [
@@ -341,12 +381,12 @@ class CaseSharingServiceFederationTest extends TestCase
         $container = $this->createMock(ContainerInterface::class);
         $container->method('get')->willThrowException(new \RuntimeException('federation leaf not installed'));
 
-        $service = new CaseSharingService(
-            settingsService: $settings,
-            appManager: $appManager,
-            container: $container,
-            logger: $this->createMock(LoggerInterface::class),
-            auditTrailService: $this->createMock(TenantAuditTrailService::class),
+        $service = self::makeSharingService(
+            $settings,
+            $appManager,
+            $container,
+            $this->createMock(LoggerInterface::class),
+            $this->createMock(TenantAuditTrailService::class),
         );
 
         $result = $service->createFederatedShare('case-1', 'partner@remote.example', ['title'], [], 'bekijken', 'alice');
@@ -379,12 +419,12 @@ class CaseSharingServiceFederationTest extends TestCase
         $appManager = $this->createMock(IAppManager::class);
         $appManager->method('isInstalled')->willReturn(false);
 
-        $service = new CaseSharingService(
-            settingsService: $this->createMock(SettingsService::class),
-            appManager: $appManager,
-            container: $this->createMock(ContainerInterface::class),
-            logger: $this->createMock(LoggerInterface::class),
-            auditTrailService: $this->createMock(TenantAuditTrailService::class),
+        $service = self::makeSharingService(
+            $this->createMock(SettingsService::class),
+            $appManager,
+            $this->createMock(ContainerInterface::class),
+            $this->createMock(LoggerInterface::class),
+            $this->createMock(TenantAuditTrailService::class),
         );
 
         $result = $service->revokeFederatedShare('anything', 'bob');

--- a/tests/Unit/Service/CaseTransferServiceFederationTest.php
+++ b/tests/Unit/Service/CaseTransferServiceFederationTest.php
@@ -32,6 +32,8 @@ namespace OCA\Procest\Tests\Unit\Service;
 use OCA\Procest\Service\CaseTransferService;
 use OCA\Procest\Service\SettingsService;
 use OCA\Procest\Service\TenantAuditTrailService;
+use OCA\Procest\Service\Transfer\TransferRegisterGateway;
+use OCA\Procest\Service\Transfer\TransferShareBroker;
 use OCP\App\IAppManager;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -245,6 +247,40 @@ class CaseTransferServiceFederationTest extends TestCase
     private CaseTransferService $service;
 
     /**
+     * Assemble CaseTransferService with real transfer collaborators.
+     *
+     * The register gateway and share broker are real objects rather than
+     * mocks: every assertion in this class is about behaviour they inherited
+     * verbatim from CaseTransferService, and they stay driven entirely by the
+     * mocked app manager and container passed in here.
+     *
+     * @param SettingsService         $settings   Settings service (mock).
+     * @param IAppManager             $appManager App manager (mock).
+     * @param ContainerInterface      $container  DI container (mock).
+     * @param LoggerInterface         $logger     Logger (mock).
+     * @param TenantAuditTrailService $auditTrail Audit trail (mock).
+     *
+     * @return CaseTransferService
+     */
+    private static function makeTransferService(
+        SettingsService $settings,
+        IAppManager $appManager,
+        ContainerInterface $container,
+        LoggerInterface $logger,
+        TenantAuditTrailService $auditTrail,
+    ): CaseTransferService {
+        $gateway = new TransferRegisterGateway($appManager, $container, $logger);
+
+        return new CaseTransferService(
+            settingsService: $settings,
+            gateway: $gateway,
+            shareBroker: new TransferShareBroker($gateway, $logger),
+            logger: $logger,
+            auditTrail: $auditTrail,
+        );
+    }//end makeTransferService()
+
+    /**
      * @return void
      */
     protected function setUp(): void
@@ -279,12 +315,12 @@ class CaseTransferServiceFederationTest extends TestCase
             }
         );
 
-        $this->service = new CaseTransferService(
-            settingsService: $settings,
-            appManager: $appManager,
-            container: $container,
-            logger: $this->createMock(LoggerInterface::class),
-            auditTrail: $this->createMock(TenantAuditTrailService::class),
+        $this->service = self::makeTransferService(
+            $settings,
+            $appManager,
+            $container,
+            $this->createMock(LoggerInterface::class),
+            $this->createMock(TenantAuditTrailService::class),
         );
     }//end setUp()
 
@@ -509,12 +545,12 @@ class CaseTransferServiceFederationTest extends TestCase
             }
         );
 
-        $service = new CaseTransferService(
-            settingsService: $settings,
-            appManager: $appManager,
-            container: $container,
-            logger: $this->createMock(LoggerInterface::class),
-            auditTrail: $this->createMock(TenantAuditTrailService::class),
+        $service = self::makeTransferService(
+            $settings,
+            $appManager,
+            $container,
+            $this->createMock(LoggerInterface::class),
+            $this->createMock(TenantAuditTrailService::class),
         );
 
         $result = $service->initiateTransfer('case-1', 'org-a', 'org-b', 'reason', '2026-08-01', 'alice', 'partner@remote.example');

--- a/tests/Unit/Service/Cmmn/CaseModelEngineTest.php
+++ b/tests/Unit/Service/Cmmn/CaseModelEngineTest.php
@@ -29,8 +29,12 @@ namespace OCA\Procest\Tests\Unit\Service\Cmmn;
 
 use OCA\Procest\Service\Cmmn\CaseModelEngine;
 use OCA\Procest\Service\Cmmn\CaseModelLoader;
+use OCA\Procest\Service\Cmmn\CasePlanRepository;
 use OCA\Procest\Service\Cmmn\IllegalPlanItemTransitionException;
+use OCA\Procest\Service\Cmmn\PlanItemCascade;
+use OCA\Procest\Service\Cmmn\PlanItemStateMachine;
 use OCA\Procest\Service\Cmmn\PlanItemTransitions;
+use OCA\Procest\Service\Cmmn\PlanItemTree;
 use OCA\Procest\Service\Cmmn\SentryEvaluator;
 use OCA\Procest\Service\SettingsService;
 use OCA\Procest\Tests\Unit\Service\FakeTermijnStore;
@@ -100,12 +104,20 @@ final class CaseModelEngineTest extends TestCase
 
         $loader = new CaseModelLoader($settings, $this->createMock(LoggerInterface::class));
 
+        // The repository, cascade, state machine and tree are real
+        // collaborators, not mocks: every assertion in this class is about
+        // behaviour they inherited verbatim from CaseModelEngine, and they
+        // stay driven entirely by the mocked SettingsService above.
+        $transitions  = new PlanItemTransitions();
+        $tree         = new PlanItemTree($transitions);
+        $stateMachine = new PlanItemStateMachine($transitions);
+
         return new CaseModelEngine(
-            $settings,
-            $loader,
-            $this->createMock(LoggerInterface::class),
-            new PlanItemTransitions(),
-            new SentryEvaluator(),
+            new CasePlanRepository($settings, $loader, $this->createMock(LoggerInterface::class)),
+            new PlanItemCascade($transitions, new SentryEvaluator(), $tree, $stateMachine),
+            $stateMachine,
+            $tree,
+            $transitions,
         );
     }//end engine()
 

--- a/tests/Unit/Service/ConsultationServiceTest.php
+++ b/tests/Unit/Service/ConsultationServiceTest.php
@@ -26,6 +26,8 @@ declare(strict_types=1);
 namespace OCA\Procest\Tests\Unit\Service;
 
 use OCA\Procest\Service\AdviceDelegationService;
+use OCA\Procest\Service\Consultation\ConsultationDependencyGraph;
+use OCA\Procest\Service\Consultation\ConsultationRepository;
 use OCA\Procest\Service\ConsultationService;
 use OCA\Procest\Service\SettingsService;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -140,10 +142,17 @@ class ConsultationServiceTest extends TestCase
         $this->settings         = $this->createMock(SettingsService::class);
         $this->logger           = $this->createMock(LoggerInterface::class);
         $this->adviceDelegation = $this->createMock(AdviceDelegationService::class);
+        // The repository and dependency graph are real collaborators, not
+        // mocks: every assertion below is about behaviour they inherited
+        // verbatim from ConsultationService, and the repository is still
+        // driven entirely by the mocked SettingsService.
+        $repository             = new ConsultationRepository($this->settings, $this->logger);
         $this->service          = new ConsultationService(
             settingsService: $this->settings,
             logger: $this->logger,
             adviceDelegation: $this->adviceDelegation,
+            repository: $repository,
+            dependencyGraph: new ConsultationDependencyGraph($repository),
         );
 
     }//end setUp()


### PR DESCRIPTION
Clears all six remaining `ExcessiveClassComplexity` findings in the case/consultation service cluster **by decomposition**. No `@SuppressWarnings` added, no phpmd/psalm/phpstan baseline created or extended, no threshold in `phpmd.xml` touched.

## Before → after (phpmd class complexity, threshold 50)

| Class | Before | After |
|---|---:|---:|
| `lib/Service/CaseEmailService.php` | 80 | **31** |
| `lib/Service/CaseRelationService.php` | 86 | **39** |
| `lib/Service/CaseSharingService.php` | 109 | **25** |
| `lib/Service/CaseTransferService.php` | 63 | **40** |
| `lib/Service/ConsultationService.php` | 77 | **40** |
| `lib/Service/Cmmn/CaseModelEngine.php` | 117 | **30** |

## New classes and what each owns

Every new class is well under the threshold (largest is 41), carries the full docblock header convention, and has `@psalm-suppress UnusedClass` per the repo's established convention for injected collaborators.

**`OCA\Procest\Service\Email\`**
| Class | WMC | Owns |
|---|---:|---|
| `CaseEmailRepository` | 28 | Every OpenRegister read/write case email performs: templates, case→variable flattening, identifier→UUID lookup, sent/received message journalling. |
| `CaseContactDirectory` | 15 | The four shapes a contact address takes on a case (`email`, `initiator`, `betrokkenen`, `contacts`), reduced to one normalised allow-list. |
| `CaseEmailAttachmentResolver` | 9 | The H5 control: attachments resolved through the *calling user's own* folder, so path traversal outside it is impossible. |

**`OCA\Procest\Service\Relation\`**
| Class | WMC | Owns |
|---|---:|---|
| `CaseRelationCodec` | 23 | The on-disk shape of `case.relatedCases` and every pure operation over a relation list (decode, build entry, pair membership/removal). Pure — no OR, no session, no logging. |
| `CaseRelationStore` | 17 | The only place case objects are read/written for peer relations. A read resolving to `null` **is** the RBAC access guard callers fail closed on. |
| `CaseHierarchyOverlapGuard` | 9 | Read-only detection of an existing hoofdzaak/deelzaak link, so a peer relation is refused when the hierarchy already expresses it. |

**`OCA\Procest\Service\Sharing\`**
| Class | WMC | Owns |
|---|---:|---|
| `OpenRegisterSharingGateway` | 17 | Single point of OR resolution for all three sharing modes (installed-check + method-exists check + `toArray` normalisation). |
| `CaseAccessPolicy` | 20 | "May this user act on this case?" — including the deliberate fail-**open** for same-instance sharing, now stated in one auditable place. |
| `CaseTokenShareService` | 21 | Public "track your case" token links, minted/listed/revoked entirely through OR's shares leaf (ADR-022). |
| `FederatedCaseShareService` | 37 | Cross-org OCM shares: the redacted snapshot, the allow-list rejection, the always-`read` grant, and single-sourced revocation. Fails **closed** throughout. |

**`OCA\Procest\Service\Transfer\`**
| Class | WMC | Owns |
|---|---:|---|
| `TransferRegisterGateway` | 12 | OR resolution for the transfer surface (ObjectService, FederationShareService, FederatedShareMapper). |
| `TransferShareBroker` | 14 | Both ends of the transfer-scoped token: minting it, and the four-condition scope-confinement check that stops a read-only case token authenticating a transfer. |

**`OCA\Procest\Service\Consultation\`**
| Class | WMC | Owns |
|---|---:|---|
| `ConsultationRepository` | 33 | All OR I/O for consultations: list, fetch, secure-token resolve, overdue query, `ADV-{year}-{seq}` allocation, delete. |
| `ConsultationDependencyGraph` | 12 | `dependsOn` cycle detection (DFS with a carried visited set). |

**`OCA\Procest\Service\Cmmn\`**
| Class | WMC | Owns |
|---|---:|---|
| `CasePlanRepository` | 41 | Case/caseType loading (incl. the `handlingModel: cmmn` engine-selection refusal), plan-item loading + structural validation, state decode, and the single `saveObject()` per mutation (REQ-CMMN-006). |
| `PlanItemCascade` | 21 | The fixed-point loop and the single evaluation pass — order independence (per-pass snapshot) and termination (`MAX_CASCADE_DEPTH`). |
| `PlanItemStateMachine` | 20 | One validated transition plus its structural side effects (stage-complete disables unplanned discretionary children; stage-terminate force-terminates descendants) and the bounded event log. |
| `PlanItemTree` | 9 | Pure structural queries: is the parent stage active, are all mandatory children terminal. |

`CaseSharingService` is now the seam between the three sharing modes and keeps the in-app partner hand-off (which is zaak-domain logic, ADR-022) plus `FEDERATION_ALLOWED_FIELDS` — that constant stays put because `src/utils/federatedShareHelpers.js` mirrors it by name.

## Suppressions

**None added.** One **removed**: the class-level `@SuppressWarnings(PHPMD.ExcessiveClassComplexity)` on `CaseModelEngine`. It was ineffective anyway — it sat on the *file* docblock rather than the class docblock, which is why the class still reported 117 — and it is now unnecessary.

One pre-existing suppression is **carried verbatim**, not newly introduced: `@SuppressWarnings(PHPMD.CyclomaticComplexity)` on `cascadePass()`, which moved from `CaseModelEngine` to `PlanItemCascade` with its original stated reason (one evaluation pass over the state machine's own branches; splitting it would scatter one pass across several methods that all need the same `$context` snapshot).

## Behaviour

All method bodies moved verbatim. The single behavioural-surface change: `CaseEmailRepository::recordSentEmail()` takes the already-resolved envelope from-address as a parameter instead of re-reading `email_from_address` from app config. The value is identical — `sendEmail()` throws before reaching this point if that key is empty or still on the reserved `example.nl` domain.

Test changes are constructor wiring only. Each affected test now assembles the real collaborators (not mocks) from the same mocked `SettingsService` / `IAppManager` / `ContainerInterface` it already had, so every existing assertion exercises the same code paths unchanged.

## Measurements

Run in Docker (host PHP is 8.2; the repo requires ≥ 8.3 — `vendor/bin/*` on the host exits 255 and prints nothing, which is indistinguishable from "clean").

```
docker run --rm -v "$PWD":/app -w /app php:8.3-cli php vendor/bin/phpmd lib text phpmd.xml
# exit=2  findings=19  stderr_bytes=0     (baseline on development: 25 — exactly -6, no new finding anywhere in lib/)

docker run --rm -v "$PWD":/app -w /app php:8.3-cli php vendor/bin/phpcs --standard=phpcs.xml
# exit=0

docker run --rm -v "$PWD":/app -w /app php:8.3-cli php vendor/bin/phpstan analyse --memory-limit=1G
# exit=0   [OK] No errors

docker run --rm -v "$PWD":/app -w /app nextcloud:latest php vendor/bin/psalm --threads=1 --no-cache
# exit=0   No errors found!

docker run --rm -v "$PWD":/app -w /app nextcloud:latest php vendor/bin/phpunit --no-coverage
# exit=0   Tests: 1684, Assertions: 5614, Deprecations: 10, Skipped: 5
#          (identical to the development baseline: 1684 / 0 failures / 10 deprecations / 5 skipped)
```

Note on psalm: run under `php:8.3-cli` it exits 2 with 25 `UndefinedClass: ZipArchive` errors. That image lacks `ext-zip`; all 25 are in `CaseDefinitionImportService`, `CaseDefinitionExportService` and `ZipManifestBuilder`, none of which this branch touches. Under an image that has `ext-zip`, psalm reports **No errors found** and exits 0.

The `-6` was verified by diffing the full phpmd output against the baseline, not by comparing counts — the only difference is the six removed lines.
