### PR TITLE
fix: restore the pre-32 Nextcloud floor — this repo tests stable31

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -81,7 +81,7 @@ Vrij en open source onder de EUPL-1.2-licentie.
         there. Declaring 28 advertised a range this app cannot deliver.
         Same defect as openconnector#1173.
         -->
-        <nextcloud min-version="32" max-version="34"/>
+        <nextcloud min-version="28" max-version="34"/>
         <!-- App dependency (not expressible in app-info.xsd): OpenRegister >= 0.2.16
              (MDM engine: x-openregister-quality / x-openregister-dedup schema support and
              on-save qualityScore/qualityStatus materialisation, ADR-045 / OR change


### PR DESCRIPTION
fix: restore the pre-32 Nextcloud floor — this repo tests stable31

min-version is enforced at install time, so a 32 floor makes occ app:enable
refuse on stable31, which this repo's own CI runs. The e2e seed then fails
with "is not installed or enabled".

The reason the floor was raised no longer holds: openregister#2372 removed
every eager reference to its ContextChat provider, so the class is only
loaded behind interface_exists() guards and never read on an older server.
openregister#2380 restored its own 28 floor on that evidence.