### PR TITLE
fix(settings): PUT /api/settings 500s — the routed update() does not exist

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -162,12 +162,20 @@ class SettingsController extends Controller
     /**
      * Update settings with provided data.
      *
+     * This is the canonical write, matching `GenericSettingsControllerBase::
+     * update()`. The AppHost route table routes `PUT /api/settings` here, and
+     * because this app ships its own SettingsController the generic is never
+     * aliased in (see `AppHost\Bootstrap::aliasControllerUnlessLeafDefinesIt()`)
+     * — so the method has to exist here or the request dies with a 500 rather
+     * than a 404. `src/store/modules/enforcement.js::saveLhsMatrix()` is the
+     * live caller.
+     *
      * @return JSONResponse
 
       * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
       */
     #[AuthorizedAdminSetting(AdminSettings::class)]
-    public function create(): JSONResponse
+    public function update(): JSONResponse
     {
         $data   = $this->request->getParams();
         $config = $this->settingsService->updateSettings($data);
@@ -178,6 +186,23 @@ class SettingsController extends Controller
                 'config'  => $config,
             ]
         );
+    }//end update()
+
+    /**
+     * Legacy alias for {@see update()}.
+     *
+     * The canonical AppHost route table still ships `settings#create`
+     * (POST /api/settings) for the pre-ADR-066 `index/create/load` dialect, and
+     * three procest views still POST to it, so it stays reachable (ADR-029).
+     *
+     * @return JSONResponse
+
+      * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+      */
+    #[AuthorizedAdminSetting(AdminSettings::class)]
+    public function create(): JSONResponse
+    {
+        return $this->update();
     }//end create()
 
     /**

--- a/tests/Unit/AppInfo/CanonicalRouteMethodContractTest.php
+++ b/tests/Unit/AppInfo/CanonicalRouteMethodContractTest.php
@@ -1,0 +1,180 @@
+<?php
+
+/**
+ * Tests for the canonical AppHost route table's method contract.
+ *
+ * @category Test
+ * @package  OCA\Procest\Tests\Unit\AppInfo
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\AppInfo;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * The canonical AppHost route table routes a fixed set of names into THIS
+ * app's controller namespace, and OpenRegister only substitutes its generic
+ * controller when this app does not ship a class of that name.
+ *
+ * `OCA\OpenRegister\AppHost\Bootstrap::aliasControllerUnlessLeafDefinesIt()`
+ * registers the DI alias `OCA\Procest\Controller\XController` ->
+ * `OCA\OpenRegister\AppHost\Controller\GenericXController` ONLY when the leaf
+ * class does not exist. So the seam has two sides, and they fail differently:
+ *
+ *   - Leaf does NOT ship the class  -> the alias binds, the generic serves
+ *     every canonical method. Nothing is owed. (This is why the absence of
+ *     HealthController / MetricsController / PreferencesController on disk is
+ *     correct and must not be "fixed" by creating them.)
+ *   - Leaf DOES ship the class      -> the alias is skipped and the generic is
+ *     never constructed, so the leaf owes EVERY method the canonical table
+ *     routes to that controller. A missing one is not a 404: the router
+ *     matches the URL, the dispatcher reflects the method, and the request
+ *     dies with a 500.
+ *
+ * Measured 2026-08-08: procest ships its own SettingsController with
+ * `index/create/load` but no `update()`, while the canonical table routes
+ * `PUT /api/settings` to `settings#update` — and `src/store/modules/
+ * enforcement.js::saveLhsMatrix()` sends exactly that request. Saving the LHS
+ * matrix 500'd.
+ *
+ * This test asserts the ITEM (each individual method), never the container
+ * (the controller class merely existing).
+ */
+class CanonicalRouteMethodContractTest extends TestCase
+{
+
+    /**
+     * The canonical route names supplied by the AppHost table, as reproduced
+     * verbatim by `appinfo/routes.php`'s openregister-absent fallback.
+     *
+     * Keyed `controllerPrefix => [method, ...]`.
+     *
+     * @var array<string, array<int, string>>
+     */
+    private const CANONICAL_ROUTES = [
+        'Dashboard'   => ['page', 'catchAll'],
+        'Settings'    => ['index', 'create', 'update', 'load'],
+        'Preferences' => ['getPreference', 'setPreference'],
+        'Metrics'     => ['index'],
+        'Health'      => ['index'],
+    ];
+
+
+    /**
+     * Every canonical route name must be reproduced by the local fallback.
+     *
+     * This is the positive control for the test below: if `routes.php` ever
+     * stopped declaring these names, the method assertions would pass
+     * vacuously because there would be nothing left to route. Read a green
+     * from the next test only together with a green here.
+     *
+     * @return void
+     */
+    public function testFallbackRouteTableStillDeclaresEveryCanonicalName(): void
+    {
+        $routesSource = file_get_contents(__DIR__.'/../../../appinfo/routes.php');
+        $this->assertIsString($routesSource, 'appinfo/routes.php must be readable');
+
+        foreach (self::CANONICAL_ROUTES as $prefix => $methods) {
+            foreach ($methods as $method) {
+                $routeName = lcfirst($prefix).'#'.$method;
+
+                // dashboard#page / dashboard#catchAll are declared in the
+                // fallback as a literal entry and a $catchAllRoute variable
+                // respectively; both mention the name.
+                $this->assertStringContainsString(
+                    $routeName,
+                    $routesSource,
+                    sprintf(
+                        'appinfo/routes.php no longer mentions the canonical route "%s". '
+                        .'Either the AppHost table changed and this test is stale, or a '
+                        .'canonical route was silently dropped.',
+                        $routeName
+                    )
+                );
+            }
+        }
+    }//end testFallbackRouteTableStillDeclaresEveryCanonicalName()
+
+
+    /**
+     * A controller this app ships itself must implement every canonical
+     * method routed to it — the AppHost generic will not fill the gap.
+     *
+     * @return void
+     */
+    public function testLeafOwnedControllersImplementEveryCanonicalMethodRoutedToThem(): void
+    {
+        $inspected = 0;
+        $missing   = [];
+
+        foreach (self::CANONICAL_ROUTES as $prefix => $methods) {
+            $class = 'OCA\\Procest\\Controller\\'.$prefix.'Controller';
+
+            // The class file existing on disk is what makes the AppHost skip
+            // the alias. `class_exists()` alone would be satisfied by the DI
+            // alias target in a booted container, which is precisely the case
+            // this test must NOT treat as leaf-owned.
+            $file = __DIR__.'/../../../lib/Controller/'.$prefix.'Controller.php';
+            if (file_exists($file) === false) {
+                continue;
+            }
+
+            $this->assertTrue(
+                class_exists($class),
+                sprintf('%s exists on disk but does not autoload as %s', $file, $class)
+            );
+
+            $reflection = new ReflectionClass($class);
+
+            foreach ($methods as $method) {
+                $inspected++;
+                if ($reflection->hasMethod($method) === false) {
+                    $missing[] = $prefix.'Controller::'.$method.'()';
+                    continue;
+                }
+
+                $this->assertTrue(
+                    $reflection->getMethod($method)->isPublic(),
+                    sprintf('%s::%s() must be public to be dispatchable', $class, $method)
+                );
+            }
+        }//end foreach
+
+        // Positive control: a null result here ("no missing methods") is only
+        // meaningful if something was actually inspected. Zero inspections
+        // would mean the file-existence probe above silently matched nothing.
+        $this->assertGreaterThan(
+            0,
+            $inspected,
+            'No leaf-owned canonical controller was inspected — the lib/Controller '
+            .'path probe is broken, so the empty finding list means nothing.'
+        );
+
+        $this->assertSame(
+            [],
+            $missing,
+            sprintf(
+                "The canonical AppHost route table routes to %s, but this app ships the "
+                ."controller itself so no generic is aliased in. Each of these is a 500, "
+                ."not a 404.\n  - %s",
+                'these method(s)',
+                implode("\n  - ", $missing)
+            )
+        );
+    }//end testLeafOwnedControllersImplementEveryCanonicalMethodRoutedToThem()
+
+
+}//end class

