### PR TITLE
fix(email): expose seedDefaultTemplates — gate-57 17 → 16

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -515,6 +515,7 @@ $extra = [
         ['name' => 'emailTemplate#listTemplates',  'url' => '/api/casetypes/{caseTypeId}/email-templates',                  'verb' => 'GET'],
         ['name' => 'emailTemplate#createTemplate', 'url' => '/api/casetypes/{caseTypeId}/email-templates',                  'verb' => 'POST'],
         ['name' => 'emailTemplate#variables',      'url' => '/api/casetypes/{caseTypeId}/email-templates/variables',         'verb' => 'GET'],
+        ['name' => 'emailTemplate#seedDefaults',   'url' => '/api/casetypes/{caseTypeId}/email-templates/seed-defaults',    'verb' => 'POST'],
         ['name' => 'emailTemplate#updateTemplate', 'url' => '/api/email-templates/{templateId}',                            'verb' => 'PUT'],
         ['name' => 'emailTemplate#prefillDraft',   'url' => '/api/cases/{caseId}/email-templates/{templateId}/draft',       'verb' => 'POST'],
         ['name' => 'emailTemplate#getSettings',    'url' => '/api/settings/email',                                          'verb' => 'GET'],

--- a/lib/Controller/EmailTemplateController.php
+++ b/lib/Controller/EmailTemplateController.php
@@ -338,4 +338,40 @@ class EmailTemplateController extends Controller
 
         return new JSONResponse($this->templateService->getAvailableVariables(caseTypeId: $caseTypeId));
     }//end variables()
+
+    /**
+     * Seed the three Dutch default templates for a caseType.
+     *
+     * Idempotent: the service skips any default whose name already exists, so
+     * calling this twice creates nothing the second time and returns 0.
+     *
+     * The auth posture mirrors createTemplate() deliberately — this endpoint
+     * is a loop over exactly that call and creates nothing a user could not
+     * create one at a time, so a stricter guard here would be inconsistent
+     * rather than safer.
+     *
+     * @param string $caseTypeId Owning caseType id.
+     *
+     * @NoAdminRequired
+     *
+     * @return JSONResponse {created: int} — how many were created on this run.
+     *
+     * @spec openspec/changes/case-email-integration/tasks.md#T04
+     */
+    public function seedDefaults(string $caseTypeId): JSONResponse
+    {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['message' => 'unauthenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        try {
+            return new JSONResponse(
+                    [
+                        'created' => $this->templateService->seedDefaultTemplates(caseTypeId: $caseTypeId),
+                    ]
+                    );
+        } catch (\RuntimeException $e) {
+            return new JSONResponse(['message' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
+        }
+    }//end seedDefaults()
 }//end class

--- a/tests/Unit/Controller/EmailTemplateControllerSeedDefaultsTest.php
+++ b/tests/Unit/Controller/EmailTemplateControllerSeedDefaultsTest.php
@@ -1,0 +1,186 @@
+<?php
+
+/**
+ * EmailTemplateController::seedDefaults() Unit Tests
+ *
+ * Covers the endpoint that exposes EmailTemplateService::seedDefaultTemplates()
+ * — the authentication gate, the created-count passthrough, the idempotent
+ * second call, and RuntimeException mapping to 400.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ *
+ * @spec openspec/changes/case-email-integration/tasks.md#T04
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\EmailTemplateController;
+use OCA\Procest\Service\EmailTemplateService;
+use OCA\Procest\Service\SettingsService;
+use OCP\AppFramework\Http;
+use OCP\IAppConfig;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * Unit tests for EmailTemplateController::seedDefaults().
+ *
+ * @covers \OCA\Procest\Controller\EmailTemplateController
+ */
+final class EmailTemplateControllerSeedDefaultsTest extends TestCase
+{
+
+    /**
+     * Inbound request.
+     *
+     * @var IRequest|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private IRequest $request;
+
+    /**
+     * Backend templating service.
+     *
+     * @var EmailTemplateService|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private EmailTemplateService $templateService;
+
+    /**
+     * Current user session.
+     *
+     * @var IUserSession|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private IUserSession $userSession;
+
+    /**
+     * The controller under test.
+     *
+     * @var EmailTemplateController
+     */
+    private EmailTemplateController $controller;
+
+
+    /**
+     * Set up fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->request         = $this->createMock(IRequest::class);
+        $this->templateService = $this->createMock(EmailTemplateService::class);
+        $this->userSession     = $this->createMock(IUserSession::class);
+
+        $this->controller = new EmailTemplateController(
+            request: $this->request,
+            templateService: $this->templateService,
+            settingsService: $this->createMock(SettingsService::class),
+            appConfig: $this->createMock(IAppConfig::class),
+            userSession: $this->userSession,
+        );
+    }//end setUp()
+
+
+    /**
+     * Mark the session as authenticated.
+     *
+     * @return void
+     */
+    private function authenticate(): void
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('alice');
+        $this->userSession->method('getUser')->willReturn($user);
+    }//end authenticate()
+
+
+    /**
+     * An anonymous caller is rejected before the service is consulted.
+     *
+     * @return void
+     */
+    public function testAnonymousCallerIsRejectedAndServiceNeverRuns(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+        $this->templateService->expects($this->never())->method('seedDefaultTemplates');
+
+        $response = $this->controller->seedDefaults(caseTypeId: 'melding');
+
+        $this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+        $this->assertSame(['message' => 'unauthenticated'], $response->getData());
+    }//end testAnonymousCallerIsRejectedAndServiceNeverRuns()
+
+
+    /**
+     * The created count is passed through, and the caseType id reaches the service.
+     *
+     * @return void
+     */
+    public function testSeedsDefaultsAndReturnsCreatedCount(): void
+    {
+        $this->authenticate();
+
+        $this->templateService->expects($this->once())
+            ->method('seedDefaultTemplates')
+            ->with(caseTypeId: 'melding')
+            ->willReturn(3);
+
+        $response = $this->controller->seedDefaults(caseTypeId: 'melding');
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame(['created' => 3], $response->getData());
+    }//end testSeedsDefaultsAndReturnsCreatedCount()
+
+
+    /**
+     * A second call creates nothing — the endpoint reports 0, not an error.
+     *
+     * @return void
+     */
+    public function testSecondCallIsIdempotentAndReportsZeroCreated(): void
+    {
+        $this->authenticate();
+
+        $this->templateService->expects($this->once())
+            ->method('seedDefaultTemplates')
+            ->willReturn(0);
+
+        $response = $this->controller->seedDefaults(caseTypeId: 'melding');
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame(['created' => 0], $response->getData());
+    }//end testSecondCallIsIdempotentAndReportsZeroCreated()
+
+
+    /**
+     * A business-rule failure becomes a 400, not a 500.
+     *
+     * @return void
+     */
+    public function testRuntimeExceptionBecomesBadRequest(): void
+    {
+        $this->authenticate();
+
+        $this->templateService->method('seedDefaultTemplates')
+            ->willThrowException(new RuntimeException('caseType not found'));
+
+        $response = $this->controller->seedDefaults(caseTypeId: 'nope');
+
+        $this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+        $this->assertSame(['message' => 'caseType not found'], $response->getData());
+    }//end testRuntimeExceptionBecomesBadRequest()
+}//end class


