### PR TITLE
fix(security): PHP_CodeSniffer 3.13.5 → 3.13.6 (CVE-2026-67434, OS command injection)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5950,16 +5950,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.5",
+            "version": "3.13.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
                 "shasum": ""
             },
             "require": {
@@ -6025,7 +6025,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-04T16:30:35+00:00"
+            "time": "2026-08-06T00:17:32+00:00"
         },
         {
             "name": "symfony/config",


### PR DESCRIPTION
`quality / Security (composer)` is now red on **every** procest PR:

```
Advisory ID: PKSA-rdkp-vv9z-mjkg
CVE: CVE-2026-67434
Title: OS Command injection
Affected versions: <3.13.6|>=4.0.0,<4.0.2
Reported at: 2026-08-05T23:53:11+00:00
```
https://github.com/PHPCSStandards/PHP_CodeSniffer/security/advisories/GHSA-hmqg-cxww-wqhq

## Why development's last runs are green

The advisory was published **yesterday**, and `roave/security-advisories` is installed as `dev-latest` on each run. The same lockfile was clean on 2026-08-05 and is vulnerable on 2026-08-06 **with no commit in between**. Those green runs are not evidence the lockfile is fine — they are evidence of *when they ran*.

## The change

The `^3.9` constraint in `composer.json` already permits the fixed version, so this is a lockfile move only — **1 update, 0 installs, 0 removals**, and the diff touches exactly one version string. No `composer.json` change needed.

Verified after the bump: `phpcs --version` reports 3.13.6, and phpcs still **runs and still reports** over `lib/AppInfo`. A linter that silently stopped starting would look exactly like a clean run — the trap this repo has hit before (exit 255 in `platform_check.php`, printing no findings).