### PR TITLE
chore(quality): adopt the central PHPStan base config

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -516,16 +516,16 @@
         },
         {
             "name": "conduction/hydra-gates",
-            "version": "v1.7.0",
+            "version": "v1.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ConductionNL/.github.git",
-                "reference": "b9c6520a648468ab2055ba4ce498348b31ab1f57"
+                "reference": "487e8d235b650a211328d5dfd1dbf90531b26436"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/b9c6520a648468ab2055ba4ce498348b31ab1f57",
-                "reference": "b9c6520a648468ab2055ba4ce498348b31ab1f57",
+                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/487e8d235b650a211328d5dfd1dbf90531b26436",
+                "reference": "487e8d235b650a211328d5dfd1dbf90531b26436",
                 "shasum": ""
             },
             "require": {
@@ -564,9 +564,9 @@
             "support": {
                 "docs": "https://github.com/ConductionNL/.github/blob/main/hydra-gates/README.md",
                 "issues": "https://github.com/ConductionNL/.github/issues",
-                "source": "https://github.com/ConductionNL/.github/tree/v1.7.0"
+                "source": "https://github.com/ConductionNL/.github/tree/v1.7.1"
             },
-            "time": "2026-08-12T09:38:06+00:00"
+            "time": "2026-08-12T12:57:31+00:00"
         },
         {
             "name": "consolidation/annotated-command",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,23 +1,22 @@
+# Procest — Conduction PHPStan config.
+#
+# The shared base is the single source of truth. Everything here is either the
+# app's own tracked debt or an ignore naming a symbol that exists in no other
+# fleet app. Anything you are tempted to add that another app would also need
+# belongs in the base, not here.
+#
 # No baseline. Procest carries zero suppressed PHPStan errors: `phpstan-baseline.neon`
 # was deleted once its last 10 live entries (injected-but-unused constructor
 # dependencies) were fixed at source. Do NOT reintroduce it — a baseline makes the
 # `phpstan` leg of `composer check:strict` exit 0 while real errors remain, which is
 # exactly what it was doing here. Fix at source, or add a documented `ignoreErrors`
 # pattern below with a written justification.
+includes:
+    - vendor/conduction/hydra-gates/quality-config/phpstan-base.neon
 
 parameters:
-    level: 5
-    paths:
-        - lib
-    bootstrapFiles:
-        - phpstan-bootstrap.php
-    excludePaths:
-        - vendor
-        - vendor-bin
-        # Apps that ship a verbatim template snapshot under lib/Resources/template/ (e.g. openbuilt).
-        - lib/Resources/template
-    scanDirectories:
-        - vendor/nextcloud/ocp
+    # App-specific only. The base already sets level, paths, bootstrapFiles,
+    # excludePaths, scanDirectories and every fleet-wide ignore.
     typeAliases:
         # OCP declares `@psalm-type DataResponseType = ...` in the DataResponse
         # class docblock and immediately uses it as a @template bound. PHPStan
@@ -27,48 +26,10 @@ parameters:
         # verbatim copy of the OCP alias, not a widening — it makes the generic
         # bound resolvable instead of silencing the rule.
         DataResponseType: 'array|int|float|string|bool|object|null|\stdClass|\JsonSerializable'
-    reportUnmatchedIgnoredErrors: false
+
     ignoreErrors:
-        # Nextcloud server internals (\OC, OC_App, OC\) not stubbed in nextcloud/ocp
-        - '#Call to an undefined method OC::#'
-        - '#Class OC not found#'
-        - '#Access to static property \$server on an unknown class OC#'
-        - '#unknown class OC\\#'
-        - '#Caught class OC\\#'
-        - '#unknown class OC_App#'
-        - '#Class OC_App not found#'
-        # OCA\DAV is server-internal and not in nextcloud/ocp stubs
-        - '#unknown class OCA\\DAV\\#'
-        - '#Class OCA\\DAV\\#'
-        # OCA classes from other apps (OpenRegister) not available during static analysis
-        - '#unknown class OCA\\OpenRegister\\#'
-        - '#OCA\\OpenRegister\\[a-zA-Z\\]+.*not found#'
-        - '#on an unknown class OCA\\OpenRegister\\#'
-        - '#has invalid return type OCA\\OpenRegister\\#'
-        - '#has invalid type OCA\\OpenRegister\\#'
-        - '#implements unknown interface OCA\\OpenRegister\\#'
-        # GuzzleHttp is available at runtime via Nextcloud but not in composer require
-        - '#unknown class GuzzleHttp\\#'
-        - '#GuzzleHttp\\[a-zA-Z\\]+.*not found#'
-        - '#on an unknown class GuzzleHttp\\#'
-        - '#invalid type GuzzleHttp\\#'
-        - '#Caught class GuzzleHttp\\#'
-        # Doctrine\DBAL is shipped by Nextcloud server but not stubbed in nextcloud/ocp
-        - '#unknown class Doctrine\\DBAL\\#'
-        - '#Doctrine\\DBAL\\[a-zA-Z\\]+.*not found#'
-        - '#on an unknown class Doctrine\\DBAL\\#'
-        # Dynamic HTTP status codes from business rule validation results
-        # (matches both `Parameter $statusCode` and `Parameter #N $statusCode` forms emitted by phpstan)
-        - '#Parameter (\#\d+ )?\$statusCode of class OCP\\AppFramework\\Http\\JSONResponse constructor expects#'
-        # registerRepairStep exists on server; not yet in nextcloud/ocp stub used for analysis
-        - '#Call to an undefined method OCP\\AppFramework\\Bootstrap\\IRegistrationContext::registerRepairStep#'
         # registerJob exists on server; not yet in nextcloud/ocp stub used for analysis
         - '#Call to an undefined method OCP\\AppFramework\\Bootstrap\\IRegistrationContext::registerJob#'
-        # OCP stub gaps for methods that exist at runtime
-        - '#Call to an undefined method OCP\\IRequest::getContent\(\)#'
-        - '#Call to an undefined method OCP\\IRequest::setParameter\(\)#'
-        - '#Call to an undefined method OCP\\Mail\\IMessage::attachFile\(\)#'
-        - '#Call to an undefined method OCP\\AppFramework\\Db\\Entity::jsonSerialize#'
         # registerEventListener accepts the listener FQCN string at runtime; the
         # OCP generic signature is narrower than the server resolver.
         - '#Parameter \$listener of method OCP\\AppFramework\\Bootstrap\\IRegistrationContext::registerEventListener\(\) expects class-string#'


### PR DESCRIPTION
## What

`phpstan.neon` now includes the shared base that ships in `conduction/hydra-gates`
(`quality-config/phpstan-base.neon`). Everything the base already provides — level,
paths, bootstrapFiles, excludePaths, scanDirectories and the fleet-wide ignore list —
is removed from the app file. What stays is only what is genuinely local:

- the `DataResponseType` `typeAliases` entry (a verbatim copy of the OCP alias, so the
  generic bound resolves instead of being silenced)
- six ignores this app alone needs: `registerJob`, the `registerEventListener` and
  `IJobList::add` class-string narrowings, the `@implements` subtype it cannot prove,
  the `\OC_Util` `method_exists` guard, and one path-scoped always-false comparison

This app deliberately ships no `phpstan-baseline.neon` — the header comment explaining
why is carried over verbatim.

This is step 2b of the Nextcloud CI/CD alignment programme.

## Why hydra-gates moves to v1.7.1

v1.7.0 shipped the base file with bare relative paths. PHPStan resolves a relative
path against the directory of the config that *declares* it, so `lib` there meant
`vendor/conduction/hydra-gates/quality-config/lib` and the run aborted before
analysing anything. v1.7.1 prefixes every path with `%currentWorkingDirectory%/`.
`composer.lock` is regenerated for that one package; nothing else moved.

## How it was verified

`phpstan dump-parameters` was captured on both sides in a PHP 8.3 container. The five
load-bearing keys — level, paths, excludePaths, bootstrapFiles, scanDirectories —
resolve byte-identically, same sha256 over the extracted block. The analysis ran over
610 files before and 610 files after, with 0 findings before and 0 after.
The remaining difference in the full parameter dump is the extra ignore patterns the
base contributes (ContextChat, SystemTag, Bookmarks), which can only suppress, never
add.

The method was positive-controlled on the first app migrated: dropping an app-local
ignore makes real errors appear, and adding an entry under `paths` moves the resolved
key — so a byte-identical comparison here is a result, not an instrument that reports
"same" whatever it is fed.

## Scope

Only PHPStan files. `phpmd.xml`, stylelint and prettier are untouched here; a
separate change covers those.
