### PR TITLE
chore(ci): move hydra-gates-ref v1.3.0 -> v1.4.0

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -181,4 +181,13 @@ jobs:
       # "DID NOT RUN". v1.3.0 ships 36 such declarations. Measured on doriath
       # (PR #160): gates 4/24/33 went from unexplained "DID NOT RUN" to
       # explicit NOT APPLICABLE, and Hydra Gates went failure -> success.
-      hydra-gates-ref: v1.3.0
+      hydra-gates-ref: v1.4.0
+      # PIN MOVED v1.3.0 -> v1.4.0 (fleet consumer-ref sweep, 2026-08-05).
+      # A pinned ref is a silent expiry date on every upstream fix: this repo
+      # cannot receive a gate-package fix until this line moves. v1.4.0 is the
+      # latest tag and the FIRST one carrying `hydra-gates/scripts/axe-run.cjs`
+      # (verified absent at v1.3.0), so it is also the first that has #168's
+      # axe DOM scoping and #165's gate-46 fix.
+      # `enable-axe` is deliberately still NOT set — a vanilla Nextcloud 34
+      # reports serious/critical violations on core's OWN routes that DOM
+      # scoping does not remove. Enabling axe is a separate decision.


### PR DESCRIPTION
## What

Moves this repo's `hydra-gates-ref` pin from **v1.3.0** to **v1.4.0** in `.github/workflows/code-quality.yml`. One line of config; the rest of the diff is the comment recording why.

## Why

`quality.yml` is consumed at `@main`, but the gates package is pinned per-caller. **A pinned ref is a silent expiry date on every upstream fix** — this repo cannot receive a gate-package change until this line moves. That has already bitten this programme twice:

- 22 repos pinned `v1.0.1` predating a batch of fixes, leaving 16 gates dead fleet-wide (`ConductionNL/.github#159`);
- a `require-full-coverage` default flipped on `@main` reached v1.0.1 runners that predate the coverage accounting, producing `exit 98` (`ConductionNL/.github#173`).

v1.4.0 is the latest tag and is **the only tag containing `hydra-gates/scripts/axe-run.cjs`** — verified absent at v1.3.0, present at v1.4.0. So at v1.3.0 this repo could not use `enable-axe: true` at all, and had neither `#168`'s axe DOM scoping nor `#165`'s gate-46 fix.

## Explicitly not in this PR

`enable-axe: true` is **not** set. Ordering matters: the ref lands first. Enabling axe is a separate decision — a vanilla Nextcloud 34 still reports serious/critical violations on core's *own* routes that DOM scoping does not remove.

## Verification

v1.4.0 gates *more* than v1.3.0, so a `Hydra Gates` verdict that changes here is a real finding, not a sweep artefact. The failing-job set is compared against this repo's own `development` baseline before merge; genuine gate findings are reported, not silenced.

Part of a 15-repo consumer-ref sweep.