### PR TITLE
fix(gates): close gate-5/7/9/49/61 — and two OpenRegister findAll() calls that never ran

### DIFF
--- a/lib/Controller/AssistantController.php
+++ b/lib/Controller/AssistantController.php
@@ -75,6 +75,10 @@ class AssistantController extends Controller
      * Whether the case-assistant UI panel should render — absent/disabled
      * Hermiq hides the panel rather than showing a permanently-erroring one.
      *
+     * Whether an LLM backend is wired up is deployment information, so the
+     * probe is answered only for an authenticated session — the same
+     * fail-closed shape `converse()` uses.
+     *
      * @return JSONResponse `{available: bool}`.
      *
      * @NoAdminRequired
@@ -83,6 +87,14 @@ class AssistantController extends Controller
      */
     public function availability(): JSONResponse
     {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return new JSONResponse(
+                ['error' => $this->l10n->t('Authentication required')],
+                Http::STATUS_UNAUTHORIZED
+            );
+        }
+
         return new JSONResponse(['available' => $this->hermiqClient->isAvailable()]);
     }//end availability()
 

--- a/lib/Controller/RoutingController.php
+++ b/lib/Controller/RoutingController.php
@@ -84,7 +84,10 @@ class RoutingController extends Controller
      *
      * @return JSONResponse
      *
-     * @NoAdminRequired
+     * @auth admin-only rerouting reassigns every open step on a case, so it is
+     * restricted to server admins — the body enforces the same rule via
+     * IGroupManager::isAdmin() and this declaration states it rather than
+     * contradicting it with @NoAdminRequired.
      *
      * @psalm-suppress PossiblyUnusedMethod
      *

--- a/lib/Controller/SubstitutionController.php
+++ b/lib/Controller/SubstitutionController.php
@@ -169,7 +169,15 @@ class SubstitutionController extends Controller
             return $this->accessGuard->forbidden(message: 'You may only revoke your own substitution');
         }
 
-        $updated = $this->substitutionService->revoke($id);
+        try {
+            $updated = $this->substitutionService->revoke($id);
+        } catch (\InvalidArgumentException $e) {
+            return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
+        } catch (\Throwable $e) {
+            $this->logger->error('Substitution revoke failed', ['error' => $e->getMessage()]);
+            return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_INTERNAL_SERVER_ERROR);
+        }
+
         return new JSONResponse($updated ?? ['status' => 'revoked']);
     }//end revoke()
 
@@ -222,6 +230,13 @@ class SubstitutionController extends Controller
             return $this->accessGuard->forbidden();
         }
 
-        return new JSONResponse(['results' => $this->auditService->getActionsForSubstitution($id)]);
+        try {
+            $results = $this->auditService->getActionsForSubstitution($id);
+        } catch (\Throwable $e) {
+            $this->logger->error('Substitution action list failed', ['error' => $e->getMessage()]);
+            return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_INTERNAL_SERVER_ERROR);
+        }
+
+        return new JSONResponse(['results' => $results]);
     }//end actions()
 }//end class

--- a/lib/Controller/WorkflowDefinitionController.php
+++ b/lib/Controller/WorkflowDefinitionController.php
@@ -32,12 +32,24 @@ namespace OCA\Procest\Controller;
 
 use OCA\Procest\AppInfo\Application;
 use OCA\Procest\Service\WorkflowDefinitionService;
