### PR TITLE
fix(dso): wire createCase() into the intake path — gate-57 16 → 15

### DIFF
--- a/lib/Service/DsoIntakeService.php
+++ b/lib/Service/DsoIntakeService.php
@@ -73,88 +73,7 @@ class DsoIntakeService
      */
     public function processAanvraag(array $dsoMessage): array
     {
-        $objectService = $this->settingsService->getObjectService();
-        if ($objectService === null) {
-            throw new RuntimeException('OpenRegister is not available');
-        }
-
-        $register = $this->settingsService->getConfigValue('register');
-        if (empty($register) === true) {
-            throw new RuntimeException('Procest register not configured');
-        }
-
-        // Extract fields from DSO message.
-        $activiteiten  = $dsoMessage['activiteiten'] ?? [];
-        $locatie       = $dsoMessage['locatie'] ?? '';
-        $aanvrager     = $dsoMessage['aanvrager'] ?? [];
-        $bouwkosten    = $dsoMessage['bouwkosten'] ?? 0;
-        $procedureType = $dsoMessage['procedureType'] ?? 'regulier';
-        $dsoZaaknummer = $dsoMessage['zaaknummer'] ?? '';
-
-        // Build activity description.
-        $activityNames = $this->extractActivityNames(activiteiten: $activiteiten);
-        $activityStr   = implode(', ', array_filter($activityNames));
-
-        // Determine processing deadline.
-        $deadline = self::DEADLINE_DURATIONS[$procedureType] ?? self::DEADLINE_DURATIONS['regulier'];
-
-        // Create the case.
-        $caseSchema = $this->settingsService->getConfigValue('case_schema');
-
-        $title = 'Omgevingsvergunning';
-        if ($activityStr !== '') {
-            $title .= ': '.$activityStr;
-        }
-
-        $description = 'Vergunningaanvraag ontvangen via DSO/Omgevingsloket';
-        if ($dsoZaaknummer !== '') {
-            $description .= ' (DSO: '.$dsoZaaknummer.')';
-        }
-
-        $caseData = [
-            'title'       => $title,
-            'description' => $description,
-            'startDate'   => date('Y-m-d'),
-            'priority'    => 'normal',
-        ];
-
-        $caseObj = $objectService->saveObject(object: $caseData, register: $register, schema: $caseSchema);
-        $caseId  = $caseObj->getUuid();
-
-        // Store DSO-specific properties.
-        $propertySchema = $this->settingsService->getConfigValue('case_property_schema');
-        $locatieValue   = $locatie;
-        if (is_array($locatie) === true) {
-            $locatieValue = json_encode($locatie);
-        }
-
-        $this->storeCaseProperties(
-            objectService: $objectService,
-            register: $register,
-            schema: $propertySchema,
-            caseId: $caseId,
-            properties: [
-                'dsoZaaknummer' => $dsoZaaknummer,
-                'activiteiten'  => $activityStr,
-                'locatie'       => $locatieValue,
-                'bouwkosten'    => (string) $bouwkosten,
-                'procedureType' => $procedureType,
-                'aanvragerNaam' => $aanvrager['naam'] ?? '',
-            ],
-        );
-
-        $this->logger->info(
-            'DSO intake processed: case '.$caseId.' (DSO: '.$dsoZaaknummer.')',
-            ['app' => Application::APP_ID],
-        );
-
-        return [
-            'caseId'        => $caseId,
-            'dsoZaaknummer' => $dsoZaaknummer,
-            'activiteiten'  => $activityNames,
-            'procedureType' => $procedureType,
-            'deadline'      => $deadline,
-        ];
+        return $this->createCase(mappedData: $this->map(dsoMessage: $dsoMessage));
     }//end processAanvraag()
 
     /**
@@ -320,43 +239,39 @@ class DsoIntakeService
             'priority'    => $mappedData['priority'] ?? 'normal',
         ];
 
-        $caseObj = $objectService->saveObject($register, $caseSchema, $caseData);
+        // OpenRegister's signature is
+        // saveObject(array|ObjectEntity $object, ?array $extend = [], $register = null, $schema = null, ...)
+        // so the register/schema slugs MUST be passed by name — positionally
+        // they would land in $object and $extend and raise a TypeError.
+        $caseObj = $objectService->saveObject(object: $caseData, register: $register, schema: $caseSchema);
         $caseId  = $caseObj->getUuid();
 
+        $dsoZaaknummer  = $mappedData['dsoZaaknummer'] ?? '';
         $propertySchema = $this->settingsService->getConfigValue('case_property_schema');
-        $properties     = [
-            'dsoZaaknummer' => $mappedData['dsoZaaknummer'] ?? '',
-            'activiteiten'  => $mappedData['activiteiten'] ?? '',
-            'locatie'       => $mappedData['locatie'] ?? '',
-            'bouwkosten'    => $mappedData['bouwkosten'] ?? '',
-            'procedureType' => $mappedData['procedureType'] ?? '',
-            'aanvragerNaam' => $mappedData['aanvragerNaam'] ?? '',
-        ];
 
-        foreach ($properties as $name => $value) {
-            if ($value === '') {
-                continue;
-            }
-
-            $objectService->saveObject(
-                $register,
-                $propertySchema,
-                [
-                    'case'  => $caseId,
-                    'name'  => $name,
-                    'value' => $value,
-                ]
-            );
-        }
+        $this->storeCaseProperties(
+            objectService: $objectService,
+            register: $register,
+            schema: $propertySchema,
+            caseId: $caseId,
+            properties: [
+                'dsoZaaknummer' => $dsoZaaknummer,
+                'activiteiten'  => $mappedData['activiteiten'] ?? '',
+                'locatie'       => $mappedData['locatie'] ?? '',
+                'bouwkosten'    => $mappedData['bouwkosten'] ?? '',
+                'procedureType' => $mappedData['procedureType'] ?? '',
+                'aanvragerNaam' => $mappedData['aanvragerNaam'] ?? '',
+            ],
+        );
 
         $this->logger->info(
-            'DSO intake: created case '.$caseId,
+            'DSO intake processed: case '.$caseId.' (DSO: '.$dsoZaaknummer.')',
             ['app' => Application::APP_ID],
         );
 
         return [
             'caseId'        => $caseId,
-            'dsoZaaknummer' => $mappedData['dsoZaaknummer'] ?? '',
+            'dsoZaaknummer' => $dsoZaaknummer,
             'activiteiten'  => $mappedData['activityNames'] ?? [],
             'procedureType' => $mappedData['procedureType'] ?? '',
             'deadline'      => $mappedData['deadline'] ?? '',

--- a/tests/Unit/Service/DsoIntakeServiceTest.php
+++ b/tests/Unit/Service/DsoIntakeServiceTest.php
@@ -1,0 +1,536 @@
+<?php
+
+/**
+ * DsoIntakeService Unit Tests
+ *
+ * Characterization tests for the Procest DsoIntakeService. These pin the
+ * observable behaviour of the live DSO webhook path (`processAanvraag`):
+ * the exact ObjectService::saveObject() call sequence — including the
+ * ARGUMENT POSITIONS the named arguments bind to — the case-property rows
+ * that are written or skipped, and the byte shape of the returned payload
+ * that the webhook echoes back to the Omgevingsloket.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/specs/dso-omgevingsloket-client/spec.md
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Service;
+
+use OCA\Procest\Service\DsoIntakeService;
+use OCA\Procest\Service\SettingsService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * ObjectService stub mirroring OpenRegister's real saveObject() signature.
+ *
+ * The parameter ORDER and NAMES here are load-bearing: they are a verbatim
+ * (narrowed) copy of
+ * `OCA\OpenRegister\Service\ObjectService::saveObject(array|ObjectEntity $object,
+ * ?array $extend = [], Register|string|int|null $register = null,
+ * Schema|string|int|null $schema = null, ...)`.
+ *
+ * Because Procest calls saveObject() with NAMED arguments, PHP binds those
+ * names against this declaration — so a caller that reverts to the positional
+ * `saveObject($register, $schema, $data)` order lands a string in `$object`
+ * and a string in `$extend`, which this declaration rejects. That is what
+ * makes the argument-order assertions below non-vacuous.
+ */
+interface DsoIntakeObjectServiceStub
+{
+
+    /**
+     * Save or update an object.
+     *
+     * @param array               $object   The object payload.
+     * @param array|null          $extend   Properties to extend the object with.
+     * @param string|int|null     $register The register object or its ID/UUID.
+     * @param string|int|null     $schema   The schema object or its ID/UUID.
+     *
+     * @return object The saved object.
+     */
+    public function saveObject(
+        array $object,
+        ?array $extend=[],
+        string | int | null $register=null,
+        string | int | null $schema=null
+    ): object;
+}//end interface
+
+/**
+ * Saved-object double exposing only the getUuid() accessor Procest uses.
+ */
+final class DsoIntakeSavedObjectDouble
+{
+
+    /**
+     * Constructor.
+     *
+     * @param string $uuid The UUID this saved object reports.
+     */
+    public function __construct(private readonly string $uuid)
+    {
+    }//end __construct()
+
+    /**
+     * Get the object UUID.
+     *
+     * @return string The UUID.
+     */
+    public function getUuid(): string
+    {
+        return $this->uuid;
+    }//end getUuid()
+}//end class
+
+/**
+ * Recording ObjectService fake.
+ *
+ * A hand-written fake rather than a PHPUnit mock on purpose: PHP itself binds
+ * the named arguments against the declared signature, so the recorded call log
+ * reflects real parameter binding rather than PHPUnit's argument marshalling.
+ */
+final class DsoIntakeRecordingObjectService implements DsoIntakeObjectServiceStub
+{
+
+    /**
+     * Recorded saveObject() invocations, in call order.
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    public array $calls = [];
+
+    /**
+     * Save or update an object, recording how the arguments bound.
+     *
+     * @param array           $object   The object payload.
+     * @param array|null      $extend   Properties to extend the object with.
+     * @param string|int|null $register The register slug.
+     * @param string|int|null $schema   The schema slug.
+     *
+     * @return object The saved object double.
+     */
+    public function saveObject(
+        array $object,
+        ?array $extend=[],
+        string | int | null $register=null,
+        string | int | null $schema=null
+    ): object {
+        $this->calls[] = [
+            'object'   => $object,
+            'extend'   => $extend,
+            'register' => $register,
+            'schema'   => $schema,
+        ];
+
+        return new DsoIntakeSavedObjectDouble('case-uuid-'.count($this->calls));
+    }//end saveObject()
+}//end class
+
+/**
+ * Characterization tests for DsoIntakeService.
+ *
+ * @covers \OCA\Procest\Service\DsoIntakeService
+ */
+class DsoIntakeServiceTest extends TestCase
+{
+
+    /**
+     * Mocked SettingsService.
+     *
+     * @var SettingsService|MockObject
+     */
+    private SettingsService $settings;
+
+    /**
+     * Mocked LoggerInterface.
+     *
+     * @var LoggerInterface|MockObject
+     */
+    private LoggerInterface $logger;
+
+    /**
+     * Service under test.
+     *
+     * @var DsoIntakeService
+     */
+    private DsoIntakeService $service;
+
+    /**
+     * Set up test fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->settings = $this->createMock(SettingsService::class);
+        $this->logger   = $this->createMock(LoggerInterface::class);
+        $this->service  = new DsoIntakeService(
+            settingsService: $this->settings,
+            logger: $this->logger,
+        );
+    }//end setUp()
+
+    /**
+     * Wire the mocked SettingsService to a recording ObjectService.
+     *
+     * @param string $register       The configured register slug.
+     * @param string $caseSchema     The configured case schema slug.
+     * @param string $propertySchema The configured case property schema slug.
+     *
+     * @return DsoIntakeRecordingObjectService The recorder handed to the service.
+     */
+    private function wireObjectService(
+        string $register='procest',
+        string $caseSchema='zaak',
+        string $propertySchema='zaakeigenschap'
+    ): DsoIntakeRecordingObjectService {
+        $recorder = new DsoIntakeRecordingObjectService();
+        $this->settings->method('getObjectService')->willReturn($recorder);
+        $this->settings->method('getConfigValue')->willReturnMap(
+            [
+                ['register', $register],
+                ['case_schema', $caseSchema],
+                ['case_property_schema', $propertySchema],
+            ]
+        );
+
+        return $recorder;
+    }//end wireObjectService()
+
+    /**
+     * A representative full DSO vergunningaanvraag payload.
+     *
+     * @return array<string, mixed> The payload.
+     */
+    private function fullPayload(): array
+    {
+        return [
+            'zaaknummer'    => 'DSO-2026-0042',
+            'activiteiten'  => [
+                ['naam' => 'Bouwactiviteit'],
+                ['naam' => 'Kapactiviteit'],
+            ],
+            'locatie'       => 'Dorpsstraat 1, Utrecht',
+            'aanvrager'     => ['naam' => 'Jan de Vries'],
+            'bouwkosten'    => 125000,
+            'procedureType' => 'uitgebreid',
+        ];
+    }//end fullPayload()
+
+    /**
+     * processAanvraag throws when OpenRegister is unavailable.
+     *
+     * @return void
+     */
+    public function testProcessAanvraagThrowsWhenObjectServiceUnavailable(): void
+    {
+        $this->settings->method('getObjectService')->willReturn(null);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('OpenRegister is not available');
+
+        $this->service->processAanvraag(dsoMessage: $this->fullPayload());
+    }//end testProcessAanvraagThrowsWhenObjectServiceUnavailable()
+
+    /**
+     * processAanvraag throws when the register is not configured.
+     *
+     * @return void
+     */
+    public function testProcessAanvraagThrowsWhenRegisterNotConfigured(): void
+    {
+        $this->wireObjectService(register: '');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Procest register not configured');
+
+        $this->service->processAanvraag(dsoMessage: $this->fullPayload());
+    }//end testProcessAanvraagThrowsWhenRegisterNotConfigured()
+
+    /**
+     * The case object is saved first, with register/schema in the named slots.
+     *
+     * This pins the ARGUMENT BINDING, not just the values: `$object` must
+     * receive the case payload, `$extend` must stay at its `[]` default, and
+     * the register/schema slugs must land in `$register` / `$schema`.
+     *
+     * @return void
+     */
+    public function testProcessAanvraagSavesCaseWithNamedArgumentBinding(): void
+    {
+        $recorder = $this->wireObjectService();
+
+        $this->service->processAanvraag(dsoMessage: $this->fullPayload());
+
+        $this->assertSame(
+            [
+                'object'   => [
+                    'title'       => 'Omgevingsvergunning: Bouwactiviteit, Kapactiviteit',
+                    'description' => 'Vergunningaanvraag ontvangen via DSO/Omgevingsloket (DSO: DSO-2026-0042)',
+                    'startDate'   => date('Y-m-d'),
+                    'priority'    => 'normal',
+                ],
+                'extend'   => [],
+                'register' => 'procest',
+                'schema'   => 'zaak',
+            ],
+            $recorder->calls[0]
+        );
+    }//end testProcessAanvraagSavesCaseWithNamedArgumentBinding()
+
+    /**
+     * Every non-empty DSO property is written as its own case-property object.
+     *
+     * @return void
+     */
+    public function testProcessAanvraagWritesCasePropertyRowsInOrder(): void
+    {
+        $recorder = $this->wireObjectService();
+
+        $this->service->processAanvraag(dsoMessage: $this->fullPayload());
+
+        $this->assertCount(7, $recorder->calls);
+
+        $expected = [
+            ['dsoZaaknummer', 'DSO-2026-0042'],
+            ['activiteiten', 'Bouwactiviteit, Kapactiviteit'],
+            ['locatie', 'Dorpsstraat 1, Utrecht'],
+            ['bouwkosten', '125000'],
+            ['procedureType', 'uitgebreid'],
+            ['aanvragerNaam', 'Jan de Vries'],
+        ];
+
+        $properties = array_slice($recorder->calls, 1);
+
+        foreach ($expected as $index => [$name, $value]) {
+            $this->assertSame(
+                [
+                    'object'   => [
+                        'case'  => 'case-uuid-1',
+                        'name'  => $name,
+                        'value' => $value,
+                    ],
+                    'extend'   => [],
+                    'register' => 'procest',
+                    'schema'   => 'zaakeigenschap',
+                ],
+                $properties[$index],
+                'case property #'.$index.' ('.$name.')'
+            );
+        }
+    }//end testProcessAanvraagWritesCasePropertyRowsInOrder()
+
+    /**
+     * Empty property values are skipped rather than written as blank rows.
+     *
+     * An empty payload still writes bouwkosten ("0" — the numeric default
+     * stringifies to a non-empty value) and the defaulted procedureType.
+     *
+     * @return void
+     */
+    public function testProcessAanvraagSkipsEmptyPropertyValues(): void
+    {
+        $recorder = $this->wireObjectService();
+
+        $this->service->processAanvraag(dsoMessage: []);
+
+        $this->assertCount(3, $recorder->calls);
+        $this->assertSame(
+            [
+                ['case' => 'case-uuid-1', 'name' => 'bouwkosten', 'value' => '0'],
+                ['case' => 'case-uuid-1', 'name' => 'procedureType', 'value' => 'regulier'],
+            ],
+            [$recorder->calls[1]['object'], $recorder->calls[2]['object']]
+        );
+    }//end testProcessAanvraagSkipsEmptyPropertyValues()
+
+    /**
+     * An empty payload still produces the bare title and description.
+     *
+     * @return void
+     */
+    public function testProcessAanvraagBuildsBareTitleWithoutActivities(): void
+    {
+        $recorder = $this->wireObjectService();
+
+        $this->service->processAanvraag(dsoMessage: []);
+
+        $this->assertSame(
+            [
+                'title'       => 'Omgevingsvergunning',
+                'description' => 'Vergunningaanvraag ontvangen via DSO/Omgevingsloket',
+                'startDate'   => date('Y-m-d'),
+                'priority'    => 'normal',
+            ],
+            $recorder->calls[0]['object']
+        );
+    }//end testProcessAanvraagBuildsBareTitleWithoutActivities()
+
+    /**
+     * A structured locatie object is stored JSON-encoded.
+     *
+     * @return void
+     */
+    public function testProcessAanvraagJsonEncodesStructuredLocatie(): void
+    {
+        $recorder = $this->wireObjectService();
+
+        $this->service->processAanvraag(
+            dsoMessage: [
+                'locatie' => [
+                    'straat'    => 'Dorpsstraat',
+                    'huisnummer' => 1,
+                ],
+            ]
+        );
+
+        $locatieRows = array_values(
+            array_filter(
+                $recorder->calls,
+                static fn (array $call): bool => ($call['object']['name'] ?? '') === 'locatie'
+            )
+        );
+
+        $this->assertCount(1, $locatieRows);
+        $this->assertSame(
+            '{"straat":"Dorpsstraat","huisnummer":1}',
+            $locatieRows[0]['object']['value']
+        );
+    }//end testProcessAanvraagJsonEncodesStructuredLocatie()
+
+    /**
+     * Scalar activiteiten entries are used verbatim as activity names.
+     *
+     * @return void
+     */
+    public function testProcessAanvraagAcceptsScalarActiviteiten(): void
+    {
+        $recorder = $this->wireObjectService();
+
+        $result = $this->service->processAanvraag(
+            dsoMessage: ['activiteiten' => ['Sloopactiviteit', 'Milieubelastende activiteit']]
+        );
+
+        $this->assertSame(
+            'Omgevingsvergunning: Sloopactiviteit, Milieubelastende activiteit',
+            $recorder->calls[0]['object']['title']
+        );
+        $this->assertSame(
+            ['Sloopactiviteit', 'Milieubelastende activiteit'],
+            $result['activiteiten']
+        );
+    }//end testProcessAanvraagAcceptsScalarActiviteiten()
+
+    /**
+     * The webhook response body keeps its exact five-key shape.
+     *
+     * This array is serialised straight into the 201 JSONResponse the
+     * Omgevingsloket receives, so it is an external contract.
+     *
+     * @return void
+     */
+    public function testProcessAanvraagReturnsWebhookResponseShape(): void
+    {
+        $this->wireObjectService();
+
+        $result = $this->service->processAanvraag(dsoMessage: $this->fullPayload());
+
+        $this->assertSame(
+            [
+                'caseId'        => 'case-uuid-1',
+                'dsoZaaknummer' => 'DSO-2026-0042',
+                'activiteiten'  => ['Bouwactiviteit', 'Kapactiviteit'],
+                'procedureType' => 'uitgebreid',
+                'deadline'      => 'P182D',
+            ],
+            $result
+        );
+    }//end testProcessAanvraagReturnsWebhookResponseShape()
+
+    /**
+     * The regulier deadline is the default for a missing or unknown type.
+     *
+     * @param string|null $procedureType    The procedure type in the payload.
+     * @param string      $expectedDeadline The ISO 8601 duration expected back.
+     *
+     * @dataProvider deadlineProvider
+     *
+     * @return void
+     */
+    public function testProcessAanvraagResolvesDeadlinePerProcedureType(
+        ?string $procedureType,
+        string $expectedDeadline
+    ): void {
+        $this->wireObjectService();
+
+        $payload = [];
+        if ($procedureType !== null) {
+            $payload['procedureType'] = $procedureType;
+        }
+
+        $result = $this->service->processAanvraag(dsoMessage: $payload);
+
+        $this->assertSame($expectedDeadline, $result['deadline']);
+    }//end testProcessAanvraagResolvesDeadlinePerProcedureType()
+
+    /**
+     * Procedure type to expected deadline duration.
+     *
+     * @return array<string, array{0: string|null, 1: string}>
+     */
+    public static function deadlineProvider(): array
+    {
+        return [
+            'missing type falls back to regulier' => [null, 'P56D'],
+            'regulier'                            => ['regulier', 'P56D'],
+            'uitgebreid'                          => ['uitgebreid', 'P182D'],
+            'unknown type falls back to regulier' => ['onbekend', 'P56D'],
+        ];
+    }//end deadlineProvider()
+
+    /**
+     * Intake is logged once, naming the created case and the DSO reference.
+     *
+     * @return void
+     */
+    public function testProcessAanvraagLogsTheCreatedCase(): void
+    {
+        $this->wireObjectService();
+
+        $this->logger->expects($this->once())
+            ->method('info')
+            ->with(
+                'DSO intake processed: case case-uuid-1 (DSO: DSO-2026-0042)',
+                ['app' => 'procest']
+            );
+
+        $this->service->processAanvraag(dsoMessage: $this->fullPayload());
+    }//end testProcessAanvraagLogsTheCreatedCase()
+
+    /**
+     * getDeadlineDuration exposes the same table the intake path uses.
+     *
+     * @return void
+     */
+    public function testGetDeadlineDurationMatchesIntakeDeadlines(): void
+    {
+        $this->assertSame('P56D', $this->service->getDeadlineDuration('regulier'));
+        $this->assertSame('P182D', $this->service->getDeadlineDuration('uitgebreid'));
+        $this->assertSame('P56D', $this->service->getDeadlineDuration('onbekend'));
+    }//end testGetDeadlineDurationMatchesIntakeDeadlines()
+}//end class


