### PR TITLE
fix(nav): stop the domain settings page claiming the platform's "Settings"

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -244,7 +244,7 @@
 			"id": "CaseTypesMenu",
 			"label": "Case types",
 			"icon": "FolderCogOutline",
-			"route": "Settings",
+			"route": "ProcestConfiguration",
 			"section": "settings",
 			"order": 95
 		},
@@ -382,9 +382,9 @@
 		},
 		{
 			"id": "SettingsMenu",
-			"label": "Settings",
+			"label": "Configuration",
 			"icon": "CogOutline",
-			"route": "Settings",
+			"route": "ProcestConfiguration",
 			"section": "settings",
 			"order": 99
 		},
@@ -2613,15 +2613,15 @@
 			}
 		},
 		{
-			"id": "Settings",
+			"id": "ProcestConfiguration",
 			"route": "/settings",
 			"type": "settings",
-			"title": "Settings",
+			"title": "Configuration",
 			"config": {
 				"sections": [
 					{
 						"id": "admin",
-						"title": "Settings"
+						"title": "Configuration"
 					}
 				]
 			},

--- a/src/views/DoorlooptijdDashboard.vue
+++ b/src/views/DoorlooptijdDashboard.vue
@@ -71,7 +71,7 @@
 		<div v-else-if="showNoSlaState" class="doorlooptijd-empty">
 			<p>{{ t('procest', 'No SLA targets configured. Set processing deadlines on case types in Settings to enable compliance tracking.') }}</p>
 			<NcButton type="primary"
-				@click="$router.push({ name: 'Settings' })">
+				@click="$router.push({ name: 'ProcestConfiguration' })">
 				{{ t('procest', 'Go to Settings') }}
 			</NcButton>
 		</div>
@@ -446,6 +446,24 @@ export default {
 @keyframes pulse {
 	0%, 100% { opacity: 1; }
 	50% { opacity: 0.5; }
+}
+
+/*
+ * Respect a reduced-motion preference (WCAG 2.3.3; gate-45).
+ *
+ * The three skeletons above pulse indefinitely while the dashboard loads, and
+ * an indefinite animation is exactly what someone with vestibular sensitivity
+ * sets this preference to avoid. The skeleton still needs to read as "not real
+ * data yet", so the animation is dropped and a dimmed, static state is kept
+ * rather than the placeholder becoming indistinguishable from a loaded card.
+ */
+@media (prefers-reduced-motion: reduce) {
+	.skeleton-kpi,
+	.skeleton-chart,
+	.skeleton-table {
+		animation: none;
+		opacity: 0.6;
+	}
 }
 
 /* Empty states */

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -70,9 +70,13 @@ test.describe('Sidebar Navigation', () => {
 
 	test('settings button is visible', async ({ page }) => {
 		await page.goto('/index.php/apps/procest')
-		// Settings button at the bottom of the app sidebar. Target the
-		// dedicated settings toggle by its testid so it doesn't collide with
-		// the "SettingsMenu" nav entry (both render the text "Settings").
+		// Settings button at the bottom of the app sidebar — the platform gear
+		// foldout, which legitimately says "Settings".
+		//
+		// The testid is still the right target, but the collision it was
+		// guarding against is gone: the SettingsMenu nav entry was relabelled
+		// "Configuration" under ADR-079 D4, precisely because two things
+		// reading "Settings" rendered "Settings > Settings".
 		await expect(page.getByTestId('cn-nav-settings').getByRole('button', { name: 'Settings' })).toBeVisible()
 	})
 


### PR DESCRIPTION
`gate-63` (ADR-079) blocks **every** procest manifest edit, not just one PR. It reports PASS on `development` only because it **skips** when the manifest is not in the diff — so the first PR to touch `src/manifest.json` inherits two failures it did not cause. #758 hit exactly that.

| | finding |
|---|---|
| **D1** | page `Settings` is a `type:settings` page whose id and title claim the platform meaning of Settings, while app configuration belongs at `/settings/admin/<app>` |
| **D4** | a settings-foldout entry labelled `Settings` inside a foldout button already called Settings — the nav literally renders **Settings > Settings** |

## Renamed, not deleted — and the distinction matters

The gate's WARN suggests **deleting** the in-app page as a duplicate of `lib/Settings/AdminSettings.php`. **It is not a duplicate.** `CaseTypesMenu` routes to this same page, so it *hosts the case-type management surface* — the one `admin-settings.spec.ts` asserts renders "its management surface and add control". Deleting it would have removed a live surface to satisfy a lint.

D1's own wording allows the safe remedy: *"a domain page that happens to be called settings must be **renamed**"*.

```
page id             Settings -> ProcestConfiguration
page title          Settings -> Configuration
section title       Settings -> Configuration
SettingsMenu label  Settings -> Configuration   (D4)
```

**The route path `/settings` is deliberately unchanged** — it is a bookmarkable URL, the gate keys on id/title rather than path, and `pages.spec.ts` navigates to it three times.

## A page id *is* its vue-router route name, so the rename had real callers

- `src/views/DoorlooptijdDashboard.vue` pushed `{ name: 'Settings' }` from the "Go to Settings" empty-state button. Updated — otherwise that button would have navigated nowhere.
- `tests/e2e/navigation.spec.ts` targets the gear foldout by testid and still passes: the foldout legitimately says "Settings". Its comment warned about colliding with the `SettingsMenu` entry — which is precisely the collision D4 describes and this PR removes. Comment updated to say so.

## Also fixes the gate-45 finding this pulled into scope

Three skeleton loaders in `DoorlooptijdDashboard.vue` animate **indefinitely** with no `prefers-reduced-motion` fallback (WCAG 2.3.3). An indefinite pulse is what someone with vestibular sensitivity sets that preference to avoid. The animation is now dropped under the media query and replaced with a dimmed static state, so a skeleton still reads as "not real data yet" rather than becoming indistinguishable from a loaded card.

## Verified

- **ALL 59 APPLICABLE GATES GREEN — and all 59 ran.**
- `check:manifest` passes (58 pages, 0 ajv errors).
- gate-63's remaining output is the non-blocking duplicate-home WARN. That stands as a genuine question for the PO — *should the in-app configuration screen exist at all?* — rather than something to silence by deleting a working screen.

Unblocks #758.
