### PR TITLE
refactor(settings): extract readEffectiveConfiguration() — clears the last phpmd finding

### DIFF
--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -552,48 +552,12 @@ class SettingsService
             ];
         }
 
-        $configPath = __DIR__.'/../Settings/procest_register.json';
-        if (file_exists($configPath) === false) {
-            $this->logger->error(
-                'Procest: Configuration file not found at '.$configPath
-            );
-            return [
-                'success' => false,
-                'message' => 'Configuration file not found',
-            ];
+        $effective = $this->readEffectiveConfiguration();
+        if (isset($effective['error']) === true) {
+            return $effective['error'];
         }
 
-        $configContent = file_get_contents($configPath);
-        $configData    = json_decode($configContent, true);
-
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            $this->logger->error('Procest: Invalid JSON in configuration file');
-            return [
-                'success' => false,
-                'message' => 'Invalid JSON in configuration file',
-            ];
-        }
-
-        // ADR-037: deep-merge any modular register fragments from
-        // lib/Settings/register.d/*.json on top of the monolith. This lets
-        // concurrent same-app builds add registers/schemas via isolated
-        // fragment files instead of all editing procest_register.json and
-        // conflicting. Fragments are applied in sorted filename order.
-        // The merge also returns a hash of the fragment set. It is deliberately
-        // not captured: it used to be folded into the version below so that
-        // adding or changing a fragment forced a re-import, but OpenRegister
-        // gates with version_compare, which treats `+…` as further version
-        // parts and compares them LEXICALLY rather than as semver build
-        // metadata — so whether the gate fired depended on how two md5 hashes
-        // happened to sort. Unchanged content re-imported about half the time;
-        // a real change was skipped the other half. OpenRegister now hashes the
-        // merged configuration itself and skips on hash equality, which detects
-        // a changed fragment from the data. The version stays a version.
-        [$configData] = $this->fragments->merge(
-            base: $configData,
-            fragmentDir: __DIR__.'/../Settings/register.d'
-        );
-
+        $configData    = $effective['data'];
         $configVersion = ($configData['info']['version'] ?? '0.0.0');
 
         try {
@@ -630,6 +594,69 @@ class SettingsService
             ];
         }//end try
     }//end loadConfiguration()
+
+    /**
+     * Read procest_register.json and deep-merge the ADR-037 register fragments
+     * on top of it, producing the effective register configuration to import.
+     *
+     * Returns either `['data' => array]` on success or `['error' => array]`
+     * carrying the caller-facing failure shape, so {@see loadConfiguration()}
+     * stays a single import flow rather than also being a file reader.
+     *
+     * @return array{data?: array, error?: array}
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+     */
+    private function readEffectiveConfiguration(): array
+    {
+        $configPath = __DIR__.'/../Settings/procest_register.json';
+        if (file_exists($configPath) === false) {
+            $this->logger->error(
+                'Procest: Configuration file not found at '.$configPath
+            );
+            return [
+                'error' => [
+                    'success' => false,
+                    'message' => 'Configuration file not found',
+                ],
+            ];
+        }
+
+        $configContent = file_get_contents($configPath);
+        $configData    = json_decode($configContent, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            $this->logger->error('Procest: Invalid JSON in configuration file');
+            return [
+                'error' => [
+                    'success' => false,
+                    'message' => 'Invalid JSON in configuration file',
+                ],
+            ];
+        }
+
+        // ADR-037: deep-merge any modular register fragments from
+        // lib/Settings/register.d/*.json on top of the monolith. This lets
+        // concurrent same-app builds add registers/schemas via isolated
+        // fragment files instead of all editing procest_register.json and
+        // conflicting. Fragments are applied in sorted filename order.
+        // The merge also returns a hash of the fragment set. It is deliberately
+        // not captured: it used to be folded into the version so that adding or
+        // changing a fragment forced a re-import, but OpenRegister gates with
+        // version_compare, which treats `+…` as further version parts and
+        // compares them LEXICALLY rather than as semver build metadata — so
+        // whether the gate fired depended on how two md5 hashes happened to
+        // sort. Unchanged content re-imported about half the time; a real
+        // change was skipped the other half. OpenRegister now hashes the merged
+        // configuration itself and skips on hash equality, which detects a
+        // changed fragment from the data. The version stays a version.
+        [$configData] = $this->fragments->merge(
+            base: $configData,
+            fragmentDir: __DIR__.'/../Settings/register.d'
+        );
+
+        return ['data' => $configData];
+    }//end readEffectiveConfiguration()
 
     /**
      * Get all current settings as an associative array.

--- a/tests/Unit/Service/SettingsServiceTest.php
+++ b/tests/Unit/Service/SettingsServiceTest.php
@@ -33,6 +33,7 @@ use Psr\Log\LoggerInterface;
  *
  * @covers \OCA\Procest\Service\SettingsService
  *
+ * @uses \OCA\Procest\Service\Settings\RegisterFragmentMerger
  * @uses \OCA\Procest\Service\Settings\SchemaAnnotationReconciler
  * @uses \OCA\Procest\Service\Settings\SchemaKeyReconciler
  */
