### PR TITLE
fix(spec): repoint 36 @spec tags at anchors that exist — gate-46 36 → 0

### DIFF
--- a/tests/Unit/BackgroundJob/DsoDeadlineJobTest.php
+++ b/tests/Unit/BackgroundJob/DsoDeadlineJobTest.php
@@ -15,7 +15,7 @@
  *
  * @link https://procest.nl
  *
- * @spec openspec/changes/dso-omgevingsloket/tasks.md#T14
+ * @spec openspec/changes/dso-omgevingsloket/tasks.md#T05
  */
 
 declare(strict_types=1);
@@ -156,7 +156,7 @@ class DsoDeadlineJobTest extends TestCase
      *
      * @return void
      *
-     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T14
+     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T05
      */
     public function testGetRemainingWorkingDaysReturnsPositiveForFutureDate(): void
     {
@@ -176,7 +176,7 @@ class DsoDeadlineJobTest extends TestCase
      *
      * @return void
      *
-     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T14
+     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T05
      */
     public function testGetRemainingWorkingDaysReturnsNegativeForPastDate(): void
     {
@@ -198,7 +198,7 @@ class DsoDeadlineJobTest extends TestCase
      *
      * @return void
      *
-     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T14
+     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T05
      */
     public function testRunCatchesExceptionsPerTask(): void
     {

--- a/tests/Unit/Controller/DsoControllerTest.php
+++ b/tests/Unit/Controller/DsoControllerTest.php
@@ -15,7 +15,7 @@
  *
  * @link https://procest.nl
  *
- * @spec openspec/changes/dso-omgevingsloket/tasks.md#T17
+ * @spec openspec/changes/dso-omgevingsloket/tasks.md#T06
  */
 
 declare(strict_types=1);
@@ -485,7 +485,7 @@ class DsoControllerTest extends TestCase
      *
      * @return void
      *
-     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T17
+     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T06
      */
     public function testTransitionStatusReturns401WhenUnauthenticated(): void
     {
@@ -501,7 +501,7 @@ class DsoControllerTest extends TestCase
      *
      * @return void
      *
-     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T17
+     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T06
      */
     public function testTransitionStatusReturns400WhenStatusMissing(): void
     {
@@ -524,7 +524,7 @@ class DsoControllerTest extends TestCase
      *
      * @return void
      *
-     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T17
+     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T06
      */
     public function testTransitionStatusReturns403WhenNotAuthorized(): void
     {
@@ -573,7 +573,7 @@ class DsoControllerTest extends TestCase
      *
      * @return void
      *
-     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T17
+     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T06
      */
     public function testGenerateBeschikkingReturns400WhenOutcomeMissing(): void
     {

--- a/tests/Unit/Controller/NotesControllerTest.php
+++ b/tests/Unit/Controller/NotesControllerTest.php
@@ -17,7 +17,7 @@
  *
  * @link https://procest.nl
  *
- * @spec openspec/changes/ncvue-w2-leaves-adoption/specs/ncvue-w2-leaves-adoption/spec.md#mentions
+ * @spec openspec/changes/ncvue-w2-leaves-adoption/specs/ncvue-w2-leaves-adoption/spec.md#REQ-W2L-003
  */
 
 declare(strict_types=1);

--- a/tests/Unit/Event/VergunningStatusChangedEventTest.php
+++ b/tests/Unit/Event/VergunningStatusChangedEventTest.php
@@ -15,7 +15,7 @@
  *
  * @link https://procest.nl
  *
- * @spec openspec/changes/dso-omgevingsloket/tasks.md#T15
+ * @spec openspec/changes/dso-omgevingsloket/tasks.md#T04
  */
 
 declare(strict_types=1);
@@ -38,7 +38,7 @@ class VergunningStatusChangedEventTest extends TestCase
      *
      * @return void
      *
-     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T15
+     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T04
      */
     public function testEventExtendsOcpEvent(): void
     {
@@ -59,7 +59,7 @@ class VergunningStatusChangedEventTest extends TestCase
      *
      * @return void
      *
-     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T15
+     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T04
      */
     public function testGettersReturnConstructorValues(): void
     {
@@ -87,7 +87,7 @@ class VergunningStatusChangedEventTest extends TestCase
      *
      * @return void
      *
-     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T15
+     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T04
      */
     public function testNullableFieldsAcceptNull(): void
     {

--- a/tests/Unit/Listener/VergunningaanvraagCreatedListenerTest.php
+++ b/tests/Unit/Listener/VergunningaanvraagCreatedListenerTest.php
@@ -16,7 +16,7 @@
  *
  * @link https://procest.nl
  *
- * @spec openspec/changes/dso-omgevingsloket/tasks.md#T16
+ * @spec openspec/changes/dso-omgevingsloket/tasks.md#T04
  */
 
 declare(strict_types=1);
@@ -95,7 +95,7 @@ class VergunningaanvraagCreatedListenerTest extends TestCase
      *
      * @return void
      *
-     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T16
+     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T04
      */
     public function testHandleIgnoresNonObjectCreatedEvents(): void
     {
@@ -113,7 +113,7 @@ class VergunningaanvraagCreatedListenerTest extends TestCase
      *
      * @return void
      *
-     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T16
+     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T04
      */
     public function testHandleIgnoresNonMatchingSchema(): void
     {
@@ -148,7 +148,7 @@ class VergunningaanvraagCreatedListenerTest extends TestCase
      *
      * @return void
      *
-     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T16
+     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T04
      */
     public function testHandleCallsDsoCaseServiceOnMatch(): void
     {

--- a/tests/Unit/Notification/NotifierTest.php
+++ b/tests/Unit/Notification/NotifierTest.php
@@ -18,7 +18,7 @@
  *
  * @link https://procest.nl
  *
- * @spec openspec/changes/ncvue-w2-leaves-adoption/specs/ncvue-w2-leaves-adoption/spec.md#mentions
+ * @spec openspec/changes/ncvue-w2-leaves-adoption/specs/ncvue-w2-leaves-adoption/spec.md#REQ-W2L-003
  */
 
 declare(strict_types=1);

--- a/tests/Unit/Service/AiServicePiiDetectionTest.php
+++ b/tests/Unit/Service/AiServicePiiDetectionTest.php
@@ -19,7 +19,7 @@
  * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
  * SPDX-License-Identifier: EUPL-1.2
  *
- * @spec openspec/changes/woo-llm-anonymisation/tasks.md#task-1-2
+ * @spec openspec/changes/woo-llm-anonymisation/tasks.md#task-1-1
  */
 
 declare(strict_types=1);

--- a/tests/Unit/Service/BeschikkingGenerationServiceTest.php
+++ b/tests/Unit/Service/BeschikkingGenerationServiceTest.php
@@ -15,7 +15,7 @@
  *
  * @link https://procest.nl
  *
- * @spec openspec/changes/dso-omgevingsloket/tasks.md#T12
+ * @spec openspec/changes/dso-omgevingsloket/tasks.md#T03
  */
 
 declare(strict_types=1);
@@ -92,7 +92,7 @@ class BeschikkingGenerationServiceTest extends TestCase
      *
      * @return void
      *
-     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T12
+     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T03
      */
     public function testConstructorSetsProperties(): void
     {
@@ -113,7 +113,7 @@ class BeschikkingGenerationServiceTest extends TestCase
      *
      * @return void
      *
-     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T12
+     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T03
      */
     public function testGenerateBeschikkingWhenDocudeskUnavailableReturnsStub(): void
     {
@@ -146,7 +146,7 @@ class BeschikkingGenerationServiceTest extends TestCase
      *
      * @return void
      *
-     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T12
+     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T03
      */
     public function testGenerateBeschikkingOutcomeSelectsCorrectTemplate(): void
     {

--- a/tests/Unit/Service/DsoCaseServiceTest.php
+++ b/tests/Unit/Service/DsoCaseServiceTest.php
@@ -16,7 +16,7 @@
  *
  * @link https://procest.nl
  *
- * @spec openspec/changes/dso-omgevingsloket/tasks.md#T11
+ * @spec openspec/changes/dso-omgevingsloket/tasks.md#T02
  */
 
 declare(strict_types=1);
@@ -142,7 +142,7 @@ class DsoCaseServiceTest extends TestCase
      *
      * @return void
      *
-     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T11
+     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T02
      */
     public function testComputeDeadlineReguliere(): void
     {
@@ -180,7 +180,7 @@ class DsoCaseServiceTest extends TestCase
      *
      * @return void
      *
-     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T11
+     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T02
      */
     public function testComputeDeadlineUitgebreide(): void
     {
@@ -209,7 +209,7 @@ class DsoCaseServiceTest extends TestCase
      *
      * @return void
      *
-     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T11
+     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T02
      */
     public function testComputeDeadlineSkipsWeekends(): void
     {
@@ -239,7 +239,7 @@ class DsoCaseServiceTest extends TestCase
      *
      * @return void
      *
-     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T11
+     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T02
      */
     public function testComputeDeadlineSkipsEasterHolidays(): void
     {
@@ -288,7 +288,7 @@ class DsoCaseServiceTest extends TestCase
      *
      * @return void
      *
-     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T11
+     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T02
      */
     public function testCreateZaakFromVergunningaanvraagCallsObjectService(): void
     {

--- a/tests/Unit/Service/MentionNotificationServiceTest.php
+++ b/tests/Unit/Service/MentionNotificationServiceTest.php
@@ -17,7 +17,7 @@
  *
  * @link https://procest.nl
  *
- * @spec openspec/changes/ncvue-w2-leaves-adoption/specs/ncvue-w2-leaves-adoption/spec.md#mentions
+ * @spec openspec/changes/ncvue-w2-leaves-adoption/specs/ncvue-w2-leaves-adoption/spec.md#REQ-W2L-003
  */
 
 declare(strict_types=1);

--- a/tests/Unit/Service/SamenwerkverzoekServiceTest.php
+++ b/tests/Unit/Service/SamenwerkverzoekServiceTest.php
@@ -15,7 +15,7 @@
  *
  * @link https://procest.nl
  *
- * @spec openspec/changes/dso-omgevingsloket/tasks.md#T13
+ * @spec openspec/changes/dso-omgevingsloket/tasks.md#T03
  */
 
 declare(strict_types=1);
@@ -136,7 +136,7 @@ class SamenwerkverzoekServiceTest extends TestCase
      *
      * @return void
      *
-     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T13
+     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T03
      */
     public function testInitiateSamenwerkingCreatesObject(): void
     {
@@ -214,7 +214,7 @@ class SamenwerkverzoekServiceTest extends TestCase
      *
      * @return void
      *
-     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T13
+     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T03
      */
     public function testRespondToSamenwerkingAcceptUpdatesStatus(): void
     {
@@ -273,7 +273,7 @@ class SamenwerkverzoekServiceTest extends TestCase
      *
      * @return void
      *
-     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T13
+     * @spec openspec/changes/dso-omgevingsloket/tasks.md#T03
      */
     public function testRespondToSamenwerkingRejectUpdatesStatus(): void
     {

--- a/tests/Unit/Service/StatusTransitionGroupAuthTest.php
+++ b/tests/Unit/Service/StatusTransitionGroupAuthTest.php
@@ -37,7 +37,7 @@ use Psr\Log\LoggerInterface;
  *
  * @covers \OCA\Procest\Service\Transitions\TransitionAuthorizer
  *
- * @spec openspec/changes/migrate-role-routing-to-or-rbac/tasks.md#P-6.2
+ * @spec openspec/changes/migrate-role-routing-to-or-rbac/tasks.md#P-5.1
  */
 final class StatusTransitionGroupAuthTest extends TestCase
 {


### PR DESCRIPTION
## What

Ten distinct `@spec` targets in `tests/` did not resolve. All ten name a task or requirement **that was never written** — not one that moved or was archived. Gate-46 resolves through `build_archive_index`, so the archived location is not the problem.

**gate-46 spec-anchor-existence: 36 findings / 10 targets → 0.**

## The single repeated cause

Seven DSO test files cite a `T11`–`T17` task block in `openspec/changes/dso-omgevingsloket/tasks.md`. That file numbers its implementation tasks `T01`–`T08` and its verifications `V01`–`V10`. There is no `T11`. The block reads like an author's private numbering for "the test for task N", offset by ten — `DsoLvAuthServiceTest` in the same directory uses `#T03` and has always resolved.

Each tag is repointed at the task that actually created the code under test:

| test | was | now | task text |
|---|---|---|---|
| `DsoCaseServiceTest` | `#T11` | `#T02` | Create `lib/Service/DsoCaseService.php` |
| `BeschikkingGenerationServiceTest` | `#T12` | `#T03` | Create `BeschikkingGenerationService.php` |
| `SamenwerkverzoekServiceTest` | `#T13` | `#T03` | …and `SamenwerkverzoekService.php` |
| `DsoDeadlineJobTest` | `#T14` | `#T05` | Create `lib/BackgroundJob/DsoDeadlineJob.php` |
| `VergunningStatusChangedEventTest` | `#T15` | `#T04` | Create `VergunningStatusChangedEvent.php` |
| `VergunningaanvraagCreatedListenerTest` | `#T16` | `#T04` | …and `VergunningaanvraagCreatedListener.php` |
| `DsoControllerTest` | `#T17` | `#T06` | Create `lib/Controller/DsoController.php` |

## The other three

- **`#mentions` → `#REQ-W2L-003`** (3 files). `ncvue-w2-leaves-adoption/spec.md` has `### Requirement: REQ-W2L-003 — Note @mention Triggers A Real Nextcloud Notification`. `mentions` was shorthand for a heading that does not contain that word.
- **`#P-6.2` → `#P-5.1`**. `migrate-role-routing-to-or-rbac/tasks.md` names `tests/Unit/Service/StatusTransitionGroupAuthTest.php` explicitly — under **P-5.1**, not P-6. P-6 has one item, P-6.1, already cited by `WorkflowStepAuthorizationResolverTest`.
- **`#task-1-2` → `#task-1-1`**. `woo-llm-anonymisation` section 1 has a single item, `1.1 AiService::detectDeterministicPiiSpans()` — which is what `AiServicePiiDetectionTest` covers.

## What this change deliberately is not

**No spec text was added, renumbered, or invented to make a tag resolve.** Every new target is a line that already existed in the archived change. Writing a `T11`–`T17` block into `tasks.md` would have made the gate green while turning the shipped code into its own acceptance criteria; that is the failure mode this repo has hit before, and it is the reason the tags move rather than the specs.

Only docblock text changed — no test body, no assertion, no production code.

## Both directions

Run with the gate's own resolver (`scripts/lib/check_spec_anchors.py` from `ConductionNL/.github@main`, full scope — every `.php`/`.vue`/`.js`/`.ts`/`.md` under `lib/`, `src/`, `tests/`):

- **before:** 36 findings, 10 distinct targets
- **after:** 0 findings
- **planted true positive:** a throwaway `tests/Unit/ZzPlantedTpTest.php` carrying `@spec …/tasks.md#T14` was reported — `tests/Unit/ZzPlantedTpTest.php: @spec anchor not found in openspec/changes/dso-omgevingsloket/tasks.md → #T14` — then removed, and the count returned to 0. The gate can still fail; it is not passing because it stopped looking.
