### PR TITLE
fix(apphost): stop cross-app OpenRegister references from 500ing every procest route

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -29,7 +29,17 @@ declare(strict_types=1);
 // The procest-bespoke dashboard PWA assets (dashboard#serviceWorker /
 // dashboard#webManifest) and every domain route below are passed through as
 // `$extra`; they are inserted before the catch-all so they keep priority.
-return \OCA\OpenRegister\AppHost\Routes::standard([
+//
+// ⚠️ The AppHost builder is invoked through a `class_exists()` guard. Nextcloud
+// `include`s this file for EVERY procest request, so an unguarded static call
+// to a class in another app makes every route in the app fatal with HTTP 500
+// when openregister is absent — not just the AppHost ones. Procest does not
+// declare `<app>openregister</app>`, so an admin can create exactly that
+// configuration. Fixing only the controllers MOVES the fatal here rather than
+// removing it. The fallback branch below reproduces `Routes::standard()`'s
+// output locally so procest still routes without openregister.
+// See decidesk#377 / #388.
+$extra = [
         // Backend manifest delta — case-type navigation (case-type-navigation).
         // Consumed by useAppManifest('procest', bundled, { mergeStrategy: 'delta' }).
         ['name' => 'manifest#manifest',  'url' => '/api/manifest',           'verb' => 'GET'],
@@ -683,5 +693,55 @@ return \OCA\OpenRegister\AppHost\Routes::standard([
 
         // NOTE: dashboard#page (`/`) and the SPA catch-all (`/{path}`,
         // dashboard#catchAll) are supplied by Routes::standard(); both resolve to
-        // procest's DashboardController, which extends GenericDashboardController.
-]);
+        // procest's DashboardController, which implements them locally.
+];
+
+// Preferred path: the OpenRegister AppHost owns the canonical route table.
+// `class_exists()` autoloads without fatalling when the class is unavailable.
+if (class_exists('OCA\OpenRegister\AppHost\Routes') === true) {
+    return \OCA\OpenRegister\AppHost\Routes::standard($extra);
+}
+
+// Fallback: openregister is not installed. Reproduce `Routes::standard()`
+// locally — canonical routes first (minus any name `$extra` overrides), then
+// `$extra`, then the SPA catch-all LAST so it never shadows a real route.
+$canonicalRoutes = [
+    ['name' => 'dashboard#page', 'url' => '/', 'verb' => 'GET'],
+    ['name' => 'settings#index', 'url' => '/api/settings', 'verb' => 'GET'],
+    ['name' => 'settings#create', 'url' => '/api/settings', 'verb' => 'POST'],
+    ['name' => 'settings#update', 'url' => '/api/settings', 'verb' => 'PUT'],
+    ['name' => 'settings#load', 'url' => '/api/settings/load', 'verb' => 'POST'],
+    ['name' => 'preferences#getPreference', 'url' => '/api/preferences/{key}', 'verb' => 'GET'],
+    ['name' => 'preferences#setPreference', 'url' => '/api/preferences/{key}', 'verb' => 'PUT'],
+    ['name' => 'metrics#index', 'url' => '/api/metrics', 'verb' => 'GET'],
+    ['name' => 'health#index', 'url' => '/api/health', 'verb' => 'GET'],
+];
+
+$catchAllRoute = [
+    'name'         => 'dashboard#catchAll',
+    'url'          => '/{path}',
+    'verb'         => 'GET',
+    'requirements' => ['path' => '.+'],
+    'defaults'     => ['path' => ''],
+];
+
+$extraNames = [];
+foreach ($extra as $extraRoute) {
+    if (isset($extraRoute['name']) === true) {
+        $extraNames[(string) $extraRoute['name']] = true;
+    }
+}
+
+$mergedRoutes = [];
+foreach ($canonicalRoutes as $canonicalRoute) {
+    if (isset($extraNames[$canonicalRoute['name']]) === true) {
+        continue;
+    }
+
+    $mergedRoutes[] = $canonicalRoute;
+}
+
+$mergedRoutes   = array_merge($mergedRoutes, $extra);
+$mergedRoutes[] = $catchAllRoute;
+
+return ['routes' => $mergedRoutes];

--- a/lib/AppInfo/Registrar/AppHostRegistrar.php
+++ b/lib/AppInfo/Registrar/AppHostRegistrar.php
@@ -77,6 +77,17 @@ class AppHostRegistrar
      * collaborator would have to make the very same static call — moving the
      * finding instead of removing it.
      *
+     * ⚠️ The call is behind a `class_exists()` guard. This runs inside procest's
+     * `Application::register()`, which Nextcloud executes on EVERY request, so
+     * an unguarded static call to a class in another app fatals the whole
+     * instance-wide request — not merely this app's AppHost features. Procest
+     * does not declare `<app>openregister</app>`, so an admin can create exactly
+     * that configuration. `Bootstrap::class` on the imported name is resolved by
+     * the compiler to a plain string and never autoloads, so the guard itself is
+     * safe. When openregister is absent the engine registrations are simply
+     * skipped: procest still boots and still routes, and the AppHost-backed
+     * endpoints degrade individually. See decidesk#377 / #388.
+     *
      * @param IRegistrationContext $context The registration context.
      *
      * @return void
@@ -87,6 +98,12 @@ class AppHostRegistrar
      */
     public function register(IRegistrationContext $context): void
     {
+        if (class_exists(Bootstrap::class) === false) {
+            // OpenRegister is absent or disabled. Skip the engine registration
+            // rather than fatalling every request; see the note above.
+            return;
+        }
+
         Bootstrap::register(
             $context,
             Application::APP_ID,

--- a/lib/Controller/DashboardController.php
+++ b/lib/Controller/DashboardController.php
@@ -3,12 +3,21 @@
 /**
  * Procest Dashboard Controller
  *
- * Thin subclass of the OpenRegister AppHost GenericDashboardController.
- *
- * The SPA shell (`page()` / `catchAll()`) is inherited unchanged from the
- * engine; only the two procest-specific PWA asset endpoints
- * (`serviceWorker()` / `webManifest()`) — required by the
+ * SPA host implemented by COMPOSITION, not inheritance. The SPA shell
+ * (`page()` / `catchAll()`) is behaviourally identical to the OpenRegister
+ * AppHost `GenericDashboardController` this class used to subclass, but is
+ * implemented locally against OCP only. The two procest-specific PWA asset
+ * endpoints (`serviceWorker()` / `webManifest()`) — required by the
  * mobiel-inspectie-offline Progressive Web App — remain bespoke here.
+ *
+ * ⚠️ DO NOT "simplify" this back into a subclass of the AppHost generic, and do
+ * not `use`-import an OpenRegister class here. Nextcloud's router
+ * `ReflectionClass()`es every file in `lib/Controller/` while MATCHING a route,
+ * so an unresolvable parent makes EVERY route in procest return HTTP 500 —
+ * including routes with no OpenRegister involvement at all. Procest does not
+ * declare `<app>openregister</app>`, so an admin can create exactly that
+ * configuration. `extends` is resolved by the AUTOLOADER, not the DI container,
+ * so no amount of lazy registration can rescue it. See decidesk#377 / #388.
  *
  * @category Controller
  * @package  OCA\Procest\Controller
@@ -31,12 +40,14 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Controller;
 
-use OCA\OpenRegister\AppHost\Controller\GenericDashboardController;
 use OCA\Procest\AppInfo\Application;
+use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\DataDownloadResponse;
+use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IRequest;
 
 /**
@@ -44,7 +55,7 @@ use OCP\IRequest;
  *
  * @psalm-suppress UnusedClass
  */
-class DashboardController extends GenericDashboardController
+class DashboardController extends Controller
 {
     /**
      * App-root-relative location of the bundled PWA assets.
@@ -56,9 +67,8 @@ class DashboardController extends GenericDashboardController
     /**
      * Constructor.
      *
-     * Supplies the procest app id to the engine base controller so Nextcloud's
-     * DI can auto-wire this subclass from `IRequest` alone (the engine base
-     * otherwise takes an injected `string $appName` via the Bootstrap factory).
+     * Supplies the procest app id so Nextcloud's DI can auto-wire this
+     * controller from `IRequest` alone.
      *
      * @param IRequest $request HTTP request.
      */
@@ -66,6 +76,48 @@ class DashboardController extends GenericDashboardController
     {
         parent::__construct(appName: Application::APP_ID, request: $request);
     }//end __construct()
+
+    /**
+     * Render the main SPA page from `templates/index.php`.
+     *
+     * `#[NoAdminRequired]` / `#[NoCSRFRequired]` were previously INHERITED from
+     * the AppHost generic; they are declared explicitly here so the auth posture
+     * is byte-for-byte unchanged by dropping the inheritance.
+     *
+     * @return TemplateResponse The rendered procest index template.
+     *
+     * @spec openspec/changes/adopt-apphost/tasks.md#task-2.1
+     */
+    #[NoAdminRequired]
+    #[NoCSRFRequired]
+    public function page(): TemplateResponse
+    {
+        return $this->renderIndex();
+    }//end page()
+
+    /**
+     * Serve the SPA for deep links (Vue history mode). Delegates to {@see page()}.
+     *
+     * @return TemplateResponse The rendered procest index template.
+     *
+     * @spec openspec/changes/adopt-apphost/tasks.md#task-2.1
+     */
+    #[NoAdminRequired]
+    #[NoCSRFRequired]
+    public function catchAll(): TemplateResponse
+    {
+        return $this->page();
+    }//end catchAll()
+
+    /**
+     * Build the `index` TemplateResponse.
+     *
+     * @return TemplateResponse The rendered procest index template.
+     */
+    protected function renderIndex(): TemplateResponse
+    {
+        return new TemplateResponse($this->appName, 'index');
+    }//end renderIndex()
 
     /**
      * Serve the mobiel-inspectie-offline Service Worker script.


### PR DESCRIPTION
## The defect

Nextcloud's router `ReflectionClass()`es **every file in `lib/Controller/`** while *matching* a route, `include`s `appinfo/routes.php` on every request, **and** runs `Application::register()` on every request. Procest bound OpenRegister classes in **all three** positions:

| Position | Binding |
|---|---|
| `lib/Controller/DashboardController.php:47` | `extends GenericDashboardController` |
| `appinfo/routes.php:32` | `\OCA\OpenRegister\AppHost\Routes::standard(...)` |
| `lib/AppInfo/Registrar/AppHostRegistrar.php:90` | **unguarded** `Bootstrap::register(...)` |

With openregister absent, **every** procest route returns HTTP 500 — including routes with no OpenRegister involvement at all. Procest does **not** declare `<app>openregister</app>`, so an admin can create exactly that configuration.

The third one is the worst and was **not** in the original fleet scan: `AppHostRegistrar::register()` runs inside `Application::register()`, so it fatalled the request **before the router was even reached**. Fixing only the controller would have moved the fatal, not removed it — and fixing controller + routes.php would *still* have left the app dead.

**Lazy DI cannot fix this.** `extends` is resolved by the **autoloader**, not the container.

⚠️ Deliberately **not** fixed by adding `<app>openregister</app>`: that makes `occ app:enable` fail rather than making the app work (rejected in decidesk#388).

## The fix — composition, not inheritance

- **`DashboardController`** extends `OCP\AppFramework\Controller` and implements `page()` / `catchAll()` / `renderIndex()` locally. The previously **inherited** `#[NoAdminRequired]` / `#[NoCSRFRequired]` are now **declared explicitly**, so the auth posture is byte-for-byte unchanged. The bespoke PWA endpoints (`serviceWorker()` / `webManifest()`, `#[PublicPage]` + `#[NoCSRFRequired]`) are untouched.
- **`appinfo/routes.php`** calls the AppHost builder behind `class_exists()` with a local fallback table.
- **`AppHostRegistrar`** guards `Bootstrap::register()` with `class_exists(Bootstrap::class)`. `::class` on an imported name is resolved by the compiler to a plain string and never autoloads, so the guard itself is safe. When openregister is absent the engine registrations are skipped: procest still boots and still routes, and the AppHost-backed endpoints degrade individually.
- Each broken binding carries a "do not simplify this back" note.

No route names, URLs, verbs, auth attributes or response shapes change when openregister **is** installed.

## Evidence

Probe mirroring `Router::getAttributeRoutes()` — scan `lib/Controller/*.php`, `new ReflectionClass()` each — with **openregister absent**:

| | controllers | reflected ok | fail | `routes.php` |
|---|---|---|---|---|
| `origin/development` | 90 | 89 | **1** | **fatal** |
| this branch | 90 | **90** | **0** | **371 routes** |

**Positive control:** a throwaway class extending the absent generic still fatals under the same probe, so it is not blind. **Negative control:** an OCP-only controller reflects fine. Both controls pass on every run reported here.

⚠️ The probe deliberately does **not** load the app's `vendor/autoload.php`: procest's **`autoload-dev`** maps `OCA\OpenRegister\` onto `tests/Stubs/`. That mapping does **not** exist in a `composer install --no-dev` release build, and it is precisely what **masks** this defect in CI today.

**Bootstrap guard, directly measured:** the unguarded static call fatals (`Class "OCA\OpenRegister\AppHost\Bootstrap" not found`); the guarded form skips cleanly with no fatal.

**Route-table equivalence:** real `Routes::standard()` vs. the fallback branch is `===` identical — **371 routes, same order, same `$extra`-overrides-canonical semantics**, catch-all last. **Negative control:** a one-field mutation of that array is correctly reported as different.

## Local gates (PHP 8.4, container)

`lint` ✅ · `phpcs` ✅ **0 errors** on the changed `lib/` files · `psalm` ✅ **0** · `phpstan` ✅ **0** · `phpunit` ✅ **1686 tests, 5632 assertions, 0 failures**

⚠️ Note: an early Psalm run reported 9 `UndefinedClass` errors in files this PR does not touch. That was an artefact of a **broken `vendor` symlink mount** in the throwaway worktree, not a real finding — re-measured with a clean mount, Psalm is green, confirmed against the `origin/development` baseline.

Fleet context: same shape fixed in decidesk#388 (merged); docudesk, pipelinq and nldesign carry it too.