### PR TITLE
fix(quality): decompose the parafering / tenant / role service cluster (10 phpmd findings)

### DIFF
--- a/lib/Service/Beschikking/LibresignResultAssembler.php
+++ b/lib/Service/Beschikking/LibresignResultAssembler.php
@@ -1,0 +1,260 @@
+<?php
+
+/**
+ * Procest LibreSign result assembler.
+ *
+ * Turns LibreSign's raw API responses into the two contracts procest actually
+ * publishes: the `sign()` result (which requires materialising the signed PDF
+ * and persisting it through the EXISTING ZgwDocumentService binary storage
+ * path) and the validatierapport. Split out of LibresignSigningAdapter so that
+ * adapter keeps the LibreSign *conversation* — availability, signer identity,
+ * request, poll loop — while reading LibreSign's status vocabulary and shaping
+ * what procest hands back, plus the file plumbing behind it, live here.
+ *
+ * Status interpretation lives with result assembly on purpose: the internal
+ * status value is itself part of the validatierapport, so a single owner keeps
+ * the vocabulary the adapter branches on and the vocabulary the report
+ * publishes from drifting apart.
+ *
+ * No new storage mechanism is introduced: the signed bytes are read from
+ * Nextcloud by file id and written back through ZgwDocumentService, exactly as
+ * before the split.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Beschikking
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/specs/libresign-besluit-signing/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Beschikking;
+
+use DateTimeImmutable;
+use OCA\Procest\Service\ZgwDocumentService;
+use OCP\Files\File;
+use OCP\Files\IRootFolder;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Builds procest's signed-result and validatierapport contracts.
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/specs/libresign-besluit-signing/spec.md
+ */
+class LibresignResultAssembler
+{
+    /**
+     * The validatierapport `soort` discriminator.
+     *
+     * @var string
+     */
+    private const REPORT_SOORT = 'libresign-handtekening-rapport';
+
+    /**
+     * The norm the validatierapport claims conformance to.
+     *
+     * @var string
+     */
+    private const REPORT_NORM = 'eIDAS / ETSI EN 319 102-1 (LibreSign)';
+
+    /**
+     * Internal status: the request is still awaiting signature.
+     *
+     * @var string
+     */
+    public const PENDING = LibresignStatusMapper::PENDING;
+
+    /**
+     * Internal status: the document is signed.
+     *
+     * @var string
+     */
+    public const SIGNED = LibresignStatusMapper::SIGNED;
+
+    /**
+     * Internal status: the signer declined.
+     *
+     * @var string
+     */
+    public const DECLINED = LibresignStatusMapper::DECLINED;
+
+    /**
+     * Internal status: LibreSign reported a value outside the known vocabulary.
+     *
+     * @var string
+     */
+    public const UNKNOWN = LibresignStatusMapper::UNKNOWN;
+
+    /**
+     * Constructor.
+     *
+     * @param IRootFolder           $rootFolder      Reads the LibreSign-produced signed file by id.
+     * @param ZgwDocumentService    $documentService The EXISTING binary document storage service.
+     * @param LibresignStatusMapper $statusMapper    Maps LibreSign status values onto the internal
+     *                                               vocabulary (stateless; defaults to a fresh instance).
+     */
+    public function __construct(
+        private readonly IRootFolder $rootFolder,
+        private readonly ZgwDocumentService $documentService,
+        private readonly LibresignStatusMapper $statusMapper=new LibresignStatusMapper(),
+    ) {
+    }//end __construct()
+
+    /**
+     * Read the internal status value out of a raw LibreSign status payload.
+     *
+     * @param array<string, mixed> $status The raw LibreSign status payload.
+     *
+     * @return string One of self::PENDING / SIGNED / DECLINED / UNKNOWN.
+     *
+     * @spec openspec/specs/libresign-besluit-signing/spec.md
+     */
+    public function mapStatus(array $status): string
+    {
+        $raw = (string) ($status['statusText'] ?? ($status['status'] ?? ''));
+
+        return $this->statusMapper->map($raw);
+    }//end mapStatus()
+
+    /**
+     * Download the LibreSign-produced signed PDF, persist it via the existing
+     * document storage service, and return the full sign() contract.
+     *
+     * @param string               $bestandId     The original PDF file id.
+     * @param string               $ondertekenaar The signer UID (owns the signed file in NC storage).
+     * @param string               $uuid          The LibreSign request uuid.
+     * @param array<string, mixed> $status        The last polled LibreSign status payload.
+     *
+     * @return array<string, string>
+     *
+     * @throws RuntimeException 'libresign_signed_file_missing' when the signed file cannot be read.
+     *
+     * @spec openspec/specs/libresign-besluit-signing/spec.md
+     */
+    public function assembleSignedResult(
+        string $bestandId,
+        string $ondertekenaar,
+        string $uuid,
+        array $status,
+    ): array {
+        $signedFileId = (int) ($status['file']['signedFileId'] ?? 0);
+        if ($signedFileId <= 0) {
+            throw new RuntimeException('libresign_signed_file_missing');
+        }
+
+        $content  = $this->readSignedFileContent(uid: $ondertekenaar, fileId: $signedFileId);
+        $fileName = 'beschikking-'.$bestandId.'-signed.pdf';
+
+        // Persist through the EXISTING zaakdossier binary storage path — no new storage
+        // mechanism. storeRaw() returns the byte count; getFileId() resolves the id it just
+        // wrote, both against the same service.
+        $this->documentService->storeRaw(uuid: $bestandId, fileName: $fileName, content: $content);
+        $newFileId = $this->documentService->getFileId(uuid: $bestandId, fileName: $fileName);
+
+        return [
+            'signedBestandId'        => (string) $newFileId,
+            'validatieRapportId'     => $uuid,
+            'certificaatSerienummer' => (string) ($status['certificateSerialNumber'] ?? ('libresign-'.$uuid)),
+            'tspProviderEidasId'     => 'LibreSign',
+            'ondertekeningTijdstip'  => (new DateTimeImmutable())->format('c'),
+        ];
+    }//end assembleSignedResult()
+
+    /**
+     * Build the validatierapport for a resolved LibreSign status.
+     *
+     * @param string               $validatieRapportId The LibreSign request uuid.
+     * @param array<string, mixed> $status             The raw LibreSign status payload.
+     *
+     * @return array<string, mixed>
+     *
+     * @spec openspec/specs/libresign-besluit-signing/spec.md
+     */
+    public function assembleValidationReport(
+        string $validatieRapportId,
+        array $status,
+    ): array {
+        $mappedStatus = $this->mapStatus(status: $status);
+
+        return [
+            'validatieRapportId' => $validatieRapportId,
+            'soort'              => self::REPORT_SOORT,
+            'norm'               => self::REPORT_NORM,
+            'geldig'             => ($mappedStatus === self::SIGNED),
+            'status'             => $mappedStatus,
+            'signers'            => (array) ($status['signers'] ?? []),
+            'gegenereerdOp'      => (new DateTimeImmutable())->format('c'),
+        ];
+    }//end assembleValidationReport()
+
+    /**
+     * Build the degraded, structured-but-invalid validatierapport used when the
+     * LibreSign transport fails.
+     *
+     * Deliberately answers rather than throws, matching MockSigningAdapter's
+     * always-answers shape: a caller must never read a transport failure as a
+     * valid signature.
+     *
+     * @param string $validatieRapportId The LibreSign request uuid.
+     *
+     * @return array<string, mixed>
+     *
+     * @spec openspec/specs/libresign-besluit-signing/spec.md
+     */
+    public function assembleFailedValidationReport(string $validatieRapportId): array
+    {
+        return [
+            'validatieRapportId' => $validatieRapportId,
+            'soort'              => self::REPORT_SOORT,
+            'norm'               => self::REPORT_NORM,
+            'geldig'             => false,
+            'foutmelding'        => 'libresign_api_error',
+            'gegenereerdOp'      => (new DateTimeImmutable())->format('c'),
+        ];
+    }//end assembleFailedValidationReport()
+
+    /**
+     * Read the LibreSign-produced signed file's bytes by Nextcloud file id.
+     *
+     * @param string $uid    The Nextcloud user whose folder holds the signed file.
+     * @param int    $fileId The Nextcloud file id.
+     *
+     * @return string
+     *
+     * @throws RuntimeException 'libresign_signed_file_missing'.
+     */
+    private function readSignedFileContent(string $uid, int $fileId): string
+    {
+        try {
+            $userFolder = $this->rootFolder->getUserFolder($uid);
+            $nodes      = $userFolder->getById($fileId);
+        } catch (Throwable $e) {
+            throw new RuntimeException('libresign_signed_file_missing', 0, $e);
+        }
+
+        if (count($nodes) === 0) {
+            throw new RuntimeException('libresign_signed_file_missing');
+        }
+
+        $node = $nodes[0];
+        if (($node instanceof File) === false) {
+            throw new RuntimeException('libresign_signed_file_missing');
+        }
+
+        return $node->getContent();
+    }//end readSignedFileContent()
+}//end class

--- a/lib/Service/Beschikking/LibresignSigningAdapter.php
+++ b/lib/Service/Beschikking/LibresignSigningAdapter.php
@@ -7,10 +7,11 @@
  * (LibreCode), the Nextcloud-native eIDAS-aligned digital signing app.
  * Resolves the signer identity from the mandaat-authorised actor UID
  * (design.md §4), creates a LibreSign signature request via
- * LibresignApiClient, performs a short bounded status poll mapping
- * LibreSign's status vocabulary via LibresignStatusMapper, and — once
- * signed — persists the signed PDF through the EXISTING
- * ZgwDocumentService binary storage path (no new storage mechanism).
+ * LibresignApiClient, and performs a short bounded status poll. Reading
+ * LibreSign's status vocabulary, persisting the signed PDF through the
+ * EXISTING ZgwDocumentService binary storage path (no new storage mechanism),
+ * and shaping the results procest publishes all belong to
+ * LibresignResultAssembler.
  *
  * See openspec/changes/libresign-besluit-signing/design.md for the full
  * rationale, including why sign() stays synchronous against an inherently
@@ -37,11 +38,9 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service\Beschikking;
 
-use DateTimeImmutable;
 use OCA\Procest\AppInfo\Application;
 use OCA\Procest\Service\ZgwDocumentService;
 use OCP\App\IAppManager;
-use OCP\Files\File;
 use OCP\Files\IRootFolder;
 use OCP\IAppConfig;
 use OCP\IUserManager;
@@ -51,6 +50,10 @@ use Throwable;
 
 /**
  * LibreSign-backed implementation of the beschikking signing adapter.
+ *
+ * Owns the LibreSign conversation only; the shape of what procest hands back —
+ * and the signed-file plumbing behind it — belongs to
+ * {@see LibresignResultAssembler}.
  *
  * @spec openspec/specs/libresign-besluit-signing/spec.md
  */
