### PR TITLE
fix(pwa): the service worker swallowed every PDOK-via-openconnector call

### DIFF
--- a/lib/Controller/DashboardController.php
+++ b/lib/Controller/DashboardController.php
@@ -47,6 +47,7 @@ use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\DataDownloadResponse;
+use OCP\AppFramework\Http\EmptyContentSecurityPolicy;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IRequest;
 
@@ -127,6 +128,19 @@ class DashboardController extends Controller
      * no-CSRF because the worker must register before the user is interactive
      * and runs without the SPA's request context.
      *
+     * ⚠️ THE CSP ON THIS RESPONSE IS LOAD-BEARING. A Service Worker inherits
+     * the Content-Security-Policy of its OWN script response, not the one on
+     * the page that registered it. Nextcloud's default for a controller
+     * response is an EmptyContentSecurityPolicy — `default-src 'none'` with no
+     * `connect-src` — under which EVERY `fetch()` the worker makes is blocked
+     * and rejects with `TypeError: Failed to fetch`. Measured on a Nextcloud
+     * 32 instance: with the default policy, `fetch(request)`,
+     * `fetch(request.url)` and `fetch(url, {mode: 'same-origin'})` all threw
+     * inside the worker, so both strategies in `public/service-worker.js`
+     * (`cacheFirst` / `networkFirst`) could never populate a cache and always
+     * fell through to `Response.error()`. Any request the worker claimed with
+     * `respondWith()` was therefore guaranteed to fail in the page.
+     *
      * @return DataDownloadResponse The service-worker JavaScript.
      *
      * @spec openspec/specs/mobiel-inspectie-offline/spec.md#requirement-offline-daily-planning-synchronization
@@ -143,6 +157,15 @@ class DashboardController extends Controller
 
         $response = new DataDownloadResponse($body, 'service-worker.js', 'application/javascript', $status);
         $response->addHeader('Service-Worker-Allowed', '/');
+
+        $csp = new EmptyContentSecurityPolicy();
+        // The offline sync strategy talks back to this Nextcloud.
+        $csp->addAllowedConnectDomain('\'self\'');
+        // The tile strategy talks to the BRT achtergrondkaart WMTS host, which
+        // is the only third-party host public/service-worker.js will fetch.
+        $csp->addAllowedConnectDomain('https://service.pdok.nl');
+        $response->setContentSecurityPolicy($csp);
+
         return $response;
     }//end serviceWorker()
 

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -18,6 +18,16 @@
  * OpenRegister requests, and the network-first fallback turned that into a
  * `Response.error()` (surfacing in the page as `TypeError: Failed to fetch`).
  *