### PR DESCRIPTION
## What

`DsoIntakeService` carried **two implementations of DSO intake**. The live webhook path — `processAanvraag()`, reached via `POST /api/vth/dso/intake` (HMAC-signed DSO webhook, `DSOIntakeController::intake()`) — did extract → build → save → save-properties inline. Next to it sat an extracted `map()` + `createCase()` pair with **zero callers**: an abandoned "make intake testable" refactor where the inline version was kept and the extracted pair was never wired.

This closes the gate-57 finding by **wiring the orphan, not deleting it**.

## The latent bug

`createCase()` was not merely unreachable — it had **never run**. It called OpenRegister's `ObjectService` positionally:

```php
$objectService->saveObject($register, $caseSchema, $caseData);
```

against the real signature (`openregister/lib/Service/ObjectService.php:1189`):

```php
saveObject(array|ObjectEntity $object, ?array $extend = [], Register|string|int|null $register = null, Schema|string|int|null $schema = null, ...)
```

So the register slug landed in `array|ObjectEntity $object` and the schema slug in `?array $extend` — a `TypeError` on the first call. The same bug was in its case-property loop. `processAanvraag()` had it right, using named arguments.

## Changes

- `processAanvraag()` delegates to `map()` + `createCase()` — **one** implementation of the intake write instead of two (~80 lines of duplication gone).
- `createCase()` passes register/schema **by name**, fixing the latent `TypeError`, and reuses the existing `storeCaseProperties()` helper (which already had the argument order right) for property rows.
- `createCase()` adopts the live path's log line, so the message the webhook has always emitted is preserved.
- `map()`'s output shape and `processAanvraag()`'s return shape are unchanged — the return array is the webhook's response body and an external contract.

