### PR TITLE
chore(license): normalise licence declarations to EUPL-1.2

### DIFF
--- a/docs/Technical/government-compliance.md
+++ b/docs/Technical/government-compliance.md
@@ -5,7 +5,7 @@
 
 **Product:** Procest
 **Categorie:** Zaakgericht werken & case management
-**Licentie:** AGPL (vrije open source)
+**Licentie:** EUPL-1.2 (vrije open source)
 **Leverancier:** Conduction B.V.
 **Platform:** Nextcloud + Open Register (self-hosted / on-premise / cloud)
 
@@ -89,7 +89,7 @@
 | # | Eis | Status | Toelichting |
 |---|-----|--------|-------------|
 | T-01 | On-premise / self-hosted installatie | Beschikbaar | Nextcloud-app, volledig on-premise |
-| T-02 | Open source (broncode beschikbaar) | Beschikbaar | AGPL licentie, GitHub |
+| T-02 | Open source (broncode beschikbaar) | Beschikbaar | EUPL-1.2 licentie, GitHub |
 | T-03 | RESTful API | Via platform | OpenRegister REST API |
 | T-04 | Event-driven architectuur | Via platform | OpenRegister events |
 | T-05 | Schaalbaarheid | Via platform | OpenRegister + Solr |

--- a/project.md
+++ b/project.md
@@ -9,7 +9,7 @@ Procest is a lightweight case management (zaakgericht werken) app for Nextcloud,
 - **Type**: Nextcloud App (PHP backend + Vue 2 frontend)
 - **Data layer**: OpenRegister (all data stored as register objects)
 - **Pattern**: Thin client — Procest provides UI/UX, OpenRegister handles persistence
-- **License**: AGPL-3.0-or-later
+- **License**: EUPL-1.2
 
 See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for detailed architecture and data model decisions.
 

--- a/tests/e2e/case-types-tabs.spec.ts
+++ b/tests/e2e/case-types-tabs.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Procest Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Case-types admin smoke — covers the 7-tab integration spec'd by
  * case-types-03-result-role-tabs and case-types-04-property-doc-decision-tabs.

--- a/tests/e2e/docs-screenshots.spec.ts
+++ b/tests/e2e/docs-screenshots.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Procest Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Documentation screenshot capture suite — procest.
  *

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Procest Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Playwright globalSetup — logs into Nextcloud once and persists the
  * resulting cookie jar / localStorage to `tests/e2e/.auth/user.json`.

--- a/tests/e2e/helpers/addressFixtures.ts
+++ b/tests/e2e/helpers/addressFixtures.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Procest Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Address-fixture seeding helper for the PDOK-via-openconnector e2e layer
  * (migrate-pdok-to-openconnector, task PR-4).

--- a/tests/e2e/helpers/fixtures.ts
+++ b/tests/e2e/helpers/fixtures.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Procest Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Seeded-fixture helper for the DEEP, data-dependent procest e2e layer.
  *

--- a/tests/e2e/helpers/nav.ts
+++ b/tests/e2e/helpers/nav.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Procest Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Shared navigation helpers for Procest e2e tests.
  *

--- a/tests/e2e/spec-coverage/admin-settings.spec.ts
+++ b/tests/e2e/spec-coverage/admin-settings.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Procest Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 spec-coverage tests for admin-settings spec.
  * Each test is tagged with the scenario it covers.

