### PR TITLE
fix(security): rate-limit the remaining public endpoints

### DIFF
--- a/lib/Controller/DSOIntakeController.php
+++ b/lib/Controller/DSOIntakeController.php
@@ -29,6 +29,7 @@ use OCA\Procest\AppInfo\Application;
 use OCA\Procest\Service\DsoIntakeService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\JSONResponse;
@@ -96,6 +97,11 @@ class DSOIntakeController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	// DSO intake receiver — the caller is the Digitaal Stelsel Omgevingswet,
+	// not a browser, and it authenticates by its own credential. A generous
+	// ceiling against a delivery storm; too tight here would DROP statutory
+	// submissions, which is a worse failure than absorbing a burst.
+	#[AnonRateLimit(limit: 300, period: 60)]
 	public function intake(): JSONResponse {
 		// OCP\AppFramework\Http\Request::getContent() is marked protected, so
 		// calling it across class scopes throws Error at runtime. Read the

--- a/lib/Controller/DashboardController.php
+++ b/lib/Controller/DashboardController.php
@@ -43,6 +43,7 @@ namespace OCA\Procest\Controller;
 use OCA\Procest\AppInfo\Application;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
@@ -142,6 +143,10 @@ class DashboardController extends Controller {
 	 */
 	#[NoCSRFRequired]
 	#[PublicPage]
+	// PWA assets — the browser fetches these on install and on every update
+	// check, so the ceiling only exists to stop them being used as a load
+	// generator. No credential, so no brute-force counter.
+	#[AnonRateLimit(limit: 240, period: 60)]
 	public function serviceWorker(): DataDownloadResponse {
 		$body = $this->readPublicAsset(name: 'service-worker.js');
 		$status = Http::STATUS_OK;
@@ -172,6 +177,7 @@ class DashboardController extends Controller {
 	 */
 	#[NoCSRFRequired]
 	#[PublicPage]
+	#[AnonRateLimit(limit: 240, period: 60)]
 	public function webManifest(): DataDownloadResponse {
 		$body = $this->readPublicAsset(name: 'manifest.webmanifest');
 		$status = Http::STATUS_OK;

--- a/lib/Controller/DwangsomPaymentCallbackController.php
+++ b/lib/Controller/DwangsomPaymentCallbackController.php
@@ -34,6 +34,7 @@ use DateTimeImmutable;
 use OCA\Procest\Service\DwangsomUitbetalingService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\JSONResponse;
@@ -78,6 +79,10 @@ class DwangsomPaymentCallbackController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	// Payment provider callback. Same reasoning as the DSO receiver: the
+	// caller is a provider retrying on its own schedule, and dropping a
+	// payment notification is worse than absorbing a burst.
+	#[AnonRateLimit(limit: 300, period: 60)]
 	public function callback(): JSONResponse {
 		// The OCP IRequest::getContent() method is marked protected in
 		// OC\AppFramework\Http\Request, so we cannot call it across scopes —

--- a/lib/Controller/RaadsinformatieFeedController.php
+++ b/lib/Controller/RaadsinformatieFeedController.php
@@ -31,6 +31,7 @@ use OCA\Procest\Service\SettingsService;
 use OCA\Procest\Service\Support\SearchesObjects;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\DataDisplayResponse;
@@ -92,6 +93,10 @@ class RaadsinformatieFeedController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	// Raadsinformatie is a published open-data feed — public access is the
+	// statutory point of it, so these are runaway ceilings, not gates, and
+	// carry no brute-force counter.
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function vergaderingen(string $organisation = ''): DataDisplayResponse {
 		return $this->buildFeed(
 			type: 'vergaderingen',
@@ -112,6 +117,7 @@ class RaadsinformatieFeedController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function agendapunten(string $organisation = ''): DataDisplayResponse {
 		return $this->buildFeed(
 			type: 'agendapunten',
@@ -132,6 +138,7 @@ class RaadsinformatieFeedController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function documenten(string $organisation = ''): DataDisplayResponse {
 		return $this->buildFeed(
 			type: 'documenten',

--- a/lib/Controller/StufController.php
+++ b/lib/Controller/StufController.php
@@ -48,6 +48,7 @@ use OCA\Procest\Service\Stuf\StufSoapRequestDispatcher;
 use OCA\Procest\Settings\AdminSettings;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
@@ -100,6 +101,10 @@ class StufController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	// StUF-ZKN SOAP receivers. The caller is a municipal middleware component
+	// on its own retry schedule, so the ceiling is generous — dropping a StUF
+	// delivery is worse than absorbing a burst.
+	#[AnonRateLimit(limit: 300, period: 60)]
 	public function zaken(): DataDisplayResponse {
 		return $this->dispatcher->dispatch(
 			rawBody: file_get_contents('php://input'),
@@ -118,6 +123,7 @@ class StufController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	#[AnonRateLimit(limit: 300, period: 60)]
 	public function personen(): DataDisplayResponse {
 		return $this->dispatcher->dispatch(
 			rawBody: file_get_contents('php://input'),
@@ -190,6 +196,7 @@ class StufController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	#[AnonRateLimit(limit: 300, period: 60)]
 	public function inkomend(): DataResponse {
 		$rawXml = (string)file_get_contents(filename: 'php://input');
 		if ($rawXml === '') {


### PR DESCRIPTION
The ten `#[PublicPage]` endpoints with no ceiling: DSO intake, PWA service worker + web manifest, dwangsom payment callback, raadsinformatie feed (3), StUF-ZKN receivers (3).

**No brute-force counters** — none takes a guessable credential. The receivers authenticate by the caller's own provider credential; the feeds are published open data.

### The limits are not uniform, and the reasoning matters more than the numbers

- **300/60 on the machine receivers** (DSO intake, payment callback, StUF). These callers retry on their *own* schedule and bursts are normal. Setting them tight would **drop statutory submissions and payment notifications** — failing closed on somebody else's delivery guarantee is worse than absorbing a burst, and the failure lands on *their* side where we don't see it.
- **120/60 on the raadsinformatie feed** — published open government data; public access is the statutory point, so a runaway ceiling rather than a gate.
- **240/60 on PWA assets** — fetched on install and every update check.

### These are guesses, not measurements

Nobody here has traffic data for a real municipal StUF middleware. I'd rather say that than present a chosen number as a tuned one. Erring loose on the receivers is the safer side of the uncertainty — happy to tighten once someone can point at real burst behaviour.

### Verification

Full suite: **1899 tests, identical to baseline** — Warnings 1, Deprecations 7, Skipped 5 before and after.

Completes the ADR-081/082 sweep for procest (ConductionNL/hydra#554).