### PR TITLE
fix(security): three unguarded surfaces — unauthenticated StUF SOAP, user-writable mailbox settings, unscoped dossier download

### DIFF
--- a/lib/Controller/AdviceController.php
+++ b/lib/Controller/AdviceController.php
@@ -31,6 +31,7 @@ namespace OCA\Procest\Controller;
 
 use OCA\Procest\AppInfo\Application;
 use OCA\Procest\Service\AdviceService;
+use OCA\Procest\Service\CaseAccessGuard;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
@@ -52,6 +53,7 @@ class AdviceController extends Controller {
 	 * @param AdviceService $adviceService The advice service
 	 * @param IUserSession $userSession The user session
 	 * @param LoggerInterface $logger The logger
+	 * @param CaseAccessGuard $caseAccessGuard Per-case authorization (fails closed)
 	 */
 	public function __construct(
 		string $appName,
@@ -59,6 +61,7 @@ class AdviceController extends Controller {
 		private readonly AdviceService $adviceService,
 		private readonly IUserSession $userSession,
 		private readonly LoggerInterface $logger,
+		private readonly CaseAccessGuard $caseAccessGuard,
 	) {
 		parent::__construct(appName: $appName, request: $request);
 	}//end __construct()
@@ -190,6 +193,15 @@ class AdviceController extends Controller {
 	/**
 	 * Get all advice requests for a specific case.
 	 *
+	 * Per-object guard: `CaseAccessGuard::hasCaseReadAccess()`.
+	 *
+	 * `GET /api/vth/cases/{id}/advice-requests` is a per-case sub-resource and
+	 * `$id` is the CASE uuid, so the case-membership predicate applies directly
+	 * — no `OwningCaseResolver` hop is needed. This is the same relationship
+	 * `AdviceAuthorizationGuard::isHandlerOfLinkedCase()` already tests on the
+	 * transition and reminder paths (assignee of the linked case, admin
+	 * bypass); the case-level LIST simply never had it.
+	 *
 	 * @param string $id UUID of the case
 	 *
 	 * @return JSONResponse List of advice requests
@@ -203,6 +215,10 @@ class AdviceController extends Controller {
 		$user = $this->userSession->getUser();
 		if ($user === null) {
 			throw new OCSForbiddenException('Not authenticated');
+		}
+
+		if ($this->caseAccessGuard->hasCaseReadAccess(caseId: $id, user: $user) === false) {
+			return new JSONResponse(data: ['error' => 'Not authorized'], statusCode: Http::STATUS_FORBIDDEN);
 		}
 
 		$advice = $this->adviceService->getAdviceForCase(caseId: $id);

--- a/lib/Controller/EmailTemplateController.php
+++ b/lib/Controller/EmailTemplateController.php
@@ -239,12 +239,18 @@ class EmailTemplateController extends Controller {
 	/**
 	 * Read the masked IMAP / poller settings.
 	 *
-	 * @NoAdminRequired
+	 * ADMIN-ONLY. These are instance-wide connection settings for the shared
+	 * case mailbox, not per-user preferences: host, port, username, folder and
+	 * the poller cadence. Even with the password masked, the host/username pair
+	 * describes the municipality's mail infrastructure, so it follows the same
+	 * posture as `createTemplate()` above — `#[AuthorizedAdminSetting]` and no
+	 * `@NoAdminRequired` beside it.
 	 *
 	 * @return JSONResponse
 	 *
 	 * @spec openspec/changes/case-email-integration/tasks.md#T06
 	 */
+	#[AuthorizedAdminSetting(settings: AdminSettings::class)]
 	public function getSettings(): JSONResponse {
 		if ($this->userSession->getUser() === null) {
 			return new JSONResponse(['message' => 'unauthenticated'], Http::STATUS_UNAUTHORIZED);
@@ -270,12 +276,21 @@ class EmailTemplateController extends Controller {
 	 * `setValueString` with the `sensitive` flag so they are masked in
 	 * `occ config:list`.
 	 *
-	 * @NoAdminRequired
+	 * ADMIN-ONLY. Under `@NoAdminRequired` this wrote INSTANCE-WIDE app config
+	 * — `email_imap_host`, `email_imap_user` and the shared-mailbox password —
+	 * behind nothing but a "is anyone logged in" check, so any authenticated
+	 * account could repoint the municipality's case mailbox at a host it
+	 * controls. It also armed `testImap()` below, which dials whatever host is
+	 * stored and reports reachability, into an internal port prober. There is
+	 * no per-object guard to add here: the object IS the instance settings, so
+	 * the correct posture is the admin attribute this controller already uses
+	 * for `createTemplate()` / `updateTemplate()` / `seedDefaults()`.
 	 *
 	 * @return JSONResponse
 	 *
 	 * @spec openspec/changes/case-email-integration/tasks.md#T06
 	 */
+	#[AuthorizedAdminSetting(settings: AdminSettings::class)]
 	public function saveSettings(): JSONResponse {
 		if ($this->userSession->getUser() === null) {
 			return new JSONResponse(['message' => 'unauthenticated'], Http::STATUS_UNAUTHORIZED);
@@ -313,12 +328,15 @@ class EmailTemplateController extends Controller {
 	 * Returns either `{ok: true}` or `{ok: false, error}` — never blocks the
 	 * UI, never throws transport errors to the caller.
 	 *
-	 * @NoAdminRequired
+	 * ADMIN-ONLY, for the same reason as `saveSettings()`: it opens a socket to
+	 * the configured host:port and reports whether the connect succeeded, which
+	 * is a reachability oracle for whatever address an admin has stored.
 	 *
 	 * @return JSONResponse
 	 *
 	 * @spec openspec/changes/case-email-integration/tasks.md#T06
 	 */
+	#[AuthorizedAdminSetting(settings: AdminSettings::class)]
 	public function testImap(): JSONResponse {
 		if ($this->userSession->getUser() === null) {
 			return new JSONResponse(['message' => 'unauthenticated'], Http::STATUS_UNAUTHORIZED);

--- a/lib/Controller/InspectionChecklistController.php
+++ b/lib/Controller/InspectionChecklistController.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 namespace OCA\Procest\Controller;
 
 use OCA\Procest\AppInfo\Application;
+use OCA\Procest\Service\CaseAccessGuard;
 use OCA\Procest\Service\InspectionChecklistService;
 use OCA\Procest\Settings\AdminSettings;
 use OCP\AppFramework\Controller;
@@ -68,6 +69,7 @@ class InspectionChecklistController extends Controller {
 		private readonly IUserSession $userSession,
 		private readonly IGroupManager $groupManager,
 		private readonly LoggerInterface $logger,
+		private readonly CaseAccessGuard $caseAccessGuard,
 	) {
 		parent::__construct(appName: $appName, request: $request);
 	}//end __construct()
@@ -235,6 +237,15 @@ class InspectionChecklistController extends Controller {
 	/**
 	 * Get all inspection results for a case.
 	 *
+	 * Per-object guard: `CaseAccessGuard::hasCaseReadAccess()`.
+	 *
+	 * `GET /api/vth/cases/{id}/inspection-results` is a per-case sub-resource
+	 * and `$id` is the CASE uuid, so the case-membership predicate applies
+	 * directly. Inspection results carry enforcement findings against a named
+	 * address, so this is a per-case read of supervision data and not a
+	 * catalogue lookup like the checklist DEFINITIONS above (which are admin
+	 * CRUD and guarded as such).
+	 *
 	 * @param string $id UUID of the case
 	 *
 	 * @return JSONResponse List of inspectionResult objects
@@ -248,6 +259,10 @@ class InspectionChecklistController extends Controller {
 		$user = $this->userSession->getUser();
 		if ($user === null) {
 			throw new OCSForbiddenException('Not authenticated');
+		}
+
+		if ($this->caseAccessGuard->hasCaseReadAccess(caseId: $id, user: $user) === false) {
+			return new JSONResponse(data: ['error' => 'Not authorized'], statusCode: Http::STATUS_FORBIDDEN);
 		}
 
 		$results = $this->checklistService->getResultsForCase(caseId: $id);

--- a/lib/Controller/ZaakdossierDownloadController.php
+++ b/lib/Controller/ZaakdossierDownloadController.php
@@ -39,6 +39,7 @@ declare(strict_types=1);
 namespace OCA\Procest\Controller;
 
 use OCA\Procest\Http\RangeStreamResponse;
+use OCA\Procest\Service\CaseAccessGuard;
 use OCA\Procest\Service\Zaakdossier\DossierZipExporter;
 use OCA\Procest\Service\Zaakdossier\InformatieobjectReader;
 use OCP\AppFramework\Controller;
@@ -67,6 +68,7 @@ class ZaakdossierDownloadController extends Controller {
 	 * @param DossierZipExporter $zipExporter The ZIP export collaborator.
 	 * @param IUserSession $userSession The user session.
 	 * @param LoggerInterface $logger The logger.
+	 * @param CaseAccessGuard $caseAccessGuard Per-case authorization (fails closed).
 	 *
 	 * @return void
 	 */
@@ -77,12 +79,31 @@ class ZaakdossierDownloadController extends Controller {
 		private readonly DossierZipExporter $zipExporter,
 		private readonly IUserSession $userSession,
 		private readonly LoggerInterface $logger,
+		private readonly CaseAccessGuard $caseAccessGuard,
 	) {
 		parent::__construct(appName: $appName, request: $request);
 	}//end __construct()
 
 	/**
 	 * Export a case dossier as a ZIP with manifest, clearance-filtered.
+	 *
+	 * Per-object guard: `CaseAccessGuard::hasCaseReadAccess()`.
+	 *
+	 * ⚠️ THE CLEARANCE FILTER DEEPER DOWN IS NOT THIS GUARD. `buildZipData()`
+	 * routes through `ZipManifestBuilder::filterByClearance()` →
+	 * `InformatieobjectAccessGuard::filterDossierForUser()`, which compares the
+	 * caller's clearance ORDINAL against each document's
+	 * `vertrouwelijkheidaanduiding`. That is a classification filter: it decides
+	 * how sensitive a document the caller may see, and says nothing about
+	 * whether the caller has anything to do with THIS case. So before this
+	 * guard, any authenticated account whose clearance cleared the documents
+	 * could download any case's dossier by supplying its id.
+	 *
+	 * The sibling capability was already guarded this way:
+	 * `DossierExportController::plan()` calls `hasCaseReadAccess()` before
+	 * returning the export PLAN. This endpoint returns the BYTES the plan
+	 * describes, so the two were inconsistent rather than deliberately
+	 * different.
 	 *
 	 * @param string $caseId The case UUID.
 	 *
@@ -96,6 +117,10 @@ class ZaakdossierDownloadController extends Controller {
 		$user = $this->userSession->getUser();
 		if ($user === null) {
 			return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+		}
+
+		if ($this->caseAccessGuard->hasCaseReadAccess(caseId: $caseId, user: $user) === false) {
+			return new JSONResponse(['error' => 'Not authorized'], Http::STATUS_FORBIDDEN);
 		}
 
 		try {

--- a/lib/Controller/ZaakdossierDownloadController.php
+++ b/lib/Controller/ZaakdossierDownloadController.php
@@ -46,7 +46,6 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataDownloadResponse;
 use OCP\AppFramework\Http\JSONResponse;
-use OCP\AppFramework\Http\Response;
 use OCP\IRequest;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
@@ -192,13 +191,13 @@ class ZaakdossierDownloadController extends Controller {
 	 *
 	 * @param string $uuid The informatieobject (enkelvoudiginformatieobject) UUID.
 	 *
-	 * @return Response|JSONResponse Full (200) or partial (206) content, or an error status.
+	 * @return RangeStreamResponse|JSONResponse Full (200) or partial (206) content, or an error status.
 	 *
 	 * @NoAdminRequired
 	 *
 	 * @spec openspec/changes/document-zaakdossier/tasks.md#T05
 	 */
-	public function downloadZgwDocumenten(string $uuid): Response|JSONResponse {
+	public function downloadZgwDocumenten(string $uuid): RangeStreamResponse|JSONResponse {
 		$user = $this->userSession->getUser();
 		if ($user === null) {
 			return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);

--- a/lib/Service/Stuf/StufSoapRequestDispatcher.php
+++ b/lib/Service/Stuf/StufSoapRequestDispatcher.php
@@ -58,6 +58,8 @@ class StufSoapRequestDispatcher {
 	 *
 	 * @param StufResponseBuilder $responses The inbound response builder.
 	 * @param StufZknMessageResponder $responder The per-message-type responder.
+	 * @param StufEnvelopeInspector $inspector Resolves the sending endpoint and
+	 *                                        verifies its WSSE UsernameToken.
 	 * @param LoggerInterface $logger The logger.
 	 *
 	 * @return void
@@ -65,6 +67,7 @@ class StufSoapRequestDispatcher {
 	public function __construct(
 		private readonly StufResponseBuilder $responses,
 		private readonly StufZknMessageResponder $responder,
+		private readonly StufEnvelopeInspector $inspector,
 		private readonly LoggerInterface $logger,
 	) {
 	}//end __construct()
@@ -92,6 +95,11 @@ class StufSoapRequestDispatcher {
 			);
 		}
 
+		$authFault = $this->authenticateSender(rawBody: $rawBody, service: $service);
+		if ($authFault instanceof DataDisplayResponse) {
+			return $authFault;
+		}
+
 		$parsed = $this->parseSoapDocument(rawBody: $rawBody, service: $service);
 		if ($parsed instanceof DataDisplayResponse) {
 			return $parsed;
@@ -109,6 +117,76 @@ class StufSoapRequestDispatcher {
 
 		return $this->responder->respond(message: $messageElement);
 	}//end dispatch()
+
+	/**
+	 * Authenticate the sending zaaksysteem before any message is interpreted.
+	 *
+	 * WHY THIS EXISTS. `StufController::zaken()` and `::personen()` carry
+	 * `#[PublicPage]` + `#[NoCSRFRequired]` — correctly, because the caller is a
+	 * municipal zaaksysteem with no Nextcloud session — and until now that was
+	 * the ONLY thing standing between an anonymous HTTP client and
+	 * {@see StufZknMessageResponder::respond()}, which dispatches `zakLk01`
+	 * (case create/update), `zakLv01` (case query), `npsLv01` (person query by
+	 * BSN) and `edcLk01` (document create/update).
+	 *
+	 * Today every one of those four handlers is a stub that answers with an
+	 * empty `zakLa01` / `npsLa01` / `Bv01` and reaches no storage, so nothing
+	 * currently leaks — and that is exactly why the guard belongs here NOW.
+	 * The handlers carry the comment "In a full implementation, query
+	 * OpenRegister…"; the day someone writes that body, an unauthenticated
+	 * caller would be reading zaken and persons by BSN. A missing check that is
+	 * masked by an unfinished body is not a check.
+	 *
+	 * `inkomend()` — the third public StUF route on this controller — already
+	 * verifies a WSSE UsernameToken against the sending endpoint's stored
+	 * credentials. This applies the same predicate to the other two, so all
+	 * three inbound routes share one posture.
+	 *
+	 * FAIL-CLOSED IN BOTH DIRECTIONS: an envelope whose `stuf:zender` matches no
+	 * configured `StufEndpoint` is refused, and {@see
+	 * StufEnvelopeInspector::verifyWsse()} itself returns false when the matched
+	 * endpoint has no username or no resolvable password in the vault. An
+	 * unconfigured instance therefore refuses rather than admits.
+	 *
+	 * The refusal is a SOAP Fault, not an HTTP error page, for the same reason
+	 * every other refusal in this class is: the caller only speaks SOAP. It
+	 * deliberately does not distinguish "unknown sender" from "bad password",
+	 * so the endpoint is not an oracle for which zaaksystemen are configured.
+	 *
+	 * @param string $rawBody The raw inbound envelope.
+	 * @param string $service The service type ('zaken' or 'personen').
+	 *
+	 * @return DataDisplayResponse|null A SOAP Fault when refused, null when the
+	 *                                  sender is authenticated.
+	 *
+	 * @spec openspec/specs/stuf-integration/spec.md
+	 */
+	private function authenticateSender(string $rawBody, string $service): ?DataDisplayResponse {
+		$endpoint = $this->inspector->resolveEndpoint(envelopeXml: $rawBody);
+		if ($endpoint === null) {
+			$this->logger->warning(
+				'StUF inbound refused at {service}: could not resolve a configured endpoint from the envelope zender',
+				['service' => $service]
+			);
+			return $this->fault(
+				message: 'Authenticatie mislukt',
+				statusCode: Http::STATUS_UNAUTHORIZED
+			);
+		}
+
+		if ($this->inspector->verifyWsse(envelopeXml: $rawBody, endpoint: $endpoint) === false) {
+			$this->logger->warning(
+				'StUF inbound refused at {service}: WSSE signature mismatch for endpoint {id}',
+				['service' => $service, 'id' => ($endpoint['id'] ?? '')]
+			);
+			return $this->fault(
+				message: 'Authenticatie mislukt',
+				statusCode: Http::STATUS_UNAUTHORIZED
+			);
+		}
+
+		return null;
+	}//end authenticateSender()
 
 	/**
 	 * Parse an inbound SOAP envelope with XXE/DTD protections.

--- a/tests/Unit/Controller/InspectionChecklistControllerTest.php
+++ b/tests/Unit/Controller/InspectionChecklistControllerTest.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
 namespace OCA\Procest\Tests\Unit\Controller;
 
 use OCA\Procest\Controller\InspectionChecklistController;
+use OCA\Procest\Service\CaseAccessGuard;
 use OCA\Procest\Service\InspectionChecklistService;
 use OCP\AppFramework\Http;
 use OCP\IGroupManager;
@@ -67,6 +68,11 @@ class InspectionChecklistControllerTest extends TestCase {
 	private LoggerInterface $logger;
 
 	/**
+	 * @var CaseAccessGuard|\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private CaseAccessGuard $caseAccessGuard;
+
+	/**
 	 * @var InspectionChecklistController
 	 */
 	private InspectionChecklistController $controller;
@@ -82,6 +88,7 @@ class InspectionChecklistControllerTest extends TestCase {
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->caseAccessGuard = $this->createMock(CaseAccessGuard::class);
 
 		$this->controller = new InspectionChecklistController(
 			appName: 'procest',
@@ -90,6 +97,7 @@ class InspectionChecklistControllerTest extends TestCase {
 			userSession: $this->userSession,
 			groupManager: $this->groupManager,
 			logger: $this->logger,
+			caseAccessGuard: $this->caseAccessGuard,
 		);
 	}//end setUp()
 
@@ -157,6 +165,11 @@ class InspectionChecklistControllerTest extends TestCase {
 		$mockUser->method('getUID')->willReturn('inspector1');
 		$this->userSession->method('getUser')->willReturn($mockUser);
 
+		// Until the per-case guard landed, "is anyone logged in" WAS this
+		// endpoint's entire authorization model, and this case asserted exactly
+		// that. It now has to state the relationship it always assumed.
+		$this->caseAccessGuard->method('hasCaseReadAccess')->willReturn(true);
+
 		$this->inspectionChecklistService
 			->method('getResultsForCase')
 			->willReturn([]);
@@ -165,4 +178,25 @@ class InspectionChecklistControllerTest extends TestCase {
 
 		$this->assertSame(expected: Http::STATUS_OK, actual: $response->getStatus());
 	}//end testGetResultsReturns200()
+
+	/**
+	 * An authenticated caller who does not work on the case is refused, and no
+	 * inspection result is read.
+	 *
+	 * @return void
+	 */
+	public function testGetResultsRefusesACallerWithoutCaseAccess(): void {
+		$mockUser = $this->createMock(IUser::class);
+		$mockUser->method('getUID')->willReturn('outsider');
+		$this->userSession->method('getUser')->willReturn($mockUser);
+
+		$this->caseAccessGuard->method('hasCaseReadAccess')->willReturn(false);
+		$this->inspectionChecklistService
+			->expects($this->never())
+			->method('getResultsForCase');
+
+		$response = $this->controller->getResults(id: 'someone-elses-case');
+
+		$this->assertSame(expected: Http::STATUS_FORBIDDEN, actual: $response->getStatus());
+	}//end testGetResultsRefusesACallerWithoutCaseAccess()
 }//end class

--- a/tests/Unit/Controller/ZaakdossierDownloadControllerGuardTest.php
+++ b/tests/Unit/Controller/ZaakdossierDownloadControllerGuardTest.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * Unit tests for the per-case guard on the zaakdossier ZIP download.
+ *
+ * The endpoint hands out every document of a case as one archive. Its own
+ * `#[NoAdminRequired]` posture is correct — caseworkers, not admins, download
+ * dossiers — so the refusal has to come from `CaseAccessGuard`, and these two
+ * arms are what prove it does.
+ *
+ * The clearance filter inside `buildZipData()` is deliberately NOT what is
+ * under test here: it decides how sensitive a document the caller may see, not
+ * whether the caller belongs to this case.
+ *
+ * @category Test
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * @spec openspec/changes/document-zaakdossier/tasks.md#T05
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\ZaakdossierDownloadController;
+use OCA\Procest\Service\CaseAccessGuard;
+use OCA\Procest\Service\Zaakdossier\DossierZipExporter;
+use OCA\Procest\Service\Zaakdossier\InformatieobjectReader;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataDownloadResponse;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Tests that a caller unrelated to the case cannot download its dossier.
+ *
+ * @covers \OCA\Procest\Controller\ZaakdossierDownloadController
+ */
+class ZaakdossierDownloadControllerGuardTest extends TestCase {
+	/**
+	 * @var DossierZipExporter|MockObject
+	 */
+	private $zipExporter;
+
+	/**
+	 * @var CaseAccessGuard|MockObject
+	 */
+	private $caseAccessGuard;
+
+	/**
+	 * @var IUserSession|MockObject
+	 */
+	private $userSession;
+
+	/**
+	 * Set up the collaborators with an authenticated caller.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		$this->zipExporter = $this->createMock(DossierZipExporter::class);
+		$this->caseAccessGuard = $this->createMock(CaseAccessGuard::class);
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('outsider');
+
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->userSession->method('getUser')->willReturn($user);
+	}//end setUp()
+
+	/**
+	 * Build the subject under test.
+	 *
+	 * @return ZaakdossierDownloadController
+	 */
+	private function controller(): ZaakdossierDownloadController {
+		$request = $this->createMock(IRequest::class);
+		$request->method('getParam')->willReturnCallback(
+			static function (string $key, $default = null) {
+				return $default;
+			}
+		);
+
+		return new ZaakdossierDownloadController(
+			'procest',
+			$request,
+			$this->createMock(InformatieobjectReader::class),
+			$this->zipExporter,
+			$this->userSession,
+			$this->createMock(LoggerInterface::class),
+			$this->caseAccessGuard
+		);
+	}//end controller()
+
+	/**
+	 * A caller who is neither assignee nor admin is refused, and no document is
+	 * even collected — the refusal precedes every read.
+	 *
+	 * @return void
+	 */
+	public function testCallerWithoutCaseAccessIsRefusedBeforeAnyDocumentIsRead(): void {
+		$this->caseAccessGuard->method('hasCaseReadAccess')->willReturn(false);
+		$this->zipExporter->expects($this->never())->method('collectDocuments');
+		$this->zipExporter->expects($this->never())->method('buildZipData');
+
+		$response = $this->controller()->downloadZip('someone-elses-case');
+
+		$this->assertInstanceOf(JSONResponse::class, $response);
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+	}//end testCallerWithoutCaseAccessIsRefusedBeforeAnyDocumentIsRead()
+
+	/**
+	 * A caller who works on the case still gets the archive. Without this arm a
+	 * guard that refused unconditionally would satisfy the arm above.
+	 *
+	 * @return void
+	 */
+	public function testCallerWithCaseAccessStillGetsTheArchive(): void {
+		$this->caseAccessGuard->method('hasCaseReadAccess')->willReturn(true);
+		$this->zipExporter->method('collectDocuments')->willReturn([]);
+		$this->zipExporter->expects($this->once())
+			->method('buildZipData')
+			->willReturn('PK-zip-bytes');
+
+		$response = $this->controller()->downloadZip('my-own-case');
+
+		$this->assertInstanceOf(DataDownloadResponse::class, $response);
+	}//end testCallerWithCaseAccessStillGetsTheArchive()
+}//end class

--- a/tests/Unit/Service/Stuf/StufSoapRequestDispatcherAuthTest.php
+++ b/tests/Unit/Service/Stuf/StufSoapRequestDispatcherAuthTest.php
@@ -1,0 +1,184 @@
+<?php
+
+/**
+ * Unit tests for the inbound StUF sender authentication.
+ *
+ * These four cases exist because `StufController::zaken()` and `::personen()`
+ * are `#[PublicPage]` routes: nothing in Nextcloud's middleware stack will ever
+ * refuse a caller on them, so the refusal has to come from the dispatcher and
+ * has to be tested here.
+ *
+ * The suite is written so that DELETING the guard makes it red: two arms assert
+ * a refusal that only exists because the guard runs (unknown sender, bad WSSE),
+ * and one asserts that a verified sender still reaches the responder — so a
+ * guard that refused everything would fail too.
+ *
+ * @category Test
+ * @package  OCA\Procest\Tests\Unit\Service\Stuf
+ *
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * @spec openspec/specs/stuf-integration/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Service\Stuf;
+
+use OCA\Procest\Service\Stuf\StufEnvelopeInspector;
+use OCA\Procest\Service\Stuf\StufResponseBuilder;
+use OCA\Procest\Service\Stuf\StufSoapRequestDispatcher;
+use OCA\Procest\Service\Stuf\StufZknMessageResponder;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataDisplayResponse;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Tests that an inbound StUF envelope is authenticated before it is
+ * interpreted.
+ *
+ * @covers \OCA\Procest\Service\Stuf\StufSoapRequestDispatcher
+ */
+class StufSoapRequestDispatcherAuthTest extends TestCase {
+	/**
+	 * A minimal, well-formed StUF envelope carrying a zender and a WSSE token.
+	 */
+	private const ENVELOPE = '<?xml version="1.0"?>'
+		. '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"'
+		. ' xmlns:stuf="http://www.egem.nl/StUF/StUF0301"'
+		. ' xmlns:zkn="http://www.egem.nl/StUF/sector/zkn/0310">'
+		. '<soap:Body><zkn:zakLv01><stuf:stuurgegevens>'
+		. '<stuf:zender><stuf:applicatie>ZAAKSYSTEEM</stuf:applicatie></stuf:zender>'
+		. '</stuf:stuurgegevens></zkn:zakLv01></soap:Body></soap:Envelope>';
+
+	/**
+	 * @var StufResponseBuilder|MockObject
+	 */
+	private $responses;
+
+	/**
+	 * @var StufZknMessageResponder|MockObject
+	 */
+	private $responder;
+
+	/**
+	 * @var StufEnvelopeInspector|MockObject
+	 */
+	private $inspector;
+
+	/**
+	 * Set up the collaborators.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		$this->responses = $this->createMock(StufResponseBuilder::class);
+		$this->responder = $this->createMock(StufZknMessageResponder::class);
+		$this->inspector = $this->createMock(StufEnvelopeInspector::class);
+
+		$this->responses->method('buildSoapFault')->willReturn('<fault/>');
+		$this->responder->method('soapResponse')->willReturnCallback(
+			static function (string $xml, int $statusCode = Http::STATUS_OK): DataDisplayResponse {
+				return new DataDisplayResponse($xml, $statusCode);
+			}
+		);
+	}//end setUp()
+
+	/**
+	 * Build the subject under test.
+	 *
+	 * @return StufSoapRequestDispatcher
+	 */
+	private function dispatcher(): StufSoapRequestDispatcher {
+		return new StufSoapRequestDispatcher(
+			$this->responses,
+			$this->responder,
+			$this->inspector,
+			$this->createMock(LoggerInterface::class)
+		);
+	}//end dispatcher()
+
+	/**
+	 * An envelope whose zender matches no configured endpoint is refused, and
+	 * the responder is never reached.
+	 *
+	 * @return void
+	 */
+	public function testUnknownSenderIsRefusedWithoutReachingTheResponder(): void {
+		$this->inspector->method('resolveEndpoint')->willReturn(null);
+		$this->responder->expects($this->never())->method('respond');
+
+		$response = $this->dispatcher()->dispatch(self::ENVELOPE, 'zaken');
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+	}//end testUnknownSenderIsRefusedWithoutReachingTheResponder()
+
+	/**
+	 * A known endpoint whose WSSE token does not verify is refused, and the
+	 * responder is never reached.
+	 *
+	 * @return void
+	 */
+	public function testWsseMismatchIsRefusedWithoutReachingTheResponder(): void {
+		$this->inspector->method('resolveEndpoint')->willReturn(['id' => 'ep-1']);
+		$this->inspector->method('verifyWsse')->willReturn(false);
+		$this->responder->expects($this->never())->method('respond');
+
+		$response = $this->dispatcher()->dispatch(self::ENVELOPE, 'personen');
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+	}//end testWsseMismatchIsRefusedWithoutReachingTheResponder()
+
+	/**
+	 * The refusal must not distinguish an unknown sender from a bad password —
+	 * otherwise the public route is an oracle for which zaaksystemen exist.
+	 *
+	 * ⚠️ The two `assertSame` comparisons below are NOT sufficient on their own.
+	 * Deleting the guard makes both arms return the SAME non-refusal, so the
+	 * equality holds trivially and this case stayed green while the two cases
+	 * above went red — measured, by removing the guard and re-running. The
+	 * `STATUS_UNAUTHORIZED` assertion is what makes this arm able to fail.
+	 *
+	 * @return void
+	 */
+	public function testBothRefusalsAreIndistinguishableToTheCaller(): void {
+		$this->inspector->method('resolveEndpoint')->willReturn(null);
+		$unknown = $this->dispatcher()->dispatch(self::ENVELOPE, 'zaken');
+
+		$this->setUp();
+		$this->inspector->method('resolveEndpoint')->willReturn(['id' => 'ep-1']);
+		$this->inspector->method('verifyWsse')->willReturn(false);
+		$badPassword = $this->dispatcher()->dispatch(self::ENVELOPE, 'zaken');
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $unknown->getStatus());
+		$this->assertSame($unknown->getStatus(), $badPassword->getStatus());
+		$this->assertSame($unknown->render(), $badPassword->render());
+	}//end testBothRefusalsAreIndistinguishableToTheCaller()
+
+	/**
+	 * A verified sender is admitted — the guard denies, it does not close the
+	 * route. Without this arm a guard that refused unconditionally would pass
+	 * the two arms above.
+	 *
+	 * @return void
+	 */
+	public function testVerifiedSenderReachesTheResponder(): void {
+		$this->inspector->method('resolveEndpoint')->willReturn(['id' => 'ep-1']);
+		$this->inspector->method('verifyWsse')->willReturn(true);
+		$this->responder->expects($this->once())
+			->method('respond')
+			->willReturn(new DataDisplayResponse('<ok/>', Http::STATUS_OK));
+
+		$response = $this->dispatcher()->dispatch(self::ENVELOPE, 'zaken');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+	}//end testVerifiedSenderReachesTheResponder()
+}//end class


### PR DESCRIPTION
## What this is

An audit of procest's **79 `@PublicPage` methods** — the fleet's largest public
surface, and one gate-7 could not see at all until `.github#373` widened its
scope filter. Two findings, both guard-only.

## 1. Two StUF SOAP routes had no authentication whatsoever

`POST /api/stuf/zaken` and `POST /api/stuf/personen` are `#[PublicPage]` +
`#[NoCSRFRequired]` — correctly, the caller is a zaaksysteem with no Nextcloud
session — and reached `StufZknMessageResponder::respond()` with nothing in
between. That responder dispatches:

| message | meaning |
|---|---|
| `zakLk01` | case create / update |
| `zakLv01` | case query |
| `npsLv01` | **person query by BSN** |
| `edcLk01` | document create / update |

**Nothing leaks today.** All four handlers are stubs that answer with an empty
`zakLa01` / `npsLa01` / `Bv01` and reach no storage. Each carries the comment
*"In a full implementation, query OpenRegister…"*.

That is exactly why the guard lands **now**, and why the bodies stay stubs. The
missing check is masked by an unfinished body, not absent by design — the day
someone writes that body, an anonymous caller reads zaken and persons by BSN.
**Guard first, repair second.**

The predicate is the one this same controller's third public route,
`inkomend()`, already applies: resolve the sending `StufEndpoint` from
`stuf:zender`, then verify its WSSE UsernameToken.

- **Fail-closed both ways.** An unresolvable sender is refused, and
  `verifyWsse()` itself returns `false` when the matched endpoint has no
  username or no vault-resolvable password — so an unconfigured instance
  refuses rather than admits.
- **The refusal is a SOAP Fault**, not an HTTP error page, matching every other
  refusal in `StufSoapRequestDispatcher`.
- **The two refusals are byte-identical**, so the route is not an oracle for
  which zaaksystemen are configured.

## 2. Shared-mailbox settings were writable by any authenticated user

`EmailTemplateController::getSettings` / `saveSettings` / `testImap` carried
`@NoAdminRequired` plus a bare "is anyone logged in" check, while reading and
writing **instance-wide** app config: `email_imap_host`, `email_imap_user` and
the shared-mailbox password.

Any authenticated account — a citizen, a temp — could repoint the
municipality's case mailbox at a host it controls. It also armed `testImap()`,
which dials whatever host is stored and reports whether the connect succeeded,
into an **internal port prober**.

There is no per-object guard to add: the object *is* the instance settings. So
these adopt the `#[AuthorizedAdminSetting(AdminSettings::class)]` posture this
same controller already uses for `createTemplate()`, `updateTemplate()` and
`seedDefaults()` — with `@NoAdminRequired` removed rather than left beside it,
following the precedent already documented at `createTemplate()`.

## The review question

*Does this make anything return 200 that previously errored?* **No.** Both
changes only ever deny.

## Evidence

Four new tests, negative-controlled by replacing the guard call with a no-op:

| arm | guard present | guard removed |
|---|---|---|
| unknown sender refused, responder never reached | pass | **fail** |
| WSSE mismatch refused, responder never reached | pass | **fail** |
| both refusals indistinguishable | pass | **fail** |
| verified sender still reaches the responder | pass | pass |

The first control run showed only **2** red, not 3: the "indistinguishable"
case passed **vacuously**, because with no guard both arms return the same
non-refusal and the equality holds trivially. It now asserts the `401` as well,
and the comment in the test records why. The fourth arm is what stops a guard
that refuses everything from passing the other three.

Local full-scope gates, `.github@main` `923f57d`:

| | before | after |
|---|---|---|
| gate-7 no-admin-idor | 31 | **30** |
| gate-25 contract-coverage | 118 | **117** |
| every other gate | unchanged | unchanged |

`OK (32 tests, 98 assertions)` across `tests/Unit/Service/Stuf/`, and
`OK (5 tests, 13 assertions)` on `EmailTemplateControllerSeedDefaultsTest`.

---

## 3. A clearance filter is not an access guard (second commit)

`ZaakdossierDownloadController::downloadZip($caseId)` hands out **every document
of a case as one ZIP**, under `@NoAdminRequired` and a 401 preamble.

It *looks* guarded — the docblock says "clearance-filtered", the injected reader
is documented as "the clearance-gated document reader", and `buildZipData()`
really does route through `ZipManifestBuilder::filterByClearance()`. That filter
is:

```php
$userOrdinal = $this->getUserClearanceOrdinal(user: $user);
$docOrdinal  = $this->ordinalOf(level: $record['vertrouwelijkheidaanduiding']);
if ($userOrdinal >= $docOrdinal) { $allowed[] = $record; }
```

It decides **how sensitive** a document the caller may see. It says nothing
about whether the caller has anything to do with **this case**. So a caller
whose clearance cleared the documents got the whole dossier of a case they have
no relationship to.

**The decisive evidence is a sibling, not an argument about what the guard
should be.** `DossierExportController::plan($caseId)` — which returns only the
export *plan* — already calls `CaseAccessGuard::hasCaseReadAccess()`. This
endpoint returns the *bytes that plan describes*. The app had already decided;
one site did not get the memo.

Negative-controlled: flipping the comparison to one that can never hold turns
the refusal arm red (the exporter is reached) while the admitted-caller arm
stays green.

## Gate movement, same package (`.github@main` `923f57d`), same invocation

| gate | before | after |
|---|---:|---:|
| 7 no-admin-idor | 31 | **29** |
| 25 contract-coverage | 118 | **116** |
| 3 / 19 / 26 / 53 / 57 / 62 | 3 / 1142 / 78 / 8 / 19 / 1 | unchanged |

⚠️ `rc=8` before and after — **the failing-gate count does not move**, because
none of these gates reaches zero. Both numbers are in the table on purpose.

---

## 4. Two per-case VTH sub-resource reads (third commit)

`GET /api/vth/cases/{id}/advice-requests` and
`GET /api/vth/cases/{id}/inspection-results` — the route already names the case,
so `{id}` **is** the case uuid and `CaseAccessGuard::hasCaseReadAccess()` applies
with no resolver hop.

It is also the relationship the app already tests next door:
`AdviceAuthorizationGuard::isHandlerOfLinkedCase()` resolves `advice['case']`
and compares the assignee, with an admin bypass, on both the transition and the
reminder paths. The case-level **list** simply never had it.

⚠️ **An existing test caught this for me.** `testGetResultsReturns200` went red,
because *"is anyone logged in"* was this endpoint's entire authorization model
and that test asserted exactly that. It now states the relationship it always
assumed, and a companion case asserts the 403 with the service never reached.
`InspectionChecklistControllerTest` also needed its constructor updated — the
same 6→7 argument drift that has silenced whole test classes elsewhere in this
fleet, except here it errored loudly, which is the lucky version.

## Cumulative gate movement (`.github@main` `923f57d`, `--full`, same tree root)

| gate | before | after |
|---|---:|---:|
| **7 no-admin-idor** | **31** | **27** |
| 25 contract-coverage | 118 | **116** |
| 3 / 19 / 26 / 53 / 57 / 62 | 3 / 1142 / 78 / 8 / 19 / 1 | unchanged |

`rc=8` before and after. **The failing-gate count does not move**, because none
of these gates reaches zero — both numbers are here on purpose.

## Not touched, deliberately

- **#811's 35 unrepaired `is_array()` predicates.** No repair is in this PR.
  Those endpoints carry no guard *because nothing reaches the body*, so a repair
  without a guard ships the IDOR. `DwangsomCalculationService` is byte-unchanged.
- **`SubsidieController`'s 10 unguarded endpoints** — filed as #829 instead. The
  subsidy chain carries no `zaak`, so `CaseAccessGuard` does not apply, and
  `openspec/specs/subsidieverlening-keten/spec.md` states no authorization rule
  at all. Both plausible models would be inventions.

## UI impact of the admin gate: none for legitimate users

Checked rather than assumed. `EmailSettings.vue` has exactly two mount points:

- `src/emailSettings.js` — a **Nextcloud admin-settings section** entry point
  (`CnVersionInfoCard` → `CnSettingsSection` → `EmailSettings`), which the
  settings framework already renders only for admins;
- `src/views/settings/AdminRoot.vue`, which is **not** registered in
  `src/router/index.js` (correct per ADR-004 / gate-1 — an admin settings
  component in the in-app router would expose it as a public frontend route).

So every caller that legitimately reaches `PUT /api/settings/email` today is
already an admin. The change aligns the API with the UI that calls it and closes
the gap where the API was reachable **without** that UI.
