### PR TITLE
ci(quality): move the hydra-gates pin v1.0.1 -> v1.2.0

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -139,11 +139,27 @@ jobs:
       frontend-checks: '["check:manifest", "check:vue3-compile", "test:l10n"]'
 
       # ── Hydra mechanical gates ───────────────────────────────────────────
-      # `enable-hydra-gates` defaults to FALSE, so this tier has never executed
-      # here — the job reported `skipped`, which the Quality Report renders
-      # identically to a pass. Pinned to v1.0.1 so a change to the gate package
-      # cannot move this repo's verdict without a commit here.
+      # The tier is ON. Pinned to a tag, not `main`, so a change to the gate
+      # package cannot move this repo's verdict without a commit here.
+      #
+      # Moved v1.0.1 -> v1.2.0. Two things this repo's last run needed:
+      #
+      #   1. gate-22 (manifest-validation) reported `FAIL — 0` here. The
+      #      finding is real; the COUNT was the bug — `$(grep -c … || echo 1)`
+      #      captures BOTH grep's printed "0" AND the fallback "1", so the
+      #      "clamp to at least 1" guard errored instead of firing and the
+      #      reason was orphaned onto a second line no `^\[gate-` consumer
+      #      reads. Fixed by the shared `_count` helper in v1.1.0.
+      #
+      #   2. gate-5 (route-auth) reported 4 findings. v1.0.1's gate-5 could not
+      #      tell "this routed method has no auth attribute" from "I could not
+      #      resolve the controller class", and reported both as the former.
+      #      v1.2.0 separates them (ConductionNL/.github#162, closing #153).
+      #      Whichever of the 4 are genuine will still fail — and v1.2.0 also
+      #      starts judging camelCase route slugs, which v1.0.1's
+      #      `'[a-z_]+#…'` regex never matched, so EXPECT NEW REAL FINDINGS.
+      #
       # `enable-axe` deliberately NOT set: a vanilla Nextcloud 34 already carries
       # serious/critical violations from core's own UI.
       enable-hydra-gates: true
-      hydra-gates-ref: v1.0.1
+      hydra-gates-ref: v1.2.0


### PR DESCRIPTION
Moves this repo's `hydra-gates-ref` pin from `v1.0.1` to `v1.2.0`.

## Why

`v1.0.1`'s **gate-5 (route-auth)** had four defects. Two were reported as
[ConductionNL/.github#153](https://github.com/ConductionNL/.github/issues/153);
the other two were found while fixing it, and one of those is the expensive
direction:

1. **A resolution failure was reported as a security finding.** When
   `lib/Controller/<X>Controller.php` did not exist, the verdict read
   "N routed method(s) missing auth attribute". On ADR-040 AppHost adopters
   those files are absent *by design* — the controllers are OpenRegister
   generics aliased at runtime — and the attributes live in the openregister
   package. The gate was reporting "I cannot see it" as "it is absent".
2. **It was not diff-scoped.** The missing-file branch `continue`d *before*
   the `_in_scope` call, so those findings fired on a `package.json`-only
   Dependabot bump. Now scoped per ADR-020.
3. **camelCase route slugs were invisible.** Gate-5 read route names through
   `'[a-z_]+#…'`. Gate-14 already used a wider regex; the narrower one was the
   *security* gate. On scholiq, 14 of 37 routed names matched — the other 23
   were never opened.
4. **The 20-line attribute lookback was not bounded by the start of the
   method,** so a short guarded method within 20 lines above an unguarded one
   donated its `#[NoAdminRequired]` to its neighbour. A false negative, and
   invisible, because a pass leaves no log.

Fixed in ConductionNL/.github#162 with 25 control-pair assertions, mutation-tested
against three realistic degradations.

`v1.2.0` also brings, from `v1.1.0`, a **countable gate-22** (it printed
`FAIL — 0` while a real finding sat in its log) and the runner's **COVERAGE
accounting** — `v1.0.1`'s summary printed only `N gate(s) failed`, so a gate
that never ran was indistinguishable from one that passed.

## Expect red

Gate-5 now sees code it never saw. **New findings from this PR are the point of
it, not a regression.** Nothing has been baselined or suppressed to keep a repo
green.

⚠️ Note for whoever reads the job log: the Hydra Gates job on *this* PR diffs a
single workflow file, and the gates are diff-scoped — so its green says almost
nothing. The measurement that matters is the next real code PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