### PR DESCRIPTION
## What

`EmailTemplateService::seedDefaultTemplates()` has been fully implemented since `case-email-integration` T04 and **no caller has ever reached it**. It seeds the three Dutch default templates for a caseType, idempotent by name.

This is exactly the shape gate-57 exists to catch: a built capability with no way in. The fix is to **wire it, not delete it**.

**gate-57 orphaned-write-capability: 17 → 16.**

Adds `EmailTemplateController::seedDefaults()`, routed at `POST /api/casetypes/{caseTypeId}/email-templates/seed-defaults`.

## Auth posture

Mirrors `createTemplate()` deliberately. This endpoint is a loop over exactly that call and creates nothing a user could not create one template at a time, so a stricter guard here would be *inconsistent* rather than safer. gate-9 (semantic-auth) checks the attribute matches what the body does, and it passes.

## Evidence, both directions

Measured full-scope with the gate package CI actually runs — `ConductionNL/.github @ b8c7ead`, the SHA `hydra-gates-ref: main` resolved to.

| check | result |
|---|---|
| gate-57 | **17 → 16** |
| gate-5 route-auth, gate-7 no-admin-idor, gate-9 semantic-auth, gate-14 route-reachability, gate-16 spec-coverage | still PASS — no new gate |
| phpcs (`composer phpcs`, scoped to `lib/`) | **721 on this branch, 721 on `development`** — identical, all pre-existing |
| phpstan | `[OK] No errors` |
| psalm | nothing on the changed files |
| PHPUnit | **1746 passed**, 5 skipped (pre-existing) |

**The endpoint does not become invisible debt.** gate-25 (contract-coverage) reports **126 with the new test file and 127 without it** — verified by moving the test aside, re-running, and restoring. The new endpoint is credited because a real test covers it, not because anything was annotated.

**The auth gate is proven able to fail.** Replacing the session check with `if (false)` turns `testAnonymousCallerIsRejectedAndServiceNeverRuns` red:

```
Failed asserting that 400 is identical to 401.
FAILURES! Tests: 4, Assertions: 9, Failures: 1.
```

Restored afterwards; 4/4 green.

## Note on the remaining 16

A rigorous re-count (constructor-injection, not substring grep) puts the split at **14 with an existing consumer / 3 with none** — `Bezwaar\BeroepService`, `ConflictOfInterestService`, and `Service\Inspection\ChecklistService`. An earlier 12/5 figure of mine was wrong: `ChecklistService` matched as a substring of the unrelated `InspectionChecklistService`.

**All 17 carry a `@spec` annotation — none is unannotated dead code**, and four methods point at canonical `openspec/specs/` rather than a change dir (`cmmn-adaptive-case`, `inspection-checklists` ×2, `status-transition-engine`). Deleting those would be a functionality loss against a canonical spec, so the default disposition for this gate in procest is *wire*, not *remove*.
