### PR TITLE
fix(apphost): register OpenRegister's autoloader before adopting AppHost (ADR-040)

### DIFF
--- a/lib/AppInfo/Registrar/AppHostRegistrar.php
+++ b/lib/AppInfo/Registrar/AppHostRegistrar.php
@@ -88,6 +88,35 @@ class AppHostRegistrar
      * skipped: procest still boots and still routes, and the AppHost-backed
      * endpoints degrade individually. See decidesk#377 / #388.
      *
+     * ⚠️ AND THAT GUARD IS WHY THE PRELUDE BELOW IS NEEDED (ADR-040).
+     * `class_exists()` answers with the autoloader as it stands AT THIS MOMENT,
+     * and during boot that is not the autoloader as it ends up. Apps register
+     * one at a time in SORTED order: `OC_App::getEnabledApps()` does `sort()`,
+     * and `Coordinator::registerApps()` walks that list calling
+     * `registerAutoloading($appId)` and then `$application->register()` per app.
+     * So every app's `register()` runs before the PSR-4 prefix of every
+     * alphabetically LATER app exists.
+     *
+     * `procest` sorts after `openregister`, so today this works — by alphabet
+     * alone, not by design. That makes the defect LATENT rather than absent,
+     * and latent here is the dangerous kind, because the guard converts it into
+     * SILENCE: `class_exists()` would answer false, this method would return
+     * early, and the app would boot, route and look healthy while every
+     * AppHost-backed endpoint 500s. Not 404 — 500, because
+     * `Controller\HealthController` exists only as a Bootstrap DI alias onto
+     * `AppHost\Controller\GenericHealthController`, so the route matches and
+     * the resolution fails. Renaming this app, or moving this code into one
+     * that sorts earlier, is all it would take. Measured elsewhere in the
+     * fleet: openconnector records `class_exists at register(): false` on a
+     * clean install, and doriath's audit listener recorded ZERO dispatched
+     * events because an unguarded reference aborted the rest of `register()`.
+     *
+     * Registering OpenRegister's autoloader first costs one call and removes
+     * the dependence on sort order entirely. It is wrapped in
+     * try/catch(\Throwable) because `getAppPath()` throws when the app is not
+     * installed — which is a legitimate state here, and precisely the one the
+     * `class_exists()` guard below then handles.
+     *
      * @param IRegistrationContext $context The registration context.
      *
      * @return void
