### PR TITLE
refactor(procest): TermijnNotificationDispatchJob → DeadlineNotificationDispatchJob

### DIFF
--- a/lib/BackgroundJob/DeadlineNotificationDispatchJob.php
+++ b/lib/BackgroundJob/DeadlineNotificationDispatchJob.php
@@ -66,6 +66,8 @@ class DeadlineNotificationDispatchJob extends QueuedJob
      *                        `type`, `termijnInstanceId`, `recipientUserId`, `context`.
      *
      * @return void
+     *
+     * @spec openspec/specs/burger-notifications/spec.md
      */
     protected function run($argument): void
     {

--- a/lib/BackgroundJob/DeadlineNotificationDispatchJob.php
+++ b/lib/BackgroundJob/DeadlineNotificationDispatchJob.php
@@ -42,7 +42,7 @@ use Psr\Log\LoggerInterface;
  *
  * @psalm-suppress UnusedClass
  */
-class TermijnNotificationDispatchJob extends QueuedJob
+class DeadlineNotificationDispatchJob extends QueuedJob
 {
     /**
      * Constructor.
@@ -70,7 +70,7 @@ class TermijnNotificationDispatchJob extends QueuedJob
     protected function run($argument): void
     {
         if (is_array($argument) === false) {
-            $this->logger->warning('TermijnNotificationDispatchJob: invalid argument');
+            $this->logger->warning('DeadlineNotificationDispatchJob: invalid argument');
             return;
         }
 
@@ -80,7 +80,7 @@ class TermijnNotificationDispatchJob extends QueuedJob
         $context           = (array) ($argument['context'] ?? []);
 
         if ($type === '' || $termijnInstanceId === '' || $recipientUserId === '') {
-            $this->logger->warning('TermijnNotificationDispatchJob: missing required argument keys', $argument);
+            $this->logger->warning('DeadlineNotificationDispatchJob: missing required argument keys', $argument);
             return;
         }
 
@@ -92,12 +92,12 @@ class TermijnNotificationDispatchJob extends QueuedJob
                 $context,
             );
             $this->logger->info(
-                'TermijnNotificationDispatchJob: delivered',
+                'DeadlineNotificationDispatchJob: delivered',
                 ['type' => $type, 'recipient' => $recipientUserId, 'instance' => $termijnInstanceId]
             );
         } catch (\Throwable $e) {
             $this->logger->error(
-                'TermijnNotificationDispatchJob: delivery failed',
+                'DeadlineNotificationDispatchJob: delivery failed',
                 ['error' => $e->getMessage(), 'type' => $type, 'recipient' => $recipientUserId]
             );
         }

--- a/lib/Service/TermijnNotificationService.php
+++ b/lib/Service/TermijnNotificationService.php
@@ -31,7 +31,7 @@ declare(strict_types=1);
 namespace OCA\Procest\Service;
 
 use InvalidArgumentException;
-use OCA\Procest\BackgroundJob\TermijnNotificationDispatchJob;
+use OCA\Procest\BackgroundJob\DeadlineNotificationDispatchJob;
 use OCP\BackgroundJob\IJobList;
 use Psr\Log\LoggerInterface;
 
@@ -94,7 +94,7 @@ class TermijnNotificationService
         }
 
         $this->jobList->add(
-                TermijnNotificationDispatchJob::class,
+                DeadlineNotificationDispatchJob::class,
                 [
                     'type'              => $type,
                     'termijnInstanceId' => $termijnInstanceId,


### PR DESCRIPTION
A **code-only** slice of `openspec/changes/english-vocabulary`, and the first procest slice — chosen because it is one of very few procest identifiers that is neither ZGW protocol vocabulary nor wired by string.

## Why `Deadline`, and why that's app-specific

`termijn` here is a **statutory deadline being monitored**, not a contract term. That reading is deliberately local: hrmq uses `termijn` for notice periods (`aanzegtermijn`), decidesk for terms of office (`TermijnRegeling`). Three apps, three meanings, one Dutch word — it must never become a fleet word, and the fleet spec says so.

## Why this one is safe

Referenced only via `::class` from `TermijnNotificationService`, so a missed reference is a **compile error**, not a job that silently never dispatches. Checked rather than assumed: no route entry, no register-fragment wiring, no phpmd/phpstan/psalm baseline suppression keyed to the old path.

## Not in this commit

`TermijnNotificationService` keeps its name — it belongs with the termijnbewaking slice, where the `Termijn*` schemas (`termijnDefinitie`, `termijnInstance`, `termijnGebeurtenis`) move together with their register fragments.

Archived changes under `openspec/changes/archive/` keep the old name; they record what was built at the time.

## Still blocking procest's main slice
`Besluit` → `Decision` cannot proceed: procest **already declares a `decision` schema** (*"A formal decision on a case"*) alongside `besluit`. That's a schema *merge*, which ADR-037 would resolve by concatenating list values — the shillinq#485 mechanism. It needs a modelling decision first, recorded as task 1.1 in the app's spec.

## Verification
`php -l` clean; class name matches file name; `use` statement still ordered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)