### PR TITLE
refactor(mandaat): rename the mandateringsBesluit schema to mandateDecision

### DIFF
--- a/lib/Controller/MandaatMatrixController.php
+++ b/lib/Controller/MandaatMatrixController.php
@@ -248,17 +248,23 @@ class MandaatMatrixController extends Controller
             return $denied;
         }
 
-        $body          = $this->jsonBody();
-        $besluitNummer = (string) ($body['besluitNummer'] ?? '');
-        $besluitNaam   = (string) ($body['besluitNaam'] ?? '');
-        $decideskUuid  = (string) ($body['decideskUuid'] ?? '');
-        $csv           = (string) ($body['csv'] ?? '');
-        if ($besluitNummer === '' || $besluitNaam === '' || $csv === '') {
-            return $this->badRequest(msg: 'besluitNummer, besluitNaam and csv are required');
+        $body = $this->jsonBody();
+
+        // The request body keys are a PUBLISHED CONTRACT, not internal names:
+        // an existing caller posts besluitNummer/besluitNaam today. The new
+        // English keys are preferred, the Dutch ones still accepted, so this
+        // rename cannot break a client that has not been updated yet. Drop the
+        // fallback only once no caller sends the old keys.
+        $decisionNumber = (string) ($body['decisionNumber'] ?? $body['besluitNummer'] ?? '');
+        $decisionName   = (string) ($body['decisionName'] ?? $body['besluitNaam'] ?? '');
+        $decideskUuid   = (string) ($body['decideskUuid'] ?? '');
+        $csv            = (string) ($body['csv'] ?? '');
+        if ($decisionNumber === '' || $decisionName === '' || $csv === '') {
+            return $this->badRequest(msg: 'decisionNumber, decisionName and csv are required');
         }
 
         try {
-            $r = $this->import->importFromCsv($besluitNummer, $besluitNaam, $decideskUuid, $csv);
+            $r = $this->import->importFromCsv($decisionNumber, $decisionName, $decideskUuid, $csv);
             return new JSONResponse($r, Http::STATUS_CREATED);
         } catch (Throwable $e) {
             return new JSONResponse(['message' => $e->getMessage()], Http::STATUS_BAD_REQUEST);

--- a/lib/Repair/RenameDutchDeadlineColumns.php
+++ b/lib/Repair/RenameDutchDeadlineColumns.php
@@ -104,16 +104,35 @@ class RenameDutchDeadlineColumns implements IRepairStep
      * @var array<string, string>
      */
     private const COLUMN_MAP = [
-        'naam'                => 'name',
-        'onderwerp'           => 'subject',
-        'omschrijving'        => 'description',
-        'beschrijving'        => 'description',
-        'toelichting'         => 'notes',
-        'motivering'          => 'rationale',
-        'afdeling'            => 'department',
-        'aantal_verlengingen' => 'extension_count',
-        'einddatum_actueel'   => 'end_date_actual',
-        'pauze_deadline'      => 'pause_deadline',
+        'naam'                 => 'name',
+        'onderwerp'            => 'subject',
+        'omschrijving'         => 'description',
+        'beschrijving'         => 'description',
+        'toelichting'          => 'notes',
+        'motivering'           => 'rationale',
+        'afdeling'             => 'department',
+        'aantal_verlengingen'  => 'extension_count',
+        'einddatum_actueel'    => 'end_date_actual',
+        'pauze_deadline'       => 'pause_deadline',
+
+        // Mandate-decision slug rename (61-mandaat-matrix).
+        //
+        // Each of these was verified to be owned by EXACTLY ONE schema before
+        // being added. That check is not optional: this map is applied to every
+        // shard table in the procest registers, so a column name shared with a
+        // schema that still declares the Dutch spelling would have its data
+        // migrated out from under its own declaration.
+        //
+        // `wettelijke_grondslag` is the reason the check exists and is
+        // deliberately ABSENT here: five other schemas (dwangsomUitbetaling,
+        // mandaat, subsidieBeschikking, termijnDefinitie, terugvordering) still
+        // declare it. It moves fleet-wide, with them, in one slice.
+        'besluit_nummer'       => 'decision_number',
+        'besluit_naam'         => 'decision_name',
+        'in_werkingtreding'    => 'effective_from',
+        'verval_datum'         => 'expiry_date',
+        'vorig_besluit'        => 'previous_decision',
+        'mandaterings_besluit' => 'mandate_decision',
     ];
 
     /**

--- a/lib/Service/Mandaat/MandaatRepository.php
+++ b/lib/Service/Mandaat/MandaatRepository.php
@@ -116,7 +116,7 @@ class MandaatRepository
                 objectService: $objectService,
                 register: $register,
                 schema: $mSchema,
-                filters: ['mandateringsBesluit' => $besluitId]
+                filters: ['mandateDecision' => $besluitId]
             );
         } catch (\Throwable $e) {
             $mandaten = [];
@@ -171,16 +171,16 @@ class MandaatRepository
     }//end loadRoleIndex()
 
     /**
-     * Find the prior vastgesteld besluit for a besluit number.
+     * Find the prior adopted decision for a decision number.
      *
-     * @param string      $besluitNummer Number.
-     * @param string|null $excludeId     Optional id to exclude.
+     * @param string      $decisionNumber Number.
+     * @param string|null $excludeId      Optional id to exclude.
      *
-     * @return array<string, mixed>|null The prior vastgesteld besluit, or null.
+     * @return array<string, mixed>|null The prior adopted decision, or null.
      *
      * @spec openspec/changes/mandaat-matrix-04-decidesk-import/tasks.md
      */
-    public function findPriorBesluit(string $besluitNummer, ?string $excludeId=null): ?array
+    public function findPriorDecision(string $decisionNumber, ?string $excludeId=null): ?array
     {
         $objectService = $this->settingsService->getObjectService();
         $register      = (string) $this->settingsService->getConfigValue('register');
@@ -194,7 +194,7 @@ class MandaatRepository
                 objectService: $objectService,
                 register: $register,
                 schema: $schema,
-                filters: ['besluitNummer' => $besluitNummer]
+                filters: ['decisionNumber' => $decisionNumber]
             );
         } catch (\Throwable $e) {
             return null;
@@ -211,7 +211,7 @@ class MandaatRepository
         }
 
         return null;
-    }//end findPriorBesluit()
+    }//end findPriorDecision()
 
     /**
      * Find the mandaten linked to a besluit.
@@ -236,7 +236,7 @@ class MandaatRepository
                 objectService: $objectService,
                 register: $register,
                 schema: $schema,
-                filters: ['mandateringsBesluit' => $besluitId]
+                filters: ['mandateDecision' => $besluitId]
             );
         } catch (\Throwable $e) {
             return [];

--- a/lib/Service/MandaatImportService.php
+++ b/lib/Service/MandaatImportService.php
@@ -71,22 +71,22 @@ class MandaatImportService
     }//end __construct()
 
     /**
-     * Import a MandateringsBesluit from CSV text.
+     * Import a mandate decision from CSV text.
      *
-     * @param string $besluitNummer Besluit identifier.
-     * @param string $besluitNaam   Besluit name.
-     * @param string $decideskUuid  Source Decidesk besluit id.
-     * @param string $csvContents   The CSV payload (RFC 4180; first row is header).
+     * @param string $decisionNumber Decision identifier.
+     * @param string $decisionName   Decision name.
+     * @param string $decideskUuid   Source Decidesk decision id.
+     * @param string $csvContents    The CSV payload (RFC 4180; first row is header).
      *
-     * @return array<string, mixed> {mandateringsBesluitId, totalMandaten, newCount, changedCount, removedCount, diff}
+     * @return array<string, mixed> {mandateDecisionId, totalMandaten, newCount, changedCount, removedCount, diff}
      *
      * @throws RuntimeException When the CSV is malformed or a rol cannot be resolved.
      *
      * @spec openspec/changes/mandaat-matrix-04-decidesk-import/tasks.md
      */
     public function importFromCsv(
-        string $besluitNummer,
-        string $besluitNaam,
+        string $decisionNumber,
+        string $decisionName,
         string $decideskUuid,
         string $csvContents
     ): array {
@@ -98,19 +98,21 @@ class MandaatImportService
         // Resolve rol-name → rolId.
         $resolved = $this->resolveRolReferences(rows: $rows);
 
-        // Create the besluit (concept).
+        // Create the decision (concept). The schemaConfigKey stays
+        // 'mandaterings_besluit_schema': it is the app-config key the schema id
+        // is already stored under on existing installs, not a display name.
         $besluit = $this->repository->save(
             schemaConfigKey: 'mandaterings_besluit_schema',
             object: [
-                'besluitNummer' => $besluitNummer,
-                'besluitNaam'   => $besluitNaam,
-                'status'        => 'concept',
-                'decideskUuid'  => $decideskUuid,
+                'decisionNumber' => $decisionNumber,
+                'decisionName'   => $decisionName,
+                'status'         => 'concept',
+                'decideskUuid'   => $decideskUuid,
             ]
         );
 
-        // Find the prior besluit version (by besluitNummer) for diff.
-        $prior         = $this->repository->findPriorBesluit(besluitNummer: $besluitNummer);
+        // Find the prior decision version (by decisionNumber) for diff.
+        $prior         = $this->repository->findPriorDecision(decisionNumber: $decisionNumber);
         $priorMandaten = [];
         if ($prior !== null) {
             $priorMandaten = $this->repository->findMandatenForBesluit(
@@ -161,13 +163,13 @@ class MandaatImportService
         $diff         = array_merge($diff, $removed);
 
         return [
-            'mandateringsBesluitId' => (string) $besluit['id'],
-            'totalMandaten'         => count($resolved),
-            'newCount'              => $newCount,
-            'changedCount'          => $changedCount,
-            'removedCount'          => $removedCount,
-            'unchangedCount'        => $unchangedCount,
-            'diff'                  => $diff,
+            'mandateDecisionId' => (string) $besluit['id'],
+            'totalMandaten'     => count($resolved),
+            'newCount'          => $newCount,
+            'changedCount'      => $changedCount,
+            'removedCount'      => $removedCount,
+            'unchangedCount'    => $unchangedCount,
+            'diff'              => $diff,
         ];
     }//end importFromCsv()
 
@@ -212,7 +214,7 @@ class MandaatImportService
     {
         return [
             'mandaatNummer'       => (string) $row['mandaatNummer'],
-            'mandateringsBesluit' => $besluitId,
+            'mandateDecision'     => $besluitId,
             'omschrijving'        => (string) ($row['omschrijving'] ?? ''),
             'gemandateerdeRol'    => (string) $row['gemandateerdeRol'],
             'wettelijkeGrondslag' => (string) ($row['wettelijkeGrondslag'] ?? ''),
@@ -320,8 +322,8 @@ class MandaatImportService
         }
 
         $now = (new DateTimeImmutable())->format('Y-m-d');
-        $besluit['status']           = 'vastgesteld';
-        $besluit['inWerkingtreding'] = ($besluit['inWerkingtreding'] ?? $now);
+        $besluit['status']        = 'vastgesteld';
+        $besluit['effectiveFrom'] = ($besluit['effectiveFrom'] ?? $now);
         $besluit = $objectService->saveObject($register, $bSchema, $besluit);
 
         // Flip mandaten to active.
@@ -334,13 +336,13 @@ class MandaatImportService
         );
 
         // Expire prior besluit.
-        $prior = $this->repository->findPriorBesluit(
-            besluitNummer: (string) $besluit['besluitNummer'],
+        $prior = $this->repository->findPriorDecision(
+            decisionNumber: (string) $besluit['decisionNumber'],
             excludeId: $besluitId
         );
         if ($prior !== null) {
-            $prior['status']      = 'vervallen';
-            $prior['vervalDatum'] = $now;
+            $prior['status']     = 'vervallen';
+            $prior['expiryDate'] = $now;
             $objectService->saveObject($register, $bSchema, $prior);
         }
 

--- a/lib/Service/Settings/SchemaSlugMap.php
+++ b/lib/Service/Settings/SchemaSlugMap.php
@@ -149,7 +149,11 @@ class SchemaSlugMap
         'dwangsomBerekening'           => 'dwangsom_berekening_schema',
         'dwangsomUitbetaling'          => 'dwangsom_uitbetaling_schema',
         // Mandaat-matrix authorization engine.
-        'mandateringsBesluit'          => 'mandaterings_besluit_schema',
+        // KEY renamed with the schema slug; VALUE deliberately left as-is. The
+        // value is the app-config key under which this schema's numeric id is
+        // already stored on every existing install — renaming it would orphan
+        // that id and the schema would silently resolve to nothing.
+        'mandateDecision'              => 'mandaterings_besluit_schema',
         'mandaat'                      => 'mandaat_schema',
         'organisatieRol'               => 'organisatie_rol_schema',
         'medewerkerRolToewijzing'      => 'medewerker_rol_toewijzing_schema',

--- a/lib/Settings/register.d/61-mandaat-matrix.json
+++ b/lib/Settings/register.d/61-mandaat-matrix.json
@@ -3,7 +3,7 @@
     "registers": {
       "procest": {
         "schemas": [
-          "mandateringsBesluit",
+          "mandateDecision",
           "mandaat",
           "organisatieRol",
           "medewerkerRolToewijzing",
@@ -13,24 +13,24 @@
       }
     },
     "schemas": {
-      "mandateringsBesluit": {
-        "slug": "mandateringsBesluit",
+      "mandateDecision": {
+        "slug": "mandateDecision",
         "icon": "Gavel",
         "version": "1.0.0",
         "x-schema-org": "schema:DigitalDocument",
-        "title": "Mandaterings Besluit",
-        "description": "Mandateringsbesluit (decision of the bestuursorgaan) — collection of Mandaat rows valid from inWerkingtreding until vervalDatum.",
+        "title": "Mandate Decision",
+        "description": "A mandate decision taken by the governing body — a collection of Mandate rows valid from effectiveFrom until expiryDate.",
         "type": "object",
-        "required": ["besluitNummer", "besluitNaam", "status"],
+        "required": ["decisionNumber", "decisionName", "status"],
         "properties": {
-          "besluitNummer":     {"type": "string", "title": "Decision Number", "description": "Unique number identifying this mandate decision.", "facetable": true, "maxLength": 64},
-          "besluitNaam":       {"type": "string", "title": "Decision Name", "description": "Human-readable name of this mandate decision.", "maxLength": 255},
-          "status":            {"type": "string", "title": "Status", "description": "Current lifecycle status of the mandate decision.", "enum": ["concept", "vastgesteld", "vervallen"], "default": "concept", "facetable": true},
-          "inWerkingtreding":  {"type": "string", "title": "Entry Into Force", "description": "Date on which this mandate decision enters into force.", "format": "date"},
-          "vervalDatum":       {"type": "string", "title": "Expiry Date", "description": "Date on which this mandate decision expires.", "format": "date"},
-          "wettelijkeGrondslag": {"type": "string", "title": "Legal Basis", "description": "Statutory or regulatory basis for this mandate decision.", "maxLength": 255},
-          "decideskUuid":      {"type": "string", "title": "Decidesk UUID", "description": "Source besluit id in Decidesk"},
-          "vorigBesluit":      {"type": "string", "title": "Previous Decision", "description": "Prior MandateringsBesluit (for vervangt-by chain)"}
+          "decisionNumber":    {"type": "string", "title": "Decision Number", "description": "Unique number identifying this mandate decision.", "facetable": true, "maxLength": 64},
+          "decisionName":      {"type": "string", "title": "Decision Name", "description": "Human-readable name of this mandate decision.", "maxLength": 255},
+          "status":            {"type": "string", "title": "Status", "description": "Current lifecycle status of the mandate decision. The enum VALUES are stored data, not identifiers: renaming them rewrites every existing row and is a separate migration from this property rename.", "enum": ["concept", "vastgesteld", "vervallen"], "default": "concept", "facetable": true},
+          "effectiveFrom":     {"type": "string", "title": "Entry Into Force", "description": "Date on which this mandate decision enters into force.", "format": "date"},
+          "expiryDate":        {"type": "string", "title": "Expiry Date", "description": "Date on which this mandate decision expires.", "format": "date"},
+          "wettelijkeGrondslag": {"type": "string", "title": "Legal Basis", "description": "Statutory or regulatory basis for this mandate decision. DELIBERATELY NOT RENAMED in this change: five other procest schemas (dwangsomUitbetaling, mandaat, subsidieBeschikking, termijnDefinitie, terugvordering) still declare wettelijkeGrondslag. The column migration is register-scoped, so renaming it here would migrate their data out from under declarations that still use the Dutch name. It moves fleet-wide, in one slice, with them.", "maxLength": 255},
+          "decideskUuid":      {"type": "string", "title": "Decidesk UUID", "description": "Source decision id in Decidesk"},
+          "previousDecision":  {"type": "string", "title": "Previous Decision", "description": "Prior mandate decision, forming the supersession chain."}
         }
       },
       "mandaat": {
@@ -40,10 +40,10 @@
         "title": "Mandaat",
         "description": "Individual mandate granting authority to a role.",
         "type": "object",
-        "required": ["mandaatNummer", "mandateringsBesluit", "gemandateerdeRol", "bevoegdheidType"],
+        "required": ["mandaatNummer", "mandateDecision", "gemandateerdeRol", "bevoegdheidType"],
         "properties": {
           "mandaatNummer":         {"type": "string", "title": "Mandate Number", "description": "Unique number identifying this mandate.", "facetable": true, "maxLength": 64},
-          "mandateringsBesluit":   {"type": "string", "title": "Mandate Decision", "description": "Reference to the MandateringsBesluit that issued this mandate."},
+          "mandateDecision":       {"type": "string", "title": "Mandate Decision", "description": "Reference to the mandate decision that issued this mandate."},
           "omschrijving":          {"type": "string", "title": "Description", "description": "Description of this mandate."},
           "bevoegdheidType":       {"type": "string", "title": "Authority Type", "description": "Type classification of the authority granted by this mandate.", "enum": ["mandaat", "volmacht", "machtiging"], "default": "mandaat", "facetable": true},
           "gemandateerdeRol":      {"type": "string", "title": "Delegated Role", "description": "OrganisatieRol id"},

--- a/src/views/cases/widgets/MandaatMatrixWidget.vue
+++ b/src/views/cases/widgets/MandaatMatrixWidget.vue
@@ -26,7 +26,7 @@
 			</dd>
 
 			<dt>{{ t('procest', 'Source decision') }}</dt>
-			<dd>{{ mandaat.mandateringsBesluit || '-' }}</dd>
+			<dd>{{ mandaat.mandateDecision || '-' }}</dd>
 
 			<dt>{{ t('procest', 'Role holders') }}</dt>
 			<dd>

--- a/tests/Unit/Service/MandaatImportServiceTest.php
+++ b/tests/Unit/Service/MandaatImportServiceTest.php
@@ -49,7 +49,9 @@ class MandaatImportServiceTest extends TestCase
             static function (string $key): string {
                 return match ($key) {
                     'register'                       => 'procest',
-                    'mandaterings_besluit_schema'    => 'mandateringsBesluit',
+                    // Config KEY unchanged (it holds the stored schema id on
+                    // existing installs); the resolved schema SLUG is renamed.
+                    'mandaterings_besluit_schema'    => 'mandateDecision',
                     'mandaat_schema'                 => 'mandaat',
                     'organisatie_rol_schema'         => 'organisatieRol',
                     default                          => '',
@@ -83,7 +85,7 @@ class MandaatImportServiceTest extends TestCase
         self::assertSame(0, $r['changedCount']);
         self::assertSame(0, $r['removedCount']);
 
-        $besluit = $this->objects->store['mandateringsBesluit'][$r['mandateringsBesluitId']];
+        $besluit = $this->objects->store['mandateDecision'][$r['mandateDecisionId']];
         self::assertSame('concept', $besluit['status']);
         self::assertCount(2, $this->objects->store['mandaat']);
 
@@ -122,7 +124,7 @@ class MandaatImportServiceTest extends TestCase
     {
         $csv = "mandaatNummer,omschrijving,rolNaam,plafondCents\nWMO-001,X,Consulent,500000\n";
         $r = $this->service->importFromCsv('B-2026-4', 'X', 'decidesk-uuid-4', $csv);
-        $approved = $this->service->approveImport((string) $r['mandateringsBesluitId']);
+        $approved = $this->service->approveImport((string) $r['mandateDecisionId']);
 
         self::assertSame('vastgesteld', $approved['status']);
         $m = array_values($this->objects->store['mandaat'])[0];
@@ -137,7 +139,7 @@ class MandaatImportServiceTest extends TestCase
         // First import + approve.
         $csv1 = "mandaatNummer,omschrijving,rolNaam,plafondCents\nWMO-001,Original,Consulent,500000\n";
         $r1 = $this->service->importFromCsv('B-2026-5', 'V1', 'decidesk-uuid-5', $csv1);
-        $this->service->approveImport((string) $r1['mandateringsBesluitId']);
+        $this->service->approveImport((string) $r1['mandateDecisionId']);
 
         // Re-import with different plafond + a removed row.
         $csv2 = "mandaatNummer,omschrijving,rolNaam,plafondCents\nWMO-001,Updated,Consulent,1000000\n";


### PR DESCRIPTION
Applies the ratified **besluit = decision** equivalence to procest's mandate schema.

`mandateringsBesluit` → **`mandateDecision`** (key, slug, title, description), plus five properties and the cross-schema reference that names it:

| before | after |
|---|---|
| `besluitNummer` | `decisionNumber` |
| `besluitNaam` | `decisionName` |
| `inWerkingtreding` | `effectiveFrom` |
| `vervalDatum` | `expiryDate` |
| `vorigBesluit` | `previousDecision` |
| `mandaat.mandateringsBesluit` | `mandaat.mandateDecision` |

## There was never a schema merge to do

I had this slice recorded as blocked, on the grounds that procest *already declares a `decision` schema, so renaming `Besluit` onto it is a merge*. Measured: procest declares exactly one `decision` schema, already fully English with twelve English properties, and **there is no bare `Besluit` schema anywhere** to collide with it. The premise was wrong.

## What is deliberately not renamed

**`wettelijkeGrondslag` stays.** It is owned by five other procest schemas (`dwangsomUitbetaling`, `mandaat`, `subsidieBeschikking`, `termijnDefinitie`, `terugvordering`) that still declare the Dutch spelling, and the column migration is **register-scoped** — renaming it here migrates their data out from under their own declarations. A shared property half-renamed is worse than one untouched. (`legalBasis` also already exists on another procest schema.)

**The `status` enum values** (`concept`/`vastgesteld`/`vervallen`) stay — enum values are stored data; rewriting them rewrites every row. Same call as openconnector#1213.

**The SchemaSlugMap *value*** stays `mandaterings_besluit_schema`. Only the key is the slug; the value is the app-config key holding this schema's numeric id on every existing install. Renaming it orphans that id and the schema silently resolves to nothing.

**The import endpoint accepts both spellings** — its body keys are a published contract, so an un-updated client keeps working.

## Migration

Six columns added to the existing register-scoped repair step. **Each was verified to be owned by exactly one schema before being added** — that check is what kept `wettelijke_grondslag` out. Same hazard decidesk's step avoids by scoping to a register, except here it is *within* one app.

## Three pre-existing UI bugs found — deliberately not "fixed" by renaming

- `MandaatEditor.vue` binds `form.inWerkingtreding` onto a **mandaat**, which declares `validFrom`/`validUntil` and has no such property.
- `MandaatMatrixTable.vue` reads `b.vervaldatum` — lowercase `d` — matching no schema property at all.
- `BevoegdhedenPanel.vue` reads both off API rows whose shape I cannot confirm without running it.

Renaming these would have cemented bindings that already point at nothing. Only `MandaatMatrixWidget.vue`, which reads the renamed reference, was updated. The other three need their own look.

## Verification

- **1867 tests, 6346 assertions green** (5 skipped — same as baseline)
- `php -l` clean; fragment parses as JSON
- **Named-argument parity**: `findPriorBesluit` → `findPriorDecision`, parameter `besluitNummer` → `decisionNumber`; both call sites moved and diffed against the declaration
- **phpcs 0 errors** on every file touched except `MandaatImportServiceTest`, which carries 46 — identical count on the unmodified file, measured by stashing