### PR TITLE
chore(deps): move to @conduction/nextcloud-vue 2.2.0-vue3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.0",
 			"license": "EUPL-1.2",
 			"dependencies": {
-				"@conduction/nextcloud-vue": "3.0.0-vue3.6",
+				"@conduction/nextcloud-vue": "2.2.0-vue3.1",
 				"@nextcloud/auth": "^2.6.0",
 				"@nextcloud/axios": "~2.5.2",
 				"@nextcloud/capabilities": "^1.2.1",
@@ -568,9 +568,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "3.0.0-vue3.6",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-3.0.0-vue3.6.tgz",
-			"integrity": "sha512-6x8VapVLF22eCQB+CdoC1OkB3oLiIM31OceexDrvu/L++8Z5HYV2X3Xcgl8ZGy29jcqbtrjDNaZ5WbaDrzm8fA==",
+			"version": "2.2.0-vue3.1",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.2.0-vue3.1.tgz",
+			"integrity": "sha512-NXxYi52JDn3QHvlo23bLoY6Gm/ecnj95PO89cZ8hFqP/sWyzkajM4agcID//p0v+t/ESS+8Q2R1dfLwqyCmMdQ==",
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@ckpack/vue-color": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"extends @nextcloud/browserslist-config"
 	],
 	"dependencies": {
-		"@conduction/nextcloud-vue": "3.0.0-vue3.6",
+		"@conduction/nextcloud-vue": "2.2.0-vue3.1",
 		"@nextcloud/auth": "^2.6.0",
 		"@nextcloud/axios": "~2.5.2",
 		"@nextcloud/capabilities": "^1.2.1",


### PR DESCRIPTION
Moves off the withdrawn `3.0.0-vue3.*` line onto the resumed 2.x prerelease line.

The 3.0 major was cut from a genuine `BREAKING CHANGE:` footer (the retired action-list flow editors), but it applied to a prerelease channel only our own apps consume, so the line is resumed at 2.x rather than carried forward. The six `3.0.0-vue3.*` versions are being withdrawn from npm once every app is off them.

**Despite the lower version number this is not a downgrade in content.** `2.2.0-vue3.1` is a superset of `3.0.0-vue3.6`: it additionally carries the recovered Vue 2 -> Vue 3 component conversion (196 specs, 137 components, 51 missing `emits`) and the CnGraphCanvas port/loop work.

### Verification

Two traps had to be stepped around, so the evidence is stated precisely:

- **Lockfile** regenerated with **npm 10.8.2**, matching CI's node 20 toolchain. Local npm 11 prunes optional entries that do not apply to the current platform, which makes CI's `npm ci` fail with `Missing: pinia@4.0.2 / vite@8.2.0 ... from lock file`. Running `npm ci` locally does **not** reproduce it — npm 11 accepts the lockfile it just wrote. Verified with `npx npm@10.8.2 ci --dry-run` (exit 0).
- **Build** run as `USE_LOCAL_LIB=false npm run build` (exit 0, no unresolved modules). That flag is load-bearing: this repo's `webpack.config.js` aliases `@conduction/nextcloud-vue` to a sibling `../nextcloud-vue/src` checkout whenever one exists, so a plain build can silently compile the sibling's source instead of the package under test.