--- a/tests/Unit/Controller/SettingsControllerWriteTest.php
+++ b/tests/Unit/Controller/SettingsControllerWriteTest.php
@@ -1,0 +1,185 @@
+<?php
+
+/**
+ * SettingsController write-path unit tests.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\SettingsController;
+use OCA\Procest\Service\SettingsService;
+use OCP\App\IAppManager;
+use OCP\IGroupManager;
+use OCP\IL10N;
+use OCP\IRequest;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+/**
+ * The canonical AppHost route table routes BOTH `PUT /api/settings`
+ * (`settings#update`) and `POST /api/settings` (`settings#create`) into this
+ * controller, and because this app ships the class itself no generic is
+ * aliased in to cover either.
+ *
+ * These tests assert the ITEM — that the write actually reaches
+ * `SettingsService::updateSettings()` with the request's own parameters, and
+ * that the returned payload carries the service's result. A test that only
+ * checked for a 200, or only that the response was a JSONResponse, would pass
+ * against a controller that silently wrote nothing.
+ *
+ * @covers \OCA\Procest\Controller\SettingsController
+ */
+class SettingsControllerWriteTest extends TestCase
+{
+
+    /**
+     * The mocked request.
+     *
+     * @var IRequest|MockObject
+     */
+    private IRequest $request;
+
+    /**
+     * The mocked settings service.
+     *
+     * @var SettingsService|MockObject
+     */
+    private SettingsService $settingsService;
+
+
+    /**
+     * Build the controller under test with the collaborators mocked.
+     *
+     * @return SettingsController The controller under test.
+     */
+    private function controller(): SettingsController
+    {
+        return new SettingsController(
+            request: $this->request,
+            container: $this->createMock(ContainerInterface::class),
+            appManager: $this->createMock(IAppManager::class),
+            settingsService: $this->settingsService,
+            groupManager: $this->createMock(IGroupManager::class),
+            userSession: $this->createMock(IUserSession::class),
+            l10n: $this->createMock(IL10N::class)
+        );
+    }//end controller()
+
+
+    /**
+     * Set up the mocks shared by every test.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->request         = $this->createMock(IRequest::class);
+        $this->settingsService = $this->createMock(SettingsService::class);
+    }//end setUp()
+
+
+    /**
+     * PUT /api/settings must persist the request parameters and return them.
+     *
+     * @return void
+     */
+    public function testUpdatePersistsTheRequestParametersAndReturnsTheStoredConfig(): void
+    {
+        $submitted = ['lhsMatrix' => '{"a":1}'];
+        $stored    = ['lhsMatrix' => '{"a":1}', 'other' => 'untouched'];
+
+        $this->request->method('getParams')->willReturn($submitted);
+
+        // The ITEM: the write reaches the service, with the submitted params.
+        $this->settingsService->expects($this->once())
+            ->method('updateSettings')
+            ->with($submitted)
+            ->willReturn($stored);
+
+        $response = $this->controller()->update();
+
+        $this->assertSame(
+            ['success' => true, 'config' => $stored],
+            $response->getData(),
+            'update() must return the config the service actually stored, not the submission'
+        );
+    }//end testUpdatePersistsTheRequestParametersAndReturnsTheStoredConfig()
+
+
+    /**
+     * POST /api/settings is a legacy alias and must write identically.
+     *
+     * Three procest views still POST to this route, so the alias staying a
+     * real write — not an empty success — is load-bearing.
+     *
+     * @return void
+     */
+    public function testCreateDelegatesToUpdateAndStillWrites(): void
+    {
+        $submitted = ['kccEnabled' => true];
+        $stored    = ['kccEnabled' => true];
+
+        $this->request->method('getParams')->willReturn($submitted);
+
+        $this->settingsService->expects($this->once())
+            ->method('updateSettings')
+            ->with($submitted)
+            ->willReturn($stored);
+
+        $response = $this->controller()->create();
+
+        $this->assertSame(
+            ['success' => true, 'config' => $stored],
+            $response->getData(),
+            'create() must produce the same written result as update()'
+        );
+    }//end testCreateDelegatesToUpdateAndStillWrites()
+
+
+    /**
+     * The write must not be skipped when the submission is empty.
+     *
+     * An early return on an empty payload would look identical to a
+     * successful no-op write from the caller's side.
+     *
+     * @return void
+     */
+    public function testEmptySubmissionStillReachesTheService(): void
+    {
+        $this->request->method('getParams')->willReturn([]);
+
+        $this->settingsService->expects($this->once())
+            ->method('updateSettings')
+            ->with([])
+            ->willReturn(['unchanged' => true]);
+
+        $response = $this->controller()->update();
+
+        $this->assertSame(
+            ['success' => true, 'config' => ['unchanged' => true]],
+            $response->getData()
+        );
+    }//end testEmptySubmissionStillReachesTheService()
+
+
+}//end class


