### PR TITLE
refactor(procest): $termijnService -> $deadlineService

### DIFF
--- a/lib/Controller/DeadlineController.php
+++ b/lib/Controller/DeadlineController.php
@@ -60,18 +60,18 @@ class DeadlineController extends Controller
     /**
      * Constructor.
      *
-     * @param string                   $appName     App id.
-     * @param IRequest                 $request     Request.
-     * @param DeadlineService          $termijn     Termijn service.
-     * @param DeadlinePauseService     $pause       Pause service.
-     * @param DeadlineExtensionService $extension   Extension service.
-     * @param IUserSession             $userSession User session.
-     * @param LoggerInterface          $logger      Logger.
+     * @param string                   $appName         App id.
+     * @param IRequest                 $request         Request.
+     * @param DeadlineService          $deadlineService Deadline service.
+     * @param DeadlinePauseService     $pause           Pause service.
+     * @param DeadlineExtensionService $extension       Extension service.
+     * @param IUserSession             $userSession     User session.
+     * @param LoggerInterface          $logger          Logger.
      */
     public function __construct(
         string $appName,
         IRequest $request,
-        private readonly DeadlineService $termijn,
+        private readonly DeadlineService $deadlineService,
         private readonly DeadlinePauseService $pause,
         private readonly DeadlineExtensionService $extension,
         private readonly IUserSession $userSession,
@@ -127,7 +127,7 @@ class DeadlineController extends Controller
         }
 
         try {
-            $row = $this->termijn->createTermijnInstance($zaakId, $zaaktype);
+            $row = $this->deadlineService->createTermijnInstance($zaakId, $zaaktype);
             return new JSONResponse($row, Http::STATUS_CREATED);
         } catch (Throwable $e) {
             return $this->error(e: $e, log: 'Termijn create failed');
@@ -152,7 +152,7 @@ class DeadlineController extends Controller
             return $denied;
         }
 
-        $row = $this->termijn->getTermijnInstance($id);
+        $row = $this->deadlineService->getTermijnInstance($id);
         if ($row === null) {
             return $this->notFound(msg: 'TermijnInstance not found: '.$id);
         }
