### PR TITLE
refactor(ai): extract AiAuditService from AiService — clears the last phpmd finding

### DIFF
--- a/lib/Controller/AiAuditExportController.php
+++ b/lib/Controller/AiAuditExportController.php
@@ -28,7 +28,7 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Controller;
 
-use OCA\Procest\Service\AiService;
+use OCA\Procest\Service\Ai\AiAuditService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
@@ -60,7 +60,7 @@ class AiAuditExportController extends Controller
     private const MAX_EXPORT_ROWS = 10000;
 
     /**
-     * Page size used while internally iterating {@see AiService::listAuditEntries()}
+     * Page size used while internally iterating {@see AiAuditService::listAuditEntries()}
      * to assemble the (uncapped, up to MAX_EXPORT_ROWS) export set.
      */
     private const PAGE_SIZE = 200;
@@ -97,7 +97,7 @@ class AiAuditExportController extends Controller
      * @param IRequest        $request      Incoming request
      * @param IUserSession    $userSession  Current user session
      * @param IGroupManager   $groupManager Group manager (for RBAC check)
-     * @param AiService       $aiService    The AI service (audit listing)
+     * @param AiAuditService  $auditService The AI oversight audit service (audit listing)
      * @param LoggerInterface $logger       PSR-3 logger
      */
     public function __construct(
@@ -105,7 +105,7 @@ class AiAuditExportController extends Controller
         IRequest $request,
         private readonly IUserSession $userSession,
         private readonly IGroupManager $groupManager,
-        private readonly AiService $aiService,
+        private readonly AiAuditService $auditService,
         private readonly LoggerInterface $logger,
     ) {
         parent::__construct(appName: $appName, request: $request);
@@ -196,7 +196,7 @@ class AiAuditExportController extends Controller
      * Collect audit entries across pages up to {@see self::MAX_EXPORT_ROWS}.
      *
      * No pagination cap is applied on the caller-facing filters — this
-     * iterates {@see AiService::listAuditEntries()} internally page by page
+     * iterates {@see AiAuditService::listAuditEntries()} internally page by page
      * (bounded page size) so a single export call never asks OpenRegister
      * for an unbounded result set in one query.
      *
@@ -212,7 +212,7 @@ class AiAuditExportController extends Controller
         $totalCount = 0;
 
         do {
-            $page       = $this->aiService->listAuditEntries(
+            $page       = $this->auditService->listAuditEntries(
                 filters: $filters,
                 limit: self::PAGE_SIZE,
                 offset: $offset,

--- a/lib/Controller/AiController.php
+++ b/lib/Controller/AiController.php
@@ -30,6 +30,7 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Controller;
 
+use OCA\Procest\Service\Ai\AiAuditService;
 use OCA\Procest\Service\AiService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
@@ -52,11 +53,12 @@ class AiController extends Controller
     /**
      * Constructor for AiController.
      *
-     * @param string          $appName     The application name
-     * @param IRequest        $request     The request object
-     * @param AiService       $aiService   The AI service
-     * @param IUserSession    $userSession The user session
-     * @param LoggerInterface $logger      The logger interface
+     * @param string          $appName      The application name
+     * @param IRequest        $request      The request object
+     * @param AiService       $aiService    The AI service
+     * @param AiAuditService  $auditService The AI oversight audit service
+     * @param IUserSession    $userSession  The user session
+     * @param LoggerInterface $logger       The logger interface
      *
      * @return void
      */
@@ -64,6 +66,7 @@ class AiController extends Controller
         string $appName,
         IRequest $request,
         private AiService $aiService,
+        private AiAuditService $auditService,
         private IUserSession $userSession,
         private LoggerInterface $logger,
     ) {
@@ -300,7 +303,7 @@ class AiController extends Controller
         }
 
         $userId = $user->getUID();
-        $result = $this->aiService->recordUserAction(
+        $result = $this->auditService->recordUserAction(
             $caseId,
             $type,
             $userAction,
@@ -317,7 +320,7 @@ class AiController extends Controller
      * Get AI audit trail entries.
      *
      * Queries the recorded `aiAuditEntry` objects from OpenRegister via
-     * {@see AiService::listAuditEntries()} — filterable by `caseId`/`type`,
+     * {@see AiAuditService::listAuditEntries()} — filterable by `caseId`/`type`,
      * paged via `limit`/`offset`, newest first.
      *
      * @return JSONResponse
@@ -338,7 +341,7 @@ class AiController extends Controller
         $offset = (int) $this->request->getParam('offset', '0');
 
         try {
-            $result = $this->aiService->listAuditEntries(
+            $result = $this->auditService->listAuditEntries(
                 filters: array_filter(['caseId' => $caseId, 'type' => $type]),
                 limit: $limit,
                 offset: $offset,

--- a/lib/Service/Ai/AiAuditService.php
+++ b/lib/Service/Ai/AiAuditService.php
@@ -1,0 +1,162 @@
+<?php
+
+/**
+ * Procest AI audit service.
+ *
+ * The oversight surface of the AI feature set: recording what a human did with
+ * an AI suggestion (accept / reject / modify), recording a conversational
+ * assistant exchange, and reading the Algoritmeregister trail back for the
+ * oversight page and the CSV export.
+ *
+ * Split out of {@see \OCA\Procest\Service\AiService} so that model
+ * orchestration (deciding whether a feature is on, building a prompt, making
+ * the one outbound model call) and oversight (what was suggested, what a human
+ * did with it, and who can read that back) are separate responsibilities.
+ * Storage itself stays in {@see AiAuditLog}; this class is the surface the
+ * controllers and assistant services consume.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Ai
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/changes/ai-oversight-log/tasks.md#1.1
+ * @spec openspec/specs/case-assistant-via-hermiq/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Ai;
+
+/**
+ * Records and reads the AI oversight audit trail.
+ *
+ * @spec openspec/changes/ai-oversight-log/tasks.md#1.1
+ */
+class AiAuditService
+{
+    /**
+     * Constructor.
+     *
+     * @param AiAuditLog      $audit         The oversight audit trail storage.
+     * @param AiModelIdentity $modelIdentity The configured model identifier.
+     *
+     * @return void
+     */
+    public function __construct(
+        private AiAuditLog $audit,
+        private AiModelIdentity $modelIdentity,
+    ) {
+    }//end __construct()
+
+    /**
+     * Record a user action on an AI suggestion (accept, reject, modify).
+     *
+     * @param string      $caseId      The case ID
+     * @param string      $type        AI type (classification, extraction, etc.)
+     * @param string      $userAction  User action (accepted, rejected, modified)
+     * @param array       $suggestion  The original suggestion
+     * @param array|null  $actualValue The value actually applied
+     * @param string|null $reason      Reason for rejection/modification
+     * @param string      $userId      The current user ID
+     *
+     * @return array
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+     */
+    public function recordUserAction(
+        string $caseId,
+        string $type,
+        string $userAction,
+        array $suggestion,
+        ?array $actualValue,
+        ?string $reason,
+        string $userId,
+    ): array {
+        $this->recordAuditEntry(
+                entry: [
+                    'type'        => $type,
+                    'action'      => $userAction,
+                    'caseId'      => $caseId,
+                    'model'       => $this->modelIdentity->identifier(),
+                    'suggestion'  => $suggestion,
+                    'userAction'  => $userAction,
+                    'actualValue' => ($actualValue ?? []),
+                    'reason'      => ($reason ?? ''),
+                    'userId'      => $userId,
+                    'timestamp'   => date('c'),
+                ]
+                );
+
+        return ['success' => true];
+    }//end recordUserAction()
+
+    /**
+     * List recorded AI audit entries from OpenRegister, newest first.
+     *
+     * Reads the same audit sink {@see AiAuditLog::record()} writes to. Degrades
+     * gracefully (empty result, warning logged, no throw) when AI audit storage
+     * is not configured or the OpenRegister lookup fails, so a misconfigured
+     * instance never 500s the oversight surface.
+     *
+     * @param array<string, mixed> $filters Optional filters: 'caseId', 'type'.
+     * @param int                  $limit   Page size (clamped to 1-200, default 50).
+     * @param int                  $offset  Paging offset (clamped to >= 0).
+     *
+     * @return array{entries: array<int, array<string, mixed>>, total: int|null, limit: int, offset: int}
+     *
+     * @spec openspec/changes/ai-oversight-log/tasks.md#1.1
+     */
+    public function listAuditEntries(array $filters=[], int $limit=50, int $offset=0): array
+    {
+        return $this->audit->list(filters: $filters, limit: $limit, offset: $offset);
+    }//end listAuditEntries()
+
+    /**
+     * Record a pre-built audit entry for the conversational case assistant.
+     *
+     * The case-assistant surface lives in `AssistantController` /
+     * `HermiqAssistantClient` — a separate class per the fleet rule that AI
+     * functionality / LLM calls live in Hermiq, not in `AiService`. Those
+     * callers build their own entry and hand it here, so the existing
+     * Algoritmeregister oversight trail
+     * (`listAuditEntries()`/`AiAuditExportController`) covers the
+     * conversational surface too, with no second audit mechanism. This method
+     * carries no LLM logic; it only forwards an already-built entry to the
+     * existing writer.
+     *
+     * @param array $entry The audit entry data — same shape as the other
+     *                     `recordAuditEntry()` call sites (`type`, `action`,
+     *                     `caseId`, `model`, `prompt`, `suggestion`,
+     *                     `confidence`, `userId`, `timestamp`, `responseTimeMs`).
+     *
+     * @return void
+     *
+     * @spec openspec/specs/case-assistant-via-hermiq/spec.md
+     */
+    public function recordAssistantAuditEntry(array $entry): void
+    {
+        $this->recordAuditEntry(entry: $entry);
+    }//end recordAssistantAuditEntry()
+
+    /**
+     * Record an AI audit trail entry in OpenRegister.
+     *
+     * @param array $entry The audit entry data
+     *
+     * @return void
+     */
+    private function recordAuditEntry(array $entry): void
+    {
+        $this->audit->record(entry: $entry);
+    }//end recordAuditEntry()
+}//end class

--- a/lib/Service/Ai/AiModelIdentity.php
+++ b/lib/Service/Ai/AiModelIdentity.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * Procest AI model identity.
+ *
+ * Resolves the human-readable identifier of the currently configured AI model
+ * (`<type>/<name>`) from app config. Stamped onto every oversight audit entry
+ * and reported by the AI health check, so the Algoritmeregister trail always
+ * says WHICH model produced a suggestion.
+ *
+ * Extracted from {@see \OCA\Procest\Service\AiService} so that the model
+ * orchestration layer and the oversight layer ({@see AiAuditService}) read the
+ * identifier from one place and can never drift on the config keys involved.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Ai
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/changes/ai-oversight-log/tasks.md#1.1
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Ai;
+
+use OCA\Procest\AppInfo\Application;
+use OCP\IAppConfig;
+
+/**
+ * Resolves the configured AI model identifier.
+ *
+ * @spec openspec/changes/ai-oversight-log/tasks.md#1.1
+ */
+class AiModelIdentity
+{
+    /**
+     * Constructor.
+     *
+     * @param IAppConfig $appConfig The app configuration service.
+     *
+     * @return void
+     */
+    public function __construct(
+        private IAppConfig $appConfig,
+    ) {
+    }//end __construct()
+
+    /**
+     * Get the configured AI model identifier.
+     *
+     * @return string The identifier in `<type>/<name>` form.
+     *
+     * @spec openspec/changes/ai-oversight-log/tasks.md#1.1
+     */
+    public function identifier(): string
+    {
+        $type = $this->appConfig->getValueString(Application::APP_ID, 'ai_model_type', 'local');
+        $name = $this->appConfig->getValueString(Application::APP_ID, 'ai_model_name', 'unknown');
+
+        return $type.'/'.$name;
+    }//end identifier()
+}//end class

--- a/lib/Service/AiService.php
+++ b/lib/Service/AiService.php
@@ -34,6 +34,7 @@ namespace OCA\Procest\Service;
 use OCA\Procest\AppInfo\Application;
 use OCA\Procest\Service\Ai\AiAuditLog;
 use OCA\Procest\Service\Ai\AiEndpointGuard;
+use OCA\Procest\Service\Ai\AiModelIdentity;
 use OCA\Procest\Service\Ai\AiPiiRedactor;
 use OCA\Procest\Service\Ai\AiPromptFactory;
 use OCP\IAppConfig;
@@ -52,6 +53,10 @@ use RuntimeException;
  * {@see AiPiiRedactor}, makes the one outbound model call (guarded by
  * {@see AiEndpointGuard}) and records the result via {@see AiAuditLog}.
  *
+ * The oversight surface — recording what a human did with a suggestion,
+ * recording a conversational assistant exchange, and reading the trail back —
+ * lives in {@see \OCA\Procest\Service\Ai\AiAuditService}.
+ *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  *
@@ -69,6 +74,7 @@ class AiService
      * @param AiPiiRedactor   $pii           The PII detector / scrubber
      * @param AiEndpointGuard $endpointGuard The model-URL SSRF guard
      * @param AiAuditLog      $audit         The oversight audit trail
+     * @param AiModelIdentity $modelIdentity The configured model identifier
      * @param LoggerInterface $logger        The logger interface
      *
      * @return void
@@ -79,6 +85,7 @@ class AiService
         private AiPiiRedactor $pii,
         private AiEndpointGuard $endpointGuard,
         private AiAuditLog $audit,
+        private AiModelIdentity $modelIdentity,
         private LoggerInterface $logger,
     ) {
     }//end __construct()
@@ -489,71 +496,6 @@ class AiService
     }//end suggestNextStep()
 
     /**
-     * Record a user action on an AI suggestion (accept, reject, modify).
-     *
-     * @param string      $caseId      The case ID
-     * @param string      $type        AI type (classification, extraction, etc.)
-     * @param string      $userAction  User action (accepted, rejected, modified)
-     * @param array       $suggestion  The original suggestion
-     * @param array|null  $actualValue The value actually applied
-     * @param string|null $reason      Reason for rejection/modification
-     * @param string      $userId      The current user ID
-     *
-     * @return array
-     *
-     * @SuppressWarnings(PHPMD.ExcessiveParameterList) — audit entries need full context
-
-     * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
-     */
-    public function recordUserAction(
-        string $caseId,
-        string $type,
-        string $userAction,
-        array $suggestion,
-        ?array $actualValue,
-        ?string $reason,
-        string $userId,
-    ): array {
-        $this->recordAuditEntry(
-                entry: [
-                    'type'        => $type,
-                    'action'      => $userAction,
-                    'caseId'      => $caseId,
-                    'model'       => $this->getModelIdentifier(),
-                    'suggestion'  => $suggestion,
-                    'userAction'  => $userAction,
-                    'actualValue' => ($actualValue ?? []),
-                    'reason'      => ($reason ?? ''),
-                    'userId'      => $userId,
-                    'timestamp'   => date('c'),
-                ]
-                );
-
-        return ['success' => true];
-    }//end recordUserAction()
-
-    /**
-     * List recorded AI audit entries from OpenRegister, newest first.
-     *
-     * Reads the same audit sink {@see AiAuditLog::record()} writes to. Degrades
-     * gracefully (empty result, warning logged, no throw) when AI audit storage
-     * is not configured or the OpenRegister lookup fails, so a misconfigured
-     * instance never 500s the oversight surface.
-     *
-     * @param array<string, mixed> $filters Optional filters: 'caseId', 'type'.
-     * @param int                  $limit   Page size (clamped to 1-200, default 50).
-     * @param int                  $offset  Paging offset (clamped to >= 0).
-     *
-     * @return array{entries: array<int, array<string, mixed>>, total: int|null, limit: int, offset: int}
-     *
-     * @spec openspec/changes/ai-oversight-log/tasks.md#1.1
-     */
-    public function listAuditEntries(array $filters=[], int $limit=50, int $offset=0): array
-    {
-        return $this->audit->list(filters: $filters, limit: $limit, offset: $offset);
-    }//end listAuditEntries()
-
-    /**
      * Test AI model connectivity.
      *
      * @return array Health check result
@@ -620,10 +562,7 @@ class AiService
      */
     private function getModelIdentifier(): string
     {
-        $type = $this->appConfig->getValueString(Application::APP_ID, 'ai_model_type', 'local');
-        $name = $this->appConfig->getValueString(Application::APP_ID, 'ai_model_name', 'unknown');
-
-        return $type.'/'.$name;
+        return $this->modelIdentity->identifier();
     }//end getModelIdentifier()
 
     /**
@@ -801,35 +740,6 @@ class AiService
 
         return $parsed;
     }//end decodeAiModelResponse()
-
-    /**
-     * Record an audit entry for a case-assistant-via-hermiq conversational
-     * exchange, using the SAME audit sink (register/schema, append-only
-     * OpenRegister write) every discrete AI operation in this class already
-     * writes to — so the existing AI oversight trail
-     * (`listAuditEntries()`/`AiAuditExportController`) covers the
-     * conversational surface too, with no second audit mechanism.
-     *
-     * A thin public forwarder is needed (rather than widening
-     * `recordAuditEntry()` itself to public) because the case-assistant
-     * surface lives in `AssistantController`/`HermiqAssistantClient` — a
-     * separate class per the fleet rule that AI functionality/LLM calls live
-     * in Hermiq, not in this class. This method carries no LLM logic; it only
-     * forwards an already-built entry to the existing writer.
-     *
-     * @param array $entry The audit entry data — same shape as the other
-     *                     `recordAuditEntry()` call sites (`type`, `action`,
-     *                     `caseId`, `model`, `prompt`, `suggestion`,
-     *                     `confidence`, `userId`, `timestamp`, `responseTimeMs`).
-     *
-     * @return void
-     *
-     * @spec openspec/specs/case-assistant-via-hermiq/spec.md
-     */
-    public function recordAssistantAuditEntry(array $entry): void
-    {
-        $this->recordAuditEntry(entry: $entry);
-    }//end recordAssistantAuditEntry()
 
     /**
      * Record an AI audit trail entry in OpenRegister.

--- a/lib/Service/Assistant/CaseAssistantService.php
+++ b/lib/Service/Assistant/CaseAssistantService.php
@@ -10,7 +10,7 @@
  * documents, contacts, or initiator PII), forwards it to Hermiq via
  * `HermiqAssistantClient`, persists the Hermiq session per (user, case) so
  * follow-up turns keep continuity, and records the exchange through the
- * existing `AiService` audit sink.
+ * existing `AiAuditService` audit sink.
  *
  * FLEET RULE: this class contains NO LLM/prompt logic — Hermiq owns the
  * conversation. This is context assembly + authorization + audit plumbing.
@@ -38,7 +38,7 @@ namespace OCA\Procest\Service\Assistant;
 
 use Exception;
 use OCA\Procest\AppInfo\Application;
-use OCA\Procest\Service\AiService;
+use OCA\Procest\Service\Ai\AiAuditService;
 use OCA\Procest\Service\SettingsService;
 use OCP\IConfig;
 use Psr\Log\LoggerInterface;
@@ -83,14 +83,14 @@ class CaseAssistantService
      *
      * @param SettingsService       $settingsService Resolves the OpenRegister ObjectService + config.
      * @param HermiqAssistantClient $hermiqClient    Thin HTTP client to Hermiq's assistant surface.
-     * @param AiService             $aiService       Existing AI oversight audit sink.
+     * @param AiAuditService        $auditService    Existing AI oversight audit sink.
      * @param IConfig               $config          Per-user Hermiq session continuity storage.
      * @param LoggerInterface       $logger          Structured logger.
      */
     public function __construct(
         private readonly SettingsService $settingsService,
         private readonly HermiqAssistantClient $hermiqClient,
-        private readonly AiService $aiService,
+        private readonly AiAuditService $auditService,
         private readonly IConfig $config,
         private readonly LoggerInterface $logger,
     ) {
@@ -142,7 +142,7 @@ class CaseAssistantService
             $this->config->setUserValue($userId, Application::APP_ID, $sessionKey, $result['sessionId']);
         }
 
-        $this->aiService->recordAssistantAuditEntry(
+        $this->auditService->recordAssistantAuditEntry(
             entry: [
                 'type'           => 'assistant',
                 'action'         => 'conversation',

--- a/lib/Service/WOOAnonymisationAssistService.php
+++ b/lib/Service/WOOAnonymisationAssistService.php
@@ -53,6 +53,7 @@ namespace OCA\Procest\Service;
 
 use InvalidArgumentException;
 use OCA\Procest\AppInfo\Application;
+use OCA\Procest\Service\Ai\AiAuditService;
 use OCA\Procest\Service\Assistant\HermiqAnonymisationClient;
 use OCA\Procest\Service\Assistant\HermiqAssistantException;
 use Psr\Log\LoggerInterface;
@@ -85,6 +86,7 @@ class WOOAnonymisationAssistService
      * Constructor.
      *
      * @param AiService                    $aiService         Deterministic PII rules floor.
+     * @param AiAuditService               $auditService      AI oversight audit sink.
      * @param HermiqAnonymisationClient    $hermiqClient      Thin HTTP client to Hermiq's
      *                                                        detect-pii surface.
      * @param WOODocumentAssessmentService $assessmentService Reads/writes the wooAssessment
@@ -98,6 +100,7 @@ class WOOAnonymisationAssistService
      */
     public function __construct(
         private readonly AiService $aiService,
+        private readonly AiAuditService $auditService,
         private readonly HermiqAnonymisationClient $hermiqClient,
         private readonly WOODocumentAssessmentService $assessmentService,
         private readonly WOORedactionService $redactionService,
@@ -172,7 +175,7 @@ class WOOAnonymisationAssistService
             proposal: $proposal
         );
 
-        $this->aiService->recordAssistantAuditEntry(
+        $this->auditService->recordAssistantAuditEntry(
             entry: [
                 'type'           => 'anonymisation',
                 'action'         => 'proposal',

--- a/tests/Unit/Controller/AiAuditExportControllerTest.php
+++ b/tests/Unit/Controller/AiAuditExportControllerTest.php
@@ -26,7 +26,7 @@ declare(strict_types=1);
 namespace OCA\Procest\Tests\Unit\Controller;
 
 use OCA\Procest\Controller\AiAuditExportController;
-use OCA\Procest\Service\AiService;
+use OCA\Procest\Service\Ai\AiAuditService;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataDownloadResponse;
 use OCP\AppFramework\Http\JSONResponse;
@@ -45,7 +45,7 @@ use Psr\Log\LoggerInterface;
 class AiAuditExportControllerTest extends TestCase
 {
 
-    private AiService $aiService;
+    private AiAuditService $auditService;
 
     private IGroupManager $groupManager;
 
@@ -78,7 +78,7 @@ class AiAuditExportControllerTest extends TestCase
             request: $this->request,
             userSession: $userSession,
             groupManager: $this->groupManager,
-            aiService: $this->aiService,
+            auditService: $this->auditService,
             logger: $this->logger,
         );
     }//end makeController()
@@ -91,7 +91,7 @@ class AiAuditExportControllerTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->aiService    = $this->createMock(AiService::class);
+        $this->auditService = $this->createMock(AiAuditService::class);
         $this->groupManager = $this->createMock(IGroupManager::class);
         $this->request      = $this->createMock(IRequest::class);
         $this->logger       = $this->createMock(LoggerInterface::class);
@@ -114,7 +114,7 @@ class AiAuditExportControllerTest extends TestCase
             ['format', 'csv', 'csv'],
         ]);
 
-        $this->aiService->method('listAuditEntries')->willReturn([
+        $this->auditService->method('listAuditEntries')->willReturn([
             'entries' => [
                 [
                     'id'         => 'e1',
@@ -162,7 +162,7 @@ class AiAuditExportControllerTest extends TestCase
             ['format', 'csv', 'csv'],
         ]);
 
-        $this->aiService->method('listAuditEntries')
+        $this->auditService->method('listAuditEntries')
             ->willReturn(['entries' => [], 'total' => null, 'limit' => 200, 'offset' => 0]);
 
         $controller = $this->makeController('admin-1');
@@ -182,7 +182,7 @@ class AiAuditExportControllerTest extends TestCase
         $this->groupManager->method('isInGroup')->willReturn(false);
         $this->groupManager->method('isAdmin')->willReturn(false);
 
-        $this->aiService->expects($this->never())->method('listAuditEntries');
+        $this->auditService->expects($this->never())->method('listAuditEntries');
 
         $controller = $this->makeController('plain-user');
         $response   = $controller->export();
@@ -223,7 +223,7 @@ class AiAuditExportControllerTest extends TestCase
         ]);
 
         $entries = [['id' => 'e1', 'type' => 'qa']];
-        $this->aiService->method('listAuditEntries')
+        $this->auditService->method('listAuditEntries')
             ->willReturn(['entries' => $entries, 'total' => null, 'limit' => 200, 'offset' => 0]);
 
         $controller = $this->makeController('auditor-1');

--- a/tests/Unit/Controller/AiControllerAuditIndexTest.php
+++ b/tests/Unit/Controller/AiControllerAuditIndexTest.php
@@ -5,7 +5,7 @@
  *
  * Asserts the audit-listing stub is gone (no more "implement with
  * OpenRegister object listing" placeholder), filters/paging params pass
- * through to AiService::listAuditEntries(), and failures are handled
+ * through to AiAuditService::listAuditEntries(), and failures are handled
  * without leaking exception internals as a 200.
  *
  * @category Tests
@@ -28,6 +28,7 @@ declare(strict_types=1);
 namespace OCA\Procest\Tests\Unit\Controller;
 
 use OCA\Procest\Controller\AiController;
+use OCA\Procest\Service\Ai\AiAuditService;
 use OCA\Procest\Service\AiService;
 use OCP\AppFramework\Http;
 use OCP\IRequest;
@@ -46,6 +47,8 @@ class AiControllerAuditIndexTest extends TestCase
 
     private AiService $aiService;
 
+    private AiAuditService $auditService;
+
     private IUserSession $userSession;
 
     private IRequest $request;
@@ -63,6 +66,7 @@ class AiControllerAuditIndexTest extends TestCase
     {
         parent::setUp();
         $this->aiService       = $this->createMock(AiService::class);
+        $this->auditService    = $this->createMock(AiAuditService::class);
         $this->userSession     = $this->createMock(IUserSession::class);
         $this->request         = $this->createMock(IRequest::class);
         $this->logger           = $this->createMock(LoggerInterface::class);
@@ -75,6 +79,7 @@ class AiControllerAuditIndexTest extends TestCase
             appName: 'procest',
             request: $this->request,
             aiService: $this->aiService,
+            auditService: $this->auditService,
             userSession: $this->userSession,
             logger: $this->logger,
         );
@@ -97,7 +102,7 @@ class AiControllerAuditIndexTest extends TestCase
 
         $entries = [['id' => 'e1', 'type' => 'classification', 'caseId' => 'case-a']];
 
-        $this->aiService->expects($this->once())
+        $this->auditService->expects($this->once())
             ->method('listAuditEntries')
             ->with(
                 $this->callback(fn (array $filters) => ($filters['caseId'] ?? null) === 'case-a'),
@@ -138,7 +143,7 @@ class AiControllerAuditIndexTest extends TestCase
             ['offset', '0', '20'],
         ]);
 
-        $this->aiService->expects($this->once())
+        $this->auditService->expects($this->once())
             ->method('listAuditEntries')
             ->with(
                 ['caseId' => 'case-b', 'type' => 'summary'],
@@ -164,11 +169,12 @@ class AiControllerAuditIndexTest extends TestCase
             appName: 'procest',
             request: $this->request,
             aiService: $this->aiService,
+            auditService: $this->auditService,
             userSession: $userSession,
             logger: $this->logger,
         );
 
-        $this->aiService->expects($this->never())->method('listAuditEntries');
+        $this->auditService->expects($this->never())->method('listAuditEntries');
 
         $response = $controller->auditIndex();
 
@@ -189,7 +195,7 @@ class AiControllerAuditIndexTest extends TestCase
             ['offset', '0', '0'],
         ]);
 
-        $this->aiService->method('listAuditEntries')
+        $this->auditService->method('listAuditEntries')
             ->willThrowException(new \RuntimeException('boom'));
 
         $response = $this->controller->auditIndex();

--- a/tests/Unit/Service/Ai/AiAuditServiceListTest.php
+++ b/tests/Unit/Service/Ai/AiAuditServiceListTest.php
@@ -1,14 +1,14 @@
 <?php
 
 /**
- * AiService::listAuditEntries() Unit Tests
+ * AiAuditService::listAuditEntries() Unit Tests
  *
  * Covers filter/paging pass-through, limit clamping, and graceful
  * degradation (empty result + warning, no throw) when AI audit storage is
  * unconfigured or the OpenRegister lookup fails.
  *
  * @category Tests
- * @package  OCA\Procest\Tests\Unit\Service
+ * @package  OCA\Procest\Tests\Unit\Service\Ai
  *
  * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
@@ -24,13 +24,11 @@
 
 declare(strict_types=1);
 
-namespace OCA\Procest\Tests\Unit\Service;
+namespace OCA\Procest\Tests\Unit\Service\Ai;
 
 use OCA\Procest\Service\Ai\AiAuditLog;
-use OCA\Procest\Service\Ai\AiEndpointGuard;
-use OCA\Procest\Service\Ai\AiPiiRedactor;
-use OCA\Procest\Service\Ai\AiPromptFactory;
-use OCA\Procest\Service\AiService;
+use OCA\Procest\Service\Ai\AiAuditService;
+use OCA\Procest\Service\Ai\AiModelIdentity;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -58,15 +56,15 @@ interface AiAuditObjectServiceStub
 }//end interface
 
 /**
- * Unit tests for AiService::listAuditEntries().
+ * Unit tests for AiAuditService::listAuditEntries().
  *
- * @covers \OCA\Procest\Service\AiService
+ * @covers \OCA\Procest\Service\Ai\AiAuditService
  *
  * @uses \OCA\Procest\Service\Ai\AiAuditLog
- * @uses \OCA\Procest\Service\Ai\AiEndpointGuard
+ * @uses \OCA\Procest\Service\Ai\AiModelIdentity
  * @uses \OCA\Procest\Service\Support\SearchesObjects
  */
-class AiServiceAuditListTest extends TestCase
+class AiAuditServiceListTest extends TestCase
 {
 
     /**
@@ -84,7 +82,7 @@ class AiServiceAuditListTest extends TestCase
      */
     private LoggerInterface $logger;
 
-    private AiService $service;
+    private AiAuditService $service;
 
     /**
      * Set up test fixtures.
@@ -98,13 +96,9 @@ class AiServiceAuditListTest extends TestCase
         $this->container = $this->createMock(ContainerInterface::class);
         $this->logger     = $this->createMock(LoggerInterface::class);
 
-        $this->service = new AiService(
-            appConfig: $this->appConfig,
-            prompts: new AiPromptFactory(),
-            pii: new AiPiiRedactor(),
-            endpointGuard: new AiEndpointGuard($this->logger),
+        $this->service = new AiAuditService(
             audit: new AiAuditLog($this->appConfig, $this->container, $this->logger),
-            logger: $this->logger,
+            modelIdentity: new AiModelIdentity($this->appConfig),
         );
     }//end setUp()
 

--- a/tests/Unit/Service/Ai/AiAuditServiceRecordTest.php
+++ b/tests/Unit/Service/Ai/AiAuditServiceRecordTest.php
@@ -1,0 +1,165 @@
+<?php
+
+/**
+ * AiAuditService recording Unit Tests
+ *
+ * Guards the two write paths onto the Algoritmeregister oversight trail:
+ * `recordUserAction()` (builds the entry, stamping the configured model) and
+ * `recordAssistantAuditEntry()` (forwards an already-built entry verbatim).
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Service\Ai
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/ai-oversight-log/tasks.md#1.1
+ * @spec openspec/specs/case-assistant-via-hermiq/spec.md
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Service\Ai;
+
+use OCA\Procest\Service\Ai\AiAuditLog;
+use OCA\Procest\Service\Ai\AiAuditService;
+use OCA\Procest\Service\Ai\AiModelIdentity;
+use OCP\IAppConfig;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for AiAuditService's write paths.
+ *
+ * @covers \OCA\Procest\Service\Ai\AiAuditService
+ *
+ * @uses \OCA\Procest\Service\Ai\AiModelIdentity
+ */
+class AiAuditServiceRecordTest extends TestCase
+{
+
+    /**
+     * Build a service whose audit sink is the supplied mock and whose model
+     * identity resolves to `openai/gpt-4o`.
+     *
+     * @param AiAuditLog $audit The audit sink mock.
+     *
+     * @return AiAuditService
+     */
+    private function service(AiAuditLog $audit): AiAuditService
+    {
+        $appConfig = $this->createMock(IAppConfig::class);
+        $appConfig->method('getValueString')
+            ->willReturnCallback(
+                static fn (string $app, string $key, string $default): string => match ($key) {
+                    'ai_model_type' => 'openai',
+                    'ai_model_name' => 'gpt-4o',
+                    default         => $default,
+                }
+            );
+
+        return new AiAuditService(
+            audit: $audit,
+            modelIdentity: new AiModelIdentity($appConfig),
+        );
+    }//end service()
+
+    /**
+     * recordUserAction() writes one entry carrying the case, the human
+     * decision, the applied value and the configured model identifier.
+     *
+     * @return void
+     */
+    public function testRecordUserActionWritesEntryWithModelAndDecision(): void
+    {
+        $captured = null;
+
+        $audit = $this->createMock(AiAuditLog::class);
+        $audit->expects($this->once())
+            ->method('record')
+            ->willReturnCallback(
+                function (array $entry) use (&$captured): void {
+                    $captured = $entry;
+                }
+            );
+
+        $result = $this->service($audit)->recordUserAction(
+            caseId: 'case-1',
+            type: 'classification',
+            userAction: 'modified',
+            suggestion: ['documentType' => 'aanvraag'],
+            actualValue: ['documentType' => 'bezwaar'],
+            reason: 'misread the header',
+            userId: 'alice',
+        );
+
+        $this->assertSame(['success' => true], $result);
+        $this->assertSame('classification', $captured['type']);
+        $this->assertSame('modified', $captured['action']);
+        $this->assertSame('modified', $captured['userAction']);
+        $this->assertSame('case-1', $captured['caseId']);
+        $this->assertSame('openai/gpt-4o', $captured['model']);
+        $this->assertSame(['documentType' => 'aanvraag'], $captured['suggestion']);
+        $this->assertSame(['documentType' => 'bezwaar'], $captured['actualValue']);
+        $this->assertSame('misread the header', $captured['reason']);
+        $this->assertSame('alice', $captured['userId']);
+        $this->assertNotEmpty($captured['timestamp']);
+    }//end testRecordUserActionWritesEntryWithModelAndDecision()
+
+    /**
+     * A null actualValue/reason is normalised rather than written as null,
+     * so the schema never receives a null where it expects array/string.
+     *
+     * @return void
+     */
+    public function testRecordUserActionNormalisesNullActualValueAndReason(): void
+    {
+        $captured = null;
+
+        $audit = $this->createMock(AiAuditLog::class);
+        $audit->method('record')->willReturnCallback(
+            function (array $entry) use (&$captured): void {
+                $captured = $entry;
+            }
+        );
+
+        $this->service($audit)->recordUserAction(
+            caseId: 'case-2',
+            type: 'routing',
+            userAction: 'accepted',
+            suggestion: [],
+            actualValue: null,
+            reason: null,
+            userId: 'bob',
+        );
+
+        $this->assertSame([], $captured['actualValue']);
+        $this->assertSame('', $captured['reason']);
+    }//end testRecordUserActionNormalisesNullActualValueAndReason()
+
+    /**
+     * recordAssistantAuditEntry() forwards a pre-built entry to the same sink
+     * without rewriting it — the conversational surface owns its own shape.
+     *
+     * @return void
+     */
+    public function testRecordAssistantAuditEntryForwardsEntryVerbatim(): void
+    {
+        $entry = [
+            'type'   => 'assistant',
+            'caseId' => 'case-3',
+            'model'  => 'hermiq',
+            'userId' => 'carol',
+        ];
+
+        $audit = $this->createMock(AiAuditLog::class);
+        $audit->expects($this->once())->method('record')->with($entry);
+
+        $this->service($audit)->recordAssistantAuditEntry($entry);
+    }//end testRecordAssistantAuditEntryForwardsEntryVerbatim()
+}//end class

--- a/tests/Unit/Service/Ai/AiModelIdentityTest.php
+++ b/tests/Unit/Service/Ai/AiModelIdentityTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * AiModelIdentity Unit Tests
+ *
+ * Guards the `<type>/<name>` identifier stamped onto every oversight audit
+ * entry and reported by the AI health check — including the `local`/`unknown`
+ * fallbacks an unconfigured instance relies on.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Service\Ai
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/ai-oversight-log/tasks.md#1.1
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Service\Ai;
+
+use OCA\Procest\Service\Ai\AiModelIdentity;
+use OCP\IAppConfig;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for AiModelIdentity.
+ *
+ * @covers \OCA\Procest\Service\Ai\AiModelIdentity
+ */
+class AiModelIdentityTest extends TestCase
+{
+
+    /**
+     * The configured model type and name are joined with a slash.
+     *
+     * @return void
+     */
+    public function testIdentifierJoinsConfiguredTypeAndName(): void
+    {
+        $appConfig = $this->createMock(IAppConfig::class);
+        $appConfig->method('getValueString')
+            ->willReturnCallback(
+                static fn (string $app, string $key, string $default): string => match ($key) {
+                    'ai_model_type' => 'openai',
+                    'ai_model_name' => 'gpt-4o',
+                    default         => $default,
+                }
+            );
+
+        $this->assertSame('openai/gpt-4o', (new AiModelIdentity($appConfig))->identifier());
+    }//end testIdentifierJoinsConfiguredTypeAndName()
+
+    /**
+     * An unconfigured instance falls back to `local/unknown` rather than
+     * writing an empty `model` field into the audit trail.
+     *
+     * @return void
+     */
+    public function testIdentifierFallsBackToLocalUnknown(): void
+    {
+        $appConfig = $this->createMock(IAppConfig::class);
+        $appConfig->method('getValueString')
+            ->willReturnCallback(
+                static fn (string $app, string $key, string $default): string => $default
+            );
+
+        $this->assertSame('local/unknown', (new AiModelIdentity($appConfig))->identifier());
+    }//end testIdentifierFallsBackToLocalUnknown()
+}//end class

--- a/tests/Unit/Service/AiServiceAuditLoggingCompletenessTest.php
+++ b/tests/Unit/Service/AiServiceAuditLoggingCompletenessTest.php
@@ -34,6 +34,7 @@ namespace OCA\Procest\Tests\Unit\Service;
 
 use OCA\Procest\Service\Ai\AiAuditLog;
 use OCA\Procest\Service\Ai\AiEndpointGuard;
+use OCA\Procest\Service\Ai\AiModelIdentity;
 use OCA\Procest\Service\Ai\AiPiiRedactor;
 use OCA\Procest\Service\Ai\AiPromptFactory;
 use OCA\Procest\Service\AiService;
@@ -165,6 +166,7 @@ class AiServiceAuditLoggingCompletenessTest extends TestCase
             pii: new AiPiiRedactor(),
             endpointGuard: new AiEndpointGuard($logger),
             audit: new AiAuditLog($this->appConfig, $this->container, $logger),
+            modelIdentity: new AiModelIdentity($this->appConfig),
             logger: $logger,
         );
     }//end setUp()

--- a/tests/Unit/Service/AiServiceAuditLoggingCompletenessTest.php
+++ b/tests/Unit/Service/AiServiceAuditLoggingCompletenessTest.php
@@ -92,6 +92,7 @@ class StubbedAiService extends AiService
  *
  * @uses \OCA\Procest\Service\Ai\AiAuditLog
  * @uses \OCA\Procest\Service\Ai\AiEndpointGuard
+ * @uses \OCA\Procest\Service\Ai\AiModelIdentity
  * @uses \OCA\Procest\Service\Ai\AiPromptFactory
  */
 class AiServiceAuditLoggingCompletenessTest extends TestCase

--- a/tests/Unit/Service/AiServicePiiDetectionTest.php
+++ b/tests/Unit/Service/AiServicePiiDetectionTest.php
@@ -28,6 +28,7 @@ namespace OCA\Procest\Tests\Unit\Service;
 
 use OCA\Procest\Service\Ai\AiAuditLog;
 use OCA\Procest\Service\Ai\AiEndpointGuard;
+use OCA\Procest\Service\Ai\AiModelIdentity;
 use OCA\Procest\Service\Ai\AiPiiRedactor;
 use OCA\Procest\Service\Ai\AiPromptFactory;
 use OCA\Procest\Service\AiService;
@@ -64,6 +65,7 @@ class AiServicePiiDetectionTest extends TestCase
             pii: new AiPiiRedactor(),
             endpointGuard: new AiEndpointGuard($logger),
             audit: new AiAuditLog($appConfig, $this->createMock(ContainerInterface::class), $logger),
+            modelIdentity: new AiModelIdentity($appConfig),
             logger: $logger,
         );
     }//end service()

--- a/tests/Unit/Service/AiServicePiiDetectionTest.php
+++ b/tests/Unit/Service/AiServicePiiDetectionTest.php
@@ -42,6 +42,7 @@ use OCP\IAppConfig;
  *
  * @uses \OCA\Procest\Service\Ai\AiAuditLog
  * @uses \OCA\Procest\Service\Ai\AiEndpointGuard
+ * @uses \OCA\Procest\Service\Ai\AiModelIdentity
  * @uses \OCA\Procest\Service\Ai\AiPiiRedactor
  * @uses \OCA\Procest\Service\AiService
  */

--- a/tests/Unit/Service/Assistant/CaseAssistantServiceTest.php
+++ b/tests/Unit/Service/Assistant/CaseAssistantServiceTest.php
@@ -6,7 +6,7 @@
  * Exercises validation (400s), fail-closed case loading (404 on missing OR /
  * unknown / unreadable case — never distinguished), the bounded case-context
  * summary sent to Hermiq, per-(user,case) session continuity via IConfig, and
- * audit recording through the existing AiService sink.
+ * audit recording through the existing AiAuditService sink.
  *
  * @category Tests
  * @package  OCA\Procest\Tests\Unit\Service\Assistant
@@ -30,7 +30,7 @@ declare(strict_types=1);
 namespace OCA\Procest\Tests\Unit\Service\Assistant;
 
 use Exception;
-use OCA\Procest\Service\AiService;
+use OCA\Procest\Service\Ai\AiAuditService;
 use OCA\Procest\Service\Assistant\CaseAssistantService;
 use OCA\Procest\Service\Assistant\HermiqAssistantClient;
 use OCA\Procest\Service\SettingsService;
@@ -98,11 +98,11 @@ class CaseAssistantServiceTest extends TestCase
     private HermiqAssistantClient $hermiqClient;
 
     /**
-     * Mock AiService.
+     * Mock AiAuditService.
      *
-     * @var AiService&MockObject
+     * @var AiAuditService&MockObject
      */
-    private AiService $aiService;
+    private AiAuditService $auditService;
 
     /**
      * Mock IConfig.
@@ -128,7 +128,7 @@ class CaseAssistantServiceTest extends TestCase
             }
         );
         $this->hermiqClient = $this->createMock(HermiqAssistantClient::class);
-        $this->aiService     = $this->createMock(AiService::class);
+        $this->auditService  = $this->createMock(AiAuditService::class);
         $this->config        = $this->createMock(IConfig::class);
     }//end setUp()
 
@@ -142,7 +142,7 @@ class CaseAssistantServiceTest extends TestCase
         return new CaseAssistantService(
             $this->settingsService,
             $this->hermiqClient,
-            $this->aiService,
+            $this->auditService,
             $this->config,
             $this->createMock(LoggerInterface::class)
         );
@@ -232,7 +232,7 @@ class CaseAssistantServiceTest extends TestCase
     /**
      * Happy path: builds a bounded summary from only the safe fields, sends
      * the prior Hermiq session for continuity, persists the new session, and
-     * records an audit entry via AiService.
+     * records an audit entry via AiAuditService.
      *
      * @return void
      */
@@ -276,7 +276,7 @@ class CaseAssistantServiceTest extends TestCase
             ->method('setUserValue')
             ->with('alice', 'procest', 'assistant_session_case-1', 'new-session');
 
-        $this->aiService->expects($this->once())
+        $this->auditService->expects($this->once())
             ->method('recordAssistantAuditEntry')
             ->with($this->callback(function (array $entry) {
                 return $entry['type'] === 'assistant'

--- a/tests/Unit/Service/WOOAnonymisationAssistServiceTest.php
+++ b/tests/Unit/Service/WOOAnonymisationAssistServiceTest.php
@@ -7,7 +7,7 @@
  * the rules-floor merge invariant (an LLM proposal can only ADD spans, never
  * remove/shrink a rule-detected one), fail-closed behaviour on any Hermiq
  * failure, rules-only behaviour when the LLM assist is unavailable, and that
- * every proposal call is recorded through the existing AiService audit sink.
+ * every proposal call is recorded through the existing AiAuditService audit sink.
  *
  * @category Tests
  * @package  OCA\Procest\Tests\Unit\Service
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Tests\Unit\Service;
 
+use OCA\Procest\Service\Ai\AiAuditService;
 use OCA\Procest\Service\AiService;
 use OCA\Procest\Service\Assistant\HermiqAnonymisationClient;
 use OCA\Procest\Service\Assistant\HermiqAssistantException;
@@ -48,6 +49,11 @@ class WOOAnonymisationAssistServiceTest extends TestCase
      * @var AiService|\PHPUnit\Framework\MockObject\MockObject
      */
     private AiService $aiService;
+
+    /**
+     * @var AiAuditService|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private AiAuditService $auditService;
 
     /**
      * @var HermiqAnonymisationClient|\PHPUnit\Framework\MockObject\MockObject
@@ -77,6 +83,7 @@ class WOOAnonymisationAssistServiceTest extends TestCase
     protected function setUp(): void
     {
         $this->aiService         = $this->createMock(AiService::class);
+        $this->auditService      = $this->createMock(AiAuditService::class);
         $this->hermiqClient      = $this->createMock(HermiqAnonymisationClient::class);
         $this->assessmentService = $this->createMock(WOODocumentAssessmentService::class);
         $this->redactionService  = $this->createMock(WOORedactionService::class);
@@ -110,6 +117,7 @@ class WOOAnonymisationAssistServiceTest extends TestCase
     {
         return new WOOAnonymisationAssistService(
             $this->aiService,
+            $this->auditService,
             $this->hermiqClient,
             $this->assessmentService,
             $this->redactionService,
@@ -350,7 +358,7 @@ class WOOAnonymisationAssistServiceTest extends TestCase
 
     /**
      * Every proposeSpans() call records an audit entry through the existing
-     * AiService sink, regardless of outcome (rules-only, LLM failure, or
+     * AiAuditService sink, regardless of outcome (rules-only, LLM failure, or
      * full merge).
      *
      * @return void
@@ -361,7 +369,7 @@ class WOOAnonymisationAssistServiceTest extends TestCase
         $this->hermiqClient->method('isAvailable')->willReturn(false);
 
         $capturedEntry = null;
-        $this->aiService->expects($this->once())->method('recordAssistantAuditEntry')->willReturnCallback(
+        $this->auditService->expects($this->once())->method('recordAssistantAuditEntry')->willReturnCallback(
             function (array $entry) use (&$capturedEntry): void {
                 $capturedEntry = $entry;
             }


### PR DESCRIPTION
## What

`ConductionNL/procest` had exactly **one** phpmd finding left on `development`:

```
lib/Service/AiService.php:62  TooManyPublicMethods
The class AiService has 12 public methods. Consider refactoring AiService to keep number of public methods under 10.
```

This clears it with a real refactor — no suppression, no threshold change, no baseline.

## How

`AiService` was 845 lines doing two jobs. The three **oversight** methods move into a new `OCA\Procest\Service\Ai\AiAuditService`:

- `recordUserAction()`
- `listAuditEntries()`
- `recordAssistantAuditEntry()`

That leaves `AiService` doing model orchestration only (is the feature on, build the prompt, scrub PII, make the one outbound guarded call), while "what did a human do with this suggestion" and "read the Algoritmeregister trail back" live in `AiAuditService`. Storage stays where it already was, in `AiAuditLog` — this is a surface split, not a second sink. **12 → 9** phpmd-counted public methods.

The model identifier (`<type>/<name>`) is needed by both halves, so instead of duplicating the config lookup it moves into a small `AiModelIdentity`, injected into each. Behaviour unchanged.

> Note: `TooManyPublicMethods` ignores `get*`/`set*`/`is*`/`has*`/`with*` by default, so `isEnabled`, `isFeatureEnabled` and `getAiSettings` were never counted — making them private would have moved the number by zero.

### Call sites updated

| File | Change |
|---|---|
| `lib/Controller/AiController.php` | takes both services (`recordUserAction` + `listAuditEntries` → audit; 6 AI ops stay) |
| `lib/Controller/AiAuditExportController.php` | audit-only, swapped outright |
| `lib/Service/Assistant/CaseAssistantService.php` | audit-only, swapped outright |
| `lib/Service/WOOAnonymisationAssistService.php` | needs both — also uses `detectDeterministicPiiSpans` |

**No DI registration change:** these services are autowired; nothing in `lib/AppInfo/` references any `Ai*` class.

## Also fixed

Dropped a **dead** `@SuppressWarnings(PHPMD.ExcessiveParameterList)` that sat on `recordUserAction`. The method has 7 parameters against a threshold of 10 — it suppressed nothing. Verified by removing it and re-running phpmd. Net: this PR **removes** one suppression annotation and adds none.

## Verification

Measured in a worktree pinned to `origin/development` @ `6d650bec9`, phpmd over **595 files** in `lib/`, PHP 8.4 container (host PHP is 8.2 and dies in `platform_check.php` with exit 255, which greps as a clean run).

| | before | after |
|---|---|---|
| phpmd | **exit 2**, 1 finding | **exit 0**, 0 findings |
| positive control (injected probe file) | exit 2, **3** probe findings | exit 2, **3** probe findings |

The positive control is the point: a clean phpmd run and a phpmd that never started look identical, so both arms were checked with a deliberately-dirty probe file.

`composer check:strict`, real exit codes (not `tail`'s):

| step | before | after |
|---|---|---|
| lint | 0 | 0 |
| phpcs | 0 (501 warnings) | 0 (501 warnings) |
| phpmd | **2** | **0** |
| psalm | 0 | 0 |
| phpstan | 0 | 0 |
| phpunit | 0 — 1686 tests, 5632 assertions, 10 deprecations, 5 skipped | 0 — **1691** tests, **5649** assertions, 10 deprecations, 5 skipped |

Intermediate runs went through 38 errors → 23 errors → 0, so the suite demonstrably responds to this tree rather than passing by inertia.

## New tests

The extracted model-identifier logic had **no test anywhere** in the repo, so it would have broken silently. Added:

- `AiModelIdentityTest` — configured `<type>/<name>`, and the `local/unknown` fallback an unconfigured instance relies on
- `AiAuditServiceRecordTest` — `recordUserAction()` stamps the model + normalises null `actualValue`/`reason`; `recordAssistantAuditEntry()` forwards verbatim

**Mutation-checked:** flipping the `/` separator in `AiModelIdentity` turns 3 of the new tests red, so they assert something.

## Not done

- No `@SuppressWarnings`, `@psalm-suppress`, `phpcs:ignore`, `phpstan-ignore`, `markTestSkipped` or `.skip(` added
- No baseline file created (there is none in this repo)
- `phpmd.xml`, `phpcs.xml`, `psalm.xml`, `phpstan.neon`, `phpunit.xml`, `composer.json` untouched
- No behaviour change — methods moved, not redesigned