### PR TITLE
chore(ci): stop pinning hydra-gates — track the package at @main

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -199,28 +199,21 @@ jobs:
       frontend-checks: '["check:manifest", "check:vue3-compile", "test:l10n"]'
 
       # ── Hydra mechanical gates ───────────────────────────────────────────
-      # `enable-hydra-gates` defaults to FALSE, so this tier has never executed
+      # `enable-hydra-gates` defaults to FALSE, so this tier had never executed
       # here — the job reported `skipped`, which the Quality Report renders
-      # identically to a pass. Pinned to v1.3.0 so a change to the gate package
-      # cannot move this repo's verdict without a commit here.
-      # `enable-axe` deliberately NOT set: a vanilla Nextcloud 34 already carries
-      # serious/critical violations from core's own UI.
+      # identically to a pass.
       enable-hydra-gates: true
-      # PIN MOVED v1.0.1 -> v1.3.0. `hydra-gates-require-full-coverage`
-      # (default ON) fails a run when a gate whose subject matter EXISTS did
-      # not report; its contract is that a not-applicable gate must DECLARE
-      # itself. v1.0.1 contains ZERO `_skip` calls — no na/structural/wiring
-      # vocabulary at all — so such a gate emits NOTHING and is counted as
-      # "DID NOT RUN". v1.3.0 ships 36 such declarations. Measured on doriath
-      # (PR #160): gates 4/24/33 went from unexplained "DID NOT RUN" to
-      # explicit NOT APPLICABLE, and Hydra Gates went failure -> success.
-      hydra-gates-ref: v1.4.0
-      # PIN MOVED v1.3.0 -> v1.4.0 (fleet consumer-ref sweep, 2026-08-05).
-      # A pinned ref is a silent expiry date on every upstream fix: this repo
-      # cannot receive a gate-package fix until this line moves. v1.4.0 is the
-      # latest tag and the FIRST one carrying `hydra-gates/scripts/axe-run.cjs`
-      # (verified absent at v1.3.0), so it is also the first that has #168's
-      # axe DOM scoping and #165's gate-46 fix.
+      # No `hydra-gates-ref` here on purpose. The shared workflow defaults it
+      # to @main, and this workflow is itself consumed at @main, so the two
+      # sides move together and a gate fix reaches this repo without a commit
+      # in this repo. A pin is a silent expiry date: 22 repos sat on v1.0.1 and
+      # 16 gates were dead fleet-wide while every one reported PASS (.github#159),
+      # and a default flipped at @main later reached those old runners and made
+      # them red on gates they had no subject matter for (.github#173).
+      # To hold this repo still for a specific reason, set the input explicitly
+      # and say why — it is still honoured. To roll back for everyone, revert on
+      # ConductionNL/.github main.
+      #
       # `enable-axe` is deliberately still NOT set — a vanilla Nextcloud 34
       # reports serious/critical violations on core's OWN routes that DOM
       # scoping does not remove. Enabling axe is a separate decision.


### PR DESCRIPTION
## What

Deletes the `hydra-gates-ref:` line from `.github/workflows/code-quality.yml`. Nothing replaces it — the input's default in the shared workflow **is already `main`**, so removing the override is the whole change.

`enable-hydra-gates` is untouched. `enable-axe` is untouched.

## Why not just keep (or bump) the pin

This repo consumes `ConductionNL/.github/.github/workflows/quality.yml` **`@main`**. Pinning the *gates package* to a tag while consuming the *workflow* at `@main` splits the two halves apart: the runner moves with upstream, the package it runs does not. We have now been bitten by that split from both directions.

- **Falsely green — `.github#159`.** All 22 repos were pinned to `v1.0.1`, which predated the fixes that made the gates actually execute. **16 gates were dead fleet-wide and every one of them reported PASS.** A check that did not run looks exactly like one that passed.
- **Falsely red — `.github#173`.** A default was flipped at `.github` `main` and reached those same old pinned runners, which had no accounting to honour it with, so they went **red on gates they had no subject matter for**.

Bumping the pin fixes neither — it just resets the clock and guarantees the same two failures on the next release. Unpinned, both sides move together and a gate fix reaches this repo without a commit in this repo.

The pin-justifying comment block (the version history, the reproducibility argument) is replaced with a short note saying why there is deliberately no ref here. The rationale for having the gates on at all is kept.

## Rollback and escape hatch

- **For everyone:** revert on `ConductionNL/.github` `main`. One commit, whole fleet.
- **For this one repo:** set `hydra-gates-ref:` explicitly again with a comment saying why. The input is still honoured — this PR removes an *override*, not a capability.

## Safety net

`ConductionNL/.github#177` adds a **resolve probe** plus the **gates package test suite** gating `.github` `main`, so a gates change that would not resolve, or that would break the runner, is caught before it can reach `@main` consumers like this one.

## Verification

- `grep -n "hydra-gates" .github/workflows/code-quality.yml` — no `hydra-gates-ref:` key remains.
- `yaml.safe_load` on the workflow parses clean.