@@ -269,4 +270,95 @@ class SettingsServiceTest extends TestCase
     }//end testLoadConfigurationFailsWithoutOpenRegister()
 
 
+    /**
+     * loadConfiguration() reads procest_register.json, deep-merges the ADR-037
+     * register.d fragments on top of it, and hands the RESULT to
+     * ConfigurationService::importFromApp() under the file's own version.
+     *
+     * Guards the read/parse/merge path: without this, that whole path could be
+     * broken (wrong file, unparsed JSON, fragments dropped) and the only
+     * existing loadConfiguration test — the OpenRegister-unavailable early
+     * return — would still pass, because it returns before any of it runs.
+     *
+     * @return void
+     */
+    public function testLoadConfigurationImportsMergedConfigUnderItsOwnVersion(): void
+    {
+        $this->appManager->method('isEnabledForUser')->willReturn(true);
+        $this->appManager->method('isInstalled')->willReturn(true);
+
+        $configurationService = $this->createMock(ProcestConfigurationServiceStub::class);
+
+        $captured = [];
+        $configurationService->expects($this->once())
+            ->method('importFromApp')
+            ->willReturnCallback(
+                function (string $appId, array $data, string $version, bool $force) use (&$captured): array {
+                    $captured = [
+                        'appId'   => $appId,
+                        'data'    => $data,
+                        'version' => $version,
+                        'force'   => $force,
+                    ];
+                    return ['registers' => [], 'schemas' => []];
+                }
+            );
+
+        $this->container->method('get')->willReturnCallback(
+            static function (string $class) use ($configurationService) {
+                if ($class === 'OCA\OpenRegister\Service\ConfigurationService') {
+                    return $configurationService;
+                }
+
+                throw new \RuntimeException('not resolvable in this test: '.$class);
+            }
+        );
+
+        $result = $this->service->loadConfiguration();
+
+        // The on-disk configuration is what must have been read and merged.
+        $onDisk = json_decode(
+            file_get_contents(__DIR__.'/../../../lib/Settings/procest_register.json'),
+            true
+        );
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('procest', $captured['appId']);
+        $this->assertFalse($captured['force']);
+        $this->assertSame($onDisk['info']['version'], $captured['version']);
+        $this->assertSame($onDisk['info']['version'], $result['version']);
+
+        // Parsed, not handed over as a raw string, and carrying the file's own
+        // content rather than an empty array.
+        $this->assertIsArray($captured['data']);
+        $this->assertArrayHasKey('info', $captured['data']);
+        $this->assertNotEmpty($captured['data']);
+
+        // The version must stay a bare version — never a `+frag.<hash>` build
+        // suffix, which OpenRegister's version_compare gate compares
+        // lexically (see #721).
+        $this->assertStringNotContainsString('+', $captured['version']);
+    }//end testLoadConfigurationImportsMergedConfigUnderItsOwnVersion()
+
+
 }//end class