## Safety net: characterization tests first

`processAanvraag()` is a live webhook path that had **no unit tests**. So `tests/Unit/Service/DsoIntakeServiceTest.php` (15 tests) was written **first, against the pre-refactor code**, pinning:

- the exact `saveObject()` call sequence, **including which parameter each named argument binds to**;
- which case-property rows are written and which are skipped, and in what order;
- the byte shape of the JSON returned to the Omgevingsloket;
- deadline resolution per procedure type, and the config/availability guards.

They were green before the refactor and are green after it, **unedited**.

## Planted true positive

The ObjectService test double declares OpenRegister's **real parameter order**, so the argument-order assertions are not vacuous. Re-introducing the positional call:

```php
$caseObj = $objectService->saveObject($register, $caseSchema, $caseData);
```

fails **12 of the 15 tests**:

```
TypeError: OCA\Procest\Tests\Unit\Service\DsoIntakeRecordingObjectService::saveObject():
Argument #1 ($object) must be of type array, string given,
called in /home/rubenlinde/g57-dso/lib/Service/DsoIntakeService.php on line 246
```

Restored afterwards; the suite is green on the pushed commit.

## Verification

hydra-gates @ `ConductionNL/.github` `b8c7ead`, 66 gates listed, exit 8 on both runs.

| Check | Before | After |
|---|---|---|
| **gate-57** orphaned-write-capability | **16** | **15** |
| **gate-25** contract-coverage | 126 | 126 (findings log byte-identical) |
| Failing-gate ID set | `3,19,22,25,26,53,57,62` | identical — no new gate fails |
| `composer phpstan` | — | no errors |
| `composer phpcs` | 1 error + 501 warnings / 219 files | identical |
| `vendor/bin/phpunit` | 1746 passed, 5 skipped | 1761 passed, 5 skipped |

The gate-57 log diff is exactly one removed line:

```
< lib/Service/DsoIntakeService.php:303 method=createCase rule=orphaned-write-capability class=DsoIntakeService
```

No gate was weakened: no baselines, excludes, skipped or deleted tests, or raised thresholds.

## Behaviour note

On a **malformed** payload while OpenRegister is unavailable, mapping now runs before the config guards, so such a request surfaces the mapping error rather than `OpenRegister is not available`. Both are a 500 from the webhook and neither message is part of the response contract. For well-formed payloads the guards fire exactly as before.

One micro-normalisation: `map()` casts `locatie` to string, so a `locatie` sent as a bare number is now stored as `"123"` rather than `123`. Strings and structured objects (JSON-encoded) — the shapes DSO actually sends — are byte-identical.
