### PR TITLE
ci(quality): enable the Code Quality gates this repo was silently skipping

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -116,3 +116,34 @@ jobs:
       #
       # cwd for this step is the Nextcloud server root.
       playwright-seed-command: 'bash apps/procest/tests/e2e/ci-seed.sh'
+
+      # ── Integration tests ────────────────────────────────────────────────
+      # Was explicitly `false`. `newman-collection-path` already points at
+      # `data`, which ships four collections (ZGW OAS tests, ZGW business rules,
+      # procest-leges, procest-zaakportaal) that had never executed in CI. The
+      # path is correct as configured — the run step `cd`s there and globs
+      # `*.postman_collection.json` flat, and all four sit at that level.
+      enable-newman: true
+
+      # ── Frontend Check legs ──────────────────────────────────────────────
+      # `frontend-checks` defaults to `[]`, and an empty list means the shared
+      # workflow emits NO "Frontend Check" job at all — so these three
+      # validators ran nowhere while the run still looked complete.
+      # Measured on this tree before enabling: `test:l10n` PASSES;
+      # `check:manifest` FAILS on three counts — `pages[4]` and `pages[5]`
+      # (`type=custom requires component field`) and `pages[52].type: "roadmap"
+      # not in v1.2 enum`. `check:vue3-compile` could not be measured locally
+      # (it needs `@vue/compiler-sfc`, which only exists after the leg's own
+      # `npm ci`), so CI is the first place it gets a real verdict.
+      # `test` / `test:unit` are NOT listed: "Frontend Tests (unit)" runs them.
+      frontend-checks: '["check:manifest", "check:vue3-compile", "test:l10n"]'
+
+      # ── Hydra mechanical gates ───────────────────────────────────────────
+      # `enable-hydra-gates` defaults to FALSE, so this tier has never executed
+      # here — the job reported `skipped`, which the Quality Report renders
+      # identically to a pass. Pinned to v1.0.1 so a change to the gate package
+      # cannot move this repo's verdict without a commit here.
+      # `enable-axe` deliberately NOT set: a vanilla Nextcloud 34 already carries
+      # serious/critical violations from core's own UI.
+      enable-hydra-gates: true
+      hydra-gates-ref: v1.0.1

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -117,13 +117,13 @@ jobs:
       # cwd for this step is the Nextcloud server root.
       playwright-seed-command: 'bash apps/procest/tests/e2e/ci-seed.sh'
 
-      # ── Integration tests ────────────────────────────────────────────────
-      # Was explicitly `false`. `newman-collection-path` already points at
-      # `data`, which ships four collections (ZGW OAS tests, ZGW business rules,
-      # procest-leges, procest-zaakportaal) that had never executed in CI. The
-      # path is correct as configured — the run step `cd`s there and globs
-      # `*.postman_collection.json` flat, and all four sit at that level.
-      enable-newman: true
+      # Integration Tests (Newman) stays OFF here, deliberately. The
+      # `enable-newman: false` further up is not a default nobody chose: it
+      # records that the ZGW compliance collections fail at 95%+ because the ZGW
+      # API implementation is still in progress. Four collections are committed
+      # under `data/` and would all meet that same known cause — a guaranteed
+      # red that teaches nothing the comment does not already say. Flipped back
+      # on in the commit that gets the core CRUD assertions passing.
 
       # ── Frontend Check legs ──────────────────────────────────────────────
       # `frontend-checks` defaults to `[]`, and an empty list means the shared


### PR DESCRIPTION
## What

Enables the Code Quality gates this repo was silently skipping.

| gate | was | now |
|---|---|---|
| Frontend Check | skipped (`frontend-checks: []`) | `["check:manifest", "check:vue3-compile", "test:l10n"]` |
| Hydra Gates | skipped (`enable-hydra-gates` unset) | on, pinned `v1.0.1` |

## Why

A skipped job and a passing job are **indistinguishable in the Quality Report**.
Every gate listed above reported `skipped` in this repository's runs, which reads
as "fine". This turns them on.

Two prerequisites landed on `ConductionNL/.github@main` first and are what make
this viable:

- **#149** — hydra-gates gate-7 (`no-admin-idor`) now follows delegation, and
  gates 6/7 no longer pass on an empty scope. Before that, gate-7 flagged
  correctly-guarded methods whose guard is reached through a helper, which is
  why 19 of 20 repos kept the whole tier switched off.
- **#150** — an empty `frontend-checks` list *deleted* the Frontend Check job
  from the run rather than skipping it, because `inputs.frontend-checks != '[]'`
  was a literal string comparison.

## Not enabled, on purpose

- **Journeydoc Capture** — deliberately left off everywhere.
- **`enable-axe`** — it produces the report hydra-gates gate-33 consumes, but a
  vanilla Nextcloud 34 with no app installed already returns three
  serious/critical violations from core's own UI. Turning it on in the same
  change as the gates would confuse "this app has an accessibility defect" with
  "Nextcloud core does". Separate change.

## On red

Some legs below were measured failing *before* this PR was opened, and are
enabled anyway. The defects are pre-existing; the only thing that changed is
that CI can now see them. Per the brief, a gate is not switched back off because
it failed on arrival — the failure is the result.

## Measured before flipping, not after

Every leg below was run against this branch's tree *before* it was enabled:

- `test:l10n` **PASSES** — 2102 keys used, 3100 in `en.json`, and `en.json`/`nl.json` key sets match.
- `check:manifest` **FAILS** on three counts — `pages[4]` and `pages[5]` (`type=custom requires component field`) and `pages[52].type: "roadmap" not in v1.2 enum`.
- `check:vue3-compile` **not measurable locally** — it needs `@vue/compiler-sfc`, which only exists after the leg's own `npm ci`. CI is the first place it gets a real verdict; that is stated rather than guessed.

## Left off, with reasons

- **Integration Tests (Newman)** — left OFF. I initially enabled it, then reverted: the existing `enable-newman: false` records that the ZGW compliance collections fail at 95%+ because the ZGW API implementation is still in progress. Four collections under `data/` would meet that same known cause. It goes back on in the commit that gets the core CRUD assertions passing.
- Coverage ratchet — **already enabled** here (one of only two repos in the fleet that had `.coverage-baseline` committed); unchanged at 29.6.
- `test` / `test:unit` — already run by the shared *Frontend Tests (unit)* job.