@@ -78,30 +81,44 @@ class LibresignSigningAdapter implements SigningAdapterInterface
     private $sleeper;
 
     /**
+     * Builds the signed-result and validatierapport contracts.
+     *
+     * @var LibresignResultAssembler
+     */
+    private LibresignResultAssembler $assembler;
+
+    /**
      * Constructor.
      *
-     * @param LibresignApiClient    $apiClient       The thin LibreSign HTTP client.
-     * @param IAppManager           $appManager      Feature-gate: is LibreSign enabled.
-     * @param IAppConfig            $appConfig       App config (poll attempts/interval, service auth).
-     * @param IUserManager          $userManager     Resolves the signer's NC account.
-     * @param IRootFolder           $rootFolder      Reads the LibreSign-produced signed file by id.
-     * @param ZgwDocumentService    $documentService The EXISTING binary document storage service.
-     * @param LoggerInterface       $logger          Structured logger.
-     * @param LibresignStatusMapper $statusMapper    Maps LibreSign status values onto the internal vocabulary
-     *                                               (stateless; defaults to a fresh instance).
-     * @param callable|null         $sleeper         Optional injectable `function(int $s): void` (tests pass a no-op).
+     * `$rootFolder` and `$documentService` are accepted (rather than resolved
+     * from an injected assembler) so the DI factory's named-argument call site
+     * stays unchanged; both are handed straight to the assembler that owns
+     * them.
+     *
+     * @param LibresignApiClient $apiClient       The thin LibreSign HTTP client.
+     * @param IAppManager        $appManager      Feature-gate: is LibreSign enabled.
+     * @param IAppConfig         $appConfig       App config (poll attempts/interval, service auth).
+     * @param IUserManager       $userManager     Resolves the signer's NC account.
+     * @param IRootFolder        $rootFolder      Reads the LibreSign-produced signed file by id.
+     * @param ZgwDocumentService $documentService The EXISTING binary document storage service.
+     * @param LoggerInterface    $logger          Structured logger.
+     * @param callable|null      $sleeper         Optional injectable `function(int $s): void` (tests pass a no-op).
      */
     public function __construct(
         private readonly LibresignApiClient $apiClient,
         private readonly IAppManager $appManager,
         private readonly IAppConfig $appConfig,
         private readonly IUserManager $userManager,
-        private readonly IRootFolder $rootFolder,
-        private readonly ZgwDocumentService $documentService,
+        IRootFolder $rootFolder,
+        ZgwDocumentService $documentService,
         private readonly LoggerInterface $logger,
-        private readonly LibresignStatusMapper $statusMapper=new LibresignStatusMapper(),
         ?callable $sleeper=null,
     ) {
+        $this->assembler = new LibresignResultAssembler(
+            rootFolder: $rootFolder,
+            documentService: $documentService,
+        );
+
         $this->sleeper = ($sleeper ?? static function (int $seconds): void {
             if ($seconds > 0) {
                 sleep($seconds);
@@ -156,18 +173,18 @@ class LibresignSigningAdapter implements SigningAdapterInterface
 
         for ($attempt = 0; $attempt < $attempts; $attempt++) {
             $status = $this->apiClient->getStatus($uuid);
-            $raw    = (string) ($status['statusText'] ?? ($status['status'] ?? ''));
-            $mapped = $this->statusMapper->map($raw);
+            $mapped = $this->assembler->mapStatus(status: $status);
 
-            if ($mapped === LibresignStatusMapper::UNKNOWN) {
+            if ($mapped === LibresignResultAssembler::UNKNOWN) {
+                $raw = (string) ($status['statusText'] ?? ($status['status'] ?? ''));
                 $this->logger->warning(
                     'LibresignSigningAdapter: unrecognised LibreSign status value',
                     ['app' => Application::APP_ID, 'uuid' => $uuid, 'raw' => $raw],
                 );
             }
 
-            if ($mapped === LibresignStatusMapper::SIGNED) {
-                return $this->storeSignedResult(
+            if ($mapped === LibresignResultAssembler::SIGNED) {
+                return $this->assembler->assembleSignedResult(
                     bestandId: $bestandId,
                     ondertekenaar: $ondertekenaar,
                     uuid: $uuid,
@@ -175,7 +192,7 @@ class LibresignSigningAdapter implements SigningAdapterInterface
                 );
             }
 
-            if ($mapped === LibresignStatusMapper::DECLINED) {
+            if ($mapped === LibresignResultAssembler::DECLINED) {
                 throw new RuntimeException('libresign_signing_declined');
             }
 
@@ -202,33 +219,17 @@ class LibresignSigningAdapter implements SigningAdapterInterface
     public function fetchValidationReport(string $validatieRapportId): array
     {
         try {
-            $status = $this->apiClient->getStatus($validatieRapportId);
-            $raw    = (string) ($status['statusText'] ?? ($status['status'] ?? ''));
-            $mapped = $this->statusMapper->map($raw);
-
-            return [
-                'validatieRapportId' => $validatieRapportId,
-                'soort'              => 'libresign-handtekening-rapport',
-                'norm'               => 'eIDAS / ETSI EN 319 102-1 (LibreSign)',
-                'geldig'             => ($mapped === LibresignStatusMapper::SIGNED),
-                'status'             => $mapped,
-                'signers'            => (array) ($status['signers'] ?? []),
-                'gegenereerdOp'      => (new DateTimeImmutable())->format('c'),
-            ];
+            return $this->assembler->assembleValidationReport(
+                validatieRapportId: $validatieRapportId,
+                status: $this->apiClient->getStatus($validatieRapportId),
+            );
         } catch (Throwable $e) {
             $this->logger->warning(
                 'LibresignSigningAdapter: fetchValidationReport degraded to an invalid report',
                 ['app' => Application::APP_ID, 'validatieRapportId' => $validatieRapportId, 'error' => $e->getMessage()],
             );
 
-            return [
-                'validatieRapportId' => $validatieRapportId,
-                'soort'              => 'libresign-handtekening-rapport',
-                'norm'               => 'eIDAS / ETSI EN 319 102-1 (LibreSign)',
-                'geldig'             => false,
-                'foutmelding'        => 'libresign_api_error',
-                'gegenereerdOp'      => (new DateTimeImmutable())->format('c'),
-            ];
+            return $this->assembler->assembleFailedValidationReport(validatieRapportId: $validatieRapportId);
         }//end try
     }//end fetchValidationReport()
 
@@ -274,73 +275,4 @@ class LibresignSigningAdapter implements SigningAdapterInterface
             'displayName' => $user->getDisplayName(),
         ];
     }//end resolveSigner()
-
-    /**
-     * Download the LibreSign-produced signed PDF and persist it via the existing document
-     * storage service, returning the full sign() contract.
-     *
-     * @param string               $bestandId     The original PDF file id.
-     * @param string               $ondertekenaar The signer UID (owns the signed file in NC storage).
-     * @param string               $uuid          The LibreSign request uuid.
-     * @param array<string, mixed> $status        The last polled LibreSign status payload.
-     *
-     * @return array<string, string>
-     *
-     * @throws RuntimeException 'libresign_signed_file_missing' when the signed file cannot be read.
-     */
-    private function storeSignedResult(string $bestandId, string $ondertekenaar, string $uuid, array $status): array
-    {
-        $signedFileId = (int) ($status['file']['signedFileId'] ?? 0);
-        if ($signedFileId <= 0) {
-            throw new RuntimeException('libresign_signed_file_missing');
-        }
-
-        $content  = $this->readSignedFileContent(uid: $ondertekenaar, fileId: $signedFileId);
-        $fileName = 'beschikking-'.$bestandId.'-signed.pdf';
-
-        // Persist through the EXISTING zaakdossier binary storage path — no new storage
-        // mechanism. storeRaw() returns the byte count; getFileId() resolves the id it just
-        // wrote, both against the same service.
-        $this->documentService->storeRaw(uuid: $bestandId, fileName: $fileName, content: $content);
-        $newFileId = $this->documentService->getFileId(uuid: $bestandId, fileName: $fileName);
-
-        return [
-            'signedBestandId'        => (string) $newFileId,
-            'validatieRapportId'     => $uuid,
-            'certificaatSerienummer' => (string) ($status['certificateSerialNumber'] ?? ('libresign-'.$uuid)),
-            'tspProviderEidasId'     => 'LibreSign',
-            'ondertekeningTijdstip'  => (new DateTimeImmutable())->format('c'),
-        ];
-    }//end storeSignedResult()
-
-    /**
-     * Read the LibreSign-produced signed file's bytes by Nextcloud file id.
-     *
-     * @param string $uid    The Nextcloud user whose folder holds the signed file.
-     * @param int    $fileId The Nextcloud file id.
-     *
-     * @return string
-     *
-     * @throws RuntimeException 'libresign_signed_file_missing'.
-     */
-    private function readSignedFileContent(string $uid, int $fileId): string
-    {
-        try {
-            $userFolder = $this->rootFolder->getUserFolder($uid);
-            $nodes      = $userFolder->getById($fileId);
-        } catch (Throwable $e) {
-            throw new RuntimeException('libresign_signed_file_missing', 0, $e);
-        }
-
-        if (count($nodes) === 0) {
-            throw new RuntimeException('libresign_signed_file_missing');
-        }
-
-        $node = $nodes[0];
-        if (($node instanceof File) === false) {
-            throw new RuntimeException('libresign_signed_file_missing');
-        }
-
-        return $node->getContent();
-    }//end readSignedFileContent()
 }//end class

--- a/lib/Service/Dso/DsoStatusChangeNotifier.php
+++ b/lib/Service/Dso/DsoStatusChangeNotifier.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * Procest DsoStatusChangeNotifier.
+ *
+ * Dispatches the VergunningStatusChangedEvent when a DSO vergunningzaak
+ * changes status. Split out of DsoCaseService alongside the existing
+ * DsoDoorsturenNotifier: building and dispatching a domain event is a contract
+ * downstream listeners bind to, so it belongs in a collaborator of its own
+ * rather than inline in the transition method that happens to trigger it
+ * (ADR-022).
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Dso
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/changes/dso-omgevingsloket/tasks.md#T03
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Dso;
+
+use OCA\Procest\Event\VergunningStatusChangedEvent;
+use OCP\EventDispatcher\IEventDispatcher;
+
+/**
+ * Emits the VergunningStatusChanged event for downstream listeners.
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/changes/dso-omgevingsloket/tasks.md#T03
+ */
+class DsoStatusChangeNotifier
+{
+    /**
+     * Constructor.
+     *
+     * @param IEventDispatcher $eventDispatcher The event dispatcher.
+     */
+    public function __construct(
+        private readonly IEventDispatcher $eventDispatcher,
+    ) {
+    }//end __construct()
+
+    /**
+     * Dispatch the typed status-changed event for a transitioned zaak.
+     *
+     * @param string      $aanvraagRef  The vergunningaanvraag UUID reference.
+     * @param string      $oldStatus    The previous status value.
+     * @param string      $newStatus    The new status value.
+     * @param string|null $besluitdatum Optional decision date (ISO 8601).
+     * @param string|null $toelichting  Optional explanation text.
+     * @param string      $userId       The Nextcloud UID that triggered the transition.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T03
+     */
+    public function dispatchStatusChanged(
+        string $aanvraagRef,
+        string $oldStatus,
+        string $newStatus,
+        ?string $besluitdatum,
+        ?string $toelichting,
+        string $userId,
+    ): void {
+        $event = new VergunningStatusChangedEvent(
+            aanvraagRef: $aanvraagRef,
+            oldStatus: $oldStatus,
+            newStatus: $newStatus,
+            besluitdatum: $besluitdatum,
+            toelichting: $toelichting,
+            userId: $userId,
+        );
+
+        $this->eventDispatcher->dispatchTyped(event: $event);
+    }//end dispatchStatusChanged()
+}//end class

--- a/lib/Service/DsoCaseService.php
+++ b/lib/Service/DsoCaseService.php
@@ -27,9 +27,8 @@ namespace OCA\Procest\Service;
 use DateTimeImmutable;
 use Exception;
 use OCA\Procest\AppInfo\Application;
-use OCA\Procest\Event\VergunningStatusChangedEvent;
+use OCA\Procest\Service\Dso\DsoStatusChangeNotifier;
 use OCA\Procest\Service\Support\SearchesObjects;
-use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IAppConfig;
 use OCP\IUser;
 use Psr\Container\ContainerInterface;
@@ -82,15 +81,15 @@ class DsoCaseService
     /**
      * Constructor.
      *
-     * @param IAppConfig         $appConfig       The application config service
-     * @param ContainerInterface $container       The DI container (ObjectService resolved lazily)
-     * @param IEventDispatcher   $eventDispatcher The event dispatcher
-     * @param LoggerInterface    $logger          The logger
+     * @param IAppConfig              $appConfig The application config service
+     * @param ContainerInterface      $container The DI container (ObjectService resolved lazily)
+     * @param DsoStatusChangeNotifier $notifier  Emits the VergunningStatusChanged domain event
+     * @param LoggerInterface         $logger    The logger
      */
     public function __construct(
         private readonly IAppConfig $appConfig,
         private readonly ContainerInterface $container,
-        private readonly IEventDispatcher $eventDispatcher,
+        private readonly DsoStatusChangeNotifier $notifier,
         private readonly LoggerInterface $logger,
     ) {
     }//end __construct()
@@ -283,7 +282,7 @@ class DsoCaseService
             );
         }
 
-        $event = new VergunningStatusChangedEvent(
+        $this->notifier->dispatchStatusChanged(
             aanvraagRef: $aanvraagRef,
             oldStatus: $oldStatus,
             newStatus: $newStatus,
@@ -291,7 +290,6 @@ class DsoCaseService
             toelichting: $toelichting,
             userId: $userId,
         );
-        $this->eventDispatcher->dispatchTyped(event: $event);
 
         return $updatedZaak;
     }//end transitionStatus()

--- a/lib/Service/Email/EmailTemplateRepository.php
+++ b/lib/Service/Email/EmailTemplateRepository.php
@@ -1,0 +1,229 @@
+<?php
+
+/**
+ * Procest email template repository.
+ *
+ * Owns every OpenRegister read/write the emailTemplate registry needs: the
+ * active-template query for a caseType, single-template load, template
+ * persistence, and the case load that prefill renders against. Split out of
+ * EmailTemplateService so that service keeps only the template *domain* rules
+ * — version bumping, seeding, placeholder resolution — while the knowledge of
+ * which register/schema pair holds which record, and how OpenRegister's
+ * entity-or-array return shape collapses into a plain array, lives here.
+ *
+ * A missing or unconfigured register/schema is not an error on the read path:
+ * it degrades to null / an empty list exactly as the pre-split service did.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Email
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/changes/case-email-integration/tasks.md#T04
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Email;
+
+use OCA\Procest\Service\SettingsService;
+use OCA\Procest\Service\Support\SearchesObjects;
+use RuntimeException;
+
+/**
+ * OpenRegister persistence for emailTemplate records and their cases.
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/changes/case-email-integration/tasks.md#T04
+ */
+class EmailTemplateRepository
+{
+
+    use SearchesObjects;
+
+    /**
+     * Constructor.
+     *
+     * @param SettingsService $settingsService Shared OR/settings resolver.
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+    ) {
+    }//end __construct()
+
+    /**
+     * List the active templates for a caseType.
+     *
+     * @param string $caseTypeId CaseType id/slug.
+     *
+     * @return array<int, array<string, mixed>>
+     *
+     * @spec openspec/changes/case-email-integration/tasks.md#T04
+     */
+    public function findActiveByCaseType(string $caseTypeId): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return [];
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('email_template_schema');
+        if (empty($register) === true || empty($schema) === true) {
+            return [];
+        }
+
+        $rows = $this->searchObjectsAsArrays(
+            objectService: $objectService,
+            register: $register,
+            schema: $schema,
+            filters: [
+                'caseType' => $caseTypeId,
+                '_limit'   => 100,
+            ],
+        );
+
+        return array_values(
+            array_filter(
+                $rows,
+                static fn (array $row): bool => ($row['isActive'] ?? true) === true
+            )
+        );
+    }//end findActiveByCaseType()
+
+    /**
+     * Persist (insert OR update) a template payload via OpenRegister.
+     *
+     * @param array<string, mixed> $payload Template fields.
+     *
+     * @return array<string, mixed> The saved object, or the payload when OR
+     *                              returns an unusable shape.
+     *
+     * @throws RuntimeException When OpenRegister is unavailable or the
+     *                          emailTemplate schema is not configured.
+     *
+     * @spec openspec/changes/case-email-integration/tasks.md#T04
+     */
+    public function saveTemplate(array $payload): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            throw new RuntimeException('ObjectService unavailable');
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('email_template_schema');
+        if (empty($register) === true || empty($schema) === true) {
+            throw new RuntimeException('emailTemplate schema is not configured');
+        }
+
+        $saved = $objectService->saveObject(
+            object: $payload,
+            register: $register,
+            schema: $schema,
+        );
+
+        $saved = $this->toArrayOrNull(value: $saved);
+        if ($saved === null) {
+            return $payload;
+        }
+
+        return $saved;
+    }//end saveTemplate()
+
+    /**
+     * Load a template by id/slug.
+     *
+     * @param string $templateId Template id.
+     *
+     * @return array<string, mixed>|null Null when unconfigured, unavailable or unknown.
+     *
+     * @spec openspec/changes/case-email-integration/tasks.md#T04
+     */
+    public function findTemplate(string $templateId): ?array
+    {
+        return $this->findIn(configKey: 'email_template_schema', id: $templateId);
+    }//end findTemplate()
+
+    /**
+     * Load a case, with the derived `_isFinal` flag merged in.
+     *
+     * @param string $caseId Case UUID.
+     *
+     * @return array<string, mixed>|null Null when unconfigured, unavailable or unknown.
+     *
+     * @spec openspec/changes/case-email-integration/tasks.md#T04
+     */
+    public function findCase(string $caseId): ?array
+    {
+        $case = $this->findIn(configKey: 'case_schema', id: $caseId);
+        if ($case === null) {
+            return null;
+        }
+
+        $case['_isFinal'] = (empty($case['endDate']) === false);
+
+        return $case;
+    }//end findCase()
+
+    /**
+     * Fetch one object from the register schema behind the given config key.
+     *
+     * @param string $configKey The settings key naming the schema.
+     * @param string $id        The object id/slug.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function findIn(string $configKey, string $id): ?array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return null;
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue($configKey);
+        if (empty($register) === true || empty($schema) === true) {
+            return null;
+        }
+
+        try {
+            $obj = $objectService->find($id, register: $register, schema: $schema);
+        } catch (\Throwable) {
+            return null;
+        }
+
+        return $this->toArrayOrNull(value: $obj);
+    }//end findIn()
+
+    /**
+     * Collapse OpenRegister's entity-or-array return shape into a plain array.
+     *
+     * @param mixed $value The value returned by the ObjectService.
+     *
+     * @return array<string, mixed>|null Null when the value is neither an array
+     *                                   nor a JSON-serialisable entity.
+     */
+    private function toArrayOrNull(mixed $value): ?array
+    {
+        if (is_object($value) === true && method_exists($value, 'jsonSerialize') === true) {
+            $value = $value->jsonSerialize();
+        }
+
+        if (is_array($value) === true) {
+            return $value;
+        }
+
+        return null;
+    }//end toArrayOrNull()
+}//end class

--- a/lib/Service/EmailTemplateService.php
+++ b/lib/Service/EmailTemplateService.php
@@ -29,17 +29,19 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service;
 
-use OCA\Procest\Service\Support\SearchesObjects;
+use OCA\Procest\Service\Email\EmailTemplateRepository;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 
 /**
  * CRUD + prefill for emailTemplate records.
+ *
+ * OpenRegister access is delegated to EmailTemplateRepository; what stays here
+ * is the template domain itself — versioning, seeding and placeholder
+ * resolution.
  */
 class EmailTemplateService
 {
-
-    use SearchesObjects;
 
     /**
      * Default templates seeded when a caseType has no email templates.
@@ -73,11 +75,11 @@ class EmailTemplateService
     /**
      * Constructor.
      *
-     * @param SettingsService $settingsService Shared OR/settings resolver.
-     * @param LoggerInterface $logger          Logger.
+     * @param EmailTemplateRepository $repository OpenRegister persistence for templates and cases.
+     * @param LoggerInterface         $logger     Logger.
      */
     public function __construct(
-        private readonly SettingsService $settingsService,
+        private readonly EmailTemplateRepository $repository,
         private readonly LoggerInterface $logger,
     ) {
     }//end __construct()
@@ -103,7 +105,7 @@ class EmailTemplateService
             'isActive' => true,
         ];
 
-        return $this->saveTemplate(payload: $payload);
+        return $this->repository->saveTemplate(payload: $payload);
     }//end createTemplate()
 
     /**
@@ -121,7 +123,7 @@ class EmailTemplateService
      */
     public function updateTemplate(string $templateId, array $data): array
     {
-        $existing = $this->loadTemplate(templateId: $templateId);
+        $existing = $this->repository->findTemplate(templateId: $templateId);
         if ($existing === null) {
             throw new RuntimeException('Template not found');
         }
@@ -132,7 +134,7 @@ class EmailTemplateService
         $previous = $existing;
         $previous['isActive'] = false;
         try {
-            $this->saveTemplate(payload: $previous);
+            $this->repository->saveTemplate(payload: $previous);
         } catch (\Throwable $e) {
             $this->logger->warning(
                 'Could not deactivate previous email template version',
@@ -150,7 +152,7 @@ class EmailTemplateService
             'previousVersion' => $existing['id'] ?? null,
         ];
 
-        return $this->saveTemplate(payload: $payload);
+        return $this->repository->saveTemplate(payload: $payload);
     }//end updateTemplate()
 
     /**
@@ -164,33 +166,7 @@ class EmailTemplateService
      */
     public function listTemplates(string $caseTypeId): array
     {
-        $objectService = $this->settingsService->getObjectService();
-        if ($objectService === null) {
-            return [];
-        }
-
-        $register = $this->settingsService->getConfigValue('register');
-        $schema   = $this->settingsService->getConfigValue('email_template_schema');
-        if (empty($register) === true || empty($schema) === true) {
-            return [];
-        }
-
-        $rows = $this->searchObjectsAsArrays(
-            objectService: $objectService,
-            register: $register,
-            schema: $schema,
-            filters: [
-                'caseType' => $caseTypeId,
-                '_limit'   => 100,
-            ],
-        );
-
-        return array_values(
-                array_filter(
-            $rows,
-            static fn (array $row): bool => ($row['isActive'] ?? true) === true
-        )
-                );
+        return $this->repository->findActiveByCaseType(caseTypeId: $caseTypeId);
     }//end listTemplates()
 
     /**
@@ -250,12 +226,12 @@ class EmailTemplateService
      */
     public function prefillDraft(string $caseId, string $templateId): array
     {
-        $template = $this->loadTemplate(templateId: $templateId);
+        $template = $this->repository->findTemplate(templateId: $templateId);
         if ($template === null) {
             throw new RuntimeException('Template not found');
         }
 
-        $case = $this->loadCase(caseId: $caseId);
+        $case = $this->repository->findCase(caseId: $caseId);
         if ($case === null) {
             throw new RuntimeException('Case not found');
         }
@@ -379,126 +355,6 @@ class EmailTemplateService
 
         return $unresolved;
     }//end collectUnresolved()
-
-    /**
-     * Persist (insert OR update) a template payload via OR.
-     *
-     * @param array<string, mixed> $payload Template fields.
-     *
-     * @return array<string, mixed>
-     */
-    private function saveTemplate(array $payload): array
-    {
-        $objectService = $this->settingsService->getObjectService();
-        if ($objectService === null) {
-            throw new RuntimeException('ObjectService unavailable');
-        }
-
-        $register = $this->settingsService->getConfigValue('register');
-        $schema   = $this->settingsService->getConfigValue('email_template_schema');
-        if (empty($register) === true || empty($schema) === true) {
-            throw new RuntimeException('emailTemplate schema is not configured');
-        }
-
-        $saved = $objectService->saveObject(
-            object: $payload,
-            register: $register,
-            schema: $schema,
-        );
-
-        if (is_object($saved) === true && method_exists($saved, 'jsonSerialize') === true) {
-            $saved = $saved->jsonSerialize();
-        }
-
-        if (is_array($saved) === true) {
-            return $saved;
-        }
-
-        return $payload;
-    }//end saveTemplate()
-
-    /**
-     * Load a template by id/slug.
-     *
-     * @param string $templateId Template id.
-     *
-     * @return array<string, mixed>|null
-     */
-    private function loadTemplate(string $templateId): ?array
-    {
-        $objectService = $this->settingsService->getObjectService();
-        if ($objectService === null) {
-            return null;
-        }
-
-        $register = $this->settingsService->getConfigValue('register');
-        $schema   = $this->settingsService->getConfigValue('email_template_schema');
-        if (empty($register) === true || empty($schema) === true) {
-            return null;
-        }
-
-        try {
-            $obj = $objectService->find($templateId, register: $register, schema: $schema);
-        } catch (\Throwable) {
-            return null;
-        }
-
-        if ($obj === null) {
-            return null;
-        }
-
-        if (is_object($obj) === true && method_exists($obj, 'jsonSerialize') === true) {
-            $obj = $obj->jsonSerialize();
-        }
-
-        if (is_array($obj) === true) {
-            return $obj;
-        }
-
-        return null;
-    }//end loadTemplate()
-
-    /**
-     * Load a case (with the derived `_isFinal` flag merged in).
-     *
-     * @param string $caseId Case UUID.
-     *
-     * @return array<string, mixed>|null
-     */
-    private function loadCase(string $caseId): ?array
-    {
-        $objectService = $this->settingsService->getObjectService();
-        if ($objectService === null) {
-            return null;
-        }
-
-        $register = $this->settingsService->getConfigValue('register');
-        $schema   = $this->settingsService->getConfigValue('case_schema');
-        if (empty($register) === true || empty($schema) === true) {
-            return null;
-        }
-
-        try {
-            $obj = $objectService->find($caseId, register: $register, schema: $schema);
-        } catch (\Throwable) {
-            return null;
-        }
-
-        if ($obj === null) {
-            return null;
-        }
-
-        if (is_object($obj) === true && method_exists($obj, 'jsonSerialize') === true) {
-            $obj = $obj->jsonSerialize();
-        }
-
-        if (is_array($obj) === false) {
-            return null;
-        }
-
-        $obj['_isFinal'] = (empty($obj['endDate']) === false);
-        return $obj;
-    }//end loadCase()
 
     /**
      * Build the variable map for a single case.

--- a/lib/Service/Mandaat/MandaatCsvParser.php
+++ b/lib/Service/Mandaat/MandaatCsvParser.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * Procest mandaat CSV parser.
+ *
+ * Turns a Decidesk CSV export into data rows and parses the individual cell
+ * dialects it uses: `1/true/ja/yes/y` for a boolean and a semicolon-separated
+ * list for a multi-value column. Split out of MandaatImportService so that
+ * service keeps the import *decision* — what is new, changed or removed
+ * against the prior besluit version — while the wire format it happens to
+ * arrive in is parsed here.
+ *
+ * The required-column check lives here too, and it fails loudly: an export
+ * missing a mandatory column must abort the import rather than silently
+ * produce mandaten with empty fields.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Mandaat
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/changes/mandaat-matrix-04-decidesk-import/tasks.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Mandaat;
+
+use RuntimeException;
+
+/**
+ * Parses the Decidesk mandaat CSV export and its cell dialects.
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/changes/mandaat-matrix-04-decidesk-import/tasks.md
+ */
+class MandaatCsvParser
+{
+    /**
+     * Columns an import CSV must carry.
+     *
+     * @var string[]
+     */
+    public const REQUIRED_COLUMNS = ['mandaatNummer', 'omschrijving', 'rolNaam', 'plafondCents'];
+
+    /**
+     * Values a boolean CSV cell may carry for "true".
+     *
+     * @var string[]
+     */
+    private const TRUTHY_VALUES = ['1', 'true', 'ja', 'yes', 'y'];
+
+    /**
+     * Parse RFC-4180-ish CSV with first row = header.
+     *
+     * @param string $csv CSV.
+     *
+     * @return array<int, array<string, string>> The data rows keyed by header name.
+     *
+     * @throws RuntimeException When a required column is missing from the header.
+     *
+     * @spec openspec/changes/mandaat-matrix-04-decidesk-import/tasks.md
+     */
+    public function parse(string $csv): array
+    {
+        $lines = preg_split('/\r\n|\n|\r/', trim($csv));
+        if ($lines === false || count($lines) < 2) {
+            return [];
+        }
+
+        $header  = str_getcsv($lines[0]);
+        $missing = array_diff(self::REQUIRED_COLUMNS, $header);
+        if (count($missing) > 0) {
+            throw new RuntimeException('Missing required CSV columns: '.implode(', ', $missing));
+        }
+
+        $rows      = [];
+        $lineCount = count($lines);
+        for ($i = 1; $i < $lineCount; $i++) {
+            $line = trim((string) $lines[$i]);
+            if ($line === '') {
+                continue;
+            }
+
+            $values = str_getcsv($line);
+            $rows[] = array_combine($header, array_pad($values, count($header), ''));
+        }
+
+        return $rows;
+    }//end parse()
+
+    /**
+     * Parse a boolean from CSV text.
+     *
+     * @param string $value Boolean text.
+     *
+     * @return bool True for `1`, `true`, `ja`, `yes` or `y` (case-insensitive).
+     *
+     * @spec openspec/changes/mandaat-matrix-04-decidesk-import/tasks.md
+     */
+    public function parseBool(string $value): bool
+    {
+        return in_array(strtolower(trim($value)), self::TRUTHY_VALUES, true);
+    }//end parseBool()
+
+    /**
+     * Parse a semicolon-separated list from CSV text.
+     *
+     * @param string $value Semicolon-separated list.
+     *
+     * @return array<int, string> The trimmed, non-empty entries.
+     *
+     * @spec openspec/changes/mandaat-matrix-04-decidesk-import/tasks.md
+     */
+    public function parseList(string $value): array
+    {
+        $value = trim($value);
+        if ($value === '') {
+            return [];
+        }
+
+        return array_values(array_filter(array_map('trim', explode(';', $value))));
+    }//end parseList()
+}//end class

--- a/lib/Service/Mandaat/MandaatRepository.php
+++ b/lib/Service/Mandaat/MandaatRepository.php
@@ -1,0 +1,282 @@
+<?php
+
+/**
+ * Procest mandaat repository.
+ *
+ * The single OpenRegister access path for the mandaat matrix: the
+ * rolNaam→rolId index, the prior vastgesteld besluit for a besluit number, the
+ * mandaten belonging to a besluit, the schema/register context an approval
+ * needs, the bulk activation of a besluit's mandaten, and the generic
+ * configured-schema save. Split out of MandaatImportService so that service
+ * keeps the import *decision* — new vs changed vs removed, and the approval
+ * state machine — while every register/schema lookup lives here.
+ *
+ * The read paths degrade rather than throw when OpenRegister or a schema is
+ * unconfigured: the caller's own guards decide whether an empty result is
+ * fatal, exactly as before the split.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Mandaat
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/changes/mandaat-matrix-04-decidesk-import/tasks.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Mandaat;
+
+use OCA\Procest\Service\SettingsService;
+use OCA\Procest\Service\Support\SearchesObjects;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * OpenRegister access for MandateringsBesluiten, Mandaten and OrganisatieRollen.
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/changes/mandaat-matrix-04-decidesk-import/tasks.md
+ */
+class MandaatRepository
+{
+    use SearchesObjects;
+
+    /**
+     * Constructor.
+     *
+     * @param SettingsService $settingsService Settings (config + ObjectService).
+     * @param LoggerInterface $logger          Logger.
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Resolve the object service, register and schemas needed to approve an import.
+     *
+     * @return array<string, mixed> {objectService, register, bSchema, mSchema}
+     *
+     * @throws RuntimeException When the mandaat services are not configured.
+     *
+     * @spec openspec/changes/mandaat-matrix-04-decidesk-import/tasks.md
+     */
+    public function resolveApprovalContext(): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        $register      = (string) $this->settingsService->getConfigValue('register');
+        $bSchema       = (string) $this->settingsService->getConfigValue('mandaterings_besluit_schema');
+        $mSchema       = (string) $this->settingsService->getConfigValue('mandaat_schema');
+        if ($objectService === null || $register === '' || $bSchema === '' || $mSchema === '') {
+            throw new RuntimeException('Mandaat services not configured');
+        }
+
+        return [
+            'objectService' => $objectService,
+            'register'      => $register,
+            'bSchema'       => $bSchema,
+            'mSchema'       => $mSchema,
+        ];
+    }//end resolveApprovalContext()
+
+    /**
+     * Flip every mandaat of a besluit to active, defaulting a missing validFrom.
+     *
+     * @param object $objectService The OpenRegister object service.
+     * @param string $register      The register id.
+     * @param string $mSchema       The mandaat schema id.
+     * @param string $besluitId     The owning MandateringsBesluit id.
+     * @param string $now           The activation date (Y-m-d).
+     *
+     * @return void
+     *
+     * @spec openspec/changes/mandaat-matrix-04-decidesk-import/tasks.md
+     */
+    public function activateMandatenForBesluit(
+        object $objectService,
+        string $register,
+        string $mSchema,
+        string $besluitId,
+        string $now
+    ): void {
+        try {
+            $mandaten = $this->searchObjectsAsArrays(
+                objectService: $objectService,
+                register: $register,
+                schema: $mSchema,
+                filters: ['mandateringsBesluit' => $besluitId]
+            );
+        } catch (\Throwable $e) {
+            $mandaten = [];
+        }
+
+        foreach ($mandaten as $m) {
+            $m['status'] = 'active';
+            if (isset($m['validFrom']) === false || $m['validFrom'] === '') {
+                $m['validFrom'] = $now;
+            }
+
+            $objectService->saveObject($register, $mSchema, $m);
+        }
+    }//end activateMandatenForBesluit()
+
+    /**
+     * Build a rolNaam to rolId index from OrganisatieRol objects.
+     *
+     * @return array<string, string> rolNaam → rolId.
+     *
+     * @spec openspec/changes/mandaat-matrix-04-decidesk-import/tasks.md
+     */
+    public function loadRoleIndex(): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        $register      = (string) $this->settingsService->getConfigValue('register');
+        $schema        = (string) $this->settingsService->getConfigValue('organisatie_rol_schema');
+        if ($objectService === null || $register === '' || $schema === '') {
+            return [];
+        }
+
+        try {
+            $rows = $this->searchObjectsAsArrays(
+                objectService: $objectService,
+                register: $register,
+                schema: $schema,
+                filters: []
+            );
+        } catch (\Throwable $e) {
+            return [];
+        }
+
+        $out = [];
+        foreach ($rows as $row) {
+            $rolNaam = (string) ($row['rolNaam'] ?? '');
+            if ($rolNaam !== '') {
+                $out[$rolNaam] = (string) ($row['id'] ?? '');
+            }
+        }
+
+        return $out;
+    }//end loadRoleIndex()
+
+    /**
+     * Find the prior vastgesteld besluit for a besluit number.
+     *
+     * @param string      $besluitNummer Number.
+     * @param string|null $excludeId     Optional id to exclude.
+     *
+     * @return array<string, mixed>|null The prior vastgesteld besluit, or null.
+     *
+     * @spec openspec/changes/mandaat-matrix-04-decidesk-import/tasks.md
+     */
+    public function findPriorBesluit(string $besluitNummer, ?string $excludeId=null): ?array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        $register      = (string) $this->settingsService->getConfigValue('register');
+        $schema        = (string) $this->settingsService->getConfigValue('mandaterings_besluit_schema');
+        if ($objectService === null || $register === '' || $schema === '') {
+            return null;
+        }
+
+        try {
+            $rows = $this->searchObjectsAsArrays(
+                objectService: $objectService,
+                register: $register,
+                schema: $schema,
+                filters: ['besluitNummer' => $besluitNummer]
+            );
+        } catch (\Throwable $e) {
+            return null;
+        }
+
+        foreach ($rows as $row) {
+            if ($excludeId !== null && (string) ($row['id'] ?? '') === $excludeId) {
+                continue;
+            }
+
+            if (($row['status'] ?? '') === 'vastgesteld') {
+                return $row;
+            }
+        }
+
+        return null;
+    }//end findPriorBesluit()
+
+    /**
+     * Find the mandaten linked to a besluit.
+     *
+     * @param string $besluitId Besluit id.
+     *
+     * @return array<int, array<string, mixed>> The besluit's mandaten.
+     *
+     * @spec openspec/changes/mandaat-matrix-04-decidesk-import/tasks.md
+     */
+    public function findMandatenForBesluit(string $besluitId): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        $register      = (string) $this->settingsService->getConfigValue('register');
+        $schema        = (string) $this->settingsService->getConfigValue('mandaat_schema');
+        if ($objectService === null || $register === '' || $schema === '') {
+            return [];
+        }
+
+        try {
+            return (array) $this->searchObjectsAsArrays(
+                objectService: $objectService,
+                register: $register,
+                schema: $schema,
+                filters: ['mandateringsBesluit' => $besluitId]
+            );
+        } catch (\Throwable $e) {
+            return [];
+        }
+    }//end findMandatenForBesluit()
+
+    /**
+     * Persist a single object for the configured schema.
+     *
+     * @param string               $schemaConfigKey Config key naming the schema.
+     * @param array<string, mixed> $object          Payload.
+     *
+     * @return array<string, mixed> The saved object, or the payload when the
+     *                              save could not be performed.
+     *
+     * @spec openspec/changes/mandaat-matrix-04-decidesk-import/tasks.md
+     */
+    public function save(string $schemaConfigKey, array $object): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        $register      = (string) $this->settingsService->getConfigValue('register');
+        $schema        = (string) $this->settingsService->getConfigValue($schemaConfigKey);
+        if ($objectService === null || $register === '' || $schema === '') {
+            return $object;
+        }
+
+        try {
+            $saved = $objectService->saveObject($register, $schema, $object);
+            if (is_array($saved) === true) {
+                return $saved;
+            }
+
+            return $object;
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Mandaat import persist failed',
+                ['key' => $schemaConfigKey, 'error' => $e->getMessage()]
+            );
+
+            return $object;
+        }
+    }//end save()
+}//end class