@@ -98,6 +127,10 @@ class AppHostRegistrar
      */
     public function register(IRegistrationContext $context): void
     {
+        // The ADR-040 prelude that makes the guard below answer correctly runs
+        // in OpenRegisterAutoloadRegistrar, immediately before this registrar
+        // in ServiceRegistrar. It is a separate class only to keep this one
+        // under PHPMD's coupling limit; see its docblock for the mechanism.
         if (class_exists(Bootstrap::class) === false) {
             // OpenRegister is absent or disabled. Skip the engine registration
             // rather than fatalling every request; see the note above.

--- a/lib/AppInfo/Registrar/OpenRegisterAutoloadRegistrar.php
+++ b/lib/AppInfo/Registrar/OpenRegisterAutoloadRegistrar.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * OpenRegister autoload prelude (ADR-040).
+ *
+ * Puts OpenRegister's PSR-4 prefix on the autoloader before anything in this
+ * app's `register()` tries to resolve a class from it. See the class docblock
+ * for why that is not automatic.
+ *
+ * @category AppInfo
+ * @package  OCA\Procest\AppInfo\Registrar
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/specs/beschikking-generatie/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\AppInfo\Registrar;
+
+/**
+ * Registers OpenRegister's autoloader ahead of this app's AppHost adoption.
+ *
+ * WHY THIS IS NEEDED AT ALL.
+ *
+ * Apps register ONE AT A TIME, in SORTED order. `OC_App::getEnabledApps()`
+ * does `sort($apps)`, and `Coordinator::registerApps()` walks that sorted list
+ * calling `OC_App::registerAutoloading($appId)` and then
+ * `$application->register()` per app. So every app's `register()` runs BEFORE
+ * the PSR-4 prefix of every alphabetically LATER app exists — on a completely
+ * healthy instance, with OpenRegister installed and enabled.
+ *
+ * `procest` sorts after `openregister`, so this happens to work today. By
+ * alphabet, not by design. That makes the defect LATENT rather than absent,
+ * and latent is the dangerous kind here, because {@see AppHostRegistrar}'s
+ * `class_exists()` guard converts it into SILENCE: the guard would answer
+ * false, the engine registration would be skipped, and the app would boot,
+ * route and look healthy while every AppHost-backed endpoint returned 500.
+ *
+ * 500 rather than 404 is the part worth internalising. Classes like
+ * `Controller\HealthController` exist ONLY as Bootstrap DI aliases onto
+ * `AppHost\Controller\GenericHealthController`, so the route still MATCHES and
+ * it is the resolution that fails. Renaming this app, or moving the adoption
+ * into one that sorts earlier, is all it would take.
+ *
+ * Measured twice elsewhere in the fleet, both silent: openconnector's own
+ * source records `class_exists at register(): false` on a clean install, and
+ * doriath's audit listener recorded ZERO dispatched events because an
+ * unguarded AppHost reference aborted the rest of `register()` — the app
+ * stayed enabled and kept serving with half its wiring missing.
+ *
+ * WHY IT LIVES IN ITS OWN CLASS. The three references below
+ * (`OCP\Server`, `OCP\App\IAppManager`, `OC_App`) are dependencies, and
+ * inlining them into {@see AppHostRegistrar} took that class from 12 to 15 on
+ * PHPMD's CouplingBetweenObjects — over the limit of 13. A separate registrar
+ * keeps the prelude adjacent to what needs it without loading the cost onto a
+ * class that already carries nine widget/provider references.
+ *
+ * `registerAutoloading()` is the right call and `IAppManager::loadApp()` is
+ * NOT an acceptable substitute: the former touches only the autoloader and is
+ * idempotent (it early-returns on an `$alreadyRegistered` key), while the
+ * latter sets `loadedApps[..]=true` and calls `Coordinator::bootApp()`,
+ * booting OpenRegister before its own `register()` has run.
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/specs/beschikking-generatie/spec.md
+ */
+class OpenRegisterAutoloadRegistrar
+{
+    /**
+     * Put OpenRegister's PSR-4 prefix on the autoloader.
+     *
+     * Wrapped in `try/catch(\Throwable)` because `getAppPath()` throws when the
+     * app is not installed — a legitimate state for procest, which does not
+     * declare `<app>openregister</app>`. That case is then handled by
+     * {@see AppHostRegistrar}'s `class_exists()` guard, which after this call
+     * answers a question about whether OpenRegister is INSTALLED rather than
+     * one about whether this app's id happens to sort after it.
+     *
+     * @return void
+     *
+     * @SuppressWarnings(PHPMD.StaticAccess) OC_App::registerAutoloading() is the ADR-040 prelude; there is no injectable equivalent.
+     *
+     * @spec openspec/specs/beschikking-generatie/spec.md
+     */
+    public function register(): void
+    {
+        // The app id is written as a LITERAL on both lines rather than hoisted
+        // into a constant. gate-64 recognises the prelude by matching an
+        // 'openregister' literal inside the registerAutoloading() argument
+        // list, so a constant here reads to the gate as no prelude at all —
+        // verified: with a constant the checker still reported "1 AppHost
+        // adoption(s) without the autoload prelude".
+        try {
+            $path = \OCP\Server::get(\OCP\App\IAppManager::class)
+                ->getAppPath('openregister');
+
+            \OC_App::registerAutoloading('openregister', $path);
+        } catch (\Throwable) {
+            // OpenRegister is not installed. Nothing to autoload; the
+            // class_exists() guard in AppHostRegistrar turns this into a clean
+            // skip rather than a fatal.
+        }
+    }//end register()
+}//end class

--- a/lib/AppInfo/Registrar/OpenRegisterAutoloadRegistrar.php
+++ b/lib/AppInfo/Registrar/OpenRegisterAutoloadRegistrar.php
@@ -90,6 +90,15 @@ class OpenRegisterAutoloadRegistrar
      *
      * @return void
      *
+     * `OC_App` is a legacy Nextcloud global with no OCP counterpart and no
+     * stub in the psalm baseline, so psalm reports UndefinedClass for it. The
+     * class is real and public API for this purpose — `Coordinator` itself
+     * calls `OC_App::registerAutoloading()` — so the suppression is narrowed to
+     * this method rather than the file, and it must NOT be widened: any OTHER
+     * undefined class in here should still be an error.
+     *
+     * @psalm-suppress UndefinedClass OC_App is a legacy NC global with no OCP equivalent; Coordinator calls it for exactly this.
+     *
      * @SuppressWarnings(PHPMD.StaticAccess) OC_App::registerAutoloading() is the ADR-040 prelude; there is no injectable equivalent.
      *
      * @spec openspec/specs/beschikking-generatie/spec.md

--- a/lib/AppInfo/Registrar/ServiceRegistrar.php
+++ b/lib/AppInfo/Registrar/ServiceRegistrar.php
@@ -56,6 +56,14 @@ class ServiceRegistrar
      */
     public function register(IRegistrationContext $context): void
     {
+        // MUST be first, and specifically before AppHostRegistrar (ADR-040).
+        // Apps register in sorted order, so `OCA\OpenRegister\` is not yet
+        // autoloadable for any app sorting before `openregister`; procest only
+        // escapes that by alphabet. Without this line AppHostRegistrar's
+        // class_exists() guard would silently answer false and every
+        // AppHost-backed endpoint would 500. See its docblock.
+        (new OpenRegisterAutoloadRegistrar())->register();
+
         (new AppHostRegistrar())->register(context: $context);
         (new BespokeServiceRegistrar())->register(context: $context);
 

--- a/tests/Unit/AppInfo/Registrar/OpenRegisterAutoloadRegistrarTest.php
+++ b/tests/Unit/AppInfo/Registrar/OpenRegisterAutoloadRegistrarTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * OpenRegisterAutoloadRegistrar Unit Tests
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\AppInfo\Registrar
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\AppInfo\Registrar;
+
+use OCA\Procest\AppInfo\Registrar\OpenRegisterAutoloadRegistrar;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The ADR-040 autoload prelude must never be the thing that breaks boot.
+ *
+ * WHAT THIS CAN AND CANNOT TEST.
+ *
+ * It cannot assert that the autoloader was registered: that needs a real
+ * Nextcloud container, a real installed OpenRegister, and the app-registration
+ * ORDER that produces the defect in the first place — which is exactly why the
+ * positive case is covered by tests/e2e/apphost-adoption.spec.ts against a
+ * running instance instead.
+ *
+ * What it CAN test is the half that has no browser symptom and is easy to get
+ * wrong: the DEGRADED path. `register()` runs inside
+ * `Application::register()`, which Nextcloud executes on EVERY request. If it
+ * throws when OpenRegister is absent, it does not merely disable a feature —
+ * it takes down every request to the instance, because Coordinator's failure
+ * handling is per-app registration and an uncaught error there aborts the rest
+ * of procest's wiring.
+ *
+ * `IAppManager::getAppPath()` throws `AppPathNotFoundException` for an app
+ * that is not installed, and in a bare unit-test process `\OCP\Server::get()`
+ * has no container at all — so this test exercises the catch arm by simply
+ * running outside Nextcloud, which is the same shape as "OpenRegister is not
+ * installed". That is the state procest explicitly supports: it does not
+ * declare `<app>openregister</app>`, so an admin can create it.
+ *
+ * @covers \OCA\Procest\AppInfo\Registrar\OpenRegisterAutoloadRegistrar
+ */
+class OpenRegisterAutoloadRegistrarTest extends TestCase
+{
+    /**
+     * With OpenRegister unavailable, register() completes silently.
+     *
+     * The assertion is the absence of a throw. PHPUnit fails the test on any
+     * uncaught exception, so `expectNotToPerformAssertions()` would hide
+     * nothing here — but an explicit assertion after the call states the
+     * intent, and would fail if the method ever started returning early in a
+     * way that skipped it.
+     *
+     * @return void
+     */
+    public function testRegisterSwallowsAnAbsentOpenRegister(): void
+    {
+        $registrar = new OpenRegisterAutoloadRegistrar();
+
+        $registrar->register();
+
+        self::assertTrue(
+            true,
+            'register() must return normally when OpenRegister cannot be resolved — it runs '
+            .'inside Application::register() on every request, so throwing here would take '
+            .'down the whole instance rather than degrade one feature.'
+        );
+    }
+
+    /**
+     * Calling it twice is safe.
+     *
+     * `OC_App::registerAutoloading()` is idempotent (it early-returns on an
+     * `$alreadyRegistered` key), and nothing in this class holds state, so a
+     * second call must be a no-op rather than a double registration or a
+     * throw. ServiceRegistrar calls it once today; that is not a property to
+     * rely on silently.
+     *
+     * @return void
+     */
+    public function testRegisterIsIdempotent(): void
+    {
+        $registrar = new OpenRegisterAutoloadRegistrar();
+
+        $registrar->register();
+        $registrar->register();
+
+        self::assertTrue(true, 'a second register() must not throw');
+    }
+}

--- a/tests/e2e/apphost-adoption.spec.ts
+++ b/tests/e2e/apphost-adoption.spec.ts
@@ -1,0 +1,130 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * AppHost adoption survives boot — the ADR-040 autoload prelude, observed.
+ *
+ * WHAT THIS PROTECTS, AND WHY IT NEEDS A RUNNING NEXTCLOUD.
+ *
+ * `health#index` and `metrics#index` are not procest classes. They exist only
+ * as DI aliases that OpenRegister's `AppHost\Bootstrap::register()` installs
+ * onto its own generic controllers, and that registration happens inside
+ * procest's `Application::register()`.
+ *
+ * Apps register ONE AT A TIME, in SORTED order: `OC_App::getEnabledApps()`
+ * does `sort()`, and `Coordinator::registerApps()` calls
+ * `registerAutoloading($appId)` then `$application->register()` per app. So
+ * every app's `register()` runs BEFORE the PSR-4 prefix of every
+ * alphabetically LATER app exists. Without the prelude in
+ * `lib/AppInfo/Registrar/OpenRegisterAutoloadRegistrar.php`, `OCA\OpenRegister\`
+ * is not autoloadable at that moment for any app sorting before it.
+ *
+ * The failure is quiet: `AppHostRegistrar` guards the entry point with
+ * `class_exists()`, so the miss does not fatal — it SKIPS. The app boots, the
+ * SPA renders, the nav works, and smoke.spec.ts passes.
+ *
+ * ⚠️ STATUS CODE IS NOT THE DISCRIMINATOR, AND ASSUMING IT WAS COST A REWRITE.
+ * The first version of this spec asserted `status < 500` and `status !== 404`.
+ * Both pass on a completely broken adoption, because procest's SPA catch-all
+ * answers ANY unmatched path with the app shell:
+ *
+ *     GET /api/health                  -> 200  application/json
+ *     GET /api/definitely-not-a-route  -> 200  text/html      <-- measured
+ *
+ * A route that no longer resolves therefore returns 200 HTML, not 404 and not
+ * 500. So these assertions read the CONTENT TYPE and the BODY SHAPE, which the
+ * catch-all cannot fake: the shell is HTML and can never be Prometheus text or
+ * a JSON health document.
+ *
+ * `procest` currently sorts after `openregister`, so the adoption also happens
+ * to work by alphabet alone. That is exactly why the property is written down
+ * rather than trusted — renaming the app, or moving the adoption into one that
+ * sorts earlier, would flip it, and this spec is what would notice.
+ *
+ * @spec openspec/specs/beschikking-generatie/spec.md
+ */
+
+import { test, expect } from '@playwright/test'
+import { BASE_URL } from './base-url'
+
+const API_HEADERS = { 'OCS-APIRequest': 'true' }
+
+test.describe('AppHost adoption (ADR-040)', () => {
+	test('health#index is served by the AppHost generic, not the SPA catch-all', async ({ request }) => {
+		const res = await request.get(`${BASE_URL}/index.php/apps/procest/api/health`, {
+			headers: { ...API_HEADERS, Accept: 'application/json' },
+			failOnStatusCode: false,
+		})
+
+		const contentType = res.headers()['content-type'] ?? ''
+		const body = await res.text()
+
+		// The catch-all returns `text/html` with the app shell. Only the real
+		// AppHost controller can return JSON here, so this single assertion is
+		// what distinguishes "the alias was installed" from "the alias was
+		// silently skipped and something else answered".
+		expect(
+			contentType,
+			`health returned ${res.status()} ${contentType}. text/html means the SPA `
+			+ 'catch-all answered — Bootstrap::register() never installed the AppHost '
+			+ 'alias, i.e. OCA\\OpenRegister\\ was not autoloadable during procest\'s '
+			+ 'register(). See lib/AppInfo/Registrar/OpenRegisterAutoloadRegistrar.php.',
+		).toContain('application/json')
+
+		const doc = JSON.parse(body)
+		expect(doc.app).toBe('procest')
+		expect(doc.status).toBeTruthy()
+		// The generic reports its own view of OpenRegister. If the adoption were
+		// half-wired this key would not be here at all.
+		expect(doc.checks, 'the AppHost health generic always reports a checks block').toBeTruthy()
+	})
+
+	test('metrics#index emits Prometheus text, which the SPA shell cannot', async ({ request }) => {
+		const res = await request.get(`${BASE_URL}/index.php/apps/procest/api/metrics`, {
+			headers: API_HEADERS,
+			failOnStatusCode: false,
+		})
+
+		const contentType = res.headers()['content-type'] ?? ''
+		const body = await res.text()
+
+		expect(
+			contentType,
+			`metrics returned ${res.status()} ${contentType}; expected Prometheus text. `
+			+ 'See the health assertion above for what an HTML answer means.',
+		).toContain('text/plain')
+
+		// Prometheus exposition format. The app shell starts `<!DOCTYPE html>`,
+		// so this cannot be satisfied by the catch-all under any circumstance.
+		expect(body.startsWith('# HELP'), `body began: ${body.slice(0, 60)}`).toBe(true)
+		expect(body).toContain('procest_info')
+	})
+
+	test('the catch-all really does answer 200 (guard against a dead discriminator)', async ({ request }) => {
+		// The two assertions above are only meaningful while the catch-all
+		// behaves as described. If procest ever starts returning a real 404 for
+		// unmatched API paths, the content-type checks stop being the ONLY thing
+		// standing between a broken adoption and a green suite — and whoever
+		// changes that should see this test fail and read the note above.
+		const res = await request.get(
+			`${BASE_URL}/index.php/apps/procest/api/definitely-not-a-route`,
+			{ headers: API_HEADERS, failOnStatusCode: false },
+		)
+
+		expect(res.status(), 'if this is now 404, update the reasoning in this file').toBe(200)
+		expect(res.headers()['content-type'] ?? '').toContain('text/html')
+	})
+
+	test('the SPA still boots with the prelude in place', async ({ page }) => {
+		// Guards the other direction: registering another app's autoloader during
+		// register() must not break procest's own boot. A prelude that threw, or
+		// that booted OpenRegister early via loadApp(), would surface here.
+		const errors: string[] = []
+		page.on('pageerror', (e) => errors.push(String(e)))
+
+		await page.goto('/index.php/apps/procest')
+		await expect(page).toHaveURL(/.*procest/)
+		await expect(page.locator('body')).not.toContainText('Internal Server Error')
+		expect(errors, `uncaught page errors: ${errors.join(' | ')}`).toHaveLength(0)
+	})
+})


### PR DESCRIPTION
gate-64 fails procest on #748, and it is right to. `AppHostRegistrar` references `OCA\OpenRegister\AppHost\Bootstrap` with nothing under `lib/AppInfo/` putting OpenRegister's PSR-4 prefix on the autoloader first.

## The mechanism

Apps register **one at a time, in sorted order**: `OC_App::getEnabledApps()` does `sort()`, and `Coordinator::registerApps()` calls `registerAutoloading($appId)` then `$application->register()` per app. So every app's `register()` runs *before* the PSR-4 prefix of every alphabetically later app exists.

`procest` sorts after `openregister`, so today this works — **by alphabet, not by design**. That makes it latent rather than absent, and latent is the bad kind here: the `class_exists()` guard turns the miss into **silence**. The guard answers false, the engine registration is skipped, and the app boots, routes and looks healthy while every AppHost-backed endpoint fails. Renaming the app, or moving the adoption into one that sorts earlier, is all it would take.

Measured elsewhere in the fleet: openconnector's own source records `class_exists at register(): false` on a clean install; doriath's audit listener recorded **zero** dispatched events.

## Two things that shaped the implementation

**The prelude lives in its own registrar.** Inlining the three references (`OCP\Server`, `OCP\App\IAppManager`, `OC_App`) took `AppHostRegistrar` from 12 to **15** on PHPMD's `CouplingBetweenObjects`, over the limit of 13. A clean gate-64 bought with a new phpmd failure is not a fix.

**The app id is a literal on both lines.** gate-64 recognises the prelude by matching an `'openregister'` literal *inside the `registerAutoloading()` argument list*, so hoisting it into a constant reads to the gate as no prelude at all — verified: the checker still reported the adoption as unguarded.

## Tests, and a discriminator that wasn't

`tests/e2e/apphost-adoption.spec.ts` asserts the two routes that exist **only** as AppHost DI aliases actually resolve. The first version asserted `status < 500` and `status !== 404` — and **both pass on a completely broken adoption**:

```
GET /api/health                  -> 200  application/json
GET /api/definitely-not-a-route  -> 200  text/html      <-- measured
```

procest's SPA catch-all answers any unmatched path with the app shell, so a route that stops resolving returns **200 HTML**, not 404 and not 500. The assertions therefore read content type and body shape — a JSON `app`/`checks` document, and Prometheus `# HELP procest_info` text — neither of which the shell can produce. A fourth test pins the catch-all's own 200/`text/html` behaviour, so if that ever becomes a real 404 the reasoning gets re-read rather than silently invalidated.

**Verified against a live instance: 4 passed.** Mutation-checked by pointing both probes at the catch-all path — the two content-type assertions failed, the other two passed.

phpcs clean, phpmd clean, gate-64 OK; the same checker still reports the unfixed `development` tree as "1 AppHost adoption(s) without the autoload prelude".