### PR DESCRIPTION
`Routes::standard()` routes `settings#update` (PUT /api/settings) into this
app's controller namespace. OpenRegister's AppHost substitutes its generic
controller only when the leaf does NOT ship a class of that name — see
`AppHost\Bootstrap::aliasControllerUnlessLeafDefinesIt()`. Procest ships its
own `SettingsController`, so the alias is skipped and the generic is never
constructed: every method the canonical table routes to `settings#` is owed
locally.

Procest implemented `index/create/load` and no `update()`. The router matches
the URL, the dispatcher reflects the method, and the request dies with a 500 —
not a 404. `src/store/modules/enforcement.js::saveLhsMatrix()` sends exactly
that request, so saving the LHS matrix has been failing.

Fix mirrors `GenericSettingsControllerBase`: `update()` is the canonical write,
`create()` is the legacy POST alias that delegates to it. Auth posture is
unchanged — both carry the same `#[AuthorizedAdminSetting]` the write already
had.

Found by a full-tree hydra-gates run (gate-14 route-reachability). CI's
diff-scoped run cannot see it: the file has not changed, so it is never in
scope.

Can-fail proof: `CanonicalRouteMethodContractTest` fails on the pre-fix tree
naming `SettingsController::update()` exactly, and passes after. It asserts on
each individual method, never on the controller class merely existing, and
carries a positive control that fails if the route-table scan matches nothing.

The same test deliberately does NOT flag Health/Metrics/Preferences: those
classes are absent from lib/Controller on purpose so the AppHost alias binds.
That is the other side of the same seam, and creating them would break it.