--- a/lib/Service/MandaatImportService.php
+++ b/lib/Service/MandaatImportService.php
@@ -35,28 +35,38 @@ declare(strict_types=1);
 namespace OCA\Procest\Service;
 
 use DateTimeImmutable;
-use OCA\Procest\Service\Support\SearchesObjects;
-use Psr\Log\LoggerInterface;
+use OCA\Procest\Service\Mandaat\MandaatCsvParser;
+use OCA\Procest\Service\Mandaat\MandaatRepository;
 use RuntimeException;
 
 /**
  * CSV import of a MandateringsBesluit from a Decidesk export.
+ *
+ * The wire format is parsed by {@see MandaatCsvParser} and every register read
+ * or write goes through {@see MandaatRepository}; what stays here is the import
+ * decision — new vs changed vs removed — and the approval state machine.
  */
 class MandaatImportService
 {
-    use SearchesObjects;
-
-    public const REQUIRED_COLUMNS = ['mandaatNummer', 'omschrijving', 'rolNaam', 'plafondCents'];
+    /**
+     * Columns an import CSV must carry.
+     *
+     * Canonically owned by {@see MandaatCsvParser}; aliased here so existing
+     * callers of `MandaatImportService::REQUIRED_COLUMNS` keep working.
+     *
+     * @var string[]
+     */
+    public const REQUIRED_COLUMNS = MandaatCsvParser::REQUIRED_COLUMNS;
 
     /**
      * Constructor.
      *
-     * @param SettingsService $settingsService Settings.
-     * @param LoggerInterface $logger          Logger.
+     * @param MandaatRepository $repository OpenRegister access for the mandaat matrix.
+     * @param MandaatCsvParser  $csvParser  Decidesk CSV export parser.
      */
     public function __construct(
-        private readonly SettingsService $settingsService,
-        private readonly LoggerInterface $logger,
+        private readonly MandaatRepository $repository,
+        private readonly MandaatCsvParser $csvParser,
     ) {
     }//end __construct()
 
@@ -80,7 +90,7 @@ class MandaatImportService
         string $decideskUuid,
         string $csvContents
     ): array {
-        $rows = $this->parseCsv(csv: $csvContents);
+        $rows = $this->csvParser->parse(csv: $csvContents);
         if (count($rows) === 0) {
             throw new RuntimeException('CSV is empty or missing data rows');
         }
@@ -89,7 +99,7 @@ class MandaatImportService
         $resolved = $this->resolveRolReferences(rows: $rows);
 
         // Create the besluit (concept).
-        $besluit = $this->save(
+        $besluit = $this->repository->save(
             schemaConfigKey: 'mandaterings_besluit_schema',
             object: [
                 'besluitNummer' => $besluitNummer,
@@ -100,10 +110,12 @@ class MandaatImportService
         );
 
         // Find the prior besluit version (by besluitNummer) for diff.
-        $prior         = $this->findPriorBesluit(besluitNummer: $besluitNummer);
+        $prior         = $this->repository->findPriorBesluit(besluitNummer: $besluitNummer);
         $priorMandaten = [];
         if ($prior !== null) {
-            $priorMandaten = $this->findMandatenForBesluit(besluitId: (string) ($prior['id'] ?? ''));
+            $priorMandaten = $this->repository->findMandatenForBesluit(
+                besluitId: (string) ($prior['id'] ?? '')
+            );
         }
 
         // Create one mandaat per CSV row.
@@ -114,7 +126,7 @@ class MandaatImportService
         foreach ($resolved as $row) {
             $payload = $this->buildMandaatPayload(row: $row, besluitId: (string) $besluit['id']);
 
-            $this->save(schemaConfigKey: 'mandaat_schema', object: $payload);
+            $this->repository->save(schemaConfigKey: 'mandaat_schema', object: $payload);
 
             $existing = $this->findPriorMandaat(
                 priorMandaten: $priorMandaten,
@@ -170,7 +182,7 @@ class MandaatImportService
      */
     private function resolveRolReferences(array $rows): array
     {
-        $roleIndex = $this->loadRoleIndex();
+        $roleIndex = $this->repository->loadRoleIndex();
         $resolved  = [];
         foreach ($rows as $idx => $row) {
             $rolNaam = (string) ($row['rolNaam'] ?? '');
@@ -206,8 +218,8 @@ class MandaatImportService
             'wettelijkeGrondslag' => (string) ($row['wettelijkeGrondslag'] ?? ''),
             'voorwaarden'         => [
                 'plafondCents'  => (int) ($row['plafondCents'] ?? 0),
-                'subdelegatie'  => $this->parseBool(value: (string) ($row['subdelegatie'] ?? 'false')),
-                'decisionTypes' => $this->parseList(value: (string) ($row['decisionTypes'] ?? '')),
+                'subdelegatie'  => $this->csvParser->parseBool(value: (string) ($row['subdelegatie'] ?? 'false')),
+                'decisionTypes' => $this->csvParser->parseList(value: (string) ($row['decisionTypes'] ?? '')),
             ],
             'status'              => 'concept',
         ];
@@ -292,7 +304,7 @@ class MandaatImportService
      */
     public function approveImport(string $besluitId): array
     {
-        $context       = $this->resolveApprovalContext();
+        $context       = $this->repository->resolveApprovalContext();
         $objectService = $context['objectService'];
         $register      = $context['register'];
         $bSchema       = $context['bSchema'];
@@ -313,7 +325,7 @@ class MandaatImportService
         $besluit = $objectService->saveObject($register, $bSchema, $besluit);
 
         // Flip mandaten to active.
-        $this->activateMandatenForBesluit(
+        $this->repository->activateMandatenForBesluit(
             objectService: $objectService,
             register: $register,
             mSchema: $mSchema,
@@ -322,7 +334,10 @@ class MandaatImportService
         );
 
         // Expire prior besluit.
-        $prior = $this->findPriorBesluit(besluitNummer: (string) $besluit['besluitNummer'], excludeId: $besluitId);
+        $prior = $this->repository->findPriorBesluit(
+            besluitNummer: (string) $besluit['besluitNummer'],
+            excludeId: $besluitId
+        );
         if ($prior !== null) {
             $prior['status']      = 'vervallen';
             $prior['vervalDatum'] = $now;
@@ -331,263 +346,4 @@ class MandaatImportService
 
         return $besluit;
     }//end approveImport()
-
-    /**
-     * Resolve the object service, register and schemas needed to approve an import.
-     *
-     * @return array<string, mixed> {objectService, register, bSchema, mSchema}
-     *
-     * @throws RuntimeException When the mandaat services are not configured.
-     */
-    private function resolveApprovalContext(): array
-    {
-        $objectService = $this->settingsService->getObjectService();
-        $register      = (string) $this->settingsService->getConfigValue('register');
-        $bSchema       = (string) $this->settingsService->getConfigValue('mandaterings_besluit_schema');
-        $mSchema       = (string) $this->settingsService->getConfigValue('mandaat_schema');
-        if ($objectService === null || $register === '' || $bSchema === '' || $mSchema === '') {
-            throw new RuntimeException('Mandaat services not configured');
-        }
-
-        return [
-            'objectService' => $objectService,
-            'register'      => $register,
-            'bSchema'       => $bSchema,
-            'mSchema'       => $mSchema,
-        ];
-    }//end resolveApprovalContext()
-
-    /**
-     * Flip every mandaat of a besluit to active, defaulting a missing validFrom.
-     *
-     * @param object $objectService The OpenRegister object service.
-     * @param string $register      The register id.
-     * @param string $mSchema       The mandaat schema id.
-     * @param string $besluitId     The owning MandateringsBesluit id.
-     * @param string $now           The activation date (Y-m-d).
-     *
-     * @return void
-     */
-    private function activateMandatenForBesluit(
-        object $objectService,
-        string $register,
-        string $mSchema,
-        string $besluitId,
-        string $now
-    ): void {
-        try {
-            $mandaten = $this->searchObjectsAsArrays(
-                objectService: $objectService,
-                register: $register,
-                schema: $mSchema,
-                filters: ['mandateringsBesluit' => $besluitId]
-            );
-        } catch (\Throwable $e) {
-            $mandaten = [];
-        }
-
-        foreach ($mandaten as $m) {
-            $m['status'] = 'active';
-            if (isset($m['validFrom']) === false || $m['validFrom'] === '') {
-                $m['validFrom'] = $now;
-            }
-
-            $objectService->saveObject($register, $mSchema, $m);
-        }
-    }//end activateMandatenForBesluit()
-
-    /**
-     * Parse RFC-4180-ish CSV with first row = header.
-     *
-     * @param string $csv CSV.
-     *
-     * @return array<int, array<string, string>>
-     */
-    private function parseCsv(string $csv): array
-    {
-        $lines = preg_split('/\r\n|\n|\r/', trim($csv));
-        if ($lines === false || count($lines) < 2) {
-            return [];
-        }
-
-        $header  = str_getcsv($lines[0]);
-        $missing = array_diff(self::REQUIRED_COLUMNS, $header);
-        if (count($missing) > 0) {
-            throw new RuntimeException('Missing required CSV columns: '.implode(', ', $missing));
-        }
-
-        $rows      = [];
-        $lineCount = count($lines);
-        for ($i = 1; $i < $lineCount; $i++) {
-            $line = trim((string) $lines[$i]);
-            if ($line === '') {
-                continue;
-            }
-
-            $values = str_getcsv($line);
-            $rows[] = array_combine($header, array_pad($values, count($header), ''));
-        }
-
-        return $rows;
-    }//end parseCsv()
-
-    /**
-     * Build a rolNaam to rolId index from OrganisatieRol objects.
-     *
-     * @return array<string, string> rolNaam → rolId
-     */
-    private function loadRoleIndex(): array
-    {
-        $objectService = $this->settingsService->getObjectService();
-        $register      = (string) $this->settingsService->getConfigValue('register');
-        $schema        = (string) $this->settingsService->getConfigValue('organisatie_rol_schema');
-        if ($objectService === null || $register === '' || $schema === '') {
-            return [];
-        }
-
-        try {
-            $rows = $this->searchObjectsAsArrays(objectService: $objectService, register: $register, schema: $schema, filters: []);
-        } catch (\Throwable $e) {
-            return [];
-        }
-
-        $out = [];
-        foreach ($rows as $row) {
-            $rolNaam = (string) ($row['rolNaam'] ?? '');
-            if ($rolNaam !== '') {
-                $out[$rolNaam] = (string) ($row['id'] ?? '');
-            }
-        }
-
-        return $out;
-    }//end loadRoleIndex()
-
-    /**
-     * Find the prior vastgesteld besluit for a besluit number.
-     *
-     * @param string      $besluitNummer Number.
-     * @param string|null $excludeId     Optional id to exclude.
-     *
-     * @return array<string, mixed>|null
-     */
-    private function findPriorBesluit(string $besluitNummer, ?string $excludeId=null): ?array
-    {
-        $objectService = $this->settingsService->getObjectService();
-        $register      = (string) $this->settingsService->getConfigValue('register');
-        $schema        = (string) $this->settingsService->getConfigValue('mandaterings_besluit_schema');
-        if ($objectService === null || $register === '' || $schema === '') {
-            return null;
-        }
-
-        try {
-            $rows = $this->searchObjectsAsArrays(
-                objectService: $objectService,
-                register: $register,
-                schema: $schema,
-                filters: ['besluitNummer' => $besluitNummer]
-            );
-        } catch (\Throwable $e) {
-            return null;
-        }
-
-        foreach ($rows as $row) {
-            if ($excludeId !== null && (string) ($row['id'] ?? '') === $excludeId) {
-                continue;
-            }
-
-            if (($row['status'] ?? '') === 'vastgesteld') {
-                return $row;
-            }
-        }
-
-        return null;
-    }//end findPriorBesluit()
-
-    /**
-     * Find the mandaten linked to a besluit.
-     *
-     * @param string $besluitId Besluit id.
-     *
-     * @return array<int, array<string, mixed>>
-     */
-    private function findMandatenForBesluit(string $besluitId): array
-    {
-        $objectService = $this->settingsService->getObjectService();
-        $register      = (string) $this->settingsService->getConfigValue('register');
-        $schema        = (string) $this->settingsService->getConfigValue('mandaat_schema');
-        if ($objectService === null || $register === '' || $schema === '') {
-            return [];
-        }
-
-        try {
-            return (array) $this->searchObjectsAsArrays(
-                objectService: $objectService,
-                register: $register,
-                schema: $schema,
-                filters: ['mandateringsBesluit' => $besluitId]
-            );
-        } catch (\Throwable $e) {
-            return [];
-        }
-    }//end findMandatenForBesluit()
-
-    /**
-     * Persist a single object for the configured schema.
-     *
-     * @param string               $schemaConfigKey Config key.
-     * @param array<string, mixed> $object          Payload.
-     *
-     * @return array<string, mixed>
-     */
-    private function save(string $schemaConfigKey, array $object): array
-    {
-        $objectService = $this->settingsService->getObjectService();
-        $register      = (string) $this->settingsService->getConfigValue('register');
-        $schema        = (string) $this->settingsService->getConfigValue($schemaConfigKey);
-        if ($objectService === null || $register === '' || $schema === '') {
-            return $object;
-        }
-
-        try {
-            $saved = $objectService->saveObject($register, $schema, $object);
-            if (is_array($saved) === true) {
-                return $saved;
-            }
-
-            return $object;
-        } catch (\Throwable $e) {
-            $this->logger->error('Mandaat import persist failed', ['key' => $schemaConfigKey, 'error' => $e->getMessage()]);
-            return $object;
-        }
-    }//end save()
-
-    /**
-     * Parse a boolean from CSV text.
-     *
-     * @param string $value Boolean text.
-     *
-     * @return bool
-     */
-    private function parseBool(string $value): bool
-    {
-        $value = strtolower(trim($value));
-        return in_array($value, ['1', 'true', 'ja', 'yes', 'y'], true);
-    }//end parseBool()
-
-    /**
-     * Parse a semicolon-separated list from CSV text.
-     *
-     * @param string $value Comma-separated list.
-     *
-     * @return array<int, string>
-     */
-    private function parseList(string $value): array
-    {
-        $value = trim($value);
-        if ($value === '') {
-            return [];
-        }
-
-        return array_values(array_filter(array_map('trim', explode(';', $value))));
-    }//end parseList()
 }//end class

--- a/lib/Service/Milestone/MilestoneRepository.php
+++ b/lib/Service/Milestone/MilestoneRepository.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * Procest milestone repository.
+ *
+ * The single OpenRegister read path for milestone definitions (per caseType)
+ * and milestone records (per case). Split out of MilestoneService so both that
+ * service and StalledCaseDetector can read the same data without either
+ * depending on the other — a repository in the middle is what keeps those two
+ * collaborators free of a construction cycle.
+ *
+ * An unconfigured definition/record schema is not an error on the read path:
+ * it yields an empty list, exactly as the pre-split service did. A missing
+ * OpenRegister *is* an error on the definition path, because a caller that
+ * silently sees "no milestones" would report every case as having no progress.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Milestone
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/specs/milestone-tracking/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Milestone;
+
+use OCA\Procest\Service\SettingsService;
+use OCA\Procest\Service\Support\SearchesObjects;
+use RuntimeException;
+
+/**
+ * OpenRegister reads for milestone definitions and records.
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/specs/milestone-tracking/spec.md
+ */
+class MilestoneRepository
+{
+
+    use SearchesObjects;
+
+    /**
+     * Constructor.
+     *
+     * @param SettingsService $settingsService Settings service (config + ObjectService).
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+    ) {
+    }//end __construct()
+
+    /**
+     * Get the milestone definitions declared for a case type.
+     *
+     * @param string $caseTypeId The case type UUID.
+     *
+     * @return array<int, array<string, mixed>> Milestone definitions.
+     *
+     * @throws RuntimeException When OpenRegister is unavailable.
+     *
+     * @spec openspec/specs/milestone-tracking/spec.md
+     */
+    public function findDefinitions(string $caseTypeId): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            throw new RuntimeException('OpenRegister is not available');
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('milestone_definition_schema');
+
+        if (empty($register) === true || empty($schema) === true) {
+            return [];
+        }
+
+        return $this->searchObjectsAsArrays(
+            objectService: $objectService,
+            register: $register,
+            schema: $schema,
+            filters: ['caseType' => $caseTypeId, '_limit' => 100],
+        );
+    }//end findDefinitions()
+
+    /**
+     * Get the milestone records recorded against a case.
+     *
+     * @param string $caseId The case UUID.
+     *
+     * @return array<int, array<string, mixed>> Milestone records.
+     *
+     * @spec openspec/specs/milestone-tracking/spec.md
+     */
+    public function findRecords(string $caseId): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return [];
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('milestone_record_schema');
+
+        if (empty($register) === true || empty($schema) === true) {
+            return [];
+        }
+
+        return $this->searchObjectsAsArrays(
+            objectService: $objectService,
+            register: $register,
+            schema: $schema,
+            filters: ['case' => $caseId, '_limit' => 100],
+        );
+    }//end findRecords()
+}//end class

--- a/lib/Service/Milestone/StalledCaseDetector.php
+++ b/lib/Service/Milestone/StalledCaseDetector.php
@@ -1,0 +1,313 @@
+<?php
+
+/**
+ * Procest stalled-case detector.
+ *
+ * Owns the "which cases are waiting too long?" question: it scans the open
+ * cases, finds each one's earliest unreached milestone, projects that
+ * milestone's deadline from the case start date over working days, and reports
+ * the case when the deadline is more than the caller's grace period in the
+ * past. Split out of MilestoneService so that service keeps milestone CRUD and
+ * per-case progress, while the deadline arithmetic and the skip rules that
+ * decide what "stalled" means live here.
+ *
+ * Skips are deliberate and silent: a case with no id, a closed case, a case
+ * with no case type and a case with no parsable start date are all
+ * un-assessable rather than stalled, and reporting them would flood the signal
+ * this report exists to carry.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Milestone
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/specs/milestone-tracking/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Milestone;
+
+use DateTimeImmutable;
+use OCA\Procest\Service\SettingsService;
+use OCA\Procest\Service\Support\SearchesObjects;
+
+/**
+ * Reports the cases that have run past their earliest unreached milestone.
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/specs/milestone-tracking/spec.md
+ */
+class StalledCaseDetector
+{
+
+    use SearchesObjects;
+
+    /**
+     * Status substrings that mark a case as closed and therefore un-assessable.
+     *
+     * @var string[]
+     */
+    private const CLOSED_STATUS_NEEDLES = [
+        'afgesloten',
+        'afgehandeld',
+        'geweigerd',
+        'ingetrokken',
+        'gearchiveerd',
+    ];
+
+    /**
+     * Constructor.
+     *
+     * @param SettingsService     $settingsService Settings service (config + ObjectService).
+     * @param MilestoneRepository $repository      Milestone definitions/records reader.
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+        private readonly MilestoneRepository $repository,
+    ) {
+    }//end __construct()
+
+    /**
+     * Find active cases that have stalled past a milestone deadline.
+     *
+     * @param int $thresholdDays Grace days past the computed deadline before a
+     *                           case is flagged (default 0 = flag on overdue).
+     *
+     * @return array<int, array<string, mixed>> One entry per stalled case:
+     *                                          caseId, caseTitle, caseType,
+     *                                          assignee, milestoneIdentifier,
+     *                                          milestoneLabel, deadline,
+     *                                          daysOverdue.
+     *
+     * @spec openspec/specs/milestone-tracking/spec.md
+     */
+    public function findStalledCases(int $thresholdDays=0): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return [];
+        }
+
+        $register   = $this->settingsService->getConfigValue('register');
+        $caseSchema = $this->settingsService->getConfigValue('case_schema');
+        if ($register === '' || $caseSchema === '') {
+            return [];
+        }
+
+        $cases = $this->searchObjectsAsArrays(
+            objectService: $objectService,
+            register: $register,
+            schema: $caseSchema,
+            filters: ['_limit' => 1000],
+        );
+
+        $today   = new DateTimeImmutable('today');
+        $stalled = [];
+
+        foreach ($cases as $case) {
+            $stall = $this->getStallRow(case: $case, today: $today, thresholdDays: $thresholdDays);
+            if ($stall !== null) {
+                $stalled[] = $stall;
+            }
+        }//end foreach
+
+        return $stalled;
+    }//end findStalledCases()
+
+    /**
+     * Build the stall report row for a single case, or null when it is not stalled.
+     *
+     * Cases without an id, closed cases, cases without a case type and cases
+     * without a parsable start date are skipped (null).
+     *
+     * @param array<string, mixed> $case          The case object.
+     * @param DateTimeImmutable    $today         Today (date only).
+     * @param int                  $thresholdDays Grace days past the deadline.
+     *
+     * @return array<string, mixed>|null Stall row, or null when on track or skipped.
+     */
+    private function getStallRow(array $case, DateTimeImmutable $today, int $thresholdDays): ?array
+    {
+        $caseId = (string) ($case['id'] ?? ($case['uuid'] ?? ''));
+        $status = strtolower((string) ($case['status'] ?? ''));
+        if ($caseId === '' || $this->isClosedStatus(status: $status) === true) {
+            return null;
+        }
+
+        $caseTypeId = (string) ($case['caseType'] ?? '');
+        if ($caseTypeId === '') {
+            return null;
+        }
+
+        $startDate = $this->parseCaseStart(case: $case);
+        if ($startDate === null) {
+            return null;
+        }
+
+        $stall = $this->evaluateStall(
+            caseId: $caseId,
+            caseTypeId: $caseTypeId,
+            startDate: $startDate,
+            today: $today,
+            thresholdDays: $thresholdDays,
+        );
+
+        if ($stall === null) {
+            return null;
+        }
+
+        $stall['caseTitle'] = (string) ($case['title'] ?? '');
+        $stall['caseType']  = $caseTypeId;
+        $stall['assignee']  = (string) ($case['assignee'] ?? '');
+
+        return $stall;
+    }//end getStallRow()
+
+    /**
+     * Evaluate whether a single case has stalled on its earliest unreached
+     * milestone and, if so, build the report row.
+     *
+     * @param string            $caseId        The case UUID.
+     * @param string            $caseTypeId    The case type UUID.
+     * @param DateTimeImmutable $startDate     The case start date.
+     * @param DateTimeImmutable $today         Today (date only).
+     * @param int               $thresholdDays Grace days past the deadline.
+     *
+     * @return array<string, mixed>|null Stall row, or null when on track.
+     */
+    private function evaluateStall(
+        string $caseId,
+        string $caseTypeId,
+        DateTimeImmutable $startDate,
+        DateTimeImmutable $today,
+        int $thresholdDays,
+    ): ?array {
+        $definitions = $this->repository->findDefinitions(caseTypeId: $caseTypeId);
+        if (count($definitions) === 0) {
+            return null;
+        }
+
+        // Order definitions by their numeric `order`.
+        usort(
+            $definitions,
+            static fn(array $a, array $b): int => ((int) ($a['order'] ?? 0) <=> (int) ($b['order'] ?? 0))
+        );
+
+        $records   = $this->repository->findRecords(caseId: $caseId);
+        $reachedBy = [];
+        foreach ($records as $record) {
+            if ((bool) ($record['reached'] ?? true) === true) {
+                $reachedBy[(string) ($record['milestoneDefinition'] ?? '')] = true;
+            }
+        }
+
+        foreach ($definitions as $def) {
+            $defId = (string) ($def['id'] ?? ($def['uuid'] ?? ''));
+            if (isset($reachedBy[$defId]) === true) {
+                continue;
+            }
+
+            // First unreached milestone — this is what the case waits on.
+            $expectedDays = (int) ($def['expectedDurationWorkingDays'] ?? 0);
+            $deadline     = $this->addWorkingDays(start: $startDate, workingDays: $expectedDays);
+            $daysOverdue  = (int) $deadline->diff($today)->format('%r%a');
+
+            if ($daysOverdue > $thresholdDays) {
+                return [
+                    'caseId'              => $caseId,
+                    'milestoneIdentifier' => (string) ($def['identifier'] ?? ''),
+                    'milestoneLabel'      => (string) ($def['label'] ?? ($def['name'] ?? '')),
+                    'deadline'            => $deadline->format('Y-m-d'),
+                    'daysOverdue'         => $daysOverdue,
+                ];
+            }
+
+            // Earliest unreached milestone is within deadline -> on track.
+            return null;
+        }//end foreach
+
+        // All milestones reached -> case complete, not stalled.
+        return null;
+    }//end evaluateStall()
+
+    /**
+     * Parse a case's start date into a date-only immutable value.
+     *
+     * @param array<string, mixed> $case The case object.
+     *
+     * @return DateTimeImmutable|null The start date, or null when absent/invalid.
+     */
+    private function parseCaseStart(array $case): ?DateTimeImmutable
+    {
+        $raw = (string) ($case['startDate'] ?? ($case['created'] ?? ''));
+        if ($raw === '') {
+            return null;
+        }
+
+        try {
+            return new DateTimeImmutable(substr($raw, 0, 10));
+        } catch (\Throwable $e) {
+            return null;
+        }
+    }//end parseCaseStart()
+
+    /**
+     * Determine whether a (lower-cased) case status represents a closed case.
+     *
+     * @param string $status Lower-cased status string.
+     *
+     * @return bool True when the case is closed and should be skipped.
+     */
+    private function isClosedStatus(string $status): bool
+    {
+        foreach (self::CLOSED_STATUS_NEEDLES as $needle) {
+            if (str_contains($status, $needle) === true) {
+                return true;
+            }
+        }
+
+        return false;
+    }//end isClosedStatus()
+
+    /**
+     * Add a number of working days (Mon-Fri) to a start date.
+     *
+     * Weekends are skipped. Dutch public holidays are not subtracted here; the
+     * milestone layer's deadlines are advisory (per the proposal's out-of-scope
+     * note on contractual SLA enforcement).
+     *
+     * @param DateTimeImmutable $start       The start date.
+     * @param int               $workingDays Working days to add (>= 0).
+     *
+     * @return DateTimeImmutable The resulting deadline date.
+     */
+    private function addWorkingDays(DateTimeImmutable $start, int $workingDays): DateTimeImmutable
+    {
+        if ($workingDays <= 0) {
+            return $start;
+        }
+
+        $date  = $start;
+        $added = 0;
+        while ($added < $workingDays) {
+            $date = $date->modify('+1 day');
+            $dow  = (int) $date->format('N');
+            if ($dow < 6) {
+                $added++;
+            }
+        }
+
+        return $date;
+    }//end addWorkingDays()
+}//end class

--- a/lib/Service/MilestoneService.php
+++ b/lib/Service/MilestoneService.php
@@ -27,14 +27,19 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service;
 
-use DateTimeImmutable;
 use OCA\Procest\AppInfo\Application;
+use OCA\Procest\Service\Milestone\MilestoneRepository;
+use OCA\Procest\Service\Milestone\StalledCaseDetector;
 use OCA\Procest\Service\Support\SearchesObjects;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 
 /**
  * Service for milestone tracking and progress calculation.
+ *
+ * Reads go through {@see MilestoneRepository} and the stalled-case report is
+ * owned by {@see StalledCaseDetector}; what stays here is milestone mutation
+ * (mark/reverse) and per-case progress.
  */
 class MilestoneService
 {
@@ -44,11 +49,15 @@ class MilestoneService
     /**
      * Constructor.
      *
-     * @param SettingsService $settingsService Settings service
-     * @param LoggerInterface $logger          Logger
+     * @param SettingsService     $settingsService Settings service
+     * @param MilestoneRepository $repository      Milestone definitions/records reader
+     * @param StalledCaseDetector $stalledDetector Stalled-case report
+     * @param LoggerInterface     $logger          Logger
      */
     public function __construct(
         private readonly SettingsService $settingsService,
+        private readonly MilestoneRepository $repository,
+        private readonly StalledCaseDetector $stalledDetector,
         private readonly LoggerInterface $logger,
     ) {
     }//end __construct()
@@ -66,24 +75,7 @@ class MilestoneService
      */
     public function getMilestones(string $caseTypeId): array
     {
-        $objectService = $this->settingsService->getObjectService();
-        if ($objectService === null) {
-            throw new RuntimeException('OpenRegister is not available');
-        }
-
-        $register = $this->settingsService->getConfigValue('register');
-        $schema   = $this->settingsService->getConfigValue('milestone_definition_schema');
-
-        if (empty($register) === true || empty($schema) === true) {
-            return [];
-        }
-
-        return $this->searchObjectsAsArrays(
-            objectService: $objectService,
-            register: $register,
-            schema: $schema,
-            filters: ['caseType' => $caseTypeId, '_limit' => 100],
-        );
+        return $this->repository->findDefinitions(caseTypeId: $caseTypeId);
     }//end getMilestones()
 
     /**
@@ -108,7 +100,7 @@ class MilestoneService
             ];
         }
 
-        $records   = $this->getMilestoneRecords(caseId: $caseId);
+        $records   = $this->repository->findRecords(caseId: $caseId);
         $recordMap = [];
         foreach ($records as $record) {
             $recordMap[$record['milestoneDefinition'] ?? ''] = $record;
@@ -313,249 +305,6 @@ class MilestoneService
      */
     public function findStalledCases(int $thresholdDays=0): array
     {
-        $objectService = $this->settingsService->getObjectService();
-        if ($objectService === null) {
-            return [];
-        }
-
-        $register   = $this->settingsService->getConfigValue('register');
-        $caseSchema = $this->settingsService->getConfigValue('case_schema');
-        if ($register === '' || $caseSchema === '') {
-            return [];
-        }
-
-        $cases = $this->searchObjectsAsArrays(
-            objectService: $objectService,
-            register: $register,
-            schema: $caseSchema,
-            filters: ['_limit' => 1000],
-        );
-
-        $today   = new DateTimeImmutable('today');
-        $stalled = [];
-
-        foreach ($cases as $case) {
-            $stall = $this->getStallRow(case: $case, today: $today, thresholdDays: $thresholdDays);
-            if ($stall !== null) {
-                $stalled[] = $stall;
-            }
-        }//end foreach
-
-        return $stalled;
+        return $this->stalledDetector->findStalledCases(thresholdDays: $thresholdDays);
     }//end findStalledCases()
-
-    /**
-     * Build the stall report row for a single case, or null when it is not stalled.
-     *
-     * Cases without an id, closed cases, cases without a case type and cases
-     * without a parsable start date are skipped (null).
-     *
-     * @param array<string, mixed> $case          The case object.
-     * @param \DateTimeImmutable   $today         Today (date only).
-     * @param int                  $thresholdDays Grace days past the deadline.
-     *
-     * @return array<string, mixed>|null Stall row, or null when on track or skipped.
-     */
-    private function getStallRow(array $case, \DateTimeImmutable $today, int $thresholdDays): ?array
-    {
-        $caseId = (string) ($case['id'] ?? ($case['uuid'] ?? ''));
-        $status = strtolower((string) ($case['status'] ?? ''));
-        if ($caseId === '' || $this->isClosedStatus(status: $status) === true) {
-            return null;
-        }
-
-        $caseTypeId = (string) ($case['caseType'] ?? '');
-        if ($caseTypeId === '') {
-            return null;
-        }
-
-        $startDate = $this->parseCaseStart(case: $case);
-        if ($startDate === null) {
-            return null;
-        }
-
-        $stall = $this->evaluateStall(
-            caseId: $caseId,
-            caseTypeId: $caseTypeId,
-            startDate: $startDate,
-            today: $today,
-            thresholdDays: $thresholdDays,
-        );
-
-        if ($stall === null) {
-            return null;
-        }
-
-        $stall['caseTitle'] = (string) ($case['title'] ?? '');
-        $stall['caseType']  = $caseTypeId;
-        $stall['assignee']  = (string) ($case['assignee'] ?? '');
-
-        return $stall;
-    }//end getStallRow()
-
-    /**
-     * Evaluate whether a single case has stalled on its earliest unreached
-     * milestone and, if so, build the report row.
-     *
-     * @param string             $caseId        The case UUID.
-     * @param string             $caseTypeId    The case type UUID.
-     * @param \DateTimeImmutable $startDate     The case start date.
-     * @param \DateTimeImmutable $today         Today (date only).
-     * @param int                $thresholdDays Grace days past the deadline.
-     *
-     * @return array<string, mixed>|null Stall row, or null when on track.
-     */
-    private function evaluateStall(
-        string $caseId,
-        string $caseTypeId,
-        \DateTimeImmutable $startDate,
-        \DateTimeImmutable $today,
-        int $thresholdDays,
-    ): ?array {
-        $definitions = $this->getMilestones(caseTypeId: $caseTypeId);
-        if (count($definitions) === 0) {
-            return null;
-        }
-
-        // Order definitions by their numeric `order`.
-        usort(
-            $definitions,
-            static fn(array $a, array $b): int => ((int) ($a['order'] ?? 0) <=> (int) ($b['order'] ?? 0))
-        );
-
-        $records   = $this->getMilestoneRecords(caseId: $caseId);
-        $reachedBy = [];
-        foreach ($records as $record) {
-            if ((bool) ($record['reached'] ?? true) === true) {
-                $reachedBy[(string) ($record['milestoneDefinition'] ?? '')] = true;
-            }
-        }
-
-        foreach ($definitions as $def) {
-            $defId = (string) ($def['id'] ?? ($def['uuid'] ?? ''));
-            if (isset($reachedBy[$defId]) === true) {
-                continue;
-            }
-
-            // First unreached milestone — this is what the case waits on.
-            $expectedDays = (int) ($def['expectedDurationWorkingDays'] ?? 0);
-            $deadline     = $this->addWorkingDays(start: $startDate, workingDays: $expectedDays);
-            $daysOverdue  = (int) $deadline->diff($today)->format('%r%a');
-
-            if ($daysOverdue > $thresholdDays) {
-                return [
-                    'caseId'              => $caseId,
-                    'milestoneIdentifier' => (string) ($def['identifier'] ?? ''),
-                    'milestoneLabel'      => (string) ($def['label'] ?? ($def['name'] ?? '')),
-                    'deadline'            => $deadline->format('Y-m-d'),
-                    'daysOverdue'         => $daysOverdue,
-                ];
-            }
-
-            // Earliest unreached milestone is within deadline -> on track.
-            return null;
-        }//end foreach
-
-        // All milestones reached -> case complete, not stalled.
-        return null;
-    }//end evaluateStall()
-
-    /**
-     * Parse a case's start date into a date-only immutable value.
-     *
-     * @param array<string, mixed> $case The case object.
-     *
-     * @return \DateTimeImmutable|null The start date, or null when absent/invalid.
-     */
-    private function parseCaseStart(array $case): ?\DateTimeImmutable
-    {
-        $raw = (string) ($case['startDate'] ?? ($case['created'] ?? ''));
-        if ($raw === '') {
-            return null;
-        }
-
-        try {
-            return new DateTimeImmutable(substr($raw, 0, 10));
-        } catch (\Throwable $e) {
-            return null;
-        }
-    }//end parseCaseStart()
-
-    /**
-     * Determine whether a (lower-cased) case status represents a closed case.
-     *
-     * @param string $status Lower-cased status string.
-     *
-     * @return bool True when the case is closed and should be skipped.
-     */
-    private function isClosedStatus(string $status): bool
-    {
-        foreach (['afgesloten', 'afgehandeld', 'geweigerd', 'ingetrokken', 'gearchiveerd'] as $needle) {
-            if (str_contains($status, $needle) === true) {
-                return true;
-            }
-        }
-
-        return false;
-    }//end isClosedStatus()
-
-    /**
-     * Add a number of working days (Mon-Fri) to a start date.
-     *
-     * Weekends are skipped. Dutch public holidays are not subtracted here; the
-     * milestone layer's deadlines are advisory (per the proposal's out-of-scope
-     * note on contractual SLA enforcement).
-     *
-     * @param \DateTimeImmutable $start       The start date.
-     * @param int                $workingDays Working days to add (>= 0).
-     *
-     * @return \DateTimeImmutable The resulting deadline date.
-     */
-    private function addWorkingDays(\DateTimeImmutable $start, int $workingDays): \DateTimeImmutable
-    {
-        if ($workingDays <= 0) {
-            return $start;
-        }
-
-        $date  = $start;
-        $added = 0;
-        while ($added < $workingDays) {
-            $date = $date->modify('+1 day');
-            $dow  = (int) $date->format('N');
-            if ($dow < 6) {
-                $added++;
-            }
-        }
-
-        return $date;
-    }//end addWorkingDays()
-
-    /**
-     * Get milestone records for a case.
-     *
-     * @param string $caseId The case UUID
-     *
-     * @return array<int, array<string, mixed>> Milestone records
-     */
-    private function getMilestoneRecords(string $caseId): array
-    {
-        $objectService = $this->settingsService->getObjectService();
-        if ($objectService === null) {
-            return [];
-        }
-
-        $register = $this->settingsService->getConfigValue('register');
-        $schema   = $this->settingsService->getConfigValue('milestone_record_schema');
-
-        if (empty($register) === true || empty($schema) === true) {
-            return [];
-        }
-
-        return $this->searchObjectsAsArrays(
-            objectService: $objectService,
-            register: $register,
-            schema: $schema,
-            filters: ['case' => $caseId, '_limit' => 100],
-        );
-    }//end getMilestoneRecords()
 }//end class

--- a/lib/Service/Parafeer/ParafeerStepGuard.php
+++ b/lib/Service/Parafeer/ParafeerStepGuard.php
@@ -1,0 +1,235 @@
+<?php
+
+/**
+ * Procest parafeer step guard.
+ *
+ * The fail-closed gate every parafeeractie passes through: it resolves the
+ * voorstel's current step from its route snapshot, asserts the caller is that
+ * step's actor (or a mandated delegate), and refuses an action that the step
+ * type does not permit or that is missing its mandatory free-text field. Split
+ * out of ParafeerActieService so that service records and propagates actions
+ * while the question "is this caller allowed to do this here?" has one owner.
+ *
+ * Every path throws rather than returning a boolean, and no path has a
+ * permissive default: an unknown step type, an unresolvable snapshot and a
+ * non-actor caller are all refusals (OWASP A01:2021, ADR-005 Rule 3).
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Parafeer
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/changes/parafering-actions/tasks.md#T02
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Parafeer;
+
+use OCP\AppFramework\OCS\OCSBadRequestException;
+use OCP\AppFramework\OCS\OCSForbiddenException;
+use OCP\IUser;
+
+/**
+ * Resolves the active parafering step and authorises the action against it.
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/changes/parafering-actions/tasks.md#T02
+ */
+class ParafeerStepGuard
+{
+    /**
+     * Action: actor advised on an advies step.
+     *
+     * @var string
+     */
+    public const ACTION_ADVISED = 'advised';
+
+    /**
+     * Action: actor parafered a parafering step.
+     *
+     * @var string
+     */
+    public const ACTION_PARAFERED = 'parafered';
+
+    /**
+     * Action: actor accorded an accordering step.
+     *
+     * @var string
+     */
+    public const ACTION_ACCORDED = 'accorded';
+
+    /**
+     * Action: actor returned the voorstel to the steller.
+     *
+     * @var string
+     */
+    public const ACTION_RETURNED = 'returned';
+
+    /**
+     * Step type: advies.
+     *
+     * @var string
+     */
+    public const STEP_TYPE_ADVIES = 'advies';
+
+    /**
+     * Step type: parafering.
+     *
+     * @var string
+     */
+    public const STEP_TYPE_PARAFERING = 'parafering';
+
+    /**
+     * Step type: accordering.
+     *
+     * @var string
+     */
+    public const STEP_TYPE_ACCORDERING = 'accordering';
+
+    /**
+     * The actions each step type permits. A step type absent from this table
+     * permits nothing.
+     *
+     * @var array<string, string[]>
+     */
+    private const ALLOWED_ACTIONS = [
+        self::STEP_TYPE_ADVIES      => [self::ACTION_ADVISED, self::ACTION_RETURNED],
+        self::STEP_TYPE_PARAFERING  => [self::ACTION_PARAFERED, self::ACTION_RETURNED],
+        self::STEP_TYPE_ACCORDERING => [self::ACTION_ACCORDED, self::ACTION_RETURNED],
+    ];
+
+    /**
+     * Resolve the current step from the route snapshot.
+     *
+     * @param array<string, mixed> $voorstel The voorstel array.
+     *
+     * @return array<string, mixed> The current step (order, type, actor, label).
+     *
+     * @throws OCSBadRequestException When no current step is set or the route snapshot is missing/invalid.
+     *
+     * @spec openspec/changes/parafering-actions/tasks.md#T02
+     */
+    public function resolveCurrentStep(array $voorstel): array
+    {
+        $currentStep = (int) ($voorstel['currentStep'] ?? 0);
+        if ($currentStep < 1) {
+            throw new OCSBadRequestException('Voorstel has no active step');
+        }
+
+        $snapshotRaw = $voorstel['routeSnapshot'] ?? null;
+        if ($snapshotRaw === null) {
+            throw new OCSBadRequestException('Voorstel has no route snapshot');
+        }
+
+        $decoded = $snapshotRaw;
+        if (is_string($snapshotRaw) === true) {
+            $decoded = json_decode($snapshotRaw, true);
+        }
+
+        if (is_array($decoded) === false) {
+            throw new OCSBadRequestException('Invalid route snapshot');
+        }
+
+        foreach ($decoded as $step) {
+            if (is_array($step) === true && (int) ($step['order'] ?? 0) === $currentStep) {
+                return $step;
+            }
+        }
+
+        throw new OCSBadRequestException('Current step not found in route snapshot');
+    }//end resolveCurrentStep()
+
+    /**
+     * Authorize the current user against the step actor (or valid delegate).
+     *
+     * @param array<string, mixed> $step        The current step.
+     * @param IUser                $currentUser The authenticated user.
+     * @param string|null          $onBehalfOf  The principal UID when acting as delegate.
+     * @param string|null          $mandate     The mandate reference.
+     *
+     * @return void
+     *
+     * @throws OCSForbiddenException When the current user is not the step actor and no valid delegate is configured.
+     *
+     * @spec openspec/changes/parafering-actions/tasks.md#T02
+     */
+    public function authorize(array $step, IUser $currentUser, ?string $onBehalfOf, ?string $mandate): void
+    {
+        $stepActor = (string) ($step['actor'] ?? '');
+        $userUid   = $currentUser->getUID();
+
+        if ($stepActor === $userUid) {
+            return;
+        }
+
+        if ($onBehalfOf !== null && $onBehalfOf === $stepActor && $mandate !== null && $mandate !== '') {
+            // Mandate-based delegate authorization. The mandate registry check is the
+            // responsibility of the frontend "Namens" selector (which only exposes
+            // configured mandates) and the future MandaatService — see roadmap.
+            return;
+        }
+
+        throw new OCSForbiddenException('Not authorized for this parafering step');
+    }//end authorize()
+
+    /**
+     * Validate that the action is allowed for the given step type.
+     *
+     * @param array<string, mixed> $step   The current step (must include 'type').
+     * @param string               $action The proposed action.
+     *
+     * @return void
+     *
+     * @throws OCSBadRequestException When the action is invalid for the step type.
+     *
+     * @spec openspec/changes/parafering-actions/tasks.md#T02
+     */
+    public function validateActionForStepType(array $step, string $action): void
+    {
+        $stepType = (string) ($step['type'] ?? '');
+        $allowed  = self::ALLOWED_ACTIONS;
+
+        if (isset($allowed[$stepType]) === false || in_array($action, $allowed[$stepType], true) === false) {
+            throw new OCSBadRequestException('Invalid action for this step type');
+        }
+    }//end validateActionForStepType()
+
+    /**
+     * Validate required fields per action.
+     *
+     * Step-type-specific rules live in
+     * {@see self::validateActionForStepType()}; this check is purely about the
+     * mandatory free-text fields, so it takes no step.
+     *
+     * @param string $action  The action.
+     * @param string $comment The comment (may be empty).
+     * @param string $advice  The advice (may be empty).
+     *
+     * @return void
+     *
+     * @throws OCSBadRequestException When mandatory comment/advice is missing.
+     *
+     * @spec openspec/changes/parafering-actions/tasks.md#T02
+     */
+    public function validateRequiredFields(string $action, string $comment, string $advice): void
+    {
+        if ($action === self::ACTION_RETURNED && $comment === '') {
+            throw new OCSBadRequestException('Return reason is required');
+        }
+
+        if ($action === self::ACTION_ADVISED && $advice === '') {
+            throw new OCSBadRequestException('Advice text is required for advies steps');
+        }
+    }//end validateRequiredFields()
+}//end class

--- a/lib/Service/Parafeer/ParafeerVoorstelRepository.php
+++ b/lib/Service/Parafeer/ParafeerVoorstelRepository.php
@@ -1,0 +1,151 @@
+<?php
+
+/**
+ * Procest parafeer voorstel repository.
+ *
+ * Resolves the (register, voorstel schema, parafeeractie schema) triple the
+ * parafering action recorder works against, and loads a single voorstel by
+ * UUID. Split out of ParafeerActieService so that service keeps action
+ * recording and step advancement while the configuration lookup and the load
+ * that must fail as a bad request live here.
+ *
+ * A missing register/schema is an exception, not an empty answer: silently
+ * recording actions against an unconfigured register would lose them.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Parafeer
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/changes/parafering-actions/tasks.md#T02
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Parafeer;
+
+use OCA\Procest\Service\SettingsService;
+use OCA\Procest\Service\Support\ObjectArrayNormalizer;
+use OCP\AppFramework\OCS\OCSBadRequestException;
+use RuntimeException;
+
+/**
+ * Register/schema resolution and voorstel loads for the parafering actions.
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/changes/parafering-actions/tasks.md#T02
+ */
+class ParafeerVoorstelRepository
+{
+    /**
+     * Constructor.
+     *
+     * @param SettingsService       $settingsService The settings/config bridge to OpenRegister.
+     * @param ObjectArrayNormalizer $normalizer      Collapses OpenRegister's array-or-entity shape.
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+        private readonly ObjectArrayNormalizer $normalizer,
+    ) {
+    }//end __construct()
+
+    /**
+     * Resolve the OpenRegister ObjectService, or null when OpenRegister is absent.
+     *
+     * Callers that can degrade (read paths) test for null; callers that cannot
+     * use {@see self::requireObjectService()}.
+     *
+     * @return object|null The ObjectService, or null.
+     *
+     * @spec openspec/changes/parafering-actions/tasks.md#T02
+     */
+    public function objectServiceOrNull(): ?object
+    {
+        return $this->settingsService->getObjectService();
+    }//end objectServiceOrNull()
+
+    /**
+     * Resolve the OpenRegister ObjectService, throwing when it is unavailable.
+     *
+     * @return object The ObjectService.
+     *
+     * @throws RuntimeException When OpenRegister is not available.
+     *
+     * @spec openspec/changes/parafering-actions/tasks.md#T02
+     */
+    public function requireObjectService(): object
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            throw new RuntimeException('OpenRegister is not available');
+        }
+
+        return $objectService;
+    }//end requireObjectService()
+
+    /**
+     * Resolve the OpenRegister register and schemas from settings.
+     *
+     * @return array{0: string, 1: string, 2: string} [register, voorstelSchema, parafeeractieSchema]
+     *
+     * @throws RuntimeException When register/schemas are not configured.
+     *
+     * @spec openspec/changes/parafering-actions/tasks.md#T02
+     */
+    public function resolveSchemas(): array
+    {
+        $register       = $this->settingsService->getConfigValue('register');
+        $voorstelSchema = $this->settingsService->getConfigValue('voorstel_schema');
+        $actieSchema    = $this->settingsService->getConfigValue('parafeeractie_schema');
+
+        if (empty($register) === true || empty($voorstelSchema) === true || empty($actieSchema) === true) {
+            throw new RuntimeException('Procest register/schemas not configured');
+        }
+
+        return [(string) $register, (string) $voorstelSchema, (string) $actieSchema];
+    }//end resolveSchemas()
+
+    /**
+     * Fetch a voorstel by UUID.
+     *
+     * @param object $objectService The OpenRegister ObjectService.
+     * @param string $register      The register identifier.
+     * @param string $schema        The voorstel schema identifier.
+     * @param string $voorstelId    The voorstel UUID.
+     *
+     * @return array<string, mixed> The voorstel as an associative array.
+     *
+     * @throws OCSBadRequestException When the voorstel cannot be located.
+     *
+     * @spec openspec/changes/parafering-actions/tasks.md#T02
+     */
+    public function findVoorstel(
+        object $objectService,
+        string $register,
+        string $schema,
+        string $voorstelId,
+    ): array {
+        try {
+            $voorstel = $objectService->find($voorstelId, register: $register, schema: $schema);
+        } catch (\Throwable $e) {
+            throw new OCSBadRequestException('Voorstel not found');
+        }
+
+        $array = $this->normalizer->toArray(value: $voorstel);
+        if (empty($array) === true) {
+            throw new OCSBadRequestException('Voorstel not found');
+        }
+
+        return $array;
+    }//end findVoorstel()
+}//end class

--- a/lib/Service/ParafeerActieService.php
+++ b/lib/Service/ParafeerActieService.php
@@ -33,7 +33,10 @@ use DateTimeImmutable;
 use DateTimeInterface;
 use OCA\Procest\AppInfo\Application;
 use OCA\Procest\Event\ParafeerTransitionEvent;
+use OCA\Procest\Service\Parafeer\ParafeerStepGuard;
+use OCA\Procest\Service\Parafeer\ParafeerVoorstelRepository;
 use OCA\Procest\Service\Parafeer\ParaferingActionMapper;
+use OCA\Procest\Service\Support\ObjectArrayNormalizer;
 use OCA\Procest\Service\Support\SearchesObjects;
 use OCP\AppFramework\OCS\OCSBadRequestException;
 use OCP\AppFramework\OCS\OCSForbiddenException;
@@ -55,7 +58,8 @@ use RuntimeException;
  *
  * @psalm-suppress UnusedClass
  *
- * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) — pre-existing; still 21 after the step-guard,
+ *   voorstel-repository and array-normalisation seams were extracted.
  */
 class ParafeerActieService
 {
@@ -64,43 +68,61 @@ class ParafeerActieService
 
     /**
      * Action: actor advised on an advies step.
+     *
+     * Canonically owned by {@see ParafeerStepGuard}, which enforces it.
+     *
+     * @var string
      */
-    public const ACTION_ADVISED = 'advised';
+    public const ACTION_ADVISED = ParafeerStepGuard::ACTION_ADVISED;
 
     /**
      * Action: actor parafered a parafering step.
+     *
+     * @var string
      */
-    public const ACTION_PARAFERED = 'parafered';
+    public const ACTION_PARAFERED = ParafeerStepGuard::ACTION_PARAFERED;
 
     /**
      * Action: actor accorded an accordering step.
+     *
+     * @var string
      */
-    public const ACTION_ACCORDED = 'accorded';
+    public const ACTION_ACCORDED = ParafeerStepGuard::ACTION_ACCORDED;
 
     /**
      * Action: actor returned the voorstel to the steller.
+     *
+     * @var string
      */
-    public const ACTION_RETURNED = 'returned';
+    public const ACTION_RETURNED = ParafeerStepGuard::ACTION_RETURNED;
 
     /**
      * Action: step was skipped.
+     *
+     * @var string
      */
     public const ACTION_SKIPPED = 'skipped';
 
     /**
      * Step type: advies.
+     *
+     * @var string
      */
-    public const STEP_TYPE_ADVIES = 'advies';
+    public const STEP_TYPE_ADVIES = ParafeerStepGuard::STEP_TYPE_ADVIES;
 
     /**
      * Step type: parafering.
+     *
+     * @var string
      */
-    public const STEP_TYPE_PARAFERING = 'parafering';
+    public const STEP_TYPE_PARAFERING = ParafeerStepGuard::STEP_TYPE_PARAFERING;
 
     /**
      * Step type: accordering.
+     *
+     * @var string
      */
-    public const STEP_TYPE_ACCORDERING = 'accordering';
+    public const STEP_TYPE_ACCORDERING = ParafeerStepGuard::STEP_TYPE_ACCORDERING;
 
     /**
      * Voorstel status: in_parafering (active route).
@@ -125,22 +147,26 @@ class ParafeerActieService
     /**
      * Constructor.
      *
-     * @param SettingsService               $settingsService     The settings service (provides ObjectService access).
      * @param ParaferingNotificationService $notificationService The Nextcloud notification service.
      * @param IRootFolder                   $rootFolder          The Nextcloud root folder (for PDF signing).
      * @param LoggerInterface               $logger              The logger.
      * @param IEventDispatcher              $eventDispatcher     The event dispatcher (parafering transition events).
      * @param ParaferingApprovalBridge      $approvalBridge      Bridge to OpenRegister approval-workflow (ADR-022).
      * @param ParaferingActionMapper        $actionMapper        Pure shaping of action input, payload and route steps.
+     * @param ParafeerStepGuard             $stepGuard           Current-step resolution + fail-closed authorisation.
+     * @param ParafeerVoorstelRepository    $voorstelRepository  Register/schema resolution + voorstel loads.
+     * @param ObjectArrayNormalizer         $normalizer          Collapses OpenRegister's array-or-entity shape.
      */
     public function __construct(
-        private readonly SettingsService $settingsService,
         private readonly ParaferingNotificationService $notificationService,
         private readonly IRootFolder $rootFolder,
         private readonly LoggerInterface $logger,
         private readonly IEventDispatcher $eventDispatcher,
         private readonly ParaferingApprovalBridge $approvalBridge,
         private readonly ParaferingActionMapper $actionMapper,
+        private readonly ParafeerStepGuard $stepGuard,
+        private readonly ParafeerVoorstelRepository $voorstelRepository,
+        private readonly ObjectArrayNormalizer $normalizer,
     ) {
     }//end __construct()
 
@@ -258,32 +284,29 @@ class ParafeerActieService
      */
     private function performRecordAction(string $voorstelId, array $data, IUser $currentUser): array
     {
-        [$register, $voorstelSchema, $actieSchema] = $this->resolveSchemas();
-        $objectService = $this->settingsService->getObjectService();
-        if ($objectService === null) {
-            throw new RuntimeException('OpenRegister is not available');
-        }
+        [$register, $voorstelSchema, $actieSchema] = $this->voorstelRepository->resolveSchemas();
+        $objectService = $this->voorstelRepository->requireObjectService();
 
-        $voorstel = $this->findVoorstel(
+        $voorstel = $this->voorstelRepository->findVoorstel(
             objectService: $objectService,
             register: $register,
             schema: $voorstelSchema,
             voorstelId: $voorstelId,
         );
-        $step     = $this->resolveCurrentStep(voorstel: $voorstel);
+        $step     = $this->stepGuard->resolveCurrentStep(voorstel: $voorstel);
 
         $input   = $this->actionMapper->parseActionInput(data: $data);
         $action  = (string) $input['action'];
         $comment = (string) $input['comment'];
 
-        $this->authorize(
+        $this->stepGuard->authorize(
             step: $step,
             currentUser: $currentUser,
             onBehalfOf: $input['onBehalfOf'],
             mandate: $input['mandate'],
         );
-        $this->validateActionForStepType(step: $step, action: $action);
-        $this->validateRequiredFields(
+        $this->stepGuard->validateActionForStepType(step: $step, action: $action);
+        $this->stepGuard->validateRequiredFields(
             action: $action,
             comment: $comment,
             advice: (string) $input['advice'],
@@ -323,7 +346,7 @@ class ParafeerActieService
             );
 
             return [
-                'parafeeractie' => $this->toArray(value: $savedActie),
+                'parafeeractie' => $this->normalizer->toArray(value: $savedActie),
                 'voorstel'      => ['id' => $voorstelId, 'status' => self::STATUS_TERUGGESTUURD],
             ];
         }
@@ -347,8 +370,8 @@ class ParafeerActieService
         );
 
         return [
-            'parafeeractie' => $this->toArray(value: $savedActie),
-            'voorstel'      => $this->toArray(value: $updatedVoorstel),
+            'parafeeractie' => $this->normalizer->toArray(value: $savedActie),
+            'voorstel'      => $this->normalizer->toArray(value: $updatedVoorstel),
         ];
     }//end performRecordAction()
 
@@ -566,8 +589,8 @@ class ParafeerActieService
     public function listActions(string $voorstelId): array
     {
         try {
-            [$register, , $actieSchema] = $this->resolveSchemas();
-            $objectService = $this->settingsService->getObjectService();
+            [$register, , $actieSchema] = $this->voorstelRepository->resolveSchemas();
+            $objectService = $this->voorstelRepository->objectServiceOrNull();
             if ($objectService === null) {
                 return [];
             }
@@ -582,7 +605,7 @@ class ParafeerActieService
             $rows = [];
             if (is_array($results) === true) {
                 foreach ($results as $row) {
-                    $rows[] = $this->toArray(value: $row);
+                    $rows[] = $this->normalizer->toArray(value: $row);
                 }
             }
 
@@ -686,174 +709,6 @@ class ParafeerActieService
     }//end applyPdfSignature()
 
     /**
-     * Resolve the OpenRegister register and schemas from settings.
-     *
-     * @return array{0: string, 1: string, 2: string} [register, voorstelSchema, parafeeractieSchema]
-     *
-     * @throws \RuntimeException When register/schemas are not configured.
-     */
-    private function resolveSchemas(): array
-    {
-        $register       = $this->settingsService->getConfigValue('register');
-        $voorstelSchema = $this->settingsService->getConfigValue('voorstel_schema');
-        $actieSchema    = $this->settingsService->getConfigValue('parafeeractie_schema');
-
-        if (empty($register) === true || empty($voorstelSchema) === true || empty($actieSchema) === true) {
-            throw new RuntimeException('Procest register/schemas not configured');
-        }
-
-        return [(string) $register, (string) $voorstelSchema, (string) $actieSchema];
-    }//end resolveSchemas()
-
-    /**
-     * Fetch a voorstel by UUID.
-     *
-     * @param object $objectService The OpenRegister ObjectService.
-     * @param string $register      The register identifier.
-     * @param string $schema        The voorstel schema identifier.
-     * @param string $voorstelId    The voorstel UUID.
-     *
-     * @return array<string, mixed>
-     *
-     * @throws OCSBadRequestException When the voorstel cannot be located.
-     */
-    private function findVoorstel(object $objectService, string $register, string $schema, string $voorstelId): array
-    {
-        try {
-            $voorstel = $objectService->find($voorstelId, register: $register, schema: $schema);
-        } catch (\Throwable $e) {
-            throw new OCSBadRequestException('Voorstel not found');
-        }
-
-        $array = $this->toArray(value: $voorstel);
-        if (empty($array) === true) {
-            throw new OCSBadRequestException('Voorstel not found');
-        }
-
-        return $array;
-    }//end findVoorstel()
-
-    /**
-     * Resolve the current step from the route snapshot.
-     *
-     * @param array<string, mixed> $voorstel The voorstel array.
-     *
-     * @return array<string, mixed> The current step (order, type, actor, label).
-     *
-     * @throws OCSBadRequestException When no current step is set or route snapshot missing.
-     */
-    private function resolveCurrentStep(array $voorstel): array
-    {
-        $currentStep = (int) ($voorstel['currentStep'] ?? 0);
-        if ($currentStep < 1) {
-            throw new OCSBadRequestException('Voorstel has no active step');
-        }
-
-        $snapshotRaw = $voorstel['routeSnapshot'] ?? null;
-        if ($snapshotRaw === null) {
-            throw new OCSBadRequestException('Voorstel has no route snapshot');
-        }
-
-        $decoded = $snapshotRaw;
-        if (is_string($snapshotRaw) === true) {
-            $decoded = json_decode($snapshotRaw, true);
-        }
-
-        if (is_array($decoded) === false) {
-            throw new OCSBadRequestException('Invalid route snapshot');
-        }
-
-        foreach ($decoded as $step) {
-            if (is_array($step) === true && (int) ($step['order'] ?? 0) === $currentStep) {
-                return $step;
-            }
-        }
-
-        throw new OCSBadRequestException('Current step not found in route snapshot');
-    }//end resolveCurrentStep()
-
-    /**
-     * Authorize the current user against the step actor (or valid delegate).
-     *
-     * @param array<string, mixed> $step        The current step.
-     * @param IUser                $currentUser The authenticated user.
-     * @param string|null          $onBehalfOf  The principal UID when acting as delegate.
-     * @param string|null          $mandate     The mandate reference.
-     *
-     * @return void
-     *
-     * @throws OCSForbiddenException When the current user is not the step actor and no valid delegate is configured.
-     */
-    private function authorize(array $step, IUser $currentUser, ?string $onBehalfOf, ?string $mandate): void
-    {
-        $stepActor = (string) ($step['actor'] ?? '');
-        $userUid   = $currentUser->getUID();
-
-        if ($stepActor === $userUid) {
-            return;
-        }
-
-        if ($onBehalfOf !== null && $onBehalfOf === $stepActor && $mandate !== null && $mandate !== '') {
-            // Mandate-based delegate authorization. The mandate registry check is the
-            // responsibility of the frontend "Namens" selector (which only exposes
-            // configured mandates) and the future MandaatService — see roadmap.
-            return;
-        }
-
-        throw new OCSForbiddenException('Not authorized for this parafering step');
-    }//end authorize()
-
-    /**
-     * Validate that the action is allowed for the given step type.
-     *
-     * @param array<string, mixed> $step   The current step (must include 'type').
-     * @param string               $action The proposed action.
-     *
-     * @return void
-     *
-     * @throws OCSBadRequestException When the action is invalid for the step type.
-     */
-    private function validateActionForStepType(array $step, string $action): void
-    {
-        $stepType = (string) ($step['type'] ?? '');
-        $allowed  = [
-            self::STEP_TYPE_ADVIES      => [self::ACTION_ADVISED, self::ACTION_RETURNED],
-            self::STEP_TYPE_PARAFERING  => [self::ACTION_PARAFERED, self::ACTION_RETURNED],
-            self::STEP_TYPE_ACCORDERING => [self::ACTION_ACCORDED, self::ACTION_RETURNED],
-        ];
-
-        if (isset($allowed[$stepType]) === false || in_array($action, $allowed[$stepType], true) === false) {
-            throw new OCSBadRequestException('Invalid action for this step type');
-        }
-    }//end validateActionForStepType()
-
-    /**
-     * Validate required fields per action.
-     *
-     * Step-type-specific rules live in
-     * {@see self::validateActionForStepType()}; this check is purely about the
-     * mandatory free-text fields, so it takes no step.
-     *
-     * @param string $action  The action.
-     * @param string $comment The comment (may be empty).
-     * @param string $advice  The advice (may be empty).
-     *
-     * @return void
-     *
-     * @throws OCSBadRequestException When mandatory comment/advice is missing.
-     */
-    private function validateRequiredFields(string $action, string $comment, string $advice): void
-    {
-        if ($action === self::ACTION_RETURNED && $comment === '') {
-            throw new OCSBadRequestException('Return reason is required');
-        }
-
-        if ($action === self::ACTION_ADVISED && $advice === '') {
-            throw new OCSBadRequestException('Advice text is required for advies steps');
-        }
-    }//end validateRequiredFields()
-
-    /**
      * Handle a "returned" action: update voorstel status and notify steller.
      *
      * @param object               $objectService  The OpenRegister ObjectService.
@@ -942,41 +797,6 @@ class ParafeerActieService
 
         $updated = $objectService->saveObject(object: $updateData, register: $register, schema: $voorstelSchema, uuid: (string) $voorstelId);
 
-        return $this->toArray(value: $updated);
+        return $this->normalizer->toArray(value: $updated);
     }//end advanceVoorstel()
-
-    /**
-     * Normalize an OpenRegister return value to an array.
-     *
-     * ObjectService can return either an array (older API) or an object exposing
-     * a jsonSerialize/toArray method (newer API). This helper collapses both.
-     *
-     * @param mixed $value The value to normalize.
-     *
-     * @return array<string, mixed>
-     */
-    private function toArray($value): array
-    {
-        if (is_array($value) === true) {
-            return $value;
-        }
-
-        if (is_object($value) === true) {
-            if (method_exists($value, 'jsonSerialize') === true) {
-                $serialized = $value->jsonSerialize();
-                if (is_array($serialized) === true) {
-                    return $serialized;
-                }
-            }
-
-            if (method_exists($value, 'toArray') === true) {
-                $converted = $value->toArray();
-                if (is_array($converted) === true) {
-                    return $converted;
-                }
-            }
-        }
-
-        return [];
-    }//end toArray()
 }//end class

--- a/lib/Service/ParafeerRouteService.php
+++ b/lib/Service/ParafeerRouteService.php
@@ -35,7 +35,9 @@ use DateTimeImmutable;
 use DateTimeInterface;
 use OCA\Procest\AppInfo\Application;
 use OCA\Procest\Event\ParafeerTransitionEvent;
-use OCA\Procest\Service\Routing\RoutingStrategyMissingException;
+use OCA\Procest\Service\Parafering\ParaferingStepActivator;
+use OCA\Procest\Service\Parafering\VoorstelRouteMapper;
+use OCA\Procest\Service\Support\ObjectArrayNormalizer;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
@@ -53,7 +55,9 @@ use Throwable;
  *
  * @psalm-suppress UnusedClass
  *
- * @SuppressWarnings(PHPMD.CouplingBetweenObjects) — orchestrates ObjectService + IUserSession
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) — orchestrates ObjectService, IUserSession,
+ *   the event dispatcher and the parafering collaborators; still 15 after the step-activation,
+ *   route-mapping and array-normalisation seams were extracted.
  */
 class ParafeerRouteService
 {
@@ -83,17 +87,21 @@ class ParafeerRouteService
      * @param SettingsService          $settingsService The Procest settings/config bridge to OpenRegister
      * @param IUserSession             $userSession     The current Nextcloud user session
      * @param LoggerInterface          $logger          The logger
-     * @param RoleResolverService      $roleResolver    Central role-routing engine
+     * @param ParaferingStepActivator  $stepActivator   Step activation + concrete actor resolution
      * @param IEventDispatcher         $eventDispatcher The event dispatcher
      * @param ParaferingApprovalBridge $approvalBridge  Bridge to OpenRegister approval-workflow (ADR-022)
+     * @param VoorstelRouteMapper      $routeMapper     Route-snapshot / audit-trail shaping
+     * @param ObjectArrayNormalizer    $normalizer      Collapses OpenRegister's array-or-entity shape
      */
     public function __construct(
         private readonly SettingsService $settingsService,
         private readonly IUserSession $userSession,
         private readonly LoggerInterface $logger,
-        private readonly RoleResolverService $roleResolver,
+        private readonly ParaferingStepActivator $stepActivator,
         private readonly IEventDispatcher $eventDispatcher,
         private readonly ParaferingApprovalBridge $approvalBridge,
+        private readonly VoorstelRouteMapper $routeMapper,
+        private readonly ObjectArrayNormalizer $normalizer,
     ) {
     }//end __construct()
 
@@ -163,15 +171,15 @@ class ParafeerRouteService
         [$objectService, $register, $voorstelSchema] = $this->bootstrapVoorstel();
         $routeSchema = $this->requireConfig(key: 'parafeerroute_schema');
 
-        $voorstel = $this->toArray(value: $objectService->find($voorstelId, register: $register, schema: $voorstelSchema));
+        $voorstel = $this->normalizer->toArrayWithCast(value: $objectService->find($voorstelId, register: $register, schema: $voorstelSchema));
 
         $routeRef = (string) ($voorstel['parafeerroute'] ?? '');
         if ($routeRef === '') {
             throw new RuntimeException('Voorstel has no linked parafeerroute');
         }
 
-        $route = $this->toArray(value: $objectService->find($routeRef, register: $register, schema: $routeSchema));
-        $steps = $this->normalizeSteps(value: $route['steps'] ?? []);
+        $route = $this->normalizer->toArrayWithCast(value: $objectService->find($routeRef, register: $register, schema: $routeSchema));
+        $steps = $this->routeMapper->normalizeSteps(value: $route['steps'] ?? []);
         if (count($steps) === 0) {
             throw new RuntimeException('Linked parafeerroute has no steps');
         }
@@ -189,9 +197,11 @@ class ParafeerRouteService
             $voorstel['approvalChainUuid'] = $chainUuid;
         }
 
-        $voorstel = $this->toArray(value: $objectService->saveObject(object: $voorstel, register: $register, schema: $voorstelSchema));
+        $voorstel = $this->normalizer->toArrayWithCast(
+            value: $objectService->saveObject(object: $voorstel, register: $register, schema: $voorstelSchema)
+        );
 
-        $this->activateStep(voorstel: $voorstel, step: 1, steps: $steps);
+        $this->stepActivator->activateStep(voorstel: $voorstel, step: 1, steps: $steps);
 
         $this->dispatchTransition(
             voorstelId: (string) ($voorstel['id'] ?? $voorstel['uuid'] ?? $voorstelId),
@@ -262,8 +272,8 @@ class ParafeerRouteService
         [$objectService, $register, $voorstelSchema] = $this->bootstrapVoorstel();
         $actieSchema = $this->requireConfig(key: 'parafeeractie_schema');
 
-        $voorstel = $this->toArray(value: $objectService->find($voorstelId, register: $register, schema: $voorstelSchema));
-        $steps    = $this->normalizeSteps(value: $voorstel['routeSnapshot'] ?? '[]');
+        $voorstel = $this->normalizer->toArrayWithCast(value: $objectService->find($voorstelId, register: $register, schema: $voorstelSchema));
+        $steps    = $this->routeMapper->normalizeSteps(value: $voorstel['routeSnapshot'] ?? '[]');
 
         if (($voorstel['status'] ?? '') !== self::STATUS_IN_PARAFERING) {
             throw new RuntimeException('Voorstel is not in parafering');
@@ -344,8 +354,8 @@ class ParafeerRouteService
         [$objectService, $register, $voorstelSchema] = $this->bootstrapVoorstel();
         $actieSchema = $this->requireConfig(key: 'parafeeractie_schema');
 
-        $voorstel = $this->toArray(value: $objectService->find($voorstelId, register: $register, schema: $voorstelSchema));
-        $steps    = $this->normalizeSteps(value: $voorstel['routeSnapshot'] ?? '[]');
+        $voorstel = $this->normalizer->toArrayWithCast(value: $objectService->find($voorstelId, register: $register, schema: $voorstelSchema));
+        $steps    = $this->routeMapper->normalizeSteps(value: $voorstel['routeSnapshot'] ?? '[]');
 
         $target = null;
         foreach ($steps as $candidate) {
@@ -391,7 +401,7 @@ class ParafeerRouteService
             ),
         );
 
-        $voorstel = $this->appendAuditTrail(
+        $voorstel = $this->routeMapper->appendAuditTrail(
             voorstel: $voorstel,
             entry: [
                 'action'    => 'step_skipped',
@@ -422,12 +432,14 @@ class ParafeerRouteService
                 register: $register,
                 voorstelSchema: $voorstelSchema,
                 voorstel: $voorstel,
-                steps: $this->normalizeSteps(value: $voorstel['routeSnapshot']),
+                steps: $this->routeMapper->normalizeSteps(value: $voorstel['routeSnapshot']),
                 fromStep: $step,
             );
         }
 
-        return $this->toArray(value: $objectService->saveObject(object: $voorstel, register: $register, schema: $voorstelSchema));
+        return $this->normalizer->toArrayWithCast(
+            value: $objectService->saveObject(object: $voorstel, register: $register, schema: $voorstelSchema)
+        );
     }//end skipStep()
 
     /**
@@ -452,8 +464,8 @@ class ParafeerRouteService
     {
         [$objectService, $register, $voorstelSchema] = $this->bootstrapVoorstel();
 
-        $voorstel = $this->toArray(value: $objectService->find($voorstelId, register: $register, schema: $voorstelSchema));
-        $steps    = $this->normalizeSteps(value: $voorstel['routeSnapshot'] ?? '[]');
+        $voorstel = $this->normalizer->toArrayWithCast(value: $objectService->find($voorstelId, register: $register, schema: $voorstelSchema));
+        $steps    = $this->routeMapper->normalizeSteps(value: $voorstel['routeSnapshot'] ?? '[]');
 
         $currentStep = (int) ($voorstel['currentStep'] ?? 0);
         $insertAfter = $afterStep;
@@ -493,7 +505,7 @@ class ParafeerRouteService
         $voorstel['routeSnapshot'] = json_encode($rebuilt);
 
         $userId   = $this->requireUserId();
-        $voorstel = $this->appendAuditTrail(
+        $voorstel = $this->routeMapper->appendAuditTrail(
             voorstel: $voorstel,
             entry: [
                 'action'    => 'step_added',
@@ -509,7 +521,9 @@ class ParafeerRouteService
             ],
         );
 
-        $saved = $this->toArray(value: $objectService->saveObject(object: $voorstel, register: $register, schema: $voorstelSchema));
+        $saved = $this->normalizer->toArrayWithCast(
+            value: $objectService->saveObject(object: $voorstel, register: $register, schema: $voorstelSchema)
+        );
 
         $this->dispatchTransition(
             voorstelId: (string) ($saved['id'] ?? $saved['uuid'] ?? $voorstelId),
@@ -554,7 +568,9 @@ class ParafeerRouteService
 
         if ($nextStep === null) {
             $voorstel['status'] = self::STATUS_GEACCORDEERD;
-            $voorstel           = $this->toArray(value: $objectService->saveObject(object: $voorstel, register: $register, schema: $voorstelSchema));
+            $voorstel           = $this->normalizer->toArrayWithCast(
+                value: $objectService->saveObject(object: $voorstel, register: $register, schema: $voorstelSchema)
+            );
             $this->logger->info(
                 'Procest: voorstel {id} fully accorded',
                 [
@@ -575,210 +591,14 @@ class ParafeerRouteService
         }//end if
 
         $voorstel['currentStep'] = $nextStep;
-        $voorstel = $this->toArray(value: $objectService->saveObject(object: $voorstel, register: $register, schema: $voorstelSchema));
+        $voorstel = $this->normalizer->toArrayWithCast(
+            value: $objectService->saveObject(object: $voorstel, register: $register, schema: $voorstelSchema)
+        );
 
-        $this->activateStep(voorstel: $voorstel, step: $nextStep, steps: $steps);
+        $this->stepActivator->activateStep(voorstel: $voorstel, step: $nextStep, steps: $steps);
 
         return $voorstel;
     }//end advanceVoorstel()
-
-    /**
-     * Activate a step: log a notification intent and (best-effort) create a task.
-     *
-     * Notification dispatch and task creation are delegated to the platform
-     * services when available. Failures are logged but do not abort routing.
-     *
-     * @param array<string, mixed>             $voorstel The voorstel
-     * @param int                              $step     The step order to activate
-     * @param array<int, array<string, mixed>> $steps    The decoded routeSnapshot
-     *
-     * @return void
-     */
-    private function activateStep(array $voorstel, int $step, array $steps): void
-    {
-        $stepInfo = null;
-        foreach ($steps as $candidate) {
-            if ((int) ($candidate['order'] ?? 0) === $step) {
-                $stepInfo = $candidate;
-                break;
-            }
-        }
-
-        if ($stepInfo === null) {
-            return;
-        }
-
-        $resolvedActors = $this->resolveStepActors(stepInfo: $stepInfo, voorstel: $voorstel);
-
-        $this->logger->info(
-            'Procest: activated parafering step {step} of voorstel {voorstelId} for actor {actor}',
-            [
-                'step'       => $step,
-                'voorstelId' => $voorstel['id'] ?? $voorstel['uuid'] ?? '',
-                'actor'      => (string) ($stepInfo['actor'] ?? ''),
-                'resolved'   => $resolvedActors,
-                'app'        => Application::APP_ID,
-            ],
-        );
-    }//end activateStep()
-
-    /**
-     * Resolve the concrete actor set for a step.
-     *
-     * For role-typed actors, the step's actor UUID is treated as the
-     * `roleType` parameter of an implicit single-role rule and dispatched to
-     * the shared RoleResolverService — this inherits delegation + workload
-     * features automatically. For user-typed actors the original UUID is
-     * returned as-is.
-     *
-     * @param array<string, mixed> $stepInfo The step from routeSnapshot
-     * @param array<string, mixed> $voorstel The voorstel object (provides caseRef + caseType)
-     *
-     * @return array<int, string>
-     *
-     * @spec openspec/changes/role-based-step-routing/tasks.md#T07
-     */
-    private function resolveStepActors(array $stepInfo, array $voorstel): array
-    {
-        $actorType = (string) ($stepInfo['actorType'] ?? 'user');
-        $actor     = (string) ($stepInfo['actor'] ?? '');
-        if ($actor === '') {
-            return [];
-        }
-
-        if ($actorType !== 'role') {
-            return [$actor];
-        }
-
-        $caseRef = (string) ($voorstel['case'] ?? ($voorstel['zaak'] ?? ''));
-        if ($caseRef === '') {
-            return [$actor];
-        }
-
-        $case = ['id' => $caseRef, 'caseType' => (string) ($voorstel['caseType'] ?? '')];
-        $rule = $stepInfo['routingRule'] ?? null;
-        if (is_array($rule) === false || isset($rule['strategy']) === false) {
-            $rule = [
-                'strategy' => RoleResolverService::STRATEGY_SINGLE_ROLE,
-                'roleType' => $actor,
-            ];
-        }
-
-        try {
-            return $this->roleResolver->resolve($rule, $case);
-        } catch (RoutingStrategyMissingException $e) {
-            $this->logger->warning(
-                'Procest: parafering step references unknown routing strategy: '.$e->getMessage(),
-            );
-            return [$actor];
-        } catch (Throwable $e) {
-            $this->logger->warning(
-                'Procest: failed to resolve parafering step actors: '.$e->getMessage(),
-            );
-            return [$actor];
-        }
-    }//end resolveStepActors()
-
-    /**
-     * Append an entry to the voorstel auditTrail field.
-     *
-     * @param array<string, mixed> $voorstel The voorstel
-     * @param array<string, mixed> $entry    The entry to append
-     *
-     * @return array<string, mixed>
-     */
-    private function appendAuditTrail(array $voorstel, array $entry): array
-    {
-        $trail = $voorstel['auditTrail'] ?? [];
-        if (is_string($trail) === true) {
-            $decoded = json_decode($trail, true);
-            $trail   = [];
-            if (is_array($decoded) === true) {
-                $trail = $decoded;
-            }
-        }
-
-        if (is_array($trail) === false) {
-            $trail = [];
-        }
-
-        $trail[] = $entry;
-        $voorstel['auditTrail'] = $trail;
-
-        return $voorstel;
-    }//end appendAuditTrail()
-
-    /**
-     * Normalize a steps value (JSON string or array) to a plain ordered array.
-     *
-     * @param mixed $value The raw value from routeSnapshot or schema field
-     *
-     * @return array<int, array<string, mixed>>
-     */
-    private function normalizeSteps(mixed $value): array
-    {
-        if (is_string($value) === true) {
-            $decoded = json_decode($value, true);
-            $value   = [];
-            if (is_array($decoded) === true) {
-                $value = $decoded;
-            }
-        }
-
-        if (is_array($value) === false) {
-            return [];
-        }
-
-        $steps = [];
-        foreach ($value as $candidate) {
-            if (is_array($candidate) === true) {
-                $steps[] = $candidate;
-            }
-        }
-
-        usort(
-            $steps,
-            static function (array $left, array $right): int {
-                return ((int) ($left['order'] ?? 0)) <=> ((int) ($right['order'] ?? 0));
-            },
-        );
-
-        return $steps;
-    }//end normalizeSteps()
-
-    /**
-     * Convert an arbitrary ObjectService return value to an associative array.
-     *
-     * @param mixed $value The returned object/array
-     *
-     * @return array<string, mixed>
-     */
-    private function toArray(mixed $value): array
-    {
-        if (is_array($value) === true) {
-            return $value;
-        }
-
-        if (is_object($value) === true) {
-            if (method_exists($value, 'jsonSerialize') === true) {
-                $serialized = $value->jsonSerialize();
-                if (is_array($serialized) === true) {
-                    return $serialized;
-                }
-            }
-
-            if (method_exists($value, 'toArray') === true) {
-                $arr = $value->toArray();
-                if (is_array($arr) === true) {
-                    return $arr;
-                }
-            }
-
-            return (array) $value;
-        }
-
-        return [];
-    }//end toArray()
 
     /**
      * Resolve ObjectService and the (register, voorstel schema) pair.

--- a/lib/Service/Parafering/ParaferingStepActivator.php
+++ b/lib/Service/Parafering/ParaferingStepActivator.php
@@ -1,0 +1,165 @@
+<?php
+
+/**
+ * Procest parafering step activator.
+ *
+ * Activates one step of a parafeerroute: locates the step in the route
+ * snapshot, resolves its abstract actor into the concrete set of users that
+ * may act on it, and records the activation. Split out of ParafeerRouteService
+ * so that service keeps the transition sequencing while the actor question —
+ * the one place a routing rule meets the shared RoleResolverService — has a
+ * single owner.
+ *
+ * For role-typed actors the step's actor UUID is treated as the `roleType`
+ * parameter of an implicit single-role rule, which is what makes delegation
+ * and workload routing apply to parafering steps for free. Resolution failure
+ * degrades to the literal actor rather than to an empty set: a step with no
+ * resolvable actor would silently strand the voorstel.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Parafering
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/changes/role-based-step-routing/tasks.md#T07
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Parafering;
+
+use OCA\Procest\AppInfo\Application;
+use OCA\Procest\Service\RoleResolverService;
+use OCA\Procest\Service\Routing\RoutingStrategyMissingException;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Activates a parafering step and resolves its concrete actor set.
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/changes/role-based-step-routing/tasks.md#T07
+ */
+class ParaferingStepActivator
+{
+    /**
+     * Constructor.
+     *
+     * @param RoleResolverService $roleResolver Central role-routing engine.
+     * @param LoggerInterface     $logger       The logger.
+     */
+    public function __construct(
+        private readonly RoleResolverService $roleResolver,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Activate the step with the given order within a route snapshot.
+     *
+     * A step order that is absent from the snapshot is a no-op, matching the
+     * pre-split behaviour.
+     *
+     * @param array<string, mixed>             $voorstel The voorstel.
+     * @param int                              $step     The step order to activate.
+     * @param array<int, array<string, mixed>> $steps    The decoded routeSnapshot.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/role-based-step-routing/tasks.md#T07
+     */
+    public function activateStep(array $voorstel, int $step, array $steps): void
+    {
+        $stepInfo = null;
+        foreach ($steps as $candidate) {
+            if ((int) ($candidate['order'] ?? 0) === $step) {
+                $stepInfo = $candidate;
+                break;
+            }
+        }
+
+        if ($stepInfo === null) {
+            return;
+        }
+
+        $resolvedActors = $this->resolveStepActors(stepInfo: $stepInfo, voorstel: $voorstel);
+
+        $this->logger->info(
+            'Procest: activated parafering step {step} of voorstel {voorstelId} for actor {actor}',
+            [
+                'step'       => $step,
+                'voorstelId' => $voorstel['id'] ?? $voorstel['uuid'] ?? '',
+                'actor'      => (string) ($stepInfo['actor'] ?? ''),
+                'resolved'   => $resolvedActors,
+                'app'        => Application::APP_ID,
+            ],
+        );
+    }//end activateStep()
+
+    /**
+     * Resolve the concrete actor set for a step.
+     *
+     * For role-typed actors, the step's actor UUID is treated as the
+     * `roleType` parameter of an implicit single-role rule and dispatched to
+     * the shared RoleResolverService — this inherits delegation + workload
+     * features automatically. For user-typed actors the original UUID is
+     * returned as-is.
+     *
+     * @param array<string, mixed> $stepInfo The step from routeSnapshot.
+     * @param array<string, mixed> $voorstel The voorstel object (provides caseRef + caseType).
+     *
+     * @return array<int, string> The resolved actor UIDs.
+     *
+     * @spec openspec/changes/role-based-step-routing/tasks.md#T07
+     */
+    public function resolveStepActors(array $stepInfo, array $voorstel): array
+    {
+        $actorType = (string) ($stepInfo['actorType'] ?? 'user');
+        $actor     = (string) ($stepInfo['actor'] ?? '');
+        if ($actor === '') {
+            return [];
+        }
+
+        if ($actorType !== 'role') {
+            return [$actor];
+        }
+
+        $caseRef = (string) ($voorstel['case'] ?? ($voorstel['zaak'] ?? ''));
+        if ($caseRef === '') {
+            return [$actor];
+        }
+
+        $case = ['id' => $caseRef, 'caseType' => (string) ($voorstel['caseType'] ?? '')];
+        $rule = $stepInfo['routingRule'] ?? null;
+        if (is_array($rule) === false || isset($rule['strategy']) === false) {
+            $rule = [
+                'strategy' => RoleResolverService::STRATEGY_SINGLE_ROLE,
+                'roleType' => $actor,
+            ];
+        }
+
+        try {
+            return $this->roleResolver->resolve($rule, $case);
+        } catch (RoutingStrategyMissingException $e) {
+            $this->logger->warning(
+                'Procest: parafering step references unknown routing strategy: '.$e->getMessage(),
+            );
+            return [$actor];
+        } catch (Throwable $e) {
+            $this->logger->warning(
+                'Procest: failed to resolve parafering step actors: '.$e->getMessage(),
+            );
+            return [$actor];
+        }
+    }//end resolveStepActors()
+}//end class

--- a/lib/Service/Parafering/VoorstelRouteMapper.php
+++ b/lib/Service/Parafering/VoorstelRouteMapper.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * Procest voorstel route mapper.
+ *
+ * Pure shaping of the two voorstel fields the parafering route engine reads
+ * and writes as loosely-typed data: `routeSnapshot`, which may arrive as a
+ * JSON string or an array and must come back as an order-sorted list of step
+ * arrays, and `auditTrail`, which is appended to under the same
+ * string-or-array ambiguity. Split out of ParafeerRouteService so that service
+ * keeps workflow execution and this conversion has one owner.
+ *
+ * Every path is total: an unparsable snapshot yields an empty step list and a
+ * non-array audit trail is replaced rather than appended to, so a malformed
+ * stored value can never make the engine throw mid-transition.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Parafering
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/changes/parafeerroute-engine/tasks.md#T04
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Parafering;
+
+/**
+ * Normalises route snapshots and appends audit-trail entries.
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/changes/parafeerroute-engine/tasks.md#T04
+ */
+class VoorstelRouteMapper
+{
+    /**
+     * Append an entry to the voorstel auditTrail field.
+     *
+     * @param array<string, mixed> $voorstel The voorstel.
+     * @param array<string, mixed> $entry    The entry to append.
+     *
+     * @return array<string, mixed> The voorstel with the entry appended.
+     *
+     * @spec openspec/changes/parafeerroute-engine/tasks.md#T04
+     */
+    public function appendAuditTrail(array $voorstel, array $entry): array
+    {
+        $trail = $voorstel['auditTrail'] ?? [];
+        if (is_string($trail) === true) {
+            $decoded = json_decode($trail, true);
+            $trail   = [];
+            if (is_array($decoded) === true) {
+                $trail = $decoded;
+            }
+        }
+
+        if (is_array($trail) === false) {
+            $trail = [];
+        }
+
+        $trail[] = $entry;
+        $voorstel['auditTrail'] = $trail;
+
+        return $voorstel;
+    }//end appendAuditTrail()
+
+    /**
+     * Normalize a steps value (JSON string or array) to a plain ordered array.
+     *
+     * @param mixed $value The raw value from routeSnapshot or schema field.
+     *
+     * @return array<int, array<string, mixed>> The steps, sorted by `order`.
+     *
+     * @spec openspec/changes/parafeerroute-engine/tasks.md#T04
+     */
+    public function normalizeSteps(mixed $value): array
+    {
+        if (is_string($value) === true) {
+            $decoded = json_decode($value, true);
+            $value   = [];
+            if (is_array($decoded) === true) {
+                $value = $decoded;
+            }
+        }
+
+        if (is_array($value) === false) {
+            return [];
+        }
+
+        $steps = [];
+        foreach ($value as $candidate) {
+            if (is_array($candidate) === true) {
+                $steps[] = $candidate;
+            }
+        }
+
+        usort(
+            $steps,
+            static function (array $left, array $right): int {
+                return ((int) ($left['order'] ?? 0)) <=> ((int) ($right['order'] ?? 0));
+            },
+        );
+
+        return $steps;
+    }//end normalizeSteps()
+}//end class

--- a/lib/Service/RoleResolverService.php
+++ b/lib/Service/RoleResolverService.php
@@ -33,8 +33,8 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service;
 
-use DateTimeImmutable;
 use OCA\Procest\AppInfo\Application;
+use OCA\Procest\Service\Routing\RoleDelegationResolver;
 use OCA\Procest\Service\Routing\RoutingStrategyMissingException;
 use OCA\Procest\Service\Routing\StrategyRegistry;
 use OCP\ICache;
@@ -47,9 +47,6 @@ use Throwable;
  * Central role-routing engine.
  *
  * @spec openspec/changes/role-based-step-routing/tasks.md#T02
- *
- * @SuppressWarnings(PHPMD.CouplingBetweenObjects) — orchestrates strategies,
- *   OpenRegister, cache and logger.
  */
 class RoleResolverService
 {
@@ -78,15 +75,17 @@ class RoleResolverService
     /**
      * Constructor.
      *
-     * @param StrategyRegistry $registry        Strategy registry
-     * @param SettingsService  $settingsService Bridge to ObjectService + config
-     * @param ICacheFactory    $cacheFactory    Cache factory
-     * @param LoggerInterface  $logger          Logger
+     * @param StrategyRegistry       $registry        Strategy registry
+     * @param SettingsService        $settingsService Bridge to ObjectService + config
+     * @param ICacheFactory          $cacheFactory    Cache factory
+     * @param RoleDelegationResolver $delegation      Active-window delegate substitution
+     * @param LoggerInterface        $logger          Logger
      */
     public function __construct(
         private readonly StrategyRegistry $registry,
         private readonly SettingsService $settingsService,
         ICacheFactory $cacheFactory,
+        private readonly RoleDelegationResolver $delegation,
         private readonly LoggerInterface $logger,
     ) {
         $this->cache = $cacheFactory->createLocal(Application::APP_ID.'_routing');
@@ -187,7 +186,7 @@ class RoleResolverService
                 ->resolve(['strategy' => self::STRATEGY_SINGLE_ROLE, 'roleType' => $fallback], $case, $roles);
         }
 
-        $resolved = $this->applyDelegation(participants: $primary, roles: $roles);
+        $resolved = $this->delegation->apply(participants: $primary, roles: $roles);
 
         if ($caseId !== '') {
             $this->cache->set($cacheKey, $resolved, self::CACHE_TTL);
@@ -261,93 +260,6 @@ class RoleResolverService
         // resolver hits are rebuilt within 60s anyway.
         $this->cache->clear();
     }//end invalidateCache()
-
-    /**
-     * Substitute delegates inside an active delegation window; break cycles.
-     *
-     * @param array<int, string>               $participants Raw resolver output
-     * @param array<int, array<string, mixed>> $roles        All case roles
-     *
-     * @return array<int, string>
-     */
-    private function applyDelegation(array $participants, array $roles): array
-    {
-        $now    = new DateTimeImmutable('now');
-        $byUser = [];
-        foreach ($roles as $role) {
-            $participant = (string) ($role['participant'] ?? '');
-            if ($participant !== '') {
-                $byUser[$participant] = $role;
-            }
-        }
-
-        $result = [];
-        foreach ($participants as $participant) {
-            $result[] = $this->resolveDelegate(
-                participant: $participant,
-                byUser: $byUser,
-                now: $now,
-            );
-        }
-
-        return $result;
-    }//end applyDelegation()
-
-    /**
-     * Resolve one participant to its active delegate (single hop, cycle-safe).
-     *
-     * @param string                              $participant The original participant
-     * @param array<string, array<string, mixed>> $byUser      Case roles indexed by participant
-     * @param DateTimeImmutable                   $now         The evaluation moment
-     *
-     * @return string The delegate when an active window applies, else the participant
-     */
-    private function resolveDelegate(string $participant, array $byUser, DateTimeImmutable $now): string
-    {
-        $resolved = $participant;
-        $visited  = [$participant => true];
-        while (isset($byUser[$resolved]) === true) {
-            $role     = $byUser[$resolved];
-            $from     = (string) ($role['delegateFrom'] ?? '');
-            $until    = (string) ($role['delegateUntil'] ?? '');
-            $delegate = (string) ($role['delegate'] ?? '');
-            if ($delegate === '' || $from === '' || $until === '') {
-                break;
-            }
-
-            try {
-                $fromAt  = new DateTimeImmutable($from);
-                $untilAt = new DateTimeImmutable($until);
-            } catch (Throwable $e) {
-                break;
-            }
-
-            if ($now < $fromAt || $now > $untilAt) {
-                break;
-            }
-
-            if (isset($visited[$delegate]) === true) {
-                $this->logger->warning(
-                    'Procest: delegation cycle detected',
-                    [
-                        'event'    => 'RoleRoutingDelegationCycle',
-                        'original' => $participant,
-                        'delegate' => $delegate,
-                        'app'      => Application::APP_ID,
-                    ],
-                );
-                break;
-            }
-
-            $visited[$delegate] = true;
-            $resolved           = $delegate;
-
-            // Per spec: break after exactly one hop.
-            break;
-        }//end while
-
-        return $resolved;
-    }//end resolveDelegate()
 
     /**
      * Build a cache key from rule + caseId.

--- a/lib/Service/Routing/RoleDelegationResolver.php
+++ b/lib/Service/Routing/RoleDelegationResolver.php
@@ -1,0 +1,152 @@
+<?php
+
+/**
+ * Procest role delegation resolver.
+ *
+ * Owns the `role.delegate` substitution step of role routing: given the raw
+ * participants a routing strategy produced and the case's role records, it
+ * swaps each participant for its delegate when — and only when — an active
+ * `delegateFrom`/`delegateUntil` window covers the evaluation moment. Split
+ * out of RoleResolverService so that service keeps rule normalisation,
+ * strategy dispatch and caching, while the delegation window arithmetic and
+ * its cycle guard live in one auditable place.
+ *
+ * Substitution is deliberately single-hop and cycle-safe: a delegate that
+ * points back at an already-visited participant is logged and refused rather
+ * than followed, so a mis-configured delegation chain can never route a task
+ * to an unbounded set of users.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Routing
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/specs/role-based-step-routing/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Routing;
+
+use DateTimeImmutable;
+use OCA\Procest\AppInfo\Application;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Substitutes participants for their active delegates, cycle-safe.
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/specs/role-based-step-routing/spec.md
+ */
+class RoleDelegationResolver
+{
+    /**
+     * Constructor.
+     *
+     * @param LoggerInterface $logger Logger (records refused delegation cycles).
+     */
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Substitute delegates inside an active delegation window; break cycles.
+     *
+     * @param array<int, string>               $participants Raw resolver output.
+     * @param array<int, array<string, mixed>> $roles        All case roles.
+     *
+     * @return array<int, string> The participants with active delegates substituted in.
+     *
+     * @spec openspec/specs/role-based-step-routing/spec.md
+     */
+    public function apply(array $participants, array $roles): array
+    {
+        $now    = new DateTimeImmutable('now');
+        $byUser = [];
+        foreach ($roles as $role) {
+            $participant = (string) ($role['participant'] ?? '');
+            if ($participant !== '') {
+                $byUser[$participant] = $role;
+            }
+        }
+
+        $result = [];
+        foreach ($participants as $participant) {
+            $result[] = $this->resolveDelegate(
+                participant: $participant,
+                byUser: $byUser,
+                now: $now,
+            );
+        }
+
+        return $result;
+    }//end apply()
+
+    /**
+     * Resolve one participant to its active delegate (single hop, cycle-safe).
+     *
+     * @param string                              $participant The original participant.
+     * @param array<string, array<string, mixed>> $byUser      Case roles indexed by participant.
+     * @param DateTimeImmutable                   $now         The evaluation moment.
+     *
+     * @return string The delegate when an active window applies, else the participant.
+     */
+    private function resolveDelegate(string $participant, array $byUser, DateTimeImmutable $now): string
+    {
+        $resolved = $participant;
+        $visited  = [$participant => true];
+        while (isset($byUser[$resolved]) === true) {
+            $role     = $byUser[$resolved];
+            $from     = (string) ($role['delegateFrom'] ?? '');
+            $until    = (string) ($role['delegateUntil'] ?? '');
+            $delegate = (string) ($role['delegate'] ?? '');
+            if ($delegate === '' || $from === '' || $until === '') {
+                break;
+            }
+
+            try {
+                $fromAt  = new DateTimeImmutable($from);
+                $untilAt = new DateTimeImmutable($until);
+            } catch (Throwable $e) {
+                break;
+            }
+
+            if ($now < $fromAt || $now > $untilAt) {
+                break;
+            }
+
+            if (isset($visited[$delegate]) === true) {
+                $this->logger->warning(
+                    'Procest: delegation cycle detected',
+                    [
+                        'event'    => 'RoleRoutingDelegationCycle',
+                        'original' => $participant,
+                        'delegate' => $delegate,
+                        'app'      => Application::APP_ID,
+                    ],
+                );
+                break;
+            }
+
+            $visited[$delegate] = true;
+            $resolved           = $delegate;
+
+            // Per spec: break after exactly one hop.
+            break;
+        }//end while
+
+        return $resolved;
+    }//end resolveDelegate()
+}//end class

--- a/lib/Service/Support/ObjectArrayNormalizer.php
+++ b/lib/Service/Support/ObjectArrayNormalizer.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * Procest OpenRegister return-value normalizer.
+ *
+ * OpenRegister's ObjectService returns either a plain array (older API) or an
+ * entity exposing `jsonSerialize()` / `toArray()` (newer API), so every caller
+ * that wants an associative array has to collapse both shapes. Split out of
+ * the parafering services, which each carried their own private copy.
+ *
+ * Two methods, deliberately: the strict form treats an object it cannot
+ * serialise as "no data" and answers `[]`, while the cast form falls back to
+ * `(array) $value` and exposes the object's public properties. The route
+ * engine relied on the cast fallback and the action recorder relied on the
+ * empty answer — collapsing them into one behaviour would silently change one
+ * of the two, so both are kept and named for what they do.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Support
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/changes/parafering-actions/tasks.md#T02
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Support;
+
+/**
+ * Collapses OpenRegister's array-or-entity return shape into an array.
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/changes/parafering-actions/tasks.md#T02
+ */
+class ObjectArrayNormalizer
+{
+    /**
+     * Normalise a return value to an array, answering `[]` for anything that
+     * cannot be serialised.
+     *
+     * @param mixed $value The value to normalise.
+     *
+     * @return array<string, mixed> The associative array, or `[]`.
+     *
+     * @spec openspec/changes/parafering-actions/tasks.md#T02
+     */
+    public function toArray(mixed $value): array
+    {
+        if (is_array($value) === true) {
+            return $value;
+        }
+
+        return ($this->serialiseObject(value: $value) ?? []);
+    }//end toArray()
+
+    /**
+     * Normalise a return value to an array, falling back to an object cast.
+     *
+     * Use where the caller previously relied on an un-serialisable object
+     * still yielding its public properties rather than an empty array.
+     *
+     * @param mixed $value The value to normalise.
+     *
+     * @return array<string, mixed> The associative array, or `[]` for scalars/null.
+     *
+     * @spec openspec/changes/parafeerroute-engine/tasks.md#T04
+     */
+    public function toArrayWithCast(mixed $value): array
+    {
+        if (is_array($value) === true) {
+            return $value;
+        }
+
+        if (is_object($value) === false) {
+            return [];
+        }
+
+        return ($this->serialiseObject(value: $value) ?? (array) $value);
+    }//end toArrayWithCast()
+
+    /**
+     * Try the two serialisation methods OpenRegister entities expose.
+     *
+     * @param mixed $value The candidate object.
+     *
+     * @return array<string, mixed>|null The serialised array, or null when the
+     *                                   value is not a serialisable object.
+     */
+    private function serialiseObject(mixed $value): ?array
+    {
+        if (is_object($value) === false) {
+            return null;
+        }
+
+        if (method_exists($value, 'jsonSerialize') === true) {
+            $serialized = $value->jsonSerialize();
+            if (is_array($serialized) === true) {
+                return $serialized;
+            }
+        }
+
+        if (method_exists($value, 'toArray') === true) {
+            $converted = $value->toArray();
+            if (is_array($converted) === true) {
+                return $converted;
+            }
+        }
+
+        return null;
+    }//end serialiseObject()
+}//end class

--- a/lib/Service/Tenant/TenantBrandingSanitiser.php
+++ b/lib/Service/Tenant/TenantBrandingSanitiser.php
@@ -1,0 +1,232 @@
+<?php
+
+/**
+ * Procest tenant branding sanitiser.
+ *
+ * Owns the fail-closed validation of every tenant-supplied branding input:
+ * the hex-colour check on primary/secondary colours, the MIME-type + 5 MB
+ * guard on an uploaded logo, and the whitelist-based custom-CSS sanitiser.
+ * Split out of TenantConfigurationService so that service keeps configuration
+ * *storage* — read, merge, persist — while the rules that decide what a tenant
+ * is allowed to inject into other users' pages live in one auditable place.
+ *
+ * Both CSS rules are deliberately whitelist-shaped rather than blacklist-
+ * shaped: an unrecognised property is dropped and a sheet containing any
+ * dangerous token is discarded whole, so a novel injection vector fails closed
+ * instead of passing through unrecognised.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Tenant
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/specs/security-hardening/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Tenant;
+
+use InvalidArgumentException;
+
+/**
+ * Fail-closed validation of tenant-supplied branding input.
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/specs/security-hardening/spec.md
+ */
+class TenantBrandingSanitiser
+{
+    /**
+     * Maximum logo size in bytes (5MB).
+     *
+     * @var int
+     */
+    public const LOGO_MAX_BYTES = 5_242_880;
+
+    /**
+     * Allowed logo MIME types.
+     *
+     * @var array<int, string>
+     */
+    public const LOGO_ALLOWED_MIME = ['image/png', 'image/jpeg', 'image/svg+xml', 'image/webp'];
+
+    /**
+     * Custom-CSS property whitelist (sanitiser).
+     *
+     * @var array<int, string>
+     */
+    public const CSS_PROPERTY_WHITELIST = [
+        'color',
+        'background-color',
+        'border-color',
+        'font-family',
+        'font-size',
+        'font-weight',
+        'border-radius',
+        'padding',
+        'margin',
+        '--nc-color-primary',
+        '--nc-color-primary-element',
+        '--nc-color-text',
+        '--nc-border-radius',
+    ];
+
+    /**
+     * CSS tokens that discard the whole sheet when present.
+     *
+     * @var array<int, string>
+     */
+    private const CSS_DANGEROUS_TOKENS = ['url(', 'expression(', '@import', 'javascript:', '<', '>'];
+
+    /**
+     * Sanitise a branding payload — hex-color check, whitelist custom CSS.
+     *
+     * @param array<string,mixed> $branding Input.
+     *
+     * @return array<string,mixed> Sanitised.
+     *
+     * @throws InvalidArgumentException When a hex color is invalid, or the logo
+     *                                 upload fails the MIME/size guard.
+     *
+     * @spec openspec/specs/security-hardening/spec.md
+     */
+    public function sanitiseBranding(array $branding): array
+    {
+        $out = [];
+        if (isset($branding['logo']) === true) {
+            // Fail closed: when the upload carries MIME/size metadata, enforce
+            // the logo MIME-type + 5 MB guard before accepting it.
+            // validateLogoUpload() throws InvalidArgumentException on a
+            // disallowed MIME type or an oversized file.
+            $logoMime  = (string) ($branding['logoMimeType'] ?? '');
+            $logoBytes = (int) ($branding['logoBytes'] ?? 0);
+            if ($logoMime !== '' || $logoBytes > 0) {
+                $this->validateLogoUpload(mimeType: $logoMime, bytes: $logoBytes);
+            }
+
+            $out['logo'] = (string) $branding['logo'];
+        }
+
+        foreach (['primaryColor', 'secondaryColor'] as $colorField) {
+            if (isset($branding[$colorField]) === true) {
+                $val = (string) $branding[$colorField];
+                if ($this->isHexColor(val: $val) === false) {
+                    throw new InvalidArgumentException('Invalid hex color for '.$colorField.': '.$val);
+                }
+
+                $out[$colorField] = $val;
+            }
+        }
+
+        if (isset($branding['fontFamily']) === true) {
+            $out['fontFamily'] = (string) $branding['fontFamily'];
+        }
+
+        if (isset($branding['customCSS']) === true) {
+            $out['customCSS'] = $this->sanitiseCustomCss(css: (string) $branding['customCSS']);
+        }
+
+        return $out;
+    }//end sanitiseBranding()
+
+    /**
+     * Whitelist-based CSS sanitiser. Strips any rule with a property not in
+     * the whitelist or a value containing `url(`, `@import`, `expression`.
+     *
+     * @param string $css Raw CSS.
+     *
+     * @return string Sanitised CSS.
+     *
+     * @spec openspec/specs/security-hardening/spec.md
+     */
+    public function sanitiseCustomCss(string $css): string
+    {
+        // Drop dangerous tokens entirely.
+        foreach (self::CSS_DANGEROUS_TOKENS as $bad) {
+            if (stripos($css, $bad) !== false) {
+                return '';
+            }
+        }
+
+        $lines = preg_split('/[\n;]/', $css);
+        if ($lines === false) {
+            $lines = [];
+        }
+
+        $kept = [];
+        foreach ($lines as $line) {
+            $trim = trim($line);
+            if ($trim === '') {
+                continue;
+            }
+
+            $parts = explode(':', $trim, 2);
+            if (count($parts) !== 2) {
+                continue;
+            }
+
+            $prop = trim(strtolower($parts[0]));
+            $val  = trim($parts[1]);
+            if (in_array($prop, self::CSS_PROPERTY_WHITELIST, true) === false) {
+                continue;
+            }
+
+            $kept[] = $prop.': '.$val;
+        }
+
+        if (count($kept) > 0) {
+            return implode('; ', $kept).';';
+        }
+
+        return '';
+    }//end sanitiseCustomCss()
+
+    /**
+     * Validate that an uploaded logo passes the MIME + size guard.
+     *
+     * @param string $mimeType Uploaded MIME.
+     * @param int    $bytes    Size in bytes.
+     *
+     * @return void
+     *
+     * @throws InvalidArgumentException When the MIME type is not allowed or the
+     *                                 file exceeds the 5 MB ceiling.
+     *
+     * @spec openspec/specs/security-hardening/spec.md
+     */
+    public function validateLogoUpload(string $mimeType, int $bytes): void
+    {
+        if (in_array($mimeType, self::LOGO_ALLOWED_MIME, true) === false) {
+            throw new InvalidArgumentException('Unsupported logo MIME type: '.$mimeType);
+        }
+
+        if ($bytes > self::LOGO_MAX_BYTES) {
+            throw new InvalidArgumentException('Logo exceeds 5MB');
+        }
+    }//end validateLogoUpload()
+
+    /**
+     * Check whether a string is a 6-digit hex color.
+     *
+     * @param string $val 6-digit hex (with leading #).
+     *
+     * @return bool True when the value is exactly `#rrggbb`.
+     *
+     * @spec openspec/specs/security-hardening/spec.md
+     */
+    public function isHexColor(string $val): bool
+    {
+        return preg_match('/^#[0-9a-fA-F]{6}$/', $val) === 1;
+    }//end isHexColor()
+}//end class

--- a/lib/Service/TenantConfigurationService.php
+++ b/lib/Service/TenantConfigurationService.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
 namespace OCA\Procest\Service;
 
 use InvalidArgumentException;
+use OCA\Procest\Service\Tenant\TenantBrandingSanitiser;
 use OCP\App\IAppManager;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
@@ -32,6 +33,10 @@ use Throwable;
 
 /**
  * Per-tenant configuration with sanitised branding inputs.
+ *
+ * Branding validation is owned by {@see TenantBrandingSanitiser}; this service
+ * owns configuration storage — read, merge, persist — plus locale and feature
+ * flags.
  */
 class TenantConfigurationService
 {
@@ -51,47 +56,44 @@ class TenantConfigurationService
 
     /**
      * Maximum logo size in bytes (5MB).
+     *
+     * Canonically owned by {@see TenantBrandingSanitiser}; aliased here so
+     * existing callers keep working.
+     *
+     * @var int
      */
-    public const LOGO_MAX_BYTES = 5_242_880;
+    public const LOGO_MAX_BYTES = TenantBrandingSanitiser::LOGO_MAX_BYTES;
 
     /**
      * Allowed logo MIME types.
      *
+     * Canonically owned by {@see TenantBrandingSanitiser}.
+     *
      * @var array<int, string>
      */
-    public const LOGO_ALLOWED_MIME = ['image/png', 'image/jpeg', 'image/svg+xml', 'image/webp'];
+    public const LOGO_ALLOWED_MIME = TenantBrandingSanitiser::LOGO_ALLOWED_MIME;
 
     /**
      * Custom-CSS property whitelist (sanitiser).
      *
+     * Canonically owned by {@see TenantBrandingSanitiser}.
+     *
      * @var array<int, string>
      */
-    public const CSS_PROPERTY_WHITELIST = [
-        'color',
-        'background-color',
-        'border-color',
-        'font-family',
-        'font-size',
-        'font-weight',
-        'border-radius',
-        'padding',
-        'margin',
-        '--nc-color-primary',
-        '--nc-color-primary-element',
-        '--nc-color-text',
-        '--nc-border-radius',
-    ];
+    public const CSS_PROPERTY_WHITELIST = TenantBrandingSanitiser::CSS_PROPERTY_WHITELIST;
 
     /**
      * Constructor.
      *
-     * @param IAppManager        $appManager App manager.
-     * @param ContainerInterface $container  Service container.
-     * @param LoggerInterface    $logger     Logger.
+     * @param IAppManager             $appManager App manager.
+     * @param ContainerInterface      $container  Service container.
+     * @param TenantBrandingSanitiser $sanitiser  Fail-closed branding input validation.
+     * @param LoggerInterface         $logger     Logger.
      */
     public function __construct(
         private readonly IAppManager $appManager,
         private readonly ContainerInterface $container,
+        private readonly TenantBrandingSanitiser $sanitiser,
         private readonly LoggerInterface $logger,
     ) {
     }//end __construct()
@@ -245,41 +247,7 @@ class TenantConfigurationService
      */
     public function sanitiseBranding(array $branding): array
     {
-        $out = [];
-        if (isset($branding['logo']) === true) {
-            // Fail closed: when the upload carries MIME/size metadata, enforce
-            // the logo MIME-type + 5 MB guard before accepting it.
-            // validateLogoUpload() throws InvalidArgumentException on a
-            // disallowed MIME type or an oversized file.
-            $logoMime  = (string) ($branding['logoMimeType'] ?? '');
-            $logoBytes = (int) ($branding['logoBytes'] ?? 0);
-            if ($logoMime !== '' || $logoBytes > 0) {
-                $this->validateLogoUpload(mimeType: $logoMime, bytes: $logoBytes);
-            }
-
-            $out['logo'] = (string) $branding['logo'];
-        }
-
-        foreach (['primaryColor', 'secondaryColor'] as $colorField) {
-            if (isset($branding[$colorField]) === true) {
-                $val = (string) $branding[$colorField];
-                if ($this->isHexColor(val: $val) === false) {
-                    throw new InvalidArgumentException('Invalid hex color for '.$colorField.': '.$val);
-                }
-
-                $out[$colorField] = $val;
-            }
-        }
-
-        if (isset($branding['fontFamily']) === true) {
-            $out['fontFamily'] = (string) $branding['fontFamily'];
-        }
-
-        if (isset($branding['customCSS']) === true) {
-            $out['customCSS'] = $this->sanitiseCustomCss(css: (string) $branding['customCSS']);
-        }
-
-        return $out;
+        return $this->sanitiser->sanitiseBranding(branding: $branding);
     }//end sanitiseBranding()
 
     /**
@@ -292,45 +260,7 @@ class TenantConfigurationService
      */
     public function sanitiseCustomCss(string $css): string
     {
-        // Drop dangerous tokens entirely.
-        $dangerous = ['url(', 'expression(', '@import', 'javascript:', '<', '>'];
-        foreach ($dangerous as $bad) {
-            if (stripos($css, $bad) !== false) {
-                return '';
-            }
-        }
-
-        $lines = preg_split('/[\n;]/', $css);
-        if ($lines === false) {
-            $lines = [];
-        }
-
-        $kept = [];
-        foreach ($lines as $line) {
-            $trim = trim($line);
-            if ($trim === '') {
-                continue;
-            }
-
-            $parts = explode(':', $trim, 2);
-            if (count($parts) !== 2) {
-                continue;
-            }
-
-            $prop = trim(strtolower($parts[0]));
-            $val  = trim($parts[1]);
-            if (in_array($prop, self::CSS_PROPERTY_WHITELIST, true) === false) {
-                continue;
-            }
-
-            $kept[] = $prop.': '.$val;
-        }
-
-        if (count($kept) > 0) {
-            return implode('; ', $kept).';';
-        }
-
-        return '';
+        return $this->sanitiser->sanitiseCustomCss(css: $css);
     }//end sanitiseCustomCss()
 
     /**
@@ -345,13 +275,7 @@ class TenantConfigurationService
      */
     public function validateLogoUpload(string $mimeType, int $bytes): void
     {
-        if (in_array($mimeType, self::LOGO_ALLOWED_MIME, true) === false) {
-            throw new InvalidArgumentException('Unsupported logo MIME type: '.$mimeType);
-        }
-
-        if ($bytes > self::LOGO_MAX_BYTES) {
-            throw new InvalidArgumentException('Logo exceeds 5MB');
-        }
+        $this->sanitiser->validateLogoUpload(mimeType: $mimeType, bytes: $bytes);
     }//end validateLogoUpload()
 
     /**
@@ -363,7 +287,7 @@ class TenantConfigurationService
      */
     public function isHexColor(string $val): bool
     {
-        return preg_match('/^#[0-9a-fA-F]{6}$/', $val) === 1;
+        return $this->sanitiser->isHexColor(val: $val);
     }//end isHexColor()
 
     /**

--- a/lib/Service/Zaakdossier/InformatieobjectStatusLifecycle.php
+++ b/lib/Service/Zaakdossier/InformatieobjectStatusLifecycle.php
@@ -1,0 +1,226 @@
+<?php
+
+/**
+ * Procest informatieobject status lifecycle.
+ *
+ * Owns the ZGW DRC `concept -> definitief -> gearchiveerd` lifecycle for a
+ * single informatieobject: which transitions are legal, what a legal
+ * transition writes back (including the `vergrendeldOp` lock stamp that
+ * `definitief` sets), and how a bulk run reports per-id success and failure.
+ * Split out of ZaakdossierService so that service keeps the dossier as a whole
+ * — upload, join, grouping, metadata — while the state machine that governs a
+ * single document lives in one place.
+ *
+ * The transition table is forward-only and a same-state transition is refused,
+ * so a document can never be silently un-locked by replaying its own status.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Zaakdossier
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/changes/document-zaakdossier/tasks.md#T02
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Zaakdossier;
+
+use InvalidArgumentException;
+use OCA\Procest\AppInfo\Application;
+use OCA\Procest\Service\SettingsService;
+use OCA\Procest\Service\Support\SearchesObjects;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * The forward-only status state machine for a ZGW informatieobject.
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/changes/document-zaakdossier/tasks.md#T02
+ */
+class InformatieobjectStatusLifecycle
+{
+
+    use SearchesObjects;
+
+    /**
+     * Valid informatieobject statuses.
+     *
+     * @var string[]
+     */
+    public const VALID_STATUSES = [
+        'concept',
+        'definitief',
+        'gearchiveerd',
+    ];
+
+    /**
+     * Allowed forward-only status transitions (from => [allowed-to, ...]).
+     *
+     * @var array<string, string[]>
+     */
+    public const STATUS_TRANSITIONS = [
+        'concept'      => ['definitief'],
+        'definitief'   => ['gearchiveerd'],
+        'gearchiveerd' => [],
+    ];
+
+    /**
+     * Constructor.
+     *
+     * @param SettingsService $settingsService Settings service (config + ObjectService).
+     * @param LoggerInterface $logger          Logger.
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Determine whether a status transition is permitted (forward-only).
+     *
+     * @param string $from The current status.
+     * @param string $to   The requested status.
+     *
+     * @return bool True when allowed.
+     *
+     * @spec openspec/changes/document-zaakdossier/tasks.md#T02
+     */
+    public function isTransitionAllowed(string $from, string $to): bool
+    {
+        if ($from === $to) {
+            return false;
+        }
+
+        $allowed = (self::STATUS_TRANSITIONS[$from] ?? []);
+
+        return in_array($to, $allowed, true);
+    }//end isTransitionAllowed()
+
+    /**
+     * Transition a single informatieobject to a new status.
+     *
+     * @param string $infoObjectId The informatieobject UUID.
+     * @param string $newStatus    The requested status.
+     *
+     * @return array<string, mixed> The updated informatieobject summary.
+     *
+     * @throws RuntimeException         When OpenRegister/config is unavailable or the document is missing.
+     * @throws InvalidArgumentException When the status is unknown or the transition is not permitted.
+     *
+     * @spec openspec/changes/document-zaakdossier/tasks.md#T02
+     */
+    public function transition(string $infoObjectId, string $newStatus): array
+    {
+        if (in_array($newStatus, self::VALID_STATUSES, true) === false) {
+            throw new InvalidArgumentException('Invalid status: '.$newStatus);
+        }
+
+        [$objectService, $register] = $this->requireRegister();
+        $infoSchema = $this->settingsService->getConfigValue('dossier_informatieobject_schema');
+
+        $current = $this->findObjectAsArray(
+            objectService: $objectService,
+            register: $register,
+            schema: $infoSchema,
+            id: $infoObjectId,
+        );
+
+        if ($current === null) {
+            throw new RuntimeException('Informatieobject not found: '.$infoObjectId);
+        }
+
+        $currentStatus = (string) ($current['status'] ?? 'concept');
+        if ($this->isTransitionAllowed(from: $currentStatus, to: $newStatus) === false) {
+            throw new InvalidArgumentException(
+                'Invalid status transition from '.$currentStatus.' to '.$newStatus
+            );
+        }
+
+        $updateData = ['status' => $newStatus];
+        if ($newStatus === 'definitief') {
+            $updateData['vergrendeldOp'] = date('Y-m-d\TH:i:s');
+        }
+
+        $objectService->saveObject(object: $updateData, register: $register, schema: $infoSchema, uuid: $infoObjectId);
+
+        $this->logger->info(
+            'Procest dossier: informatieobject '.$infoObjectId.' transitioned '.$currentStatus.' -> '.$newStatus,
+            ['app' => Application::APP_ID],
+        );
+
+        // Carry `vergrendeldOp` through only when the transition set it to a
+        // non-null value. Kept as an isset() test rather than
+        // array_intersect_key(), which would also carry an explicitly-null
+        // value through and write a null back over the stored field.
+        $vergrendeldOp = [];
+        if (isset($updateData['vergrendeldOp']) === true) {
+            $vergrendeldOp = ['vergrendeldOp' => $updateData['vergrendeldOp']];
+        }
+
+        return array_merge(
+            ['id' => $infoObjectId, 'status' => $newStatus],
+            $vergrendeldOp,
+        );
+    }//end transition()
+
+    /**
+     * Apply a bulk status transition, returning a per-id success/failure list.
+     *
+     * @param string[] $infoObjectIds The informatieobject UUIDs.
+     * @param string   $newStatus     The requested status.
+     *
+     * @return array<int, array<string, mixed>> Per-id results with `id`, `success`, optional `error`.
+     *
+     * @spec openspec/changes/document-zaakdossier/tasks.md#T02
+     */
+    public function transitionMany(array $infoObjectIds, string $newStatus): array
+    {
+        $results = [];
+        foreach ($infoObjectIds as $id) {
+            $id = (string) $id;
+            try {
+                $this->transition(infoObjectId: $id, newStatus: $newStatus);
+                $results[] = ['id' => $id, 'success' => true];
+            } catch (\Throwable $e) {
+                $results[] = ['id' => $id, 'success' => false, 'error' => $e->getMessage()];
+            }
+        }
+
+        return $results;
+    }//end transitionMany()
+
+    /**
+     * Resolve the ObjectService and register, throwing when unavailable.
+     *
+     * @return array{0: object, 1: string} The object service and register slug.
+     *
+     * @throws RuntimeException When OpenRegister or the register config is unavailable.
+     */
+    private function requireRegister(): array
+    {
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            throw new RuntimeException('OpenRegister is not available');
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        if ($register === '') {
+            throw new RuntimeException('Dossier register not configured');
+        }
+
+        return [$objectService, $register];
+    }//end requireRegister()
+}//end class

--- a/lib/Service/ZaakdossierService.php
+++ b/lib/Service/ZaakdossierService.php
@@ -35,11 +35,16 @@ use DomainException;
 use InvalidArgumentException;
 use OCA\Procest\AppInfo\Application;
 use OCA\Procest\Service\Support\SearchesObjects;
+use OCA\Procest\Service\Zaakdossier\InformatieobjectStatusLifecycle;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 
 /**
  * Service orchestrating the ZGW DRC zaakdossier.
+ *
+ * The per-document status state machine is owned by
+ * {@see InformatieobjectStatusLifecycle}; this service orchestrates the
+ * dossier around it.
  */
 class ZaakdossierService
 {
@@ -47,34 +52,38 @@ class ZaakdossierService
 
     /**
      * Valid informatieobject statuses.
+     *
+     * Canonically owned by {@see InformatieobjectStatusLifecycle}; aliased here
+     * so existing callers of `ZaakdossierService::VALID_STATUSES` keep working.
+     *
+     * @var string[]
      */
-    public const VALID_STATUSES = [
-        'concept',
-        'definitief',
-        'gearchiveerd',
-    ];
+    public const VALID_STATUSES = InformatieobjectStatusLifecycle::VALID_STATUSES;
 
     /**
      * Allowed forward-only status transitions (from => [allowed-to, ...]).
+     *
+     * Canonically owned by {@see InformatieobjectStatusLifecycle}; aliased here
+     * for backwards compatibility.
+     *
+     * @var array<string, string[]>
      */
-    public const STATUS_TRANSITIONS = [
-        'concept'      => ['definitief'],
-        'definitief'   => ['gearchiveerd'],
-        'gearchiveerd' => [],
-    ];
+    public const STATUS_TRANSITIONS = InformatieobjectStatusLifecycle::STATUS_TRANSITIONS;
 
     /**
      * Constructor.
      *
-     * @param SettingsService             $settingsService Settings service (config + ObjectService).
-     * @param ZgwDocumentService          $documentService Binary file storage service.
-     * @param InformatieobjectAccessGuard $accessGuard     Classification access guard.
-     * @param LoggerInterface             $logger          Logger.
+     * @param SettingsService                 $settingsService Settings service (config + ObjectService).
+     * @param ZgwDocumentService              $documentService Binary file storage service.
+     * @param InformatieobjectAccessGuard     $accessGuard     Classification access guard.
+     * @param InformatieobjectStatusLifecycle $statusLifecycle Per-document status state machine.
+     * @param LoggerInterface                 $logger          Logger.
      */
     public function __construct(
         private readonly SettingsService $settingsService,
         private readonly ZgwDocumentService $documentService,
         private readonly InformatieobjectAccessGuard $accessGuard,
+        private readonly InformatieobjectStatusLifecycle $statusLifecycle,
         private readonly LoggerInterface $logger,
     ) {
     }//end __construct()
@@ -265,56 +274,7 @@ class ZaakdossierService
      */
     public function transitionStatus(string $infoObjectId, string $newStatus): array
     {
-        if (in_array($newStatus, self::VALID_STATUSES, true) === false) {
-            throw new InvalidArgumentException('Invalid status: '.$newStatus);
-        }
-
-        [$objectService, $register] = $this->requireRegister();
-        $infoSchema = $this->settingsService->getConfigValue('dossier_informatieobject_schema');
-
-        $current = $this->findObjectAsArray(
-            objectService: $objectService,
-            register: $register,
-            schema: $infoSchema,
-            id: $infoObjectId,
-        );
-
-        if ($current === null) {
-            throw new RuntimeException('Informatieobject not found: '.$infoObjectId);
-        }
-
-        $currentStatus = (string) ($current['status'] ?? 'concept');
-        if ($this->isTransitionAllowed(from: $currentStatus, to: $newStatus) === false) {
-            throw new InvalidArgumentException(
-                'Invalid status transition from '.$currentStatus.' to '.$newStatus
-            );
-        }
-
-        $updateData = ['status' => $newStatus];
-        if ($newStatus === 'definitief') {
-            $updateData['vergrendeldOp'] = date('Y-m-d\TH:i:s');
-        }
-
-        $objectService->saveObject(object: $updateData, register: $register, schema: $infoSchema, uuid: $infoObjectId);
-
-        $this->logger->info(
-            'Procest dossier: informatieobject '.$infoObjectId.' transitioned '.$currentStatus.' -> '.$newStatus,
-            ['app' => Application::APP_ID],
-        );
-
-        // Carry `vergrendeldOp` through only when the transition set it to a
-        // non-null value. Kept as an isset() test rather than
-        // array_intersect_key(), which would also carry an explicitly-null
-        // value through and write a null back over the stored field.
-        $vergrendeldOp = [];
-        if (isset($updateData['vergrendeldOp']) === true) {
-            $vergrendeldOp = ['vergrendeldOp' => $updateData['vergrendeldOp']];
-        }
-
-        return array_merge(
-            ['id' => $infoObjectId, 'status' => $newStatus],
-            $vergrendeldOp,
-        );
+        return $this->statusLifecycle->transition(infoObjectId: $infoObjectId, newStatus: $newStatus);
     }//end transitionStatus()
 
     /**
@@ -329,12 +289,7 @@ class ZaakdossierService
      */
     public function isTransitionAllowed(string $from, string $to): bool
     {
-        if ($from === $to) {
-            return false;
-        }
-
-        $allowed = (self::STATUS_TRANSITIONS[$from] ?? []);
-        return in_array($to, $allowed, true);
+        return $this->statusLifecycle->isTransitionAllowed(from: $from, to: $to);
     }//end isTransitionAllowed()
 
     /**
@@ -436,18 +391,7 @@ class ZaakdossierService
      */
     public function bulkTransitionStatus(array $infoObjectIds, string $newStatus): array
     {
-        $results = [];
-        foreach ($infoObjectIds as $id) {
-            $id = (string) $id;
-            try {
-                $this->transitionStatus(infoObjectId: $id, newStatus: $newStatus);
-                $results[] = ['id' => $id, 'success' => true];
-            } catch (\Throwable $e) {
-                $results[] = ['id' => $id, 'success' => false, 'error' => $e->getMessage()];
-            }
-        }
-
-        return $results;
+        return $this->statusLifecycle->transitionMany(infoObjectIds: $infoObjectIds, newStatus: $newStatus);
     }//end bulkTransitionStatus()
 
     /**

--- a/tests/Unit/Service/DsoCaseServiceTest.php
+++ b/tests/Unit/Service/DsoCaseServiceTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Tests\Unit\Service;
 
+use OCA\Procest\Service\Dso\DsoStatusChangeNotifier;
 use OCA\Procest\Service\DsoCaseService;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IAppConfig;
@@ -121,10 +122,12 @@ class DsoCaseServiceTest extends TestCase
         $this->eventDispatcher = $this->createMock(IEventDispatcher::class);
         $this->logger          = $this->createMock(LoggerInterface::class);
 
+        // A REAL notifier over the same mocked dispatcher, so an assertion on
+        // $this->eventDispatcher still observes the event the service emits.
         $this->service = new DsoCaseService(
             appConfig: $this->appConfig,
             container: $this->container,
-            eventDispatcher: $this->eventDispatcher,
+            notifier: new DsoStatusChangeNotifier(eventDispatcher: $this->eventDispatcher),
             logger: $this->logger,
         );
     }//end setUp()

--- a/tests/Unit/Service/MandaatImportServiceTest.php
+++ b/tests/Unit/Service/MandaatImportServiceTest.php
@@ -22,6 +22,8 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Tests\Unit\Service;
 
+use OCA\Procest\Service\Mandaat\MandaatCsvParser;
+use OCA\Procest\Service\Mandaat\MandaatRepository;
 use OCA\Procest\Service\MandaatImportService;
 use OCA\Procest\Service\SettingsService;
 use PHPUnit\Framework\TestCase;
@@ -30,6 +32,8 @@ use RuntimeException;
 
 /**
  * @covers \OCA\Procest\Service\MandaatImportService
+ * @covers \OCA\Procest\Service\Mandaat\MandaatRepository
+ * @covers \OCA\Procest\Service\Mandaat\MandaatCsvParser
  */
 class MandaatImportServiceTest extends TestCase
 {
@@ -52,7 +56,12 @@ class MandaatImportServiceTest extends TestCase
                 };
             },
         );
-        $this->service = new MandaatImportService($settings, $this->createMock(LoggerInterface::class));
+        // REAL repository + parser over the same fake object store, so these
+        // tests still exercise the production register access and CSV parsing.
+        $this->service = new MandaatImportService(
+            repository: new MandaatRepository($settings, $this->createMock(LoggerInterface::class)),
+            csvParser: new MandaatCsvParser(),
+        );
 
         // Seed roles.
         $this->objects->saveObject('procest', 'organisatieRol', ['id' => 'rol-consulent', 'rolNaam' => 'Consulent']);

--- a/tests/Unit/Service/MilestoneServiceStalledTest.php
+++ b/tests/Unit/Service/MilestoneServiceStalledTest.php
@@ -23,6 +23,8 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Tests\Unit\Service;
 
+use OCA\Procest\Service\Milestone\MilestoneRepository;
+use OCA\Procest\Service\Milestone\StalledCaseDetector;
 use OCA\Procest\Service\MilestoneService;
 use OCA\Procest\Service\SettingsService;
 use PHPUnit\Framework\TestCase;
@@ -32,6 +34,8 @@ use Psr\Log\LoggerInterface;
  * Unit tests for MilestoneService::findStalledCases().
  *
  * @covers \OCA\Procest\Service\MilestoneService
+ * @covers \OCA\Procest\Service\Milestone\StalledCaseDetector
+ * @covers \OCA\Procest\Service\Milestone\MilestoneRepository
  */
 class MilestoneServiceStalledTest extends TestCase
 {
@@ -62,6 +66,32 @@ class MilestoneServiceStalledTest extends TestCase
         $this->logger          = $this->createMock(LoggerInterface::class);
 
     }//end setUp()
+
+
+    /**
+     * Build the service under test with REAL collaborators.
+     *
+     * The repository and the stalled-case detector are deliberately real, not
+     * mocks: these tests assert the production stall arithmetic, so a mocked
+     * detector would only ever replay its own canned answer.
+     *
+     * @return MilestoneService The service wired over the mocked settings service.
+     */
+    private function buildService(): MilestoneService
+    {
+        $repository = new MilestoneRepository(settingsService: $this->settingsService);
+
+        return new MilestoneService(
+            settingsService: $this->settingsService,
+            repository: $repository,
+            stalledDetector: new StalledCaseDetector(
+                settingsService: $this->settingsService,
+                repository: $repository,
+            ),
+            logger: $this->logger,
+        );
+
+    }//end buildService()
 
 
     /**
@@ -180,7 +210,7 @@ class MilestoneServiceStalledTest extends TestCase
         );
 
         $this->wireSettings($objectService);
-        $service = new MilestoneService($this->settingsService, $this->logger);
+        $service = $this->buildService();
 
         $stalled = $service->findStalledCases(thresholdDays: 0);
 
@@ -229,7 +259,7 @@ class MilestoneServiceStalledTest extends TestCase
         );
 
         $this->wireSettings($objectService);
-        $service = new MilestoneService($this->settingsService, $this->logger);
+        $service = $this->buildService();
 
         $this->assertCount(0, $service->findStalledCases(thresholdDays: 0));
 
@@ -271,7 +301,7 @@ class MilestoneServiceStalledTest extends TestCase
         );
 
         $this->wireSettings($objectService);
-        $service = new MilestoneService($this->settingsService, $this->logger);
+        $service = $this->buildService();
 
         $this->assertCount(0, $service->findStalledCases(thresholdDays: 0));
 
@@ -322,7 +352,7 @@ class MilestoneServiceStalledTest extends TestCase
         );
 
         $this->wireSettings($objectService);
-        $service = new MilestoneService($this->settingsService, $this->logger);
+        $service = $this->buildService();
 
         $this->assertCount(0, $service->findStalledCases(thresholdDays: 0));
 

--- a/tests/Unit/Service/TenantConfigurationServiceTest.php
+++ b/tests/Unit/Service/TenantConfigurationServiceTest.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace OCA\Procest\Tests\Unit\Service;
 
 use InvalidArgumentException;
+use OCA\Procest\Service\Tenant\TenantBrandingSanitiser;
 use OCA\Procest\Service\TenantConfigurationService;
 use OCP\App\IAppManager;
 use PHPUnit\Framework\TestCase;
@@ -26,6 +27,7 @@ use Psr\Log\LoggerInterface;
 
 /**
  * @covers \OCA\Procest\Service\TenantConfigurationService
+ * @covers \OCA\Procest\Service\Tenant\TenantBrandingSanitiser
  */
 class TenantConfigurationServiceTest extends TestCase
 {
@@ -34,9 +36,13 @@ class TenantConfigurationServiceTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+        // A REAL sanitiser, not a mock: these tests assert the production
+        // fail-closed branding rules, so a mocked collaborator would only
+        // replay its own canned answer.
         $this->svc = new TenantConfigurationService(
             appManager: $this->createMock(IAppManager::class),
             container: $this->createMock(ContainerInterface::class),
+            sanitiser: new TenantBrandingSanitiser(),
             logger: $this->createMock(LoggerInterface::class),
         );
     }

--- a/tests/Unit/Service/ZaakdossierServiceTest.php
+++ b/tests/Unit/Service/ZaakdossierServiceTest.php
@@ -31,6 +31,7 @@ namespace OCA\Procest\Tests\Unit\Service;
 use OCA\Procest\Service\InformatieobjectAccessGuard;
 use OCA\Procest\Service\SettingsService;
 use OCA\Procest\Service\ZaakdossierService;
+use OCA\Procest\Service\Zaakdossier\InformatieobjectStatusLifecycle;
 use OCA\Procest\Service\ZgwDocumentService;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -159,10 +160,17 @@ class ZaakdossierServiceTest extends TestCase
             groupManager: $this->createMock(\OCP\IGroupManager::class),
             logger: $this->createMock(LoggerInterface::class),
         );
+        // A REAL lifecycle collaborator over the same mocked settings, so the
+        // status-transition tests below still exercise the production state
+        // machine end to end rather than a mock's canned answers.
         $this->service = new ZaakdossierService(
             settingsService: $this->settings,
             documentService: $this->documents,
             accessGuard: $this->accessGuard,
+            statusLifecycle: new InformatieobjectStatusLifecycle(
+                settingsService: $this->settings,
+                logger: $this->createMock(LoggerInterface::class),
+            ),
             logger: $this->createMock(LoggerInterface::class),
         );
 


### PR DESCRIPTION
## What

Clears the **10 remaining PHPMD architectural findings** in the parafering / tenant / role service cluster **by decomposition**. No `@SuppressWarnings` was added, no phpmd/psalm/phpstan baseline was created or extended, and `phpmd.xml` thresholds are untouched.

## Before → after, per class

### `ExcessiveClassComplexity` (WMC, threshold 50 — reports at `>= 50`)

| class | before | after | extracted |
|---|---:|---:|---|
| `lib/Service/EmailTemplateService.php` | 50 | **22** | `Email\EmailTemplateRepository` |
| `lib/Service/ZaakdossierService.php` | 50 | **42** | `Zaakdossier\InformatieobjectStatusLifecycle` |
| `lib/Service/RoleResolverService.php` | 51 | **38** | `Routing\RoleDelegationResolver` |
| `lib/Service/MilestoneService.php` | 53 | **18** | `Milestone\MilestoneRepository`, `Milestone\StalledCaseDetector` |
| `lib/Service/TenantConfigurationService.php` | 54 | **32** | `Tenant\TenantBrandingSanitiser` |
| `lib/Service/MandaatImportService.php` | 73 | **27** | `Mandaat\MandaatRepository`, `Mandaat\MandaatCsvParser` |
| `lib/Service/ParafeerRouteService.php` | 74 | **45** | `Parafering\ParaferingStepActivator`, `Parafering\VoorstelRouteMapper`, `Support\ObjectArrayNormalizer` |
| `lib/Service/ParafeerActieService.php` | 79 | **43** | `Parafeer\ParafeerStepGuard`, `Parafeer\ParafeerVoorstelRepository`, `Support\ObjectArrayNormalizer` |

### `CouplingBetweenObjects` (threshold 13 — reports at `>= 13`)

| class | before | after | extracted |
|---|---:|---:|---|
| `lib/Service/DsoCaseService.php` | 13 | **12** | `Dso\DsoStatusChangeNotifier` |
| `lib/Service/Beschikking/LibresignSigningAdapter.php` | 14 | **12** | `Beschikking\LibresignResultAssembler` |

## New classes and what each one owns

| class | owns |
|---|---|
| `lib/Service/Email/EmailTemplateRepository.php` | Every OpenRegister read/write the emailTemplate registry needs — active-template query, single-template load, template persistence, and the case load prefill renders against. `EmailTemplateService` keeps the template *domain*: versioning, seeding, placeholder resolution. |
| `lib/Service/Zaakdossier/InformatieobjectStatusLifecycle.php` | The forward-only `concept → definitief → gearchiveerd` state machine for a single informatieobject: which transitions are legal, what a legal transition writes (including the `vergrendeldOp` lock stamp), and per-id bulk reporting. |
| `lib/Service/Routing/RoleDelegationResolver.php` | The `role.delegate` substitution step: active-window arithmetic and the single-hop cycle guard that refuses (and logs) a delegation loop. |
| `lib/Service/Milestone/MilestoneRepository.php` | The single OpenRegister read path for milestone definitions and records — the repository in the middle is what keeps `MilestoneService` and `StalledCaseDetector` free of a construction cycle. |
| `lib/Service/Milestone/StalledCaseDetector.php` | The stalled-case report: earliest unreached milestone, working-day deadline projection, and the skip rules that define "stalled". |
| `lib/Service/Tenant/TenantBrandingSanitiser.php` | Fail-closed validation of tenant-supplied branding: hex-colour check, logo MIME + 5 MB guard, whitelist-based custom-CSS sanitiser. |
| `lib/Service/Mandaat/MandaatRepository.php` | Every register/schema lookup for the mandaat matrix: role index, prior besluit, besluit mandaten, approval context, bulk activation, configured-schema save. |
| `lib/Service/Mandaat/MandaatCsvParser.php` | The Decidesk CSV wire format: header/required-column check, data rows, and the boolean + semicolon-list cell dialects. |
| `lib/Service/Parafering/ParaferingStepActivator.php` | Activating one route step and resolving its abstract actor into concrete users via the shared `RoleResolverService`. |
| `lib/Service/Parafering/VoorstelRouteMapper.php` | Pure shaping of the two loosely-typed voorstel fields: `routeSnapshot` normalisation (JSON-string-or-array → order-sorted steps) and `auditTrail` appending. |
| `lib/Service/Parafeer/ParafeerStepGuard.php` | The fail-closed gate every parafeeractie passes: current-step resolution, actor/delegate authorisation, step-type action matrix, mandatory-field check. |
| `lib/Service/Parafeer/ParafeerVoorstelRepository.php` | Register/schema resolution and voorstel loads for the parafering actions, plus `ObjectService` resolution in both a degrading and a throwing form. |
| `lib/Service/Support/ObjectArrayNormalizer.php` | Collapsing OpenRegister's array-or-entity return shape. Two named methods on purpose: the route engine relied on a `(array)` cast fallback and the action recorder relied on an empty answer — merging them into one behaviour would have silently changed one of the two. |
| `lib/Service/Dso/DsoStatusChangeNotifier.php` | Building and dispatching `VergunningStatusChangedEvent`, alongside the existing `DsoDoorsturenNotifier`. |
| `lib/Service/Beschikking/LibresignResultAssembler.php` | Reading LibreSign's status vocabulary and shaping what procest publishes — the `sign()` result (incl. materialising and persisting the signed PDF through the **existing** `ZgwDocumentService` path) and the validatierapport. |

## Suppressions

- **Removed** the now-unnecessary class-level `@SuppressWarnings(PHPMD.CouplingBetweenObjects)` on `RoleResolverService` — measured CBO is **12** after the split, and phpmd stays silent without it.
- **Kept** the pre-existing suppressions on `ParafeerActieService` and `ParafeerRouteService`. I removed them, re-measured, and they are **still required** (CBO **21** and **15** respectively); both are now annotated with the measured post-split value rather than left as bare tags. No new suppression was added anywhere.

## Behaviour preservation

- Every public method signature is preserved; extracted logic is reached through one-line delegates, so no caller outside the ten files had to change.
- Moved public constants are aliased back on their original class (`ZaakdossierService::VALID_STATUSES`, `TenantConfigurationService::LOGO_MAX_BYTES`, `MandaatImportService::REQUIRED_COLUMNS`, the `ParafeerActieService` action/step-type constants).
- `LibresignSigningAdapter`'s constructor keeps its `rootFolder:` / `documentService:` named parameters so the DI factory in `AppInfo/Application.php` is untouched; both are handed straight to the assembler.
- Tests wire **real** collaborators rather than mocks, so the production logic they assert is still the logic under test (status transitions, stall arithmetic, branding sanitisation, CSV parsing, register access).

## Measured results

Every measurement below was run in Docker (host PHP is 8.2.x; the repo requires >= 8.3, and `vendor/bin/*` on the host exits 255 while printing nothing — which is indistinguishable from "clean").

```
# phpmd — exactly what `composer phpmd` (and therefore CI) runs
docker run --rm -v "$PWD":/app -w /app php:8.3-cli \
  php vendor/bin/phpmd lib text phpmd.xml > /tmp/p2.out 2> /tmp/p2.err
# before: exit=2 findings=25 stderr_bytes=0
# after:  exit=2 findings=15 stderr_bytes=0
```

25 → 15, a drop of exactly the 10 findings in scope. None of the ten classes appears in the output any more, and the 15 that remain are byte-identical to the pre-existing ones — no new finding was introduced anywhere in `lib/`.

```
docker run --rm -v "$PWD":/app -w /app nextcloud:latest php vendor/bin/phpunit --no-coverage
# Tests: 1684, Assertions: 5614, Deprecations: 10, Skipped: 5  — 0 failures (matches the development baseline)

docker run --rm -v "$PWD":/app -w /app php:8.3-cli php vendor/bin/phpcs --standard=phpcs.xml
# exit=0

docker run --rm -v "$PWD":/app -w /app nextcloud:latest php vendor/bin/psalm --threads=1 --no-cache
# exit=0 — "No errors found!"

docker run --rm -v "$PWD":/app -w /app nextcloud:latest php vendor/bin/phpstan analyse --memory-limit=1G
# exit=0 — "[OK] No errors"
```

Note on the image choice: `php:8.3-cli` has **no ext-zip**, which makes psalm emit 7 spurious `UndefinedClass: ZipArchive` errors in files unrelated to this change (`CaseDefinitionImportService`, `ZipManifestBuilder`) — the same reason phpunit must run on `nextcloud:latest`. Psalm and phpstan were therefore measured on `nextcloud:latest`; phpmd and phpcs are unaffected and were measured on `php:8.3-cli` exactly as `composer` invokes them.

## Guarding against the else/NPath trap

Removing an `else` can *raise* NPath complexity, because sequential guard clauses multiply where an if/else adds. phpmd was re-run after every batch of edits and the total was confirmed to go **down** with **no new finding anywhere in `lib/`** — including the two intermediate runs that caught real regressions this pass: an `ExcessiveParameterList` on a 10-argument constructor (fixed by moving `ObjectService` resolution into `ParafeerVoorstelRepository`) and the two Parafeer `CouplingBetweenObjects` findings that appeared when their suppressions were speculatively removed (restored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
