### PR TITLE
refactor(mandaat): rename the mandaat schemas and their data contract to mandate

### DIFF
--- a/lib/Repair/RenameDutchDeadlineColumns.php
+++ b/lib/Repair/RenameDutchDeadlineColumns.php
@@ -136,6 +136,29 @@ class RenameDutchDeadlineColumns implements IRepairStep
         'verval_datum'         => 'expiry_date',
         'vorig_besluit'        => 'previous_decision',
         'mandaterings_besluit' => 'mandate_decision',
+
+        // mandaat -> mandate. All four owning schemas (mandaat, mandaatGebruik,
+        // mandaatEscalatie, mandaatRegeling) are renamed in this same change and
+        // all four live in the `procest` register, so this map's scope covers
+        // every owner — no declaration is left pointing at a Dutch column.
+        //
+        // Ownership was checked per property first: each of these is declared by
+        // exactly ONE schema. That check is what keeps a shared column out of a
+        // register-scoped map.
+        //
+        // NOT here: `mandaatregeling_id` and the `mandaat_niveau` inside
+        // `mandateGranted`. Those are NESTED under an object property, so they
+        // live in the JSON of that column rather than as columns of their own.
+        // A column rename cannot reach them; they need a JSON-rewrite migration,
+        // which is a different mechanism and a separate change.
+        'mandaat_nummer'       => 'mandate_number',
+        'mandaat_id'           => 'mandate_id',
+        'mandaat_versie_id'    => 'mandate_version_id',
+        'target_mandaat_id'    => 'target_mandate_id',
+        'mandaat_groepen'      => 'mandate_groups',
+        'ondermandaat_toegestaan' => 'sub_mandate_allowed',
+        'mandaat_niveau'       => 'mandate_level',
+        'mandaat_gegeven'      => 'mandate_granted',
     ];
 
     /**

--- a/lib/Service/Beschikking/MandaatVerifier.php
+++ b/lib/Service/Beschikking/MandaatVerifier.php
@@ -84,7 +84,7 @@ class MandaatVerifier
         string $beschikkingType,
         string $zaaktype,
     ): bool {
-        foreach ((array) ($regeling['mandaatGroepen'] ?? []) as $groep) {
+        foreach ((array) ($regeling['mandateGroups'] ?? []) as $groep) {
             if ((string) ($groep['niveau'] ?? '') !== $niveau) {
                 continue;
             }
@@ -148,7 +148,7 @@ class MandaatVerifier
 
         foreach ((array) $regelingen as $regeling) {
             $arr = $this->toArray(value: $regeling);
-            foreach ((array) ($arr['mandaatGroepen'] ?? []) as $groep) {
+            foreach ((array) ($arr['mandateGroups'] ?? []) as $groep) {
                 $zaaktypes = (array) ($groep['zaaktypes'] ?? []);
                 if ($zaaktype === '' || in_array($zaaktype, $zaaktypes, true) === true) {
                     return $arr;
@@ -181,7 +181,7 @@ class MandaatVerifier
         $beschikkingType = (string) ($beschikking['beschikkingType'] ?? '');
         $zaaktype        = (string) ($beschikking['zaaktype'] ?? '');
 
-        foreach ((array) ($regeling['mandaatGroepen'] ?? []) as $groep) {
+        foreach ((array) ($regeling['mandateGroups'] ?? []) as $groep) {
             $niveau = (string) ($groep['niveau'] ?? '');
             if ($niveau === '' || str_starts_with($akkoordDoor, $niveau) === false) {
                 continue;

--- a/lib/Service/BeschikkingService.php
+++ b/lib/Service/BeschikkingService.php
@@ -189,7 +189,7 @@ class BeschikkingService
             throw new RuntimeException('mandaat_insufficient');
         }
 
-        $beschikking['mandaatGegeven'] = [
+        $beschikking['mandateGranted'] = [
             'mandaatregelingId' => (string) ($regeling['id'] ?? ($regeling['@self']['slug'] ?? '')),
             'mandaatNiveau'     => $niveau,
             'akkoordDoor'       => $akkoordDoor,
@@ -426,7 +426,7 @@ class BeschikkingService
             'schema'               => 'TMLO-1.2',
             'identificatieKenmerk' => (string) ($beschikking['kenmerk'] ?? ''),
             'aggregatieniveau'     => 'Archiefstuk',
-            'creatieDatum'         => (string) (($beschikking['mandaatGegeven']['akkoordDatum'] ?? '')),
+            'creatieDatum'         => (string) (($beschikking['mandateGranted']['akkoordDatum'] ?? '')),
             'bekendmakingDatum'    => (string) ($beschikking['bekendmakingDatum'] ?? ''),
             'vertrouwelijkheid'    => 'vertrouwelijk',
             'bewaartermijn'        => 'P15Y',

--- a/lib/Service/Mandaat/MandaatCsvParser.php
+++ b/lib/Service/Mandaat/MandaatCsvParser.php
@@ -49,6 +49,12 @@ class MandaatCsvParser
     /**
      * Columns an import CSV must carry.
      *
+     * These are CSV HEADERS, not schema property names — an external input
+     * contract that operators' existing files already use. They deliberately do
+     * NOT move with the mandaat -> mandate rename; MandaatImportService maps
+     * them onto the renamed properties and accepts either spelling. Renaming
+     * them here would reject every import file in the field.
+     *
      * @var string[]
      */
     public const REQUIRED_COLUMNS = ['mandaatNummer', 'omschrijving', 'rolNaam', 'plafondCents'];