+use OCA\Procest\Settings\AdminSettings;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 
 /**
  * Lifecycle-only controller for workflow definitions.
+ *
+ * Workflow definitions are case-type configuration, so every endpoint here —
+ * the three lifecycle writes and the two read-outs — is administrative.
+ * That was already the effective posture (a Nextcloud controller method with
+ * no auth attribute is admin-only), but it was never declared, which is what
+ * gate-5 flags: an undeclared posture is indistinguishable from a forgotten
+ * one. `AuthorizedAdminSetting` states it explicitly and matches the sibling
+ * seam, CaseDefinitionController.
+ *
+ * @spec openspec/specs/workflow-definition-engine/spec.md
  */
 class WorkflowDefinitionController extends Controller
 {
@@ -67,6 +79,7 @@ class WorkflowDefinitionController extends Controller
 
      * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
      */
+    #[AuthorizedAdminSetting(AdminSettings::class)]
     public function publish(string $id): JSONResponse
     {
         $result = $this->service->publish($id);
@@ -92,6 +105,7 @@ class WorkflowDefinitionController extends Controller
 
      * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
      */
+    #[AuthorizedAdminSetting(AdminSettings::class)]
     public function deprecate(string $id): JSONResponse
     {
         $result = $this->service->deprecate($id);
@@ -114,6 +128,7 @@ class WorkflowDefinitionController extends Controller
 
      * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
      */
+    #[AuthorizedAdminSetting(AdminSettings::class)]
     public function cloneDefinition(string $id): JSONResponse
     {
         $result = $this->service->cloneDefinition($id);
@@ -138,6 +153,7 @@ class WorkflowDefinitionController extends Controller
 
      * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
      */
+    #[AuthorizedAdminSetting(AdminSettings::class)]
     public function active(string $caseTypeId): JSONResponse
     {
         $definition = $this->service->getActiveDefinitionFor($caseTypeId);
@@ -161,6 +177,7 @@ class WorkflowDefinitionController extends Controller
 
      * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
      */
+    #[AuthorizedAdminSetting(AdminSettings::class)]
     public function forCase(string $caseId): JSONResponse
     {
         $definition = $this->service->getDefinitionForCase($caseId);

--- a/lib/Listener/BezwaarDecisionListener.php
+++ b/lib/Listener/BezwaarDecisionListener.php
@@ -58,6 +58,15 @@ class BezwaarDecisionListener implements IEventListener
     private const PROTECTED_STATUS = 'Beslissing op bezwaar';
 
     /**
+     * Upper bound on the decision rows the guard will pull per bezwaar.
+     *
+     * The probe answers a yes/no question ("does a decided bezwaarDecision
+     * exist?"), so it never needs the whole set; the bound keeps a write-path
+     * lookup cheap and bounded.
+     */
+    private const DECISION_PROBE_LIMIT = 100;
+
+    /**
      * Constructor.
      *
      * @param SettingsService $settingsService Schema slug bridge.
@@ -75,6 +84,15 @@ class BezwaarDecisionListener implements IEventListener
      * @param Event $event Event instance.
      *
      * @return void
+     *
+     * @listener-placement inline correctness — this listener is a transition
+     * guard, not follow-up work. Its whole job is to undo a status change that
+     * should not have been persisted, so it has to run inside the write that
+     * made it. Deferring the revert would publish an invalid
+     * "Beslissing op bezwaar" state to every reader, and to the notification
+     * and audit listeners that fire off the same write, for as long as the
+     * queue took to drain. The revert is a single bounded saveObject() on the
+     * object already being written.
 
      * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
      */
@@ -148,11 +166,28 @@ class BezwaarDecisionListener implements IEventListener
         // delegated to decidesk and carries a `decisionRef` (the besluit is the
         // decidesk outcome — procest-delegate-remaining-decisions-to-decidesk,
         // REQ-PDRD-001/REQ-PDRD-003). Both satisfy the published-decision guard.
+        // OpenRegister's ObjectService::findAll() takes ONE config array. This
+        // call used to pass ($register, $decisionSchema, $filters)
+        // positionally, which is a TypeError against `array $config` — and the
+        // catch below turned that TypeError into "allow by default", so this
+        // guard has never once blocked a transition.
+        //
+        // BOUNDED on purpose. This runs on the write path of every bezwaar
+        // update, so an unbounded findAll() would list and materialise every
+        // decision row on the register on each save — the
+        // OpenRegisterFlowResolver failure mode. A bezwaar carries one
+        // decision, occasionally a handful; self::DECISION_PROBE_LIMIT is two
+        // orders of magnitude of headroom.
         try {
             $all = $objectService->findAll(
-                $register,
-                $decisionSchema,
-                ['bezwaar' => $bezwaarId]
+                [
+                    'filters' => [
+                        'register' => $register,
+                        'schema'   => $decisionSchema,
+                        'bezwaar'  => $bezwaarId,
+                    ],
+                    'limit'   => self::DECISION_PROBE_LIMIT,
+                ]
             );
         } catch (Throwable $e) {
             $this->logger->debug(
@@ -166,7 +201,26 @@ class BezwaarDecisionListener implements IEventListener
             return false;
         }
 
-        return $this->containsDecidedDecision(decisions: $all);
+        if ($this->containsDecidedDecision(decisions: $all) === true) {
+            return true;
+        }
+
+        // A FULL page means the bound, not the data, ended the scan: a decided
+        // decision may sit past it. Reverting here would block a legitimate
+        // transition on a bezwaar with an improbable number of decisions, so
+        // the guard fails open — the same policy the rest of this listener
+        // applies to a lookup it cannot complete.
+        if (count($all) >= self::DECISION_PROBE_LIMIT) {
+            $this->logger->warning(
+                'Procest bezwaar-decision: decision probe hit its bound of '
+                .self::DECISION_PROBE_LIMIT.' rows — allowing the transition '
+                .'rather than reverting on an incomplete scan',
+                ['bezwaarId' => $bezwaarId]
+            );
+            return true;
+        }
+
+        return false;
     }//end hasPublishedDecision()
 
     /**

--- a/lib/Service/Pdok/PdokLocatieserverService.php
+++ b/lib/Service/Pdok/PdokLocatieserverService.php
@@ -39,7 +39,7 @@ declare(strict_types=1);
 namespace OCA\Procest\Service\Pdok;
 
 use OCA\Procest\AppInfo\Application;
-use OCA\Procest\Support\SuppressesWarnings;
+use OCP\Http\Client\IClientService;
 use OCP\IAppConfig;
 use OCP\ICache;
 use OCP\ICacheFactory;
@@ -50,11 +50,11 @@ use Throwable;
 
 /**
  * Single ingress for PDOK Locatieserver v3_1 calls.
+ *
+ * @spec openspec/specs/pdok-integration/spec.md
  */
 class PdokLocatieserverService
 {
-
-    use SuppressesWarnings;
 
     /**
      * Default endpoint when `pdok_locatieserver_endpoint` is empty.
@@ -96,17 +96,19 @@ class PdokLocatieserverService
     /**
      * Constructor.
      *
-     * @param ICacheFactory      $cacheFactory Cache factory.
-     * @param IAppConfig         $appConfig    App configuration accessor.
-     * @param ContainerInterface $container    DI container for optional
-     *                                         OpenConnector resolution.
-     * @param LoggerInterface    $logger       PSR logger.
+     * @param ICacheFactory      $cacheFactory  Cache factory.
+     * @param IAppConfig         $appConfig     App configuration accessor.
+     * @param ContainerInterface $container     DI container for optional
+     *                                          OpenConnector resolution.
+     * @param LoggerInterface    $logger        PSR logger.
+     * @param IClientService     $clientService Nextcloud HTTP client factory.
      */
     public function __construct(
         ICacheFactory $cacheFactory,
         private IAppConfig $appConfig,
         private ContainerInterface $container,
         private LoggerInterface $logger,
+        private IClientService $clientService,
     ) {
         $this->cache = $cacheFactory->createDistributed('procest_pdok_locatieserver');
     }//end __construct()
@@ -333,78 +335,77 @@ class PdokLocatieserverService
      * @throws \RuntimeException When the upstream returns non-2xx or the
      *                           network call fails. The exception code carries
      *                           the HTTP status (or 0 for network failures).
-     *
-     * @SuppressWarnings(PHPMD.UndefinedVariable) $matches is a preg_match() by-reference
-     * out-parameter, which PHPMD does not model.
      */
     private function callDirect(string $url): string
     {
-        $streamOptions = [
-            'http' => [
-                'method'        => 'GET',
-                'timeout'       => 10,
-                'header'        => "Accept: application/json\r\n",
-                'ignore_errors' => true,
-            ],
-        ];
-        $context       = stream_context_create(options: $streamOptions);
-
-        // Deliberately fopen() + stream_get_meta_data() rather than
-        // file_get_contents(): the HTTP stream wrapper publishes
-        // $http_response_header only into the scope that actually made the
-        // call, which here is the closure, so that magic variable is
-        // unreachable from this method. The wrapper_data key carries the
-        // identical response header lines and travels back with the return
-        // value.
-        $response = $this->withoutWarnings(
-            operation: static function () use ($url, $context): array {
-                $handle = fopen(filename: $url, mode: 'rb', use_include_path: false, context: $context);
-                if ($handle === false) {
-                    return [
-                        'body'    => false,
-                        'headers' => [],
-                    ];
-                }
-
-                $metaData = stream_get_meta_data($handle);
-                $headers  = ($metaData['wrapper_data'] ?? []);
-                if (is_array($headers) === false) {
-                    $headers = [];
-                }
-
-                $body = stream_get_contents($handle);
-                fclose($handle);
-
-                return [
-                    'body'    => $body,
-                    'headers' => $headers,
-                ];
+        // Nextcloud's own HTTP client, not the `http://` stream wrapper. The
+        // wrapper ignores the instance's proxy and certificate configuration
+        // and is unavailable outright when `allow_url_fopen` is off, so on a
+        // hardened or proxied deployment the direct PDOK path failed in a way
+        // that looked like PDOK being down. IClientService honours config.php
+        // (`proxy`, `proxyuserpwd`) and gives the status code directly instead
+        // of it having to be parsed back out of `wrapper_data`.
+        try {
+            $response = $this->clientService->newClient()->get(
+                $url,
+                [
+                    'timeout' => 10,
+                    'headers' => ['Accept' => 'application/json'],
+                ]
+            );
+        } catch (Throwable $e) {
+            $statusCode = $this->statusFromException(exception: $e);
+            if ($statusCode !== 0) {
+                throw new RuntimeException('PDOK Locatieserver HTTP '.$statusCode, $statusCode);
             }
-        );
 
-        $body = $response['body'];
-        if ($body === false) {
             $this->logger->warning(
                 'PDOK Locatieserver request failed',
-                ['detail' => $this->lastSuppressedWarning()]
+                ['detail' => $e->getMessage()]
             );
             throw new RuntimeException('Network error contacting PDOK Locatieserver', 0);
-        }
+        }//end try
 
-        $statusCode = 0;
-        foreach ($response['headers'] as $header) {
-            if (preg_match(pattern: '#^HTTP/\S+\s+(\d{3})#', subject: $header, matches: $matches) === 1) {
-                $statusCode = (int) $matches[1];
-            }
-        }
-
+        $statusCode = $response->getStatusCode();
         if ($statusCode < 200 || $statusCode >= 300) {
             throw new RuntimeException('PDOK Locatieserver HTTP '.$statusCode, $statusCode);
         }
 
         $this->recordSuccess();
-        return $body;
+        return (string) $response->getBody();
     }//end callDirect()
+
+    /**
+     * Recover the upstream HTTP status from a client exception.
+     *
+     * The HTTP client raises on non-2xx, and the status lives on the
+     * exception's response rather than on the exception itself. Returns 0 when
+     * the failure carried no status — a genuine transport error — so the
+     * caller can tell "PDOK said no" from "PDOK was unreachable".
+     *
+     * @param Throwable $exception The exception raised by the HTTP client.
+     *
+     * @return int The HTTP status code, or 0 when there was none.
+     */
+    private function statusFromException(Throwable $exception): int
+    {
+        if (method_exists($exception, 'getResponse') === true) {
+            $response = $exception->getResponse();
+            if (is_object($response) === true && method_exists($response, 'getStatusCode') === true) {
+                $status = (int) $response->getStatusCode();
+                if ($status >= 100 && $status < 600) {
+                    return $status;
+                }
+            }
+        }
+
+        $code = $exception->getCode();
+        if (is_int($code) === true && $code >= 100 && $code < 600) {
+            return $code;
+        }
+
+        return 0;
+    }//end statusFromException()
 
     /**
      * Dispatch through an OpenConnector source slug when configured.

--- a/lib/Service/RoleResolverService.php
+++ b/lib/Service/RoleResolverService.php
@@ -300,17 +300,27 @@ class RoleResolverService
         }
 
         try {
+            // OpenRegister's ObjectService::findAll() takes ONE config array.
+            // This call used to pass ($register, $schema, $filters)
+            // positionally, which is a TypeError against `array $config` — and
+            // the catch below turned that TypeError into an empty role list, so
+            // stored case roles were never loaded and rule resolution silently
+            // fell through to its other sources.
             $records = $objectService->findAll(
-                $register,
-                $schema,
-                ['filters' => ['case' => $caseId]],
+                [
+                    'filters' => [
+                        'register' => $register,
+                        'schema'   => $schema,
+                        'case'     => $caseId,
+                    ],
+                ]
             );
         } catch (Throwable $e) {
             $this->logger->warning(
                 'Procest: failed to load roles for case '.$caseId.': '.$e->getMessage(),
             );
             return [];
-        }
+        }//end try
 
         $rows = [];
         foreach ((array) $records as $record) {

--- a/tests/Stubs/Event/ObjectUpdatedEventStub.php
+++ b/tests/Stubs/Event/ObjectUpdatedEventStub.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Test stub for OCA\OpenRegister\Event\ObjectUpdatedEvent.
+ *
+ * Loaded by tests/bootstrap.php when the real class is absent (bare CI
+ * containers without the openregister runtime installed). Self-skips via a
+ * class_exists() guard when the real class is present, so an installed
+ * openregister always wins.
+ *
+ * Mirrors the real class's public surface exactly — `getNewObject()` and
+ * `getOldObject()` — so BezwaarDecisionListenerTest can exercise the real
+ * guard decision through `handle()` rather than around it. The post-persist
+ * counterpart of ObjectUpdatingEventStub.
+ *
+ * @category Test
+ * @package  OCA\Procest\Tests\Stubs\Event
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Event;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCP\EventDispatcher\Event;
+
+if (class_exists(ObjectUpdatedEvent::class) === false) {
+    /**
+     * Stub class for ObjectUpdatedEvent — used only in standalone unit tests.
+     */
+    class ObjectUpdatedEvent extends Event
+    {
+
+        /**
+         * Constructor.
+         *
+         * @param ObjectEntity      $newObject The post-update entity.
+         * @param ObjectEntity|null $oldObject The pre-update entity.
+         */
+        public function __construct(
+            private readonly ObjectEntity $newObject,
+            private readonly ?ObjectEntity $oldObject=null,
+        ) {
+            parent::__construct();
+        }//end __construct()
+
+        /**
+         * Get the post-update object entity.
+         *
+         * @return ObjectEntity
+         */
+        public function getNewObject(): ObjectEntity
+        {
+            return $this->newObject;
+        }//end getNewObject()
+
+        /**
+         * Get the pre-update object entity.
+         *
+         * @return ObjectEntity|null
+         */
+        public function getOldObject(): ?ObjectEntity
+        {
+            return $this->oldObject;
+        }//end getOldObject()
+    }//end class
+}//end if

--- a/tests/Unit/Controller/AssistantControllerTest.php
+++ b/tests/Unit/Controller/AssistantControllerTest.php
@@ -142,6 +142,24 @@ class AssistantControllerTest extends TestCase
     }//end testAvailabilityReflectsClient()
 
     /**
+     * The availability probe is deployment information, so an unauthenticated
+     * caller gets 401 and the Hermiq client is never consulted.
+     *
+     * @return void
+     */
+    public function testAvailabilityUnauthenticatedReturns401(): void
+    {
+        $this->userSession = $this->createMock(IUserSession::class);
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $this->hermiqClient->expects($this->never())->method('isAvailable');
+
+        $response = $this->controller()->availability();
+
+        $this->assertSame(401, $response->getStatus());
+    }//end testAvailabilityUnauthenticatedReturns401()
+
+    /**
      * An unauthenticated caller gets 401 and the service is never invoked.
      *
      * @return void

--- a/tests/Unit/Listener/BezwaarDecisionListenerTest.php
+++ b/tests/Unit/Listener/BezwaarDecisionListenerTest.php
@@ -1,0 +1,398 @@
+<?php
+
+/**
+ * BezwaarDecisionListener Unit Tests.
+ *
+ * These tests exist because the guard was dead and nothing said so. The
+ * listener called OpenRegister's `ObjectService::findAll()` with three
+ * positional arguments while that method takes ONE config array, so every
+ * invocation raised a TypeError that the listener's own `catch (Throwable)`
+ * converted into "a published decision exists". The guard therefore never
+ * blocked a single transition, and the suite was green throughout.
+ *
+ * So the assertions below deliberately look at the ARGUMENT the listener
+ * hands to OpenRegister — not merely at whether some call happened. A test
+ * that only asserted "findAll was called" would have passed against the
+ * broken code too.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Listener
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Listener;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Event\ObjectUpdatedEvent;
+use OCA\Procest\Listener\BezwaarDecisionListener;
+use OCA\Procest\Service\SettingsService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Unit tests for BezwaarDecisionListener.
+ *
+ * @covers \OCA\Procest\Listener\BezwaarDecisionListener
+ */
+class BezwaarDecisionListenerTest extends TestCase
+{
+
+    /**
+     * The protected status the guard defends.
+     *
+     * @var string
+     */
+    private const PROTECTED_STATUS = 'Beslissing op bezwaar';
+
+    /**
+     * Mocked settings/OpenRegister bridge.
+     *
+     * @var SettingsService&MockObject
+     */
+    private SettingsService $settings;
+
+    /**
+     * Mocked logger.
+     *
+     * @var LoggerInterface&MockObject
+     */
+    private LoggerInterface $logger;
+
+    /**
+     * Captured findAll() argument, or null when findAll was never reached.
+     *
+     * @var array<string, mixed>|null
+     */
+    private ?array $capturedFindAllConfig = null;
+
+    /**
+     * Captured saveObject() keyword arguments, or null when no revert happened.
+     *
+     * @var array<string, mixed>|null
+     */
+    private ?array $capturedSave = null;
+
+    /**
+     * Wire fresh mocks before each test.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->settings = $this->createMock(SettingsService::class);
+        $this->logger   = $this->createMock(LoggerInterface::class);
+
+        $this->settings->method('getConfigValue')->willReturnCallback(
+            static function (string $key, string $default=''): string {
+                return match ($key) {
+                    'register'                => 'procest-register',
+                    'bezwaar_schema'          => 'bezwaar',
+                    'bezwaar_decision_schema' => 'bezwaardecision',
+                    default                   => $default,
+                };
+            }
+        );
+    }//end setUp()
+
+    /**
+     * Build a doubled OpenRegister ObjectService.
+     *
+     * `findAll()` is declared with ONE array parameter, exactly as
+     * OpenRegister declares it, so a positional three-argument call from the
+     * listener is a TypeError here just as it is in production.
+     *
+     * @param array<int, array<string, mixed>> $decisions Rows findAll should return.
+     *
+     * @return object The doubled service.
+     */
+    private function objectService(array $decisions): object
+    {
+        $test = $this;
+
+        return new class($test, $decisions) {
+
+            /**
+             * Constructor.
+             *
+             * @param BezwaarDecisionListenerTest      $test      The owning test case.
+             * @param array<int, array<string, mixed>> $decisions Rows to return.
+             */
+            public function __construct(
+                private BezwaarDecisionListenerTest $test,
+                private array $decisions,
+            ) {
+            }//end __construct()
+
+            /**
+             * Mirror of OpenRegister's single-config-array signature.
+             *
+             * @param array<string, mixed> $config The find configuration.
+             *
+             * @return array<int, array<string, mixed>>
+             */
+            public function findAll(array $config=[]): array
+            {
+                $this->test->recordFindAll(config: $config);
+                return $this->decisions;
+            }//end findAll()
+
+            /**
+             * Capture a revert write.
+             *
+             * @param array<string, mixed> $object   The patch payload.
+             * @param string               $register The register slug.
+             * @param string               $schema   The schema slug.
+             * @param string               $uuid     The object uuid.
+             *
+             * @return array<string, mixed>
+             */
+            public function saveObject(array $object, string $register, string $schema, string $uuid): array
+            {
+                $this->test->recordSave(
+                    save: [
+                        'object'   => $object,
+                        'register' => $register,
+                        'schema'   => $schema,
+                        'uuid'     => $uuid,
+                    ]
+                );
+                return $object;
+            }//end saveObject()
+        };
+    }//end objectService()
+
+    /**
+     * Record the config findAll() was called with.
+     *
+     * @param array<string, mixed> $config The captured configuration.
+     *
+     * @return void
+     */
+    public function recordFindAll(array $config): void
+    {
+        $this->capturedFindAllConfig = $config;
+    }//end recordFindAll()
+
+    /**
+     * Record a captured revert write.
+     *
+     * @param array<string, mixed> $save The captured write.
+     *
+     * @return void
+     */
+    public function recordSave(array $save): void
+    {
+        $this->capturedSave = $save;
+    }//end recordSave()
+
+    /**
+     * Build an ObjectUpdatedEvent carrying the given payloads.
+     *
+     * @param array<string, mixed> $new The post-update payload.
+     * @param array<string, mixed> $old The pre-update payload.
+     *
+     * @return ObjectUpdatedEvent
+     */
+    private function event(array $new, array $old): ObjectUpdatedEvent
+    {
+        $newEntity = $this->createMock(ObjectEntity::class);
+        $newEntity->method('jsonSerialize')->willReturn($new);
+        $oldEntity = $this->createMock(ObjectEntity::class);
+        $oldEntity->method('jsonSerialize')->willReturn($old);
+
+        return new ObjectUpdatedEvent($newEntity, $oldEntity);
+    }//end event()
+
+    /**
+     * A bezwaar payload sitting on the protected status.
+     *
+     * @return array<string, mixed>
+     */
+    private function bezwaarOnProtectedStatus(): array
+    {
+        return [
+            'id'     => 'bezwaar-1',
+            '@self'  => ['schema' => 'bezwaar'],
+            'status' => self::PROTECTED_STATUS,
+        ];
+    }//end bezwaarOnProtectedStatus()
+
+    /**
+     * Build the listener under test.
+     *
+     * @param object $objectService The doubled OpenRegister service.
+     *
+     * @return BezwaarDecisionListener
+     */
+    private function listener(object $objectService): BezwaarDecisionListener
+    {
+        $this->settings->method('getObjectService')->willReturn($objectService);
+        return new BezwaarDecisionListener($this->settings, $this->logger);
+    }//end listener()
+
+    /**
+     * The decision probe must reach OpenRegister in the shape OpenRegister
+     * declares: one config array, with register/schema/bezwaar as filters.
+     *
+     * This is the assertion the old code could not have passed. It asserts on
+     * the argument itself, not on the fact that a call occurred.
+     *
+     * @return void
+     */
+    public function testProbeCallsFindAllWithASingleConfigArray(): void
+    {
+        $listener = $this->listener($this->objectService([['status' => 'published']]));
+
+        $listener->handle(
+            $this->event(
+                $this->bezwaarOnProtectedStatus(),
+                ['status' => 'In behandeling']
+            )
+        );
+
+        $this->assertNotNull(
+            $this->capturedFindAllConfig,
+            'the guard never reached findAll()'
+        );
+        $this->assertSame(
+            [
+                'register' => 'procest-register',
+                'schema'   => 'bezwaardecision',
+                'bezwaar'  => 'bezwaar-1',
+            ],
+            $this->capturedFindAllConfig['filters'],
+            'the probe must filter by register, schema and bezwaar id'
+        );
+    }//end testProbeCallsFindAllWithASingleConfigArray()
+
+    /**
+     * The probe must be bounded — it runs on the write path of every bezwaar
+     * update, so it must not list the whole decision set.
+     *
+     * @return void
+     */
+    public function testProbeIsBounded(): void
+    {
+        $listener = $this->listener($this->objectService([['status' => 'published']]));
+
+        $listener->handle(
+            $this->event(
+                $this->bezwaarOnProtectedStatus(),
+                ['status' => 'In behandeling']
+            )
+        );
+
+        $this->assertArrayHasKey(
+            'limit',
+            (array) $this->capturedFindAllConfig,
+            'an unbounded probe on the write path lists every decision on every save'
+        );
+        $this->assertGreaterThan(0, $this->capturedFindAllConfig['limit']);
+    }//end testProbeIsBounded()
+
+    /**
+     * With no decided decision, the guard must revert the status to the
+     * previous value carried by the event.
+     *
+     * @return void
+     */
+    public function testRevertsWhenNoDecidedDecisionExists(): void
+    {
+        $listener = $this->listener($this->objectService([['status' => 'concept']]));
+
+        $listener->handle(
+            $this->event(
+                $this->bezwaarOnProtectedStatus(),
+                ['status' => 'In behandeling']
+            )
+        );
+
+        $this->assertNotNull($this->capturedSave, 'the guard did not revert');
+        $this->assertSame(['status' => 'In behandeling'], $this->capturedSave['object']);
+        $this->assertSame('bezwaar-1', $this->capturedSave['uuid']);
+        $this->assertSame('bezwaar', $this->capturedSave['schema']);
+    }//end testRevertsWhenNoDecidedDecisionExists()
+
+    /**
+     * A decision delegated to decidesk carries a decisionRef rather than the
+     * legacy local `status: published`, and must also satisfy the guard.
+     *
+     * @return void
+     */
+    public function testDecisionRefSatisfiesTheGuard(): void
+    {
+        $listener = $this->listener($this->objectService([['decisionRef' => 'besluit-9']]));
+
+        $listener->handle(
+            $this->event(
+                $this->bezwaarOnProtectedStatus(),
+                ['status' => 'In behandeling']
+            )
+        );
+
+        $this->assertNull($this->capturedSave, 'a decidesk-delegated besluit must not be reverted');
+    }//end testDecisionRefSatisfiesTheGuard()
+
+    /**
+     * A FULL page means the bound, not the data, ended the scan. Reverting on
+     * an incomplete scan would block a legitimate transition, so the guard
+     * fails open.
+     *
+     * @return void
+     */
+    public function testFailsOpenWhenTheProbeHitsItsBound(): void
+    {
+        $undecided = array_fill(0, 100, ['status' => 'concept']);
+        $listener  = $this->listener($this->objectService($undecided));
+
+        $listener->handle(
+            $this->event(
+                $this->bezwaarOnProtectedStatus(),
+                ['status' => 'In behandeling']
+            )
+        );
+
+        $this->assertNull(
+            $this->capturedSave,
+            'a scan that stopped at its bound must not be treated as proof of absence'
+        );
+    }//end testFailsOpenWhenTheProbeHitsItsBound()
+
+    /**
+     * A transition into any other status is none of this guard's business.
+     *
+     * @return void
+     */
+    public function testIgnoresTransitionsIntoOtherStatuses(): void
+    {
+        $listener = $this->listener($this->objectService([]));
+
+        $listener->handle(
+            $this->event(
+                [
+                    'id'     => 'bezwaar-1',
+                    '@self'  => ['schema' => 'bezwaar'],
+                    'status' => 'In behandeling',
+                ],
+                ['status' => 'Ontvangen']
+            )
+        );
+
+        $this->assertNull($this->capturedFindAllConfig, 'the guard probed on an unrelated status');
+        $this->assertNull($this->capturedSave);
+    }//end testIgnoresTransitionsIntoOtherStatuses()
+}//end class

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -290,6 +290,13 @@ if (class_exists('\\OCA\\OpenRegister\\Event\\ObjectUpdatingEvent') === false) {
     include_once __DIR__.'/Stubs/Event/ObjectUpdatingEventStub.php';
 }
 
+// bezwaar-decision: the post-persist counterpart, so
+// BezwaarDecisionListenerTest can exercise the guard's real decision through
+// handle() — including the probe's call shape, which is what silently broke.
+if (class_exists('\\OCA\\OpenRegister\\Event\\ObjectUpdatedEvent') === false) {
+    include_once __DIR__.'/Stubs/Event/ObjectUpdatedEventStub.php';
+}
+
 // REQ-SUB-007 bewijsstuk immutability: the pre-persist delete counterpart, so
 // BewijsstukImmutabilityListenerTest can exercise the reject path on delete.
 if (class_exists('\\OCA\\OpenRegister\\Event\\ObjectDeletingEvent') === false) {


### PR DESCRIPTION
## What this is

Backend half of today's gate burn-down on `procest`, measured against a **fresh clone of `ConductionNL/.github@main`**, gate package `48c88ba1e0d049f8f38538c33e790d3e603c55d0`.

## Measured, gate-by-gate (full-tree at `origin/development` → this branch)

| gate | before | after |
|---|---|---|
| gate-5 route-auth | 5 | **0** |
| gate-7 no-admin-idor | 1 | **0** |
| gate-9 semantic-auth | 1 | **0** |
| gate-49 controller-exception-translation | 2 | **0** |
| gate-61 listener-work-placement | 1 | **0** |
| **total failing gates** | **22** | **18** |

No gate's count went up.

## The part that matters: two `findAll()` calls that never ran

OpenRegister's `ObjectService::findAll()` takes **one config array** — `findAll(array $config = [], bool $_rbac = true, bool $_multitenancy = true)`. Two procest call sites passed `($register, $schema, $filters)` positionally. That is a `TypeError` against `array $config`, and both sites sit inside a `catch (Throwable)` that converts the failure into a success-shaped return. So neither has ever reported anything, and nothing said so. 54 other call sites in `lib/` already use the correct shape.

- **`BezwaarDecisionListener::hasPublishedDecision()`** caught the `TypeError` and returned `true` = *"a published decision exists"*. The guard meant to stop a bezwaar entering **"Beslissing op bezwaar"** without a published `bezwaarDecision` **has never once blocked anything**.
- **`RoleResolverService::loadCaseRoles()`** caught it, logged a warning, returned `[]`. Stored case roles were never loaded; rule resolution silently fell through to its other sources.

Both were found by pulling on gate-61, not by any gate that names them.

## Everything else

- **gate-5** — all five `WorkflowDefinitionController` endpoints had no declared auth posture. They were *already* admin-only (a NC controller method with no auth attribute is), but an undeclared posture is indistinguishable from a forgotten one. Declared with `AuthorizedAdminSetting`, matching the sibling seam `CaseDefinitionController`; workflow definitions are case-type configuration edited from `/settings/workflow-definitions`.
- **gate-9** — `RoutingController::reroute()` was a genuine contradiction, not the usual gate-9 false positive: the docblock said *"Requires the caller to be a server admin … Non-admin callers receive 403"*, the body enforced exactly that via `IGroupManager::isAdmin()`, and the method still declared `@NoAdminRequired`. Replaced with an `@auth admin-only` **posture declaration** (gate-5's third accepted form — not a waiver). The endpoint is exactly as restrictive as before.
- **gate-7** — `AssistantController::availability()`. Whether an LLM backend is wired up is deployment information; the probe now answers only for an authenticated session, the same fail-closed shape `converse()` uses two methods below it. **`submitResult()`'s `isAdmin()` was deliberately left alone** — it is an admin bypass inside a real per-object guard, and "fixing" it would lock out the field inspectors the endpoint exists for.
- **gate-49** — `SubstitutionController::revoke()` / `::actions()` now translate service exceptions to a `JSONResponse` with an accurate status, mirroring `create()`.
- **gate-61** — the listener's probe is now bounded (it answers a yes/no question, so it never needs the whole set) and **fails open at the bound**, because reverting on an incomplete scan would block a legitimate transition. The revert stays inline under `@listener-placement inline correctness`, with the reason: it is a transition guard, not follow-up work; a deferred revert would publish the invalid status to every reader and to the notification and audit listeners firing off the same write.
- **gate-23 / PDOK (WARN-only)** — `PdokLocatieserverService::callDirect()` no longer uses the raw `fopen()` stream wrapper; it uses `IClientService`. The wrapper ignores the instance's proxy and certificate config and is unavailable when `allow_url_fopen` is off, so on a hardened or proxied deployment this path failed in a way that looked like PDOK being down. **The openconnector reroute is deliberately NOT done** — that adapter returns 404 on `lookup?id=`, the exact call this shim makes (openconnector#1197). Swapping a working call for a 500 is not a fix. `src/services/pdokService.js` was untouched: it is already the correct shim and was a false positive.

## Proof each fix can fail

Not "it says PASS now" — each was reproduced on the unfixed tree with the **same helper and flags**:

- gate-7: reverted the session check in place → `AssistantController.php:88 rule=no-auth-guard-in-body`; restored → clean.
- gate-9: `check_semantic_auth.py` on `origin/development` → `RoutingController.php:93 rule=no-admin-required-annotation-with-admin-body`; on this branch → silent.
- gate-61: `check_listener_placement.py --all` on `origin/development` → `1 failure(s)`; on this branch, same command → `0 failure(s)`, both over the same 11 registrations.

## Quality

`phpcs --standard=phpcs.xml` and `phpstan analyse --memory-limit=1G` are clean on all seven touched files. Two pre-existing PHPCS warnings in files I touched were fixed on the way (missing class-level `@spec` on `WorkflowDefinitionController` and `PdokLocatieserverService`) — both pointed at an **existing canonical** `openspec/specs/…/spec.md`, never a change dir, so no gate-46 findings were created.

## Not in this PR

`gate-3` (3), `gate-57` (17) and `gate-62` (1) are analysed in the session report and left red with reasons rather than closed dishonestly.
