### PR TITLE
test(e2e): prove the AppHost aliases actually resolve in a browser

### DIFF
--- a/tests/e2e/apphost-adoption.spec.ts
+++ b/tests/e2e/apphost-adoption.spec.ts
@@ -1,0 +1,130 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * AppHost adoption survives boot — the ADR-040 autoload prelude, observed.
+ *
+ * WHAT THIS PROTECTS, AND WHY IT NEEDS A RUNNING NEXTCLOUD.
+ *
+ * `health#index` and `metrics#index` are not procest classes. They exist only
+ * as DI aliases that OpenRegister's `AppHost\Bootstrap::register()` installs
+ * onto its own generic controllers, and that registration happens inside
+ * procest's `Application::register()`.
+ *
+ * Apps register ONE AT A TIME, in SORTED order: `OC_App::getEnabledApps()`
+ * does `sort()`, and `Coordinator::registerApps()` calls
+ * `registerAutoloading($appId)` then `$application->register()` per app. So
+ * every app's `register()` runs BEFORE the PSR-4 prefix of every
+ * alphabetically LATER app exists. Without the prelude in
+ * `lib/AppInfo/OpenRegisterAutoloader.php`, `OCA\OpenRegister\`
+ * is not autoloadable at that moment for any app sorting before it.
+ *
+ * The failure is quiet: `AppHostRegistrar` guards the entry point with
+ * `class_exists()`, so the miss does not fatal — it SKIPS. The app boots, the
+ * SPA renders, the nav works, and smoke.spec.ts passes.
+ *
+ * ⚠️ STATUS CODE IS NOT THE DISCRIMINATOR, AND ASSUMING IT WAS COST A REWRITE.
+ * The first version of this spec asserted `status < 500` and `status !== 404`.
+ * Both pass on a completely broken adoption, because procest's SPA catch-all
+ * answers ANY unmatched path with the app shell:
+ *
+ *     GET /api/health                  -> 200  application/json
+ *     GET /api/definitely-not-a-route  -> 200  text/html      <-- measured
+ *
+ * A route that no longer resolves therefore returns 200 HTML, not 404 and not
+ * 500. So these assertions read the CONTENT TYPE and the BODY SHAPE, which the
+ * catch-all cannot fake: the shell is HTML and can never be Prometheus text or
+ * a JSON health document.
+ *
+ * `procest` currently sorts after `openregister`, so the adoption also happens
+ * to work by alphabet alone. That is exactly why the property is written down
+ * rather than trusted — renaming the app, or moving the adoption into one that
+ * sorts earlier, would flip it, and this spec is what would notice.
+ *
+ * @spec openspec/specs/beschikking-generatie/spec.md
+ */
+
+import { test, expect } from '@playwright/test'
+import { BASE_URL } from './base-url'
+
+const API_HEADERS = { 'OCS-APIRequest': 'true' }
+
+test.describe('AppHost adoption (ADR-040)', () => {
+	test('health#index is served by the AppHost generic, not the SPA catch-all', async ({ request }) => {
+		const res = await request.get(`${BASE_URL}/index.php/apps/procest/api/health`, {
+			headers: { ...API_HEADERS, Accept: 'application/json' },
+			failOnStatusCode: false,
+		})
+
+		const contentType = res.headers()['content-type'] ?? ''
+		const body = await res.text()
+
+		// The catch-all returns `text/html` with the app shell. Only the real
+		// AppHost controller can return JSON here, so this single assertion is
+		// what distinguishes "the alias was installed" from "the alias was
+		// silently skipped and something else answered".
+		expect(
+			contentType,
+			`health returned ${res.status()} ${contentType}. text/html means the SPA `
+			+ 'catch-all answered — Bootstrap::register() never installed the AppHost '
+			+ 'alias, i.e. OCA\\OpenRegister\\ was not autoloadable during procest\'s '
+			+ 'register(). See lib/AppInfo/Registrar/OpenRegisterAutoloadRegistrar.php.',
+		).toContain('application/json')
+
+		const doc = JSON.parse(body)
+		expect(doc.app).toBe('procest')
+		expect(doc.status).toBeTruthy()
+		// The generic reports its own view of OpenRegister. If the adoption were
+		// half-wired this key would not be here at all.
+		expect(doc.checks, 'the AppHost health generic always reports a checks block').toBeTruthy()
+	})
+
+	test('metrics#index emits Prometheus text, which the SPA shell cannot', async ({ request }) => {
+		const res = await request.get(`${BASE_URL}/index.php/apps/procest/api/metrics`, {
+			headers: API_HEADERS,
+			failOnStatusCode: false,
+		})
+
+		const contentType = res.headers()['content-type'] ?? ''
+		const body = await res.text()
+
+		expect(
+			contentType,
+			`metrics returned ${res.status()} ${contentType}; expected Prometheus text. `
+			+ 'See the health assertion above for what an HTML answer means.',
+		).toContain('text/plain')
+
+		// Prometheus exposition format. The app shell starts `<!DOCTYPE html>`,
+		// so this cannot be satisfied by the catch-all under any circumstance.
+		expect(body.startsWith('# HELP'), `body began: ${body.slice(0, 60)}`).toBe(true)
+		expect(body).toContain('procest_info')
+	})
+
+	test('the catch-all really does answer 200 (guard against a dead discriminator)', async ({ request }) => {
+		// The two assertions above are only meaningful while the catch-all
+		// behaves as described. If procest ever starts returning a real 404 for
+		// unmatched API paths, the content-type checks stop being the ONLY thing
+		// standing between a broken adoption and a green suite — and whoever
+		// changes that should see this test fail and read the note above.
+		const res = await request.get(
+			`${BASE_URL}/index.php/apps/procest/api/definitely-not-a-route`,
+			{ headers: API_HEADERS, failOnStatusCode: false },
+		)
+
+		expect(res.status(), 'if this is now 404, update the reasoning in this file').toBe(200)
+		expect(res.headers()['content-type'] ?? '').toContain('text/html')
+	})
+
+	test('the SPA still boots with the prelude in place', async ({ page }) => {
+		// Guards the other direction: registering another app's autoloader during
+		// register() must not break procest's own boot. A prelude that threw, or
+		// that booted OpenRegister early via loadApp(), would surface here.
+		const errors: string[] = []
+		page.on('pageerror', (e) => errors.push(String(e)))
+
+		await page.goto('/index.php/apps/procest')
+		await expect(page).toHaveURL(/.*procest/)
+		await expect(page.locator('body')).not.toContainText('Internal Server Error')
+		expect(errors, `uncaught page errors: ${errors.join(' | ')}`).toHaveLength(0)
+	})
+})


### PR DESCRIPTION
`development` already carries the ADR-040 prelude (`lib/AppInfo/OpenRegisterAutoloader.php`, its spec, and unit tests) and gate-64 passes there. What it does **not** have is any assertion that the endpoints the prelude exists for actually answer — and that gap is the point, because this failure is silent by construction.

`health#index` and `metrics#index` are not procest classes. They exist only as DI aliases that OpenRegister's `AppHost\Bootstrap::register()` installs, and `AppHostRegistrar` guards that call with `class_exists()`. If the prelude were removed or reordered, the guard would answer false, the registration would be **skipped**, and the app would boot, route and look healthy. `smoke.spec.ts` passes either way.

## Status code is not the discriminator — assuming it was cost a rewrite

The first version asserted `status < 500` and `status !== 404`. **Both pass on a completely broken adoption**, because procest's SPA catch-all answers any unmatched path with the app shell:

```
GET /api/health                  -> 200  application/json
GET /api/definitely-not-a-route  -> 200  text/html      <-- measured
```

A route that stops resolving returns **200 HTML** — not 404, not 500. So the assertions read **content type and body shape**: a JSON `app`/`checks` document, and Prometheus `# HELP procest_info` text. Neither is something the shell can produce.

A fourth test pins the catch-all's *own* 200/`text/html` behaviour, so if that ever becomes a real 404 the reasoning above gets re-read rather than silently invalidated.

## Verification

Verified earlier today against the running dev instance: **4 passed**. Mutation-checked by pointing both probes at the catch-all path — the two content-type assertions failed and the other two passed, so they discriminate rather than merely pass. The local instance is down as of this commit, so CI is the re-run.

This is the e2e half of what became #751. The implementation half of that PR is superseded by what landed on `development`, and that `OpenRegisterAutoloader` is the better design — it takes an injectable app id so the degraded branch is reachable from a unit test. #751 is closed in favour of this.