+
+/**
+ * Stub matching the named-arg signature of OpenRegister's ConfigurationService
+ * as loadConfiguration() calls it.
+ */
+interface ProcestConfigurationServiceStub
+{
+
+    /**
+     * Import a register configuration on behalf of an app.
+     *
+     * @param string $appId   The importing app id.
+     * @param array  $data    The effective (merged) configuration.
+     * @param string $version The configuration version.
+     * @param bool   $force   Whether to re-import regardless of version.
+     *
+     * @return array
+     */
+    public function importFromApp(string $appId, array $data, string $version, bool $force): array;
+}//end interface


### PR DESCRIPTION
## Context

Follow-up to #722. That PR cleared `AiService TooManyPublicMethods`, which was the only phpmd finding at the time. Re-measuring on the merged `development` (`773a8bfc4`) turned up **a different single finding**, introduced by #721 while #722 was open:

```
lib/Service/SettingsService.php:531  ExcessiveMethodLength
The method loadConfiguration() has 102 lines of code. Current threshold is set to 100.
```

#721 replaced the `+frag.<md5>` version suffix with a long explanatory comment, which pushed the method 2 lines over. This PR clears it, so phpmd on `development` reaches **0 findings**.

## How

`loadConfiguration()` was doing two jobs:

1. **resolve** the effective register configuration — read `procest_register.json`, parse it, deep-merge the ADR-037 `register.d/*.json` fragments
2. **import** it via OpenRegister's `ConfigurationService`

Job 1 moves into a private `readEffectiveConfiguration()` returning `['data' => …]` on success or `['error' => …]` carrying the caller-facing failure shape. `loadConfiguration()` stays a single import flow instead of also being a file reader.

Behaviour is unchanged — the same two failure shapes (`Configuration file not found`, `Invalid JSON in configuration file`) are returned to the caller in the same order, with the same log calls.

## Test gap this exposed

The extracted path had **no test at all**. The only `loadConfiguration` test covers the OpenRegister-unavailable early return — which returns *before* any of the read/parse/merge code runs. So the whole path could have been broken (wrong file, unparsed JSON, fragments silently dropped) with the suite still green.

Added a test that drives `loadConfiguration()` through to `importFromApp()` and asserts it receives:
- the **on-disk** `info.version` from `procest_register.json`
- **parsed** content (an array carrying `info`), not a raw string or an empty array
- a version with **no `+` build suffix** — the #721 invariant, since OpenRegister's `version_compare` gate compares such suffixes lexically

**Mutation-checked:** making `readEffectiveConfiguration()` return an empty config turns it red (`0.13.2` → `0.0.0`).

## Verification

Worktree pinned to `origin/development` @ `773a8bfc4`, phpmd over **597 files** in `lib/`, PHP 8.4 container (host PHP is 8.2 and dies in `platform_check.php` with exit 255, which greps as a clean run).

| | before | after |
|---|---|---|
| phpmd | **exit 2**, 1 finding | **exit 0**, 0 findings |
| positive control (injected probe) | exit 2, **3** probe findings | exit 2, **3** probe findings |

Findings were matched on the `path:line  Rule  message` shape — phpmd also emits 13 `Deprecated: PDepend\...` lines naming rule classes, and a rule-name grep would manufacture phantom hits from those.

`composer check:strict`, real exit codes:

| step | before | after |
|---|---|---|
| lint | 0 | 0 |
| phpcs | 0 | 0 |
| phpmd | **2** | **0** |
| psalm | 0 | 0 |
| phpstan | 0 | 0 |
| phpunit | 0 — 1691 tests, 5649 assertions | 0 — **1692** tests, **5659** assertions |

### PHPUnit was run under Xdebug on purpose

`phpunit.xml` sets `beStrictAboutCoverageMetadata="true"` + `failOnRisky="true"`. **That check is completely inert without a coverage driver** — on #722 it caught nothing locally and then failed all 4 CI legs with 7 risky tests. PCOV does not drive it either; CI uses Xdebug. Running under Xdebug here flagged a missing `@uses RegisterFragmentMerger` immediately, before pushing.

## Not done

- No `@SuppressWarnings`, `@psalm-suppress`, `phpcs:ignore`, `phpstan-ignore`, `markTestSkipped` or `.skip(` added
- No baseline file created
- `phpmd.xml`, `phpcs.xml`, `psalm.xml`, `phpstan.neon`, `phpunit.xml`, `composer.json` untouched — the threshold stays at 100