### PR TITLE
chore(deps): pin @conduction/nextcloud-vue to 2.2.0-vue3.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.0",
 			"license": "EUPL-1.2",
 			"dependencies": {
-				"@conduction/nextcloud-vue": "2.2.0-vue3.7",
+				"@conduction/nextcloud-vue": "2.2.0-vue3.9",
 				"@nextcloud/auth": "^2.6.0",
 				"@nextcloud/axios": "~2.5.2",
 				"@nextcloud/capabilities": "^1.2.1",
@@ -571,9 +571,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "2.2.0-vue3.7",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.2.0-vue3.7.tgz",
-			"integrity": "sha512-x0aj0ACfLUDIak3/A51jVyxCPWPIFYfhv7FG2WIQA5+WKfxfJ2rzt8mIl65AmW646PZxsOz4iPo1pCm3EUeuIQ==",
+			"version": "2.2.0-vue3.9",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.2.0-vue3.9.tgz",
+			"integrity": "sha512-9HC1dhYfCqw7JeZ3mn4Zr260iBCWlWa/1slrPTdmIbODvbWlf82guAZEnMq17XvWmDJRcAVNBzYtIT2kWwZutA==",
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@ckpack/vue-color": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"extends @nextcloud/browserslist-config"
 	],
 	"dependencies": {
-		"@conduction/nextcloud-vue": "2.2.0-vue3.7",
+		"@conduction/nextcloud-vue": "2.2.0-vue3.9",
 		"@nextcloud/auth": "^2.6.0",
 		"@nextcloud/axios": "~2.5.2",
 		"@nextcloud/capabilities": "^1.2.1",


### PR DESCRIPTION
## What

Hard-pins `@conduction/nextcloud-vue` to exactly **`2.2.0-vue3.9`** (from `2.2.0-vue3.7`), the current `vue3` dist-tag head.

Follow-up to #778. The tag moved twice more while the fleet wave was running — `vue3.7` → `vue3.8` → `vue3.9` — because every merge to nc-vue's `feat/vue-3` cuts a publish. The fleet converges on **`2.2.0-vue3.9`**.

No caret, no range: `^2.2.0` does **not** match a prerelease, and `latest`/`beta` are the retired Vue 2 lineage.

## Lockfile control (npm 10.8.2)

| | result |
|---|---|
| control (pin **unchanged**) | **0 lines** |
| after bump | 8 lock lines + 2 package.json lines |

Generated with **npm 10.8.2**, the version CI runs (node 20.20.2) — not npm 11, whose lockfile rewrites broke 11 checks on opencatalogi in this same wave.

## Verification

- **`npm ci` under npm 10.8.2**: exit 0.
- **Off disk**: exactly **one** copy, `2.2.0-vue3.9`, peer `vue ^3.5.0`.
- **Registry controls**: `2.2.0-vue3.9` resolves; `3.0.0` / `3.0.0-vue3.0` return **E404**.

`2.2.0-vue3.9` is **not** pre-verified against our apps the way `2.2.0-vue3.7` was, so this run is the verification:

| | before (`vue3.7`) | after (`vue3.9`) |
|---|---|---|
| `npm ci` (npm 10.8.2) | exit 0 | exit 0 |
| `npm run build` | exit 0, 3 warnings | exit 0, 3 warnings |
| `npm run test:unit` (vitest) | 32 files / **330 passed** | 32 files / **330 passed** |
| bundle (`js/`) | 66,326,990 B | 66,333,000 B |

Bundle delta: **+6,010 B (+0.01%)**. No regression.

> Baseline note: `development`'s push run is already red on **E2E Tests (Playwright)** (3 `pdok-via-openconnector` tests) plus the `Quality Report` aggregator. That predates this PR.