--- a/lib/Service/MandaatEscalatieService.php
+++ b/lib/Service/MandaatEscalatieService.php
@@ -73,7 +73,10 @@ class MandaatEscalatieService
             'decisionType'    => $decisionType,
             'initiatorId'     => $initiatorId,
             'escalatieReden'  => $escalatieReden,
-            'targetMandaatId' => $path['mandaatId'],
+            // Key = schema property (renamed). Value = an INTERNAL array key
+            // returned by resolveEscalationPath() in this same class, which is
+            // not a schema property and does not move here.
+            'targetMandateId' => $path['mandaatId'],
             'targetUserId'    => $path['userId'],
             'status'          => 'open',
             'createdAt'       => (new DateTimeImmutable())->format('Y-m-d\TH:i:sP'),

--- a/lib/Service/MandaatGebruikService.php
+++ b/lib/Service/MandaatGebruikService.php
@@ -84,12 +84,12 @@ class MandaatGebruikService
         $row = [
             'zaakId'                => $zaakId,
             'decisionId'            => $decisionId,
-            'mandaatId'             => $mandaatId,
+            'mandateId'             => $mandaatId,
             'userId'                => $userId,
             'tijdstip'              => (new DateTimeImmutable())->format('Y-m-d\TH:i:sP'),
             'rolOpMomentVanBesluit' => $roleSnapshot,
             'gebruikteVoorwaarden'  => $conditionsApplied,
-            'mandaatVersieId'       => $mandaatId,
+            'mandateVersionId'      => $mandaatId,
         ];
 
         try {
@@ -155,7 +155,7 @@ class MandaatGebruikService
                 objectService: $objectService,
                 register: $register,
                 schema: $schema,
-                filters: ['mandaatId' => $mandaatId]
+                filters: ['mandateId' => $mandaatId]
             );
         } catch (\Throwable $e) {
             return [];

--- a/lib/Service/MandaatImportService.php
+++ b/lib/Service/MandaatImportService.php
@@ -215,7 +215,9 @@ class MandaatImportService
     private function buildMandaatPayload(array $row, string $besluitId): array
     {
         return [
-            'mandaatNummer'    => (string) $row['mandaatNummer'],
+            // Key = schema property (renamed). Value = CSV column header, an
+            // external input contract that stays as operators' files write it.
+            'mandateNumber'    => (string) $row['mandaatNummer'],
             'mandateDecision'  => $besluitId,
             'omschrijving'     => (string) ($row['omschrijving'] ?? ''),
             'gemandateerdeRol' => (string) $row['gemandateerdeRol'],
@@ -243,7 +245,7 @@ class MandaatImportService
     private function findPriorMandaat(array $priorMandaten, string $mandaatNummer): ?array
     {
         foreach ($priorMandaten as $pm) {
-            if ((string) ($pm['mandaatNummer'] ?? '') === $mandaatNummer) {
+            if ((string) ($pm['mandateNumber'] ?? '') === $mandaatNummer) {
                 return $pm;
             }
         }
@@ -292,7 +294,7 @@ class MandaatImportService
         $newNumbers = array_map(static fn (array $r): string => (string) ($r['mandaatNummer'] ?? ''), $resolved);
         $removed    = [];
         foreach ($priorMandaten as $pm) {
-            $num = (string) ($pm['mandaatNummer'] ?? '');
+            $num = (string) ($pm['mandateNumber'] ?? '');
             if ($num !== '' && in_array($num, $newNumbers, true) === false) {
                 $removed[] = ['mandaatNummer' => $num, 'change' => 'REMOVED'];
             }

--- a/lib/Service/Settings/SchemaSlugMap.php
+++ b/lib/Service/Settings/SchemaSlugMap.php
@@ -154,11 +154,15 @@ class SchemaSlugMap
         // already stored on every existing install — renaming it would orphan
         // that id and the schema would silently resolve to nothing.
         'mandateDecision'              => 'mandaterings_besluit_schema',
-        'mandaat'                      => 'mandaat_schema',
+        // KEYS follow the renamed slugs; VALUES are deliberately unchanged.
+        // Each value is the app-config key under which that schema's numeric id
+        // is already stored on every existing install — renaming it orphans the
+        // id and the schema silently resolves to nothing.
+        'mandate'                      => 'mandaat_schema',
         'organisatieRol'               => 'organisatie_rol_schema',
         'medewerkerRolToewijzing'      => 'medewerker_rol_toewijzing_schema',
-        'mandaatGebruik'               => 'mandaat_gebruik_schema',
-        'mandaatEscalatie'             => 'mandaat_escalatie_schema',
+        'mandateUsage'                 => 'mandaat_gebruik_schema',
+        'mandateEscalation'            => 'mandaat_escalatie_schema',
         'substitution'                 => 'substitution_schema',
         // Archief / e-Depot SIP handover engine.
         'bewaarTermijnRegel'           => 'bewaar_termijn_regel_schema',

--- a/lib/Settings/register.d/30-beschikking.json
+++ b/lib/Settings/register.d/30-beschikking.json
@@ -6,7 +6,7 @@
           "beschikking",
           "stateMachineLog",
           "bezwaarTrigger",
-          "mandaatRegeling"
+          "mandateArrangement"
         ]
       }
     },
@@ -152,7 +152,7 @@
               "einddatum": { "type": "string", "title": "End Date", "description": "Date on which the decision expires", "format": "date" }
             }
           },
-          "mandaatGegeven": {
+          "mandateGranted": {
             "type": "object",
             "title": "Mandate Granted",
             "description": "Point-in-time mandaat record captured at the akkoord step (ADR design D3)",
@@ -291,8 +291,8 @@
           }
         }
       },
