### PR TITLE
chore(deps): raise the Nextcloud floor to 32, and hold it to the tested matrix

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -63,12 +63,20 @@ jobs:
       app-name: procest
       php-version: "8.3"
       php-test-versions: '["8.3", "8.4"]'
-      # stable31 is REMOVED, not "dropped for coverage". `additional-apps` below
-      # installs openregister, which declares min-version="32" and therefore
-      # cannot install on NC31 — `occ app:enable openregister` fails with only a
-      # ::warning::, so the run continued WITHOUT its data layer and every
-      # /apps/openregister/... call returned Nextcloud's HTML 404 page. A stable31
-      # leg was testing an impossible configuration, so its red said nothing.
+      # stable31 is REMOVED, not "dropped for coverage".
+      #
+      # The original reason recorded here — "openregister declares
+      # min-version=32" — is STALE: measured 2026-08-08, openregister@development
+      # declares min-version="28" (openregister#2380 reverted it). Do not rely on
+      # it. What made the stable31 leg worthless still happened, though:
+      # `occ app:enable openregister` failed with only a ::warning::, so the run
+      # continued WITHOUT its data layer and every /apps/openregister/... call
+      # returned Nextcloud's HTML 404 page — a red that said nothing.
+      #
+      # The standing reason is procest's own floor: appinfo/info.xml declares
+      # <nextcloud min-version="32"/>, so a leg below 32 would test a
+      # configuration this app does not claim to support.
+      # tests/Unit/AppInfo/NextcloudFloorMatrixTest.php holds the two in sync.
       # newman, playwright and journeydoc-capture all pin
       # `fromJSON(inputs.nextcloud-test-refs)[0]`, so the FIRST entry has to be a
       # version openregister can load.

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -71,17 +71,31 @@ Vrij en open source onder de EUPL-1.2-licentie.
     <dependencies>
         <php min-version="8.3"/>
         <!--
