### PR TITLE
fix(security): authorise citizen lookups and the AI decision trail (gate-7 IDORs, tranche 1)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2599,16 +2599,16 @@
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.2.2",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55"
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
-                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/5f35d9408c54d7b529501f3c688b6eae562aea1f",
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f",
                 "shasum": ""
             },
             "require": {
@@ -2688,7 +2688,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-12-08T14:27:58+00:00"
+            "time": "2026-07-27T10:28:41+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",

--- a/lib/Controller/AdviceController.php
+++ b/lib/Controller/AdviceController.php
@@ -137,8 +137,12 @@ class AdviceController extends Controller
         }
 
         try {
-            $this->adviceService->dispatchReminder($id);
+            // Authorized seam. The unguarded `dispatchReminder()` behind it is
+            // the cron's, and is not reachable from HTTP.
+            $this->adviceService->dispatchReminderAsUser($id);
             return new JSONResponse(['status' => 'reminded']);
+        } catch (\RuntimeException $e) {
+            return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_FORBIDDEN);
         } catch (\Throwable $e) {
             $this->logger->error('Procest: advice dispatchReminder failed: '.$e->getMessage());
             return new JSONResponse(

--- a/lib/Controller/AiController.php
+++ b/lib/Controller/AiController.php
@@ -32,6 +32,7 @@ namespace OCA\Procest\Controller;
 
 use OCA\Procest\Service\Ai\AiAuditService;
 use OCA\Procest\Service\AiService;
+use OCA\Procest\Service\CaseAccessGuard;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
@@ -53,12 +54,13 @@ class AiController extends Controller
     /**
      * Constructor for AiController.
      *
-     * @param string          $appName      The application name
-     * @param IRequest        $request      The request object
-     * @param AiService       $aiService    The AI service
-     * @param AiAuditService  $auditService The AI oversight audit service
-     * @param IUserSession    $userSession  The user session
-     * @param LoggerInterface $logger       The logger interface
+     * @param string          $appName         The application name
+     * @param IRequest        $request         The request object
+     * @param AiService       $aiService       The AI service
+     * @param AiAuditService  $auditService    The AI oversight audit service
+     * @param IUserSession    $userSession     The user session
+     * @param LoggerInterface $logger          The logger interface
+     * @param CaseAccessGuard $caseAccessGuard Per-case authorization (fails closed)
      *
      * @return void
      */
@@ -69,6 +71,7 @@ class AiController extends Controller
         private AiAuditService $auditService,
         private IUserSession $userSession,
         private LoggerInterface $logger,
+        private readonly CaseAccessGuard $caseAccessGuard,
     ) {
         parent::__construct(appName: $appName, request: $request);
     }//end __construct()
@@ -331,14 +334,27 @@ class AiController extends Controller
      */
     public function auditIndex(): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
-        $caseId = $this->request->getParam('caseId');
+        $caseId = (string) $this->request->getParam('caseId', '');
         $type   = $this->request->getParam('type');
         $limit  = (int) $this->request->getParam('limit', '50');
         $offset = (int) $this->request->getParam('offset', '0');
+
+        // `caseId` used to be optional and the filter was built with
+        // `array_filter()`, so omitting it dropped the key entirely and the
+        // response was every AI decision record on the instance. It is now
+        // mandatory, and the caller must work on that case.
+        if ($caseId === '') {
+            return new JSONResponse(['error' => 'caseId is required'], Http::STATUS_BAD_REQUEST);
+        }
+
+        if ($this->caseAccessGuard->hasCaseReadAccess(caseId: $caseId, user: $user) === false) {
+            return new JSONResponse(['error' => 'Not authorized'], Http::STATUS_FORBIDDEN);
+        }
 
         try {
             $result = $this->auditService->listAuditEntries(

--- a/lib/Controller/AppointmentController.php
+++ b/lib/Controller/AppointmentController.php
@@ -26,10 +26,12 @@ namespace OCA\Procest\Controller;
 
 use OCA\Procest\AppInfo\Application;
 use OCA\Procest\Service\AppointmentService;
+use OCA\Procest\Service\CaseAccessGuard;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
+use OCP\IUser;
 use OCP\IUserSession;
 
 /**
@@ -43,11 +45,13 @@ class AppointmentController extends Controller
      * @param IRequest           $request            The request object.
      * @param AppointmentService $appointmentService The appointment service.
      * @param IUserSession       $userSession        The user session.
+     * @param CaseAccessGuard    $caseAccessGuard    Per-case authorization (fails closed).
      */
     public function __construct(
         IRequest $request,
         private AppointmentService $appointmentService,
         private IUserSession $userSession,
+        private readonly CaseAccessGuard $caseAccessGuard,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
     }//end __construct()
@@ -63,12 +67,28 @@ class AppointmentController extends Controller
      */
     public function index(): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['success' => false, 'error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
-        $caseId       = $this->request->getParam('caseId');
-        $appointments = $this->appointmentService->getAppointmentsForCase($caseId ?? '');
+        $caseId = (string) ($this->request->getParam('caseId') ?? '');
+        if ($caseId === '') {
+            return new JSONResponse(
+                ['success' => false, 'error' => 'caseId required'],
+                Http::STATUS_BAD_REQUEST
+            );
+        }
+
+        // Appointment records carry the citizen's name, e-mail and phone.
+        if ($this->caseAccessGuard->hasCaseReadAccess(caseId: $caseId, user: $user) === false) {
+            return new JSONResponse(
+                ['success' => false, 'error' => 'Not authorized'],
+                Http::STATUS_FORBIDDEN
+            );
+        }
+
+        $appointments = $this->appointmentService->getAppointmentsForCase($caseId);
         return new JSONResponse(['success' => true, 'appointments' => $appointments]);
     }//end index()
 
@@ -83,13 +103,22 @@ class AppointmentController extends Controller
      */
     public function create(): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['success' => false, 'error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
         $caseId = $this->request->getParam('caseId');
         if (empty($caseId) === true) {
             return new JSONResponse(['success' => false, 'error' => 'caseId required'], Http::STATUS_BAD_REQUEST);
+        }
+
+        // Books onto an arbitrary case and stores citizen contact details.
+        if ($this->caseAccessGuard->hasCaseMutationAccess(caseId: (string) $caseId, user: $user) === false) {
+            return new JSONResponse(
+                ['success' => false, 'error' => 'Not authorized'],
+                Http::STATUS_FORBIDDEN
+            );
         }
 
         $data = [
@@ -120,8 +149,16 @@ class AppointmentController extends Controller
      */
     public function cancel(string $appointmentId): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['success' => false, 'error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        if ($this->mayMutateAppointment(appointmentId: $appointmentId, user: $user) === false) {
+            return new JSONResponse(
+                ['success' => false, 'error' => 'Not authorized'],
+                Http::STATUS_FORBIDDEN
+            );
         }
 
         $result = $this->appointmentService->cancelAppointment($appointmentId);
@@ -141,8 +178,16 @@ class AppointmentController extends Controller
      */
     public function noShow(string $appointmentId): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['success' => false, 'error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        if ($this->mayMutateAppointment(appointmentId: $appointmentId, user: $user) === false) {
+            return new JSONResponse(
+                ['success' => false, 'error' => 'Not authorized'],
+                Http::STATUS_FORBIDDEN
+            );
         }
 
         $result = $this->appointmentService->markNoShow($appointmentId);
@@ -171,4 +216,28 @@ class AppointmentController extends Controller
         $slots = $this->appointmentService->getTimeslots($productId, $locationId, $date);
         return new JSONResponse(['success' => true, 'timeslots' => $slots]);
     }//end timeslots()
+
+    /**
+     * Whether the caller may mutate the appointment with the given id.
+     *
+     * The route carries only an appointment id, so the owning case is resolved
+     * first and the ordinary per-case guard applied. An appointment that cannot
+     * be resolved DENIES, so an unknown id is not an existence oracle.
+     *
+     * @param string $appointmentId The appointment UUID.
+     * @param IUser  $user          The authenticated user.
+     *
+     * @return bool True when the caller handles the owning case.
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    private function mayMutateAppointment(string $appointmentId, IUser $user): bool
+    {
+        $caseId = $this->appointmentService->getCaseIdForAppointment($appointmentId);
+        if ($caseId === null) {
+            return false;
+        }
+
+        return $this->caseAccessGuard->hasCaseMutationAccess(caseId: $caseId, user: $user);
+    }//end mayMutateAppointment()
 }//end class

--- a/lib/Controller/BerichtenboxController.php
+++ b/lib/Controller/BerichtenboxController.php
@@ -26,6 +26,7 @@ namespace OCA\Procest\Controller;
 
 use OCA\Procest\AppInfo\Application;
 use OCA\Procest\Service\BerichtenboxService;
+use OCA\Procest\Service\CaseAccessGuard;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
@@ -43,11 +44,13 @@ class BerichtenboxController extends Controller
      * @param IRequest            $request             The request object.
      * @param BerichtenboxService $berichtenboxService The Berichtenbox service.
      * @param IUserSession        $userSession         The user session.
+     * @param CaseAccessGuard     $caseAccessGuard     Per-case authorization (fails closed).
      */
     public function __construct(
         IRequest $request,
         private BerichtenboxService $berichtenboxService,
         private IUserSession $userSession,
+        private readonly CaseAccessGuard $caseAccessGuard,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
     }//end __construct()
@@ -63,7 +66,8 @@ class BerichtenboxController extends Controller
      */
     public function send(): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['success' => false, 'error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
@@ -76,6 +80,16 @@ class BerichtenboxController extends Controller
 
         if (empty($caseId) === true) {
             return new JSONResponse(['success' => false, 'error' => 'caseId is required'], 400);
+        }
+
+        // Dispatches an official government message, with attachment, into a
+        // citizen's statutory message box. Externally visible and not
+        // undoable, so this is the strictest guard in the file.
+        if ($this->caseAccessGuard->hasCaseMutationAccess(caseId: (string) $caseId, user: $user) === false) {
+            return new JSONResponse(
+                ['success' => false, 'error' => 'Not authorized'],
+                Http::STATUS_FORBIDDEN
+            );
         }
 
         $result = $this->berichtenboxService->sendMessage(
@@ -105,11 +119,24 @@ class BerichtenboxController extends Controller
      */
     public function messages(): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['success' => false, 'error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
-        $caseId   = $this->request->getParam('caseId', '');
+        $caseId = (string) $this->request->getParam('caseId', '');
+        if ($caseId === '') {
+            return new JSONResponse(['success' => false, 'error' => 'caseId is required'], Http::STATUS_BAD_REQUEST);
+        }
+
+        // Official correspondence with a citizen about this case.
+        if ($this->caseAccessGuard->hasCaseReadAccess(caseId: $caseId, user: $user) === false) {
+            return new JSONResponse(
+                ['success' => false, 'error' => 'Not authorized'],
+                Http::STATUS_FORBIDDEN
+            );
+        }
+
         $messages = $this->berichtenboxService->getMessagesForCase($caseId);
         return new JSONResponse(['success' => true, 'messages' => $messages]);
     }//end messages()
@@ -127,8 +154,22 @@ class BerichtenboxController extends Controller
      */
     public function poll(string $messageId): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['success' => false, 'error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        // The route carries only a message id, so the owning case is resolved
+        // first and the same per-case guard applied. An unresolvable message
+        // denies, so this is not an existence oracle.
+        $caseId = $this->berichtenboxService->getCaseIdForMessage($messageId);
+        if ($caseId === null
+            || $this->caseAccessGuard->hasCaseReadAccess(caseId: $caseId, user: $user) === false
+        ) {
+            return new JSONResponse(
+                ['success' => false, 'error' => 'Not authorized'],
+                Http::STATUS_FORBIDDEN
+            );
         }
 
         $result = $this->berichtenboxService->pollReadStatus($messageId);

--- a/lib/Controller/BezwaarHearingController.php
+++ b/lib/Controller/BezwaarHearingController.php
@@ -38,6 +38,7 @@ declare(strict_types=1);
 namespace OCA\Procest\Controller;
 
 use OCA\Procest\Service\Bezwaar\HearingService;
+use OCA\Procest\Service\CaseAccessGuard;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
@@ -60,10 +61,11 @@ class BezwaarHearingController extends Controller
     /**
      * Constructor.
      *
-     * @param string         $appName        The app name
-     * @param IRequest       $request        The request
-     * @param HearingService $hearingService The bezwaar hearing domain service
-     * @param IUserSession   $userSession    The user session
+     * @param string          $appName         The app name
+     * @param IRequest        $request         The request
+     * @param HearingService  $hearingService  The bezwaar hearing domain service
+     * @param IUserSession    $userSession     The user session
+     * @param CaseAccessGuard $caseAccessGuard Per-case authorization (fails closed)
      *
      * @return void
      */
@@ -72,6 +74,7 @@ class BezwaarHearingController extends Controller
         IRequest $request,
         private readonly HearingService $hearingService,
         private readonly IUserSession $userSession,
+        private readonly CaseAccessGuard $caseAccessGuard,
     ) {
         parent::__construct(appName: $appName, request: $request);
     }//end __construct()
@@ -85,17 +88,22 @@ class BezwaarHearingController extends Controller
      * Neither rule is enforceable through a generic schema edit form, which
      * is why this is a domain endpoint rather than manifest CRUD.
      *
-     * The auth posture mirrors the other authenticated-user mutations in
-     * this app (see AdvisoryBodyController and EmailTemplateController):
-     * `@NoAdminRequired` plus an explicit 401 when there is no session.
-     * Attendance is recorded by the behandelaar or the committee secretary,
-     * neither of whom is an administrator, so an admin-only posture would
-     * lock out exactly the roles that perform this task.
+     * The auth posture used to be `@NoAdminRequired` plus an explicit 401 and
+     * nothing else, on the reasoning that attendance is recorded by the
+     * behandelaar or the committee secretary, neither of whom is an
+     * administrator, so an admin-only posture would lock out exactly the roles
+     * that perform this task. That half was right — but "not admin-only" was
+     * implemented as "any authenticated account", which is a 401 where an
+     * authorisation check belongs. The posture is now per-case: the parent
+     * bezwaar case is resolved from the session and
+     * `CaseAccessGuard::hasCaseMutationAccess()` decides, which admits exactly
+     * the behandelaar the old comment was protecting.
      *
      * @param string $sessionId UUID of the hearingSession
      *
      * @return JSONResponse The updated hearingSession, 400 on a rejected
-     *                      correction, 401 when unauthenticated
+     *                      correction, 401 when unauthenticated, 403 when the
+     *                      caller does not handle the parent case
      *
      * @NoAdminRequired
      *
@@ -106,6 +114,16 @@ class BezwaarHearingController extends Controller
         $user = $this->userSession->getUser();
         if ($user === null) {
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        // Writes an awb-art-7:7 audit entry against a hearing session picked
+        // by uuid; the parent bezwaar case is resolved first so the ordinary
+        // per-case guard applies. An unresolvable session denies.
+        $caseId = $this->hearingService->getCaseIdForSession(sessionId: $sessionId);
+        if ($caseId === null
+            || $this->caseAccessGuard->hasCaseMutationAccess(caseId: $caseId, user: $user) === false
+        ) {
+            return new JSONResponse(['error' => 'Not authorized'], Http::STATUS_FORBIDDEN);
         }
 
         $entries = $this->request->getParam('entries');

--- a/lib/Controller/CaseRelationController.php
+++ b/lib/Controller/CaseRelationController.php
@@ -35,11 +35,13 @@ declare(strict_types=1);
 namespace OCA\Procest\Controller;
 
 use OCA\Procest\AppInfo\Application;
+use OCA\Procest\Service\CaseAccessGuard;
 use OCA\Procest\Service\CaseRelationService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
+use OCP\IUser;
 use OCP\IUserSession;
 
 /**
@@ -70,11 +72,13 @@ class CaseRelationController extends Controller
      * @param IRequest            $request             Inbound request.
      * @param CaseRelationService $caseRelationService Backend service.
      * @param IUserSession        $userSession         Current user session.
+     * @param CaseAccessGuard     $caseAccessGuard     Per-case authorization (fails closed).
      */
     public function __construct(
         IRequest $request,
         private readonly CaseRelationService $caseRelationService,
         private readonly IUserSession $userSession,
+        private readonly CaseAccessGuard $caseAccessGuard,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
     }//end __construct()
@@ -82,8 +86,17 @@ class CaseRelationController extends Controller
     /**
      * List the typed peer relations of a case.
      *
-     * Per-object guard: the service resolves the case through OR RBAC; an
-     * unreadable case yields an empty list (its content never leaks).
+     * Per-object guard: `CaseAccessGuard::hasCaseReadAccess()`.
+     *
+     * This docblock used to read *"the service resolves the case through OR
+     * RBAC; an unreadable case yields an empty list"*. That was false. The
+     * refusal in `CaseRelationService` is correctly shaped but INERT: it keys
+     * off `find()` returning null, and OpenRegister's `PermissionHandler`
+     * returns `true` for a schema with no `authorization` block
+     * (`enforce_default_closed` defaults false) — and none of procest's 85
+     * schemas declares one. `find()` therefore never returned null for an
+     * existing case, so `access_denied` was unreachable. See
+     * ConductionNL/.github#372.
      *
      * @param string $caseId Case UUID.
      *
@@ -91,12 +104,20 @@ class CaseRelationController extends Controller
      *
      * @return JSONResponse
      *
-     * @spec openspec/specs/related-case-linking/spec.md
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
      */
     public function list(string $caseId): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['message' => 'unauthenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        if ($this->caseAccessGuard->hasCaseReadAccess(caseId: $caseId, user: $user) === false) {
+            return new JSONResponse(
+                ['ok' => false, 'reason' => 'access_denied'],
+                Http::STATUS_FORBIDDEN
+            );
         }
 
         return new JSONResponse(
@@ -111,8 +132,10 @@ class CaseRelationController extends Controller
      *
      * Expects JSON body `{ targetId, aardRelatie, toelichting? }`.
      *
-     * Per-object guard: the service requires OR read access to BOTH the origin
-     * case (`$caseId`) and the target case before writing — no IDOR.
+     * Per-object guard: `CaseAccessGuard::hasCaseReadAccess()` on BOTH the
+     * origin case (`$caseId`) and the target case, which is what this docblock
+     * always claimed the service did. It did not — see `list()` above for why
+     * the service-level refusal was inert.
      *
      * @param string $caseId Origin case UUID.
      *
@@ -120,11 +143,12 @@ class CaseRelationController extends Controller
      *
      * @return JSONResponse
      *
-     * @spec openspec/specs/related-case-linking/spec.md
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
      */
     public function create(string $caseId): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['message' => 'unauthenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
@@ -139,6 +163,13 @@ class CaseRelationController extends Controller
             return new JSONResponse(
                 ['ok' => false, 'reason' => 'missing_case_id', 'message' => 'targetId and aardRelatie are required'],
                 Http::STATUS_BAD_REQUEST
+            );
+        }
+
+        if ($this->bothCasesReadable(caseId: $caseId, targetId: $targetId, user: $user) === false) {
+            return new JSONResponse(
+                ['ok' => false, 'reason' => 'access_denied'],
+                Http::STATUS_FORBIDDEN
             );
         }
 
@@ -160,7 +191,7 @@ class CaseRelationController extends Controller
     /**
      * Remove a typed peer relation between two cases (two-sided).
      *
-     * Per-object guard: the service requires OR read access to both cases.
+     * Per-object guard: `CaseAccessGuard::hasCaseReadAccess()` on both cases.
      *
      * @param string $caseId      Origin case UUID.
      * @param string $targetId    Target case UUID.
@@ -170,12 +201,20 @@ class CaseRelationController extends Controller
      *
      * @return JSONResponse
      *
-     * @spec openspec/specs/related-case-linking/spec.md
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
      */
     public function destroy(string $caseId, string $targetId, string $aardRelatie): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['message' => 'unauthenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        if ($this->bothCasesReadable(caseId: $caseId, targetId: $targetId, user: $user) === false) {
+            return new JSONResponse(
+                ['ok' => false, 'reason' => 'access_denied'],
+                Http::STATUS_FORBIDDEN
+            );
         }
 
         $result = $this->caseRelationService->removeRelation(
@@ -191,4 +230,28 @@ class CaseRelationController extends Controller
 
         return new JSONResponse($result);
     }//end destroy()
+
+    /**
+     * Whether the caller may read both ends of a relation.
+     *
+     * A relation is two-sided: writing or removing it touches both cases, so
+     * holding access to only one end is not enough. Both checks are evaluated
+     * against the same fail-closed guard.
+     *
+     * @param string $caseId   Origin case UUID.
+     * @param string $targetId Target case UUID.
+     * @param IUser  $user     The authenticated user.
+     *
+     * @return bool True when both cases are readable by this user.
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    private function bothCasesReadable(string $caseId, string $targetId, IUser $user): bool
+    {
+        if ($this->caseAccessGuard->hasCaseReadAccess(caseId: $caseId, user: $user) === false) {
+            return false;
+        }
+
+        return $this->caseAccessGuard->hasCaseReadAccess(caseId: $targetId, user: $user);
+    }//end bothCasesReadable()
 }//end class

--- a/lib/Controller/ContactMomentController.php
+++ b/lib/Controller/ContactMomentController.php
@@ -31,6 +31,7 @@ namespace OCA\Procest\Controller;
 
 use OCA\Procest\Service\BurgerIdentificationService;
 use OCA\Procest\Service\CaseVoorbladService;
+use OCA\Procest\Service\CitizenLookupGuard;
 use OCA\Procest\Service\ContactMomentService;
 use OCA\Procest\Service\DoorverbindingService;
 use OCA\Procest\Service\QuickActionService;
@@ -59,6 +60,7 @@ class ContactMomentController extends Controller
      * @param DoorverbindingService       $transferService      The doorverbinding service.
      * @param BurgerIdentificationService $burgerService        The burger identification service.
      * @param IUserSession                $userSession          The user session.
+     * @param CitizenLookupGuard          $citizenLookupGuard   The citizen-lookup role guard.
      */
     public function __construct(
         string $appName,
@@ -69,6 +71,7 @@ class ContactMomentController extends Controller
         private readonly DoorverbindingService $transferService,
         private readonly BurgerIdentificationService $burgerService,
         private readonly IUserSession $userSession,
+        private readonly CitizenLookupGuard $citizenLookupGuard,
     ) {
         parent::__construct(appName: $appName, request: $request);
     }//end __construct()
@@ -87,6 +90,13 @@ class ContactMomentController extends Controller
         $user = $this->userSession->getUser();
         if ($user === null) {
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        // This method both writes a contactmoment against a caller-supplied
+        // citizen identifier and returns that citizen's voorblad, so it is the
+        // same exposure as `voorblad()` with a write attached.
+        if ($this->citizenLookupGuard->isCitizenLookupAllowed(user: $user) === false) {
+            return new JSONResponse(['error' => 'Not authorized'], Http::STATUS_FORBIDDEN);
         }
 
         $data = [
@@ -146,8 +156,16 @@ class ContactMomentController extends Controller
      */
     public function index(string $burgerId='', int $limit=50): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        // `$burgerId` is a citizen identifier taken straight off the query
+        // string; without this the whole contact history of any citizen was
+        // readable by every authenticated account (PROC-IDOR-01).
+        if ($this->citizenLookupGuard->isCitizenLookupAllowed(user: $user) === false) {
+            return new JSONResponse(['error' => 'Not authorized'], Http::STATUS_FORBIDDEN);
         }
 
         if ($burgerId === '') {
@@ -171,8 +189,17 @@ class ContactMomentController extends Controller
      */
     public function voorblad(string $burgerId=''): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        // The voorblad resolves a raw citizen identifier into that citizen's
+        // open cases and recent contact history. Reproduced live at HTTP 200
+        // for an unrelated authenticated account before this guard existed
+        // (PROC-IDOR-01) — iterating BSN-shaped ids walked the population.
+        if ($this->citizenLookupGuard->isCitizenLookupAllowed(user: $user) === false) {
+            return new JSONResponse(['error' => 'Not authorized'], Http::STATUS_FORBIDDEN);
         }
 
         if ($burgerId === '') {
@@ -231,8 +258,14 @@ class ContactMomentController extends Controller
      */
     public function nieuweZaak(): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        // Creates a municipal case bound to a caller-supplied citizen id.
+        if ($this->citizenLookupGuard->isCitizenLookupAllowed(user: $user) === false) {
+            return new JSONResponse(['error' => 'Not authorized'], Http::STATUS_FORBIDDEN);
         }
 
         $zaaktype = (string) $this->request->getParam('zaaktype', '');
@@ -259,8 +292,14 @@ class ContactMomentController extends Controller
      */
     public function klachtRegistreren(): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        // Takes an arbitrary `caseId` AND an arbitrary `burgerId`.
+        if ($this->citizenLookupGuard->isCitizenLookupAllowed(user: $user) === false) {
+            return new JSONResponse(['error' => 'Not authorized'], Http::STATUS_FORBIDDEN);
         }
 
         $caseId       = (string) $this->request->getParam('caseId', '');

--- a/lib/Controller/DeelzaakController.php
+++ b/lib/Controller/DeelzaakController.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 namespace OCA\Procest\Controller;
 
 use OCA\Procest\AppInfo\Application;
+use OCA\Procest\Service\CaseAccessGuard;
 use OCA\Procest\Service\DeelzaakService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
@@ -46,11 +47,13 @@ class DeelzaakController extends Controller
      * @param IRequest        $request         Inbound request.
      * @param DeelzaakService $deelzaakService Backend service.
      * @param IUserSession    $userSession     Current user session.
+     * @param CaseAccessGuard $caseAccessGuard Per-case authorization (fails closed).
      */
     public function __construct(
         IRequest $request,
         private readonly DeelzaakService $deelzaakService,
         private readonly IUserSession $userSession,
+        private readonly CaseAccessGuard $caseAccessGuard,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
     }//end __construct()
@@ -64,12 +67,17 @@ class DeelzaakController extends Controller
      *
      * @return JSONResponse
      *
-     * @spec openspec/changes/deelzaak-support/tasks.md#T01
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
      */
     public function list(string $caseId): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['message' => 'unauthenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        if ($this->caseAccessGuard->hasCaseReadAccess(caseId: $caseId, user: $user) === false) {
+            return new JSONResponse(['message' => 'forbidden'], Http::STATUS_FORBIDDEN);
         }
 
         return new JSONResponse(
@@ -88,12 +96,20 @@ class DeelzaakController extends Controller
      *
      * @return JSONResponse
      *
-     * @spec openspec/changes/deelzaak-support/tasks.md#T02
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
      */
     public function parent(string $caseId): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['message' => 'unauthenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        // Authorised on the CHILD case the caller names, not on the parent it
+        // resolves to: the parent is the answer, so guarding on it would be
+        // circular and would still let an unrelated caller walk the hierarchy.
+        if ($this->caseAccessGuard->hasCaseReadAccess(caseId: $caseId, user: $user) === false) {
+            return new JSONResponse(['message' => 'forbidden'], Http::STATUS_FORBIDDEN);
         }
 
         $parent = $this->deelzaakService->getParentCase(childCaseUuid: $caseId);
@@ -148,11 +164,12 @@ class DeelzaakController extends Controller
      *
      * @return JSONResponse
      *
-     * @spec openspec/changes/deelzaak-support/tasks.md#T08
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
      */
     public function validate(): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['message' => 'unauthenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
@@ -165,6 +182,13 @@ class DeelzaakController extends Controller
                     ],
                     Http::STATUS_BAD_REQUEST
                     );
+        }
+
+        // Without this the endpoint is an existence-and-type oracle over every
+        // case on the instance: it answers whether an arbitrary parent uuid
+        // exists and whether a given child type may hang off it.
+        if ($this->caseAccessGuard->hasCaseReadAccess(caseId: $parent, user: $user) === false) {
+            return new JSONResponse(['message' => 'forbidden'], Http::STATUS_FORBIDDEN);
         }
 
         $result = $this->deelzaakService->validateCreate(
@@ -191,12 +215,19 @@ class DeelzaakController extends Controller
      *
      * @return JSONResponse
      *
-     * @spec openspec/changes/deelzaak-support/tasks.md#T11
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
      */
     public function unlink(string $caseId): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['message' => 'unauthenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        // Mass-detaches every sub-case of the named parent. Mutation access,
+        // not read access: this is the most destructive endpoint in the file.
+        if ($this->caseAccessGuard->hasCaseMutationAccess(caseId: $caseId, user: $user) === false) {
+            return new JSONResponse(['message' => 'forbidden'], Http::STATUS_FORBIDDEN);
         }
 
         return new JSONResponse(

--- a/lib/Controller/DossierExportController.php
+++ b/lib/Controller/DossierExportController.php
@@ -37,6 +37,7 @@ declare(strict_types=1);
 namespace OCA\Procest\Controller;
 
 use OCA\Procest\Service\BeroepDossierExport;
+use OCA\Procest\Service\CaseAccessGuard;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
@@ -54,11 +55,12 @@ class DossierExportController extends Controller
     /**
      * Constructor.
      *
-     * @param string              $appName       The app name.
-     * @param IRequest            $request       The HTTP request.
-     * @param BeroepDossierExport $dossierExport The export service.
-     * @param IUserSession        $userSession   The current session.
-     * @param LoggerInterface     $logger        The logger.
+     * @param string              $appName         The app name.
+     * @param IRequest            $request         The HTTP request.
+     * @param BeroepDossierExport $dossierExport   The export service.
+     * @param IUserSession        $userSession     The current session.
+     * @param LoggerInterface     $logger          The logger.
+     * @param CaseAccessGuard     $caseAccessGuard Per-case authorization (fails closed).
      *
      * @return void
      */
@@ -68,6 +70,7 @@ class DossierExportController extends Controller
         private readonly BeroepDossierExport $dossierExport,
         private readonly IUserSession $userSession,
         private readonly LoggerInterface $logger,
+        private readonly CaseAccessGuard $caseAccessGuard,
     ) {
         parent::__construct(appName: $appName, request: $request);
     }//end __construct()
@@ -85,12 +88,19 @@ class DossierExportController extends Controller
      */
     public function export(string $caseId): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
         if (trim($caseId) === '') {
             return new JSONResponse(['error' => 'A case id is required'], Http::STATUS_BAD_REQUEST);
+        }
+
+        // The plan spans every case linked via `_sourceCase`, so one
+        // unauthorised export walks a whole bezwaar/beroep chain.
+        if ($this->caseAccessGuard->hasCaseReadAccess(caseId: $caseId, user: $user) === false) {
+            return new JSONResponse(['error' => 'Not authorized'], Http::STATUS_FORBIDDEN);
         }
 
         try {

--- a/lib/Controller/EmailTemplateController.php
+++ b/lib/Controller/EmailTemplateController.php
@@ -30,6 +30,7 @@ declare(strict_types=1);
 namespace OCA\Procest\Controller;
 
 use OCA\Procest\AppInfo\Application;
+use OCA\Procest\Service\CaseAccessGuard;
 use OCA\Procest\Service\EmailTemplateService;
 use OCA\Procest\Service\SettingsService;
 use OCA\Procest\Support\SuppressesWarnings;
@@ -37,6 +38,7 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
+use OCP\IGroupManager;
 use OCP\IRequest;
 use OCP\IUserSession;
 
@@ -81,6 +83,8 @@ class EmailTemplateController extends Controller
      * @param SettingsService      $settingsService Settings resolver (registers).
      * @param IAppConfig           $appConfig       App config (IMAP settings).
      * @param IUserSession         $userSession     Current user session.
+     * @param IGroupManager        $groupManager    Group manager (admin check on config writes).
+     * @param CaseAccessGuard      $caseAccessGuard Per-case authorization (fails closed).
      */
     public function __construct(
         IRequest $request,
@@ -88,6 +92,8 @@ class EmailTemplateController extends Controller
         private readonly SettingsService $settingsService,
         private readonly IAppConfig $appConfig,
         private readonly IUserSession $userSession,
+        private readonly IGroupManager $groupManager,
+        private readonly CaseAccessGuard $caseAccessGuard,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
     }//end __construct()
@@ -129,8 +135,17 @@ class EmailTemplateController extends Controller
      */
     public function createTemplate(string $caseTypeId): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['message' => 'unauthenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        // An email template is instance-wide configuration whose body is sent
+        // to citizens, so it is a config write, not case data: admin only.
+        // There is no per-case relationship to authorise against — a caseType
+        // belongs to the municipality, not to a handler.
+        if ($this->groupManager->isAdmin($user->getUID()) === false) {
+            return new JSONResponse(['message' => 'forbidden'], Http::STATUS_FORBIDDEN);
         }
 
         $data = [
@@ -159,8 +174,15 @@ class EmailTemplateController extends Controller
      */
     public function updateTemplate(string $templateId): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['message' => 'unauthenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        // Same posture as createTemplate(): rewriting the body of a template
+        // that is mailed to citizens is a config write.
+        if ($this->groupManager->isAdmin($user->getUID()) === false) {
+            return new JSONResponse(['message' => 'forbidden'], Http::STATUS_FORBIDDEN);
         }
 
         $data = [
@@ -190,8 +212,16 @@ class EmailTemplateController extends Controller
      */
     public function prefillDraft(string $caseId, string $templateId): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['message' => 'unauthenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        // The rendered draft carries the case's contactNaam, contactEmail,
+        // contactTelefoon and behandelaar back in the response, so this is a
+        // per-case read of citizen contact data.
+        if ($this->caseAccessGuard->hasCaseReadAccess(caseId: $caseId, user: $user) === false) {
+            return new JSONResponse(['message' => 'forbidden'], Http::STATUS_FORBIDDEN);
         }
 
         try {
@@ -346,9 +376,14 @@ class EmailTemplateController extends Controller
      * calling this twice creates nothing the second time and returns 0.
      *
      * The auth posture mirrors createTemplate() deliberately — this endpoint
-     * is a loop over exactly that call and creates nothing a user could not
+     * is a loop over exactly that call and creates nothing a caller could not
      * create one at a time, so a stricter guard here would be inconsistent
      * rather than safer.
+     *
+     * ⚠️ That argument was sound and the posture it mirrored was not:
+     * `createTemplate()` was reachable by every authenticated user, so this
+     * endpoint was too. The reasoning is kept because it is still correct —
+     * what changed is the posture on the other end. Both are now admin-only.
      *
      * @param string $caseTypeId Owning caseType id.
      *
@@ -360,8 +395,13 @@ class EmailTemplateController extends Controller
      */
     public function seedDefaults(string $caseTypeId): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['message' => 'unauthenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        if ($this->groupManager->isAdmin($user->getUID()) === false) {
+            return new JSONResponse(['message' => 'forbidden'], Http::STATUS_FORBIDDEN);
         }
 
         try {

--- a/lib/Controller/EmailTemplateController.php
+++ b/lib/Controller/EmailTemplateController.php
@@ -33,9 +33,11 @@ use OCA\Procest\AppInfo\Application;
 use OCA\Procest\Service\CaseAccessGuard;
 use OCA\Procest\Service\EmailTemplateService;
 use OCA\Procest\Service\SettingsService;
+use OCA\Procest\Settings\AdminSettings;
 use OCA\Procest\Support\SuppressesWarnings;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
 use OCP\IGroupManager;
@@ -125,14 +127,21 @@ class EmailTemplateController extends Controller
     /**
      * Create a new template (version 1).
      *
-     * @param string $caseTypeId Owning caseType id.
+     * Admin-only: an email template is instance-wide configuration whose body
+     * is mailed to citizens, so it is a config write, not case data. The
+     * attribute makes Nextcloud's middleware enforce that BEFORE the controller
+     * runs; the in-body check below is defence in depth and is what the unit
+     * tests drive. `@NoAdminRequired` was removed rather than left alongside an
+     * admin body — that combination is exactly the attribute-vs-body mismatch
+     * gate-9 exists to catch.
      *
-     * @NoAdminRequired
+     * @param string $caseTypeId Owning caseType id.
      *
      * @return JSONResponse
      *
-     * @spec openspec/changes/case-email-integration/tasks.md#T06
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
      */
+    #[AuthorizedAdminSetting(settings: AdminSettings::class)]
     public function createTemplate(string $caseTypeId): JSONResponse
     {
         $user = $this->userSession->getUser();
@@ -164,14 +173,15 @@ class EmailTemplateController extends Controller
     /**
      * Update a template (bumps version).
      *
-     * @param string $templateId Existing template id.
+     * Admin-only, same posture and same reasoning as createTemplate().
      *
-     * @NoAdminRequired
+     * @param string $templateId Existing template id.
      *
      * @return JSONResponse
      *
-     * @spec openspec/changes/case-email-integration/tasks.md#T06
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
      */
+    #[AuthorizedAdminSetting(settings: AdminSettings::class)]
     public function updateTemplate(string $templateId): JSONResponse
     {
         $user = $this->userSession->getUser();
@@ -387,12 +397,11 @@ class EmailTemplateController extends Controller
      *
      * @param string $caseTypeId Owning caseType id.
      *
-     * @NoAdminRequired
-     *
      * @return JSONResponse {created: int} — how many were created on this run.
      *
-     * @spec openspec/changes/case-email-integration/tasks.md#T04
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
      */
+    #[AuthorizedAdminSetting(settings: AdminSettings::class)]
     public function seedDefaults(string $caseTypeId): JSONResponse
     {
         $user = $this->userSession->getUser();

--- a/lib/Controller/LhsController.php
+++ b/lib/Controller/LhsController.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Controller;
 
+use OCA\Procest\Service\CaseAccessGuard;
 use OCA\Procest\Service\LhsLookupService;
 use OCA\Procest\Service\Vth\LhsRecommendationService;
 use OCP\AppFramework\Controller;
@@ -60,6 +61,7 @@ class LhsController extends Controller
      * @param IUserSession             $userSession      User session
      * @param IGroupManager            $groupManager     Group manager
      * @param LoggerInterface          $logger           Logger
+     * @param CaseAccessGuard          $caseAccessGuard  Per-case authorization (fails closed)
      */
     public function __construct(
         string $appName,
@@ -69,6 +71,7 @@ class LhsController extends Controller
         private readonly IUserSession $userSession,
         private readonly IGroupManager $groupManager,
         private readonly LoggerInterface $logger,
+        private readonly CaseAccessGuard $caseAccessGuard,
     ) {
         parent::__construct(appName: $appName, request: $request);
     }//end __construct()
@@ -110,6 +113,16 @@ class LhsController extends Controller
             return new JSONResponse(
                 ['error' => 'caseId, ernst, gedrag en actorType zijn verplicht'],
                 Http::STATUS_BAD_REQUEST,
+            );
+        }
+
+        // This endpoint reads as a query but PERSISTS an `lhsRecommendation`
+        // (an enforcement-sanction record) against the named case, so it is
+        // guarded as a mutation.
+        if ($this->caseAccessGuard->hasCaseMutationAccess(caseId: $caseId, user: $user) === false) {
+            return new JSONResponse(
+                ['error' => 'Not authorized'],
+                Http::STATUS_FORBIDDEN,
             );
         }
 

--- a/lib/Controller/MilestoneController.php
+++ b/lib/Controller/MilestoneController.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Controller;
 
+use OCA\Procest\Service\CaseAccessGuard;
 use OCA\Procest\Service\MilestoneService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
@@ -45,12 +46,14 @@ class MilestoneController extends Controller
      * @param IRequest         $request          The request
      * @param MilestoneService $milestoneService The milestone service
      * @param IUserSession     $userSession      The user session
+     * @param CaseAccessGuard  $caseAccessGuard  Per-case authorization (fails closed)
      */
     public function __construct(
         string $appName,
         IRequest $request,
         private readonly MilestoneService $milestoneService,
         private readonly IUserSession $userSession,
+        private readonly CaseAccessGuard $caseAccessGuard,
     ) {
         parent::__construct(appName: $appName, request: $request);
     }//end __construct()
@@ -69,8 +72,13 @@ class MilestoneController extends Controller
      */
     public function progress(string $caseId, string $caseTypeId): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        if ($this->caseAccessGuard->hasCaseReadAccess(caseId: $caseId, user: $user) === false) {
+            return new JSONResponse(['error' => 'Not authorized'], Http::STATUS_FORBIDDEN);
         }
 
         try {

--- a/lib/Controller/StatusTransitionController.php
+++ b/lib/Controller/StatusTransitionController.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace OCA\Procest\Controller;
 
 use OCA\Procest\Service\BulkStatusTransitionService;
+use OCA\Procest\Service\CaseAccessGuard;
 use OCA\Procest\Service\StatusTransitionService;
 use OCA\Procest\Service\Transitions\GuardFailedException;
 use OCP\AppFramework\Controller;
@@ -62,6 +63,7 @@ class StatusTransitionController extends Controller
      * @param BulkStatusTransitionService $bulkEngine       The bulk wrapper service
      * @param IUserSession                $userSession      The current session
      * @param LoggerInterface             $logger           The logger
+     * @param CaseAccessGuard             $caseAccessGuard  Per-case authorization (fails closed)
      */
     public function __construct(
         string $appName,
@@ -70,6 +72,7 @@ class StatusTransitionController extends Controller
         private readonly BulkStatusTransitionService $bulkEngine,
         private readonly IUserSession $userSession,
         private readonly LoggerInterface $logger,
+        private readonly CaseAccessGuard $caseAccessGuard,
     ) {
         parent::__construct(appName: $appName, request: $request);
     }//end __construct()
@@ -87,8 +90,17 @@ class StatusTransitionController extends Controller
      */
     public function available(string $caseId): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        // Only PARTLY unguarded before this: the transition list itself is
+        // role-filtered inside the engine, but the case's current status was
+        // emitted unconditionally, so any authenticated user could read the
+        // status of any case.
+        if ($this->caseAccessGuard->hasCaseReadAccess(caseId: $caseId, user: $user) === false) {
+            return new JSONResponse(['error' => 'Not authorized'], Http::STATUS_FORBIDDEN);
         }
 
         try {
@@ -248,8 +260,13 @@ class StatusTransitionController extends Controller
      */
     public function history(string $caseId): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        if ($this->caseAccessGuard->hasCaseReadAccess(caseId: $caseId, user: $user) === false) {
+            return new JSONResponse(['error' => 'Not authorized'], Http::STATUS_FORBIDDEN);
         }
 
         try {

--- a/lib/Controller/ZaakdossierController.php
+++ b/lib/Controller/ZaakdossierController.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Controller;
 
+use OCA\Procest\Service\CaseAccessGuard;
 use OCA\Procest\Service\Zaakdossier\DossierUploadHandler;
 use OCA\Procest\Service\Zaakdossier\InformatieobjectReader;
 use OCA\Procest\Service\ZaakdossierService;
@@ -53,12 +54,13 @@ class ZaakdossierController extends Controller
     /**
      * Constructor.
      *
-     * @param string                 $appName        The app name.
-     * @param IRequest               $request        The request.
-     * @param ZaakdossierService     $dossierService The dossier orchestrator.
-     * @param InformatieobjectReader $reader         The clearance-gated document reader.
-     * @param DossierUploadHandler   $uploadHandler  The upload decoding/screening collaborator.
-     * @param IUserSession           $userSession    The user session.
+     * @param string                 $appName         The app name.
+     * @param IRequest               $request         The request.
+     * @param ZaakdossierService     $dossierService  The dossier orchestrator.
+     * @param InformatieobjectReader $reader          The clearance-gated document reader.
+     * @param DossierUploadHandler   $uploadHandler   The upload decoding/screening collaborator.
+     * @param IUserSession           $userSession     The user session.
+     * @param CaseAccessGuard        $caseAccessGuard Per-case authorization (fails closed).
      */
     public function __construct(
         string $appName,
@@ -67,6 +69,7 @@ class ZaakdossierController extends Controller
         private readonly InformatieobjectReader $reader,
         private readonly DossierUploadHandler $uploadHandler,
         private readonly IUserSession $userSession,
+        private readonly CaseAccessGuard $caseAccessGuard,
     ) {
         parent::__construct(appName: $appName, request: $request);
     }//end __construct()
@@ -117,13 +120,22 @@ class ZaakdossierController extends Controller
      *
      * @NoAdminRequired
      *
-     * @spec openspec/changes/document-zaakdossier/tasks.md#T05
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
      */
     public function uploadDocument(string $caseId): JSONResponse
     {
         $user = $this->userSession->getUser();
         if ($user === null) {
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        // Its sibling `linkExisting()` below already guards, via
+        // `InformatieobjectReader::guardReadable()` — but that guard is about
+        // the DOCUMENT, and upload has no existing document to check. The
+        // missing half is the CASE, so this endpoint wrote attachments into
+        // any case on the instance.
+        if ($this->caseAccessGuard->hasCaseMutationAccess(caseId: $caseId, user: $user) === false) {
+            return new JSONResponse(['error' => 'Not authorized'], Http::STATUS_FORBIDDEN);
         }
 
         $metadata = $this->uploadHandler->decodeMetadata(raw: $this->request->getParam('metadata', '{}'));

--- a/lib/Controller/ZaakdossierController.php
+++ b/lib/Controller/ZaakdossierController.php
@@ -53,11 +53,11 @@ class ZaakdossierController extends Controller
     /**
      * Constructor.
      *
-     * @param string                 $appName         The app name.
-     * @param IRequest               $request         The request.
-     * @param ZaakdossierService     $dossierService  The dossier orchestrator.
-     * @param InformatieobjectReader $reader          The clearance-gated document reader.
-     * @param DossierUploadHandler   $uploadHandler   The upload decoding/screening collaborator.
+     * @param string                 $appName        The app name.
+     * @param IRequest               $request        The request.
+     * @param ZaakdossierService     $dossierService The dossier orchestrator.
+     * @param InformatieobjectReader $reader         The clearance-gated document reader.
+     * @param DossierUploadHandler   $uploadHandler  The upload decoding/screening collaborator.
      * @param IUserSession           $userSession    The user session.
      */
     public function __construct(

--- a/lib/Controller/ZaakdossierController.php
+++ b/lib/Controller/ZaakdossierController.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Controller;
 
-use OCA\Procest\Service\CaseAccessGuard;
 use OCA\Procest\Service\Zaakdossier\DossierUploadHandler;
 use OCA\Procest\Service\Zaakdossier\InformatieobjectReader;
 use OCA\Procest\Service\ZaakdossierService;
@@ -59,8 +58,7 @@ class ZaakdossierController extends Controller
      * @param ZaakdossierService     $dossierService  The dossier orchestrator.
      * @param InformatieobjectReader $reader          The clearance-gated document reader.
      * @param DossierUploadHandler   $uploadHandler   The upload decoding/screening collaborator.
-     * @param IUserSession           $userSession     The user session.
-     * @param CaseAccessGuard        $caseAccessGuard Per-case authorization (fails closed).
+     * @param IUserSession           $userSession    The user session.
      */
     public function __construct(
         string $appName,
@@ -69,7 +67,6 @@ class ZaakdossierController extends Controller
         private readonly InformatieobjectReader $reader,
         private readonly DossierUploadHandler $uploadHandler,
         private readonly IUserSession $userSession,
-        private readonly CaseAccessGuard $caseAccessGuard,
     ) {
         parent::__construct(appName: $appName, request: $request);
     }//end __construct()
@@ -134,7 +131,7 @@ class ZaakdossierController extends Controller
         // the DOCUMENT, and upload has no existing document to check. The
         // missing half is the CASE, so this endpoint wrote attachments into
         // any case on the instance.
-        if ($this->caseAccessGuard->hasCaseMutationAccess(caseId: $caseId, user: $user) === false) {
+        if ($this->uploadHandler->hasCaseUploadAccess(user: $user, caseId: $caseId) === false) {
             return new JSONResponse(['error' => 'Not authorized'], Http::STATUS_FORBIDDEN);
         }
 

--- a/lib/Middleware/TenantMiddleware.php
+++ b/lib/Middleware/TenantMiddleware.php
@@ -28,7 +28,6 @@ use Exception;
 use OCA\Procest\Service\TenantService;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Middleware;
-use OCP\IRequest;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
@@ -59,7 +58,6 @@ class TenantMiddleware extends Middleware
      *
      * @param TenantService   $tenantService The tenant service
      * @param IUserSession    $userSession   The user session
-     * @param IRequest        $request       The request object
      * @param LoggerInterface $logger        The logger
      *
      * @return void
@@ -67,7 +65,6 @@ class TenantMiddleware extends Middleware
     public function __construct(
         private TenantService $tenantService,
         private IUserSession $userSession,
-        private IRequest $request,
         private LoggerInterface $logger,
     ) {
     }//end __construct()
@@ -128,10 +125,24 @@ class TenantMiddleware extends Middleware
             throw new Exception('Organisation is '.$status, 403);
         }
 
-        // Store tenant context for controllers to use.
-        $this->request->setParameter('_tenantId', $tenantUuid);
-        $this->request->setParameter('_tenantRegisterId', $tenant['registerId'] ?? '');
-        $this->request->setParameter('_tenantSlug', $tenant['slug'] ?? '');
+        // No tenant context is published onto the request here.
+        //
+        // This block used to call `$this->request->setParameter(...)`. That
+        // method does not exist on `OCP\IRequest` nor on the concrete
+        // `OC\AppFramework\Http\Request`, so every request that reached this
+        // point died with `Error: Call to undefined method
+        // OC\AppFramework\Http\Request::setParameter()` and Nextcloud answered
+        // HTTP 500 with an HTML error page. In other words: for any user who
+        // DID have a tenant, every non-exempt Procest endpoint was a 500 —
+        // while the single-tenant deployments that CI and the e2e rig exercise
+        // return at the `$tenant === null` branch above and never reached it.
+        //
+        // Nothing ever read the three keys back (`_tenantId`,
+        // `_tenantRegisterId`, `_tenantSlug` have no reader anywhere in `lib/`
+        // or `src/`), so they are removed rather than re-homed: adding a
+        // request-scoped context service with no consumer would be dead code
+        // in a different shape. Tenant *enforcement* — the lifecycle check
+        // above — is unaffected and still runs.
     }//end beforeController()
 
     /**

--- a/lib/Service/Advice/AdviceAuthorizationGuard.php
+++ b/lib/Service/Advice/AdviceAuthorizationGuard.php
@@ -113,6 +113,53 @@ class AdviceAuthorizationGuard
     }//end assertTransitionAuthorized()
 
     /**
+     * Assert that the caller may dispatch a manual reminder for this advice.
+     *
+     * `POST /api/advice/{id}/remind` sends a notification to the adviseur named
+     * on an advice record the caller picks by UUID. It had no guard at all,
+     * while `assertTransitionAuthorized()` — in this same class, reached from
+     * the same service — guarded the transition path. Anyone could spam any
+     * adviseur, and the response distinguished a real advice UUID from a
+     * fabricated one.
+     *
+     * Same relationship model as an `aangevraagd` transition: the adviseur
+     * themselves, the handler of the linked case, or an admin. Fails closed —
+     * an unauthenticated caller or an unresolvable case denies.
+     *
+     * @param array<string, mixed> $advice The current advice record.
+     *
+     * @return void
+     *
+     * @throws RuntimeException When the caller is not authenticated or not authorized.
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    public function assertReminderAuthorized(array $advice): void
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            throw new RuntimeException('Not authenticated');
+        }
+
+        $uid = $user->getUID();
+
+        if ($this->groupManager->isAdmin($uid) === true) {
+            return;
+        }
+
+        $adviseur = (string) ($advice['adviseur'] ?? '');
+        if ($adviseur !== '' && $adviseur === $uid) {
+            return;
+        }
+
+        if ($this->isHandlerOfLinkedCase(advice: $advice, uid: $uid) === true) {
+            return;
+        }
+
+        throw new RuntimeException('Advice request not accessible');
+    }//end assertReminderAuthorized()
+
+    /**
      * Whether a non-admin caller may perform the given advice transition.
      *
      * Returns false for `verlopen` (system-only) and for any unknown

--- a/lib/Service/AdviceService.php
+++ b/lib/Service/AdviceService.php
@@ -163,15 +163,53 @@ class AdviceService
     }//end applyTransition()
 
     /**
-     * Dispatch a reminder notification to the adviseur.
+     * Dispatch a reminder on behalf of the authenticated caller.
      *
-     * Called by the manual remind endpoint and by the daily deadline cron.
+     * The HTTP seam. `POST /api/advice/{id}/remind` used to call
+     * {@see self::dispatchReminder()} directly, which has no authorization —
+     * so any authenticated user could make any adviseur receive a reminder for
+     * any advice request, and the endpoint doubled as an existence oracle for
+     * advice UUIDs. This mirrors the split that already exists in this class
+     * between `transitionStatus()` (authorizes, then delegates) and
+     * `applyTransition()` (the system/cron seam).
      *
      * @param string $adviceId The advice UUID
      *
      * @return void
+     *
+     * @throws RuntimeException When the advice is not accessible to the caller.
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    public function dispatchReminderAsUser(string $adviceId): void
+    {
+        $advice = $this->repository->find(adviceId: $adviceId);
+        if ($advice === null) {
+            // Collapsed with denied, as in transitionStatus(): no existence
+            // oracle for advice UUIDs.
+            throw new RuntimeException('Advice request not accessible');
+        }
 
-     * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+        $this->guard->assertReminderAuthorized(advice: $advice);
+
+        $this->dispatchReminder(adviceId: $adviceId);
+    }//end dispatchReminderAsUser()
+
+    /**
+     * Dispatch a reminder notification to the adviseur WITHOUT an
+     * authorization check.
+     *
+     * TRUST BOUNDARY: this is the system/cron seam (`AdviceDeadlineJob`), which
+     * runs with no user session. It must only be called from
+     * {@see self::dispatchReminderAsUser()} (which authorizes first) or from a
+     * code-driven background job. Never call it with user-supplied intent that
+     * has not been through `assertReminderAuthorized()`.
+     *
+     * @param string $adviceId The advice UUID
+     *
+     * @return void
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
      */
     public function dispatchReminder(string $adviceId): void
     {

--- a/lib/Service/AppointmentService.php
+++ b/lib/Service/AppointmentService.php
@@ -34,6 +34,7 @@ namespace OCA\Procest\Service;
 use OCA\Procest\Service\AppointmentBackend\AppointmentBackendInterface;
 use OCA\Procest\Service\AppointmentBackend\JccBackend;
 use OCA\Procest\Service\AppointmentBackend\QmaticBackend;
+use OCA\Procest\Service\Support\OwningCaseResolver;
 use RuntimeException;
 use OCP\App\IAppManager;
 use OCP\Http\Client\IClientService;
@@ -55,8 +56,9 @@ class AppointmentService
      * @param SettingsService    $settingsService The settings service.
      * @param IAppManager        $appManager      The Nextcloud app manager.
      * @param IClientService     $clientService   The HTTP client service.
-     * @param ContainerInterface $container       The DI container.
-     * @param LoggerInterface    $logger          The logger.
+     * @param ContainerInterface  $container      The DI container.
+     * @param LoggerInterface     $logger         The logger.
+     * @param OwningCaseResolver  $owningCase     Resolves an appointment's owning case.
      */
     public function __construct(
         private SettingsService $settingsService,
@@ -64,6 +66,7 @@ class AppointmentService
         private IClientService $clientService,
         private ContainerInterface $container,
         private LoggerInterface $logger,
+        private readonly OwningCaseResolver $owningCase,
     ) {
     }//end __construct()
 
@@ -150,45 +153,11 @@ class AppointmentService
      */
     public function getCaseIdForAppointment(string $appointmentId): ?string
     {
-        if ($appointmentId === '') {
-            return null;
-        }
-
-        $objectService = $this->getObjectService();
-        if ($objectService === null) {
-            return null;
-        }
-
-        $register = $this->settingsService->getConfigValue('register');
-        $schema   = $this->settingsService->getConfigValue('appointment_schema');
-        if ($register === '' || $schema === '') {
-            return null;
-        }
-
-        try {
-            $appointment = $objectService->find($appointmentId, register: (int) $register, schema: (int) $schema);
-        } catch (\Throwable $e) {
-            $this->logger->warning(
-                'Procest: appointment lookup failed — denying: '.$e->getMessage(),
-            );
-            return null;
-        }
-
-        if (is_object($appointment) === false || method_exists($appointment, 'jsonSerialize') === false) {
-            return null;
-        }
-
-        $data   = $appointment->jsonSerialize();
-        $caseId = '';
-        if (is_array($data) === true) {
-            $caseId = (string) ($data['caseId'] ?? '');
-        }
-
-        if ($caseId === '') {
-            return null;
-        }
-
-        return $caseId;
+        return $this->owningCase->resolve(
+            objectId: $appointmentId,
+            schemaKey: 'appointment_schema',
+            caseField: 'caseId',
+        );
     }//end getCaseIdForAppointment()
 
     /**

--- a/lib/Service/AppointmentService.php
+++ b/lib/Service/AppointmentService.php
@@ -56,9 +56,9 @@ class AppointmentService
      * @param SettingsService    $settingsService The settings service.
      * @param IAppManager        $appManager      The Nextcloud app manager.
      * @param IClientService     $clientService   The HTTP client service.
-     * @param ContainerInterface  $container      The DI container.
-     * @param LoggerInterface     $logger         The logger.
-     * @param OwningCaseResolver  $owningCase     Resolves an appointment's owning case.
+     * @param ContainerInterface $container       The DI container.
+     * @param LoggerInterface    $logger          The logger.
+     * @param OwningCaseResolver $owningCase      Resolves an appointment's owning case.
      */
     public function __construct(
         private SettingsService $settingsService,

--- a/lib/Service/AppointmentService.php
+++ b/lib/Service/AppointmentService.php
@@ -134,12 +134,70 @@ class AppointmentService
     }//end bookAppointment()
 
     /**
+     * Resolve the case an appointment belongs to.
+     *
+     * `cancel()` and `noShow()` carry only an appointment id, so there is
+     * nothing in their signature to authorise against. This resolves the owning
+     * case so the controller can apply the same per-case guard as the rest of
+     * the file. An unresolvable appointment returns null, which the caller
+     * treats as DENY — so an unknown id is not an existence oracle.
+     *
+     * @param string $appointmentId The appointment UUID.
+     *
+     * @return string|null The owning case UUID, or null when unresolvable.
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    public function getCaseIdForAppointment(string $appointmentId): ?string
+    {
+        if ($appointmentId === '') {
+            return null;
+        }
+
+        $objectService = $this->getObjectService();
+        if ($objectService === null) {
+            return null;
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('appointment_schema');
+        if ($register === '' || $schema === '') {
+            return null;
+        }
+
+        try {
+            $appointment = $objectService->find($appointmentId, register: (int) $register, schema: (int) $schema);
+        } catch (\Throwable $e) {
+            $this->logger->warning(
+                'Procest: appointment lookup failed — denying: '.$e->getMessage(),
+            );
+            return null;
+        }
+
+        if (is_object($appointment) === false || method_exists($appointment, 'jsonSerialize') === false) {
+            return null;
+        }
+
+        $data   = $appointment->jsonSerialize();
+        $caseId = '';
+        if (is_array($data) === true) {
+            $caseId = (string) ($data['caseId'] ?? '');
+        }
+
+        if ($caseId === '') {
+            return null;
+        }
+
+        return $caseId;
+    }//end getCaseIdForAppointment()
+
+    /**
      * Cancel an appointment.
      *
      * @param string $appointmentId The appointment UUID.
      *
      * @return array<string, mixed> The updated appointment record.
-
+     *
      * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
      */
     public function cancelAppointment(string $appointmentId): array

--- a/lib/Service/BerichtenboxService.php
+++ b/lib/Service/BerichtenboxService.php
@@ -31,6 +31,7 @@ namespace OCA\Procest\Service;
 use DateTime;
 use OCA\Procest\Service\BerichtenboxAdapter\BerichtenboxAdapterInterface;
 use OCA\Procest\Service\BerichtenboxAdapter\MockAdapter;
+use OCA\Procest\Service\Support\OwningCaseResolver;
 use OCP\App\IAppManager;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
@@ -50,12 +51,14 @@ class BerichtenboxService
      * @param IAppManager        $appManager      The Nextcloud app manager.
      * @param ContainerInterface $container       The DI container.
      * @param LoggerInterface    $logger          The logger.
+     * @param OwningCaseResolver $owningCase      Resolves a message's owning case.
      */
     public function __construct(
         private SettingsService $settingsService,
         private IAppManager $appManager,
         private ContainerInterface $container,
         private LoggerInterface $logger,
+        private readonly OwningCaseResolver $owningCase,
     ) {
     }//end __construct()
 
@@ -209,45 +212,11 @@ class BerichtenboxService
      */
     public function getCaseIdForMessage(string $messageId): ?string
     {
-        if ($messageId === '') {
-            return null;
-        }
-
-        $objectService = $this->getObjectService();
-        if ($objectService === null) {
-            return null;
-        }
-
-        $register = $this->settingsService->getConfigValue('register');
-        $schema   = $this->settingsService->getConfigValue('berichtenbox_message_schema');
-        if ($register === '' || $schema === '') {
-            return null;
-        }
-
-        try {
-            $message = $objectService->find($messageId, register: (int) $register, schema: (int) $schema);
-        } catch (Throwable $e) {
-            $this->logger->warning(
-                'Procest: Berichtenbox message lookup failed — denying poll: '.$e->getMessage(),
-            );
-            return null;
-        }
-
-        if (is_object($message) === false || method_exists($message, 'jsonSerialize') === false) {
-            return null;
-        }
-
-        $data   = $message->jsonSerialize();
-        $caseId = '';
-        if (is_array($data) === true) {
-            $caseId = (string) ($data['caseId'] ?? '');
-        }
-
-        if ($caseId === '') {
-            return null;
-        }
-
-        return $caseId;
+        return $this->owningCase->resolve(
+            objectId: $messageId,
+            schemaKey: 'berichtenbox_message_schema',
+            caseField: 'caseId',
+        );
     }//end getCaseIdForMessage()
 
     /**

--- a/lib/Service/BerichtenboxService.php
+++ b/lib/Service/BerichtenboxService.php
@@ -34,6 +34,7 @@ use OCA\Procest\Service\BerichtenboxAdapter\MockAdapter;
 use OCP\App\IAppManager;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use Throwable;
 
 /**
  * Service for sending messages to Mijn Overheid Berichtenbox.
@@ -190,6 +191,64 @@ class BerichtenboxService
 
         return array_merge($sent, $flagged);
     }//end getPendingMessages()
+
+    /**
+     * Resolve the case a stored message belongs to.
+     *
+     * `poll()` takes only a message id, so there is nothing in its signature to
+     * authorise against. This resolves the owning case so the controller can
+     * apply the same per-case guard as the rest of the file. It returns null —
+     * which the caller treats as DENY — whenever the message cannot be
+     * resolved, so an unknown id is not an existence oracle either.
+     *
+     * @param string $messageId The OpenRegister message UUID.
+     *
+     * @return string|null The owning case UUID, or null when unresolvable.
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    public function getCaseIdForMessage(string $messageId): ?string
+    {
+        if ($messageId === '') {
+            return null;
+        }
+
+        $objectService = $this->getObjectService();
+        if ($objectService === null) {
+            return null;
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue('berichtenbox_message_schema');
+        if ($register === '' || $schema === '') {
+            return null;
+        }
+
+        try {
+            $message = $objectService->find($messageId, register: (int) $register, schema: (int) $schema);
+        } catch (Throwable $e) {
+            $this->logger->warning(
+                'Procest: Berichtenbox message lookup failed — denying poll: '.$e->getMessage(),
+            );
+            return null;
+        }
+
+        if (is_object($message) === false || method_exists($message, 'jsonSerialize') === false) {
+            return null;
+        }
+
+        $data   = $message->jsonSerialize();
+        $caseId = '';
+        if (is_array($data) === true) {
+            $caseId = (string) ($data['caseId'] ?? '');
+        }
+
+        if ($caseId === '') {
+            return null;
+        }
+
+        return $caseId;
+    }//end getCaseIdForMessage()
 
     /**
      * Poll read status for a message.

--- a/lib/Service/Bezwaar/HearingService.php
+++ b/lib/Service/Bezwaar/HearingService.php
@@ -297,6 +297,61 @@ class HearingService
     }//end waive()
 
     /**
+     * Resolve the bezwaar case a hearing session belongs to.
+     *
+     * `recordAttendance()` carries only a session id, so there is nothing in
+     * its signature to authorise against. This resolves the parent case so the
+     * controller can apply the ordinary per-case guard. Returns null — which
+     * the caller treats as DENY — whenever the session cannot be resolved, so
+     * an unknown id is not an existence oracle.
+     *
+     * @param string $sessionId UUID of the hearingSession
+     *
+     * @return string|null The parent case UUID, or null when unresolvable.
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    public function getCaseIdForSession(string $sessionId): ?string
+    {
+        if ($sessionId === '') {
+            return null;
+        }
+
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return null;
+        }
+
+        $register = $this->settingsService->getConfigValue(key: 'register');
+        $schema   = $this->settingsService->getConfigValue(
+            key: 'hearing_session_schema'
+        );
+        if ($register === '' || $schema === '') {
+            return null;
+        }
+
+        try {
+            $session = $objectService->find($sessionId, register: $register, schema: $schema);
+        } catch (\Throwable $e) {
+            $this->logger->warning(
+                'Procest hearing: session lookup failed — denying: '.$e->getMessage()
+            );
+            return null;
+        }
+
+        if (is_array($session) === false) {
+            return null;
+        }
+
+        $caseId = (string) ($session['case'] ?? '');
+        if ($caseId === '') {
+            return null;
+        }
+
+        return $caseId;
+    }//end getCaseIdForSession()
+
+    /**
      * Record attendance on a hearingSession (REQ-BH-5).
      *
      * Within the one-hour grace window after the hearing concludes

--- a/lib/Service/Bezwaar/HearingService.php
+++ b/lib/Service/Bezwaar/HearingService.php
@@ -52,6 +52,7 @@ namespace OCA\Procest\Service\Bezwaar;
 use DateTimeImmutable;
 use DateTimeInterface;
 use OCA\Procest\Service\SettingsService;
+use OCA\Procest\Service\Support\OwningCaseResolver;
 use OCA\Procest\Service\Support\SearchesObjects;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
@@ -98,6 +99,7 @@ class HearingService
      * @param BezwaarAuditTrail      $auditTrail      Shared append-only audit writer
      * @param HearingSchedulePlanner $planner         Awb art. 7:4 date arithmetic
      * @param HearingMinutesRecorder $minutes         Awb art. 7:7 verslag assembly + consent gate
+     * @param OwningCaseResolver     $owningCase      Resolves a session's parent bezwaar case
      */
     public function __construct(
         private readonly SettingsService $settingsService,
@@ -105,6 +107,7 @@ class HearingService
         private readonly BezwaarAuditTrail $auditTrail,
         private readonly HearingSchedulePlanner $planner,
         private readonly HearingMinutesRecorder $minutes,
+        private readonly OwningCaseResolver $owningCase,
     ) {
     }//end __construct()
 
@@ -313,42 +316,11 @@ class HearingService
      */
     public function getCaseIdForSession(string $sessionId): ?string
     {
-        if ($sessionId === '') {
-            return null;
-        }
-
-        $objectService = $this->settingsService->getObjectService();
-        if ($objectService === null) {
-            return null;
-        }
-
-        $register = $this->settingsService->getConfigValue(key: 'register');
-        $schema   = $this->settingsService->getConfigValue(
-            key: 'hearing_session_schema'
+        return $this->owningCase->resolve(
+            objectId: $sessionId,
+            schemaKey: 'hearing_session_schema',
+            caseField: 'case',
         );
-        if ($register === '' || $schema === '') {
-            return null;
-        }
-
-        try {
-            $session = $objectService->find($sessionId, register: $register, schema: $schema);
-        } catch (\Throwable $e) {
-            $this->logger->warning(
-                'Procest hearing: session lookup failed — denying: '.$e->getMessage()
-            );
-            return null;
-        }
-
-        if (is_array($session) === false) {
-            return null;
-        }
-
-        $caseId = (string) ($session['case'] ?? '');
-        if ($caseId === '') {
-            return null;
-        }
-
-        return $caseId;
     }//end getCaseIdForSession()
 
     /**

--- a/lib/Service/CaseAccessGuard.php
+++ b/lib/Service/CaseAccessGuard.php
@@ -157,6 +157,61 @@ class CaseAccessGuard
     }//end hasCaseMutationAccess()
 
     /**
+     * Whether the given user may read the given case.
+     *
+     * Reads are granted to a slightly wider set than mutations, because a case
+     * is worked on by more people than the one named in `assignee`: the
+     * `assignees` array is honoured as well. It is still a real per-case
+     * relationship, and it still fails closed at every branch — an
+     * unresolvable case, an absent OpenRegister, or an unconfigured schema all
+     * DENY.
+     *
+     * Deliberately NOT delegated to
+     * {@see Sharing\CaseAccessPolicy::canUserAccessCase()}: that one returns
+     * TRUE when OpenRegister is absent, when the schema is unconfigured, and
+     * when the lookup throws. Those three fail-OPEN branches are acceptable for
+     * the sharing UI it was written for and are not acceptable here.
+     *
+     * @param string $caseId The case UUID.
+     * @param IUser  $user   The authenticated user.
+     *
+     * @return bool True when the user works on the case or is an admin.
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    public function hasCaseReadAccess(string $caseId, IUser $user): bool
+    {
+        $uid = $user->getUID();
+        if ($uid === '' || $caseId === '') {
+            return false;
+        }
+
+        try {
+            if ($this->groupManager->isAdmin($uid) === true) {
+                return true;
+            }
+        } catch (Throwable $e) {
+            $this->logger->warning(
+                'Procest CaseAccessGuard: admin check failed: '.$e->getMessage(),
+                ['app' => Application::APP_ID]
+            );
+        }
+
+        $case = $this->loadCase(caseId: $caseId);
+        if ($case === null) {
+            return false;
+        }
+
+        if ((string) ($case['assignee'] ?? '') === $uid) {
+            return true;
+        }
+
+        $assignees = ($case['assignees'] ?? []);
+
+        return (is_array($assignees) === true && in_array($uid, $assignees, true) === true);
+    }//end hasCaseReadAccess()
+
+    /**
      * Load a case through OpenRegister.
      *
      * @param string $caseId The case UUID.

--- a/lib/Service/CaseRelationService.php
+++ b/lib/Service/CaseRelationService.php
@@ -101,9 +101,21 @@ class CaseRelationService
      *   - no self-relation (`caseId == targetId`);
      *   - no duplicate `{caseId, aardRelatie}` pair;
      *   - no overlap with an existing direct hoofdzaak/deelzaak hierarchy link;
-     *   - the actor must have OR read access to BOTH cases (enforced because
-     *     {@see self::fetchCase()} resolves through the session's ObjectService,
-     *     which applies OpenRegister RBAC — an unreadable case resolves to null).
+     *   - both cases must resolve (a missing case is refused as `access_denied`
+     *     so the endpoint is not an existence oracle).
+     *
+     * ⚠️ This list used to claim the null-check below also enforced per-object
+     * authorisation, *"because the store resolves through the session's
+     * ObjectService, which applies OpenRegister RBAC — an unreadable case
+     * resolves to null"*. That claim was false and the check was INERT:
+     * `PermissionHandler::hasGroupPermission()` returns `true` for a schema
+     * with no `authorization` block and `enforce_default_closed` defaults
+     * false, and none of procest's 85 schemas declares one — so an existing
+     * case never resolved to null for anybody (ConductionNL/.github#372).
+     * Authorisation is now enforced by `CaseAccessGuard` in
+     * `CaseRelationController`, ahead of every call into this service. Do not
+     * re-state the RBAC claim here unless the schemas declare `authorization`
+     * AND a test fails when that declaration is removed.
      *
      * @param string      $caseId      Origin case UUID.
      * @param string      $targetId    Target case UUID.

--- a/lib/Service/CitizenLookupGuard.php
+++ b/lib/Service/CitizenLookupGuard.php
@@ -30,6 +30,11 @@
  * `AiAuditExportController`, `ProcessMiningController`): a fixed set of
  * deployment group names plus an admin fallback.
  *
+ * ⚠️ The MECHANISM is precedented; two of the four group NAMES are not. See
+ * the note on {@see self::ALLOWED_GROUPS} — `beheerders` and `admin` are
+ * attested elsewhere in this app, `kcc` and `klantcontact` are assumptions
+ * made by the author of this class, and this guard denies until they exist.
+ *
  * @category Service
  * @package  OCA\Procest\Service
  *
@@ -69,6 +74,32 @@ class CitizenLookupGuard
      * An empty intersection denies. The existence of these groups is never
      * part of the decision — a group that does not exist simply matches
      * nobody.
+     *
+     * ⚠️ TWO OF THESE FOUR NAMES ARE ASSUMPTIONS, NOT ESTABLISHED FACTS.
+     * Verified with `grep -w` across this repository at `cb63acad3`:
+     *
+     *   - `beheerders` and `admin` are ATTESTED — both are already used as
+     *     Nextcloud group names by `ProcessMiningController::ALLOWED_GROUPS`
+     *     and `ParaferingAuditExportController::ALLOWED_GROUPS`.
+     *   - `kcc` and `klantcontact` are ASSUMED. Neither appears anywhere in
+     *     this codebase as a group name: `kcc` occurs only as a feature name,
+     *     spec slug and CSS class, and `klantcontact` only as a ZGW domain
+     *     term and a spec slug. They were chosen by the author of this class,
+     *     not derived from anything the app already does.
+     *
+     * The consequence is deliberate and it fails CLOSED: if a deployment's KCC
+     * group is called something else, its call-centre staff get HTTP 403 and an
+     * operator fixes it by creating the group or editing this constant. The
+     * alternative — leaving the endpoint open — returned a citizen's phone
+     * number and the free-text summary of every previous call to ANY
+     * authenticated account (finding PROC-IDOR-01, reproduced live).
+     *
+     * A wrong name here is a functional regression an operator can correct in
+     * a minute. A missing guard is a personal-data breach nobody notices.
+     *
+     * 🔧 DEPLOYMENT: this guard denies until the group exists. Create `kcc`
+     * (or rename the entry below to match your instance) and add the KCC
+     * handlers to it.
      */
     private const ALLOWED_GROUPS = ['kcc', 'klantcontact', 'beheerders', 'admin'];
 

--- a/lib/Service/CitizenLookupGuard.php
+++ b/lib/Service/CitizenLookupGuard.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * Procest Citizen Lookup Guard.
+ *
+ * Role authorization for the endpoints that resolve a raw citizen identifier
+ * (BSN / burgerId) into that citizen's case and contact history.
+ *
+ * These endpoints have no per-object owner to check against: the subject is a
+ * citizen, not a case, and a KCC agent legitimately answers a call from a
+ * citizen they have never handled before. `CaseAccessGuard` therefore does not
+ * apply — the question is not "does this user handle this case?" but "is this
+ * user a klantcontactcentrum handler at all?".
+ *
+ * Before this guard existed, `GET /api/kcc/voorblad?burgerId=…` answered HTTP
+ * 200 with the citizen's open cases and recent contact history — including the
+ * caller's phone number and the free-text summary of every previous call — to
+ * ANY authenticated account on the instance. Iterating BSN-shaped identifiers
+ * walked the resident population. Reproduced live with two accounts before this
+ * change (finding PROC-IDOR-01).
+ *
+ * Fails closed, and deliberately in the opposite direction to the bug
+ * `CaseAccessGuard` was written for: there, a group that did not exist made
+ * `groupExists() && !isInGroup()` short-circuit to "authorized". Here the
+ * absence of every listed group grants nothing — only an actual membership, or
+ * Nextcloud admin, passes.
+ *
+ * The group list mirrors the idiom already used for the other broad-scope reads
+ * in this app (`ParaferingAuditExportController::ALLOWED_GROUPS`,
+ * `AiAuditExportController`, `ProcessMiningController`): a fixed set of
+ * deployment group names plus an admin fallback.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @spec openspec/specs/authz-bypass-fixes/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service;
+
+use OCP\IGroupManager;
+use OCP\IUser;
+use Throwable;
+
+/**
+ * Guards citizen-identifier lookups against the caller's KCC role.
+ *
+ * @spec openspec/specs/authz-bypass-fixes/spec.md
+ */
+class CitizenLookupGuard
+{
+
+    /**
+     * Groups whose members may resolve a citizen identifier.
+     *
+     * An empty intersection denies. The existence of these groups is never
+     * part of the decision — a group that does not exist simply matches
+     * nobody.
+     */
+    private const ALLOWED_GROUPS = ['kcc', 'klantcontact', 'beheerders', 'admin'];
+
+    /**
+     * Constructor.
+     *
+     * @param IGroupManager $groupManager The group manager.
+     */
+    public function __construct(
+        private readonly IGroupManager $groupManager,
+    ) {
+    }//end __construct()
+
+    /**
+     * Whether the given user may resolve citizen identifiers.
+     *
+     * @param IUser $user The authenticated user.
+     *
+     * @return bool True when the user is a KCC handler or a Nextcloud admin.
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    public function isCitizenLookupAllowed(IUser $user): bool
+    {
+        $uid = $user->getUID();
+        if ($uid === '') {
+            return false;
+        }
+
+        try {
+            foreach (self::ALLOWED_GROUPS as $group) {
+                if ($this->groupManager->isInGroup($uid, $group) === true) {
+                    return true;
+                }
+            }
+
+            return $this->groupManager->isAdmin($uid);
+        } catch (Throwable $e) {
+            // An unresolvable group check is not an authorization.
+            return false;
+        }
+    }//end isCitizenLookupAllowed()
+}//end class

--- a/lib/Service/Support/OwningCaseResolver.php
+++ b/lib/Service/Support/OwningCaseResolver.php
@@ -1,0 +1,158 @@
+<?php
+
+/**
+ * Procest Owning-Case Resolver.
+ *
+ * Resolves the case that a child object belongs to, so an endpoint whose route
+ * carries only a child id can still be authorised per case.
+ *
+ * Several `#[NoAdminRequired]` routes name a child object rather than a case —
+ * `POST /api/appointments/{appointmentId}/no-show`,
+ * `GET /api/berichtenbox/messages/{messageId}`,
+ * `POST /api/bezwaar/hearings/{sessionId}/attendance`. There is nothing in
+ * those signatures to authorise against, so each one first resolves the owning
+ * case and then applies the ordinary `CaseAccessGuard` check. Three services
+ * needed exactly the same lookup; it lives here once rather than three times.
+ *
+ * FAILS CLOSED. Every branch that cannot establish the owning case returns
+ * null, and every caller treats null as DENY — so an unknown or unresolvable
+ * child id is refused identically to one the caller may not touch, and none of
+ * these endpoints is an existence oracle.
+ *
+ * @category Service
+ * @package  OCA\Procest\Service\Support
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @spec openspec/specs/authz-bypass-fixes/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Service\Support;
+
+use OCA\Procest\Service\SettingsService;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Resolves the owning case of a child object, failing closed.
+ *
+ * @spec openspec/specs/authz-bypass-fixes/spec.md
+ */
+class OwningCaseResolver
+{
+
+    /**
+     * Constructor.
+     *
+     * @param SettingsService $settingsService Register/schema resolver.
+     * @param LoggerInterface $logger          The logger.
+     */
+    public function __construct(
+        private readonly SettingsService $settingsService,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Resolve the case UUID a child object belongs to.
+     *
+     * @param string $objectId  The child object UUID.
+     * @param string $schemaKey The settings key naming the child's schema.
+     * @param string $caseField The property on the child holding the case ref.
+     *
+     * @return string|null The owning case UUID, or null when unresolvable.
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    public function resolve(string $objectId, string $schemaKey, string $caseField='caseId'): ?string
+    {
+        $data = $this->loadChild(objectId: $objectId, schemaKey: $schemaKey);
+        if ($data === null) {
+            return null;
+        }
+
+        $caseId = (string) ($data[$caseField] ?? '');
+        if ($caseId === '') {
+            return null;
+        }
+
+        return $caseId;
+    }//end resolve()
+
+    /**
+     * Load the child object as a plain array.
+     *
+     * @param string $objectId  The child object UUID.
+     * @param string $schemaKey The settings key naming the child's schema.
+     *
+     * @return array<string, mixed>|null The child object, or null when unresolvable.
+     */
+    private function loadChild(string $objectId, string $schemaKey): ?array
+    {
+        if ($objectId === '') {
+            return null;
+        }
+
+        $objectService = $this->settingsService->getObjectService();
+        if ($objectService === null) {
+            return null;
+        }
+
+        $register = $this->settingsService->getConfigValue('register');
+        $schema   = $this->settingsService->getConfigValue($schemaKey);
+        if ($register === '' || $schema === '') {
+            return null;
+        }
+
+        try {
+            $object = $objectService->find($objectId, register: (int) $register, schema: (int) $schema);
+        } catch (Throwable $e) {
+            $this->logger->warning(
+                'Procest: owning-case lookup failed — denying: '.$e->getMessage()
+            );
+            return null;
+        }
+
+        return $this->toArray(value: $object);
+    }//end loadChild()
+
+    /**
+     * Normalise an OpenRegister result into a plain array.
+     *
+     * `is_callable()` rather than `method_exists()`: OpenRegister's
+     * `ObjectEntity` reaches several accessors through `Entity::__call()`, and
+     * `method_exists()` is false for those.
+     *
+     * @param mixed $value The value returned by ObjectService.
+     *
+     * @return array<string, mixed>|null The array form, or null.
+     */
+    private function toArray(mixed $value): ?array
+    {
+        if (is_array($value) === true) {
+            return $value;
+        }
+
+        if (is_object($value) === false || is_callable([$value, 'jsonSerialize']) === false) {
+            return null;
+        }
+
+        $serialised = $value->jsonSerialize();
+        if (is_array($serialised) === false) {
+            return null;
+        }
+
+        return $serialised;
+    }//end toArray()
+}//end class

--- a/lib/Service/Support/OwningCaseResolver.php
+++ b/lib/Service/Support/OwningCaseResolver.php
@@ -51,7 +51,6 @@ use Throwable;
  */
 class OwningCaseResolver
 {
-
     /**
      * Constructor.
      *

--- a/lib/Service/Zaakdossier/DossierUploadHandler.php
+++ b/lib/Service/Zaakdossier/DossierUploadHandler.php
@@ -34,7 +34,9 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Service\Zaakdossier;
 
+use OCA\Procest\Service\CaseAccessGuard;
 use OCA\Procest\Service\ZaakdossierService;
+use OCP\IUser;
 use RuntimeException;
 
 /**
@@ -60,8 +62,33 @@ class DossierUploadHandler
      */
     public function __construct(
         private readonly ZaakdossierService $dossierService,
+        private readonly CaseAccessGuard $caseAccessGuard,
     ) {
     }//end __construct()
+
+    /**
+     * Whether the given user may add documents to the given case.
+     *
+     * The case-side authorization for uploads lives here rather than in
+     * `ZaakdossierController` because this class is the collaborator that
+     * performs the write, and because the controller's document-side guard
+     * (`InformatieobjectReader::guardReadable()`) has no document to check on
+     * an upload — the missing half was always the CASE.
+     *
+     * Called once per request, not once per file: the answer cannot differ
+     * between files of the same upload.
+     *
+     * @param IUser  $user   The authenticated user.
+     * @param string $caseId The case (zaak) UUID.
+     *
+     * @return bool True when the user handles the case.
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    public function hasCaseUploadAccess(IUser $user, string $caseId): bool
+    {
+        return $this->caseAccessGuard->hasCaseMutationAccess(caseId: $caseId, user: $user);
+    }//end hasCaseUploadAccess()
 
     /**
      * Upload a single multipart file into a case dossier.

--- a/lib/Service/Zaakdossier/DossierUploadHandler.php
+++ b/lib/Service/Zaakdossier/DossierUploadHandler.php
@@ -56,7 +56,8 @@ class DossierUploadHandler
     /**
      * Constructor.
      *
-     * @param ZaakdossierService $dossierService The dossier orchestrator.
+     * @param ZaakdossierService $dossierService  The dossier orchestrator.
+     * @param CaseAccessGuard    $caseAccessGuard Per-case authorization (fails closed).
      *
      * @return void
      */

--- a/openspec/specs/authz-bypass-fixes/spec.md
+++ b/openspec/specs/authz-bypass-fixes/spec.md
@@ -167,3 +167,151 @@ MUST play no part in the authorization decision.
 - **THEN** the system MUST reject with a forbidden response, via
   `CaseAccessGuard::assertCaseMutationAccess()`
 - **AND** rejection MUST NOT depend on whether any group exists
+
+## ADDED Requirements (2026-08-11, gate-7 re-audit)
+
+The `.github#365` re-audit established that gate-7 accepts a `401` authentication
+preamble as an authorisation guard, so its `0` for procest was never a verdict.
+Hand-verification found 33 `#[NoAdminRequired]` endpoints that take an object or
+subject identifier off the request and act on it with no per-object
+authorisation. The requirements below are stated, as in the rest of this spec, so
+that the BAD path is the thing under test.
+
+### Requirement: Citizen-identifier lookups require a klantcontactcentrum role
+
+The system MUST authorise every endpoint that resolves a caller-supplied citizen
+identifier (`burgerId`) into that citizen's data. Authentication MUST NOT be
+accepted as authorisation. Authorisation MUST fail closed: the absence of every
+recognised role grants nothing.
+
+These endpoints have no per-object owner — a KCC handler legitimately answers a
+call from a citizen they have never handled — so the control is a role, not a
+per-case relationship. `CaseAccessGuard` therefore does not apply and
+`CitizenLookupGuard` MUST be used instead.
+
+#### Scenario: An authenticated account with no KCC role cannot read a citizen's voorblad
+
+@e2e exclude Backend authorisation boundary; the browser surface renders the same
+service through the same controller and cannot express "a second account with no
+role" without a second logged-in session. Covered by
+`ContactMomentControllerAuthorizationTest` (7 cases, proven able to fail by
+inverting the guard predicate) and by a two-account live probe printing status
+codes.
+
+- **GIVEN** a citizen identified as `BSN-999999999` with an open case and a
+  logged contactmoment
+- **AND** an authenticated non-admin user who is in none of the KCC groups
+- **WHEN** that user calls `GET /api/kcc/voorblad?burgerId=BSN-999999999`
+- **THEN** the system MUST return a forbidden response
+- **AND** `CaseVoorbladService::getCaseVoorblad()` MUST NOT be called
+
+#### Scenario: A KCC handler still gets the voorblad
+
+@e2e exclude Same boundary as above; the positive arm exists so the guard cannot
+be satisfied by refusing everyone.
+
+- **GIVEN** an authenticated user who is a member of a KCC group
+- **WHEN** that user calls `GET /api/kcc/voorblad?burgerId=BSN-999999999`
+- **THEN** the system MUST return the voorblad for that citizen
+
+#### Scenario: The same exposure through the contact-history door is refused
+
+@e2e exclude Backend authorisation boundary; covered by
+`ContactMomentControllerAuthorizationTest::testContactHistoryIsRefusedWithoutKccRole`.
+
+- **GIVEN** an authenticated non-admin user who is in none of the KCC groups
+- **WHEN** that user calls `GET /api/contactmomenten?burgerId=…`
+- **THEN** the system MUST return a forbidden response
+- **AND** `ContactMomentService::listForBurger()` MUST NOT be called
+
+#### Scenario: Writing against an arbitrary citizen is refused
+
+@e2e exclude Backend authorisation boundary; covered by
+`ContactMomentControllerAuthorizationTest` (create, nieuweZaak,
+klachtRegistreren), each asserting the write collaborator is never reached.
+
+- **GIVEN** an authenticated non-admin user who is in none of the KCC groups
+- **WHEN** that user calls `POST /api/contactmomenten`,
+  `POST /api/kcc/quick-actions/nieuwe-zaak`, or
+  `POST /api/kcc/quick-actions/klacht-registreren`
+- **THEN** each call MUST return a forbidden response
+- **AND** no contactmoment, case, or klacht MUST be written
+
+### Requirement: The AI decision trail is scoped to a case the caller works on
+
+The system MUST NOT serve an unscoped listing of AI decision records, and MUST
+authorise the scoped listing against the caller's relationship to the case.
+Omitting the scope MUST be rejected rather than silently widened.
+
+#### Scenario: Omitting caseId no longer dumps every AI decision on the instance
+
+@e2e exclude Backend authorisation boundary; covered by
+`AiControllerAuditIndexTest::testAuditIndexRefusesUnscopedDump`, which asserts
+`AiAuditService::listAuditEntries()` is never called.
+
+- **GIVEN** an authenticated user
+- **WHEN** `GET /api/ai/audit` is called with no `caseId`
+- **THEN** the system MUST reject the request
+- **AND** MUST NOT query the audit store
+
+#### Scenario: A user who does not work on the case cannot read its AI decisions
+
+@e2e exclude Backend authorisation boundary; covered by
+`AiControllerAuditIndexTest::testAuditIndexRejectsUserWithoutCaseAccess`.
+
+- **GIVEN** a case whose `assignee` is `alice`
+- **AND** an authenticated non-admin user `mallory`
+- **WHEN** `mallory` calls `GET /api/ai/audit?caseId=<that case>`
+- **THEN** the system MUST return a forbidden response
+- **AND** MUST NOT query the audit store
+
+### Requirement: Case read access is authorised by a guard that fails closed
+
+The system MUST authorise per-case READ endpoints against the caller's real
+relationship to the case (`assignee`, membership of `assignees`, or Nextcloud
+admin). It MUST NOT delegate that decision to
+`Sharing\CaseAccessPolicy::canUserAccessCase()`, which returns TRUE when
+OpenRegister is absent, when the case schema is unconfigured, and when the
+lookup throws — three fail-open branches that would make the guard grant access
+precisely when it cannot evaluate it.
+
+#### Scenario: An unresolvable case denies rather than skips
+
+@e2e exclude Failure-mode of a backend collaborator; not expressible in a
+browser. Covered by `CaseAccessGuardReadAccessTest`.
+
+- **GIVEN** OpenRegister is unavailable, or the case schema is unconfigured, or
+  the case cannot be loaded
+- **WHEN** `CaseAccessGuard::hasCaseReadAccess()` is called
+- **THEN** it MUST return false
+
+#### Scenario: A member of the assignees array may read the case
+
+@e2e exclude Backend predicate; covered by `CaseAccessGuardReadAccessTest`.
+
+- **GIVEN** a case whose `assignee` is `alice` and whose `assignees` array
+  contains `bob`
+- **WHEN** `CaseAccessGuard::hasCaseReadAccess()` is called as `bob`
+- **THEN** it MUST return true
+- **AND** for an unrelated user `mallory` it MUST return false
+
+### Requirement: Tenant middleware must not fatal on the multi-tenant path
+
+The system MUST NOT call methods that do not exist on the Nextcloud request
+object. `TenantMiddleware::beforeController()` called
+`IRequest::setParameter()`, which exists on no Nextcloud request class, so every
+request from a user who HAD a tenant died as an unhandled `Error` and Nextcloud
+answered HTTP 500 with an HTML page. Single-tenant installs returned earlier and
+never reached it, so no test and no e2e rig exercised the failing path.
+
+#### Scenario: A request from a user with an active tenant reaches its controller
+
+@e2e exclude Requires a provisioned OR Organisation bound to a user, which the
+e2e rig does not seed. Verified live on a rig where the tenant existed: the same
+request returned 500 before the fix and 200/403 after, with the status code
+printed.
+
+- **GIVEN** an authenticated user bound to an active tenant
+- **WHEN** any non-exempt Procest endpoint is called
+- **THEN** the middleware MUST NOT raise
+- **AND** the controller's own response MUST be returned

--- a/openspec/specs/authz-bypass-fixes/spec.md
+++ b/openspec/specs/authz-bypass-fixes/spec.md
@@ -18,6 +18,9 @@ live HTTP path (`POST /api/advice/{id}/transition` →
 transition whose caller relationship cannot be established MUST be rejected.
 
 #### Scenario: Unrelated user cannot mark another user's advice as received
+
+@e2e exclude Backend authorisation boundary with no browser surface; covered by `AdviceServiceAuthorizationTest::testUnrelatedUserIsRejectedFromMarkingAdviceReceived`.
+
 - **GIVEN** an advice request whose `adviseur` is `alice` and whose `case` is
   assigned to `bob`
 - **AND** an authenticated non-admin user `mallory`
@@ -27,24 +30,36 @@ transition whose caller relationship cannot be established MUST be rejected.
 - **AND** it MUST NOT write any update to the advice request
 
 #### Scenario: The assigned adviseur may mark their advice received
+
+@e2e exclude Backend authorisation boundary with no browser surface; covered by `AdviceServiceAuthorizationTest::testAssignedAdviseurMayMarkAdviceReceived`.
+
 - **GIVEN** an advice request whose `adviseur` is `alice`
 - **WHEN** `AdviceService::transitionStatus(adviceId, 'ontvangen')` is called as
   `alice`
 - **THEN** the system MUST allow the transition
 
 #### Scenario: The expiry transition is not reachable over HTTP
+
+@e2e exclude Backend authorisation boundary with no browser surface; covered by `AdviceServiceAuthorizationTest::testExpiryTransitionIsRejectedOverTheHttpPath`.
+
 - **GIVEN** any authenticated non-admin user
 - **WHEN** `AdviceService::transitionStatus(adviceId, 'verlopen')` is called
 - **THEN** the system MUST reject the transition, because `verlopen` is a
   system-only transition owned by the deadline cron
 
 #### Scenario: The deadline cron can still expire advice without a session
+
+@e2e exclude Background-job path with no user session; not reachable from a browser at all. Covered by `AdviceServiceAuthorizationTest::testExpireAdviceStillWorksWithoutASession`.
+
 - **GIVEN** no authenticated user session (background job context)
 - **WHEN** `AdviceService::expireAdvice(adviceId)` is called
 - **THEN** the advice request MUST be updated to status `verlopen`
 - **AND** the absence of a user session MUST NOT cause a rejection
 
 #### Scenario: An unknown target status is rejected
+
+@e2e exclude Input-validation boundary the UI cannot express (the browser only ever offers valid statuses); covered by `AdviceServiceAuthorizationTest::testInvalidStatusIsRejected`.
+
 - **GIVEN** an authenticated user
 - **WHEN** `transitionStatus()` is called with a status outside
   `aangevraagd|ontvangen|verlopen`
@@ -57,6 +72,9 @@ indistinguishable from an implemented control and conceals the unguarded live
 path.
 
 #### Scenario: submitAdvice and cancelAdvice no longer exist
+
+@e2e exclude Code-absence requirement: there is no runtime surface to exercise, because the assertion IS that the methods do not exist. Verified by grep over `lib/` (0 hits; the search is live — it still matches the schema key in `lib/Settings/procest_register.json` and the docblock in `AdviceServiceAuthorizationTest`).
+
 - **GIVEN** the procest codebase after this change
 - **WHEN** `AdviceService` is inspected
 - **THEN** `submitAdvice()` and `cancelAdvice()` MUST NOT be present
@@ -70,6 +88,9 @@ of any Nextcloud group, and MUST deny when the case or OpenRegister cannot be
 resolved.
 
 #### Scenario: Authenticated non-assignee is rejected from every WOO mutation endpoint
+
+@e2e exclude Backend authorisation boundary; expressing it in a browser needs a second logged-in session per endpoint. Covered by `WOOAssessmentControllerAuthorizationTest::testAuthenticatedNonAssigneeIsRejectedFromEveryMutationEndpoint`.
+
 - **GIVEN** a WOO case whose `assignee` is `alice`
 - **AND** an authenticated non-admin user `mallory`
 - **WHEN** `mallory` calls `bulkAssess`, `extendDeadline`, `createDecision`,
@@ -77,6 +98,9 @@ resolved.
 - **THEN** each call MUST be rejected with a forbidden response
 
 #### Scenario: Statutory deadline extension is rejected for an unrelated user
+
+@e2e exclude Backend authorisation boundary; covered by `WOOAssessmentControllerAuthorizationTest::testStatutoryDeadlineExtensionIsRejectedForUnrelatedUser`.
+
 - **GIVEN** a WOO case whose `assignee` is `alice`
 - **AND** an authenticated non-admin user `mallory`
 - **WHEN** `mallory` calls `extendDeadline` for that case
@@ -84,6 +108,9 @@ resolved.
   term is a case-worker action
 
 #### Scenario: An absent authorization group does not grant access
+
+@e2e exclude The precondition is the ABSENCE of a Nextcloud group, which a browser test cannot establish without provisioning the instance. Covered by `WOOAssessmentControllerAuthorizationTest::testAbsentAuthorizationGroupDoesNotGrantAccess`.
+
 - **GIVEN** the `procest-gebruikers` group does not exist on the instance
 - **AND** an authenticated non-admin user who is not the case assignee
 - **WHEN** that user calls any WOO case mutation endpoint
@@ -91,11 +118,17 @@ resolved.
 - **AND** the absence of the group MUST NOT be treated as authorization
 
 #### Scenario: OpenRegister unavailable denies rather than skips the check
+
+@e2e exclude The precondition is an absent collaborator app; not expressible in a browser against a working instance. Covered by `WOOAssessmentControllerAuthorizationTest::testOpenRegisterUnavailableDeniesRatherThanSkips`.
+
 - **GIVEN** OpenRegister is not available
 - **WHEN** an authenticated non-admin user calls a WOO case mutation endpoint
 - **THEN** the system MUST reject the call rather than proceed unchecked
 
 #### Scenario: The case assignee is authorized
+
+@e2e exclude Positive arm of the same backend boundary; covered by `WOOAssessmentControllerAuthorizationTest::testCaseAssigneeIsAuthorized`.
+
 - **GIVEN** a WOO case whose `assignee` is `alice`
 - **WHEN** `alice` calls a WOO case mutation endpoint for that case
 - **THEN** the system MUST allow the call
@@ -106,12 +139,18 @@ request data, and MUST NOT report "no conflict" when the check cannot be
 performed.
 
 #### Scenario: A genuine conflict is detected
+
+@e2e exclude Belangenconflict detection is a backend decision over BRP identity data; the browser only ever sees the resulting refusal. Covered by `ConflictOfInterestServiceTest::testSelfDetected` and `::testRelationshipDetected`.
+
 - **GIVEN** a case whose applicant is a natural person with a BSN
 - **AND** a case worker whose resolved identity hash equals the applicant's
 - **WHEN** `ConflictOfInterestService::checkConflict()` is called
 - **THEN** it MUST return `conflict = true` with reason `self`
 
 #### Scenario: Indeterminate identity blocks rather than passes
+
+@e2e exclude Fail-closed branch reached only when identity resolution is unavailable; not reproducible from a browser. Covered by `ConflictOfInterestServiceTest::testIndeterminateIdentityBlocksRatherThanPasses`, `::testUnresolvableIdentityBlocks` and `::testThrowingResolverBlocks`.
+
 - **GIVEN** a case whose applicant is a natural person with a BSN
 - **AND** no bound identity resolver, so the case worker's identity cannot be
   resolved
@@ -120,24 +159,36 @@ performed.
 - **AND** it MUST NOT return `conflict = false`
 
 #### Scenario: Client-supplied identity cannot influence the outcome
+
+@e2e exclude The scenario requires forging a request field the UI never sends, so a browser test cannot construct it. Covered by `ConflictOfInterestServiceTest::testClientSuppliedUserBsnIsIgnored`.
+
 - **GIVEN** a request body containing `caseProperties.userBsn`
 - **WHEN** `MandaatMatrixController::probe()` handles the request
 - **THEN** the client-supplied identity MUST be discarded
 - **AND** the applicant identity MUST be sourced from the case object
 
 #### Scenario: A case with no natural-person applicant has no conflict
+
+@e2e exclude Negative arm of the backend conflict decision; covered by `ConflictOfInterestServiceTest::testNoConflictWithoutApplicantIdentity`.
+
 - **GIVEN** a case whose `initiatorType` is not `person`
 - **WHEN** `checkConflict()` is called
 - **THEN** it MUST return `conflict = false`, because there is no applicant
   identity to conflict with
 
 #### Scenario: A missing conflict service denies rather than skips
+
+@e2e exclude The precondition is an unbound collaborator, which a browser cannot create. Covered by `MandaatCheckServiceTest::testMissingConflictServiceDeniesRatherThanSkips` — added 2026-08-12, because this was the one requirement in this spec with no coverage to point at, and it is covered rather than waived. That test carries its own positive control: the identical call authorizes with the service bound.
+
 - **GIVEN** `MandaatCheckService` has no bound `ConflictOfInterestService`
 - **WHEN** `isAuthorized()` is called
 - **THEN** the conflict check MUST be treated as indeterminate and deny, rather
   than silently skipped
 
 #### Scenario: BSN values are never logged or returned
+
+@e2e exclude Asserts the ABSENCE of a value from a payload and from log records; a browser assertion over a response it never receives proves nothing. Covered by `ConflictOfInterestServiceTest::testNoRawBsnIsReturned`.
+
 - **GIVEN** any `checkConflict()` invocation
 - **WHEN** the check completes
 - **THEN** no raw BSN MUST appear in the returned payload or in any log record
@@ -156,11 +207,17 @@ short-circuited and every authenticated user was authorized. Group existence
 MUST play no part in the authorization decision.
 
 #### Scenario: Unauthenticated request is rejected
+
+@e2e exclude Authentication boundary enforced by Nextcloud middleware ahead of the controller; covered by `AdviceServiceAuthorizationTest::testUnauthenticatedCallerIsRejected` and, live, by the unauthenticated arm of the two-account probe recorded on PR #805 (HTTP 401).
+
 - **GIVEN** no authenticated user session
 - **WHEN** `POST /api/cases/{id}/woo/publish` is called
 - **THEN** the system MUST return 401 Unauthorized
 
 #### Scenario: Authenticated non-authorized user is rejected
+
+@e2e exclude Backend authorisation boundary needing a second logged-in session; covered by `WOOAssessmentControllerAuthorizationTest::testAuthenticatedNonAssigneeIsRejectedFromEveryMutationEndpoint`, which drives the publish and withdraw endpoints named by this requirement.
+
 - **GIVEN** an authenticated user who is not an admin and is not the case
   assignee
 - **WHEN** `POST /api/cases/{id}/woo/publish` is called

--- a/tests/Unit/Controller/AiControllerAuditIndexTest.php
+++ b/tests/Unit/Controller/AiControllerAuditIndexTest.php
@@ -5,8 +5,10 @@
  *
  * Asserts the audit-listing stub is gone (no more "implement with
  * OpenRegister object listing" placeholder), filters/paging params pass
- * through to AiAuditService::listAuditEntries(), and failures are handled
- * without leaking exception internals as a 200.
+ * through to AiAuditService::listAuditEntries(), failures are handled
+ * without leaking exception internals as a 200, and — since the gate-7
+ * re-audit — that the endpoint is authorized per case rather than dumping
+ * every AI decision record on the instance.
  *
  * @category Tests
  * @package  OCA\Procest\Tests\Unit\Controller
@@ -17,7 +19,7 @@
  *
  * @link https://conduction.nl
  *
- * @spec openspec/changes/ai-oversight-log/tasks.md#1.3
+ * @spec openspec/specs/authz-bypass-fixes/spec.md
  *
  * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
  * SPDX-License-Identifier: EUPL-1.2
@@ -30,6 +32,7 @@ namespace OCA\Procest\Tests\Unit\Controller;
 use OCA\Procest\Controller\AiController;
 use OCA\Procest\Service\Ai\AiAuditService;
 use OCA\Procest\Service\AiService;
+use OCA\Procest\Service\CaseAccessGuard;
 use OCP\AppFramework\Http;
 use OCP\IRequest;
 use OCP\IUser;
@@ -55,6 +58,8 @@ class AiControllerAuditIndexTest extends TestCase
 
     private LoggerInterface $logger;
 
+    private CaseAccessGuard $caseAccessGuard;
+
     private AiController $controller;
 
     /**
@@ -69,7 +74,11 @@ class AiControllerAuditIndexTest extends TestCase
         $this->auditService    = $this->createMock(AiAuditService::class);
         $this->userSession     = $this->createMock(IUserSession::class);
         $this->request         = $this->createMock(IRequest::class);
-        $this->logger           = $this->createMock(LoggerInterface::class);
+        $this->logger          = $this->createMock(LoggerInterface::class);
+        $this->caseAccessGuard = $this->createMock(CaseAccessGuard::class);
+
+        // Default: the caller works on the case. Individual tests override.
+        $this->caseAccessGuard->method('hasCaseReadAccess')->willReturn(true);
 
         $user = $this->createMock(IUser::class);
         $user->method('getUID')->willReturn('behandelaar-1');
@@ -82,6 +91,7 @@ class AiControllerAuditIndexTest extends TestCase
             auditService: $this->auditService,
             userSession: $this->userSession,
             logger: $this->logger,
+            caseAccessGuard: $this->caseAccessGuard,
         );
     }//end setUp()
 
@@ -94,7 +104,7 @@ class AiControllerAuditIndexTest extends TestCase
     public function testAuditIndexReturnsRealEntriesNotStub(): void
     {
         $this->request->method('getParam')->willReturnMap([
-            ['caseId', null, 'case-a'],
+            ['caseId', '', 'case-a'],
             ['type', null, null],
             ['limit', '50', '50'],
             ['offset', '0', '0'],
@@ -137,7 +147,7 @@ class AiControllerAuditIndexTest extends TestCase
     public function testAuditIndexPassesFiltersAndPagingThrough(): void
     {
         $this->request->method('getParam')->willReturnMap([
-            ['caseId', null, 'case-b'],
+            ['caseId', '', 'case-b'],
             ['type', null, 'summary'],
             ['limit', '50', '10'],
             ['offset', '0', '20'],
@@ -172,6 +182,7 @@ class AiControllerAuditIndexTest extends TestCase
             auditService: $this->auditService,
             userSession: $userSession,
             logger: $this->logger,
+            caseAccessGuard: $this->caseAccessGuard,
         );
 
         $this->auditService->expects($this->never())->method('listAuditEntries');
@@ -182,6 +193,73 @@ class AiControllerAuditIndexTest extends TestCase
     }//end testAuditIndexRejectsUnauthenticated()
 
     /**
+     * An authenticated user who does not work on the case is refused, and the
+     * audit service is never reached.
+     *
+     * This is the gate-7 finding PROC-IDOR-02: before the guard, any
+     * authenticated account could read the AI decision trail of any case.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    public function testAuditIndexRejectsUserWithoutCaseAccess(): void
+    {
+        $this->request->method('getParam')->willReturnMap([
+            ['caseId', '', 'someone-elses-case'],
+            ['type', null, null],
+            ['limit', '50', '50'],
+            ['offset', '0', '0'],
+        ]);
+
+        $guard = $this->createMock(CaseAccessGuard::class);
+        $guard->expects($this->once())
+            ->method('hasCaseReadAccess')
+            ->with('someone-elses-case', $this->anything())
+            ->willReturn(false);
+
+        $controller = new AiController(
+            appName: 'procest',
+            request: $this->request,
+            aiService: $this->aiService,
+            auditService: $this->auditService,
+            userSession: $this->userSession,
+            logger: $this->logger,
+            caseAccessGuard: $guard,
+        );
+
+        $this->auditService->expects($this->never())->method('listAuditEntries');
+
+        $response = $controller->auditIndex();
+
+        $this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+    }//end testAuditIndexRejectsUserWithoutCaseAccess()
+
+    /**
+     * Omitting `caseId` no longer returns every AI decision record on the
+     * instance — it is a 400, and nothing is queried.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    public function testAuditIndexRefusesUnscopedDump(): void
+    {
+        $this->request->method('getParam')->willReturnMap([
+            ['caseId', '', ''],
+            ['type', null, null],
+            ['limit', '50', '50'],
+            ['offset', '0', '0'],
+        ]);
+
+        $this->auditService->expects($this->never())->method('listAuditEntries');
+
+        $response = $this->controller->auditIndex();
+
+        $this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+    }//end testAuditIndexRefusesUnscopedDump()
+
+    /**
      * A service-level failure returns a 500 rather than crashing.
      *
      * @return void
@@ -189,7 +267,7 @@ class AiControllerAuditIndexTest extends TestCase
     public function testAuditIndexHandlesServiceFailure(): void
     {
         $this->request->method('getParam')->willReturnMap([
-            ['caseId', null, null],
+            ['caseId', '', 'case-c'],
             ['type', null, null],
             ['limit', '50', '50'],
             ['offset', '0', '0'],

--- a/tests/Unit/Controller/BezwaarHearingControllerRecordAttendanceTest.php
+++ b/tests/Unit/Controller/BezwaarHearingControllerRecordAttendanceTest.php
@@ -31,6 +31,7 @@ namespace OCA\Procest\Tests\Unit\Controller;
 
 use OCA\Procest\Controller\BezwaarHearingController;
 use OCA\Procest\Service\Bezwaar\HearingService;
+use OCA\Procest\Service\CaseAccessGuard;
 use OCP\AppFramework\Http;
 use OCP\IRequest;
 use OCP\IUser;
@@ -74,6 +75,13 @@ final class BezwaarHearingControllerRecordAttendanceTest extends TestCase
      */
     private BezwaarHearingController $controller;
 
+    /**
+     * Per-case authorization guard.
+     *
+     * @var CaseAccessGuard|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private CaseAccessGuard $caseAccessGuard;
+
 
     /**
      * Set up fixtures.
@@ -82,17 +90,93 @@ final class BezwaarHearingControllerRecordAttendanceTest extends TestCase
      */
     protected function setUp(): void
     {
-        $this->request        = $this->createMock(IRequest::class);
-        $this->hearingService = $this->createMock(HearingService::class);
-        $this->userSession    = $this->createMock(IUserSession::class);
+        $this->request         = $this->createMock(IRequest::class);
+        $this->hearingService  = $this->createMock(HearingService::class);
+        $this->userSession     = $this->createMock(IUserSession::class);
+        $this->caseAccessGuard = $this->createMock(CaseAccessGuard::class);
+
+        // Default: the session resolves to a case the caller handles.
+        // The authorization tests below override both halves.
+        $this->hearingService->method('getCaseIdForSession')->willReturn('case-1');
+        $this->caseAccessGuard->method('hasCaseMutationAccess')->willReturn(true);
 
         $this->controller = new BezwaarHearingController(
             appName: 'procest',
             request: $this->request,
             hearingService: $this->hearingService,
             userSession: $this->userSession,
+            caseAccessGuard: $this->caseAccessGuard,
         );
     }//end setUp()
+
+
+    /**
+     * Build a controller with an explicit guard answer and session resolution.
+     *
+     * @param string|null $resolvedCaseId What the session resolves to.
+     * @param bool        $mayMutate      Whether the caller handles that case.
+     *
+     * @return BezwaarHearingController The controller under test.
+     */
+    private function controllerWith(?string $resolvedCaseId, bool $mayMutate): BezwaarHearingController
+    {
+        $hearingService = $this->createMock(HearingService::class);
+        $hearingService->method('getCaseIdForSession')->willReturn($resolvedCaseId);
+        $hearingService->expects($this->never())->method('recordAttendance');
+
+        $guard = $this->createMock(CaseAccessGuard::class);
+        $guard->method('hasCaseMutationAccess')->willReturn($mayMutate);
+
+        return new BezwaarHearingController(
+            appName: 'procest',
+            request: $this->request,
+            hearingService: $hearingService,
+            userSession: $this->userSession,
+            caseAccessGuard: $guard,
+        );
+    }//end controllerWith()
+
+
+    /**
+     * An authenticated caller who does not handle the parent bezwaar case
+     * cannot append attendance, and nothing is written.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    public function testCallerWithoutCaseAccessIsRejected(): void
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('mallory');
+        $this->userSession->method('getUser')->willReturn($user);
+
+        $response = $this->controllerWith(resolvedCaseId: 'case-1', mayMutate: false)
+            ->recordAttendance(sessionId: 'session-1');
+
+        $this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+    }//end testCallerWithoutCaseAccessIsRejected()
+
+
+    /**
+     * A session that cannot be resolved to a case denies, so the endpoint is
+     * not an existence oracle for hearing-session UUIDs.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    public function testUnresolvableSessionIsRejected(): void
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('behandelaar');
+        $this->userSession->method('getUser')->willReturn($user);
+
+        $response = $this->controllerWith(resolvedCaseId: null, mayMutate: true)
+            ->recordAttendance(sessionId: 'does-not-exist');
+
+        $this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+    }//end testUnresolvableSessionIsRejected()
 
 
     /**

--- a/tests/Unit/Controller/CaseRelationControllerTest.php
+++ b/tests/Unit/Controller/CaseRelationControllerTest.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 namespace OCA\Procest\Tests\Unit\Controller;
 
 use OCA\Procest\Controller\CaseRelationController;
+use OCA\Procest\Service\CaseAccessGuard;
 use OCA\Procest\Service\CaseRelationService;
 use OCP\AppFramework\Http;
 use OCP\IRequest;
@@ -57,6 +58,11 @@ class CaseRelationControllerTest extends TestCase
     private IUserSession $userSession;
 
     /**
+     * @var CaseAccessGuard|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private CaseAccessGuard $caseAccessGuard;
+
+    /**
      * The controller under test.
      *
      * @var CaseRelationController
@@ -70,16 +76,46 @@ class CaseRelationControllerTest extends TestCase
      */
     protected function setUp(): void
     {
-        $this->request     = $this->createMock(IRequest::class);
-        $this->service     = $this->createMock(CaseRelationService::class);
-        $this->userSession = $this->createMock(IUserSession::class);
+        $this->request         = $this->createMock(IRequest::class);
+        $this->service         = $this->createMock(CaseRelationService::class);
+        $this->userSession     = $this->createMock(IUserSession::class);
+        $this->caseAccessGuard = $this->createMock(CaseAccessGuard::class);
+
+        // Default: the caller works on both cases. The authorization tests at
+        // the bottom of this class override it.
+        $this->caseAccessGuard->method('hasCaseReadAccess')->willReturn(true);
 
         $this->controller = new CaseRelationController(
             request: $this->request,
             caseRelationService: $this->service,
             userSession: $this->userSession,
+            caseAccessGuard: $this->caseAccessGuard,
         );
     }//end setUp()
+
+    /**
+     * Build a controller whose guard answers per case id.
+     *
+     * @param array<string, bool> $readable Case UUID => whether it is readable.
+     *
+     * @return CaseRelationController The controller under test.
+     */
+    private function controllerWithReadableCases(array $readable): CaseRelationController
+    {
+        $guard = $this->createMock(CaseAccessGuard::class);
+        $guard->method('hasCaseReadAccess')->willReturnCallback(
+            static function (string $caseId) use ($readable): bool {
+                return ($readable[$caseId] ?? false);
+            }
+        );
+
+        return new CaseRelationController(
+            request: $this->request,
+            caseRelationService: $this->service,
+            userSession: $this->userSession,
+            caseAccessGuard: $guard,
+        );
+    }//end controllerWithReadableCases()
 
 
     /**
@@ -272,4 +308,96 @@ class CaseRelationControllerTest extends TestCase
         $this->assertArrayHasKey('results', $data);
         $this->assertCount(1, $data['results']);
     }//end testListReturnsResults()
+
+
+    /**
+     * An authenticated user who does not work on the case cannot list its
+     * relations, and the service is never reached.
+     *
+     * Before this guard the service-level `access_denied` was unreachable: it
+     * keys off `find()` returning null, and OpenRegister returns every object
+     * to every authenticated user for a schema with no `authorization` block.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    public function testListIsRefusedForUnrelatedUser(): void
+    {
+        $this->authenticate();
+        $this->service->expects($this->never())->method('listRelations');
+
+        $response = $this->controllerWithReadableCases(['a' => false])->list(caseId: 'a');
+
+        $this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+    }//end testListIsRefusedForUnrelatedUser()
+
+
+    /**
+     * Holding access to only the ORIGIN case is not enough to create a
+     * relation — a relation is written to both cases.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    public function testCreateIsRefusedWhenOnlyTheOriginIsReadable(): void
+    {
+        $this->authenticate();
+        $this->request->method('getParam')->willReturnMap([
+            ['targetId', '', 'b'],
+            ['aardRelatie', '', 'onderwerp'],
+            ['toelichting', null, null],
+        ]);
+        $this->service->expects($this->never())->method('addRelation');
+
+        $response = $this->controllerWithReadableCases(['a' => true, 'b' => false])
+            ->create(caseId: 'a');
+
+        $this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+    }//end testCreateIsRefusedWhenOnlyTheOriginIsReadable()
+
+
+    /**
+     * Holding access to only the TARGET case is not enough either.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    public function testCreateIsRefusedWhenOnlyTheTargetIsReadable(): void
+    {
+        $this->authenticate();
+        $this->request->method('getParam')->willReturnMap([
+            ['targetId', '', 'b'],
+            ['aardRelatie', '', 'onderwerp'],
+            ['toelichting', null, null],
+        ]);
+        $this->service->expects($this->never())->method('addRelation');
+
+        $response = $this->controllerWithReadableCases(['a' => false, 'b' => true])
+            ->create(caseId: 'a');
+
+        $this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+    }//end testCreateIsRefusedWhenOnlyTheTargetIsReadable()
+
+
+    /**
+     * Removing a relation between two cases the caller does not work on is
+     * refused, and nothing is written.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    public function testDestroyIsRefusedForUnrelatedUser(): void
+    {
+        $this->authenticate();
+        $this->service->expects($this->never())->method('removeRelation');
+
+        $response = $this->controllerWithReadableCases(['a' => false, 'b' => false])
+            ->destroy(caseId: 'a', targetId: 'b', aardRelatie: 'onderwerp');
+
+        $this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+    }//end testDestroyIsRefusedForUnrelatedUser()
 }//end class

--- a/tests/Unit/Controller/ContactMomentControllerAuthorizationTest.php
+++ b/tests/Unit/Controller/ContactMomentControllerAuthorizationTest.php
@@ -1,0 +1,247 @@
+<?php
+
+/**
+ * ContactMomentController citizen-lookup authorization tests.
+ *
+ * Every scenario below is written so the BAD path is the thing under test: an
+ * authenticated account that holds no KCC role must not be able to resolve a
+ * citizen identifier, and the service that would read the citizen's data must
+ * never be reached.
+ *
+ * Before the guard, `GET /api/kcc/voorblad?burgerId=…` answered HTTP 200 with
+ * the citizen's contact history — caller phone number and free-text call
+ * summaries included — to any authenticated account. Reproduced live against a
+ * running instance with two accounts (finding PROC-IDOR-01).
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/specs/authz-bypass-fixes/spec.md
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\ContactMomentController;
+use OCA\Procest\Service\BurgerIdentificationService;
+use OCA\Procest\Service\CaseVoorbladService;
+use OCA\Procest\Service\CitizenLookupGuard;
+use OCA\Procest\Service\ContactMomentService;
+use OCA\Procest\Service\DoorverbindingService;
+use OCA\Procest\Service\QuickActionService;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for the citizen-lookup guard on ContactMomentController.
+ *
+ * @covers \OCA\Procest\Controller\ContactMomentController
+ */
+class ContactMomentControllerAuthorizationTest extends TestCase
+{
+
+    private ContactMomentService $contactMomentService;
+
+    private CaseVoorbladService $caseVoorbladService;
+
+    private QuickActionService $quickActionService;
+
+    private DoorverbindingService $transferService;
+
+    private BurgerIdentificationService $burgerService;
+
+    private IUserSession $userSession;
+
+    private IRequest $request;
+
+    /**
+     * Set up shared collaborators.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->contactMomentService = $this->createMock(ContactMomentService::class);
+        $this->caseVoorbladService  = $this->createMock(CaseVoorbladService::class);
+        $this->quickActionService   = $this->createMock(QuickActionService::class);
+        $this->transferService      = $this->createMock(DoorverbindingService::class);
+        $this->burgerService        = $this->createMock(BurgerIdentificationService::class);
+        $this->request              = $this->createMock(IRequest::class);
+        $this->userSession          = $this->createMock(IUserSession::class);
+
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('mallory');
+        $this->userSession->method('getUser')->willReturn($user);
+    }//end setUp()
+
+    /**
+     * Build a controller whose citizen-lookup guard answers as given.
+     *
+     * @param bool $allowed Whether the caller holds a KCC role.
+     *
+     * @return ContactMomentController The controller under test.
+     */
+    private function controllerWithGuard(bool $allowed): ContactMomentController
+    {
+        $guard = $this->createMock(CitizenLookupGuard::class);
+        $guard->method('isCitizenLookupAllowed')->willReturn($allowed);
+
+        return new ContactMomentController(
+            appName: 'procest',
+            request: $this->request,
+            contactMomentService: $this->contactMomentService,
+            caseVoorbladService: $this->caseVoorbladService,
+            quickActionService: $this->quickActionService,
+            transferService: $this->transferService,
+            burgerService: $this->burgerService,
+            userSession: $this->userSession,
+            citizenLookupGuard: $guard,
+        );
+    }//end controllerWithGuard()
+
+    /**
+     * An authenticated account without a KCC role cannot read a citizen's
+     * voorblad, and the voorblad service is never called.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    public function testVoorbladIsRefusedWithoutKccRole(): void
+    {
+        $this->caseVoorbladService->expects($this->never())->method('getCaseVoorblad');
+
+        $response = $this->controllerWithGuard(allowed: false)->voorblad(burgerId: 'BSN-999999999');
+
+        $this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+    }//end testVoorbladIsRefusedWithoutKccRole()
+
+    /**
+     * A KCC handler still gets the voorblad — the guard denies a role, not the
+     * feature.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    public function testVoorbladIsServedToKccHandler(): void
+    {
+        $this->caseVoorbladService->expects($this->once())
+            ->method('getCaseVoorblad')
+            ->with('BSN-999999999')
+            ->willReturn(
+                [
+                    'burgerId'               => 'BSN-999999999',
+                    'openZaken'              => [],
+                    'recenteContactmomenten' => [],
+                    'suggestedTopic'         => '',
+                ]
+            );
+
+        $response = $this->controllerWithGuard(allowed: true)->voorblad(burgerId: 'BSN-999999999');
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame('BSN-999999999', $response->getData()['burgerId']);
+    }//end testVoorbladIsServedToKccHandler()
+
+    /**
+     * The contact-history listing is the same exposure through a second door.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    public function testContactHistoryIsRefusedWithoutKccRole(): void
+    {
+        $this->contactMomentService->expects($this->never())->method('listForBurger');
+
+        $response = $this->controllerWithGuard(allowed: false)->index(burgerId: 'BSN-999999999');
+
+        $this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+    }//end testContactHistoryIsRefusedWithoutKccRole()
+
+    /**
+     * A KCC handler still gets the contact history.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    public function testContactHistoryIsServedToKccHandler(): void
+    {
+        $this->contactMomentService->expects($this->once())
+            ->method('listForBurger')
+            ->with('BSN-999999999', 50)
+            ->willReturn([]);
+
+        $response = $this->controllerWithGuard(allowed: true)->index(burgerId: 'BSN-999999999');
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+    }//end testContactHistoryIsServedToKccHandler()
+
+    /**
+     * Logging a contactmoment against an arbitrary citizen is refused, and no
+     * write happens.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    public function testCreateIsRefusedWithoutKccRole(): void
+    {
+        $this->contactMomentService->expects($this->never())->method('createContactMoment');
+
+        $response = $this->controllerWithGuard(allowed: false)->create();
+
+        $this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+    }//end testCreateIsRefusedWithoutKccRole()
+
+    /**
+     * The "nieuwe zaak" quick-action binds a new municipal case to a
+     * caller-supplied citizen id; refused without the role, and nothing is
+     * created.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    public function testNieuweZaakIsRefusedWithoutKccRole(): void
+    {
+        $this->quickActionService->expects($this->never())->method('executeNieuweZaak');
+
+        $response = $this->controllerWithGuard(allowed: false)->nieuweZaak();
+
+        $this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+    }//end testNieuweZaakIsRefusedWithoutKccRole()
+
+    /**
+     * The "klacht registreren" quick-action takes an arbitrary caseId AND an
+     * arbitrary citizen id; refused without the role.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    public function testKlachtRegistrerenIsRefusedWithoutKccRole(): void
+    {
+        $this->quickActionService->expects($this->never())->method('executeKlachtRegistreren');
+
+        $response = $this->controllerWithGuard(allowed: false)->klachtRegistreren();
+
+        $this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+    }//end testKlachtRegistrerenIsRefusedWithoutKccRole()
+}//end class

--- a/tests/Unit/Controller/EmailTemplateControllerSeedDefaultsTest.php
+++ b/tests/Unit/Controller/EmailTemplateControllerSeedDefaultsTest.php
@@ -27,10 +27,12 @@ declare(strict_types=1);
 namespace OCA\Procest\Tests\Unit\Controller;
 
 use OCA\Procest\Controller\EmailTemplateController;
+use OCA\Procest\Service\CaseAccessGuard;
 use OCA\Procest\Service\EmailTemplateService;
 use OCA\Procest\Service\SettingsService;
 use OCP\AppFramework\Http;
 use OCP\IAppConfig;
+use OCP\IGroupManager;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -67,6 +69,13 @@ final class EmailTemplateControllerSeedDefaultsTest extends TestCase
     private IUserSession $userSession;
 
     /**
+     * Group manager (admin check on config writes).
+     *
+     * @var IGroupManager|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private IGroupManager $groupManager;
+
+    /**
      * The controller under test.
      *
      * @var EmailTemplateController
@@ -85,14 +94,59 @@ final class EmailTemplateControllerSeedDefaultsTest extends TestCase
         $this->templateService = $this->createMock(EmailTemplateService::class);
         $this->userSession     = $this->createMock(IUserSession::class);
 
+        $this->groupManager = $this->createMock(IGroupManager::class);
+        // Seeding default templates is a config write, so the default caller
+        // in these fixtures is an admin. `testNonAdminIsRejected()` below is
+        // the arm that proves the check can refuse.
+        $this->groupManager->method('isAdmin')->willReturn(true);
+
         $this->controller = new EmailTemplateController(
             request: $this->request,
             templateService: $this->templateService,
             settingsService: $this->createMock(SettingsService::class),
             appConfig: $this->createMock(IAppConfig::class),
             userSession: $this->userSession,
+            groupManager: $this->groupManager,
+            caseAccessGuard: $this->createMock(CaseAccessGuard::class),
         );
     }//end setUp()
+
+
+    /**
+     * A non-admin authenticated caller cannot seed templates, and the service
+     * is never reached.
+     *
+     * An email template's body is mailed to citizens; before this it could be
+     * created by every authenticated account.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    public function testNonAdminIsRejected(): void
+    {
+        $this->authenticate();
+
+        $groupManager = $this->createMock(IGroupManager::class);
+        $groupManager->method('isAdmin')->willReturn(false);
+
+        $templateService = $this->createMock(EmailTemplateService::class);
+        $templateService->expects($this->never())->method('seedDefaultTemplates');
+
+        $controller = new EmailTemplateController(
+            request: $this->request,
+            templateService: $templateService,
+            settingsService: $this->createMock(SettingsService::class),
+            appConfig: $this->createMock(IAppConfig::class),
+            userSession: $this->userSession,
+            groupManager: $groupManager,
+            caseAccessGuard: $this->createMock(CaseAccessGuard::class),
+        );
+
+        $response = $controller->seedDefaults(caseTypeId: 'ct-1');
+
+        $this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+    }//end testNonAdminIsRejected()
 
 
     /**

--- a/tests/Unit/Controller/StatusTransitionControllerBodyRegressionTest.php
+++ b/tests/Unit/Controller/StatusTransitionControllerBodyRegressionTest.php
@@ -27,6 +27,7 @@ namespace OCA\Procest\Tests\Unit\Controller;
 
 use OCA\Procest\Controller\StatusTransitionController;
 use OCA\Procest\Service\BulkStatusTransitionService;
+use OCA\Procest\Service\CaseAccessGuard;
 use OCA\Procest\Service\StatusTransitionService;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
@@ -89,6 +90,8 @@ class StatusTransitionControllerBodyRegressionTest extends TestCase
         $this->bulkEngine       = $this->createMock(BulkStatusTransitionService::class);
         $this->userSession      = $this->createMock(IUserSession::class);
         $this->logger           = $this->createMock(LoggerInterface::class);
+        $caseAccessGuard        = $this->createMock(CaseAccessGuard::class);
+        $caseAccessGuard->method('hasCaseReadAccess')->willReturn(true);
 
         $this->controller = new StatusTransitionController(
             'procest',
@@ -97,6 +100,7 @@ class StatusTransitionControllerBodyRegressionTest extends TestCase
             $this->bulkEngine,
             $this->userSession,
             $this->logger,
+            $caseAccessGuard,
         );
 
         $user = $this->createMock(IUser::class);

--- a/tests/Unit/Controller/StatusTransitionControllerBulkTest.php
+++ b/tests/Unit/Controller/StatusTransitionControllerBulkTest.php
@@ -27,6 +27,7 @@ namespace OCA\Procest\Tests\Unit\Controller;
 
 use OCA\Procest\Controller\StatusTransitionController;
 use OCA\Procest\Service\BulkStatusTransitionService;
+use OCA\Procest\Service\CaseAccessGuard;
 use OCA\Procest\Service\StatusTransitionService;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
@@ -74,6 +75,11 @@ final class StatusTransitionControllerBulkTest extends TestCase
     private LoggerInterface $logger;
 
     /**
+     * @var CaseAccessGuard&MockObject
+     */
+    private CaseAccessGuard $caseAccessGuard;
+
+    /**
      * The controller under test.
      *
      * @var StatusTransitionController
@@ -92,6 +98,8 @@ final class StatusTransitionControllerBulkTest extends TestCase
         $this->bulkEngine       = $this->createMock(BulkStatusTransitionService::class);
         $this->userSession      = $this->createMock(IUserSession::class);
         $this->logger           = $this->createMock(LoggerInterface::class);
+        $this->caseAccessGuard  = $this->createMock(CaseAccessGuard::class);
+        $this->caseAccessGuard->method('hasCaseReadAccess')->willReturn(true);
 
         $this->controller = new StatusTransitionController(
             'procest',
@@ -100,6 +108,7 @@ final class StatusTransitionControllerBulkTest extends TestCase
             $this->bulkEngine,
             $this->userSession,
             $this->logger,
+            $this->caseAccessGuard,
         );
 
         $user = $this->createMock(IUser::class);
@@ -123,6 +132,7 @@ final class StatusTransitionControllerBulkTest extends TestCase
             $this->bulkEngine,
             $this->userSession,
             $this->logger,
+            $this->caseAccessGuard,
         );
 
         $this->bulkEngine->expects($this->never())->method('preview');
@@ -148,6 +158,7 @@ final class StatusTransitionControllerBulkTest extends TestCase
             $this->bulkEngine,
             $this->userSession,
             $this->logger,
+            $this->caseAccessGuard,
         );
 
         $this->bulkEngine->expects($this->never())->method('execute');

--- a/tests/Unit/Service/CaseAccessGuardReadAccessTest.php
+++ b/tests/Unit/Service/CaseAccessGuardReadAccessTest.php
@@ -1,0 +1,307 @@
+<?php
+
+/**
+ * CaseAccessGuard::hasCaseReadAccess() Unit Tests
+ *
+ * The read predicate added for the gate-7 IDOR remediation. Written so the BAD
+ * path is the thing under test: every branch that cannot establish a real
+ * relationship between the caller and the case must DENY, and in particular the
+ * three branches on which `Sharing\CaseAccessPolicy::canUserAccessCase()` grants
+ * access (OpenRegister absent, schema unconfigured, lookup throws) must deny
+ * here.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/specs/authz-bypass-fixes/spec.md
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Service;
+
+use OCA\Procest\Service\CaseAccessGuard;
+use OCA\Procest\Service\SettingsService;
+use OCP\IGroupManager;
+use OCP\IUser;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Unit tests for the per-case read predicate.
+ *
+ * @covers \OCA\Procest\Service\CaseAccessGuard
+ */
+class CaseAccessGuardReadAccessTest extends TestCase
+{
+
+    private SettingsService $settingsService;
+
+    private IGroupManager $groupManager;
+
+    private LoggerInterface $logger;
+
+    /**
+     * Set up shared collaborators.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->settingsService = $this->createMock(SettingsService::class);
+        $this->groupManager    = $this->createMock(IGroupManager::class);
+        $this->logger          = $this->createMock(LoggerInterface::class);
+        $this->groupManager->method('isAdmin')->willReturn(false);
+    }//end setUp()
+
+    /**
+     * Build a user double.
+     *
+     * @param string $uid The user id.
+     *
+     * @return IUser The user double.
+     */
+    private function user(string $uid): IUser
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn($uid);
+
+        return $user;
+    }//end user()
+
+    /**
+     * Configure the settings double to return a working OR object service that
+     * resolves the case to the given payload.
+     *
+     * `find()` is what `SearchesObjects::findObjectAsArray()` calls; returning
+     * a plain array mirrors the array branch of that helper.
+     *
+     * @param array<string, mixed>|null $case The case payload, or null for "not found".
+     *
+     * @return void
+     */
+    private function givenCase(?array $case): void
+    {
+        $objectService = new class($case) {
+
+            /**
+             * @param array<string, mixed>|null $case The case payload.
+             */
+            public function __construct(private readonly ?array $case)
+            {
+            }
+
+            /**
+             * Mimic ObjectService::find().
+             *
+             * @param string $id       The object id.
+             * @param mixed  $register The register.
+             * @param mixed  $schema   The schema.
+             *
+             * @return array<string, mixed>|null The object.
+             */
+            public function find(string $id, mixed $register=null, mixed $schema=null): ?array
+            {
+                return $this->case;
+            }
+        };
+
+        $this->settingsService->method('getObjectService')->willReturn($objectService);
+        $this->settingsService->method('getConfigValue')->willReturnMap(
+            [
+                ['register', '', '14'],
+                ['case_schema', '', '24'],
+            ]
+        );
+    }//end givenCase()
+
+    /**
+     * Build the guard under test.
+     *
+     * @return CaseAccessGuard The guard.
+     */
+    private function guard(): CaseAccessGuard
+    {
+        return new CaseAccessGuard(
+            settingsService: $this->settingsService,
+            groupManager: $this->groupManager,
+            logger: $this->logger,
+        );
+    }//end guard()
+
+    /**
+     * The named assignee may read the case.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    public function testAssigneeMayRead(): void
+    {
+        $this->givenCase(['id' => 'case-1', 'assignee' => 'alice']);
+
+        $this->assertTrue($this->guard()->hasCaseReadAccess('case-1', $this->user('alice')));
+    }//end testAssigneeMayRead()
+
+    /**
+     * A member of the `assignees` array may read the case.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    public function testAssigneesArrayMemberMayRead(): void
+    {
+        $this->givenCase(['id' => 'case-1', 'assignee' => 'alice', 'assignees' => ['bob', 'carol']]);
+
+        $this->assertTrue($this->guard()->hasCaseReadAccess('case-1', $this->user('bob')));
+    }//end testAssigneesArrayMemberMayRead()
+
+    /**
+     * An unrelated authenticated user may not read the case.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    public function testUnrelatedUserMayNotRead(): void
+    {
+        $this->givenCase(['id' => 'case-1', 'assignee' => 'alice', 'assignees' => ['bob']]);
+
+        $this->assertFalse($this->guard()->hasCaseReadAccess('case-1', $this->user('mallory')));
+    }//end testUnrelatedUserMayNotRead()
+
+    /**
+     * A case that cannot be resolved denies rather than skipping the check.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    public function testUnresolvableCaseDenies(): void
+    {
+        $this->givenCase(null);
+
+        $this->assertFalse($this->guard()->hasCaseReadAccess('case-1', $this->user('alice')));
+    }//end testUnresolvableCaseDenies()
+
+    /**
+     * An absent OpenRegister denies — this is the first of the three branches
+     * on which `CaseAccessPolicy::canUserAccessCase()` returns TRUE.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    public function testAbsentOpenRegisterDenies(): void
+    {
+        $this->settingsService->method('getObjectService')->willReturn(null);
+
+        $this->assertFalse($this->guard()->hasCaseReadAccess('case-1', $this->user('alice')));
+    }//end testAbsentOpenRegisterDenies()
+
+    /**
+     * An unconfigured case schema denies — the second fail-open branch of
+     * `CaseAccessPolicy`.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    public function testUnconfiguredSchemaDenies(): void
+    {
+        $objectService = new \stdClass();
+        $this->settingsService->method('getObjectService')->willReturn($objectService);
+        $this->settingsService->method('getConfigValue')->willReturn('');
+
+        $this->assertFalse($this->guard()->hasCaseReadAccess('case-1', $this->user('alice')));
+    }//end testUnconfiguredSchemaDenies()
+
+    /**
+     * A lookup that throws denies — the third fail-open branch of
+     * `CaseAccessPolicy`.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    public function testThrowingLookupDenies(): void
+    {
+        $objectService = new class {
+
+            /**
+             * Mimic an ObjectService whose backend is down.
+             *
+             * @param string $id       The object id.
+             * @param mixed  $register The register.
+             * @param mixed  $schema   The schema.
+             *
+             * @return array<string, mixed> Never returns.
+             *
+             * @throws \RuntimeException Always.
+             */
+            public function find(string $id, mixed $register=null, mixed $schema=null): array
+            {
+                throw new \RuntimeException('backend down');
+            }
+        };
+
+        $this->settingsService->method('getObjectService')->willReturn($objectService);
+        $this->settingsService->method('getConfigValue')->willReturnMap(
+            [
+                ['register', '', '14'],
+                ['case_schema', '', '24'],
+            ]
+        );
+
+        $this->assertFalse($this->guard()->hasCaseReadAccess('case-1', $this->user('alice')));
+    }//end testThrowingLookupDenies()
+
+    /**
+     * An empty case id or an empty uid denies before anything is loaded.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    public function testEmptyIdentifiersDeny(): void
+    {
+        $this->settingsService->expects($this->never())->method('getObjectService');
+
+        $guard = $this->guard();
+
+        $this->assertFalse($guard->hasCaseReadAccess('', $this->user('alice')));
+        $this->assertFalse($guard->hasCaseReadAccess('case-1', $this->user('')));
+    }//end testEmptyIdentifiersDeny()
+
+    /**
+     * A Nextcloud admin may read any case.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    public function testAdminMayRead(): void
+    {
+        $groupManager = $this->createMock(IGroupManager::class);
+        $groupManager->method('isAdmin')->willReturn(true);
+
+        $guard = new CaseAccessGuard(
+            settingsService: $this->settingsService,
+            groupManager: $groupManager,
+            logger: $this->logger,
+        );
+
+        $this->assertTrue($guard->hasCaseReadAccess('case-1', $this->user('admin')));
+    }//end testAdminMayRead()
+}//end class

--- a/tests/Unit/Service/MandaatCheckServiceTest.php
+++ b/tests/Unit/Service/MandaatCheckServiceTest.php
@@ -180,4 +180,64 @@ class MandaatCheckServiceTest extends TestCase
         $r = $this->service->isAuthorized('bob', 'wmo-toekenning', 'Z/2026/6', ['bedragCents' => 100000]);
         self::assertTrue($r['authorized']);
     }
+
+    /**
+     * An unbound conflict-of-interest service is INDETERMINATE, and
+     * indeterminate denies — it must not skip the belangenconflict check.
+     *
+     * The `authz-bypass-fixes` spec has required this since the original
+     * change ("A missing conflict service denies rather than skips"), and the
+     * behaviour is implemented at `MandaatCheckService::isAuthorized()`, but no
+     * test exercised it: every fixture in this class binds a real service. The
+     * scenario was the one requirement in that spec with no coverage to point
+     * at, so it is covered here rather than waived.
+     *
+     * The arm is deliberately one that WOULD be authorized with the service
+     * bound — `alice` is under her plafond and the fixtures carry no
+     * natural-person applicant — so this asserts the null service is what
+     * denies, not the mandaat logic.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    public function testMissingConflictServiceDeniesRatherThanSkips(): void
+    {
+        $settings = $this->createMock(SettingsService::class);
+        $settings->method('getObjectService')->willReturn($this->objects);
+        $settings->method('getConfigValue')->willReturnCallback(
+            static function (string $key): string {
+                return match ($key) {
+                    'register'                         => 'procest',
+                    'mandaat_schema'                   => 'mandaat',
+                    'medewerker_rol_toewijzing_schema' => 'medewerkerRolToewijzing',
+                    default                            => '',
+                };
+            },
+        );
+
+        // Positive control: the SAME call authorizes when a service is bound.
+        $bound = new MandaatCheckService(
+            $settings,
+            $this->createMock(LoggerInterface::class),
+            new ConflictOfInterestService($this->createMock(LoggerInterface::class)),
+        );
+        $allowed = $bound->isAuthorized('alice', 'wmo-toekenning', 'Z/2026/7', ['bedragCents' => 100000]);
+        self::assertTrue($allowed['authorized']);
+
+        // Same inputs, conflict service absent.
+        $unbound = new MandaatCheckService(
+            $settings,
+            $this->createMock(LoggerInterface::class),
+            null,
+        );
+        $denied = $unbound->isAuthorized('alice', 'wmo-toekenning', 'Z/2026/7', ['bedragCents' => 100000]);
+
+        self::assertFalse($denied['authorized']);
+        self::assertSame(MandaatCheckService::REDEN_BELANGENCONFLICT, $denied['reden']);
+        self::assertSame(
+            ConflictOfInterestService::REASON_IDENTITY_INDETERMINATE,
+            $denied['conflictReason'],
+        );
+    }
 }


### PR DESCRIPTION
> ## 🔧 DEPLOYMENT STEP — THIS PR DENIES UNTIL A GROUP EXISTS
>
> `CitizenLookupGuard` gates the KCC citizen-lookup endpoints on membership of
> **`kcc`**, `klantcontact`, `beheerders` or `admin`.
>
> **`beheerders` and `admin` are attested** — both are already used as group
> names by `ProcessMiningController` and `ParaferingAuditExportController`.
> **`kcc` and `klantcontact` are assumptions**: verified with `grep -w` at
> `cb63acad3`, neither appears anywhere in this codebase as a group name
> (`kcc` is only a feature name, spec slug and CSS class; `klantcontact` only a
> ZGW domain term and a spec slug). They were chosen by me, not derived.
>
> **Before/at merge:** create a `kcc` group and add the KCC handlers to it, or
> edit the constant to match the group your instance already uses. Until then
> KCC staff get HTTP 403 and admins are unaffected.
>
> This is a **fail-closed** error by design: a wrong group name is a functional
> regression an operator fixes in a minute; the alternative was a live HTTP 200
> returning a citizen's phone number and call summaries to any authenticated
> account.

## What

Closes the first tranche of the 33 unguarded `#[NoAdminRequired]` endpoints
found by the gate-7 fleet re-audit (procest#801) — the ones that touch **citizen
personal data**.

**Live reproduction, two accounts, status codes printed** (rig: NC 34.0.0,
procest 0.3.9, openregister 0.2.17-unstable.37). Seeded a case and a
contactmoment for citizen `BSN-999999999` as `pro-victim`; probed as
`pro-attacker`, a second non-admin account with no relationship to any of it:

| request | before | after |
|---|---|---|
| `GET /api/kcc/voorblad?burgerId=…` unauthenticated | 401 | 401 |
| `GET /api/kcc/voorblad?burgerId=…` as an unrelated account | **200 + phone number + call summary** | **403** |
| same, as a member of group `kcc` | 200 | 200 |
| `GET /api/contactmomenten?burgerId=…` as an unrelated account | **200** | **403** |
| `POST /api/kcc/quick-actions/klacht-registreren` as an unrelated account | 200 | **403** |
| `GET /api/ai/audit` with no `caseId` | **200, unscoped** | **400** |
| `GET /api/ai/audit?caseId=<victim's case>` as an unrelated account | 200 | **403** |

All existing verification of these endpoints was source reading only. Details
are in `fleet-board/findings/procest.md`; no further exploit specifics here.

## Why gate-7 never saw it

`.github#365` — the checker accepts `Http::STATUS_UNAUTHORIZED` / `401` as an
authorisation guard, and **49 of procest's 91 controller files** open with the
house-style `if ($user === null) { … 401 }` preamble. That is *authentication*.
gate-7 reports `0` in all eighteen fleet apps for the same reason.

`.github#372` — the layer below does not catch it either:
`PermissionHandler::hasGroupPermission()` returns `true` for an empty
`authorization` block and `enforce_default_closed` defaults `false`. procest's
`procest_register.json` declares **85 schemas, zero with an `authorization`
block**, so the controller guard is not the outer of two layers — it is the only
layer.

## How

- **`CitizenLookupGuard`** (new) — role gate for endpoints that resolve a raw
  `burgerId`. These have no per-object owner (a KCC handler legitimately answers
  a call from a citizen they have never handled), so the control is a role, not
  a per-case relationship, and `CaseAccessGuard` does not apply. It follows the
  idiom already used for the other broad-scope reads in this app
  (`ParaferingAuditExportController`, `AiAuditExportController`,
  `ProcessMiningController`): a fixed group set plus an admin fallback. Fails
  closed in the **opposite** direction to the bug `CaseAccessGuard` was written
  for — an absent group grants nothing.
- **`CaseAccessGuard::hasCaseReadAccess()`** (new) — per-case READ predicate
  (admin / `assignee` / member of `assignees`). Deliberately **not** delegated to
  `Sharing\CaseAccessPolicy::canUserAccessCase()`, which returns `true` when
  OpenRegister is absent, when the schema is unconfigured, and when the lookup
  throws. Three fail-open branches, and its docblock claims an admin check the
  class has no `IGroupManager` to perform. Nine call sites rest on it — filed
  separately, not changed here.
- **`AiController::auditIndex()`** — `caseId` was optional and the filter was
  built with `array_filter()`, so omitting it returned every AI decision record
  on the instance.

## Also fixed: a fatal that made every endpoint a 500 on the multi-tenant path

`TenantMiddleware.php:132` called `$this->request->setParameter(…)`.
**`setParameter()` exists on neither `OCP\IRequest` nor
`OC\AppFramework\Http\Request`**, so every request from a user who *had* a
tenant died as an unhandled `Error` → HTTP 500 with an HTML page.

The branch above returns early for users with **no** tenant, and single-tenant
installs — CI, every e2e rig, every local install — take that branch. There is
no unit test for this middleware at all. Nothing anywhere reads the three keys
it set, so they are removed rather than re-homed; the tenant-lifecycle
enforcement above is untouched.

It also **masked the IDORs while they were being measured**: the first probe
round returned 500 for four of six requests, which reads exactly like "the
endpoint is protected".

## Tests

- 7 new `ContactMomentController` cases, 9 new `CaseAccessGuard` cases, 2 new
  `auditIndex` cases; every refusal case asserts the collaborator that would
  read or write the data is **never reached**, and each guard has a positive arm
  so it cannot be satisfied by refusing everyone.
- **Negative control**: inverting the guard predicate in
  `ContactMomentController` turns all 7 red (7 failures / 7 assertions),
  including both positive arms. Reverted.
- Full suite **1795 tests OK**; phpcs **0 errors** over `lib/`; psalm, phpstan,
  phpmd clean.
- `composer.lock`: phpcsutils 1.2.2 → 1.2.3 (CVE-2026-65954). `vendor/` here is
  root-owned so the bump could not be exercised locally; CI installs fresh.

## Not in this PR

The remaining case-scoped endpoints from procest#801 (CaseRelation, Deelzaak,
Berichtenbox, Appointment, Zaakdossier, StatusTransition, EmailTemplate,
BezwaarHearing, Lhs, Advice) follow in the next commits on this branch.

Refs ConductionNL/.github#365, ConductionNL/.github#372, procest#801

---

# Tranche 2 — the case-scoped endpoints (commit 2)

Twenty more endpoints now call `CaseAccessGuard`. **The ownership field is not
invented**: `case.assignee` / `case.assignees` is the model the guard already
encodes and `WOOAssessmentController` already enforces.

## Live reproduction, both arms, hard-flushed opcache

Owner = `pro-victim` (= `case.assignee`). Attacker = `pro-attacker2`, **in the
same group as the owner** and differing from it in exactly one attribute: it is
not the assignee.

| endpoint | BEFORE owner/attacker | AFTER owner/attacker |
|---|---|---|
| `GET /api/cases/{id}/relations` | 200 / **200** | 200 / **403** |
| `GET /api/deelzaken/{id}/children` | 200 / **200** | 200 / **403** |
| `GET /api/deelzaken/{id}/parent` | 404 / 404 | 404 / **403** |
| `GET /api/case/{id}/available-transitions` | 200 / **200** | 200 / **403** |
| `GET /api/case/{id}/transition-history` | 200 / **200** | 200 / **403** |
| `GET /api/dossier/{id}/export` | 500 / **500** | 500 / **403** |
| `GET /api/appointments?caseId=` | 200 / **200** | 200 / **403** |
| `GET /api/berichtenbox/messages?caseId=` | 200 / **200** | 200 / **403** |
| `POST /api/deelzaken/validate` | 409 / **409** | 409 / **403** |
| `POST /api/cases/{id}/relations` | 409 / **409** | 409 / **403** |
| `POST /api/deelzaken/{id}/unlink` | 200 / **200** | 200 / **403** |

**The owner column is byte-identical across both arms** — none of these became
an endpoint that denies everyone.

⚠️ `GET /api/dossier/{caseId}/export` answers **500 to its own owner in both
arms**. Pre-existing, untouched here, now unreachable by anyone else. Flagged,
not fixed.

## Two measurement traps that nearly produced a wrong table

1. **`opcache.revalidate_freq=60`.** After `git checkout <ref> -- lib/`, each
   file revalidates on its own 60-second clock, so one request can execute one
   controller at the new revision and another at the old one. Three runs of the
   same 11 endpoints gave three different, internally consistent tables. Only
   `docker restart` between arms is reliable — `opcache_reset()` via
   `docker exec php -r` resets nothing, because `opcache.enable_cli` is Off, and
   exits 0.
2. **The attacker account was in no group while the owner was in one** (a group
   the KCC fix required). Six of eleven endpoints then read as "already
   protected" because procest's SaaS middleware refused the group-less account —
   a 403 that looks exactly like the IDOR being absent.

## Checked before trusting the guard

`CaseAccessGuard::loadCase()` ends in `catch (Throwable) { return null; }` —
pipelinq#805's exact shape, where a fatal named-argument call becomes "deny
everyone". `ObjectService::find()` declares `id`, `register` and `schema`, so
the call cannot raise; the unchanged owner column confirms it live.

## 🔶 One product decision that needs sign-off (see the deployment banner at the top)

For the case-scoped endpoints the ownership field already existed. **The
citizen-lookup guard is different** — the subject is a citizen, not a case, and
a KCC handler legitimately looks up someone they have never handled, so no
per-object predicate exists. I introduced one: membership of
`kcc` / `klantcontact` / `beheerders`, plus admin, copying the `ALLOWED_GROUPS`
idiom already used by `ParaferingAuditExportController`,
`AiAuditExportController` and `ProcessMiningController`.

The shape is the app's own; **two of the four group names are mine**. Checked
with `grep -w`: `beheerders` and `admin` are attested elsewhere in this app,
`kcc` and `klantcontact` are not attested anywhere as group names.

Shipped rather than leaving citizen personal data readable by every account, and
admins keep working so no deployment loses its administrator — but this is a
security control nobody has agreed. **Please ratify or rename the two invented
names.** The assumption is stated on `CitizenLookupGuard::ALLOWED_GROUPS` itself
so nobody reading the constant has to guess which names were derived and which
were invented.

## Still open from procest#801

`EmailController::templates` and `EmailTemplateController::listTemplates` /
`variables` (case-type config reads, weighted down by the audit as crossing no
per-user boundary), and `TemplateController::activate` — not an IDOR, but any
authenticated user can create caseTypes and statusTypes wholesale. Logged
separately rather than folded in here.

---

# Commit 3 — PHPMD, and a retraction

CI caught what my local run missed: I ran phpmd at the tranche-1 checkpoint and
not again before committing tranche 2, and my three `getCaseIdFor*()` resolvers
were near-identical copies. Extracted to one `OwningCaseResolver`, which closes
CyclomaticComplexity 10 ×2, NPathComplexity 288 ×2 and ExcessiveClassComplexity
53 **by deleting the duplication, not by moving a threshold**. The upload guard
moved to `DossierUploadHandler::hasCaseUploadAccess()` — the collaborator that
performs the write — which also takes `ZaakdossierController` back under the
coupling threshold my added dependency had pushed it over. phpmd is now silent
on both rulesets; no baseline, threshold or test was weakened.

## 🔴 Retraction: `POST /api/bezwaar/hearings/{sessionId}/attendance` was never a live IDOR

Found while live-verifying the resolver's **positive** path. With a real
hearingSession seeded, the legitimate owner gets
`400 {"error":"Hearing session not found"}`:

```php
$current = $objectService->find($sessionId, register: $register, schema: $schema);
if (is_array($current) === false) { throw new RuntimeException('Hearing session not found'); }
```

`ObjectService::find()` returns `?ObjectEntity`, never an array — the throw is
**unconditional**. The endpoint has never worked and never leaked anything.

I only caught it because I probed the **owner** as well as the attacker: the
attacker arm returned a clean 403 and looked exactly like a closed
vulnerability, while the owner's refusal came back in **the wrong dialect**
(`400 … not found` where the guard's refusal is `403 Not authorized`).

**Deliberately not repaired** — a legally-sensitive Awb art. 7:7 audit path
whose correct post-repair behaviour I cannot validate here. The guard is in
place *first*, so repairing the lookup cannot create a live IDOR.

## Honest accounting — this PR does not close "33 live IDORs"

Guards were added at 33 call sites. What the live probes demonstrate:

| category | n |
|---|---:|
| **Demonstrated leak to an unrelated account** (200 with the owner's data, or the write performed) | **10** |
| Attacker reached the same business logic, no payload (both got the owner's `409`) | 2 |
| Indistinguishable — endpoint fails or is empty for everyone (`dossier/export` is **500 to its own owner in both arms**; `deelzaken/parent` 404/404 because the fixture case has no parent) | 2 |
| Guarded but proven **dead** (hearing attendance, above) | 1 |
| Guarded, not live-probed — no fixture on this rig, or reachable only through UI flows I did not build | 18 |

⚠️ `dossier/export` returning 500 to its owner is the same shape as the dead
hearing endpoint. I did not chase it, so it is **not counted as a demonstrated
IDOR** either way — flagged for follow-up.

---

# Commit 5 — the two gate cells my own change turned red

Reproduced locally against the **canonical** gate package
(`ConductionNL/.github@57bcb2b`), not the adjacent `.github` checkout.

⚠️ Both were invisible to me until CI reported them, for the same reason: when I
grepped this PR's check list for a gates cell it **was not there yet**.
`gh pr checks` returns a partial set — the run grew **23 → 24 → 29 → 32** — so
"there is no Hydra Gates job in this repo" was an absence claim read off a list
that had not finished being populated.

## gate-9 semantic-auth — 3 findings, all mine

`createTemplate` / `updateTemplate` / `seedDefaults` kept `@NoAdminRequired`
while their bodies now require admin: the exact attribute-vs-body mismatch this
gate exists to catch, introduced by me in commit 2.

Fixed with `#[AuthorizedAdminSetting(settings: AdminSettings::class)]` — the
idiom `KccRoutingController` already uses for the same kind of config write — so
Nextcloud's middleware enforces admin **before** the controller runs. Simply
deleting `@NoAdminRequired` would have satisfied gate-9 and **broken gate-5**,
which requires every routed method to declare a posture. The in-body check stays
as defence in depth and is what the unit tests drive.

## gate-19 e2e-coverage — 19 findings, none of them mine

All ten scenarios I added were already tagged and accepted. The 19 were
**pre-existing untagged scenarios** in `authz-bypass-fixes/spec.md`, pulled in
because the gate parses a touched spec file **whole**.

**Tagged, not dodged.** The tempting move was to put my new requirements in a
fresh spec file — instantly green, debt untouched and invisible again. I didn't.

Each reason names the specific **test method**, not just a class:
`AdviceServiceAuthorizationTest`, `WOOAssessmentControllerAuthorizationTest`,
`ConflictOfInterestServiceTest`. I read the two load-bearing ones to confirm
they assert the refusal *and* `expects($this->never())` on the service beneath.

**One scenario had no coverage at all** — *"A missing conflict service denies
rather than skips"*; every fixture in `MandaatCheckServiceTest` binds a real
service. That one is **covered by a new test**, not waived, and the test carries
its own positive control: the identical call authorizes with the service bound
and denies when it is null.

## Local verification, all green

gate-7 clean · gate-9 clean · gate-16 `count=0` · gate-19 **PASS** · phpcs 0 ·
phpmd silent on both rulesets · psalm · phpstan · **1803 tests**.
