### PR TITLE
ci(main): restore the missing push trigger — main built NOTHING

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,8 +1,20 @@
 name: Code Quality
 
 on:
+  # `push` on main is the load-bearing one, and it was MISSING. Without it a
+  # push to the release branch built nothing at all — not red, not green,
+  # simply no run. Measured 2026-08-09: procest `main` had ZERO Code Quality
+  # runs on record, so nobody could say what state the branch users install
+  # was in. A branch with no runs shows no red, which is why this went unseen.
+  #
+  # `development` has carried this trigger for some time; it never reached
+  # `main` because the corrected workflow travels the release train and no
+  # release has carried it across. See ConductionNL/.github#285.
+  push:
+    branches: [main, development, feature/**, bugfix/**, hotfix/**]
   pull_request:
     branches: [main, master, development]
+  workflow_dispatch:
 
 concurrency:
   group: quality-${{ github.head_ref || github.ref }}


### PR DESCRIPTION
`code-quality.yml` on `main` has **no `push:` trigger**, only `pull_request`. A push to the release branch therefore runs **no jobs at all**.

Measured 2026-08-09: this repo's `main` has **zero** Code Quality runs on record. Not failing — **absent**. A branch with no runs shows no red, which is exactly why this went unseen while every measurement in the CI programme was made on `development`.

```yaml
# main today
on:
  pull_request:
    branches: [main, master, development]

# development, for some time now
on:
  push:
    branches: [main, development, feature/**, bugfix/**, hotfix/**]
  pull_request: ...
  workflow_dispatch:
```

The corrected trigger never reached `main` because the workflow travels the release train (`development` → `beta` → `main`) and no release has carried it across. So `main` runs whatever workflow it last received, which predates the fix.

## Deliberately workflow-only

This does **not** fix whatever `main` may be failing. It makes `main`'s state **visible**, which has to come first — right now nobody can say what state the branch users install is in.

**Expect the first run to be red.** That red is information this branch has not produced in months, and it is the point of the change.

Validated: the file parses, and the resulting triggers are `push` / `pull_request` / `workflow_dispatch` with `push` on `[main, development, feature/**, bugfix/**, hotfix/**]`.

Fleet context and the wider finding: ConductionNL/.github#285 — **no repo in the fleet has a green `main`**; docudesk's last was 2025-12-12, opencatalogi's workflow `startup_failure`s, and this repo plus procest never build it at all.