-        min-version is 32, NOT 28, because the OpenRegister dependency noted below is
-        HARD (src/manifest.json lists "openregister" as a required dependency) and
-        openregister declares min-version="32" — its lib/ContextChat/ContentProvider.php
-        implements OCP\ContextChat\IContentProvider, an interface core does not have
-        before Nextcloud 32. On NC 28-31 openregister refuses to install ("cannot be
-        installed because it is not compatible with this version of the server") and
-        every Procest entity is an OpenRegister object, so the app cannot function
-        there. Declaring 28 advertised a range this app cannot deliver.
-        Same defect as openconnector#1173.
+        min-version is 32, NOT 28.
+
+        ⚠️ The reason is NOT the one an earlier revision of this comment gave.
+        That text said "openregister declares min-version=32"; measured against
+        the canonical repo on 2026-08-08, ConductionNL/openregister@development
+        declares <nextcloud min-version="28" max-version="34"/>. It was true when
+        written and was undone by openregister#2380. The openconnector#1173 rule
+        — min-version must be >= the max of every <app> dependency's floor — is
+        therefore satisfied by any value here, and imposes no constraint at all.
+        Do not re-derive this floor from openregister's.
+
+        The floor is 32 for two reasons that are true today:
+
+        1. Nothing below 32 is tested, and an untested range is an advertised
+           claim we cannot support. .github/workflows/code-quality.yml pins
+           nextcloud-test-refs to exactly ["stable32"]; the stable31 leg was
+           REMOVED, not merely dropped for coverage.
+        2. This app declares <php min-version="8.3"/> directly above. Nextcloud
+           28 does not support PHP 8.3, so the pair (NC 28, PHP 8.3) that the
+           two lines together advertise is not a configuration that exists.
+
+        max-version stays at 34, which is the fleet-wide value everywhere except
+        openconnector (35).
         -->
-        <nextcloud min-version="28" max-version="34"/>
+        <nextcloud min-version="32" max-version="34"/>
         <!-- App dependency (not expressible in app-info.xsd): OpenRegister >= 0.2.16
              (MDM engine: x-openregister-quality / x-openregister-dedup schema support and
              on-save qualityScore/qualityStatus materialisation, ADR-045 / OR change

--- a/tests/Unit/AppInfo/NextcloudFloorMatrixTest.php
+++ b/tests/Unit/AppInfo/NextcloudFloorMatrixTest.php
@@ -1,0 +1,188 @@
+<?php
+
+/**
+ * Tests that the declared Nextcloud floor and the tested matrix agree.
+ *
+ * @category Test
+ * @package  OCA\Procest\Tests\Unit\AppInfo
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\AppInfo;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `appinfo/info.xml` states which Nextcloud versions this app supports.
+ * `.github/workflows/code-quality.yml` states which it actually runs against.
+ * Nothing has ever held the two together, and they have drifted in both
+ * directions within one week:
+ *
+ *   - #759 raised the floor to 32 while CI still ran stable31.
+ *   - #762 restored a 28 floor on the stated ground that "this repo tests
+ *     stable31" — by then CI had already been pinned to stable32 only, so the
+ *     premise was false when it was written.
+ *
+ * Two failure modes, and this test catches both:
+ *
+ *   - A tested leg BELOW the declared floor is a red (or a green) about a
+ *     configuration the app does not claim to support.
+ *   - A declared floor with NO tested leg at or above it means the supported
+ *     range is entirely unexercised.
+ *
+ * This asserts on each ITEM (every ref in the matrix), not on the container
+ * (the matrix merely being non-empty).
+ */
+class NextcloudFloorMatrixTest extends TestCase
+{
+
+
+    /**
+     * Read the declared `<nextcloud min-version>` from appinfo/info.xml.
+     *
+     * @return int The declared major version.
+     */
+    private function declaredFloor(): int
+    {
+        $xml = simplexml_load_file(__DIR__.'/../../../appinfo/info.xml');
+        $this->assertNotFalse($xml, 'appinfo/info.xml must parse as XML');
+
+        $nodes = $xml->xpath('//dependencies/nextcloud');
+        $this->assertNotEmpty($nodes, 'appinfo/info.xml declares no <nextcloud> dependency');
+
+        $min = (string) $nodes[0]['min-version'];
+        $this->assertMatchesRegularExpression(
+            '/^\d+$/',
+            $min,
+            'nextcloud min-version must be a bare major version'
+        );
+
+        return (int) $min;
+    }//end declaredFloor()
+
+
+    /**
+     * Read the `nextcloud-test-refs` legs from the quality workflow.
+     *
+     * @return array<int, int> The major version of every tested leg.
+     */
+    private function testedRefs(): array
+    {
+        $workflow = file_get_contents(__DIR__.'/../../../.github/workflows/code-quality.yml');
+        $this->assertIsString($workflow, '.github/workflows/code-quality.yml must be readable');
+
+        $matched = preg_match(
+            "/^\s*nextcloud-test-refs:\s*'(?<json>\[[^\]]*\])'/m",
+            $workflow,
+            $matches
+        );
+        $this->assertSame(
+            1,
+            $matched,
+            'Could not find a `nextcloud-test-refs:` line in code-quality.yml. '
+            .'If the key was renamed, this test is scanning for something that no '
+            .'longer exists and its green would be meaningless.'
+        );
+
+        $refs = json_decode($matches['json'], true);
+        $this->assertIsArray($refs, 'nextcloud-test-refs must be a JSON array');
+
+        $majors = [];
+        foreach ($refs as $ref) {
+            $this->assertMatchesRegularExpression(
+                '/^stable(\d+)$/',
+                (string) $ref,
+                sprintf('Unrecognised Nextcloud test ref "%s"', (string) $ref)
+            );
+            preg_match('/^stable(\d+)$/', (string) $ref, $m);
+            $majors[] = (int) $m[1];
+        }
+
+        return $majors;
+    }//end testedRefs()
+
+
+    /**
+     * The scanners must actually find something before any absence claim
+     * derived from them can be believed.
+     *
+     * @return void
+     */
+    public function testBothDeclarationsAreActuallyReadable(): void
+    {
+        $this->assertGreaterThan(0, $this->declaredFloor());
+        $this->assertNotEmpty(
+            $this->testedRefs(),
+            'The tested-ref list parsed as empty. An empty list would make every '
+            .'assertion below pass vacuously.'
+        );
+    }//end testBothDeclarationsAreActuallyReadable()
+
+
+    /**
+     * No CI leg may target a Nextcloud below the declared floor.
+     *
+     * @return void
+     */
+    public function testNoTestedLegIsBelowTheDeclaredFloor(): void
+    {
+        $floor = $this->declaredFloor();
+        $below = [];
+
+        foreach ($this->testedRefs() as $major) {
+            if ($major < $floor) {
+                $below[] = 'stable'.$major;
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $below,
+            sprintf(
+                'appinfo/info.xml declares <nextcloud min-version="%d"/>, but CI still '
+                ."runs against %s. Either drop the leg or lower the floor — a leg below "
+                .'the floor tests a configuration this app does not support, so neither '
+                .'its red nor its green means anything.',
+                $floor,
+                implode(', ', $below)
+            )
+        );
+    }//end testNoTestedLegIsBelowTheDeclaredFloor()
+
+
+    /**
+     * At least one CI leg must sit at or above the declared floor, so the
+     * supported range is exercised rather than merely asserted.
+     *
+     * @return void
+     */
+    public function testTheDeclaredFloorIsActuallyExercised(): void
+    {
+        $floor = $this->declaredFloor();
+        $refs  = $this->testedRefs();
+
+        $atOrAbove = array_filter($refs, static fn (int $major): bool => $major >= $floor);
+
+        $this->assertNotEmpty(
+            $atOrAbove,
+            sprintf(
+                'appinfo/info.xml declares a floor of %d but no CI leg runs at or above '
+                .'it (legs: %s). The declared support range is entirely untested.',
+                $floor,
+                implode(', ', array_map(static fn (int $m): string => 'stable'.$m, $refs))
+            )
+        );
+    }//end testTheDeclaredFloorIsActuallyExercised()
+
+
+}//end class


### PR DESCRIPTION
The floor has been flipped twice this week (#759 raised it, #761 was closed,
#762 reverted it) because nothing tied the declared range to the tested one.
This raises it to 32 per the fleet-wide alignment on PHP 8.3, and adds the
test that makes the next flip impossible to land silently.

WHAT I CHECKED RATHER THAN ASSUMED

The rationale already sitting in info.xml was stale, and #762 reverted the
value while leaving that rationale in place — so the file declared 28 and
explained 32. Both the info.xml comment and code-quality.yml claimed
"openregister declares min-version=32". Measured today against the canonical
repo, ConductionNL/openregister@development declares:

    <nextcloud min-version="28" max-version="34"/>

openregister#2380 undid it. So the openconnector#1172/#1173 rule — min-version
must be >= the max of every <app> dependency's floor — imposes NO constraint
here: procest declares no <app> dependencies at all, and the app it depends on
in practice has a floor of 28. Both stale comments are corrected rather than
repeated.

#762's own stated premise is also false at this tip. It reverted the floor
because "this repo tests stable31"; code-quality.yml pins
nextcloud-test-refs to exactly ["stable32"], and the stable31 leg was REMOVED.

WHY 32 IS RIGHT ON TODAY'S EVIDENCE

1. Nothing below 32 is tested. stable32 is the only leg, so 28-31 was an
   advertised App Store range with zero exercise behind it.
2. info.xml declares <php min-version="8.3"/> two lines above. Nextcloud 28
   does not support PHP 8.3, so the pair the two lines jointly advertise is
   not a configuration that can exist.

CI MATRIX: unchanged, and now checked. No leg targets NC < 32 — stable32 is
the only entry — so there is nothing to drop. max-version stays 34, the
fleet-wide value everywhere except openconnector (35).

CAN-FAIL PROOF for NextcloudFloorMatrixTest (3 mutations, measured):
  - floor 32 -> 33: 2 failures — "runs against stable32" and "no CI leg runs
    at or above it".
  - matrix ["stable32"] -> ["stable31"] at floor 32: 2 failures, naming
    stable31. This is literally the state #762 claimed to be in, so the test
    would have caught that PR.
  - both restored: OK (3 tests, 25 assertions).

It asserts on every individual ref, not on the matrix merely being non-empty,
and a separate positive control fails if either scan matches nothing — an
unparsed matrix would otherwise make every assertion pass vacuously.