### PR TITLE
refactor(settings): stop folding a fragment digest into the import version

### DIFF
--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -579,25 +579,22 @@ class SettingsService
         // concurrent same-app builds add registers/schemas via isolated
         // fragment files instead of all editing procest_register.json and
         // conflicting. Fragments are applied in sorted filename order.
-        [$configData, $fragmentHash] = $this->fragments->merge(
+        // The merge also returns a hash of the fragment set. It is deliberately
+        // not captured: it used to be folded into the version below so that
+        // adding or changing a fragment forced a re-import, but OpenRegister
+        // gates with version_compare, which treats `+…` as further version
+        // parts and compares them LEXICALLY rather than as semver build
+        // metadata — so whether the gate fired depended on how two md5 hashes
+        // happened to sort. Unchanged content re-imported about half the time;
+        // a real change was skipped the other half. OpenRegister now hashes the
+        // merged configuration itself and skips on hash equality, which detects
+        // a changed fragment from the data. The version stays a version.
+        [$configData] = $this->fragments->merge(
             base: $configData,
             fragmentDir: __DIR__.'/../Settings/register.d'
         );
 
         $configVersion = ($configData['info']['version'] ?? '0.0.0');
-
-        // The fragment hash is deliberately NOT folded into the version.
-        //
-        // It used to be, so that adding or changing a fragment forced a
-        // re-import. But OpenRegister gates with version_compare, which treats
-        // `+…` as further version parts and compares them LEXICALLY rather than
-        // as semver build metadata — so whether the gate fired depended on how
-        // two md5 hashes happened to sort. Unchanged content re-imported about
-        // half the time; a real change was skipped the other half.
-        //
-        // OpenRegister now hashes the merged configuration itself and skips on
-        // hash equality, which detects a changed fragment from the data. The
-        // version stays a version.
 
         try {
             $importResult = $configurationService->importFromApp(

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -586,18 +586,11 @@ class SettingsService
 
         $configVersion = ($configData['info']['version'] ?? '0.0.0');
 
-        // The fragment hash is deliberately NOT folded into the version.
-        //
-        // It used to be, so that adding or changing a fragment forced a
-        // re-import. But OpenRegister gates with version_compare, which treats
-        // `+…` as further version parts and compares them LEXICALLY rather than
-        // as semver build metadata — so whether the gate fired depended on how
-        // two md5 hashes happened to sort. Unchanged content re-imported about
-        // half the time; a real change was skipped the other half.
-        //
-        // OpenRegister now hashes the merged configuration itself and skips on
-        // hash equality, which detects a changed fragment from the data. The
-        // version stays a version.
+        // $fragmentHash is deliberately NOT folded into the version: OpenRegister
+        // gates with version_compare, which compares `+frag.<md5>` LEXICALLY
+        // rather than as semver build metadata, so the gate fired on how two
+        // hashes sorted. It now hashes the merged config itself and skips on
+        // hash equality (openregister#2325). See that PR for the measurements.
 
         try {
             $importResult = $configurationService->importFromApp(

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -586,12 +586,18 @@ class SettingsService
 
         $configVersion = ($configData['info']['version'] ?? '0.0.0');
 
-        // Fold the fragment-set hash into the version so that adding,
-        // changing, or removing a fragment forces ConfigurationService to
-        // re-import (the version is its idempotency key).
-        if ($fragmentHash !== '') {
-            $configVersion = $configVersion.'+frag.'.$fragmentHash;
-        }
+        // The fragment hash is deliberately NOT folded into the version.
+        //
+        // It used to be, so that adding or changing a fragment forced a
+        // re-import. But OpenRegister gates with version_compare, which treats
+        // `+…` as further version parts and compares them LEXICALLY rather than
+        // as semver build metadata — so whether the gate fired depended on how
+        // two md5 hashes happened to sort. Unchanged content re-imported about
+        // half the time; a real change was skipped the other half.
+        //
+        // OpenRegister now hashes the merged configuration itself and skips on
+        // hash equality, which detects a changed fragment from the data. The
+        // version stays a version.
 
         try {
             $importResult = $configurationService->importFromApp(


### PR DESCRIPTION
Same reasoning as opencatalogi. OpenRegister gates with `version_compare`, which compares `+frag.<md5>` lexically rather than as semver build metadata, so the gate fired based on how two md5 hashes sorted — re-importing unchanged content about half the time and skipping real changes the other half.

OpenRegister now hashes the merged configuration itself and skips on hash equality (openregister#2325), detecting a changed fragment from the data. The version stays a version.