### PR TITLE
chore: raise the Nextcloud floor to 32

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -70,7 +70,7 @@ Vrij en open source onder de EUPL-1.2-licentie.
 
     <dependencies>
         <php min-version="8.3"/>
-        <nextcloud min-version="28" max-version="34"/>
+        <nextcloud min-version="32" max-version="34"/>
         <!-- App dependency (not expressible in app-info.xsd): OpenRegister >= 0.2.16
              (MDM engine: x-openregister-quality / x-openregister-dedup schema support and
              on-save qualityScore/qualityStatus materialisation, ADR-045 / OR change


### PR DESCRIPTION
Raises the declared Nextcloud floor to 32, matching what we build and test against. CI runs nextcloud:32-apache and the dev stack is on 34; nothing exercised 28-31. Only the <nextcloud min-version> attribute changes; max-version untouched.