### PR TITLE
fix(e2e): add a globalTimeout under the 45m CI cap

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,6 +10,17 @@ export default defineConfig({
 	fullyParallel: false,
 	retries: 1,
 	workers: 1,
+	// The shared quality.yml Playwright job is `timeout-minutes: 45`, and a job
+	// cancelled by that cap produces NO verdict: Playwright never prints its
+	// tally, the `if: failure()` trace upload never fires, and the
+	// `if: always()` report upload does not run on a cancelled job either — the
+	// run you most need to read is the one that leaves nothing behind, and it
+	// still renders as "fail" in `gh pr checks` while carrying no information.
+	// Runs cancelled at ~45m16s have been observed in this fleet. Measured
+	// overhead before `Run Playwright tests` starts is 2.0-2.4 min and the
+	// uploads after it take seconds, so 38m keeps ~7 min of margin while
+	// guaranteeing both a tally and the artifacts that explain it.
+	globalTimeout: 38 * 60_000,
 	reporter: [
 		// Output paths match the shared quality.yml workflow's artifact-upload
 		// paths (server/apps/<app>/playwright-report and .../test-results) so

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -95,6 +95,21 @@ export default defineConfig({
 	// cross-worker flake.
 	workers: 1,
 	retries: process.env.CI ? 1 : 0,
+	// Stop on our own clock, ahead of the shared job's `timeout-minutes: 45`.
+	//
+	// The `actionTimeout` note below records exactly what happens without this:
+	// "a 45-minute job that CI cancelled after 65 of 122 tests". A cancelled
+	// job is not a verdict — Playwright never prints its tally, the
+	// `if: failure()` trace upload never fires, and the `if: always()` report
+	// upload does not run on a cancelled job either. The evidence that 57 tests
+	// never ran had to be reconstructed from the live log rather than read off
+	// an artifact, because there was no artifact.
+	//
+	// With a globalTimeout Playwright stops itself and exits with a count, and
+	// the uploads run. Measured overhead before `Run Playwright tests` starts
+	// is 2.0-2.4 min and the uploads take seconds, so 38m keeps ~7 min of
+	// margin under the cap.
+	globalTimeout: 38 * 60_000,
 	reporter: [
 		['html', { open: 'never', outputFolder: path.resolve(__dirname, 'playwright-report') }],
 		['junit', { outputFile: path.resolve(__dirname, 'test-results', 'results.xml') }],
@@ -120,7 +135,16 @@ export default defineConfig({
 		// Written by global-setup.ts after the admin login. Path must match
 		// `helpers/auth.ts#STORAGE_STATE`, which global-setup imports.
 		storageState: path.resolve(__dirname, '.auth', 'user.json'),
-		trace: 'on-first-retry',
+		// `on-first-retry` writes a trace only when a retry actually happens, so
+		// the trace artifact is a function of `retries`. Off CI `retries` is 0
+		// above, so a local failure has never produced a trace at all; on CI it
+		// traces the SECOND attempt only, which means the failure that does not
+		// reproduce — the one actually worth a trace — leaves no record of the
+		// attempt that failed. `retain-on-failure` traces every attempt and
+		// keeps the ones that failed: strictly more informative, and
+		// independent of the retry count. (The app-root config already used
+		// `retain-on-failure`; this file, the one CI actually loads, did not.)
+		trace: 'retain-on-failure',
 		screenshot: 'only-on-failure',
 	},
 


### PR DESCRIPTION
Part of the fleet-wide Playwright instrument sweep for ConductionNL/.github#188. Neither change can alter a verdict — both change whether you can *see* why a verdict happened.

## trace

This repo's `trace` is already `retain-on-failure`, so only the timeout half applies here.

Reproduced with two minimal Playwright projects differing only in the `trace` value, same deliberately failing test, `retries: 0` in both:

| config | trace zips written |
|---|---|
| `retries: 0` + `on-first-retry` | **0** |
| `retries: 0` + `retain-on-failure` | **1** (7.4 KB) |

## globalTimeout: 38 * 60_000

The shared `quality.yml` Playwright job is `timeout-minutes: 45`. A job cancelled by that cap yields **no verdict and no artifacts** — the trace upload is `if: failure()`, the report upload is `if: always()`, and neither runs on a cancelled job, while `gh pr checks` still renders it as "fail". Runs cancelled at ~45m16s have been observed in this fleet.

Margin, measured rather than assumed: overhead before `Run Playwright tests` starts is 2.0-2.4 min (openconnector run 31257480415 = 2m20s; opencatalogi, doriath, openregister in the same band); uploads after it take seconds. 38m + ~2.5m setup + uploads sits ~7 min under the cap. Verified that a fired `globalTimeout` exits with a tally (`3 did not run / 1 passed`) plus an HTML report and a trace zip on disk — exactly what a cancelled job does not give you.

Matches the value already landed in nldesign.