### PR TITLE
fix(security): brute-force throttle the case federation share tokens

### DIFF
--- a/lib/Controller/CaseFederationController.php
+++ b/lib/Controller/CaseFederationController.php
@@ -42,11 +42,15 @@ use OCA\Procest\Service\CaseSharingService;
 use OCA\Procest\Service\CaseTransferService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
+use OCP\AppFramework\Http\Attribute\BruteForceProtection;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use OCP\IUserSession;
+use OCP\Security\Bruteforce\IThrottler;
+use Psr\Log\LoggerInterface;
 
 /**
  * Controller for federated case shares and the shared activity stream.
@@ -56,6 +60,44 @@ use OCP\IUserSession;
  * @spec openspec/specs/federated-case-collaboration/spec.md
  */
 class CaseFederationController extends Controller {
+
+	/**
+	 * Brute-force throttler action for rejected federation share tokens.
+	 *
+	 * One action across handleFederatedTransfer, postRemoteActivity and
+	 * listRemoteActivity — they all authenticate the same way, so guesses must
+	 * not be splittable across the three to stay under a per-endpoint ceiling.
+	 *
+	 * @var string
+	 */
+	private const THROTTLE_ACTION = 'procest_case_federation_share_token';
+
+	/**
+	 * Record a rejected share token with the brute-force throttler.
+	 *
+	 * These three endpoints are `#[PublicPage]` and the token in the URL is the
+	 * only credential; a rejection means it did not resolve to a live share.
+	 *
+	 * This is the half that COUNTS. `#[BruteForceProtection]` on the endpoints
+	 * is the half that ENFORCES — BruteForceMiddleware only applies a delay
+	 * when the attribute is present, so registering without it writes a counter
+	 * nothing reads. See ADR-082.
+	 *
+	 * @return void
+	 */
+	private function registerFailedShareToken(): void {
+		try {
+			$this->throttler->registerAttempt(
+				action: self::THROTTLE_ACTION,
+				ip: $this->request->getRemoteAddress()
+			);
+		} catch (\Throwable $throttlerFailure) {
+			$this->logger->warning(
+				'CaseFederationController: registerAttempt failed: ' . $throttlerFailure->getMessage()
+			);
+		}
+	}//end registerFailedShareToken()
+
 	/**
 	 * Constructor for the CaseFederationController.
 	 *
@@ -73,6 +115,8 @@ class CaseFederationController extends Controller {
 		private CaseTransferService $caseTransferService,
 		private CaseCollaborationService $collabService,
 		private IUserSession $userSession,
+		private IThrottler $throttler,
+		private LoggerInterface $logger,
 	) {
 		parent::__construct(appName: Application::APP_ID, request: $request);
 	}//end __construct()
@@ -174,9 +218,12 @@ class CaseFederationController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	#[AnonRateLimit(limit: 30, period: 60)]
+	#[BruteForceProtection(action: self::THROTTLE_ACTION)]
 	public function handleFederatedTransfer(string $shareToken, string $transferId): JSONResponse {
 		$verified = $this->caseTransferService->resolveFederatedTransferShare($shareToken, $transferId);
 		if ($verified === null) {
+			$this->registerFailedShareToken();
 			return new JSONResponse(['success' => false, 'error' => 'Invalid or unauthorized transfer token'], Http::STATUS_FORBIDDEN);
 		}
 
@@ -285,6 +332,8 @@ class CaseFederationController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	#[AnonRateLimit(limit: 30, period: 60)]
+	#[BruteForceProtection(action: self::THROTTLE_ACTION)]
 	public function postRemoteActivity(string $shareToken, string $federatedShareId): JSONResponse {
 		$message = (string)$this->request->getParam('message', '');
 		if ($message === '') {
@@ -293,6 +342,7 @@ class CaseFederationController extends Controller {
 
 		$result = $this->collabService->postRemoteActivity($shareToken, $federatedShareId, $message);
 		if (isset($result['error']) === true) {
+			$this->registerFailedShareToken();
 			return new JSONResponse(['success' => false, 'error' => $result['error']], Http::STATUS_FORBIDDEN);
 		}
 
@@ -312,9 +362,12 @@ class CaseFederationController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	#[AnonRateLimit(limit: 60, period: 60)]
+	#[BruteForceProtection(action: self::THROTTLE_ACTION)]
 	public function listRemoteActivity(string $shareToken, string $federatedShareId): JSONResponse {
 		$result = $this->collabService->listRemoteActivity($shareToken, $federatedShareId);
 		if (isset($result['error']) === true) {
+			$this->registerFailedShareToken();
 			return new JSONResponse(['success' => false, 'error' => $result['error']], Http::STATUS_FORBIDDEN);
 		}
 

--- a/tests/Unit/Controller/CaseSharingControllerFederationTest.php
+++ b/tests/Unit/Controller/CaseSharingControllerFederationTest.php
@@ -38,6 +38,8 @@ use OCP\AppFramework\Http;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
+use OCP\Security\Bruteforce\IThrottler;
+use Psr\Log\LoggerInterface;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -82,6 +84,8 @@ class CaseSharingControllerFederationTest extends TestCase {
 			caseTransferService: $this->transferService,
 			collabService: $this->collaborationService,
 			userSession: $this->userSession,
+			throttler: $this->createMock(IThrottler::class),
+			logger: $this->createMock(LoggerInterface::class),
 		);
 	}//end setUp()
 


### PR DESCRIPTION
`handleFederatedTransfer`, `postRemoteActivity` and `listRemoteActivity` are all `#[PublicPage]` with the share token in the URL as the only credential, and had **no throttle of any kind**. A guessed token accepts or rejects a case transfer between authorities.

Unlike the other controllers in this sweep there's **no single shared guard** — each endpoint resolves the token its own way (`resolveFederatedTransferShare` returning null; the collab service returning an `error` key). Registration is therefore at all three rejection points, but under **one** action so guesses can't be split across the three.

Both halves present — `#[BruteForceProtection]` enforces, `registerAttempt()` counts; either alone is inert. See ADR-082 (ConductionNL/hydra#554).

Limits: 30/60 on the two acts, 60/60 on the read. The controller had no logger, so one is injected alongside the throttler — the `registerAttempt` failure path reports rather than swallows.

### Verification

The federation test constructs this controller directly. Worth noting there are **two** constructions in that file — `CaseSharingController` and `CaseFederationController` — and only the latter changed.

Full suite: **1889 tests, 6415 assertions, Deprecations 7, Skipped 5, OK** — identical to the baseline captured before the change.

**Not verified behaviourally**; the 429 control was run against openregister federation.