### PR TITLE
refactor(deps): inject OpenRegister instead of looking it up (ADR-083)

### DIFF
--- a/lib/Service/DsoCaseService.php
+++ b/lib/Service/DsoCaseService.php
@@ -91,8 +91,8 @@ class DsoCaseService {
 		private readonly ContainerInterface $container,
 		private readonly DsoStatusChangeNotifier $notifier,
 		private readonly LoggerInterface $logger,
-	
-		private readonly ObjectService $objectService,) {
+		private readonly ObjectService $objectService,
+	) {
 	}//end __construct()
 
 	/**

--- a/lib/Service/DsoCaseService.php
+++ b/lib/Service/DsoCaseService.php
@@ -34,6 +34,7 @@ use OCP\IUser;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Service for DSO Omgevingsloket case management.
@@ -90,7 +91,8 @@ class DsoCaseService {
 		private readonly ContainerInterface $container,
 		private readonly DsoStatusChangeNotifier $notifier,
 		private readonly LoggerInterface $logger,
-	) {
+	
+		private readonly ObjectService $objectService,) {
 	}//end __construct()
 
 	/**
@@ -374,7 +376,7 @@ class DsoCaseService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException(
 				'OpenRegister ObjectService not available: ' . $e->getMessage(),

--- a/lib/Service/SamenwerkverzoekService.php
+++ b/lib/Service/SamenwerkverzoekService.php
@@ -34,6 +34,7 @@ use OCP\IUser;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Service for samenwerkverzoek lifecycle management.
@@ -61,7 +62,8 @@ class SamenwerkverzoekService {
 		private readonly ContainerInterface $container,
 		private readonly IEventDispatcher $eventDispatcher,
 		private readonly LoggerInterface $logger,
-	) {
+	
+		private readonly ObjectService $objectService,) {
 	}//end __construct()
 
 	/**
@@ -273,7 +275,7 @@ class SamenwerkverzoekService {
 	 */
 	private function getObjectService(): object {
 		try {
-			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			return $this->objectService;
 		} catch (\Throwable $e) {
 			throw new RuntimeException(
 				'OpenRegister ObjectService not available: ' . $e->getMessage(),

--- a/lib/Service/SamenwerkverzoekService.php
+++ b/lib/Service/SamenwerkverzoekService.php
@@ -62,8 +62,8 @@ class SamenwerkverzoekService {
 		private readonly ContainerInterface $container,
 		private readonly IEventDispatcher $eventDispatcher,
 		private readonly LoggerInterface $logger,
-	
-		private readonly ObjectService $objectService,) {
+		private readonly ObjectService $objectService,
+	) {
 	}//end __construct()
 
 	/**


### PR DESCRIPTION
2 file(s) reached OpenRegister through `$this->container->get(...)` on an **unconditional** path — no availability check, no degrading catch. The dependency was announced nowhere: not in the constructor, not in the `use` block, not in any type. It appeared mid-method, as a **string**.

Now constructor-injected and typed. Behaviour is unchanged — same object, same container, resolved at construction instead of at first use. `ContainerInterface` is dropped only where nothing else used it.

**Deliberately not converted**, because they are correct as written (ADR-083 rule 1's exception): lookups behind `isInstalled()`/`getInstalledApps()`, and lookups whose `catch` degrades rather than rethrows. Converting those would make the service unconstructable without OpenRegister and turn a clean message into a 500.

Verified per file: `php -l` clean, and gate-66's lookup check reports **zero** remaining findings for each file changed.

gate-66 for this app: **3 → 1**.