### PR TITLE
fix(a11y): two modals announced their own title twice — the AVG e2e 'missing heading' was two headings

### DIFF
--- a/src/modals/InitiatorPickerModal.vue
+++ b/src/modals/InitiatorPickerModal.vue
@@ -13,7 +13,11 @@
 <template>
 	<NcModal size="normal" :name="t('procest', 'Who is the initiator?')" @close="$emit('close')">
 		<div class="initiator-picker-modal">
-			<h2>{{ t('procest', 'Who is the initiator?') }}</h2>
+			<!-- No <h2> here: NcModal's `name` prop already renders the dialog
+			     heading (h2.modal-header__name) and wires it as the dialog's
+			     accessible name. Repeating it in the body announced the title
+			     twice to a screen reader and made every
+			     getByRole('heading', …) query ambiguous. -->
 			<p class="initiator-picker-modal__hint">
 				{{ t('procest', 'Link the case to the person, company, or contact who submitted it. You can also skip this and add the initiator later.') }}
 			</p>

--- a/src/modals/InzageExportModal.vue
+++ b/src/modals/InzageExportModal.vue
@@ -14,7 +14,11 @@
 <template>
 	<NcModal size="normal" :name="t('procest', 'Data subject access export')" @close="$emit('close')">
 		<div class="inzage-export">
-			<h2>{{ t('procest', 'Data subject access export') }}</h2>
+			<!-- No <h2> here: NcModal's `name` prop already renders the dialog
+			     heading (h2.modal-header__name) and wires it as the dialog's
+			     accessible name. Repeating it in the body announced the title
+			     twice to a screen reader and made every
+			     getByRole('heading', …) query ambiguous. -->
 			<p class="inzage-export__hint">
 				{{ t('procest', 'Produces the per-subject processing extract from OpenRegister (AVG art. 15). The export itself is logged.') }}
 			</p>

