### PR TITLE
chore: CI baseline probe for main (DO NOT MERGE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,3 +216,5 @@ AGPL-3.0-or-later
 ## Authors
 
 Built by [Conduction](https://conduction.nl) — open-source software for Dutch government and public sector organizations.
+
+<!-- ci baseline probe: no-op, do not merge -->


### PR DESCRIPTION
Throwaway control PR. Sole purpose: measure `main`'s own PHPStan/Psalm status under `main`'s legacy `code-quality.yml`, which triggers on `pull_request` only and therefore has never run on a `main` push.

Diff is a single comment line appended to `README.md` — nothing under `lib/`, which is the only path `phpstan.neon` (`paths: [lib]`) and `psalm.xml` (`<directory name="lib" />`) analyse.

If PHPStan and Psalm fail here, they are pre-existing debt on `main` and not caused by #771. **This PR will be closed unmerged.**