--- a/tests/e2e/spec-coverage/bezwaar-family.spec.ts
+++ b/tests/e2e/spec-coverage/bezwaar-family.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Procest Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Behavioural UI coverage for the bezwaar (objection) lifecycle index
  * pages: Beroepen (appeals) and Bezwaaradviescommissies (advisory

--- a/tests/e2e/spec-coverage/case-email-integration.spec.ts
+++ b/tests/e2e/spec-coverage/case-email-integration.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Procest Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 spec-coverage tests for the case-email-integration spec.
  *

--- a/tests/e2e/spec-coverage/deelzaak-support.spec.ts
+++ b/tests/e2e/spec-coverage/deelzaak-support.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Procest Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 spec-coverage tests for the deelzaak (sub-case) UI surface.
  *

--- a/tests/e2e/spec-coverage/document-zaakdossier.spec.ts
+++ b/tests/e2e/spec-coverage/document-zaakdossier.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Procest Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 spec-coverage tests for the document-zaakdossier spec.
  *

--- a/tests/e2e/spec-coverage/doorlooptijd-dashboard.spec.ts
+++ b/tests/e2e/spec-coverage/doorlooptijd-dashboard.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Procest Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 spec-coverage tests for doorlooptijd-dashboard spec.
  * Each test is tagged with the scenario it covers.

--- a/tests/e2e/spec-coverage/gis-integration.spec.ts
+++ b/tests/e2e/spec-coverage/gis-integration.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Procest Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 spec-coverage tests for the gis-integration spec.
  *

--- a/tests/e2e/spec-coverage/handler-vervanging-waarneming.spec.ts
+++ b/tests/e2e/spec-coverage/handler-vervanging-waarneming.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Procest Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 spec-coverage tests for the handler-vervanging-waarneming spec.
  * Each test is tagged with the scenario it covers via @e2e. These drive the

--- a/tests/e2e/spec-coverage/kanban-board-keyboard-status-transition.spec.ts
+++ b/tests/e2e/spec-coverage/kanban-board-keyboard-status-transition.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Procest Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 spec-coverage tests for kanban-board-keyboard-status-transition
  * (WCAG 2.1.1 Keyboard fix on the Workflow Board's status-move control).

--- a/tests/e2e/spec-coverage/kcc-werkplek-zaaksysteem-bridge.spec.ts
+++ b/tests/e2e/spec-coverage/kcc-werkplek-zaaksysteem-bridge.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Procest Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 spec-coverage tests for the kcc-werkplek-zaaksysteem-bridge spec.
  *

--- a/tests/e2e/spec-coverage/my-work.spec.ts
+++ b/tests/e2e/spec-coverage/my-work.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Procest Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 spec-coverage tests for my-work spec.
  *

--- a/tests/e2e/spec-coverage/parafering-audit-via-or.spec.ts
+++ b/tests/e2e/spec-coverage/parafering-audit-via-or.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Procest Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 spec-coverage tests for the parafering-audit-via-or spec
  * (migrate-parafering-to-or-audit, ADR-022 / consume-or-audit-trail-fleet-wide).

--- a/tests/e2e/spec-coverage/pdok-via-openconnector.spec.ts
+++ b/tests/e2e/spec-coverage/pdok-via-openconnector.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Procest Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 spec-coverage tests for the migrate-pdok-to-openconnector change.
  *

--- a/tests/e2e/spec-coverage/related-case-linking.spec.ts
+++ b/tests/e2e/spec-coverage/related-case-linking.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Procest Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 spec-coverage tests for the related-case-linking UI surface
  * (the "Related cases" / Gerelateerde zaken case-detail sidebar tab).

--- a/tests/e2e/spec-coverage/settings-pages.spec.ts
+++ b/tests/e2e/spec-coverage/settings-pages.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Procest Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Behavioural UI coverage for the procest administrative settings pages.
  * Each renders an OpenRegister-backed index with a view-specific primary

--- a/tests/e2e/spec-coverage/task-management.spec.ts
+++ b/tests/e2e/spec-coverage/task-management.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Procest Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 spec-coverage tests for task-management spec.
  * Each test is tagged with the scenario it covers.

--- a/tests/e2e/spec-coverage/ui-pages.spec.ts
+++ b/tests/e2e/spec-coverage/ui-pages.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Procest Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 spec-coverage tests for the rendering UI pages of Procest.
  *

--- a/tests/e2e/spec-coverage/workflow-operations.spec.ts
+++ b/tests/e2e/spec-coverage/workflow-operations.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Procest Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Behavioural UI coverage for the operational views that sit alongside the
  * case lists: the Workflow Board (kanban of statuses), the Case Map, the

--- a/tests/e2e/visual/_visual-helpers.ts
+++ b/tests/e2e/visual/_visual-helpers.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Shared helpers for the visual-regression layer (GAP-5).
  *

--- a/tests/e2e/visual/procest.visual.spec.ts
+++ b/tests/e2e/visual/procest.visual.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Conduction B.V.
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Visual-regression baselines for Procest's key surfaces (GAP-5).
  *

--- a/tests/e2e/workflows/case-lifecycle.spec.ts
+++ b/tests/e2e/workflows/case-lifecycle.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Procest Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * DEEP, data-dependent coverage — case-lifecycle STATE MACHINE.
  *

--- a/tests/e2e/workflows/cases-crud.spec.ts
+++ b/tests/e2e/workflows/cases-crud.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Procest Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * DEEP, data-dependent UI coverage — Cases (zaken) full CRUD-with-persistence.
  *

--- a/tests/e2e/workflows/complaints-bezwaar.spec.ts
+++ b/tests/e2e/workflows/complaints-bezwaar.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Procest Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * DEEP, data-dependent coverage — complaint-family workflow items (bezwaren).
  *

--- a/tests/e2e/workflows/deelzaak-case-email.spec.ts
+++ b/tests/e2e/workflows/deelzaak-case-email.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Procest Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * DEEP e2e for this week's new UI: DEELZAAK (sub-case) support + CASE-EMAIL
  * integration. Backend unit tests already landed; this covers the user-facing


### PR DESCRIPTION
Brings every licence declaration in procest into agreement on **EUPL-1.2** — the licence already declared by `composer.json`, `package.json`, `appinfo/info.xml` and `LICENSE`.

## Changed (32 files)

| Category | Count | Detail |
|---|---|---|
| `SPDX-License-Identifier: AGPL-3.0-or-later` → `EUPL-1.2` | 30 | all under `tests/e2e/` — our own Playwright specs + helpers |
| prose licence claim `AGPL` → `EUPL-1.2` | 2 files (3 lines) | `project.md`, `docs/Technical/government-compliance.md` |
| `@license` PHPDoc tags | 0 | `lib/**.php` was already 100% EUPL-1.2 (597/597) |
| metadata files | 0 | `composer.json` / `package.json` / `appinfo/info.xml` / `LICENSE` already EUPL-1.2 |

Every touched file carries our own copyright (`SPDX-FileCopyrightText: 2026 Procest Contributors` or `Conduction B.V.`). **No `@copyright` / `SPDX-FileCopyrightText` line was altered** — holders and years are untouched.

The two prose fixes are mandated by this repo's own canonical spec, `openspec/specs/app-metadata-claims/spec.md`: *"THEN no free-text statement MUST claim the app is AGPL-licensed"*.

## Deliberately NOT changed

- `LICENSE` line 177 — `GNU Affero General Public License (AGPL) v. 3` is part of the EUPL's own **compatible-licences appendix**. It is the EUPL text itself.
- `README.md` line 284 — lists EUPL-**compatible** copyleft licences. Correct as written.
- `license-report-composer/*`, `license-report-npm/*` — generated dependency-licence reports. The AGPL rows are third-party packages (`nextcloud/ocp`, `@nextcloud/vue`, `@nextcloud/files`); the report already records procest itself as `EUPL-1.2`.
- `composer.lock`, `package-lock.json` — third-party dependency metadata.
- `openspec/specs/app-metadata-claims/spec.md` and the archived `2026-07-06-align-claims-and-licence` change — the word AGPL appears there as the thing being **prohibited**. Changing it would invert the requirement.

## Verification

| | before | after |
|---|---|---|
| phpunit (PHP 8.5 container) | 1692 tests, 5643→5659 assertions, **0 failures**, exit 0 | identical: 1692 / 5659 / 0, exit 0 |
| vitest | 32 files, 330 tests passed, exit 0 | identical |
| gate-28 `license-triangle` | PASS | PASS |

Host PHP is 8.2 and the repo pins `php: ^8.3`, so a host phpunit run exits **255** (VOID). Both runs above were done in a PHP 8.5 container, identically conditioned.

gate-28 was **already passing** for procest before this PR — the sweep worklist attributed 19 failing `lib/Service/{File,Object}/*.php` files to procest, but those files do not exist in this repo; they are **openregister's** (cross-repo attribution error in the worklist generator). procest's `lib/` is 597/597 EUPL-1.2. gate-28's ability to fail was confirmed with a positive control (temporarily flipping one `@license` to AGPL made it report FAIL; reverted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)