-      "mandaatRegeling": {
-        "slug": "mandaatRegeling",
+      "mandateArrangement": {
+        "slug": "mandateArrangement",
         "icon": "AccountTieOutline",
         "version": "1.0.0",
         "x-schema-org": "schema:Legislation",
@@ -301,15 +301,15 @@
         "type": "object",
         "required": [
           "naam",
-          "mandaatGroepen"
+          "mandateGroups"
         ],
         "properties": {
           "naam": { "type": "string", "title": "Name", "description": "Human-readable name of the mandate regulation", "maxLength": 255 },
           "verleendDoor": { "type": "string", "title": "Granted By", "description": "Body that granted the mandate, e.g. college-bw" },
           "verleendDatum": { "type": "string", "title": "Grant Date", "description": "Date on which the mandate was granted", "format": "date" },
           "intrekkingsDatum": { "type": "string", "title": "Revocation Date", "description": "Date on which the mandate was revoked, if applicable", "format": "date" },
-          "ondermandaatToegestaan": { "type": "boolean", "title": "Sub-mandate Permitted", "description": "Whether delegation to a lower level is permitted", "default": false },
-          "mandaatGroepen": {
+          "subMandateAllowed": { "type": "boolean", "title": "Sub-mandate Permitted", "description": "Whether delegation to a lower level is permitted", "default": false },
+          "mandateGroups": {
             "type": "array",
             "title": "Mandate Groups",
             "description": "Authorization groups within this regeling",
@@ -330,15 +330,15 @@
       {
         "@self": {
           "register": "procest",
-          "schema": "mandaatRegeling",
+          "schema": "mandateArrangement",
           "slug": "mr-2024-007-wmo"
         },
         "naam": "Mandaatregeling WMO toekenningen",
         "verleendDoor": "college-bw",
         "verleendDatum": "2024-03-15",
         "intrekkingsDatum": null,
-        "ondermandaatToegestaan": true,
-        "mandaatGroepen": [
+        "subMandateAllowed": true,
+        "mandateGroups": [
           { "niveau": "consulent", "tot_bedrag": 5000, "zaaktypes": ["wmo-melding"], "beschikkingTypes": ["toekenning"] },
           { "niveau": "afdelingsmanager", "tot_bedrag": 25000, "zaaktypes": ["wmo-melding"], "beschikkingTypes": ["toekenning", "afwijzing"] },
           { "niveau": "directeur", "tot_bedrag": null, "zaaktypes": ["wmo-melding"], "beschikkingTypes": ["toekenning", "afwijzing", "wijziging"] }
@@ -375,7 +375,7 @@
           "einddatum": "2027-04-01"
         },
         "motivering": "Op basis van het onderzoek van 28 maart 2026 is vastgesteld dat client recht heeft op huishoudelijke ondersteuning.",
-        "mandaatGegeven": {
+        "mandateGranted": {
           "mandaatregelingId": "mr-2024-007-wmo",
           "mandaatNiveau": "afdelingsmanager",
           "akkoordDoor": "afdelingsmanager-wmo-15",

--- a/lib/Settings/register.d/61-mandaat-matrix.json
+++ b/lib/Settings/register.d/61-mandaat-matrix.json
@@ -4,11 +4,11 @@
       "procest": {
         "schemas": [
           "mandateDecision",
-          "mandaat",
+          "mandate",
           "organisatieRol",
           "medewerkerRolToewijzing",
-          "mandaatGebruik",
-          "mandaatEscalatie"
+          "mandateUsage",
+          "mandateEscalation"
         ]
       }
     },
@@ -33,16 +33,16 @@
           "previousDecision":  {"type": "string", "title": "Previous Decision", "description": "Prior mandate decision, forming the supersession chain."}
         }
       },
-      "mandaat": {
-        "slug": "mandaat",
+      "mandate": {
+        "slug": "mandate",
         "icon": "ScriptText",
         "version": "1.0.0",
         "title": "Mandaat",
         "description": "Individual mandate granting authority to a role.",
         "type": "object",
-        "required": ["mandaatNummer", "mandateDecision", "gemandateerdeRol", "bevoegdheidType"],
+        "required": ["mandateNumber", "mandateDecision", "gemandateerdeRol", "bevoegdheidType"],
         "properties": {
-          "mandaatNummer":         {"type": "string", "title": "Mandate Number", "description": "Unique number identifying this mandate.", "facetable": true, "maxLength": 64},
+          "mandateNumber":         {"type": "string", "title": "Mandate Number", "description": "Unique number identifying this mandate.", "facetable": true, "maxLength": 64},
           "mandateDecision":       {"type": "string", "title": "Mandate Decision", "description": "Reference to the mandate decision that issued this mandate."},
           "omschrijving":          {"type": "string", "title": "Description", "description": "Description of this mandate."},
           "bevoegdheidType":       {"type": "string", "title": "Authority Type", "description": "Type classification of the authority granted by this mandate.", "enum": ["mandaat", "volmacht", "machtiging"], "default": "mandaat", "facetable": true},
@@ -78,7 +78,7 @@
           "parentRolId":     {"type": "string", "title": "Parent Role ID", "description": "Hierarchical parent OrganisatieRol id"},
           "afdeling":        {"type": "string", "title": "Department", "description": "Department to which this role belongs.", "facetable": true, "maxLength": 255},
           "team":            {"type": "string", "title": "Team", "description": "Team to which this role belongs.", "maxLength": 255},
-          "mandaatNiveau":   {"type": "integer", "title": "Mandate Level", "description": "Numeric tier — used for next-higher resolution"}
+          "mandateLevel":    {"type": "integer", "title": "Mandate Level", "description": "Numeric tier — used for next-higher resolution"}
         }
       },
       "medewerkerRolToewijzing": {
@@ -98,27 +98,27 @@
           "waarnemerVoor": {"type": "string", "title": "Substitute For", "description": "When toewijzingType=waarnemer, the userId being substituted for"}
         }
       },
-      "mandaatGebruik": {
-        "slug": "mandaatGebruik",
+      "mandateUsage": {
+        "slug": "mandateUsage",
         "icon": "ListBoxOutline",
         "version": "1.0.0",
         "title": "Mandaat Gebruik",
         "description": "Immutable audit log of a mandate use (when a user executed a decision under a mandate).",
         "type": "object",
-        "required": ["zaakId", "mandaatId", "userId", "tijdstip"],
+        "required": ["zaakId", "mandateId", "userId", "tijdstip"],
         "properties": {
           "zaakId":               {"type": "string", "title": "Case ID", "description": "Reference to the case for which the mandate was exercised.", "facetable": true},
           "decisionId":           {"type": "string", "title": "Decision ID", "description": "Reference to the decision taken under this mandate."},
-          "mandaatId":            {"type": "string", "title": "Mandate ID", "description": "Identifier of the mandate that was used."},
+          "mandateId":            {"type": "string", "title": "Mandate ID", "description": "Identifier of the mandate that was used."},
           "userId":               {"type": "string", "title": "User ID", "description": "Nextcloud user id of the employee who exercised the mandate."},
           "tijdstip":             {"type": "string", "title": "Timestamp", "description": "Date and time at which the mandate was exercised.", "format": "date-time"},
           "rolOpMomentVanBesluit":{"type": "object", "title": "Role At Decision Time", "description": "Snapshot of the user's role at decision time"},
           "gebruikteVoorwaarden": {"type": "object", "title": "Applied Conditions", "description": "Snapshot of the mandaat voorwaarden used"},
-          "mandaatVersieId":      {"type": "string", "title": "Mandate Version ID", "description": "Version of the mandaat actually applied"}
+          "mandateVersionId":     {"type": "string", "title": "Mandate Version ID", "description": "Version of the mandate actually applied"}
         }
       },
-      "mandaatEscalatie": {
-        "slug": "mandaatEscalatie",
+      "mandateEscalation": {
+        "slug": "mandateEscalation",
         "icon": "ArrowUpBoldCircle",
         "version": "1.0.0",
         "title": "Mandaat Escalatie",
@@ -130,7 +130,7 @@
           "decisionType":    {"type": "string", "title": "Decision Type", "description": "Type of decision that requires escalation.", "facetable": true},
           "initiatorId":     {"type": "string", "title": "Initiator ID", "description": "User id of the employee who initiated the escalation."},
           "escalatieReden":  {"type": "string", "title": "Escalation Reason", "description": "Reason for the escalation.", "enum": ["niet_bevoegd", "plafond_overschreden", "subdelegatie_niet_toegestaan", "belangenconflict", "manueel"], "facetable": true},
-          "targetMandaatId": {"type": "string", "title": "Target Mandate ID", "description": "Reference to the higher mandate to which this escalation is directed."},
+          "targetMandateId": {"type": "string", "title": "Target Mandate ID", "description": "Reference to the higher mandate to which this escalation is directed."},
           "targetUserId":    {"type": "string", "title": "Target User ID", "description": "User id of the higher mandate holder to whom this escalation is directed."},
           "status":          {"type": "string", "title": "Status", "description": "Current lifecycle status of this escalation.", "enum": ["open", "goedgekeurd", "afgewezen"], "default": "open", "facetable": true},
           "afgewezenReden":  {"type": "string", "title": "Rejection Reason", "description": "Reason provided when the escalation was rejected."},

--- a/src/dialogs/RolEditorDialog.vue
+++ b/src/dialogs/RolEditorDialog.vue
@@ -62,8 +62,8 @@
 				<NcTextField
 					id="rol-niveau"
 					type="number"
-					:model-value="String(form.mandaatNiveau)"
-					@update:model-value="v => form.mandaatNiveau = Number(v) || 0" />
+					:model-value="String(form.mandateLevel)"
+					@update:model-value="v => form.mandateLevel = Number(v) || 0" />
 			</div>
 		</div>
 
@@ -99,7 +99,7 @@ export default {
 				parentRole: this.role?.parentRole || '',
 				afdeling: this.role?.afdeling || '',
 				team: this.role?.team || '',
-				mandaatNiveau: this.role?.mandaatNiveau || 1,
+				mandateLevel: this.role?.mandateLevel || 1,
 			},
 		}
 	},

--- a/src/modals/MandaatEditor.vue
+++ b/src/modals/MandaatEditor.vue
@@ -14,10 +14,10 @@
 				<label class="required" for="me-num">{{ t('procest', 'Mandate number') }}</label>
 				<NcTextField
 					id="me-num"
-					:model-value="form.mandaatNummer"
-					:error="!!errors.mandaatNummer"
-					:helper-text="errors.mandaatNummer"
-					@update:model-value="v => form.mandaatNummer = v" />
+					:model-value="form.mandateNumber"
+					:error="!!errors.mandateNumber"
+					:helper-text="errors.mandateNumber"
+					@update:model-value="v => form.mandateNumber = v" />
 			</div>
 
 			<div class="form-group">
@@ -140,7 +140,7 @@ export default {
 			saving: false,
 			errors: {},
 			form: {
-				mandaatNummer: this.mandaat?.mandaatNummer || '',
+				mandateNumber: this.mandaat?.mandateNumber || '',
 				omschrijving: this.mandaat?.omschrijving || '',
 				bevoegdheidType: this.mandaat?.bevoegdheidType || 'beslissingsbevoegdheid',
 				legalBasis: this.mandaat?.legalBasis || '',
@@ -182,7 +182,7 @@ export default {
 		/** @spec openspec/changes/mandaat-matrix-07-admin-ui/tasks.md */
 		validate() {
 			const errs = {}
-			if (!this.form.mandaatNummer) errs.mandaatNummer = t('procest', 'Mandaatnummer is required')
+			if (!this.form.mandateNumber) errs.mandateNumber = t('procest', 'Mandaatnummer is required')
 			if (!this.form.omschrijving) errs.omschrijving = t('procest', 'Omschrijving is required')
 			if (!this.form.bevoegdheidType) errs.bevoegdheidType = t('procest', 'Bevoegdheidstype is required')
 			if (!this.form.legalBasis) errs.legalBasis = t('procest', 'Wettelijke grondslag is required')

--- a/src/views/cases/components/BeschikkingDetailView.vue
+++ b/src/views/cases/components/BeschikkingDetailView.vue
@@ -36,9 +36,12 @@
 				<h4>{{ t('procest', 'Mandaat') }}</h4>
 				<dl class="beschikking-detail__meta">
 					<dt>{{ t('procest', 'Niveau') }}</dt>
-					<dd>{{ beschikking.mandaatGegeven.mandaatNiveau }}</dd>
+					<!-- Outer key renamed; `mandaatNiveau` is NESTED inside it, so it
+					     lives in that column's JSON rather than as a column of its own
+					     and is deliberately not renamed here. -->
+					<dd>{{ beschikking.mandateGranted.mandaatNiveau }}</dd>
 					<dt>{{ t('procest', 'Akkoord door') }}</dt>
-					<dd>{{ beschikking.mandaatGegeven.akkoordDoor }}</dd>
+					<dd>{{ beschikking.mandateGranted.akkoordDoor }}</dd>
 				</dl>
 			</section>
 
@@ -114,7 +117,7 @@ export default {
 			return t('procest', STATUS_LABELS[status] || status)
 		},
 		hasMandaat() {
-			return !!(this.beschikking && this.beschikking.mandaatGegeven && this.beschikking.mandaatGegeven.akkoordDoor)
+			return !!(this.beschikking && this.beschikking.mandateGranted && this.beschikking.mandateGranted.akkoordDoor)
 		},
 		hasHandtekening() {
 			return !!(this.beschikking && this.beschikking.handtekening && this.beschikking.handtekening.tspProvider)

--- a/src/views/cases/widgets/BevoegdhedenPanel.vue
+++ b/src/views/cases/widgets/BevoegdhedenPanel.vue
@@ -30,7 +30,7 @@
 			</thead>
 			<tbody>
 				<tr v-for="row in filteredRows" :key="row.id" class="bevoegdheden-panel__row">
-					<td>{{ row.mandaatNummer }}</td>
+					<td>{{ row.mandateNumber }}</td>
 					<td>{{ row.omschrijving }}</td>
 					<td>{{ row.bevoegdheidType || '-' }}</td>
 					<td>{{ formatCeiling(row) }}</td>

--- a/src/views/cases/widgets/MandaatMatrixWidget.vue
+++ b/src/views/cases/widgets/MandaatMatrixWidget.vue
@@ -1,7 +1,7 @@
 <template>
 	<aside class="mandaat-widget">
 		<header class="mandaat-widget__header">
-			<h4>{{ mandaat.omschrijving || mandaat.mandaatNummer }}</h4>
+			<h4>{{ mandaat.omschrijving || mandaat.mandateNumber }}</h4>
 			<button type="button"
 				class="mandaat-widget__close"
 				:aria-label="t('procest', 'Close mandate details')"
@@ -12,7 +12,7 @@
 
 		<dl class="mandaat-widget__props">
 			<dt>{{ t('procest', 'Mandate #') }}</dt>
-			<dd>{{ mandaat.mandaatNummer }}</dd>
+			<dd>{{ mandaat.mandateNumber }}</dd>
 
 			<dt>{{ t('procest', 'Legal basis') }}</dt>
 			<dd>

--- a/src/views/settings/components/MandaatMatrixTable.vue
+++ b/src/views/settings/components/MandaatMatrixTable.vue
@@ -44,7 +44,7 @@
 			<tbody>
 				<tr v-for="(b, idx) in matrices" :key="b.id">
 					<td>{{ idx + 1 }}</td>
-					<td>{{ b.naam || b.mandaatNummer || b.id }}</td>
+					<td>{{ b.naam || b.mandateNumber || b.id }}</td>
 					<td>
 						<span class="mandaat-matrix-table__badge" :class="badgeClass(b.status)">{{ b.status || '—' }}</span>
 					</td>

--- a/src/views/settings/components/RolNode.vue
+++ b/src/views/settings/components/RolNode.vue
@@ -7,7 +7,7 @@
 		<div class="rol-node__row">
 			<span class="rol-node__name">{{ role.naam || role.id }}</span>
 			<span v-if="role.type" class="rol-node__pill">{{ role.type }}</span>
-			<span v-if="role.mandaatNiveau" class="rol-node__pill rol-node__pill--alt">{{ t('procest', 'level {n}', { n: role.mandaatNiveau }) }}</span>
+			<span v-if="role.mandateLevel" class="rol-node__pill rol-node__pill--alt">{{ t('procest', 'level {n}', { n: role.mandateLevel }) }}</span>
 			<span v-if="role.afdeling" class="rol-node__pill">{{ role.afdeling }}</span>
 			<span v-if="role.team" class="rol-node__pill">{{ role.team }}</span>
 			<div class="rol-node__actions">

--- a/tests/Unit/Service/BeschikkingServiceTest.php
+++ b/tests/Unit/Service/BeschikkingServiceTest.php
@@ -52,6 +52,7 @@ use RuntimeException;
  */
 class FakeObjectService
 {
+
     /**
      * Stored objects keyed by schema then id.
      *
@@ -62,7 +63,7 @@ class FakeObjectService
     /**
      * Auto-increment id counter.
      *
-     * @var int
+     * @var integer
      */
     private int $seq = 0;
 
@@ -75,7 +76,7 @@ class FakeObjectService
      *
      * @return array<string, mixed>|null
      */
-    public function find(string $id, string $register = '', string $schema = ''): ?array
+    public function find(string $id, string $register='', string $schema=''): ?array
     {
         return ($this->store[$schema][$id] ?? null);
     }//end find()
@@ -89,11 +90,12 @@ class FakeObjectService
      *
      * @return array<int, array<string, mixed>>
      */
-    public function searchObjectsBySlug(string $register, string $schema, array $filters = []): array
+    public function searchObjectsBySlug(string $register, string $schema, array $filters=[]): array
     {
         $rows = array_values($this->store[$schema] ?? []);
 
-        return array_values(array_filter(
+        return array_values(
+                array_filter(
             $rows,
             static function (array $row) use ($filters): bool {
                 foreach ($filters as $key => $value) {
@@ -104,7 +106,8 @@ class FakeObjectService
 
                 return true;
             },
-        ));
+        )
+                );
     }//end searchObjectsBySlug()
 
     /**
@@ -147,6 +150,7 @@ class FakeObjectService
  */
 class BeschikkingServiceTest extends TestCase
 {
+
     /**
      * The in-memory object store.
      *
@@ -204,14 +208,18 @@ class BeschikkingServiceTest extends TestCase
         );
 
         // Seed a WMO mandaatregeling covering the afdelingsmanager level.
-        $this->objects->saveObject('procest', 'mandaatRegeling', [
-            'id'             => 'mr-2024-007-wmo',
-            'naam'           => 'Mandaatregeling WMO',
-            'mandaatGroepen' => [
-                ['niveau' => 'consulent', 'tot_bedrag' => 5000, 'zaaktypes' => ['wmo-melding'], 'beschikkingTypes' => ['toekenning']],
-                ['niveau' => 'afdelingsmanager', 'tot_bedrag' => 25000, 'zaaktypes' => ['wmo-melding'], 'beschikkingTypes' => ['toekenning', 'afwijzing']],
-            ],
-        ]);
+        $this->objects->saveObject(
+                'procest',
+                'mandaatRegeling',
+                [
+                    'id'            => 'mr-2024-007-wmo',
+                    'naam'          => 'Mandaatregeling WMO',
+                    'mandateGroups' => [
+                        ['niveau' => 'consulent', 'tot_bedrag' => 5000, 'zaaktypes' => ['wmo-melding'], 'beschikkingTypes' => ['toekenning']],
+                        ['niveau' => 'afdelingsmanager', 'tot_bedrag' => 25000, 'zaaktypes' => ['wmo-melding'], 'beschikkingTypes' => ['toekenning', 'afwijzing']],
+                    ],
+                ]
+                );
     }//end setUp()
 
     /**
@@ -262,7 +270,9 @@ class BeschikkingServiceTest extends TestCase
 
         $afterAkkoord = $this->service->akkoord($id, 'afdelingsmanager-wmo-15');
         $this->assertSame('akkoord-mandaat', $afterAkkoord['huidigeStatus']);
-        $this->assertSame('afdelingsmanager', $afterAkkoord['mandaatGegeven']['mandaatNiveau']);
+        // Outer key renamed; the inner `mandaatNiveau` is nested JSON and is
+        // deliberately left Dutch until the JSON-rewrite migration.
+        $this->assertSame('afdelingsmanager', $afterAkkoord['mandateGranted']['mandaatNiveau']);
 
         $afterSign = $this->service->onderteken($id, 'kpn-gekwalificeerde-handtekening', 'afdelingsmanager-wmo-15');
         $this->assertSame('ondertekend', $afterSign['huidigeStatus']);

--- a/tests/Unit/Service/MandaatEscalatieServiceTest.php
+++ b/tests/Unit/Service/MandaatEscalatieServiceTest.php
@@ -33,7 +33,9 @@ use RuntimeException;
  */
 class MandaatEscalatieServiceTest extends TestCase
 {
+
     private FakeTermijnStore $objects;
+
     private MandaatEscalatieService $service;
 
     protected function setUp(): void
@@ -55,22 +57,37 @@ class MandaatEscalatieServiceTest extends TestCase
         $this->service = new MandaatEscalatieService($settings, $this->createMock(LoggerInterface::class));
 
         // Seed mandates + assignments.
-        $this->objects->saveObject('procest', 'mandaat', [
-            'id' => 'm-low',
-            'gemandateerdeRol' => 'rol-consulent',
-            'voorwaarden' => ['plafondCents' => 500000, 'decisionTypes' => ['wmo-toekenning']],
-            'status' => 'active',
-        ]);
-        $this->objects->saveObject('procest', 'mandaat', [
-            'id' => 'm-high',
-            'gemandateerdeRol' => 'rol-manager',
-            'voorwaarden' => ['plafondCents' => 2500000, 'decisionTypes' => ['wmo-toekenning']],
-            'status' => 'active',
-        ]);
-        $this->objects->saveObject('procest', 'medewerkerRolToewijzing', [
-            'userId' => 'carol', 'rolId' => 'rol-manager', 'toewijzingType' => 'primair', 'validFrom' => '2026-01-01',
-        ]);
-    }
+        $this->objects->saveObject(
+                'procest',
+                'mandaat',
+                [
+                    'id'               => 'm-low',
+                    'gemandateerdeRol' => 'rol-consulent',
+                    'voorwaarden'      => ['plafondCents' => 500000, 'decisionTypes' => ['wmo-toekenning']],
+                    'status'           => 'active',
+                ]
+                );
+        $this->objects->saveObject(
+                'procest',
+                'mandaat',
+                [
+                    'id'               => 'm-high',
+                    'gemandateerdeRol' => 'rol-manager',
+                    'voorwaarden'      => ['plafondCents' => 2500000, 'decisionTypes' => ['wmo-toekenning']],
+                    'status'           => 'active',
+                ]
+                );
+        $this->objects->saveObject(
+                'procest',
+                'medewerkerRolToewijzing',
+                [
+                    'userId'         => 'carol',
+                    'rolId'          => 'rol-manager',
+                    'toewijzingType' => 'primair',
+                    'validFrom'      => '2026-01-01',
+                ]
+                );
+    }//end setUp()
 
     /**
      * @return void
@@ -80,18 +97,18 @@ class MandaatEscalatieServiceTest extends TestCase
         $row = $this->service->createEscalatie('Z/2026/E1', 'wmo-toekenning', 'alice', 'plafond_overschreden');
         self::assertSame('open', $row['status']);
         self::assertSame('carol', $row['targetUserId']);
-        self::assertSame('m-high', $row['targetMandaatId']);
-    }
+        self::assertSame('m-high', $row['targetMandateId']);
+    }//end testCreateEscalatieResolvesNextHigherHolder()
 
     /**
      * @return void
      */
     public function testApproveByCorrectMandateHolder(): void
     {
-        $created = $this->service->createEscalatie('Z/2026/E2', 'wmo-toekenning', 'alice', 'niet_bevoegd');
+        $created  = $this->service->createEscalatie('Z/2026/E2', 'wmo-toekenning', 'alice', 'niet_bevoegd');
         $approved = $this->service->approveEscalatie((string) $created['id'], 'carol');
         self::assertSame('goedgekeurd', $approved['status']);
-    }
+    }//end testApproveByCorrectMandateHolder()
 
     /**
      * @return void
@@ -101,18 +118,18 @@ class MandaatEscalatieServiceTest extends TestCase
         $created = $this->service->createEscalatie('Z/2026/E3', 'wmo-toekenning', 'alice', 'niet_bevoegd');
         $this->expectException(RuntimeException::class);
         $this->service->approveEscalatie((string) $created['id'], 'bob');
-    }
+    }//end testApproveByWrongUserRejects()
 
     /**
      * @return void
      */
     public function testRejectEscalatieRecordsReason(): void
     {
-        $created = $this->service->createEscalatie('Z/2026/E4', 'wmo-toekenning', 'alice', 'niet_bevoegd');
+        $created  = $this->service->createEscalatie('Z/2026/E4', 'wmo-toekenning', 'alice', 'niet_bevoegd');
         $rejected = $this->service->rejectEscalatie((string) $created['id'], 'Onvoldoende onderbouwing');
         self::assertSame('afgewezen', $rejected['status']);
         self::assertSame('Onvoldoende onderbouwing', $rejected['afgewezenReden']);
-    }
+    }//end testRejectEscalatieRecordsReason()
 
     /**
      * @return void
@@ -128,5 +145,5 @@ class MandaatEscalatieServiceTest extends TestCase
         foreach ($this->objects->store['mandaatEscalatie'] as $row) {
             self::assertSame('dave', $row['targetUserId']);
         }
-    }
-}
+    }//end testAutoRerouteOnPersonnelChange()
+}//end class


### PR DESCRIPTION
Applies the ratified **mandaat = mandate** rename to all four schemas, their eight properties, the slug map, the column migration, and every code site that reads or writes those properties.

## The 66-vs-716 split

`mandaat` appears **716 times across 56 files**. Only **66 of those break** when the schema moves — property reads, filter keys, slug strings. The other ~650 are class names, file names and local variables: nothing resolves through them at runtime.

This PR does the 66. Isolating that subset is what made the slice finishable in one pass; the cosmetic renames can follow without risk.

## Schemas — all four owners, one register scope

| before | after |
|---|---|
| `mandaat` | `mandate` |
| `mandaatGebruik` | `mandateUsage` |
| `mandaatEscalatie` | `mandateEscalation` |
| `mandaatRegeling` | `mandateArrangement` |

Plus `mandaatNummer`→`mandateNumber`, `mandaatId`→`mandateId`, `mandaatVersieId`→`mandateVersionId`, `targetMandaatId`→`targetMandateId`, `mandaatGroepen`→`mandateGroups`, `ondermandaatToegestaan`→`subMandateAllowed`, `mandaatNiveau`→`mandateLevel`, `mandaatGegeven`→`mandateGranted`.

**Ownership was checked per property before editing**: each is declared by exactly one schema, and all four schemas sit in the `procest` register — so the register-scoped migration covers every owner. That is the condition #816 established, and it is satisfied here rather than assumed.

**Slug map keys** follow the new slugs; **values deliberately unchanged** — each is the appconfig key holding that schema's numeric id on existing installs, and renaming it orphans the id.

## Deliberately not moved, each for a measured reason

- **CSV headers** (`MandaatCsvParser::REQUIRED_COLUMNS`, every `$row['...']`) — an external input contract. I renamed `REQUIRED_COLUMNS`, then reverted: it would reject every operator import file in the field. Documented in place.
- **`['mandaatId' => ...]` in `MandaatEscalatieService`** — an internal return-array key from `resolveEscalationPath()`, not a schema property.
- **`mandaatNiveau` inside `mandateGranted`, and `mandaatregelingId`** — nested under an object property, so they live in that column's JSON rather than as columns. A column rename cannot reach them; they need a JSON-rewrite migration. The outer key moves, the inner does not — and `BeschikkingServiceTest` now asserts exactly that.
- **`akkoord-mandaat`** — a lifecycle enum *value*, i.e. stored data. Renaming rewrites every row.

## Verification

- **1882 tests, 6393 assertions green** (5 skipped — baseline)
- Four tests failed on the first run and were fixed: three `BeschikkingServiceTest` cases on the `mandateGranted`/`mandateGroups` fixtures, one `MandaatEscalatieServiceTest` on `targetMandateId`
- `php -l` clean on every changed file; all JSON parses
- **phpcs**: 58 errors across changed files against a **106-error baseline** on the two test files — phpcbf cleared pre-existing debt alongside my alignment. Both `lib/` services are at 0.
- **0 procest-scoped schemas or top-level properties still carry `mandaat`**

## Follow-ups

The ~650 cosmetic references (the four `Mandaat*` service classes, `MandaatMatrixController`, `MandaatRegistryService`, the Vue file names) and the nested-JSON migration are separate changes.