@@ -293,7 +293,7 @@ class DeadlineController extends Controller
         }
 
         try {
-            $row = $this->termijn->markTermijnCompleted(
+            $row = $this->deadlineService->markTermijnCompleted(
                 $id,
                 $completedAt,
                 $documentLink

--- a/lib/Listener/DeadlineCaseCreatedListener.php
+++ b/lib/Listener/DeadlineCaseCreatedListener.php
@@ -47,12 +47,12 @@ class DeadlineCaseCreatedListener implements IEventListener
     /**
      * Constructor.
      *
-     * @param DeadlineService          $termijnService DeadlineService.
-     * @param ObjectSchemaSlugResolver $slugResolver   Schema id-to-slug resolver.
-     * @param LoggerInterface          $logger         Logger.
+     * @param DeadlineService          $deadlineService DeadlineService.
+     * @param ObjectSchemaSlugResolver $slugResolver    Schema id-to-slug resolver.
+     * @param LoggerInterface          $logger          Logger.
      */
     public function __construct(
-        private readonly DeadlineService $termijnService,
+        private readonly DeadlineService $deadlineService,
         private readonly ObjectSchemaSlugResolver $slugResolver,
         private readonly LoggerInterface $logger,
     ) {
@@ -89,7 +89,7 @@ class DeadlineCaseCreatedListener implements IEventListener
         }
 
         try {
-            $this->termijnService->createTermijnInstance($caseId, $zaaktype);
+            $this->deadlineService->createTermijnInstance($caseId, $zaaktype);
         } catch (\Throwable $e) {
             // A case without a coupled definition is permissible — debug log only.
             $this->logger->debug(

--- a/lib/Service/DeadlineDailyScanService.php
+++ b/lib/Service/DeadlineDailyScanService.php
@@ -53,14 +53,14 @@ class DeadlineDailyScanService
      * Constructor.
      *
      * @param SettingsService                 $settingsService   Settings service.
-     * @param DeadlineService                 $termijnService    DeadlineService.
+     * @param DeadlineService                 $deadlineService   DeadlineService.
      * @param DeadlineEscalationService       $escalationService Escalation service.
      * @param LoggerInterface                 $logger            Logger.
      * @param DwangsomCalculationService|null $dwangsomService   Dwangsom calculation service.
      */
     public function __construct(
         private readonly SettingsService $settingsService,
-        private readonly DeadlineService $termijnService,
+        private readonly DeadlineService $deadlineService,
         private readonly DeadlineEscalationService $escalationService,
         private readonly LoggerInterface $logger,
         private readonly ?DwangsomCalculationService $dwangsomService=null,
@@ -228,7 +228,7 @@ class DeadlineDailyScanService
         $pauseEnd = (string) ($row['pauzeDeadline'] ?? '');
         if ($pauseEnd !== '' && $pauseEnd < $now->format('Y-m-d')) {
             $counts['pauseExpired']++;
-            $this->termijnService->recordEvent(
+            $this->deadlineService->recordEvent(
                 termijnInstanceId: $rowId,
                 type: 'pauze-verlopen',
                 grondslag: 'AWB 4:5',
@@ -271,8 +271,8 @@ class DeadlineDailyScanService
     private function recordOverschrijding(string $rowId, DateTimeImmutable $now, array &$counts): void
     {
         $counts['overschreden']++;
-        $this->termijnService->updateTermijnInstance($rowId, ['status' => 'overschreden']);
-        $this->termijnService->recordEvent(
+        $this->deadlineService->updateTermijnInstance($rowId, ['status' => 'overschreden']);
+        $this->deadlineService->recordEvent(
             termijnInstanceId: $rowId,
             type: 'overschreden',
             grondslag: 'AWB 4:13',
@@ -299,7 +299,7 @@ class DeadlineDailyScanService
         }
 
         // Re-read instance to pick up the just-updated status/notificatiesVerstuurd.
-        $latest = $this->termijnService->getTermijnInstance($rowId);
+        $latest = $this->deadlineService->getTermijnInstance($rowId);
         if ($latest === null) {
             return;
         }

--- a/lib/Service/DeadlineEscalationService.php
+++ b/lib/Service/DeadlineEscalationService.php
@@ -54,11 +54,11 @@ class DeadlineEscalationService
     /**
      * Constructor.
      *
-     * @param DeadlineService $termijnService DeadlineService for instance lookup/update.
-     * @param LoggerInterface $logger         Logger.
+     * @param DeadlineService $deadlineService DeadlineService for instance lookup/update.
+     * @param LoggerInterface $logger          Logger.
      */
     public function __construct(
-        private readonly DeadlineService $termijnService,
+        private readonly DeadlineService $deadlineService,
         private readonly LoggerInterface $logger,
     ) {
     }//end __construct()
@@ -148,7 +148,7 @@ class DeadlineEscalationService
 
         // Mark threshold as sent (duplicate suppression).
         $alreadySent[] = $threshold;
-        $this->termijnService->updateTermijnInstance(
+        $this->deadlineService->updateTermijnInstance(
             $instanceId,
             ['notificatiesVerstuurd' => array_values(array_unique(array_map('intval', $alreadySent)))]
         );

--- a/lib/Service/DeadlineExtensionService.php
+++ b/lib/Service/DeadlineExtensionService.php
@@ -58,10 +58,10 @@ class DeadlineExtensionService
     /**
      * Constructor.
      *
-     * @param DeadlineService $termijnService DeadlineService.
+     * @param DeadlineService $deadlineService DeadlineService.
      */
     public function __construct(
-        private readonly DeadlineService $termijnService,
+        private readonly DeadlineService $deadlineService,
     ) {
     }//end __construct()
 
@@ -152,7 +152,7 @@ class DeadlineExtensionService
     ): array {
         $this->assertExtensionInput(motivering: $motivering, newEinddatum: $newEinddatum);
 
-        $instance = $this->termijnService->getTermijnInstance($termijnInstanceId);
+        $instance = $this->deadlineService->getTermijnInstance($termijnInstanceId);
         if ($instance === null) {
             throw new RuntimeException('TermijnInstance not found: '.$termijnInstanceId);
         }
@@ -163,7 +163,7 @@ class DeadlineExtensionService
         $consumed    = (int) ($instance['aantalVerlengingen'] ?? 0);
         $dagenImpact = $this->calculateDagenImpact(current: $current, newEinddatum: $newEinddatum);
 
-        $updated = $this->termijnService->updateTermijnInstance(
+        $updated = $this->deadlineService->updateTermijnInstance(
             $termijnInstanceId,
             [
                 'einddatumActueel'   => $newEinddatum,
@@ -174,7 +174,7 @@ class DeadlineExtensionService
 
         $context = $this->resolveExtensionContext(mode: $mode);
 
-        $this->termijnService->recordEvent(
+        $this->deadlineService->recordEvent(
             termijnInstanceId: $termijnInstanceId,
             type: 'verleng',
             grondslag: $context['grondslag'],
@@ -301,10 +301,10 @@ class DeadlineExtensionService
         // is the data we actually need.
         $svcDef = null;
         try {
-            $reflection = new ReflectionClass($this->termijnService);
+            $reflection = new ReflectionClass($this->deadlineService);
             if ($reflection->hasProperty('definitieCache') === true) {
                 $prop  = $reflection->getProperty('definitieCache');
-                $cache = $prop->getValue($this->termijnService);
+                $cache = $prop->getValue($this->deadlineService);
                 if (is_array($cache) === true) {
                     foreach ($cache as $row) {
                         if (is_array($row) === true && (string) ($row['id'] ?? '') === $defId) {

--- a/lib/Service/DeadlineNotificationService.php
+++ b/lib/Service/DeadlineNotificationService.php
@@ -50,13 +50,13 @@ class DeadlineNotificationService
     /**
      * Constructor.
      *
-     * @param DeadlineService            $termijnService Termijn service.
-     * @param BerichtenboxRoutingService $router         Router (procest notification-router).
-     * @param LoggerInterface            $logger         Logger.
-     * @param IJobList|null              $jobList        Optional job list for async dispatch.
+     * @param DeadlineService            $deadlineService Termijn service.
+     * @param BerichtenboxRoutingService $router          Router (procest notification-router).
+     * @param LoggerInterface            $logger          Logger.
+     * @param IJobList|null              $jobList         Optional job list for async dispatch.
      */
     public function __construct(
-        private readonly DeadlineService $termijnService,
+        private readonly DeadlineService $deadlineService,
         private readonly BerichtenboxRoutingService $router,
         private readonly LoggerInterface $logger,
         private readonly ?IJobList $jobList=null,
@@ -132,7 +132,7 @@ class DeadlineNotificationService
             throw new InvalidArgumentException('Unknown template: '.$type);
         }
 
-        $instance = $this->termijnService->getTermijnInstance($termijnInstanceId);
+        $instance = $this->deadlineService->getTermijnInstance($termijnInstanceId);
         $payload  = $this->renderTemplate(type: $type, instance: $instance ?? [], context: $context);
 
         $payload['recipient']       = $recipientUserId;

--- a/lib/Service/DeadlinePauseService.php
+++ b/lib/Service/DeadlinePauseService.php
@@ -41,10 +41,10 @@ class DeadlinePauseService
     /**
      * Constructor.
      *
-     * @param DeadlineService $termijnService DeadlineService.
+     * @param DeadlineService $deadlineService DeadlineService.
      */
     public function __construct(
-        private readonly DeadlineService $termijnService,
+        private readonly DeadlineService $deadlineService,
     ) {
     }//end __construct()
 
@@ -76,7 +76,7 @@ class DeadlinePauseService
             throw new RuntimeException('Pause duration must be positive (AWB 4:5)');
         }
 
-        $instance = $this->termijnService->getTermijnInstance($termijnInstanceId);
+        $instance = $this->deadlineService->getTermijnInstance($termijnInstanceId);
         if ($instance === null) {
             throw new RuntimeException('TermijnInstance not found: '.$termijnInstanceId);
         }
@@ -90,7 +90,7 @@ class DeadlinePauseService
         $newEnd   = $current->modify('+'.$duurDagen.' days')->format('Y-m-d');
         $pauseEnd = $now->modify('+'.$duurDagen.' days')->format('Y-m-d');
 
-        $updated = $this->termijnService->updateTermijnInstance(
+        $updated = $this->deadlineService->updateTermijnInstance(
             $termijnInstanceId,
             [
                 'einddatumActueel' => $newEnd,
@@ -101,7 +101,7 @@ class DeadlinePauseService
             ]
         );
 
-        $this->termijnService->recordEvent(
+        $this->deadlineService->recordEvent(
             termijnInstanceId: $termijnInstanceId,
             type: 'pauze',
             grondslag: 'AWB 4:5',
@@ -134,7 +134,7 @@ class DeadlinePauseService
     {
         $aanvullingDatum = ($aanvullingDatum ?? new DateTimeImmutable());
 
-        $instance = $this->termijnService->getTermijnInstance($termijnInstanceId);
+        $instance = $this->deadlineService->getTermijnInstance($termijnInstanceId);
         if ($instance === null) {
             throw new RuntimeException('TermijnInstance not found: '.$termijnInstanceId);
         }
@@ -155,7 +155,7 @@ class DeadlinePauseService
         $current = new DateTimeImmutable((string) ($instance['einddatumActueel'] ?? $aanvullingDatum->format('Y-m-d')));
         $newEnd  = $current->modify('-'.$unused.' days')->format('Y-m-d');
 
-        $updated = $this->termijnService->updateTermijnInstance(
+        $updated = $this->deadlineService->updateTermijnInstance(
             $termijnInstanceId,
             [
                 'einddatumActueel' => $newEnd,
@@ -164,7 +164,7 @@ class DeadlinePauseService
             ]
         );
 
-        $this->termijnService->recordEvent(
+        $this->deadlineService->recordEvent(
             termijnInstanceId: $termijnInstanceId,
             type: 'hervat',
             grondslag: 'AWB 4:15',

--- a/lib/Service/DwangsomBezwaarService.php
+++ b/lib/Service/DwangsomBezwaarService.php
@@ -47,12 +47,12 @@ class DwangsomBezwaarService
      * Constructor.
      *
      * @param SettingsService $settingsService Settings.
-     * @param DeadlineService $termijnService  Termijn service for events.
+     * @param DeadlineService $deadlineService Termijn service for events.
      * @param LoggerInterface $logger          Logger.
      */
     public function __construct(
         private readonly SettingsService $settingsService,
-        private readonly DeadlineService $termijnService,
+        private readonly DeadlineService $deadlineService,
         private readonly LoggerInterface $logger,
     ) {
     }//end __construct()
@@ -123,7 +123,7 @@ class DwangsomBezwaarService
         // Record event on termijn.
         $instanceId = (string) ($berekening['termijnInstance'] ?? '');
         if ($instanceId !== '') {
-            $this->termijnService->recordEvent(
+            $this->deadlineService->recordEvent(
                 termijnInstanceId: $instanceId,
                 type: 'bezwaar-ingediend',
                 grondslag: $grondslag,
@@ -207,7 +207,7 @@ class DwangsomBezwaarService
 
         $instanceId = (string) ($berekening['termijnInstance'] ?? '');
         if ($instanceId !== '') {
-            $this->termijnService->recordEvent(
+            $this->deadlineService->recordEvent(
                 termijnInstanceId: $instanceId,
                 type: 'bezwaar-opgelost',
                 grondslag: $grondslag,

--- a/lib/Service/IngebrekestellingService.php
+++ b/lib/Service/IngebrekestellingService.php
@@ -49,12 +49,12 @@ class IngebrekestellingService
      * Constructor.
      *
      * @param SettingsService $settingsService Settings service.
-     * @param DeadlineService $termijnService  DeadlineService.
+     * @param DeadlineService $deadlineService DeadlineService.
      * @param LoggerInterface $logger          Logger.
      */
     public function __construct(
         private readonly SettingsService $settingsService,
-        private readonly DeadlineService $termijnService,
+        private readonly DeadlineService $deadlineService,
         private readonly LoggerInterface $logger,
     ) {
     }//end __construct()
@@ -79,7 +79,7 @@ class IngebrekestellingService
         string $kanaal,
         string $documentLink=''
     ): array {
-        $instance = $this->termijnService->getTermijnInstance($termijnInstanceId);
+        $instance = $this->deadlineService->getTermijnInstance($termijnInstanceId);
         if ($instance === null) {
             throw new RuntimeException('TermijnInstance not found: '.$termijnInstanceId);
         }
@@ -158,7 +158,7 @@ class IngebrekestellingService
         string $kanaal,
         string $documentLink
     ): array {
-        $this->termijnService->updateTermijnInstance(
+        $this->deadlineService->updateTermijnInstance(
             $termijnInstanceId,
             ['relevantIngbrekes' => $ingebrekestellingId]
         );
@@ -187,7 +187,7 @@ class IngebrekestellingService
             ]
         );
 
-        $this->termijnService->recordEvent(
+        $this->deadlineService->recordEvent(
             termijnInstanceId: $termijnInstanceId,
             type: 'ingebrekestelling-ontvangen',
             grondslag: 'AWB 4:17',
@@ -197,7 +197,7 @@ class IngebrekestellingService
             documentLink: $documentLink,
         );
 
-        $this->termijnService->recordEvent(
+        $this->deadlineService->recordEvent(
             termijnInstanceId: $termijnInstanceId,
             type: 'dwangsom-gestart',
             grondslag: 'AWB 4:17',

--- a/tests/Unit/Service/DeadlineDailyScanServiceTest.php
+++ b/tests/Unit/Service/DeadlineDailyScanServiceTest.php
@@ -45,7 +45,7 @@ class DeadlineDailyScanServiceTest extends TestCase
 {
     private FakeTermijnStore $objects;
     private SettingsService $settings;
-    private DeadlineService $termijnService;
+    private DeadlineService $deadlineService;
     private DeadlineEscalationService $escalation;
     private DeadlineDailyScanService $scan;
 
@@ -68,11 +68,11 @@ class DeadlineDailyScanServiceTest extends TestCase
 
         $this->settings        = $settings;
         $logger                = $this->createMock(LoggerInterface::class);
-        $this->termijnService  = new DeadlineService($settings, $logger);
-        $this->escalation      = new DeadlineEscalationService($this->termijnService, $logger);
+        $this->deadlineService  = new DeadlineService($settings, $logger);
+        $this->escalation      = new DeadlineEscalationService($this->deadlineService, $logger);
         $this->scan            = new DeadlineDailyScanService(
             $settings,
-            $this->termijnService,
+            $this->deadlineService,
             $this->escalation,
             $logger
         );
@@ -123,7 +123,7 @@ class DeadlineDailyScanServiceTest extends TestCase
         $sent1 = $this->escalation->notifyThreshold($instance, 14);
         self::assertTrue($sent1);
 
-        $reloaded = $this->termijnService->getTermijnInstance((string) $instance['id']);
+        $reloaded = $this->deadlineService->getTermijnInstance((string) $instance['id']);
         $sent2    = $this->escalation->notifyThreshold($reloaded, 14);
         self::assertFalse($sent2);
     }

--- a/tests/Unit/Service/DeadlineMonitoringEndToEndTest.php
+++ b/tests/Unit/Service/DeadlineMonitoringEndToEndTest.php
@@ -52,7 +52,7 @@ class DeadlineMonitoringEndToEndTest extends TestCase
 {
     private FakeTermijnStore $objects;
     private SettingsService $settings;
-    private DeadlineService $termijnService;
+    private DeadlineService $deadlineService;
     private DeadlinePauseService $pauseService;
     private DeadlineExtensionService $extService;
     private IngebrekestellingService $ingService;
@@ -84,22 +84,22 @@ class DeadlineMonitoringEndToEndTest extends TestCase
         $this->settings = $settings;
 
         $logger = $this->createMock(LoggerInterface::class);
-        $this->termijnService = new DeadlineService($settings, $logger);
-        $this->pauseService   = new DeadlinePauseService($this->termijnService);
-        $this->extService     = new DeadlineExtensionService($this->termijnService);
-        $this->ingService     = new IngebrekestellingService($settings, $this->termijnService, $logger);
+        $this->deadlineService = new DeadlineService($settings, $logger);
+        $this->pauseService   = new DeadlinePauseService($this->deadlineService);
+        $this->extService     = new DeadlineExtensionService($this->deadlineService);
+        $this->ingService     = new IngebrekestellingService($settings, $this->deadlineService, $logger);
         $this->calcService    = new DwangsomCalculationService($settings, $logger);
         $this->uitService     = new DwangsomUitbetalingService($settings);
-        $this->bezService     = new DwangsomBezwaarService($settings, $this->termijnService, $logger);
+        $this->bezService     = new DwangsomBezwaarService($settings, $this->deadlineService, $logger);
         $this->notifService   = new DeadlineNotificationService(
-            $this->termijnService,
+            $this->deadlineService,
             new BerichtenboxRoutingService($logger),
             $logger
         );
         $this->scanService    = new DeadlineDailyScanService(
             $settings,
-            $this->termijnService,
-            new DeadlineEscalationService($this->termijnService, $logger),
+            $this->deadlineService,
+            new DeadlineEscalationService($this->deadlineService, $logger),
             $logger,
             $this->calcService
         );
@@ -122,13 +122,13 @@ class DeadlineMonitoringEndToEndTest extends TestCase
      */
     public function testScenario1NormalCase(): void
     {
-        $instance = $this->termijnService->createTermijnInstance(
+        $instance = $this->deadlineService->createTermijnInstance(
             'Z/2026/S1',
             'omgevingsvergunning-regulier',
             new DateTimeImmutable('2026-06-01T10:00:00+00:00')
         );
 
-        $voltooid = $this->termijnService->markTermijnCompleted(
+        $voltooid = $this->deadlineService->markTermijnCompleted(
             (string) $instance['id'],
             new DateTimeImmutable('2026-07-15')
         );
@@ -144,8 +144,8 @@ class DeadlineMonitoringEndToEndTest extends TestCase
      */
     public function testScenario2PauseCase(): void
     {
-        $this->termijnService->getTermijnDefinitie('omgevingsvergunning-regulier');
-        $instance = $this->termijnService->createTermijnInstance(
+        $this->deadlineService->getTermijnDefinitie('omgevingsvergunning-regulier');
+        $instance = $this->deadlineService->createTermijnInstance(
             'Z/2026/S2',
             'omgevingsvergunning-regulier',
             new DateTimeImmutable('2026-06-01T10:00:00+00:00')
@@ -170,8 +170,8 @@ class DeadlineMonitoringEndToEndTest extends TestCase
      */
     public function testScenario3ExtensionCase(): void
     {
-        $this->termijnService->getTermijnDefinitie('omgevingsvergunning-regulier');
-        $instance = $this->termijnService->createTermijnInstance(
+        $this->deadlineService->getTermijnDefinitie('omgevingsvergunning-regulier');
+        $instance = $this->deadlineService->createTermijnInstance(
             'Z/2026/S3',
             'omgevingsvergunning-regulier',
             new DateTimeImmutable('2026-06-01T10:00:00+00:00')
@@ -186,7 +186,7 @@ class DeadlineMonitoringEndToEndTest extends TestCase
         self::assertSame('verlengd', $extended['status']);
         self::assertSame(1, $extended['aantalVerlengingen']);
 
-        $voltooid = $this->termijnService->markTermijnCompleted($id, new DateTimeImmutable('2026-09-20'));
+        $voltooid = $this->deadlineService->markTermijnCompleted($id, new DateTimeImmutable('2026-09-20'));
         self::assertSame('voltooid', $voltooid['status']);
     }
 

--- a/tests/Unit/Service/DeadlinePauseExtensionServiceTest.php
+++ b/tests/Unit/Service/DeadlinePauseExtensionServiceTest.php
@@ -46,7 +46,7 @@ use RuntimeException;
 class DeadlinePauseExtensionServiceTest extends TestCase
 {
     private FakeTermijnStore $objects;
-    private DeadlineService $termijnService;
+    private DeadlineService $deadlineService;
     private DeadlinePauseService $pauseService;
     private DeadlineExtensionService $extService;
 
@@ -68,9 +68,9 @@ class DeadlinePauseExtensionServiceTest extends TestCase
         );
 
         $logger = $this->createMock(LoggerInterface::class);
-        $this->termijnService = new DeadlineService($settings, $logger);
-        $this->pauseService   = new DeadlinePauseService($this->termijnService);
-        $this->extService     = new DeadlineExtensionService($this->termijnService);
+        $this->deadlineService = new DeadlineService($settings, $logger);
+        $this->pauseService   = new DeadlinePauseService($this->deadlineService);
+        $this->extService     = new DeadlineExtensionService($this->deadlineService);
 
         // Seed an Omgevingsvergunning definition (max 1 extension).
         $this->objects->saveObject('procest', 'termijnDefinitie', [
@@ -89,8 +89,8 @@ class DeadlinePauseExtensionServiceTest extends TestCase
     private function newInstance(): array
     {
         // Resolve the definition so the cache gets populated.
-        $this->termijnService->getTermijnDefinitie('omgevingsvergunning-regulier');
-        return $this->termijnService->createTermijnInstance(
+        $this->deadlineService->getTermijnDefinitie('omgevingsvergunning-regulier');
+        return $this->deadlineService->createTermijnInstance(
             'Z/2026/300',
             'omgevingsvergunning-regulier',
             new DateTimeImmutable('2026-06-01T10:00:00+00:00')
@@ -133,7 +133,7 @@ class DeadlinePauseExtensionServiceTest extends TestCase
 
         // Aanvulling arrives 4 days after pause-start (so 10 days unused).
         // After resume, deadline should pull back by 10 days → 2026-07-31.
-        $currentInstance = $this->termijnService->getTermijnInstance($id);
+        $currentInstance = $this->deadlineService->getTermijnInstance($id);
         $pauseStart      = new DateTimeImmutable($currentInstance['pauzeStartDatum']);
         $aanvulling      = $pauseStart->modify('+4 days');
 

--- a/tests/Unit/Service/IngebrekestellingServiceTest.php
+++ b/tests/Unit/Service/IngebrekestellingServiceTest.php
@@ -41,7 +41,7 @@ use Psr\Log\LoggerInterface;
 class IngebrekestellingServiceTest extends TestCase
 {
     private FakeTermijnStore $objects;
-    private DeadlineService $termijnService;
+    private DeadlineService $deadlineService;
     private IngebrekestellingService $service;
 
     protected function setUp(): void
@@ -64,8 +64,8 @@ class IngebrekestellingServiceTest extends TestCase
         );
 
         $logger               = $this->createMock(LoggerInterface::class);
-        $this->termijnService = new DeadlineService($settings, $logger);
-        $this->service        = new IngebrekestellingService($settings, $this->termijnService, $logger);
+        $this->deadlineService = new DeadlineService($settings, $logger);
+        $this->service        = new IngebrekestellingService($settings, $this->deadlineService, $logger);
 
         // Seed an AWB-default definition.
         $this->objects->saveObject('procest', 'termijnDefinitie', [


### PR DESCRIPTION
## What

Renames the injected dependency's property/parameter name across **15 files**, so it matches the `DeadlineService` type it has held since #808. Includes `DeadlineController`'s shorter `$termijn`, which is the same dependency under a different name.

**Stacked on #808.** Merge order: **#797 → #803 → #804 → #806 → #807 → #808 → this**.

## The mistake this commit made first, because it generalises

Renaming a promoted constructor property needs **two** patterns, not one:

```
$termijnService          the parameter / promoted declaration
$this->termijnService    every access
```

A search for `$termijnService` finds **only the first**. In a property access the `$` sigil belongs to `$this`, not to the member name — so `->termijnService` is a different token and doesn't match.

The first pass renamed all 15 declarations and **none of the 47 accesses**, leaving every class calling a property that no longer existed.

That isn't a subtle failure — phpunit went from 1777 passing to **20 errors and 3 failures** immediately. But it's only loud *because a suite covers this code*. The same edit in a thinly-tested file would have produced a property-access error on a path nobody runs.

The residual grep at the end of this commit therefore matches the **bare word** `termijnService`, with no sigil, so it cannot miss either spelling.

## What was deliberately left

Two bare `$termijn` variables remain and are **not** this dependency:

| file | what it actually holds |
|---|---|
| `SubsidieController` | an `int` of weeks, from `$body['termijnWeken']` |
| `BeschikkingService` | the array returned by `$this->bezwaarScheduler->computeTermijn()` |

Both are "termijn" as a **period** — a different concept from the service. Renaming them belongs with `computeTermijn()`/`termijnWeken`, not here. They were read before being skipped, not assumed.

## Verification

- `php -l` clean on all 15 files
- **phpunit, whole unit suite: 1777 tests, 6160 assertions, 5 skipped — green**, and identical to the pre-change baseline on both counts
- Every touched `lib/` file is **phpcs CLEAN**
- Residual grep for `termijnService` (unsigilled) across `lib/` and `tests/` — none
