### PR TITLE
refactor(procest): rename omschrijving/beschrijving to description

### DIFF
--- a/lib/Controller/ZaakdossierController.php
+++ b/lib/Controller/ZaakdossierController.php
@@ -248,7 +248,10 @@ class ZaakdossierController extends Controller
 
         $metadata = [
             'titel'                       => $this->request->getParam('titel'),
-            'beschrijving'                => $this->request->getParam('beschrijving'),
+            // Key = schema property (renamed). The request param keeps both
+            // spellings: it is a published contract and an un-updated client
+            // must not break.
+            'description'                 => $this->request->getParam('description') ?? $this->request->getParam('beschrijving'),
             'informatieobjecttype'        => $this->request->getParam('informatieobjecttype'),
             'vertrouwelijkheidaanduiding' => $this->request->getParam('vertrouwelijkheidaanduiding'),
         ];

--- a/lib/Service/ComplaintService.php
+++ b/lib/Service/ComplaintService.php
@@ -118,7 +118,7 @@ class ComplaintService
      */
     public function createComplaint(array $data): array
     {
-        $this->validateRequired(data: $data, required: ['onderwerp', 'omschrijving', 'ontvangstdatum']);
+        $this->validateRequired(data: $data, required: ['onderwerp', 'description', 'ontvangstdatum']);
 
         $objectService = $this->settingsService->getObjectService();
         if ($objectService === null) {

--- a/lib/Service/MandaatImportService.php
+++ b/lib/Service/MandaatImportService.php
@@ -219,7 +219,9 @@ class MandaatImportService
             // external input contract that stays as operators' files write it.
             'mandateNumber'    => (string) $row['mandaatNummer'],
             'mandateDecision'  => $besluitId,
-            'omschrijving'     => (string) ($row['omschrijving'] ?? ''),
+            // Key = schema property (renamed). Value = CSV column header, an
+            // external input contract that stays as operators' files write it.
+            'description'      => (string) ($row['description'] ?? $row['omschrijving'] ?? ''),
             'gemandateerdeRol' => (string) $row['gemandateerdeRol'],
             // Key = the schema property (renamed). Value = a CSV COLUMN HEADER,
             // which is an external input format the operator's file already
@@ -266,7 +268,7 @@ class MandaatImportService
     private function collectChangedFields(array $existing, array $payload): array
     {
         $changedFields = [];
-        foreach (['omschrijving', 'gemandateerdeRol', 'legalBasis'] as $f) {
+        foreach (['description', 'gemandateerdeRol', 'legalBasis'] as $f) {
             if ((string) ($existing[$f] ?? '') !== (string) $payload[$f]) {
                 $changedFields[] = $f;
             }

--- a/lib/Service/ZaakdossierService.php
+++ b/lib/Service/ZaakdossierService.php
@@ -148,7 +148,7 @@ class ZaakdossierService
             'creatiedatum'                => (string) ($metadata['creatiedatum'] ?? date('Y-m-d')),
             'bronorganisatie'             => (string) ($metadata['bronorganisatie'] ?? ''),
             'taal'                        => (string) ($metadata['taal'] ?? 'nld'),
-            'beschrijving'                => (string) ($metadata['beschrijving'] ?? ''),
+            'description'                 => (string) ($metadata['description'] ?? $metadata['beschrijving'] ?? ''),
             'integriteit'                 => [
                 'algoritme' => 'sha256',
                 'waarde'    => $hash,
@@ -429,7 +429,7 @@ class ZaakdossierService
             throw new DomainException('Definitieve documenten kunnen niet worden gewijzigd');
         }
 
-        $allowed    = ['titel', 'beschrijving', 'informatieobjecttype', 'vertrouwelijkheidaanduiding'];
+        $allowed    = ['titel', 'description', 'informatieobjecttype', 'vertrouwelijkheidaanduiding'];
         $updateData = [];
         foreach ($allowed as $field) {
             if (array_key_exists($field, $metadata) === true) {

--- a/lib/Settings/procest_register.json
+++ b/lib/Settings/procest_register.json
@@ -7471,7 +7471,7 @@
                 "type": "object",
                 "required": [
                     "onderwerp",
-                    "omschrijving",
+                    "description",
                     "ontvangstdatum"
                 ],
                 "properties": {
@@ -7516,7 +7516,7 @@
                         "x-translatable": true,
                         "title": "Subject"
                     },
-                    "omschrijving": {
+                    "description": {
                         "type": "string",
                         "description": "Detailed description of the complaint",
                         "title": "Description"

--- a/lib/Settings/register.d/50-subsidie.json
+++ b/lib/Settings/register.d/50-subsidie.json
@@ -195,7 +195,7 @@
                 "required": ["titel", "bewijsstukType", "gekoppeldAan"],
                 "properties": {
                     "titel": { "title": "Title", "type": "string", "maxLength": 255, "description": "Document title" },
-                    "beschrijving": { "title": "Description", "type": "string", "description": "Optional description" },
+                    "description": { "title": "Description", "type": "string", "description": "Optional description" },
                     "bewijsstukType": { "title": "Evidence Document Type", "type": "string", "enum": ["aanvraagdocument", "begroting", "projectplan", "cofinancieringsverklaring", "voortgangsrapport", "urenstaat", "factuur", "bankafschrift", "accountantsverklaring", "eindrapport", "deelnemerslijst", "ander"], "description": "Evidence type", "facetable": true },
                     "gekoppeldAan": { "title": "Linked To", "type": "string", "enum": ["aanvraag", "tussenrapportage", "vaststelling", "verplichtingsbewijs"], "description": "Source phase", "facetable": true },
                     "gekoppeldObjectRef": { "title": "Linked Object Reference", "type": "string", "format": "uuid", "description": "Actual Aanvraag/Tussenrapportage/Vaststelling reference" },

--- a/lib/Settings/register.d/61-mandaat-matrix.json
+++ b/lib/Settings/register.d/61-mandaat-matrix.json
@@ -44,7 +44,7 @@
         "properties": {
           "mandateNumber":         {"type": "string", "title": "Mandate Number", "description": "Unique number identifying this mandate.", "facetable": true, "maxLength": 64},
           "mandateDecision":       {"type": "string", "title": "Mandate Decision", "description": "Reference to the mandate decision that issued this mandate."},
-          "omschrijving":          {"type": "string", "title": "Description", "description": "Description of this mandate."},
+          "description":           {"type": "string", "title": "Description", "description": "Description of this mandate."},
           "bevoegdheidType":       {"type": "string", "title": "Authority Type", "description": "Type classification of the authority granted by this mandate.", "enum": ["mandaat", "volmacht", "machtiging"], "default": "mandaat", "facetable": true},
           "gemandateerdeRol":      {"type": "string", "title": "Delegated Role", "description": "OrganisatieRol id"},
           "legalBasis":            {"type": "string", "title": "Legal Basis", "description": "Statutory or regulatory basis for this mandate.", "maxLength": 255},

--- a/lib/Settings/register.d/70-document-zaakdossier.json
+++ b/lib/Settings/register.d/70-document-zaakdossier.json
@@ -54,7 +54,7 @@
           "creatiedatum":         {"type": "string", "title": "Creation Date", "format": "date", "description": "Creation date (ISO 8601)"},
           "bronorganisatie":      {"type": "string", "title": "Source Organization", "maxLength": 64, "description": "RSIN of the source organization"},
           "taal":                 {"type": "string", "title": "Language", "maxLength": 3, "default": "nld", "description": "ISO 639-2/B language code"},
-          "beschrijving":         {"type": "string", "title": "Description", "description": "Free-text description"},
+          "description":          {"type": "string", "title": "Description", "description": "Free-text description"},
           "link":                 {"type": "string", "title": "Link", "maxLength": 2048, "description": "External URI reference"},
           "integriteit": {
             "type": "object",
@@ -111,9 +111,9 @@
         "title": "Informatieobjecttype",
         "description": "ZGW DRC document type catalog entry. Defines the default confidentiality classification per document category.",
         "type": "object",
-        "required": ["omschrijving"],
+        "required": ["description"],
         "properties": {
-          "omschrijving":             {"type": "string", "title": "Description", "facetable": true, "maxLength": 255, "description": "Type name (e.g. Advies)"},
+          "description":              {"type": "string", "title": "Description", "facetable": true, "maxLength": 255, "description": "Type name (e.g. Advies)"},
           "informatieobjectcategorie": {"type": "string", "title": "Category", "maxLength": 255, "description": "Category grouping"},
           "vertrouwelijkheidaanduiding": {
             "type": "string",

--- a/src/modals/DocumentMetadataDialog.vue
+++ b/src/modals/DocumentMetadataDialog.vue
@@ -41,7 +41,7 @@
 				:placeholder="t('procest', 'Document title')" />
 
 			<NcTextArea
-				v-model="beschrijving"
+				v-model="description"
 				:label="t('procest', 'Description')"
 				:placeholder="t('procest', 'Optional description')" />
 
@@ -73,7 +73,7 @@ import {
 /**
  * Upload metadata dialog. Collects the required informatieobjecttype and
  * vertrouwelijkheidaanduiding (with the type's default), an editable titel and
- * an optional beschrijving, shared across all dropped/selected files, and
+ * an optional description, shared across all dropped/selected files, and
  * surfaces a per-file upload progress bar.
  *
  * @spec openspec/changes/document-zaakdossier/tasks.md#T07
@@ -120,7 +120,7 @@ export default {
 			selectedType: '',
 			selectedClassification: '',
 			titel: '',
-			beschrijving: '',
+			description: '',
 		}
 	},
 	computed: {
@@ -133,7 +133,7 @@ export default {
 		typeOptions() {
 			return this.types.map(type => ({
 				id: type.id || type.uuid,
-				label: type.omschrijving || type.id,
+				label: type.description || type.id,
 				vertrouwelijkheidaanduiding: type.vertrouwelijkheidaanduiding || 'intern',
 			}))
 		},
@@ -204,7 +204,7 @@ export default {
 				informatieobjecttype: this.selectedType,
 				vertrouwelijkheidaanduiding: this.selectedClassification,
 				titel: this.titel,
-				beschrijving: this.beschrijving,
+				description: this.description,
 			})
 		},
 	},

--- a/src/modals/MandaatEditor.vue
+++ b/src/modals/MandaatEditor.vue
@@ -24,10 +24,10 @@
 				<label class="required" for="me-omschr">{{ t('procest', 'Description') }}</label>
 				<textarea
 					id="me-omschr"
-					v-model="form.omschrijving"
+					v-model="form.description"
 					class="mandaat-editor__textarea"
 					rows="3" />
-				<span v-if="errors.omschrijving" class="field-error">{{ errors.omschrijving }}</span>
+				<span v-if="errors.description" class="field-error">{{ errors.description }}</span>
 			</div>
 
 			<div class="form-group">
@@ -141,7 +141,7 @@ export default {
 			errors: {},
 			form: {
 				mandateNumber: this.mandaat?.mandateNumber || '',
-				omschrijving: this.mandaat?.omschrijving || '',
+				description: this.mandaat?.description || '',
 				bevoegdheidType: this.mandaat?.bevoegdheidType || 'beslissingsbevoegdheid',
 				legalBasis: this.mandaat?.legalBasis || '',
 				inWerkingtreding: this.mandaat?.inWerkingtreding || new Date().toISOString().slice(0, 10),
@@ -183,7 +183,7 @@ export default {
 		validate() {
 			const errs = {}
 			if (!this.form.mandateNumber) errs.mandateNumber = t('procest', 'Mandaatnummer is required')
-			if (!this.form.omschrijving) errs.omschrijving = t('procest', 'Omschrijving is required')
+			if (!this.form.description) errs.description = t('procest', 'Omschrijving is required')
 			if (!this.form.bevoegdheidType) errs.bevoegdheidType = t('procest', 'Bevoegdheidstype is required')
 			if (!this.form.legalBasis) errs.legalBasis = t('procest', 'Wettelijke grondslag is required')
 			try {

--- a/src/views/cases/components/DossierTab.vue
+++ b/src/views/cases/components/DossierTab.vue
@@ -257,7 +257,7 @@ export default {
 			}
 		},
 		/**
-		 * Resolve a type id to its omschrijving label.
+		 * Resolve a type id to its description label.
 		 *
 		 * @param {string} typeId The type id.
 		 * @return {string} The label.
@@ -265,7 +265,7 @@ export default {
 		 */
 		typeLabel(typeId) {
 			const match = this.types.find(type => (type.id || type.uuid) === typeId)
-			return match ? (match.omschrijving || typeId) : (typeId || this.t('procest', 'Unknown type'))
+			return match ? (match.description || typeId) : (typeId || this.t('procest', 'Unknown type'))
 		},
 		/**
 		 * Open the native file picker.

--- a/src/views/cases/widgets/BevoegdhedenPanel.vue
+++ b/src/views/cases/widgets/BevoegdhedenPanel.vue
@@ -31,7 +31,7 @@
 			<tbody>
 				<tr v-for="row in filteredRows" :key="row.id" class="bevoegdheden-panel__row">
 					<td>{{ row.mandateNumber }}</td>
-					<td>{{ row.omschrijving }}</td>
+					<td>{{ row.description }}</td>
 					<td>{{ row.bevoegdheidType || '-' }}</td>
 					<td>{{ formatCeiling(row) }}</td>
 					<td>{{ row.subdelegatie ? t('procest', 'Yes') : t('procest', 'No') }}</td>

--- a/src/views/cases/widgets/MandaatMatrixWidget.vue
+++ b/src/views/cases/widgets/MandaatMatrixWidget.vue
@@ -1,7 +1,7 @@
 <template>
 	<aside class="mandaat-widget">
 		<header class="mandaat-widget__header">
-			<h4>{{ mandaat.omschrijving || mandaat.mandateNumber }}</h4>
+			<h4>{{ mandaat.description || mandaat.mandateNumber }}</h4>
 			<button type="button"
 				class="mandaat-widget__close"
 				:aria-label="t('procest', 'Close mandate details')"

--- a/src/views/complaints/components/ComplaintCreateDialog.vue
+++ b/src/views/complaints/components/ComplaintCreateDialog.vue
@@ -21,14 +21,14 @@
 			</div>
 
 			<div class="form-group">
-				<label for="complaint-create-omschrijving">{{ t('procest', 'Description') }} *</label>
+				<label for="complaint-create-description">{{ t('procest', 'Description') }} *</label>
 				<textarea
-					id="complaint-create-omschrijving"
-					v-model="form.omschrijving"
+					id="complaint-create-description"
+					v-model="form.description"
 					rows="4"
-					:class="{ 'input--error': errors.omschrijving }" />
-				<p v-if="errors.omschrijving" class="form-error">
-					{{ errors.omschrijving }}
+					:class="{ 'input--error': errors.description }" />
+				<p v-if="errors.description" class="form-error">
+					{{ errors.description }}
 				</p>
 			</div>
 
@@ -116,7 +116,7 @@ export default {
 			saving: false,
 			form: {
 				onderwerp: '',
-				omschrijving: '',
+				description: '',
 				klagerNaam: '',
 				klagerEmail: '',
 				ontvangstkanaal: null,
@@ -155,8 +155,8 @@ export default {
 			if (!this.form.onderwerp.trim()) {
 				this.errors.onderwerp = this.t('procest', 'Subject is required')
 			}
-			if (!this.form.omschrijving.trim()) {
-				this.errors.omschrijving = this.t('procest', 'Description is required')
+			if (!this.form.description.trim()) {
+				this.errors.description = this.t('procest', 'Description is required')
 			}
 			return Object.keys(this.errors).length === 0
 		},

--- a/tests/Unit/Service/MandaatImportServiceTest.php
+++ b/tests/Unit/Service/MandaatImportServiceTest.php
@@ -150,7 +150,7 @@ class MandaatImportServiceTest extends TestCase
         self::assertSame(0, $r2['removedCount']);
         $diff = $r2['diff'][0];
         self::assertSame('CHANGED', $diff['change']);
-        self::assertContains('omschrijving', $diff['fields']);
+        self::assertContains('description', $diff['fields']);
         self::assertContains('plafondCents', $diff['fields']);
     }
 }


### PR DESCRIPTION
Renames the property across **all five procest-scoped owning schemas** and every code site that reads or writes it.

| schema | before | after |
|---|---|---|
| `complaint` | `omschrijving` | `description` |
| `bewijsstuk` | `beschrijving` | `description` |
| `mandate` | `omschrijving` | `description` |
| `informatieobject` | `beschrijving` | `description` |
| `informatieobjecttype` | `omschrijving` | `description` |

## All owners in one migration scope

Ownership was checked **before** editing: these five are the only procest-scoped declarations, they collapse onto one English name without colliding (no schema declares both spellings, none already declares `description`), and all five live in the `procest` register — so the register-scoped repair step covers every owner. Verified after: **0 procest-scoped schemas still declare either spelling.**

**No migration entry needed** — both mappings are *already* in `RenameDutchDeadlineColumns::COLUMN_MAP`, with the guard that refuses to migrate when two sources target one destination in a table. Measured: that guard cannot fire, because no schema carries both.

## `agendapunt` is deliberately excluded

It lives in `ori_register.json`, which declares register slug **`ori`**, not `procest`. The repair step matches `REGISTER_SLUG_PREFIX = 'procest'`, so ORI's shard tables are outside its scope — renaming it would ship a rename with **no migration behind it**. ORI is also Open Raadsinformatie, a Dutch municipal open-data standard, so it is plausibly wire-exempt. It needs its own `ori`-scoped migration and an exemption decision.

## The breaking subset was isolated first

`omschrijving`/`beschrijving` appear **233 times — but only 42 break**. The rest are Dutch prose, comments, wire-adapter field names (StUF/ZGW/ZTC) and ORI consumers, where renaming would be wrong or pointless.

Sizing the breaking subset first is what made this finishable in one pass. The same split turned `mandaat` (716 refs, 66 breaking) into #817.

## Published contracts keep both spellings

`ZaakdossierController` reads an HTTP request param — `description` preferred, `beschrijving` still accepted, so an un-updated client does not break. `ZaakdossierService` does the same for its metadata array, and `MandaatImportService` for a CSV header.

## Verification

- **1882 tests, 6393 assertions green** (5 skipped — baseline). One test failed first (`MandaatImportServiceTest` asserting the diff field name) and was fixed.
- `php -l` clean on every changed file; all four register JSONs parse
- **phpcs: 46 errors — identical to the pre-change baseline**, measured by stashing
- Residual grep: no `omschrijving`/`beschrijving` anywhere in `src/`

> The first test run reported a phantom failure: the disk hit 100% and truncated the copied `vendor/` mid-copy, so `vendor/bin/phpunit` did not exist. I freed 5.5G of my own stale worktrees, re-copied, and re-ran. The numbers above are from the intact run.
