### PR TITLE
fix(dashboard): calendar-aligned range presets, and the real caseType label field

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -327,10 +327,10 @@
 					"persistKey": "procest-dashboard-range",
 					"default": { "preset": "month" },
 					"presets": [
-						{ "id": "week", "label": "Week", "days": 7 },
-						{ "id": "month", "label": "Month", "days": 30 },
-						{ "id": "quarter", "label": "Quarter", "days": 90 },
-						{ "id": "year", "label": "Year", "days": 365 },
+						{ "id": "week", "label": "Current week", "period": "week" },
+						{ "id": "month", "label": "Current month", "period": "month" },
+						{ "id": "quarter", "label": "Current quarter", "period": "quarter" },
+						{ "id": "year", "label": "Current year", "period": "year" },
 						{ "id": "all", "label": "All", "days": null }
 					]
 				},
@@ -384,7 +384,7 @@
 								"register": "procest",
 								"schema": "case",
 								"filter": { "isFinalStatus": false },
-								"aggregate": { "groupBy": "caseType", "metric": "count", "labelResolve": { "schema": "caseType", "labelField": "name" } },
+								"aggregate": { "groupBy": "caseType", "metric": "count", "labelResolve": { "schema": "caseType", "labelField": "title" } },
 								"drilldown": { "route": "Cases", "filterParam": "caseType" }
 							}
 						}


### PR DESCRIPTION
Two companion fixes to [nextcloud-vue#600](https://github.com/ConductionNL/nextcloud-vue/pull/600).

## Presets were rolling windows wearing calendar labels

`days: 30` on 21 May covers **22 April – 21 May**. Labelling that "Month" misstates what the numbers cover. They now use the `period` preset kind added in nextcloud-vue#600, which resolves to the **current calendar unit to date**, and are relabelled "Current week/month/quarter/year".

## The chart was resolving labels through a field that does not exist

"Cases by Type" used `labelResolve.labelField: "name"`, but the `caseType` schema has **no `name` property** — only `title`. The chart worked purely by accident, falling through to the `@self.name` fallback. Corrected to the field that actually exists. `statusType` genuinely has `name`, so that one is untouched.

## Sequencing

Both depend on nextcloud-vue#600 landing and releasing on the vue3 line. The preset change is **inert** until then — an unknown preset kind resolves to null and the previous window stands — and the labelField correction is an improvement either way. Manifest validates against the v2 schema.