### PR TITLE
refactor(stuf)!: rename inkomend to inbound, and test the guard nobody watched

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -291,10 +291,13 @@ $extra = [
         // /api/stuf/inbound. This URL is a WIRE CONTRACT: it is written into the
         // upstream system's configuration, not into ours, so renaming it alone
         // turns a working webhook into a silent 404 on somebody else's schedule.
-        // The alias keeps the Dutch spelling alive deliberately and visibly, so
-        // it is a migration step with an end rather than a name we forgot.
-    ['name' => 'stuf#inbound',   'url' => '/api/stuf/inkomend',  'verb' => 'POST',
-        'postfix' => 'legacy-dutch-alias'],
+        //
+        // It routes to its OWN method rather than reusing 'stuf#inbound' with a
+        // postfix: openregister's AppHost Routes::standard() rejects duplicate
+        // names by `name` alone and never looks at `postfix`, so the two-entries-
+        // one-name form throws "Duplicate route name" at boot and takes the whole
+        // app's routing down with it.
+    ['name' => 'stuf#inboundLegacyPath', 'url' => '/api/stuf/inkomend', 'verb' => 'POST'],
 
         // Doorlooptijd (throughput-time) dashboard metrics.
     ['name' => 'doorlooptijd#metrics', 'url' => '/api/doorlooptijd/metrics', 'verb' => 'GET'],

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -286,7 +286,15 @@ $extra = [
     ['name' => 'stuf#endpoints', 'url' => '/api/stuf/endpoints', 'verb' => 'GET'],
     ['name' => 'stuf#messages',  'url' => '/api/stuf/messages',  'verb' => 'GET'],
     ['name' => 'stuf#outbound',  'url' => '/api/stuf/outbound',  'verb' => 'POST'],
-    ['name' => 'stuf#inkomend',  'url' => '/api/stuf/inkomend',  'verb' => 'POST'],
+    ['name' => 'stuf#inbound',   'url' => '/api/stuf/inbound',   'verb' => 'POST'],
+        // DEPRECATED ALIAS — remove once every configured zaaksysteem posts to
+        // /api/stuf/inbound. This URL is a WIRE CONTRACT: it is written into the
+        // upstream system's configuration, not into ours, so renaming it alone
+        // turns a working webhook into a silent 404 on somebody else's schedule.
+        // The alias keeps the Dutch spelling alive deliberately and visibly, so
+        // it is a migration step with an end rather than a name we forgot.
+    ['name' => 'stuf#inbound',   'url' => '/api/stuf/inkomend',  'verb' => 'POST',
+        'postfix' => 'legacy-dutch-alias'],
 
         // Doorlooptijd (throughput-time) dashboard metrics.
     ['name' => 'doorlooptijd#metrics', 'url' => '/api/doorlooptijd/metrics', 'verb' => 'GET'],

--- a/lib/Controller/StufController.php
+++ b/lib/Controller/StufController.php
@@ -9,7 +9,7 @@
  *     npsLv01/edcLk01) and returns SOAP XML responses (Bv01/La01/Fo01).
  *   - OUTBOUND gateway (admin REST): vrijBericht send, endpoint listing with
  *     health, audit-log query — JSON. Plus an async confirmation receiver
- *     (`inkomend`) that matches a Bv01 crossRefnummer back to the outbound
+ *     (`inbound`) that matches a Bv01 crossRefnummer back to the outbound
  *     StufMessage row and transitions it to "bevestigd".
  *
  * The controller owns only the HTTP surface. Envelope parsing and per-message
@@ -197,8 +197,8 @@ class StufController extends Controller {
 	#[PublicPage]
 	#[NoCSRFRequired]
 	#[AnonRateLimit(limit: 300, period: 60)]
-	public function inkomend(): DataResponse {
-		$rawXml = (string)file_get_contents(filename: 'php://input');
+	public function inbound(): DataResponse {
+		$rawXml = $this->readRawBody();
 		if ($rawXml === '') {
 			return new DataResponse(data: 'empty body', statusCode: Http::STATUS_BAD_REQUEST);
 		}
@@ -208,12 +208,12 @@ class StufController extends Controller {
 			headerEndpointId: (string)$this->request->getHeader(name: 'x-procest-endpoint-id')
 		);
 		if ($endpoint === null) {
-			$this->logger->warning(message: 'StUF inkomend: could not resolve endpoint from envelope');
+			$this->logger->warning(message: 'StUF inbound: could not resolve endpoint from envelope');
 			return new DataResponse(data: 'unknown endpoint', statusCode: Http::STATUS_BAD_REQUEST);
 		}
 
 		if ($this->inspector->verifyWsse(envelopeXml: $rawXml, endpoint: $endpoint) === false) {
-			$this->logger->warning(message: 'StUF inkomend: WSSE signature mismatch for endpoint {id}', context: ['id' => ($endpoint['id'] ?? '')]);
+			$this->logger->warning(message: 'StUF inbound: WSSE signature mismatch for endpoint {id}', context: ['id' => ($endpoint['id'] ?? '')]);
 			// 422 (Unprocessable Entity) signals "invalid signature" without
 			// surfacing an NC session-auth status to the upstream zaaksysteem.
 			// This is WSSE signature verification of a PublicPage webhook, not
@@ -237,7 +237,30 @@ class StufController extends Controller {
 		$this->confirmOutbound(messageKind: $messageKind, crossRef: $crossRef, rawXml: $rawXml, caseId: $caseId);
 
 		return new DataResponse(data: 'ack', statusCode: Http::STATUS_OK);
-	}//end inkomend()
+	}//end inbound()
+
+
+	/**
+	 * Read the raw request body.
+	 *
+	 * A seam, and the reason this endpoint had no tests while its two siblings
+	 * did. `php://input` cannot be driven from a unit test, so the WSSE refusal
+	 * below it could never be watched to refuse — and a guard nobody has
+	 * watched refuse is a guard nobody has tested. Overriding this one method
+	 * is all a test needs; the production path is unchanged.
+	 *
+	 * `OCP\IRequest` exposes no raw-body accessor, so this cannot simply read
+	 * from the injected request.
+	 *
+	 * @return string The raw request body, or an empty string when there is none.
+	 *
+	 * @psalm-return   string
+	 * @phpstan-return string
+	 */
+	protected function readRawBody(): string {
+		return (string)file_get_contents(filename: 'php://input');
+
+	}//end readRawBody()
 
 	/**
 	 * List all configured StufEndpoint objects (admin REST).

--- a/lib/Controller/StufController.php
+++ b/lib/Controller/StufController.php
@@ -241,6 +241,37 @@ class StufController extends Controller {
 
 
 	/**
+	 * Serve the deprecated Dutch URL, /api/stuf/inkomend.
+	 *
+	 * Delegates to inbound(). It exists as its own method only because the URL
+	 * is a WIRE CONTRACT held in the upstream zaaksysteem's configuration:
+	 * renaming the path alone would turn a working webhook into a silent 404 on
+	 * somebody else's schedule.
+	 *
+	 * It cannot be expressed as a second routes.php entry reusing
+	 * `stuf#inbound` with a `postfix`, because openregister's AppHost
+	 * Routes::standard() rejects duplicates by `name` alone and never reads
+	 * `postfix` — that form throws "Duplicate route name" at boot and takes the
+	 * whole app's routing down. Measured: it failed procest's E2E seed.
+	 *
+	 * Remove once every configured sender posts to /api/stuf/inbound.
+	 *
+	 * @return DataResponse
+	 *
+	 * @spec openspec/specs/stuf-zkn-outbound/spec.md#requirement-async-confirmation
+	 *
+	 * @contract exclude Deprecated path alias for inbound(); the behaviour is covered by StufControllerInboundTest.
+	 */
+	#[PublicPage]
+	#[NoCSRFRequired]
+	#[AnonRateLimit(limit: 300, period: 60)]
+	public function inboundLegacyPath(): DataResponse {
+		return $this->inbound();
+
+	}//end inboundLegacyPath()
+
+
+	/**
 	 * Read the raw request body.
 	 *
 	 * A seam, and the reason this endpoint had no tests while its two siblings

--- a/lib/Service/Stuf/StufSoapRequestDispatcher.php
+++ b/lib/Service/Stuf/StufSoapRequestDispatcher.php
@@ -137,7 +137,7 @@ class StufSoapRequestDispatcher {
 	 * caller would be reading zaken and persons by BSN. A missing check that is
 	 * masked by an unfinished body is not a check.
 	 *
-	 * `inkomend()` — the third public StUF route on this controller — already
+	 * `inbound()` — the third public StUF route on this controller — already
 	 * verifies a WSSE UsernameToken against the sending endpoint's stored
 	 * credentials. This applies the same predicate to the other two, so all
 	 * three inbound routes share one posture.

--- a/tests/Unit/Controller/StufControllerInboundTest.php
+++ b/tests/Unit/Controller/StufControllerInboundTest.php
@@ -1,0 +1,302 @@
+<?php
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * Tests for the inbound StUF confirmation receiver.
+ *
+ * WHY THIS FILE EXISTS
+ *
+ * `StufController::inbound()` is a `#[PublicPage]` route. Nothing in
+ * Nextcloud's middleware stack will ever refuse a caller on it, so the refusal
+ * has to come from the controller — and until this suite, nothing watched it
+ * refuse. A guard nobody has watched refuse is a guard nobody has tested:
+ * deleting the `verifyWsse()` call left every test in the repository green.
+ *
+ * Its two sibling public routes, `zaken()` and `personen()`, already had that
+ * cover in StufSoapRequestDispatcherAuthTest. This applies the same standard to
+ * the third.
+ *
+ * The suite is written so that DELETING THE GUARD MAKES IT RED. Three arms
+ * assert a refusal that only exists because a check runs, and one asserts that
+ * a verified sender is still processed — so a controller that refused
+ * *everything* would fail too. Without that last arm, `return 422` on the first
+ * line would pass the other three.
+ *
+ * @category Test
+ * @package  OCA\Procest\Tests\Unit\Controller
+ * @author   Conduction Development Team <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://procest.app
+ */
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\StufController;
+use OCA\Procest\Service\Stuf\StufEnvelopeInspector;
+use OCA\Procest\Service\Stuf\StufMessageHandler;
+use OCA\Procest\Service\Stuf\StufMessageParser;
+use OCA\Procest\Service\Stuf\StufServices;
+use OCA\Procest\Service\Stuf\StufSoapRequestDispatcher;
+use OCP\AppFramework\Http;
+use OCP\IL10N;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Behavioural tests for StufController::inbound().
+ *
+ * @covers \OCA\Procest\Controller\StufController
+ */
+class StufControllerInboundTest extends TestCase {
+
+	/**
+	 * A minimal Bv01 confirmation envelope carrying a WSSE UsernameToken.
+	 *
+	 * The token values are deliberately present: an envelope with no token at
+	 * all would be refused by a checker that merely looks for the element,
+	 * which is a weaker guard than the one being tested.
+	 */
+	private const ENVELOPE = '<?xml version="1.0"?>'
+		. '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"'
+		. ' xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"'
+		. ' xmlns:stuf="http://www.egem.nl/StUF/StUF0301">'
+		. '<soap:Header><wsse:Security><wsse:UsernameToken>'
+		. '<wsse:Username>zaaksysteem</wsse:Username>'
+		. '<wsse:Password>correct-horse</wsse:Password>'
+		. '</wsse:UsernameToken></wsse:Security></soap:Header>'
+		. '<soap:Body><stuf:bevestiging/></soap:Body></soap:Envelope>';
+
+	/**
+	 * A configured endpoint row, as resolveEndpoint() would return it.
+	 *
+	 * @var array<string,mixed>
+	 */
+	private const ENDPOINT = ['id' => 42, 'naam' => 'ZAAKSYSTEEM'];
+
+	/**
+	 * @var StufEnvelopeInspector|MockObject
+	 */
+	private $inspector;
+
+	/**
+	 * @var StufMessageHandler|MockObject
+	 */
+	private $messageHandler;
+
+	/**
+	 * @var StufMessageParser|MockObject
+	 */
+	private $parser;
+
+	/**
+	 * Set up the collaborators.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		$this->inspector      = $this->createMock(StufEnvelopeInspector::class);
+		$this->messageHandler = $this->createMock(StufMessageHandler::class);
+		$this->parser         = $this->createMock(StufMessageParser::class);
+
+		$this->parser->method('parseBevestiging')->willReturn([]);
+		$this->inspector->method('detectBerichtSoort')->willReturn('Bv01');
+		$this->inspector->method('extractCrossRefnummer')->willReturn('xref-1');
+		$this->inspector->method('extractFunctie')->willReturn('ontvanger');
+
+	}//end setUp()
+
+
+	/**
+	 * Build the controller with the raw body pinned to a known string.
+	 *
+	 * The anonymous subclass overrides `readRawBody()`, the seam that exists
+	 * because `php://input` cannot be driven from a unit test. That seam is the
+	 * reason this endpoint went untested while its siblings did not.
+	 *
+	 * @param string $body The raw request body to serve.
+	 *
+	 * @return StufController
+	 */
+	private function controller(string $body): StufController {
+		$services = $this->createMock(StufServices::class);
+
+		// StufServices exposes its collaborators as readonly promoted
+		// properties, so they are stubbed on the mock rather than injected.
+		$reflection = new \ReflectionClass(StufServices::class);
+		$instance   = $reflection->newInstanceWithoutConstructor();
+		foreach (['messageHandler' => $this->messageHandler, 'parser' => $this->parser] as $name => $double) {
+			$property = $reflection->getProperty($name);
+			$property->setAccessible(true);
+			$property->setValue($instance, $double);
+		}
+
+		unset($services);
+
+		return new class(
+			'procest',
+			$this->createMock(IRequest::class),
+			$instance,
+			$this->createMock(StufSoapRequestDispatcher::class),
+			$this->inspector,
+			$this->createMock(IL10N::class),
+			$this->createMock(LoggerInterface::class),
+			$body,
+		) extends StufController {
+
+			/**
+			 * @param string                     $appName    App id.
+			 * @param IRequest                   $request    Request.
+			 * @param StufServices               $stuf       Services.
+			 * @param StufSoapRequestDispatcher  $dispatcher Dispatcher.
+			 * @param StufEnvelopeInspector      $inspector  Inspector.
+			 * @param IL10N                      $l10n       Translations.
+			 * @param LoggerInterface            $logger     Logger.
+			 * @param string                     $body       Raw body to serve.
+			 */
+			public function __construct(
+				string $appName,
+				IRequest $request,
+				StufServices $stuf,
+				StufSoapRequestDispatcher $dispatcher,
+				StufEnvelopeInspector $inspector,
+				IL10N $l10n,
+				LoggerInterface $logger,
+				private readonly string $body,
+			) {
+				parent::__construct(
+					appName: $appName,
+					request: $request,
+					stuf: $stuf,
+					dispatcher: $dispatcher,
+					inspector: $inspector,
+					l10n: $l10n,
+					logger: $logger,
+				);
+
+			}//end __construct()
+
+
+			/**
+			 * Serve the pinned body instead of php://input.
+			 *
+			 * @return string
+			 */
+			protected function readRawBody(): string {
+				return $this->body;
+
+			}//end readRawBody()
+
+
+		};
+
+	}//end controller()
+
+
+	/**
+	 * A tampered WSSE token is refused with 422, and the envelope is never
+	 * interpreted.
+	 *
+	 * This is THE arm the endpoint was missing. Delete the `verifyWsse()` call
+	 * in `inbound()` and this test goes red.
+	 *
+	 * @return void
+	 */
+	public function testATamperedWsseTokenIsRefused(): void {
+		$this->inspector->method('resolveEndpoint')->willReturn(self::ENDPOINT);
+		$this->inspector->method('verifyWsse')->willReturn(false);
+
+		// The refusal must happen BEFORE the envelope is recorded. An endpoint
+		// that logs first and refuses second has already accepted the message.
+		$this->messageHandler->expects($this->never())->method('logInbound');
+
+		$response = $this->controller(self::ENVELOPE)->inbound();
+
+		$this->assertSame(Http::STATUS_UNPROCESSABLE_ENTITY, $response->getStatus());
+		$this->assertSame('invalid signature', $response->getData());
+
+	}//end testATamperedWsseTokenIsRefused()
+
+
+	/**
+	 * An envelope from an unconfigured sender is refused with 400.
+	 *
+	 * @return void
+	 */
+	public function testAnUnresolvableEndpointIsRefused(): void {
+		$this->inspector->method('resolveEndpoint')->willReturn(null);
+		$this->inspector->expects($this->never())->method('verifyWsse');
+		$this->messageHandler->expects($this->never())->method('logInbound');
+
+		$response = $this->controller(self::ENVELOPE)->inbound();
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame('unknown endpoint', $response->getData());
+
+	}//end testAnUnresolvableEndpointIsRefused()
+
+
+	/**
+	 * An empty body is refused with 400 before anything is resolved.
+	 *
+	 * @return void
+	 */
+	public function testAnEmptyBodyIsRefused(): void {
+		$this->inspector->expects($this->never())->method('resolveEndpoint');
+		$this->messageHandler->expects($this->never())->method('logInbound');
+
+		$response = $this->controller('')->inbound();
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame('empty body', $response->getData());
+
+	}//end testAnEmptyBodyIsRefused()
+
+
+	/**
+	 * THE POSITIVE CONTROL — a verified sender is processed and acknowledged.
+	 *
+	 * Without this arm, a controller that answered 422 on its first line would
+	 * satisfy every refusal test above. A guard that refuses everything is not
+	 * a working guard; it is an outage.
+	 *
+	 * @return void
+	 */
+	public function testAVerifiedSenderIsProcessedAndAcknowledged(): void {
+		$this->inspector->method('resolveEndpoint')->willReturn(self::ENDPOINT);
+		$this->inspector->method('verifyWsse')->willReturn(true);
+
+		$this->messageHandler->expects($this->once())->method('logInbound');
+
+		$response = $this->controller(self::ENVELOPE)->inbound();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame('ack', $response->getData());
+
+	}//end testAVerifiedSenderIsProcessedAndAcknowledged()
+
+
+	/**
+	 * The guard is keyed to the RESOLVED endpoint, not to the envelope alone.
+	 *
+	 * A checker that verified the token against anything other than the sending
+	 * endpoint's own stored credentials would let one configured system
+	 * impersonate another. This pins the argument.
+	 *
+	 * @return void
+	 */
+	public function testTheTokenIsVerifiedAgainstTheResolvedEndpoint(): void {
+		$this->inspector->method('resolveEndpoint')->willReturn(self::ENDPOINT);
+		$this->inspector->expects($this->once())
+			->method('verifyWsse')
+			->with(self::ENVELOPE, self::ENDPOINT)
+			->willReturn(true);
+
+		$this->controller(self::ENVELOPE)->inbound();
+
+	}//end testTheTokenIsVerifiedAgainstTheResolvedEndpoint()
+
+
+}//end class


### PR DESCRIPTION
## What

1. Renames the Dutch `inkomend` StUF receiver to **`inbound`** — method, route name, canonical URL, log messages and docblocks.
2. Adds the test suite it never had: **5 tests, and deleting the WSSE guard makes them red.**

## The guard was real but unwatched

`inbound()` verifies a WSSE UsernameToken and answers `422` on mismatch. **Nothing tested it.** No test in the repo referenced the endpoint at all — delete the `verifyWsse()` call and every test stayed green.

Its two sibling public routes already had that cover in `StufSoapRequestDispatcherAuthTest`, whose docblock states the standard exactly right: these are `#[PublicPage]` routes, nothing in Nextcloud's middleware will refuse a caller, so the refusal has to come from the app **and has to be tested**. This applies that standard to the third route.

### The negative control

Guard deleted → **2 failures**, and the informative one is this: `logInbound` was called with a **tampered envelope**. The message was accepted and recorded. Guard restored → 5/5 green.

| test | what it pins |
|---|---|
| `testATamperedWsseTokenIsRefused` | `422`, and `logInbound` is **never** reached — an endpoint that records first and refuses second has already accepted the message |
| `testAnUnresolvableEndpointIsRefused` | `400`, and `verifyWsse` is never called |
| `testAnEmptyBodyIsRefused` | `400` before anything is resolved |
| `testAVerifiedSenderIsProcessedAndAcknowledged` | **the positive control** — without it, `return 422` on line one would pass every refusal test |
| `testTheTokenIsVerifiedAgainstTheResolvedEndpoint` | the token is checked against **that sender's** stored credentials, so one configured system cannot impersonate another |

## Why it was untestable

```php
$rawXml = (string)file_get_contents(filename: 'php://input');
```

`OCP\IRequest` exposes no raw-body accessor, so there was no seam. Added a `protected readRawBody()` the test overrides. **Production path unchanged** — same call, one indirection.

## The URL is a wire contract, so the old one still answers

`/api/stuf/inbound` is canonical. `/api/stuf/inkomend` remains as an **explicitly deprecated alias** routed to the same method, because that URL lives in the *upstream zaaksysteem's* configuration, not ours — renaming it alone turns a working webhook into a silent 404 on somebody else's schedule. The alias is commented as a migration step with an end.

**If procest isn't deployed anywhere yet, say so and I'll drop the alias** — it's the one line still carrying the Dutch spelling.

## Dutch that is deliberately NOT in this PR

These are **stored data values**, so changing them is a data migration, not a rename:

- `'direction' => 'inkomend'` — `ContactMomentController`, `ContactMomentService`, `StufMessageHandler`
- `"enum": ["uitgaand", "inkomend"]` — `register.d/80-stuf-zkn-outbound.json`, `procest_register.json`, `40-kcc-werkplek.json`

Existing rows carry those values; renaming the code without migrating the data breaks every read. They belong in the Dutch→English programme's data tranche.

Also still Dutch and also wire contracts: the sibling routes **`/api/stuf/zaken`** and **`/api/stuf/personen`**.

## Verification

- `php -l` clean on all changed files.
- **Full unit suite: 1904 tests, 8007 assertions, 0 failures** (run on PHP 8.4 in the container — this box has 8.2 and the app requires ^8.3).
- No stale reference to `stuf#inkomend`, `->inkomend(` or `function inkomend` anywhere in `lib/`, `tests/` or `appinfo/`; the only surviving `inkomend` is the deliberate alias URL.

Closes #843.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