+ * The reason a re-issued `fetch()` throws is now measured rather than assumed:
+ * a Service Worker inherits the CSP of its OWN script response, and Nextcloud
+ * served `/apps/procest/service-worker.js` with `default-src 'none'` and no
+ * `connect-src`, so EVERY fetch the worker made was blocked. Every request the
+ * worker claimed with `respondWith()` therefore became a network error; the
+ * worker could only ever break a request, never serve one. That is fixed in
+ * `DashboardController::serviceWorker()`, which now sends a `connect-src` the
+ * two strategies below can actually use — but the rule above stands: claim
+ * nothing this feature does not own.
+ *
  * Caching strategy (Workbox-style, hand-rolled to avoid a build-time Workbox
  * dependency in this app's webpack pipeline):
  *
@@ -44,6 +54,41 @@
 const CACHE_VERSION = 'procest-mio-v2'
 const DATA_CACHE = `${CACHE_VERSION}-data`
 const TILE_CACHE = `${CACHE_VERSION}-tiles`
+
+/**
+ * The third-party hosts this app loads map tiles from.
+ *
+ * `service.pdok.nl` serves the BRT achtergrondkaart WMTS layer used by
+ * `src/components/map/LocationPicker.vue`. It is deliberately an exact-host
+ * allow-list rather than a substring test — see `isMapTileRequest()`.
+ */
+const TILE_HOSTS = new Set(['service.pdok.nl'])
+
+/**
+ * Is this request one of the map tiles the offline layer owns?
+ *
+ * Tiles are ALWAYS third-party, so a request back to this Nextcloud is never a
+ * tile. That guard is the whole point of this function.
+ *
+ * ⚠️ REGRESSION THIS REPLACES. The predicate used to be
+ * `/(brtachtergrondkaart|wmts|pdok|service\.pdok\.nl)/i.test(url.host + url.pathname)`
+ * — a substring test over the SAME-ORIGIN path as well as the host. It
+ * therefore matched this app's own address lookups, which since the
+ * migrate-pdok-to-openconnector change live at
+ * `/index.php/apps/openconnector/api/pdok/{suggest,lookup,free,reverse}`, on
+ * the literal `pdok`. Every one of them was answered cache-first out of the
+ * TILE cache, and since a worker cannot reach the network under its script's
+ * `default-src 'none'` CSP (see DashboardController::serviceWorker()) the
+ * caller got `TypeError: Failed to fetch` instead of the 503/404 degradation
+ * `src/services/pdokService.js` implements — which rethrows on an error with
+ * no HTTP status, so the address field broke outright.
+ *
+ * @param {URL} url The parsed request URL.
+ * @return {boolean} True when the request is a third-party map tile.
+ */
+function isMapTileRequest(url) {
+	return url.origin !== self.location.origin && TILE_HOSTS.has(url.hostname)
+}
 
 self.addEventListener('install', (event) => {
 	event.waitUntil(self.skipWaiting())
@@ -115,8 +160,9 @@ self.addEventListener('fetch', (event) => {
 		return
 	}
 
-	// PDOK map tiles → cache-first.
-	if (/(brtachtergrondkaart|wmts|pdok|service\.pdok\.nl)/i.test(url.host + url.pathname)) {
+	// PDOK map tiles → cache-first. Third-party tile hosts ONLY: a request back
+	// to this Nextcloud is never a tile, whatever its path happens to spell.
+	if (isMapTileRequest(url)) {
 		event.respondWith(cacheFirst(request, TILE_CACHE))
 		return
 	}

--- a/tests/Unit/Controller/DashboardControllerServiceWorkerTest.php
+++ b/tests/Unit/Controller/DashboardControllerServiceWorkerTest.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * DashboardController PWA-asset Unit Tests
+ *
+ * Covers the one property of `serviceWorker()` that is invisible in every
+ * other test: the Content-Security-Policy on the SCRIPT response. A Service
+ * Worker inherits the CSP of its own script, not of the page that registered
+ * it, and Nextcloud's default for a controller response is
+ * `default-src 'none'` with no `connect-src` — under which every `fetch()`
+ * the worker makes is blocked and rejects with `TypeError: Failed to fetch`.
+ * Both strategies in `public/service-worker.js` then degrade to
+ * `Response.error()`, so the worker can only ever break a request, never
+ * serve one. Nothing in the app reports that; only this assertion does.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/specs/mobiel-inspectie-offline/spec.md#requirement-offline-daily-planning-synchronization
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\DashboardController;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the PWA asset endpoints on the procest dashboard controller.
+ *
+ * @covers \OCA\Procest\Controller\DashboardController
+ */
+class DashboardControllerServiceWorkerTest extends TestCase
+{
+
+    /**
+     * Controller under test.
+     *
+     * @var DashboardController
+     */
+    private DashboardController $controller;
+
+    /**
+     * Build the controller with a mocked request.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $request          = $this->createMock(IRequest::class);
+        $this->controller = new DashboardController($request);
+    }//end setUp()
+
+    /**
+     * The worker script is served, and served as JavaScript.
+     *
+     * @return void
+     */
+    public function testServiceWorkerScriptIsServed(): void
+    {
+        $response = $this->controller->serviceWorker();
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame('/', $response->getHeaders()['Service-Worker-Allowed']);
+    }//end testServiceWorkerScriptIsServed()
+
+    /**
+     * The script response MUST carry a connect-src the worker can use.
+     *
+     * Asserting the DIRECTIVE, not merely that some policy exists: the broken
+     * header was a perfectly well-formed policy that happened to forbid every
+     * network call the worker makes.
+     *
+     * @return void
+     */
+    public function testServiceWorkerScriptGrantsConnectSrc(): void
+    {
+        $policy = $this->controller->serviceWorker()->getContentSecurityPolicy();
+
+        $this->assertNotNull(
+            $policy,
+            'serviceWorker() must set an explicit CSP; without one Nextcloud applies '
+            .'default-src \'none\' and the worker cannot fetch anything at all.'
+        );
+
+        $header = $policy->buildPolicy();
+        $this->assertStringContainsString('connect-src', $header);
+        // The offline sync strategy talks back to this Nextcloud.
+        $this->assertStringContainsString('\'self\'', $header);
+        // The tile strategy talks to the BRT achtergrondkaart WMTS host.
+        $this->assertStringContainsString('https://service.pdok.nl', $header);
+    }//end testServiceWorkerScriptGrantsConnectSrc()
+
+    /**
+     * The web manifest endpoint is unaffected by the CSP change.
+     *
+     * @return void
+     */
+    public function testWebManifestIsStillServed(): void
+    {
+        $response = $this->controller->webManifest();
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+    }//end testWebManifestIsStillServed()
+}//end class

--- a/tests/e2e/helpers/addressFixtures.ts
+++ b/tests/e2e/helpers/addressFixtures.ts
@@ -87,15 +87,26 @@ function writeHeaders(token: string): Record<string, string> {
 
 /**
  * Probe whether the OR `addresses` register/schema exists in this environment.
- * Returns false when the listing endpoint 404s (sibling add-addresses-register
- * change not yet shipped), so callers can skip live address assertions.
+ *
+ * ONLY a successful read counts as "available". This used to return
+ * `res.status() !== 404`, which reads every failure — 401 from an
+ * unauthenticated context, 403, 500, a 302 to /login — as "the register is
+ * installed", and the caller then went on to seed fixtures against a register
+ * that may not exist. Measured 2026-08-10: an anonymous `request.newContext()`
+ * got 401 here, the probe answered `true`, and the seeding step failed with an
+ * error that named the fixtures instead of the missing session.
+ *
+ * A failed read is not a value. Anything that is not a 2xx means "cannot tell",
+ * and the honest response to "cannot tell" is to skip the live assertions.
+ *
  * @param api Authenticated request context.
+ * @return true only when the listing endpoint answered 2xx.
  */
 export async function addressesRegisterAvailable(api: APIRequestContext): Promise<boolean> {
 	const res = await api.get(`${API_BASE}/${ADDRESSES_REGISTER}/${ADDRESS_SCHEMA}?_limit=1`, {
 		headers: { 'OCS-APIRequest': 'true' },
 	})
-	return res.status() !== 404
+	return res.ok()
 }
 
 /**

--- a/tests/e2e/spec-coverage/pdok-via-openconnector.spec.ts
+++ b/tests/e2e/spec-coverage/pdok-via-openconnector.spec.ts
@@ -1,8 +1,8 @@
 /*
  * SPDX-FileCopyrightText: 2026 Procest Contributors
- * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  *
- * Gate-19 spec-coverage tests for the migrate-pdok-to-openconnector change.
+ * Gate-19 spec-coverage tests for the pdok-consumer capability.
  *
  * These drive the real, bundled pdokService shim inside the loaded procest
  * app context and assert — by intercepting network traffic — that every PDOK
@@ -11,6 +11,20 @@
  * that the two degraded modes (503, 404) are handled without throwing. Because
  * the openconnector responses are mocked at the network layer, these specs run
  * green without a live PDOK source or the openconnector adapter installed.
+ *
+ * ⚠️ THESE SPECS ALSO GUARD THE SERVICE WORKER, ON PURPOSE.
+ * `public/service-worker.js` is registered at the procest app-root scope and
+ * sees every fetch a procest page makes. It shipped with a tile-cache rule that
+ * substring-matched `pdok` against `url.host + url.pathname`, so it claimed
+ * this app's OWN address lookups at `/apps/openconnector/api/pdok/*` and
+ * answered them out of the map-tile cache. A worker-claimed request never
+ * reaches Playwright's `page.route()` either, so all three specs below failed
+ * with `page.evaluate: TypeError: Failed to fetch`. The fix is in the worker;
+ * `activateServiceWorker()` below is what keeps these specs able to SEE a
+ * repeat, on every instance rather than only on the ones where the worker
+ * happens to be in control. Do NOT "fix" a future failure here with
+ * `serviceWorkers: 'block'` — that hides exactly the defect these specs exist
+ * to catch.
  *
  * The end-to-end address-form population path against OR-stored fixtures (task
  * PR-3.1 / PR-4) additionally needs the openconnector PDOK adapter and the OR
@@ -28,21 +42,68 @@ import {
 	ADDRESS_RUN_PREFIX,
 } from '../helpers/addressFixtures'
 import { BASE_URL } from '../base-url'
+import { STORAGE_STATE } from '../helpers/auth'
 
 const OC_PREFIX = '/apps/openconnector/api/pdok'
 
+/** Marker header put on every fulfilled response, so a REAL server answer with the same status cannot impersonate the mock. */
+const FULFILLED_BY = 'x-procest-e2e-fulfilled'
+
+/**
+ * Resolve the scope of procest's active service worker.
+ *
+ * @param page    The page under test.
+ * @param timeout How long to wait for the worker to reach `activated`.
+ * @return the worker's scope URL.
+ */
+async function activeWorkerScope(page: import('@playwright/test').Page, timeout = 20_000): Promise<string> {
+	const deadline = Date.now() + timeout
+	while (Date.now() < deadline) {
+		const scope = await page.evaluate(async () => {
+			const regs = await navigator.serviceWorker.getRegistrations()
+			return regs.find((r) => r.active !== null)?.scope ?? null
+		})
+		if (scope !== null) {
+			return scope
+		}
+		await page.waitForTimeout(250)
+	}
+	throw new Error(
+		`procest registered no ACTIVE service worker within ${timeout}ms. `
+		+ 'src/main.js registers generateUrl(\'/apps/procest/service-worker.js\') on window load; '
+		+ 'if that registration is gone these specs no longer exercise the worker at all.',
+	)
+}
+
 /**
  * Load the procest app so the webpack bundle (and the pdokService shim within
- * it) is available in the page's module graph for evaluate-driven calls.
+ * it) is available in the page's module graph for evaluate-driven calls, WITH
+ * the app's service worker in control of the document.
+ *
+ * Control is not automatic. A document is only controlled when its own URL is
+ * inside the worker's scope, and the scope depends on the instance:
+ * `generateUrl()` keeps the `/index.php` prefix unless `front_controller_active`
+ * is set, so `/index.php/apps/procest/dashboard` is inside the scope on a plain
+ * `php -S` CI instance and OUTSIDE it on a docker image that sets the flag.
+ * That single difference is why a worker which swallowed every PDOK call was
+ * red on CI and green on every developer's machine. Navigating to the worker's
+ * own scope removes the coin flip.
+ *
+ * @param page The page under test.
  */
 async function openProcest(page: import('@playwright/test').Page): Promise<void> {
 	await page.goto('/index.php/apps/procest/dashboard')
+	await expect(page).not.toHaveURL(/login/, { timeout: 15000 })
+
+	const scope = await activeWorkerScope(page)
+	await page.goto(scope)
+	await page.waitForFunction(() => navigator.serviceWorker.controller !== null, undefined, { timeout: 20_000 })
 	await expect(page).not.toHaveURL(/login/, { timeout: 15000 })
 }
 
 test.describe('PDOK via openconnector — shim routing', () => {
 
-	// @e2e openspec/changes/migrate-pdok-to-openconnector/specs/pdok-consumer/spec.md#suggest-call-reaches-openconnector-instead-of-api-pdoknl
+	// @e2e openspec/specs/pdok-consumer/spec.md#scenario-suggest-call-reaches-openconnector-instead-of-api-pdok-nl
 	test('suggest reaches the openconnector endpoint, never api.pdok.nl', async ({ page }) => {
 		await openProcest(page)
 
@@ -55,6 +116,7 @@ test.describe('PDOK via openconnector — shim routing', () => {
 			route.fulfill({
 				status: 200,
 				contentType: 'application/json',
+				headers: { [FULFILLED_BY]: 'suggest' },
 				body: JSON.stringify({ docs: [{ id: 'adr-1', weergavenaam: 'Lauriergracht 116' }] }),
 			}),
 		)
@@ -66,26 +128,40 @@ test.describe('PDOK via openconnector — shim routing', () => {
 		// request reaches openconnector (and the api.pdok.nl abort proves none
 		// leaks directly to PDOK) — both assertions hold against the live bundle.
 		const result = await page.evaluate(async () => {
-			const res = await fetch('/index.php/apps/openconnector/api/pdok/suggest?q=Lauriergracht', {
-				headers: { 'OCS-APIRequest': 'true' },
-			})
-			const body = await res.json()
-			return body?.docs ?? []
+			try {
+				const res = await fetch('/index.php/apps/openconnector/api/pdok/suggest?q=Lauriergracht', {
+					headers: { 'OCS-APIRequest': 'true' },
+				})
+				const body = await res.json()
+				return { docs: body?.docs ?? [], fulfilledBy: res.headers.get('x-procest-e2e-fulfilled') }
+			} catch (e) {
+				return { threw: String(e) }
+			}
 		})
 
-		expect(Array.isArray(result)).toBeTruthy()
+		// A rejected fetch is its own failure mode (a service worker that claims
+		// the request, a torn-down context) and must not be reported as "no
+		// suggestions" — name it before asserting on the payload.
+		expect(result.threw, `suggest() must not reject: ${result.threw ?? ''}`).toBeUndefined()
+		// Assert the ITEM. `Array.isArray(result)` was true for the empty array a
+		// real (unintercepted) server answer produces, so it passed whether or not
+		// the request ever reached the route handler.
+		expect(result.fulfilledBy).toBe('suggest')
+		expect((result.docs as Array<{ weergavenaam: string }>).map((d) => d.weergavenaam))
+			.toContain('Lauriergracht 116')
 		const hitOpenconnector = seen.some((u) => u.includes(OC_PREFIX) && u.includes('suggest'))
 		expect(hitOpenconnector, `expected a call to ${OC_PREFIX}/suggest; saw ${JSON.stringify(seen)}`).toBeTruthy()
 		expect(seen.some((u) => u.includes('api.pdok.nl'))).toBe(false)
 	})
 
-	// @e2e openspec/changes/migrate-pdok-to-openconnector/specs/pdok-consumer/spec.md#503-response-resolves-with-null-and-surfaces-message-key
+	// @e2e openspec/specs/pdok-consumer/spec.md#scenario-503-response-resolves-with-null-and-surfaces-message_key
 	test('503 from openconnector degrades gracefully without throwing', async ({ page }) => {
 		await openProcest(page)
 		await page.route(`**${OC_PREFIX}/lookup**`, (route) =>
 			route.fulfill({
 				status: 503,
 				contentType: 'application/json',
+				headers: { [FULFILLED_BY]: 'lookup-503' },
 				body: JSON.stringify({ error: 'pdok_unavailable', message_key: 'pdok.unavailable' }),
 			}),
 		)
@@ -96,27 +172,48 @@ test.describe('PDOK via openconnector — shim routing', () => {
 					headers: { 'OCS-APIRequest': 'true' },
 				})
 				const body = await res.json().catch(() => ({}))
-				return { status: res.status, messageKey: body?.message_key ?? null }
+				return {
+					status: res.status,
+					messageKey: body?.message_key ?? null,
+					fulfilledBy: res.headers.get('x-procest-e2e-fulfilled'),
+				}
 			} catch (e) {
 				return { threw: String(e) }
 			}
 		})
 
+		// "Without throwing" is the requirement — assert it as itself, so the
+		// failure names the rejection instead of an undefined status.
+		expect(outcome.threw, `a 503 must not reject the fetch: ${outcome.threw ?? ''}`).toBeUndefined()
+		expect(outcome.fulfilledBy).toBe('lookup-503')
 		expect(outcome.status).toBe(503)
 		expect(outcome.messageKey).toBe('pdok.unavailable')
 	})
 
-	// @e2e openspec/changes/migrate-pdok-to-openconnector/specs/pdok-consumer/spec.md#openconnector-absent-surfaces-warning-without-blocking-form
+	// @e2e openspec/specs/pdok-consumer/spec.md#scenario-openconnector-absent-surfaces-warning-without-blocking-form
 	test('404 (openconnector absent) does not block the page', async ({ page }) => {
 		await openProcest(page)
-		await page.route(`**${OC_PREFIX}/suggest**`, (route) => route.fulfill({ status: 404, body: 'Not Found' }))
+		await page.route(`**${OC_PREFIX}/suggest**`, (route) => route.fulfill({
+			status: 404,
+			headers: { [FULFILLED_BY]: 'suggest-404' },
+			body: 'Not Found',
+		}))
 
 		const outcome = await page.evaluate(async () => {
-			const res = await fetch('/index.php/apps/openconnector/api/pdok/suggest?q=Tilburg', {
-				headers: { 'OCS-APIRequest': 'true' },
-			})
-			return { status: res.status }
+			try {
+				const res = await fetch('/index.php/apps/openconnector/api/pdok/suggest?q=Tilburg', {
+					headers: { 'OCS-APIRequest': 'true' },
+				})
+				return { status: res.status, fulfilledBy: res.headers.get('x-procest-e2e-fulfilled') }
+			} catch (e) {
+				return { threw: String(e) }
+			}
 		})
+		expect(outcome.threw, `an absent openconnector must not reject the fetch: ${outcome.threw ?? ''}`).toBeUndefined()
+		// On CI openconnector is genuinely not installed, so Nextcloud's own 404
+		// has the same status as the mock. Without this header the assertion below
+		// passed whether or not the request was ever intercepted.
+		expect(outcome.fulfilledBy).toBe('suggest-404')
 		expect(outcome.status).toBe(404)
 		// The page is still interactive (form not broken by an absent connector).
 		await expect(page).not.toHaveURL(/login/)
@@ -125,11 +222,20 @@ test.describe('PDOK via openconnector — shim routing', () => {
 
 test.describe('PDOK via openconnector — OR address fixtures (live)', () => {
 
-	// @e2e openspec/changes/migrate-pdok-to-openconnector/specs/pdok-consumer/spec.md#all-six-functions-are-exported-with-unchanged-signatures
+	// @e2e openspec/specs/pdok-consumer/spec.md#scenario-all-six-functions-are-exported-with-unchanged-signatures
 	test('seeded OR addresses are retrievable without PDOK/openconnector being available', async () => {
 		const ctx = await request.newContext({
-			// Single source of truth — see tests/e2e/base-url.ts.
+			// Single source of truth — see tests/e2e/base-url.ts. This used to
+			// resolve `process.env.NEXTCLOUD_URL || 'http://localhost:8080'`,
+			// and that literal is the SHARED dev container on a Conduction box:
+			// pointing the suite anywhere else with PLAYWRIGHT_BASE_URL left THIS
+			// test seeding and deleting OpenRegister objects in somebody else's
+			// environment. Observed doing exactly that on 2026-08-10.
 			baseURL: BASE_URL,
+			// Authenticated, because `addressesRegisterAvailable()` reads a
+			// protected OR endpoint: an anonymous context gets 401, which is a
+			// FAILED READ, not "the register is missing" and not "it is present".
+			storageState: STORAGE_STATE,
 		})
 		try {
 			const available = await addressesRegisterAvailable(ctx)

--- a/tests/e2e/spec-coverage/service-worker-scope.spec.ts
+++ b/tests/e2e/spec-coverage/service-worker-scope.spec.ts
@@ -1,0 +1,113 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Procest Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Guards the two properties of the mobiel-inspectie-offline Service Worker
+ * that, when broken, are invisible everywhere except the one request the
+ * worker happens to swallow.
+ *
+ *  1. SCOPE DISCIPLINE — the worker is registered at the procest app-root
+ *     scope, so it sees every fetch every procest page makes. It must claim
+ *     ONLY the traffic the offline field-inspection feature owns. It shipped
+ *     with a tile rule that substring-matched `pdok` against
+ *     `url.host + url.pathname`, which also matched this app's own address
+ *     lookups at `/apps/openconnector/api/pdok/*`.
+ *
+ *  2. THE WORKER CAN REACH THE NETWORK — a Service Worker inherits the CSP of
+ *     its own SCRIPT response, not the page's. Nextcloud's default for a
+ *     controller response is `default-src 'none'` with no `connect-src`, under
+ *     which every `fetch()` the worker makes is blocked. Both worker
+ *     strategies then degrade to `Response.error()`, i.e. the worker could
+ *     only ever break a request and never serve one — silently, because
+ *     nothing in the app reports it.
+ */
+
+import { test, expect } from '@playwright/test'
+
+/**
+ * Resolve the scope of procest's active service worker.
+ *
+ * @param page    The page under test.
+ * @param timeout How long to wait for the worker to reach `activated`.
+ * @return the worker's scope URL.
+ */
+async function activeWorkerScope(page: import('@playwright/test').Page, timeout = 20_000): Promise<string> {
+	const deadline = Date.now() + timeout
+	while (Date.now() < deadline) {
+		const scope = await page.evaluate(async () => {
+			const regs = await navigator.serviceWorker.getRegistrations()
+			return regs.find((r) => r.active !== null)?.scope ?? null
+		})
+		if (scope !== null) {
+			return scope
+		}
+		await page.waitForTimeout(250)
+	}
+	throw new Error(`procest registered no ACTIVE service worker within ${timeout}ms.`)
+}
+
+/**
+ * Open procest with its service worker in control of the document.
+ *
+ * @param page The page under test.
+ */
+async function openControlled(page: import('@playwright/test').Page): Promise<void> {
+	await page.goto('/index.php/apps/procest/dashboard')
+	await expect(page).not.toHaveURL(/login/, { timeout: 15000 })
+	const scope = await activeWorkerScope(page)
+	await page.goto(scope)
+	await page.waitForFunction(() => navigator.serviceWorker.controller !== null, undefined, { timeout: 20_000 })
+}
+
+test.describe('mobiel-inspectie-offline service worker', () => {
+
+	// @e2e openspec/specs/mobiel-inspectie-offline/spec.md#scenario-download-daily-schedule-with-cases-and-checklists
+	test('the worker script is served with a connect-src it can actually use', async ({ request }) => {
+		const res = await request.get('/index.php/apps/procest/service-worker.js', { failOnStatusCode: false })
+		expect(res.status()).toBe(200)
+		const csp = res.headers()['content-security-policy'] ?? ''
+		// Assert the DIRECTIVE, not merely that a policy exists: the broken
+		// header was a perfectly well-formed policy that happened to forbid
+		// every network call the worker makes.
+		expect(csp, `service-worker.js CSP must grant connect-src; got "${csp}"`).toContain('connect-src')
+		expect(csp).toContain("connect-src 'self'")
+		// The BRT achtergrondkaart WMTS host the tile cache fetches.
+		expect(csp).toContain('https://service.pdok.nl')
+	})
+
+	// @e2e openspec/specs/mobiel-inspectie-offline/spec.md#scenario-download-daily-schedule-with-cases-and-checklists
+	test('a request the worker CLAIMS still reaches the server', async ({ page }) => {
+		await openControlled(page)
+		// `/apps/procest/api/sync/...` is the one same-origin prefix the worker
+		// answers itself (network-first). Under the old script CSP the worker's
+		// own fetch was blocked, so this resolved to `Response.error()` and the
+		// page saw `TypeError: Failed to fetch` — the offline feature could
+		// never populate its cache in the first place.
+		const outcome = await page.evaluate(async () => {
+			try {
+				const res = await fetch('/index.php/apps/procest/api/sync/planning', {
+					headers: { 'OCS-APIRequest': 'true' },
+				})
+				return { status: res.status, type: res.type }
+			} catch (e) {
+				return { threw: String(e) }
+			}
+		})
+		expect(outcome.threw, `the worker must be able to reach the network: ${outcome.threw ?? ''}`).toBeUndefined()
+		// `error` is the opaque type a `Response.error()` carries; a real answer
+		// from Nextcloud is `basic`, whatever its status code.
+		expect(outcome.type).toBe('basic')
+	})
+
+	// Scope discipline itself (property 1 in the header) is asserted in
+	// `pdok-via-openconnector.spec.ts`, not here. A claimed request never
+	// reaches Playwright's `page.route()`, so the marker header on the
+	// fulfilled response there is a real detector for "the worker took this
+	// one" — and it was mutation-verified: restoring the old substring rule
+	// turns those three specs red. A version of that assertion written here
+	// against the response alone was NOT a detector: once the worker can
+	// reach the network again it re-fetches the same URL and hands back an
+	// indistinguishable same-origin response, so it stayed green under the
+	// planted defect. It is left out rather than left in as a check that
+	// cannot fail.
+})


### PR DESCRIPTION
## What was red

`E2E Tests (Playwright)` on `development` — run [31388005994](https://github.com/ConductionNL/procest/actions/runs/31388005994), 83 expected / 38 skipped / **4 unexpected**. Three of the four are `spec-coverage/pdok-via-openconnector.spec.ts`, all with `page.evaluate: TypeError: Failed to fetch`. (The fourth is the #719 bootstrap stall — analysed [in a comment on #719](https://github.com/ConductionNL/procest/issues/719#issuecomment-5241875378), untouched here, and deliberately not "fixed" with a threshold change.)

## Root cause — proven, not argued

The throwing frame `core-main.js?v=…:1:80554` is the `await t(e,n)` inside Nextcloud core's patched `window.fetch` (verified against `stable32`'s shipped `dist/core-main.js`), so the **network request itself failed**: the trace records `net::ERR_FAILED` and contains **no `Route.fulfill` call at all** — the handler never ran. A positive control proves `Route.fulfill` *is* traced when it runs.

A diagnostic spec pushed to a scratch branch and run on a real CI runner ([job 93482170902](https://github.com/ConductionNL/procest/actions/runs/31396776989)) settled it:

| probe | result |
|---|---|
| **no `page.route()` registered at all** | `TypeError: Failed to fetch` |
| original glob / catch-all `**` / regex / predicate / registered-before-navigation | handler hits **0**, all throw (catch-all `**` saw **0** requests) |
| **same request, page loaded outside the worker's scope** | **status 404, handler hits 1** |
| real server, no browser | 404 `text/html` |

Not Playwright. The app's own **service worker** claimed the request.

`public/service-worker.js` matched map tiles with `/(brtachtergrondkaart|wmts|pdok|service\.pdok\.nl)/i.test(url.host + url.pathname)` — a substring test that also runs over the same-origin path. Since `migrate-pdok-to-openconnector`, this app's address lookups live at `/apps/openconnector/api/pdok/*`, so all four of them matched on the literal `pdok`.

And a **second defect** underneath it: a Service Worker inherits the CSP of its *own script response*. `DashboardController::serviceWorker()` sent Nextcloud's default `default-src 'none'` with no `connect-src`, so **every `fetch()` the worker made was blocked**. Measured inside the worker on NC 32: `fetch(request)`, `fetch(request.url)` and `fetch(url, {mode:'same-origin'})` all threw. Both strategies always degraded to `Response.error()` — the worker could only break a request, never serve one, and the offline sync cache could never be populated.

Net effect for users: `pdokService.handleNetworkError()` rethrows on an error with no HTTP status, so the address field **rejected** instead of surfacing the 503/404 warning `openspec/specs/pdok-consumer/spec.md` requires.

**Why CI-only:** the worker's scope keeps the `/index.php` prefix unless `front_controller_active` is set. On CI (`php -S`) the spec's URL is inside the scope and the worker controls the page; on the docker images developers use, the same URL is outside it and the worker is invisible.

## Fixes

**Product**
- `public/service-worker.js` — exact third-party tile-host allow-list; a request back to this Nextcloud is never a tile.
- `lib/Controller/DashboardController.php` — the worker script now ships `connect-src 'self' https://service.pdok.nl`.

**Test**
- the specs navigate into the worker's own scope and wait for `navigator.serviceWorker.controller`, so the CI/dev coin flip is gone. (Deliberately **not** `serviceWorkers: 'block'` — that would hide the defect.)
- assert the ITEM: `Array.isArray(result)` was true for the empty array an unintercepted answer produces, and `toBe(404)` passed on Nextcloud's own 404 (openconnector is genuinely absent on CI). Fulfilled responses now carry a marker header a real server cannot produce.
- `addressesRegisterAvailable()` returned `status() !== 404`, so a 401 read as "installed"; now only 2xx counts.
- that test also resolved `NEXTCLOUD_URL || 'http://localhost:8080'` — the shared dev container — and seeded/deleted OpenRegister objects there. Now uses the single `BASE_URL` resolver.
- `@e2e` anchors repointed from the archived change dir to canonical `openspec/specs/pdok-consumer/spec.md`.

## Both-direction proof

Run on a disposable Nextcloud 32 + Postgres serving this branch, one mutation at a time:

| mutation | result |
|---|---|
| none (fixed) | 5 passed, 1 skipped |
| old tile predicate restored | **the 3 pdok specs red**, CSP specs green |
| CSP block removed | **the 2 service-worker specs red**, pdok specs green |
| test 3's route glob made non-matching (real 404 arrives) | **red**: `Expected "suggest-404", Received null` — the assertion the old spec had would have passed |

A fourth planned test (scope discipline asserted from the response alone) went **green under the planted defect** and was removed rather than kept as a check that cannot fail.

Refs #719
