### PR TITLE
fix(phpmd): scope the lib/Migration UnusedFormalParameter exclusion to its own ruleset

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
 		"phpcs": "./vendor/bin/phpcs --standard=phpcs.xml",
 		"phpcs:fix": "./vendor/bin/phpcbf --standard=phpcs.xml",
 		"phpcs:output": "./vendor/bin/phpcs --standard=phpcs.xml --report=json lib/ 2>/dev/null | tail -1 > phpcs-output.json",
-		"phpmd": "./vendor/bin/phpmd lib text phpmd.xml",
+		"phpmd": "E=0; ./vendor/bin/phpmd lib text phpmd.xml || E=$?; ./vendor/bin/phpmd lib text phpmd-unusedparams.xml || E=$?; exit $E",
 		"phpmetrics": "./vendor/bin/phpmetrics --report-html=phpmetrics lib/",
 		"phpmetrics:violations": "./vendor/bin/phpmetrics --violations-xml=phpmetrics/violations.xml lib/",
 		"psalm": "if [ -f vendor/bin/psalm ]; then ./vendor/bin/psalm --threads=1 --no-cache; else echo 'Psalm not installed, skipping...'; fi",

--- a/phpmd-unusedparams.xml
+++ b/phpmd-unusedparams.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<ruleset name="Unused formal parameters"
+    xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_xml_schema.xsd">
+
+    <description>
+        Second PHPMD leg: UnusedFormalParameter only.
+
+        This rule lives in its own ruleset because PHPMD honours &lt;exclude-pattern&gt;
+        ONLY as a direct child of &lt;ruleset&gt;; nested inside a &lt;rule&gt; it is parsed and
+        discarded (ConductionNL/.github#155). A direct child, however, is applied by
+        PDepend at file-collection time and drops the file from EVERY rule in the
+        ruleset. Isolating UnusedFormalParameter here means the lib/Migration
+        exclusion applies to this rule and this rule ALONE - every other rule still
+        analyses lib/Migration in the main leg.
+
+        Why lib/Migration is excluded from THIS rule: OCP\Migration\IMigrationStep
+        mandates changeSchema(IOutput $output, Closure $schemaClosure, array $options)
+        and preSchemaChange/postSchemaChange with the same three parameters. A step
+        that needs none of them still cannot drop them. The signature cannot change.
+
+        The pattern is */lib/Migration/* and deliberately NOT */Migration/* or
+        *Migration*. Those broader forms silently swallow ORDINARY CLASSES that merely
+        have "Migration" in their path - measured on openconnector, */Migration/* hides
+        a genuine finding in lib/Service/Migration/, and *Migration* additionally hides
+        every lib/Service/MigrationService.php, lib/Controller/MigrationController.php
+        and lib/Db/*Migration*.php. Those have no mandated signature and must stay
+        analysed. Only the app's own lib/Migration/ directory holds IMigrationStep
+        implementations, so only that directory is exempted.
+
+        Both legs must always run - see the "phpmd" script in composer.json, which
+        keeps the worst exit code rather than letting the first leg short-circuit
+        the second.
+    </description>
+
+    <exclude-pattern>*/lib/Migration/*</exclude-pattern>
+
+    <rule ref="rulesets/unusedcode.xml/UnusedFormalParameter"/>
+</ruleset>

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -97,7 +97,27 @@
     <rule ref="rulesets/unusedcode.xml/UnusedPrivateField"/>
     <rule ref="rulesets/unusedcode.xml/UnusedLocalVariable"/>
     <rule ref="rulesets/unusedcode.xml/UnusedPrivateMethod"/>
-    <rule ref="rulesets/unusedcode.xml/UnusedFormalParameter">
-        <exclude-pattern>*Migration*</exclude-pattern>
-    </rule>
+    <!-- UnusedFormalParameter is NOT declared here. It lives alone in
+         phpmd-unusedparams.xml, which is run as a second leg by the "phpmd"
+         composer script.
+
+         Why: this rule used to carry a NESTED
+             <exclude-pattern>*Migration*</exclude-pattern>
+         meant to spare lib/Migration, whose changeSchema/preSchemaChange/
+         postSchemaChange signatures are mandated by OCP\Migration\IMigrationStep
+         and cannot drop their unused parameters. That pattern was INERT: PHPMD
+         2.15 reads exclude-patterns in RuleSetFactory::getIgnorePattern(), which
+         walks $xml->children() - i.e. only elements DIRECTLY under <ruleset>. A
+         nested one parses without error and does nothing, so lib/Migration was
+         always scanned by this rule (ConductionNL/.github#155).
+
+         Moving the pattern up to the top level of THIS file would make it
+         effective, but it is applied by PDepend's ExcludePathFilter at
+         file-collection time, so it drops lib/Migration from EVERY rule in the
+         ruleset - real complexity, StaticAccess and method-length findings in
+         migrations would silently vanish.
+
+         Isolating the rule in its own ruleset gives the exclusion a top-level
+         home that scopes it to this one rule, while the main leg above keeps
+         analysing lib/Migration with everything else. -->
 </ruleset>


### PR DESCRIPTION
Part of the fleet PHPMD ruleset fix (ConductionNL/.github#155). Propagates the shape
already merged in `nextcloud-app-template` #125, `doriath` #157, `larpingapp` #263 and `planix` #315.

## The defect

`phpmd.xml` declared:

```xml
<rule ref="rulesets/unusedcode.xml/UnusedFormalParameter">
    <exclude-pattern>*Migration*</exclude-pattern>
</rule>
```

A **nested** `<exclude-pattern>` is **inert**. PHPMD 2.15 reads exclude-patterns in
`RuleSetFactory::getIgnorePattern()`, which walks `$xml->children()` — only elements
**directly under `<ruleset>`**. A nested one parses without error and is discarded, so
`lib/Migration` was scanned by the very rule the pattern was written to spare.

Reproduced directly on this repo's ruleset: a probe class in `lib/Migration` with three
unused formal parameters was **reported**, exit 2, with the nested pattern in place.

## Why not simply hoist the pattern

A top-level `<exclude-pattern>` is applied by PDepend's `ExcludePathFilter` at
*file-collection* time, so it drops the file from **every rule in the ruleset** — real
complexity, `StaticAccess` and method-length findings in migrations would silently vanish.

## The shape shipped here

* `phpmd.xml` no longer declares `UnusedFormalParameter`; a comment records why.
* New `phpmd-unusedparams.xml` holds that rule **alone**, with a **top-level**
  `*/Migration/*` exclude — so the exclusion is scoped to that one rule and nothing else.
* The `phpmd` composer script runs **both legs**, keeping the worst exit code so neither
  leg can short-circuit the other.

Why `lib/Migration` is exempt from this one rule: `OCP\Migration\IMigrationStep` mandates
`changeSchema(IOutput $output, Closure $schemaClosure, array $options)` and
`preSchemaChange`/`postSchemaChange` with the same three parameters. A step that needs none
of them still cannot drop them — the signature is not ours to change.

## Measurement

PHPMD **2.15.0** (the version this repo's lockfile pins) on **PHP 8.4.22**, run in a
`nextcloud:latest` container: host PHP 8.2 makes `vendor/bin/phpmd` die in
`platform_check.php` with exit **255**, which reads exactly like a clean run. Exit codes
are read directly, never through a pipe. Findings are compared as normalised
`path:line:rule` triples — PHPMD right-pads the `file:line` column in text output, so raw
line diffs are meaningless.

| | findings | leg exits |
|---|---|---|
| reported, before | 0 | leg1=0 |
| reported, after | 0 | leg1=0 leg2=0 |
| **true** (every `@SuppressWarnings` stripped on a throwaway copy), before | **286** | leg1=2 |
| **true**, after | **286** | leg1=2 leg2=2 |

The *true* count strips every `@SuppressWarnings` in `lib/` on a **throwaway copy that is
never committed**, so the comparison isolates the ruleset change from the suppressions.

**Retired: 0**

**Newly appearing (true): 0** — must be 0, and is.
**Newly appearing (reported): 0**. **Retired (reported): 0**.

Zero newly-hidden findings: every triple present before is present after, except the
retired `UnusedFormalParameter` hits inside `lib/Migration` listed above.

`lib/Migration` in this repo: **0** PHP file(s).

## Dead-gate proof

A new leg that exits 0 on the shipped tree is indistinguishable from a leg that does not
run. Proven otherwise on a **throwaway copy** (probes removed before committing) — three
probes, run through the shipped two-leg invocation:

| probe | expected | observed |
|---|---|---|
| `lib/Migration/ZzProbeMigration.php` UnusedFormalParameter | dropped | **not reported** |
| `lib/Migration/ZzProbeMigration.php` ElseExpression | still live | **reported, leg 1** |
| `lib/ZzProbe/ZzProbe.php` UnusedFormalParameter | still live | **reported, leg 2** |

```
leg1=2
leg2=2
leg1	lib/Migration/ZzProbeMigration.php:6:ElseExpression
leg2	lib/ZzProbe/ZzProbe.php:4:UnusedFormalParameter
leg2	lib/ZzProbe/ZzProbe.php:4:UnusedFormalParameter
```

Leg 2 goes from exit 0 to exit **2** under the probe, so it is live. The Migration
`ElseExpression` probe is **still reported**, so isolating the rule did **not** blind the
other rules to `lib/Migration` — which is exactly what a hoisted top-level pattern would
have done.

The rig itself was positive-controlled before the first measurement: the same probes under
the **unfixed** ruleset were reported with exit 2, including the three `UnusedFormalParameter`
hits in `lib/Migration` that the nested pattern was supposed to suppress.

## Baseline

`phpmd.baseline.xml` present: **no**. None was added, deleted or shrunk.

PHPMD **auto-discovers** `phpmd.baseline.xml` from the working directory, so removing the
`--baseline-file` flag would be a no-op — the baseline stays active either way. Verified
empirically on this fleet: identical command, baseline file present → 0 findings / exit 0;
same command with the file absent → 93 findings / exit 2.

## Suppressions

**0 deleted.** This repo has **no `lib/Migration` directory at all**, so it carried no `@SuppressWarnings(PHPMD.UnusedFormalParameter)` tags for this fix to make redundant.

**This fix therefore retires nothing in this repo.** Its value is the corrected shape — the old nested pattern was inert either way, and the new leg is proven live below.

This repo still carries 59 `UnusedFormalParameter` and 211 other suppressions elsewhere in `lib/`; those are outside this PR's scope and untouched.

Note: `lib/Service/TenantMigrationService.php` contains "Migration" in its filename. It is **not** matched by `*/lib/Migration/*` (nor by `*/Migration/*`, which needs a directory segment), but it **would** have been matched by the older `*Migration*` form. It stays fully analysed.

No `@SuppressWarnings` was added. No threshold was changed, no rule weakened, no baseline
entry added, nothing skipped.

## Tests

`phpunit -c phpunit-unit.xml`:

* before: 1692 tests, 5648 assertions, **2 failures**, 2 warnings, 10 deprecations, 5 skipped — **already RED**
* after: 1692 tests, 5648 assertions, **2 failures**, 2 warnings, 10 deprecations, 5 skipped — **still the same 2 failures, unchanged**

(The default `phpunit.xml` suite needs a live Nextcloud runtime and errors out in a bare
checkout — a pre-existing condition this change does not touch.)

## What this PR does NOT do

- does not add or remove a baseline, a `@SuppressWarnings`, a threshold change or a waiver
- does not touch any rule other than `UnusedFormalParameter`
- does not burn down any of the remaining suppression-free findings — that is separate work
