### PR TITLE
fix(security): guard the four dwangsom endpoints, then repair the dead is_array() on show() (#811)

### DIFF
--- a/lib/Controller/DwangsomController.php
+++ b/lib/Controller/DwangsomController.php
@@ -29,9 +29,11 @@ declare(strict_types=1);
 
 namespace OCA\Procest\Controller;
 
+use OCA\Procest\Service\CaseAccessGuard;
 use OCA\Procest\Service\DwangsomBezwaarService;
 use OCA\Procest\Service\DwangsomCalculationService;
 use OCA\Procest\Service\SettingsService;
+use OCA\Procest\Service\Support\OwningCaseResolver;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
@@ -55,6 +57,8 @@ class DwangsomController extends Controller
      * @param DwangsomBezwaarService     $bezwaar     Bezwaar service.
      * @param SettingsService            $settings    Settings.
      * @param IUserSession               $userSession User session.
+     * @param CaseAccessGuard            $caseAccess  Per-case authorization guard.
+     * @param OwningCaseResolver         $owningCase  Resolves a berekening's owning case.
      */
     public function __construct(
         string $appName,
@@ -63,24 +67,66 @@ class DwangsomController extends Controller
         private readonly DwangsomBezwaarService $bezwaar,
         private readonly SettingsService $settings,
         private readonly IUserSession $userSession,
+        private readonly CaseAccessGuard $caseAccess,
+        private readonly OwningCaseResolver $owningCase,
     ) {
         parent::__construct(appName: $appName, request: $request);
     }//end __construct()
 
     /**
-     * Per-object authorization guard.
+     * Per-object authorization guard for a DwangsomBerekening.
      *
-     * @return JSONResponse|null
+     * Replaces the former `ensureAuthenticated()`, which was documented as a
+     * "per-object authorization guard" and has never been one: it established
+     * that somebody was logged in and nothing else. Every method here is
+     * `@NoAdminRequired`, so that admitted any authenticated account to any
+     * berekening.
+     *
+     * A berekening has no owner field of its own. It belongs to a case through
+     * `termijnInstance` -> `zaak`, so the decision is delegated to
+     * {@see CaseAccessGuard} on the owning case, exactly as the other
+     * case-scoped surfaces in this app do.
+     *
+     * Fails closed at every branch: an unresolvable chain, an absent
+     * OpenRegister, or an unconfigured schema all DENY. A berekening whose
+     * owning case cannot be established is not a berekening anyone may act on.
+     *
+     * @param string $berekeningId The DwangsomBerekening UUID.
+     * @param bool   $mutation     True for write verbs, false for reads.
+     *
+     * @return JSONResponse|null A refusal, or null when access is granted.
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
      */
-    private function ensureAuthenticated(): ?JSONResponse
+    private function denyUnlessMayAccess(string $berekeningId, bool $mutation): ?JSONResponse
     {
         $user = $this->userSession->getUser();
         if ($user === null) {
             return new JSONResponse(['message' => 'Not authenticated'], Http::STATUS_FORBIDDEN);
         }
 
-        return null;
-    }//end ensureAuthenticated()
+        $caseId = $this->owningCase->resolveVia(
+            objectId: $berekeningId,
+            schemaKey: 'dwangsom_berekening_schema',
+            linkField: 'termijnInstance',
+            viaSchemaKey: 'termijn_instance_schema',
+            caseField: 'zaak'
+        );
+
+        if ($caseId !== null) {
+            $granted = $mutation === true
+                ? $this->caseAccess->hasCaseMutationAccess(caseId: $caseId, user: $user)
+                : $this->caseAccess->hasCaseReadAccess(caseId: $caseId, user: $user);
+            if ($granted === true) {
+                return null;
+            }
+        }
+
+        return new JSONResponse(
+            ['message' => 'Not authorized for dwangsom berekening '.$berekeningId],
+            Http::STATUS_FORBIDDEN
+        );
+    }//end denyUnlessMayAccess()
 
     /**
      * Get a DwangsomBerekening by id.
@@ -95,7 +141,7 @@ class DwangsomController extends Controller
      */
     public function show(string $id): JSONResponse
     {
-        $denied = $this->ensureAuthenticated();
+        $denied = $this->denyUnlessMayAccess(berekeningId: $id, mutation: false);
         if ($denied !== null) {
             return $denied;
         }
@@ -133,7 +179,7 @@ class DwangsomController extends Controller
      */
     public function beschikking(string $id): JSONResponse
     {
-        $denied = $this->ensureAuthenticated();
+        $denied = $this->denyUnlessMayAccess(berekeningId: $id, mutation: true);
         if ($denied !== null) {
             return $denied;
         }
@@ -159,7 +205,7 @@ class DwangsomController extends Controller
      */
     public function bezwaar(string $id): JSONResponse
     {
-        $denied = $this->ensureAuthenticated();
+        $denied = $this->denyUnlessMayAccess(berekeningId: $id, mutation: true);
         if ($denied !== null) {
             return $denied;
         }
@@ -189,7 +235,7 @@ class DwangsomController extends Controller
      */
     public function bezwaarHeroverweging(string $id): JSONResponse
     {
-        $denied = $this->ensureAuthenticated();
+        $denied = $this->denyUnlessMayAccess(berekeningId: $id, mutation: true);
         if ($denied !== null) {
             return $denied;
         }

--- a/lib/Controller/DwangsomController.php
+++ b/lib/Controller/DwangsomController.php
@@ -38,6 +38,7 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
+use OCP\IUser;
 use OCP\IUserSession;
 use Throwable;
 
@@ -45,6 +46,8 @@ use Throwable;
  * REST surface for DwangsomBerekening state + bezwaar.
  *
  * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/specs/authz-bypass-fixes/spec.md
  */
 class DwangsomController extends Controller
 {
@@ -113,13 +116,10 @@ class DwangsomController extends Controller
             caseField: 'zaak'
         );
 
-        if ($caseId !== null) {
-            $granted = $mutation === true
-                ? $this->caseAccess->hasCaseMutationAccess(caseId: $caseId, user: $user)
-                : $this->caseAccess->hasCaseReadAccess(caseId: $caseId, user: $user);
-            if ($granted === true) {
-                return null;
-            }
+        if ($caseId !== null
+            && $this->mayAccessCase(caseId: $caseId, user: $user, mutation: $mutation) === true
+        ) {
+            return null;
         }
 
         return new JSONResponse(
@@ -127,6 +127,30 @@ class DwangsomController extends Controller
             Http::STATUS_FORBIDDEN
         );
     }//end denyUnlessMayAccess()
+
+    /**
+     * Apply the verb-appropriate case check.
+     *
+     * Writes need mutation access; reads take the slightly wider read access
+     * that also honours the `assignees` array. Kept separate so the read check
+     * is never consulted on a write verb.
+     *
+     * @param string $caseId   The owning case UUID.
+     * @param IUser  $user     The authenticated user.
+     * @param bool   $mutation True for write verbs, false for reads.
+     *
+     * @return bool True when the user may proceed.
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    private function mayAccessCase(string $caseId, IUser $user, bool $mutation): bool
+    {
+        if ($mutation === true) {
+            return $this->caseAccess->hasCaseMutationAccess(caseId: $caseId, user: $user);
+        }
+
+        return $this->caseAccess->hasCaseReadAccess(caseId: $caseId, user: $user);
+    }//end mayAccessCase()
 
     /**
      * Get a DwangsomBerekening by id.
@@ -159,12 +183,49 @@ class DwangsomController extends Controller
             return new JSONResponse(['message' => 'Not found'], Http::STATUS_NOT_FOUND);
         }
 
-        if (is_array($row) === false) {
+        $berekening = $this->normalise(value: $row);
+        if ($berekening === null) {
             return new JSONResponse(['message' => 'Not found'], Http::STATUS_NOT_FOUND);
         }
 
-        return new JSONResponse($row);
+        return new JSONResponse($berekening);
     }//end show()
+
+    /**
+     * Normalise an OpenRegister result into a plain array.
+     *
+     * `ObjectService::find()` is declared `: ?ObjectEntity` and never returns an
+     * array, so the previous `is_array($row) === false` test was true for every
+     * existing berekening and `show()` answered 404 to everyone, its own case
+     * assignee included. Normalise instead of testing.
+     *
+     * `is_callable()` rather than `method_exists()`: ObjectEntity reaches
+     * several accessors through `Entity::__call()`, for which `method_exists()`
+     * is false.
+     *
+     * @param mixed $value The value returned by ObjectService.
+     *
+     * @return array<string, mixed>|null The array form, or null when absent.
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    private function normalise(mixed $value): ?array
+    {
+        if (is_array($value) === true) {
+            return $value;
+        }
+
+        if (is_object($value) === false || is_callable([$value, 'jsonSerialize']) === false) {
+            return null;
+        }
+
+        $serialised = $value->jsonSerialize();
+        if (is_array($serialised) === false) {
+            return null;
+        }
+
+        return $serialised;
+    }//end normalise()
 
     /**
      * Stop the berekening because a beschikking was filed.

--- a/lib/Service/Support/OwningCaseResolver.php
+++ b/lib/Service/Support/OwningCaseResolver.php
@@ -90,6 +90,49 @@ class OwningCaseResolver
     }//end resolve()
 
     /**
+     * Resolve the owning case across two hops.
+     *
+     * Some child objects do not reference their case directly. A
+     * `dwangsomBerekening`, for example, carries only `termijnInstance`, and it
+     * is the `termijnInstance` that carries `zaak`. Guarding those endpoints
+     * needs the whole chain, and every unresolvable link must DENY rather than
+     * fall through — a missing intermediate is not permission.
+     *
+     * @param string $objectId    The child object UUID.
+     * @param string $schemaKey   The settings key naming the child's schema.
+     * @param string $linkField   The property on the child holding the intermediate ref.
+     * @param string $viaSchemaKey The settings key naming the intermediate's schema.
+     * @param string $caseField   The property on the intermediate holding the case ref.
+     *
+     * @return string|null The owning case UUID, or null when unresolvable.
+     *
+     * @spec openspec/specs/authz-bypass-fixes/spec.md
+     */
+    public function resolveVia(
+        string $objectId,
+        string $schemaKey,
+        string $linkField,
+        string $viaSchemaKey,
+        string $caseField='zaak'
+    ): ?string {
+        $child = $this->loadChild(objectId: $objectId, schemaKey: $schemaKey);
+        if ($child === null) {
+            return null;
+        }
+
+        $intermediateId = (string) ($child[$linkField] ?? '');
+        if ($intermediateId === '') {
+            return null;
+        }
+
+        return $this->resolve(
+            objectId: $intermediateId,
+            schemaKey: $viaSchemaKey,
+            caseField: $caseField
+        );
+    }//end resolveVia()
+
+    /**
      * Load the child object as a plain array.
      *
      * @param string $objectId  The child object UUID.

--- a/lib/Service/Support/OwningCaseResolver.php
+++ b/lib/Service/Support/OwningCaseResolver.php
@@ -98,11 +98,11 @@ class OwningCaseResolver
      * needs the whole chain, and every unresolvable link must DENY rather than
      * fall through — a missing intermediate is not permission.
      *
-     * @param string $objectId    The child object UUID.
-     * @param string $schemaKey   The settings key naming the child's schema.
-     * @param string $linkField   The property on the child holding the intermediate ref.
+     * @param string $objectId     The child object UUID.
+     * @param string $schemaKey    The settings key naming the child's schema.
+     * @param string $linkField    The property on the child holding the intermediate ref.
      * @param string $viaSchemaKey The settings key naming the intermediate's schema.
-     * @param string $caseField   The property on the intermediate holding the case ref.
+     * @param string $caseField    The property on the intermediate holding the case ref.
      *
      * @return string|null The owning case UUID, or null when unresolvable.
      *

--- a/tests/Unit/Controller/DwangsomControllerAuthzTest.php
+++ b/tests/Unit/Controller/DwangsomControllerAuthzTest.php
@@ -1,0 +1,331 @@
+<?php
+
+/**
+ * DwangsomController authorization + dead-predicate tests.
+ *
+ * Two defects lived on this controller at once, and the second hid the first.
+ *
+ * 1. All four verbs are `@NoAdminRequired` and the only check they ran was a
+ *    private `ensureAuthenticated()` — documented as a "per-object
+ *    authorization guard", but it established only that somebody was logged in.
+ *    Measured live, the attacker's responses were byte-identical to the
+ *    owner's on every endpoint.
+ *
+ * 2. `ObjectService::find()` is declared `: ?ObjectEntity` and never returns an
+ *    array, so `is_array($row) === false` was true for every existing
+ *    berekening and `show()` answered 404 to everyone, its own case assignee
+ *    included. That is what made defect 1 invisible: the endpoint denied
+ *    everybody, so no probe ever saw a leak.
+ *
+ * Repairing 2 without 1 would have converted four dead endpoints into live
+ * unguarded ones, two of which mutate penalty amounts. The guard therefore
+ * landed first, and these tests pin both halves and their ordering.
+ *
+ * The ObjectService double below returns an ENTITY, not an array. A double that
+ * returned an array would make the repaired code and the broken code
+ * indistinguishable — the test would pass against the dead predicate too.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @spec openspec/specs/authz-bypass-fixes/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use JsonSerializable;
+use OCA\Procest\Controller\DwangsomController;
+use OCA\Procest\Service\CaseAccessGuard;
+use OCA\Procest\Service\DwangsomBezwaarService;
+use OCA\Procest\Service\DwangsomCalculationService;
+use OCA\Procest\Service\SettingsService;
+use OCA\Procest\Service\Support\OwningCaseResolver;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Stands in for OpenRegister's ObjectEntity.
+ *
+ * Mirrors the real collaborator: `jsonSerialize()` is declared (ObjectEntity
+ * implements JsonSerializable) while every other accessor arrives through
+ * `Entity::__call()`, for which `method_exists()` is false. Returning an array
+ * here instead would let a broken `is_array()` predicate pass the test.
+ */
+class DwangsomBerekeningEntityDouble implements JsonSerializable
+{
+    /**
+     * Constructor.
+     *
+     * @param array<string, mixed> $data The berekening payload.
+     */
+    public function __construct(private readonly array $data)
+    {
+    }//end __construct()
+
+    /**
+     * Serialise to an array, as ObjectEntity does.
+     *
+     * @return array<string, mixed> The berekening payload.
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->data;
+    }//end jsonSerialize()
+
+    /**
+     * Magic accessor, as Entity does.
+     *
+     * @param string       $name      The method name.
+     * @param array<mixed> $arguments The arguments.
+     *
+     * @return mixed
+     */
+    public function __call(string $name, array $arguments)
+    {
+        return ($this->data[lcfirst(substr($name, 3))] ?? null);
+    }//end __call()
+}//end class
+
+/**
+ * Typed stub for the OpenRegister ObjectService (named-argument safe).
+ */
+interface DwangsomObjectServiceStub
+{
+    /**
+     * Find a single object by ID.
+     *
+     * @param int|string $id       Object UUID.
+     * @param mixed      $register Register id.
+     * @param mixed      $schema   Schema id.
+     *
+     * @return mixed
+     */
+    public function find(int | string $id, mixed $register=null, mixed $schema=null): mixed;
+}//end interface
+
+/**
+ * Unit tests for DwangsomController per-object authorization and the repair.
+ *
+ * @covers \OCA\Procest\Controller\DwangsomController
+ */
+class DwangsomControllerAuthzTest extends TestCase
+{
+
+    private const BEREKENING_ID = 'af19757a-ca9b-457c-8839-98e5ef00478a';
+
+    private const CASE_ID = 'b50836fb-077e-4cfd-987f-b39b11ae036d';
+
+    /**
+     * Build a controller with the collaborators each test needs.
+     *
+     * @param OwningCaseResolver         $owningCase The owning-case resolver.
+     * @param CaseAccessGuard            $caseAccess The per-case guard.
+     * @param DwangsomCalculationService $calc       The calculation service.
+     * @param DwangsomBezwaarService     $bezwaar    The bezwaar service.
+     * @param mixed                      $found      What ObjectService::find() returns.
+     *
+     * @return DwangsomController The controller under test.
+     */
+    private function makeController(
+        OwningCaseResolver $owningCase,
+        CaseAccessGuard $caseAccess,
+        DwangsomCalculationService $calc,
+        DwangsomBezwaarService $bezwaar,
+        mixed $found=null
+    ): DwangsomController {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('pro-attacker2');
+
+        $session = $this->createMock(IUserSession::class);
+        $session->method('getUser')->willReturn($user);
+
+        $objectService = $this->createMock(DwangsomObjectServiceStub::class);
+        $objectService->method('find')->willReturn($found);
+
+        $settings = $this->createMock(SettingsService::class);
+        $settings->method('getObjectService')->willReturn($objectService);
+        $settings->method('getConfigValue')->willReturnCallback(
+            static function (string $key) {
+                return ($key === 'register' ? '14' : '149');
+            }
+        );
+
+        return new DwangsomController(
+            'procest',
+            $this->createMock(IRequest::class),
+            $calc,
+            $bezwaar,
+            $settings,
+            $session,
+            $caseAccess,
+            $owningCase
+        );
+    }//end makeController()
+
+    /**
+     * A caller with no relationship to the owning case is refused, and the
+     * business services are never reached.
+     *
+     * @return void
+     */
+    public function testUnrelatedCallerIsRefusedAndTheServicesAreNeverReached(): void
+    {
+        $owningCase = $this->createMock(OwningCaseResolver::class);
+        $owningCase->method('resolveVia')->willReturn(self::CASE_ID);
+
+        $caseAccess = $this->createMock(CaseAccessGuard::class);
+        $caseAccess->method('hasCaseReadAccess')->willReturn(false);
+        $caseAccess->method('hasCaseMutationAccess')->willReturn(false);
+
+        $calc = $this->createMock(DwangsomCalculationService::class);
+        $calc->expects($this->never())->method('stopForBeschikking');
+
+        $bezwaar = $this->createMock(DwangsomBezwaarService::class);
+        $bezwaar->expects($this->never())->method('registerBezwaar');
+        $bezwaar->expects($this->never())->method('resolveBezwaar');
+
+        $controller = $this->makeController(
+            $owningCase,
+            $caseAccess,
+            $calc,
+            $bezwaar,
+            new DwangsomBerekeningEntityDouble(['id' => self::BEREKENING_ID])
+        );
+
+        $this->assertSame(Http::STATUS_FORBIDDEN, $controller->show(self::BEREKENING_ID)->getStatus());
+        $this->assertSame(Http::STATUS_FORBIDDEN, $controller->beschikking(self::BEREKENING_ID)->getStatus());
+        $this->assertSame(Http::STATUS_FORBIDDEN, $controller->bezwaar(self::BEREKENING_ID)->getStatus());
+        $this->assertSame(
+            Http::STATUS_FORBIDDEN,
+            $controller->bezwaarHeroverweging(self::BEREKENING_ID)->getStatus()
+        );
+    }//end testUnrelatedCallerIsRefusedAndTheServicesAreNeverReached()
+
+    /**
+     * An unresolvable owning case DENIES rather than falling through.
+     *
+     * @return void
+     */
+    public function testUnresolvableOwningCaseDenies(): void
+    {
+        $owningCase = $this->createMock(OwningCaseResolver::class);
+        $owningCase->method('resolveVia')->willReturn(null);
+
+        $caseAccess = $this->createMock(CaseAccessGuard::class);
+        $caseAccess->expects($this->never())->method('hasCaseReadAccess');
+        $caseAccess->expects($this->never())->method('hasCaseMutationAccess');
+
+        $controller = $this->makeController(
+            $owningCase,
+            $caseAccess,
+            $this->createMock(DwangsomCalculationService::class),
+            $this->createMock(DwangsomBezwaarService::class),
+            new DwangsomBerekeningEntityDouble(['id' => self::BEREKENING_ID])
+        );
+
+        $this->assertSame(Http::STATUS_FORBIDDEN, $controller->show(self::BEREKENING_ID)->getStatus());
+    }//end testUnresolvableOwningCaseDenies()
+
+    /**
+     * The repair: an authorised caller gets the berekening, normalised from the
+     * ENTITY that ObjectService actually returns.
+     *
+     * Against the old `is_array($row) === false` predicate this test fails with
+     * 404 — which is the whole point of it.
+     *
+     * @return void
+     */
+    public function testAuthorisedCallerGetsTheBerekeningNormalisedFromAnEntity(): void
+    {
+        $payload = [
+            'id'               => self::BEREKENING_ID,
+            'dagtarief'        => 2300,
+            'cumulatievBedrag' => 11500,
+        ];
+
+        $owningCase = $this->createMock(OwningCaseResolver::class);
+        $owningCase->method('resolveVia')->willReturn(self::CASE_ID);
+
+        $caseAccess = $this->createMock(CaseAccessGuard::class);
+        $caseAccess->method('hasCaseReadAccess')->willReturn(true);
+
+        $controller = $this->makeController(
+            $owningCase,
+            $caseAccess,
+            $this->createMock(DwangsomCalculationService::class),
+            $this->createMock(DwangsomBezwaarService::class),
+            new DwangsomBerekeningEntityDouble($payload)
+        );
+
+        $response = $controller->show(self::BEREKENING_ID);
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame($payload, $response->getData());
+    }//end testAuthorisedCallerGetsTheBerekeningNormalisedFromAnEntity()
+
+    /**
+     * A genuinely absent berekening is still 404 for an authorised caller —
+     * the repair must not turn "missing" into "found".
+     *
+     * @return void
+     */
+    public function testAbsentBerekeningIsStillNotFoundForAnAuthorisedCaller(): void
+    {
+        $owningCase = $this->createMock(OwningCaseResolver::class);
+        $owningCase->method('resolveVia')->willReturn(self::CASE_ID);
+
+        $caseAccess = $this->createMock(CaseAccessGuard::class);
+        $caseAccess->method('hasCaseReadAccess')->willReturn(true);
+
+        $controller = $this->makeController(
+            $owningCase,
+            $caseAccess,
+            $this->createMock(DwangsomCalculationService::class),
+            $this->createMock(DwangsomBezwaarService::class),
+            null
+        );
+
+        $this->assertSame(Http::STATUS_NOT_FOUND, $controller->show(self::BEREKENING_ID)->getStatus());
+    }//end testAbsentBerekeningIsStillNotFoundForAnAuthorisedCaller()
+
+    /**
+     * Write verbs consult MUTATION access, not the wider read access.
+     *
+     * @return void
+     */
+    public function testWriteVerbsConsultMutationAccess(): void
+    {
+        $owningCase = $this->createMock(OwningCaseResolver::class);
+        $owningCase->method('resolveVia')->willReturn(self::CASE_ID);
+
+        $caseAccess = $this->createMock(CaseAccessGuard::class);
+        $caseAccess->expects($this->once())
+            ->method('hasCaseMutationAccess')
+            ->willReturn(false);
+        $caseAccess->expects($this->never())->method('hasCaseReadAccess');
+
+        $controller = $this->makeController(
+            $owningCase,
+            $caseAccess,
+            $this->createMock(DwangsomCalculationService::class),
+            $this->createMock(DwangsomBezwaarService::class),
+            new DwangsomBerekeningEntityDouble(['id' => self::BEREKENING_ID])
+        );
+
+        $this->assertSame(Http::STATUS_FORBIDDEN, $controller->beschikking(self::BEREKENING_ID)->getStatus());
+    }//end testWriteVerbsConsultMutationAccess()
+}//end class


### PR DESCRIPTION
Closes part of #811, in the order that issue asks for: **guard first, repair second, in separate commits.**

## What was wrong, and why nobody saw it

Two defects sat on `DwangsomController` at once, and the second hid the first.

All four verbs are `@NoAdminRequired`. The only check they ran was a private method called `ensureAuthenticated()`, whose docblock read *"Per-object authorization guard"*. It established that somebody was logged in and nothing else — so any authenticated account could reach any berekening.

That was invisible because of the second defect. `ObjectService::find()` is declared `: ?ObjectEntity` and never returns an array, so `is_array($row) === false` was true for every berekening that exists. The endpoints answered "not found" to everyone, their own case assignee included. A dead endpoint and a protected endpoint look identical from the attacker's side.

## Measured, not reasoned

Live rig, two accounts, both arms, on a `dwangsomBerekening` created and read back through the OpenRegister API. Owner is the case assignee; the attacker differs from the owner in exactly one attribute — it is not the assignee — and is in the same group, so a group middleware cannot refuse it and be mistaken for the object guard.

Before the change, the attacker's four responses were byte-identical to the owner's: 404, 404, 400, 400. Nothing was refusing anybody on the basis of the object. A control endpoint that both accounts are entitled to reach returned 200 throughout, so the probe does discriminate.

After the guard commit, the owner column is unchanged and the attacker gets 403 on all four. After the repair commit, the owner's GET becomes 200 and the attacker stays 403.

The review question — does this make anything return 200 that previously returned an error? — has exactly one answer here: the owner's GET. The attacker does not get that 200, and would have, had the repair landed first.

Both arms were run twice, with the container restarted between arms: `opcache.revalidate_freq` is 60 on this image, and per-file revalidation windows otherwise serve a plausible mixture of the two revisions. The guard's refusal carries a string the previous bytecode cannot contain, which is how each arm was confirmed to be the code it claimed to be.

## What this changes

`OwningCaseResolver` gains a two-hop `resolveVia()`. A berekening has no owner field; it reaches a case through `termijnInstance` then `zaak`. Every unresolvable link denies, so an unknown id is refused identically to one the caller may not touch and the endpoint is not an existence oracle.

The repair is scoped to the read verb. `beschikking()`, `bezwaar()` and `bezwaarHeroverweging()` are dead for the same reason, but their post-repair behaviour changes penalty amounts under Awb 4:17, and that is not a call to make from here. They carry the guard now, so repairing them later cannot ship an IDOR.

## Tests

The ObjectService double returns an entity, not an array. An array-returning double would pass against the broken predicate too, which is the failure mode that kept several of these green elsewhere in the fleet. Negative control: restoring the old predicate fails exactly one test, and only that one, on `404 is identical to 200`.

## Notes for review

The `24 sites` figure in #811 is an undercount — it comes from a three-line window between the `find()` call and the `is_array()` test. Widening it to seven lines finds 39 candidates, of which 3 are correct code (they serialise the entity properly) and 36 are defects. Dwangsom, ingebrekestelling, case sharing and the ZGW rules base are all in the part the narrow window missed. Detail is in the issue.

The root enabler is worth a separate decision: `SettingsService::getObjectService()` is declared `: ?object`, which erases the type and is why neither PHPStan nor Psalm has ever flagged any of these. Narrowing it would make the whole class statically visible, at the cost of turning a quiet tree loud in one step.

Full local check run under PHP 8.3 before pushing — lint, phpcs, both phpmd rulesets, psalm, phpstan and the whole PHPUnit suite, not a subset. phpstan is clean; psalm's errors are all in three files this branch does not touch. The suite is green apart from four `ZipArchive` errors caused by the `zip` extension being absent from my local PHP image and present in CI's.
