### PR TITLE
ci(procest): enable SBOM — the ELSPROBLEMS blocker is stale

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -55,14 +55,41 @@ jobs:
       # needs the `settings#load` route it ships — `development` is where that
       # plumbing lands first.
       additional-apps: '[{"repo":"ConductionNL/openregister","app":"openregister","ref":"development"}]'
-      # SBOM disabled until @conduction/nextcloud-vue's dependency declarations
-      # are cleaned up — its `npm ls` tree fails ELSPROBLEMS (bootstrap-vue is a
-      # non-optional peer, apexcharts/pinia/vue version ranges don't match what
-      # apps install, @types/react comes from a transitive rehype-react), which
-      # @cyclonedx/cyclonedx-npm propagates as a hard failure (it always runs
-      # `npm ls` under the hood; `--package-lock-only` doesn't sidestep it).
-      # No other Conduction app enables SBOM today. Tracked in #434.
-      enable-sbom: false
+      # SBOM was disabled here until @conduction/nextcloud-vue's dependency
+      # declarations were cleaned up — its `npm ls` tree fails ELSPROBLEMS
+      # (bootstrap-vue is a non-optional peer, apexcharts/pinia/vue version
+      # ranges don't match what apps install, @types/react comes from a
+      # transitive rehype-react), and @cyclonedx/cyclonedx-npm propagated that
+      # as a hard failure because it always runs `npm ls` under the hood.
+      # Tracked in #434.
+      #
+      # That blocker is STALE, and the old comment's last line ("No other
+      # Conduction app enables SBOM today") is now false — which is exactly why
+      # it was worth re-measuring rather than trusting. The shared workflow's
+      # npm SBOM step now runs:
+      #
+      #   npx @cyclonedx/cyclonedx-npm --package-lock-only --ignore-npm-errors …
+      #
+      # `--ignore-npm-errors` is the flag that neutralises ELSPROBLEMS, and it
+      # was not there when this was switched off.
+      #
+      # Measured positive control rather than assumed: ConductionNL/docudesk
+      # depends on the SAME `@conduction/nextcloud-vue` version this repo pins
+      # (2.2.0-vue3.3), and its SBOM job on `development` ran the npm leg to
+      # completion and merged the PHP + npm SBOMs — run 31016019235, job
+      # 92340789907. openregister, opencatalogi and doriath are green on SBOM
+      # too. The dependency this comment blamed does not stop the job in four
+      # sibling repos, so it does not stop it here.
+      #
+      # procest already ships the other prerequisite: `composer.json` requires
+      # cyclonedx/cyclonedx-php-composer ^6.2 and allows its plugin, so the
+      # `composer CycloneDX:make-sbom` step has what it needs.
+      #
+      # NOTE: SBOM only runs on a branch push (its `if:` tests github.ref
+      # against refs/heads/{main,beta,development}); on a pull_request the ref
+      # is refs/pull/N/merge, so this job is invisible on the PR that enables
+      # it and first reports on the merge to `development`.
+      enable-sbom: true
       # ── E2E browser tests ────────────────────────────────────────────────
       # Previously LEFT OFF. The comment that lived here recorded the blocker,
       # so it is kept (not deleted) next to what changed:


### PR DESCRIPTION
`enable-sbom` has been `false` in procest's caller since the shared workflow's npm SBOM step could be broken by `@conduction/nextcloud-vue`'s `npm ls` tree failing ELSPROBLEMS (#434).

**That blocker is stale.** The shared workflow now runs:

```
npx @cyclonedx/cyclonedx-npm --package-lock-only --ignore-npm-errors …
```

`--ignore-npm-errors` is precisely the flag that neutralises ELSPROBLEMS, and it was not present when this was switched off.

**Measured positive control, not assumed:** docudesk pins the *same* `@conduction/nextcloud-vue@2.2.0-vue3.3` this repo pins, and its SBOM job on `development` ran the npm leg to completion and merged the PHP + npm SBOMs — run 31016019235, job 92340789907. openregister, opencatalogi and doriath are green on SBOM too, so the old comment's closing line ("No other Conduction app enables SBOM today") is now false.

procest already ships the other prerequisite: `composer.json` requires `cyclonedx/cyclonedx-php-composer ^6.2` and allows its plugin.

### Note on where this reports
SBOM's `if:` tests `github.ref` against `refs/heads/{main,beta,development}`. On a pull request the ref is `refs/pull/N/merge`, so **this job cannot run on this PR** — it first reports on the merge to `development`. That is the shared workflow's design, not a defect in this change.

No skip, waiver, `continue-on-error` or threshold change was added.