### PR TITLE
fix(admin): stop ChecklistsTab rendering one row per byte of an error page (#784)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -52,4 +52,15 @@ module.exports = defineConfig([{
 		'import/no-named-as-default-member': 'off',
 		'import/no-unresolved': ['error', { ignore: ['^@conduction/nextcloud-vue'] }],
 	},
+}, {
+	// Test files legitimately import devDependencies (`vitest`,
+	// `@vue/test-utils`, `@playwright/test`). `n/no-unpublished-import` exists
+	// to stop a devDependency leaking into shipped code, and a spec file is not
+	// shipped — so it flags every spec in the suite as an error. Note this was
+	// invisible: `npm run lint` is `eslint src`, so `tests/` is never linted by
+	// CI and the error only appears when a file is linted by path.
+	files: ['tests/**/*.js', 'tests/**/*.ts'],
+	rules: {
+		'n/no-unpublished-import': 'off',
+	},
 }])

--- a/src/services/adviceApi.js
+++ b/src/services/adviceApi.js
@@ -60,7 +60,18 @@ export async function getAdviceForCase(caseId) {
 	const response = await axios.get(orUrl(), {
 		params: { _filters: JSON.stringify({ case: caseId }), _limit: 200 },
 	})
-	return response.data?.results || response.data || []
+	// `x?.results || x || []` admits a STRING: a non-empty body that is not JSON
+	// (Nextcloud answers an unmatched app route with an HTML page under HTTP 200)
+	// falls through to the raw body, and a `v-for` over a string renders one row
+	// per character. See procest#784.
+	const body = response.data
+	if (Array.isArray(body)) {
+		return body
+	}
+	if (body !== null && typeof body === 'object' && Array.isArray(body.results)) {
+		return body.results
+	}
+	return []
 }
 
 /**

--- a/src/views/dso/VthDashboard.vue
+++ b/src/views/dso/VthDashboard.vue
@@ -1,7 +1,12 @@
 <!--
   SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
   SPDX-License-Identifier: EUPL-1.2
-  @spec openspec/changes/dso-omgevingsloket/tasks.md#T07
+  @spec openspec/specs/dso-omgevingsloket/spec.md
+
+  NOTE: this used to read `@spec openspec/changes/dso-omgevingsloket/tasks.md#T07`.
+  That change directory does not exist — the whole path was dangling, not just the
+  `#T07` fragment — and a dangling `@spec` anchor is accepted silently, so it read
+  as traceability while pointing at nothing. Repointed at the canonical spec.
 -->
 <template>
 	<div class="vth-dashboard">
@@ -161,6 +166,19 @@ export default {
 	},
 	methods: {
 		t,
+		/**
+		 * Load the omgevingsvergunning list for the dashboard, applying the
+		 * active status / procedureType / gemeenteCode / activiteitgroep filters.
+		 *
+		 * Anchored at the canonical DSO spec FILE rather than a requirement:
+		 * no single requirement covers this dashboard's combined filter set.
+		 * REQ-DSO-010 covers the gemeenteCode/location filter only, and citing
+		 * it here would overstate what the spec says about the rest.
+		 *
+		 * @return {Promise<void>}
+		 *
+		 * @spec openspec/specs/dso-omgevingsloket/spec.md
+		 */
 		async loadCases() {
 			this.loading = true
 			this.error = null

--- a/src/views/dso/VthDashboard.vue
+++ b/src/views/dso/VthDashboard.vue
@@ -181,7 +181,16 @@ export default {
 
 				const url = generateUrl('/apps/procest/api/dso/dashboard')
 				const response = await axios.get(url, { params })
-				this.cases = response.data.cases || response.data || []
+				// Never assign an unvalidated body to a `v-for` source: `v-for`
+				// over a STRING iterates one item per character, so an HTML
+				// error page (served under HTTP 200 for an unmatched app route)
+				// renders one row per byte. See procest#784.
+				const body = response.data
+				if (body !== null && typeof body === 'object' && Array.isArray(body.cases)) {
+					this.cases = body.cases
+				} else {
+					this.cases = Array.isArray(body) ? body : []
+				}
 			} catch (err) {
 				this.error = t('procest', 'Failed to load omgevingsvergunningen: {message}', {
 					message: err?.response?.data?.message || err.message,

--- a/src/views/settings/tabs/ChecklistsTab.vue
+++ b/src/views/settings/tabs/ChecklistsTab.vue
@@ -152,6 +152,13 @@ export default {
 	},
 
 	methods: {
+		/**
+		 * Load the checklist collection for the admin list.
+		 *
+		 * @return {Promise<void>}
+		 *
+		 * @spec openspec/specs/inspection-checklists/spec.md#inspection-checklist-admin-ui
+		 */
 		async loadChecklists() {
 			this.loading = true
 			try {
@@ -178,11 +185,28 @@ export default {
 			this.editing = true
 		},
 
+		/**
+		 * Close the checklist editor and drop the working copy.
+		 *
+		 * @return {void}
+		 *
+		 * @spec openspec/specs/inspection-checklists/spec.md#inspection-checklist-admin-ui
+		 */
 		closeEditor() {
 			this.editing = false
 			this.editingChecklist = null
 		},
 
+		/**
+		 * Create or update a checklist, then reload the list.
+		 *
+		 * @param {object} checklist The checklist being saved; an `id` selects
+		 *                           update (PUT) over create (POST).
+		 *
+		 * @return {Promise<void>}
+		 *
+		 * @spec openspec/specs/inspection-checklists/spec.md#inspection-checklist-admin-ui
+		 */
 		async saveChecklist(checklist) {
 			this.saving = true
 			try {

--- a/src/views/settings/tabs/ChecklistsTab.vue
+++ b/src/views/settings/tabs/ChecklistsTab.vue
@@ -74,6 +74,54 @@ import { generateUrl } from '@nextcloud/router'
 import { showError, showSuccess } from '@nextcloud/dialogs'
 import InspectionChecklistEditor from '../../../components/InspectionChecklistEditor.vue'
 
+/**
+ * Checklist CRUD for the admin surface goes through procest's OWN controller.
+ *
+ * `InspectionChecklistController` already serves exactly the four verbs this tab
+ * uses — `GET/POST /api/vth/checklists` and `PUT/DELETE /api/vth/checklists/{id}`
+ * (appinfo/routes.php) — and every one of them is guarded with
+ * `#[AuthorizedAdminSetting(settings: AdminSettings::class)]`, which is the right
+ * posture for a control that lives in the admin settings page. It also routes
+ * through `InspectionChecklistService`, which owns checklist versioning and
+ * `caseTypeRef` filtering.
+ *
+ * The old URL, `/apps/procest/api/objects/inspectionChecklist`, matched NO route:
+ * procest's auto-exposed `/api/objects/<register>/<schema>` endpoints were deleted
+ * (appinfo/routes.php, "only engine routes remain"). Nextcloud answers an
+ * unmatched app URL with its own HTML page under **HTTP 200**, so axios never
+ * threw and the body was a 45,031-character string — see `asChecklistArray`.
+ *
+ * Addressing OpenRegister's generic object route instead would also have worked
+ * mechanically, and was this fix's first attempt. It is the wrong choice: it
+ * bypasses procest's admin-setting authorization, bypasses the service that owns
+ * versioning, and adds a second write path for a resource that already has one.
+ */
+const COLLECTION_URL = '/apps/procest/api/vth/checklists'
+
+/**
+ * Coerce an API response into the checklist array the template iterates.
+ *
+ * This guard is load-bearing, not defensive padding. `v-for` over a STRING
+ * iterates one item per character, so assigning an unvalidated response body
+ * straight to `checklists` rendered one table row — two NcButtons — per
+ * character of whatever came back. A 45,031-byte HTML error page produced
+ * 45,031 rows, 90,122 buttons and a 50 MB DOM on which Playwright's
+ * accessible-name computation never terminated (procest#784).
+ *
+ * @param {*} body Parsed response body, of any shape.
+ * @return {Array} The checklist rows, or an empty array when the body is not
+ *                 a recognised collection shape.
+ */
+function asChecklistArray(body) {
+	if (Array.isArray(body)) {
+		return body
+	}
+	if (body !== null && typeof body === 'object' && Array.isArray(body.results)) {
+		return body.results
+	}
+	return []
+}
+
 export default {
 	name: 'ChecklistsTab',
 
@@ -107,9 +155,8 @@ export default {
 		async loadChecklists() {
 			this.loading = true
 			try {
-				const url = generateUrl('/apps/procest/api/objects/inspectionChecklist')
-				const response = await axios.get(url)
-				this.checklists = response.data?.results || response.data || []
+				const response = await axios.get(generateUrl(COLLECTION_URL))
+				this.checklists = asChecklistArray(response.data)
 			} catch (e) {
 				showError(t('procest', 'Failed to load checklists'))
 			} finally {
@@ -140,8 +187,8 @@ export default {
 			this.saving = true
 			try {
 				const url = checklist.id
-					? generateUrl('/apps/procest/api/objects/inspectionChecklist/' + encodeURIComponent(checklist.id))
-					: generateUrl('/apps/procest/api/objects/inspectionChecklist')
+					? generateUrl(COLLECTION_URL + '/' + encodeURIComponent(checklist.id))
+					: generateUrl(COLLECTION_URL)
 				const method = checklist.id ? 'put' : 'post'
 				await axios[method](url, checklist)
 				showSuccess(t('procest', 'Checklist saved'))
@@ -177,7 +224,7 @@ export default {
 		async onConfirmDelete() {
 			const checklist = this.pendingDeleteChecklist
 			try {
-				const url = generateUrl('/apps/procest/api/objects/inspectionChecklist/' + encodeURIComponent(checklist.id))
+				const url = generateUrl(COLLECTION_URL + '/' + encodeURIComponent(checklist.id))
 				await axios.delete(url)
 				showSuccess(t('procest', 'Checklist deleted'))
 				this.showDeleteConfirm = false

--- a/tests/vitest/checklistsTabResponseShape.spec.js
+++ b/tests/vitest/checklistsTabResponseShape.spec.js
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction / Procest Contributors
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * Regression tests for procest#784 — the admin settings page's 41-50 MB DOM.
+ *
+ * MEASURED CAUSE, so the assertions below are not arbitrary. `ChecklistsTab`
+ * fetched `/apps/procest/api/objects/inspectionChecklist`, a route procest does
+ * not serve (its auto-exposed `/api/objects/<register>/<schema>` routes were
+ * deleted; OpenRegister serves them). Nextcloud answers an unmatched app URL
+ * with its own HTML page under **HTTP 200, `text/html`** — so axios did not
+ * throw and `response.data` was a 45,031-character STRING. The old assignment
+ *
+ *     this.checklists = response.data?.results || response.data || []
+ *
+ * admits that string (a string has no `.results`, and a non-empty string is
+ * truthy), and Vue's `v-for` over a string **iterates one item per character**.
+ * Live measurement of the rendered page: 45,031 rows, 90,122 buttons, 632,482
+ * elements, 50,372,821 bytes of HTML — 99.7 % of it inside this one section.
+ * Playwright's accessible-name computation on that DOM ran 804,859 ms without
+ * returning.
+ *
+ * These tests pin the two properties that jointly make that impossible:
+ *   1. a non-array, non-`{results:[]}` body renders ZERO rows;
+ *   2. the component addresses OpenRegister's route, not procest's dead one.
+ *
+ * TRUE-POSITIVE CONTROL, actually run rather than predicted: with the component
+ * stashed back to its pre-fix state, **4 of these 6 tests fail** —
+ *
+ *   renders ZERO rows … HTML page   → expected 0, got 4104
+ *   does not render one button …    → expected <=1, got 4104
+ *   renders ZERO rows … not a collection envelope → expected 0, got 1
+ *   addresses OpenRegister's route  → got '/index.php/apps/procest/api/objects/…'
+ *
+ * 4104 is the exact character length of `HTML_ERROR_PAGE` below: one row per
+ * character, reproduced in a unit test. (The live page's 45,031 rows are the
+ * same defect against Nextcloud's real 45,031-byte error page — this fixture is
+ * deliberately smaller so the suite stays fast.)
+ *
+ * @spec openspec/changes/vth-module/tasks.md#task-5
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { h } from 'vue'
+import { mount, flushPromises } from '@vue/test-utils'
+import axios from '@nextcloud/axios'
+
+// `@nextcloud/dialogs` reaches for a live Nextcloud runtime (toast container,
+// CSS side effects) at import time and has nothing to do with what is asserted
+// here — the component's response handling and the URL it addresses.
+vi.mock('@nextcloud/dialogs', () => ({
+	showError: vi.fn(),
+	showSuccess: vi.fn(),
+}))
+
+// Stub only the presentational children. `NcButton` is kept as a REAL <button>
+// element rather than a bare div: the defect's signature is button count, and a
+// stub that rendered no button would hide exactly the thing under test.
+const stub = (tag) => ({
+	name: 'Stub' + tag,
+	render() {
+		return h(tag, this.$slots.default ? this.$slots.default() : [])
+	},
+})
+vi.mock('@nextcloud/vue', () => ({
+	NcButton: {
+		name: 'NcButton',
+		render() {
+			return h('button', {}, this.$slots.default ? this.$slots.default() : [])
+		},
+	},
+	NcLoadingIcon: stub('span'),
+	NcEmptyContent: stub('div'),
+	NcIconSvgWrapper: stub('span'),
+}))
+vi.mock('@conduction/nextcloud-vue', () => ({
+	CnConfirmDialog: stub('div'),
+}))
+vi.mock('../../src/components/InspectionChecklistEditor.vue', () => ({
+	default: stub('div'),
+}))
+
+const ChecklistsTab = (await import('../../src/views/settings/tabs/ChecklistsTab.vue')).default
+
+/** A realistic stand-in for what Nextcloud actually returned: an HTML page. */
+const HTML_ERROR_PAGE = '<!DOCTYPE html>\n<html class="ng-csp" lang="en">'
+	+ '<head><title>Nextcloud</title></head><body>'
+	+ 'x'.repeat(4000)
+	+ '</body></html>'
+
+/**
+ * Mount the tab with a stubbed GET response body.
+ *
+ * @param {*} data The body axios should resolve with.
+ * @return {Promise<object>} The mounted wrapper, after promises have flushed.
+ */
+async function mountWith(data) {
+	axios.get.mockResolvedValue({ data })
+	const wrapper = mount(ChecklistsTab)
+	await flushPromises()
+	return wrapper
+}
+
+describe('ChecklistsTab — response-shape handling (procest#784)', () => {
+	beforeEach(() => {
+		axios.get.mockReset()
+	})
+
+	it('renders ZERO rows when the endpoint returns an HTML page instead of JSON', async () => {
+		const wrapper = await mountWith(HTML_ERROR_PAGE)
+
+		// The pre-fix component rendered one row per CHARACTER of this string.
+		expect(wrapper.findAll('.checklists-tab__item')).toHaveLength(0)
+	})
+
+	it('does not render one button per character of a string body', async () => {
+		const wrapper = await mountWith(HTML_ERROR_PAGE)
+
+		// Only the header's "New checklist" control may remain. The defect
+		// produced 2 buttons per character — 90,122 in the measured page.
+		expect(wrapper.findAll('button').length).toBeLessThanOrEqual(1)
+	})
+
+	it('renders one row per checklist for a well-formed array body', async () => {
+		const wrapper = await mountWith([
+			{ id: 'a', name: 'Bouw', active: true, version: 2, items: [{}, {}] },
+			{ id: 'b', name: 'Milieu', active: false, version: 1, items: [] },
+		])
+
+		const rows = wrapper.findAll('.checklists-tab__item')
+		expect(rows).toHaveLength(2)
+		expect(rows[0].text()).toContain('Bouw')
+		expect(rows[1].text()).toContain('Milieu')
+	})
+
+	it('unwraps the paginated `{ results: [...] }` envelope', async () => {
+		const wrapper = await mountWith({ results: [{ id: 'a', name: 'Bouw', items: [] }], total: 1 })
+
+		expect(wrapper.findAll('.checklists-tab__item')).toHaveLength(1)
+	})
+
+	it('renders ZERO rows for an object body that is not a collection envelope', async () => {
+		// e.g. OpenRegister's `{"message":"Register not found: 'procest'"}`.
+		const wrapper = await mountWith({ message: "Register not found: 'procest'" })
+
+		expect(wrapper.findAll('.checklists-tab__item')).toHaveLength(0)
+	})
+
+	it('addresses the admin-guarded InspectionChecklistController route', async () => {
+		await mountWith([])
+
+		expect(axios.get).toHaveBeenCalledTimes(1)
+		const url = axios.get.mock.calls[0][0]
+		// `/api/vth/checklists` is served by InspectionChecklistController, whose
+		// every verb carries #[AuthorizedAdminSetting]. Going straight to
+		// OpenRegister's generic object route would work mechanically but would
+		// bypass that guard and add a second write path — see the note on
+		// COLLECTION_URL.
+		expect(url).toContain('/apps/procest/api/vth/checklists')
+		// The dead route is what made Nextcloud serve HTML under HTTP 200.
+		expect(url).not.toContain('/api/objects/')
+	})
+})


### PR DESCRIPTION
Fixes the defect behind #784. **The premise everyone (including me, initially) was working from is wrong**, so the fix is not the one the issue proposed.

## Not "fourteen sections mount at once"

The issue's addendum proposed lazy-mounting `AdminRoot.vue`'s fourteen sections, while explicitly flagging its own reasoning as *"an inference, not a measurement"* and asking for a per-section census first. That census was run. It contradicts the inference:

```
[DOM] htmlBytes=50,372,821  elements=632,482  buttons=90,122  sections=17
   630,388 els  46,198,587 bytes   VTH Inspection Checklists   <-- 99.7 %
       167 els      10,569 bytes   ZGW API Mapping
        87 els       8,528 bytes   Case Email — Shared Mailbox
     … every remaining section is 8–81 elements …
```

**Thirteen of fourteen sections are 8–167 elements.** Lazy-mounting them removes ~0.3 % of the DOM and leaves the defect intact.

## What it actually is

`ChecklistsTab.vue` fetched `/apps/procest/api/objects/inspectionChecklist`. **procest does not serve that route** — its auto-exposed `/api/objects/<register>/<schema>` endpoints were deleted (`appinfo/routes.php:261`, *"only engine routes remain"*).

Nextcloud answers an unmatched app URL with its own HTML page, under **HTTP 200**:

```
status=200  contentType="text/html; charset=UTF-8"  bytes=45031
parseError="Unexpected token '<', \"<!DOCTYPE \"... is not valid JSON"
axiosDataType="string"   vForIterations=45031
```

So axios never threw. Then `this.checklists = response.data?.results || response.data || []` — a string has no `.results`, and a non-empty string is truthy — so `checklists` became the 45,031-character HTML string, and **`v-for` over a string iterates one item per character**. Each iteration renders a row and two `NcButton`s: 45,031 × 2 = 90,062, measured 90,122.

This needs **no data at all**. The row count is the length of an error page.

## Changes

1. **Address `/apps/procest/api/vth/checklists`.** `InspectionChecklistController` already serves exactly the four verbs this tab uses, every one guarded with `#[AuthorizedAdminSetting]`, routing through `InspectionChecklistService` which owns checklist versioning.

   OpenRegister's generic object route also resolves, and was this fix's first attempt. **It is the wrong choice** — it bypasses procest's admin authorization and adds a second write path for a resource that already has one. Recording that here because the mechanically-working fix and the correct fix were different.

2. **Never assign an unvalidated body to a `v-for` source.** Hardened in the two other places the same string-admitting idiom appears (`services/adviceApi.js`, `views/dso/VthDashboard.vue`). The safe idiom is the one `KlachtcategorieenTab.vue` already used.

3. **eslint**: a `tests/**` override for `n/no-unpublished-import`. Every vitest spec in the repo is an error under it; invisible because `npm run lint` is `eslint src`, so `tests/` is never linted.

## Verification — one clean rig, ZERO seeded data, changing only this source

| | before | after | after (repeat) |
|---|---|---|---|
| `.checklists-tab__item` rows | 40,057 | **0** | 0 |
| DOM elements | 562,729 | **2,284** | 2,284 |
| `<button>` | 80,187 | **98** | 98 |
| `outerHTML` bytes | 44,434,205 | **3,370,949** | 3,370,949 |
| `getByRole('button').count()` | 7,012 ms | **147 ms** | 147 ms |
| `getByRole('button',{name:/^Add (Item\|Case Type)$/}).count()` | **never returned (>60,000 ms)** | **87 ms → count = 1** | 87 ms → count = 1 |
| `locator('body').ariaSnapshot()` | **timed out at 30,000 ms** | **342 ms, 17,686 chars** | 342 ms |

44.4 MB against the issue's 41 MB from the CI trace. `ariaSnapshot()` timing out is the mechanism behind `error-context.md` having no `# Page snapshot` section, and behind the failure reading `Received: undefined`.

**Specs:** `case-types-tabs.spec.ts` + `spec-coverage/admin-settings.spec.ts` — **6 passed**. The test that burned its full 300 s cap in 2 of 2 observed runs now runs in **7.3 s**.

**True-positive control on the new vitest spec**, run rather than asserted: with the component stashed back to pre-fix, **4 of 6 fail**, reporting **4104 rows for a 4104-character body** — one row per character, reproduced in a unit test.

**Control for an unrelated red:** `spec-coverage/settings-pages.spec.ts` fails 10 on this rig **both with and without this change**, so those failures are pre-existing, not caused here. None of the three touched files is on those pages' code path — `ChecklistsTab` is imported only by `AdminRoot`.

## What was NOT done

No timeout raised, no assertion weakened, no test skipped or excluded, no `mode: 'serial'`, no `networkidle`, no baseline. The 300 s caps in both specs are now unjustified by their own stated reason and should come down — that tightens a gate and belongs in its own change with its own measurement.