--- a/tests/vitest/modalHeadingUniqueness.spec.js
+++ b/tests/vitest/modalHeadingUniqueness.spec.js
@@ -1,0 +1,84 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction / Procest Contributors
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * Structural guard: a modal must not repeat its own dialog title as a
+ * heading inside its body.
+ *
+ * `NcModal`'s `name` prop already renders `<h2 class="modal-header__name">`
+ * and wires it as the dialog's accessible name. A second `<h2>` in the body
+ * carrying the same string is a real WCAG defect — a screen-reader user is
+ * told the dialog's name, then immediately hears the identical heading again
+ * — and it also makes every `getByRole('heading', { name })` query ambiguous.
+ *
+ * That second effect is how this surfaced. `InzageExportModal` rendered the
+ * title twice, so the AVG e2e spec's
+ * `getByRole('heading', { name: 'Data subject access export' })` resolved to
+ * TWO elements and Playwright failed it under strict mode:
+ *
+ *   strict mode violation: ... resolved to 2 elements:
+ *     1) <h2 class="modal-header__name">Data subject access export</h2>
+ *     2) <h2 data-v-3de9aa6e="">Data subject access export</h2>
+ *
+ * It presented as an intermittent failure rather than a constant one because
+ * the two headings mount at slightly different moments: an assertion that
+ * resolves while only the header exists passes, and one that resolves after
+ * the body slot renders throws. That is why the same commit could go green on
+ * one PR and red on another.
+ *
+ * Procest's Vitest project runs in the `node` environment with no Vue mount
+ * harness (see vitest.config.js — no @vue/test-utils / jsdom / vue-loader),
+ * so `.vue` SFCs cannot be mounted here. This spec therefore asserts the
+ * invariant against the component SOURCE, which is the level the defect
+ * actually lives at: a literal duplicated between the `name` prop and a body
+ * heading. It covers every modal at once, so a newly added one is guarded on
+ * the day it lands rather than whenever someone writes an e2e test for it.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+const MODAL_DIR = join(__dirname, '..', '..', 'src', 'modals')
+
+/**
+ * Pull the translated literal out of `:name="t('procest', '...')"`.
+ *
+ * @param {string} source Component source.
+ * @return {string|null} The dialog title, or null when the modal does not set one.
+ */
+function dialogTitle(source) {
+	const m = source.match(/:name="t\('procest',\s*'((?:[^'\\]|\\.)+)'\)"/)
+	return m ? m[1] : null
+}
+
+/**
+ * Collect every heading literal rendered in the component body.
+ *
+ * @param {string} source Component source.
+ * @return {string[]} Heading literals.
+ */
+function bodyHeadings(source) {
+	return [...source.matchAll(/<h[1-6][^>]*>\s*\{\{\s*t\('procest',\s*'((?:[^'\\]|\\.)+)'\)\s*\}\}\s*<\/h[1-6]>/g)]
+		.map(m => m[1])
+}
+
+describe('modal dialog headings are not duplicated in the body', () => {
+	const files = readdirSync(MODAL_DIR).filter(f => f.endsWith('.vue'))
+
+	it('finds modal components to check (guards against an empty scope passing vacuously)', () => {
+		expect(files.length).toBeGreaterThan(0)
+	})
+
+	it.each(files)('%s does not repeat its NcModal name as a body heading', (file) => {
+		const source = readFileSync(join(MODAL_DIR, file), 'utf8')
+		const title = dialogTitle(source)
+
+		if (title === null) {
+			// Modal sets no `name` — nothing to duplicate.
+			return
+		}
+
+		expect(bodyHeadings(source)).not.toContain(title)
+	})
+})


### PR DESCRIPTION
## What this actually is

`NcModal`'s `name` prop already renders `<h2 class="modal-header__name">` and wires it as the dialog's accessible name. **`InzageExportModal` and `InitiatorPickerModal` rendered a second `<h2>` in the body with the identical string**, so a screen-reader user is told the dialog's name and then immediately hears the same heading again. Six of the eight modals that set `name` never did this — these two are the outliers, so this aligns them with the existing house pattern rather than introducing one.

## How it was found — the assertion text was misleading

An e2e failure on an unrelated PR:

```
Error: expect(locator).toBeVisible() failed
Locator: getByRole('heading', { name: 'Data subject access export' })
Expected: visible
```

That reads as *"the heading is missing"*. The real cause was underneath it, in the trace artifact's `error-context.md`:

```
Error: strict mode violation: getByRole('heading', { name: 'Data subject access export' })
resolved to 2 elements:
  1) <h2 class="modal-header__name">Data subject access export</h2>
  2) <h2 data-v-3de9aa6e="">Data subject access export</h2>
```

Not a missing heading — **two of them**. Reading the assertion alone would have led to "fix the literal" or "loosen the selector"; both would have left the accessibility defect in place.

## Why it presented as flaky

The two headings mount at slightly different moments — the header with the dialog, the second with the body slot. An assertion resolving early sees one element and passes; one resolving late sees two and throws under strict mode. **The same commit could go green on one PR and red on another**, which is exactly what happened: `avg-verwerkingenlogging.spec.ts:42` passed on #787 in 4.2s and failed twice on #788 in 4.3s, from the same base, with #788's diff touching nothing AVG-related.

So this also unblocks #788 without weakening its assertion or touching its test.

## Regression guard

`tests/vitest/modalHeadingUniqueness.spec.js` asserts the invariant across **every** modal, not just these two, so a newly added one is guarded the day it lands rather than whenever someone gets round to an e2e test for it.

Procest's Vitest project runs in `node` with no Vue mount harness (no `@vue/test-utils`/jsdom — see `vitest.config.js`), so the assertion is against component source. That is the level the defect lives at: a literal duplicated between the `name` prop and a body heading. The spec includes an explicit non-empty-scope assertion so it cannot pass by finding no files.

## Both directions

| state | result |
|---|---|
| with the fix | **12 passed** (11 modals + scope guard) |
| duplicate `<h2>` restored in `InzageExportModal` (planted TP) | **1 failed \| 11 passed** |
| removed again | **12 passed** |

Full vitest suite: **342 passed / 33 files**. `npm run lint` → exit 0. `npm run stylelint` → exit 0.

Nothing was suppressed, excluded or baselined; no e2e assertion was changed.
