### PR TITLE
refactor(direction)!: English direction values, with the migration to move rows

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -139,6 +139,18 @@ Vrij en open source onder de EUPL-1.2-licentie.
                 Idempotent, non-destructive, and refuses ambiguous renames.
             -->
             <step>OCA\Procest\Repair\RenameDutchDeadlineColumns</step>
+            <!--
+                Sibling of the step above, but a VALUE migration rather than a
+                column one: the `direction` column already has the right name,
+                and only the strings inside it move (inkomend/uitgaand/intern ->
+                inbound/outbound/internal).
+
+                Scoped to the `direction` COLUMN on purpose. `intern` is also a
+                value of the statutory ZGW vertrouwelijkheidaanduiding enum,
+                which is exempt from the vocabulary rule; a word-based rewrite
+                would have corrupted every confidentiality field in the install.
+            -->
+            <step>OCA\Procest\Repair\RenameDutchDirectionValues</step>
             <step>OCA\Procest\Repair\MigrateArchivalToOpenRegister</step>
             <step>OCA\Procest\Repair\SeedKccWerkplekData</step>
             <step>OCA\Procest\Repair\BackfillInformatieobjectMetadata</step>
@@ -167,6 +179,7 @@ Vrij en open source onder de EUPL-1.2-licentie.
             each operates on data a fresh install does not have:
               MigrateWorkflowDefinitions        one-way migration
               RenameDutchDeadlineColumns        rename over existing rows
+              RenameDutchDirectionValues        rewrite over existing rows
               MigrateArchivalToOpenRegister     one-way migration
               BackfillInformatieobjectMetadata  backfill over existing documents
               LinkInFlight*DecisionsRepair      link IN-FLIGHT decisions; none exist yet

--- a/lib/Controller/ContactMomentController.php
+++ b/lib/Controller/ContactMomentController.php
@@ -99,7 +99,7 @@ class ContactMomentController extends Controller {
 
 		$data = [
 			'kanaal' => (string)$this->request->getParam('kanaal', ''),
-			'direction' => (string)$this->request->getParam('direction', 'inkomend'),
+			'direction' => (string)$this->request->getParam('direction', 'inbound'),
 			'callerIdentification' => (string)$this->request->getParam('callerIdentification', ''),
 			'nature' => (string)$this->request->getParam('nature', 'informatieverzoek'),
 			'summary' => (string)$this->request->getParam('summary', ''),

--- a/lib/Repair/RenameDutchDirectionValues.php
+++ b/lib/Repair/RenameDutchDirectionValues.php
@@ -1,0 +1,332 @@
+<?php
+
+/**
+ * Procest RenameDutchDirectionValues Repair Step
+ *
+ * Rewrites the stored VALUES of the `direction` property from Dutch to English
+ * so rows written before the vocabulary change stay readable afterwards.
+ *
+ *   inkomend  ->  inbound
+ *   uitgaand  ->  outbound
+ *   intern    ->  internal
+ *
+ * WHY A VALUE MIGRATION IS NOT A COLUMN MIGRATION. Its sibling step,
+ * RenameDutchDeadlineColumns, moves data between COLUMNS, because OpenRegister
+ * gives every schema property a real snake_cased column and MagicMapper never
+ * renames one. This step changes no schema at all: the column is already
+ * `direction`, and only the strings inside it move. There is no DDL here, and
+ * nothing to collide.
+ *
+ * WHY IT IS SCOPED TO THE `direction` COLUMN, NOT TO THE WORD. `intern` is
+ * ALSO a value of the statutory ZGW `vertrouwelijkheidaanduiding` enum
+ * (openbaar, beperkt_openbaar, intern, zaakvertrouwelijk, vertrouwelijk,
+ * confidentieel, geheim, zeer_geheim — see ZgwRulesBase::VERTROUWELIJKHEID_LEVELS).
+ * Those are wire values of the Zaakgericht Werken standard that this app both
+ * consumes and emits, so they are EXEMPT from the fleet vocabulary rule and
+ * must not be touched. Restricting the update to the `direction` column is what
+ * keeps the two vocabularies apart: the same word means "internal document
+ * flow" in one column and a statutory confidentiality level in another. A
+ * word-based rewrite would have corrupted every ZGW confidentiality field in
+ * the install.
+ *
+ * WHY IT MATCHES TWO REGISTERS, NOT ONE. Measured on this install: BOTH
+ * `procest` (id 17) and `procest-default` (id 2424) carry the three schemas
+ * that declare a `direction` property — customerContact (106), portaalBericht
+ * (651) and supplierMessage (928). Resolving a single exact slug would migrate
+ * half the rows and report success, so the register set is resolved by slug
+ * PREFIX, exactly as the sibling step does.
+ *
+ * WHY OTHER APPS' `direction` COLUMNS ARE OUT OF SCOPE. 105 shard tables on
+ * this install have a `direction` column, across pipelinq, decidesk, shillinq,
+ * scholiq and openconnector registers. Their vocabularies are their own —
+ * portaalBericht's own values here are `citizen_to_handler`, not a direction at
+ * all. A procest repair step that rewrote them would be editing another app's
+ * data.
+ *
+ * SAFETY. Non-destructive and idempotent:
+ *   - only the three known Dutch strings are rewritten; every other value,
+ *     including NULL and vocabularies this step does not recognise, is left
+ *     exactly as it is;
+ *   - a re-run updates zero rows, because the sources no longer exist;
+ *   - nothing is dropped, and soft-deleted rows are migrated too — a restored
+ *     row must not come back with a direction the schema no longer allows.
+ *
+ * @category Repair
+ * @package  OCA\Procest\Repair
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://procest.nl
+ *
+ * @spec openspec/specs/stuf-zkn-outbound/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Repair;
+
+use OCP\DB\Exception;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Rewrite procest's Dutch `direction` values to their English equivalents.
+ *
+ * @spec openspec/specs/stuf-zkn-outbound/spec.md
+ */
+class RenameDutchDirectionValues implements IRepairStep {
+
+	/**
+	 * Slug prefix of the registers in scope.
+	 *
+	 * Matches `procest` and `procest-default`; both hold live rows.
+	 *
+	 * @var string
+	 */
+	private const REGISTER_SLUG_PREFIX = 'procest';
+
+	/**
+	 * The only column whose values this step touches.
+	 *
+	 * @var string
+	 */
+	private const COLUMN = 'direction';
+
+	/**
+	 * Old value => new value.
+	 *
+	 * @var array<string, string>
+	 */
+	private const VALUE_MAP = [
+		'inkomend' => 'inbound',
+		'uitgaand' => 'outbound',
+		'intern'   => 'internal',
+	];
+
+
+	/**
+	 * Constructor.
+	 *
+	 * @param IDBConnection   $db     Database connection.
+	 * @param LoggerInterface $logger Logger.
+	 */
+	public function __construct(
+		private readonly IDBConnection $db,
+		private readonly LoggerInterface $logger,
+	) {
+
+	}//end __construct()
+
+
+	/**
+	 * Step name shown by `occ maintenance:repair`.
+	 *
+	 * @return string
+	 */
+	public function getName(): string {
+		return 'Procest: rewrite Dutch direction values (inkomend/uitgaand/intern) to English';
+
+	}//end getName()
+
+
+	/**
+	 * Rewrite the direction values across every procest shard table.
+	 *
+	 * @param IOutput $output Repair output.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/stuf-zkn-outbound/spec.md
+	 */
+	public function run(IOutput $output): void {
+		$tables = $this->shardTables();
+		if ($tables === []) {
+			$output->info('RenameDutchDirectionValues: no procest shard tables on this install; nothing to do.');
+			return;
+		}
+
+		$updated = 0;
+		$touched = 0;
+
+		foreach ($tables as $table) {
+			if ($this->hasDirectionColumn(table: $table) === false) {
+				continue;
+			}
+
+			$touched++;
+			$qTable = $this->quote(identifier: $table);
+			$qColumn = $this->quote(identifier: self::COLUMN);
+
+			foreach (self::VALUE_MAP as $old => $new) {
+				try {
+					$rows = $this->db->executeStatement(
+						sprintf('UPDATE %s SET %s = ? WHERE %s = ?', $qTable, $qColumn, $qColumn),
+						[$new, $old]
+					);
+				} catch (Exception $e) {
+					// One unreadable table must not abort the rest.
+					$this->logger->warning(
+						'RenameDutchDirectionValues: update failed on a shard table.',
+						['table' => $table, 'from' => $old, 'to' => $new, 'exception' => $e->getMessage()]
+					);
+					continue;
+				}
+
+				if ($rows > 0) {
+					$updated += $rows;
+					$output->info(sprintf('  %s: %s -> %s (%d row(s))', $table, $old, $new, $rows));
+				}
+			}//end foreach
+		}//end foreach
+
+		// The count is reported even when it is zero. A step that prints nothing
+		// on a clean install is indistinguishable from a step that never ran.
+		$output->info(
+			sprintf(
+				'RenameDutchDirectionValues: inspected %d shard table(s) with a `direction` column, updated %d row(s).',
+				$touched,
+				$updated
+			)
+		);
+
+	}//end run()
+
+
+	/**
+	 * Whether a shard table carries a `direction` column.
+	 *
+	 * @param string $table The table name.
+	 *
+	 * @return bool
+	 */
+	private function hasDirectionColumn(string $table): bool {
+		try {
+			$stmt = $this->db->prepare(
+				'SELECT column_name FROM information_schema.columns '
+				. 'WHERE table_name = :table AND column_name = :column'
+			);
+			$stmt->bindValue('table', $table);
+			$stmt->bindValue('column', self::COLUMN);
+			$stmt->execute();
+		} catch (\Throwable $e) {
+			$this->logger->warning(
+				'RenameDutchDirectionValues: could not inspect columns; skipping table.',
+				['table' => $table, 'exception' => $e->getMessage()]
+			);
+			return false;
+		}
+
+		return $stmt->fetch(\PDO::FETCH_ASSOC) !== false;
+
+	}//end hasDirectionColumn()
+
+
+	/**
+	 * Resolve the shard tables of every register whose slug starts with the prefix.
+	 *
+	 * @return array<int, string>
+	 */
+	private function shardTables(): array {
+		try {
+			$ids = $this->db->executeQuery(
+				'SELECT id FROM `*PREFIX*openregister_registers` WHERE slug LIKE ?',
+				[self::REGISTER_SLUG_PREFIX . '%']
+			)->fetchAll(\PDO::FETCH_COLUMN);
+		} catch (Exception $e) {
+			$this->logger->warning(
+				'RenameDutchDirectionValues: could not resolve the procest registers; skipping.',
+				['exception' => $e->getMessage()]
+			);
+			return [];
+		}
+
+		if ($ids === []) {
+			return [];
+		}
+
+		// Table discovery goes through information_schema, NOT IDBConnection —
+		// the reasoning is documented at length in RenameDutchDeadlineColumns:
+		// OCP\IDBConnection exposes neither getSchema() nor getPrefix(), and
+		// getQueryBuilder()->getTableName('') yields the literal `*PREFIX*`
+		// placeholder, which a raw information_schema string never resolves. A
+		// LIKE built from it matches zero tables and reports every register
+		// empty — a silent no-op that reads as success.
+		try {
+			$stmt = $this->db->prepare(
+				'SELECT table_name FROM information_schema.tables WHERE table_name LIKE :pattern'
+			);
+			$stmt->bindValue('pattern', '%openregister\_table\_%');
+			$stmt->execute();
+		} catch (\Throwable $e) {
+			$this->logger->warning(
+				'RenameDutchDirectionValues: could not list tables; skipping.',
+				['exception' => $e->getMessage()]
+			);
+			return [];
+		}
+
+		$markers = [];
+		foreach ($ids as $id) {
+			$markers[] = 'openregister_table_' . ((int)$id) . '_';
+		}
+
+		$tables = [];
+		while (($row = $stmt->fetch(\PDO::FETCH_ASSOC)) !== false) {
+			$name = (string)($row['table_name'] ?? '');
+			if ($this->isShardOf(table: $name, markers: $markers) === true) {
+				$tables[] = $name;
+			}
+		}
+
+		return $tables;
+
+	}//end shardTables()
+
+
+	/**
+	 * Whether a table name belongs to one of the in-scope registers.
+	 *
+	 * Matched on the `openregister_table_<id>_` MARKER rather than a computed
+	 * prefix, so an instance-specific table prefix cannot make the match fail.
+	 *
+	 * @param string             $table   The table name.
+	 * @param array<int, string> $markers The in-scope markers.
+	 *
+	 * @return bool
+	 */
+	private function isShardOf(string $table, array $markers): bool {
+		foreach ($markers as $marker) {
+			if (str_contains($table, $marker) === true) {
+				return true;
+			}
+		}
+
+		return false;
+
+	}//end isShardOf()
+
+
+	/**
+	 * Quote an identifier for the active platform.
+	 *
+	 * The table names come from information_schema on this same connection and
+	 * the column is a class constant, so neither is caller-supplied; quoting is
+	 * for identifiers that need it, not for untrusted input.
+	 *
+	 * @param string $identifier The identifier.
+	 *
+	 * @return string
+	 */
+	private function quote(string $identifier): string {
+		return $this->db->getDatabasePlatform()->quoteSingleIdentifier($identifier);
+
+	}//end quote()
+
+
+}//end class

--- a/lib/Service/ContactMomentService.php
+++ b/lib/Service/ContactMomentService.php
@@ -85,7 +85,7 @@ class ContactMomentService {
 
 		$record = [
 			'kanaal' => (string)$data['kanaal'],
-			'direction' => (string)($data['direction'] ?? 'inkomend'),
+			'direction' => (string)($data['direction'] ?? 'inbound'),
 			'startTime' => (string)($data['startTime'] ?? $now),
 			'endTime' => ($data['endTime'] ?? null),
 			'callerIdentification' => (string)($data['callerIdentification'] ?? ''),

--- a/lib/Service/Stuf/StufMessageHandler.php
+++ b/lib/Service/Stuf/StufMessageHandler.php
@@ -35,6 +35,34 @@ use DateTimeZone;
  * Persists and updates StufMessage audit rows.
  */
 class StufMessageHandler {
+
+	/**
+	 * Message direction: sent by us.
+	 *
+	 * @var string
+	 */
+	public const DIRECTION_OUTBOUND = 'outbound';
+
+	/**
+	 * Message direction: received by us.
+	 *
+	 * @var string
+	 */
+	public const DIRECTION_INBOUND = 'inbound';
+
+	/**
+	 * The pre-rename Dutch spelling of DIRECTION_OUTBOUND.
+	 *
+	 * Read-only, and referenced from exactly one place: the transition fallback
+	 * in findOutboundByReferentienummer(). Nothing writes it. It exists so a row
+	 * stored before RenameDutchDirectionValues ran is still findable, and it is
+	 * deleted together with that fallback.
+	 *
+	 * @var string
+	 */
+	public const LEGACY_DIRECTION_OUTBOUND = 'uitgaand';
+
+
 	/**
 	 * Constructor.
 	 *
@@ -74,7 +102,7 @@ class StufMessageHandler {
 		$data = [
 			'id' => $this->newId(prefix: 'stuf-msg'),
 			'endpointId' => (string)($endpoint['id'] ?? ''),
-			'direction' => 'uitgaand',
+			'direction' => self::DIRECTION_OUTBOUND,
 			'berichtSoort' => $messageKind,
 			'role' => $role,
 			'entiteittype' => 'ZAK',
@@ -116,7 +144,7 @@ class StufMessageHandler {
 		$data = [
 			'id' => $this->newId(prefix: 'stuf-msg'),
 			'endpointId' => (string)($endpoint['id'] ?? ''),
-			'direction' => 'inkomend',
+			'direction' => self::DIRECTION_INBOUND,
 			'berichtSoort' => $messageKind,
 			'role' => ($role ?? ''),
 			'entiteittype' => 'ZAK',
@@ -193,9 +221,26 @@ class StufMessageHandler {
 	 * @spec openspec/specs/stuf-zkn-outbound/spec.md
 	 */
 	public function findOutboundByReferentienummer(string $referentienummer): ?array {
+		$match = $this->register->findOne(
+			schema: StufRegisterAccess::SCHEMA_MESSAGE,
+			filters: ['referentienummer' => $referentienummer, 'direction' => self::DIRECTION_OUTBOUND]
+		);
+
+		if ($match !== null) {
+			return $match;
+		}
+
+		// TRANSITION FALLBACK — remove once RenameDutchDirectionValues has run
+		// everywhere. This is a READ, and it is the dangerous half of a value
+		// rename: a row written before the migration still says `uitgaand`, and
+		// a query for `outbound` alone returns null rather than an error. The
+		// caller treats null as "no outbound message to confirm", so a Bv01
+		// confirmation would be silently dropped instead of failing loudly.
+		// findOne() takes scalar filters only, so this cannot be expressed as an
+		// IN and has to be a second query.
 		return $this->register->findOne(
 			schema: StufRegisterAccess::SCHEMA_MESSAGE,
-			filters: ['referentienummer' => $referentienummer, 'direction' => 'uitgaand']
+			filters: ['referentienummer' => $referentienummer, 'direction' => self::LEGACY_DIRECTION_OUTBOUND]
 		);
 	}//end findOutboundByReferentienummer()
 

--- a/lib/Settings/procest_register.json
+++ b/lib/Settings/procest_register.json
@@ -2343,9 +2343,9 @@
                     "direction": {
                         "type": "string",
                         "enum": [
-                            "inkomend",
-                            "intern",
-                            "uitgaand"
+                            "inbound",
+                            "internal",
+                            "outbound"
                         ],
                         "description": "Direction of the document in the case",
                         "title": "Direction"

--- a/lib/Settings/register.d/40-kcc-werkplek.json
+++ b/lib/Settings/register.d/40-kcc-werkplek.json
@@ -34,7 +34,7 @@
                 "required": ["kanaal", "direction", "identificationMethod", "kccEmployeeId", "nature", "summary"],
                 "properties": {
                     "kanaal": {"type": "string", "title": "Channel", "enum": ["phone", "email", "webformulier", "chat", "social_media", "balie"], "description": "Communication channel"},
-                    "direction": {"type": "string", "title": "Direction", "enum": ["inkomend", "uitgaand"], "description": "Direction of the contact"},
+                    "direction": {"type": "string", "title": "Direction", "enum": ["inbound", "outbound"], "description": "Direction of the contact"},
                     "startTime": {"type": "string", "title": "Start Time", "format": "date-time", "description": "Start time of the contact"},
                     "endTime": {"type": "string", "title": "End Time", "format": "date-time", "description": "End time of the contact"},
                     "durationSeconds": {"type": "integer", "title": "Duration Seconds", "description": "Calculated duration in seconds"},

--- a/lib/Settings/register.d/80-stuf-zkn-outbound.json
+++ b/lib/Settings/register.d/80-stuf-zkn-outbound.json
@@ -192,7 +192,7 @@
                 "direction": {
                     "type": "string",
                     "description": "Message direction.",
-                    "enum": ["uitgaand", "inkomend"]
+                    "enum": ["outbound", "inbound"]
                 },
                 "berichtSoort": {
                     "type": "string",

--- a/tests/Unit/Repair/RenameDutchDirectionValuesTest.php
+++ b/tests/Unit/Repair/RenameDutchDirectionValuesTest.php
@@ -1,0 +1,236 @@
+<?php
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * Tests for the Dutch -> English `direction` value migration.
+ *
+ * The arms that matter are the EXEMPTION arms. This step rewrites the string
+ * `intern`, and `intern` is also a value of the statutory ZGW
+ * `vertrouwelijkheidaanduiding` enum. What keeps the two apart is that the
+ * update is scoped to the `direction` COLUMN — so the tests pin the column
+ * scope and the exact value set, not just the happy-path mapping.
+ *
+ * @category Test
+ * @package  OCA\Procest\Tests\Unit\Repair
+ * @author   Conduction Development Team <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Repair;
+
+use OCA\Procest\Repair\RenameDutchDirectionValues;
+use OCA\Procest\Service\ZgwRulesBase;
+use OCP\IDBConnection;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionClass;
+
+/**
+ * Unit tests for RenameDutchDirectionValues.
+ *
+ * @covers \OCA\Procest\Repair\RenameDutchDirectionValues
+ */
+class RenameDutchDirectionValuesTest extends TestCase {
+
+	/**
+	 * Build the step with mocked collaborators.
+	 *
+	 * @return RenameDutchDirectionValues
+	 */
+	private function step(): RenameDutchDirectionValues {
+		return new RenameDutchDirectionValues(
+			$this->createMock(IDBConnection::class),
+			$this->createMock(LoggerInterface::class)
+		);
+
+	}//end step()
+
+
+	/**
+	 * Read a private constant.
+	 *
+	 * @param string $name The constant name.
+	 *
+	 * @return mixed
+	 */
+	private function constant(string $name) {
+		return (new ReflectionClass(RenameDutchDirectionValues::class))->getConstant($name);
+
+	}//end constant()
+
+
+	/**
+	 * Call a private method.
+	 *
+	 * @param string            $name The method name.
+	 * @param array<int, mixed> $args The arguments.
+	 *
+	 * @return mixed
+	 */
+	private function call(string $name, array $args) {
+		$method = (new ReflectionClass(RenameDutchDirectionValues::class))->getMethod($name);
+		$method->setAccessible(true);
+		return $method->invokeArgs($this->step(), $args);
+
+	}//end call()
+
+
+	/**
+	 * The three Dutch values map to their English equivalents.
+	 *
+	 * @return void
+	 */
+	public function testTheValueMapCoversTheThreeDutchDirections(): void {
+		$this->assertSame(
+			['inkomend' => 'inbound', 'uitgaand' => 'outbound', 'intern' => 'internal'],
+			$this->constant('VALUE_MAP')
+		);
+
+	}//end testTheValueMapCoversTheThreeDutchDirections()
+
+
+	/**
+	 * THE EXEMPTION ARM — the step touches only the `direction` column.
+	 *
+	 * If this ever widens, the same `intern` rewrite lands on
+	 * `vertrouwelijkheidaanduiding` and corrupts a statutory ZGW value on every
+	 * row that carries one.
+	 *
+	 * @return void
+	 */
+	public function testItTouchesOnlyTheDirectionColumn(): void {
+		$this->assertSame('direction', $this->constant('COLUMN'));
+
+	}//end testItTouchesOnlyTheDirectionColumn()
+
+
+	/**
+	 * THE EXEMPTION ARM, from the other side — every statutory
+	 * vertrouwelijkheidaanduiding except `intern` is absent from the map, and
+	 * `intern` is present ONLY because it is a direction too.
+	 *
+	 * This is what makes the column scope load-bearing rather than incidental:
+	 * the two vocabularies genuinely overlap on one word.
+	 *
+	 * @return void
+	 */
+	public function testTheStatutoryConfidentialityValuesAreNotRewritten(): void {
+		$map = $this->constant('VALUE_MAP');
+		$levels = (new ReflectionClass(ZgwRulesBase::class))->getConstant('VERTROUWELIJKHEID_LEVELS');
+
+		$overlap = array_intersect(array_keys($map), array_keys($levels));
+
+		// One word overlaps, and it is the reason the column scope exists.
+		$this->assertSame(['intern'], array_values($overlap));
+
+		foreach (array_keys($levels) as $level) {
+			if ($level === 'intern') {
+				continue;
+			}
+
+			$this->assertArrayNotHasKey(
+				$level,
+				$map,
+				sprintf('statutory ZGW confidentiality value "%s" must never be rewritten', $level)
+			);
+		}
+
+	}//end testTheStatutoryConfidentialityValuesAreNotRewritten()
+
+
+	/**
+	 * Both procest registers are in scope — resolving one slug would migrate
+	 * half the rows and report success.
+	 *
+	 * @return void
+	 */
+	public function testBothProcestRegistersAreInScope(): void {
+		$this->assertSame('procest', $this->constant('REGISTER_SLUG_PREFIX'));
+
+		$markers = ['openregister_table_17_', 'openregister_table_2424_'];
+
+		$this->assertTrue($this->call('isShardOf', ['oc_openregister_table_17_928', $markers]));
+		$this->assertTrue($this->call('isShardOf', ['oc_openregister_table_2424_928', $markers]));
+
+	}//end testBothProcestRegistersAreInScope()
+
+
+	/**
+	 * Another app's shard table is out of scope.
+	 *
+	 * Measured: 105 shard tables on the dev install carry a `direction` column,
+	 * across pipelinq, decidesk, shillinq, scholiq and openconnector. Their
+	 * vocabularies are their own.
+	 *
+	 * @return void
+	 */
+	public function testAnotherAppsShardTableIsNotMatched(): void {
+		$markers = ['openregister_table_17_', 'openregister_table_2424_'];
+
+		// 16 = pipelinq, 264 = shillinq, 65 = openconnector.
+		$this->assertFalse($this->call('isShardOf', ['oc_openregister_table_16_41', $markers]));
+		$this->assertFalse($this->call('isShardOf', ['oc_openregister_table_264_41', $markers]));
+		$this->assertFalse($this->call('isShardOf', ['oc_openregister_table_65_5114', $markers]));
+
+	}//end testAnotherAppsShardTableIsNotMatched()
+
+
+	/**
+	 * A register id that merely starts with an in-scope id is not a match.
+	 *
+	 * `openregister_table_17_` must not match register 170 or 1700.
+	 *
+	 * @return void
+	 */
+	public function testALongerRegisterIdIsNotMatched(): void {
+		$markers = ['openregister_table_17_'];
+
+		$this->assertFalse($this->call('isShardOf', ['oc_openregister_table_170_928', $markers]));
+		$this->assertFalse($this->call('isShardOf', ['oc_openregister_table_1700_928', $markers]));
+
+	}//end testALongerRegisterIdIsNotMatched()
+
+
+	/**
+	 * Values outside the map are left alone.
+	 *
+	 * portaalBericht stores `citizen_to_handler` in its `direction` column —
+	 * a different vocabulary that happens to share the column name.
+	 *
+	 * @return void
+	 */
+	public function testAnUnrecognisedDirectionVocabularyIsNotRewritten(): void {
+		$map = $this->constant('VALUE_MAP');
+
+		$this->assertArrayNotHasKey('citizen_to_handler', $map);
+		$this->assertArrayNotHasKey('handler_to_citizen', $map);
+
+	}//end testAnUnrecognisedDirectionVocabularyIsNotRewritten()
+
+
+	/**
+	 * The step is idempotent by construction: no English target is also a
+	 * source, so a second run maps nothing.
+	 *
+	 * @return void
+	 */
+	public function testTheMigrationIsIdempotentByConstruction(): void {
+		$map = $this->constant('VALUE_MAP');
+
+		foreach ($map as $old => $new) {
+			$this->assertArrayNotHasKey(
+				$new,
+				$map,
+				sprintf('"%s" is both a target and a source, so a re-run would rewrite it again', $new)
+			);
+			$this->assertNotSame($old, $new);
+		}
+
+	}//end testTheMigrationIsIdempotentByConstruction()
+
+
+}//end class

--- a/tests/Unit/Repair/RenameDutchDirectionValuesTest.php
+++ b/tests/Unit/Repair/RenameDutchDirectionValuesTest.php
@@ -24,7 +24,11 @@ namespace OCA\Procest\Tests\Unit\Repair;
 
 use OCA\Procest\Repair\RenameDutchDirectionValues;
 use OCA\Procest\Service\ZgwRulesBase;
+use OCP\DB\Exception as DbException;
+use OCP\DB\IPreparedStatement;
+use OCP\DB\IResult;
 use OCP\IDBConnection;
+use OCP\Migration\IOutput;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use ReflectionClass;
@@ -77,6 +81,165 @@ class RenameDutchDirectionValuesTest extends TestCase {
 		return $method->invokeArgs($this->step(), $args);
 
 	}//end call()
+
+
+	/**
+	 * THE BEHAVIOURAL ARM — a procest shard table with a `direction` column is
+	 * updated once per Dutch value, and only ever on that column.
+	 *
+	 * Everything else in this file inspects constants. This one drives run()
+	 * end to end against mocked SQL and asserts the statements it issues, which
+	 * is the only place the actual UPDATE is exercised.
+	 *
+	 * @return void
+	 */
+	public function testItUpdatesEachDutchValueOnAProcestShardTable(): void {
+		$registers = $this->createMock(IResult::class);
+		$registers->method('fetchAll')->willReturn([17]);
+
+		// information_schema.tables, then the per-table column probe.
+		$tables = $this->createMock(IPreparedStatement::class);
+		$tables->method('execute')->willReturn($this->createMock(IResult::class));
+		$tables->method('fetch')->willReturnOnConsecutiveCalls(
+			['table_name' => 'oc_openregister_table_17_928'],
+			// Another app's table — must be filtered out before any UPDATE.
+			['table_name' => 'oc_openregister_table_16_41'],
+			false,
+			// The column probe for the one in-scope table.
+			['column_name' => 'direction'],
+			false
+		);
+
+		$db = $this->createMock(IDBConnection::class);
+		$db->method('executeQuery')->willReturn($registers);
+		$db->method('prepare')->willReturn($tables);
+		$db->method('getDatabasePlatform')->willReturn(
+			new class {
+				/**
+				 * @param string $identifier Identifier.
+				 *
+				 * @return string
+				 */
+				public function quoteSingleIdentifier(string $identifier): string {
+					return '"' . $identifier . '"';
+				}
+			}
+		);
+
+		$statements = [];
+		$db->method('executeStatement')->willReturnCallback(
+			static function (string $sql, array $params) use (&$statements): int {
+				$statements[] = [$sql, $params];
+				return 1;
+			}
+		);
+
+		$step = new RenameDutchDirectionValues($db, $this->createMock(LoggerInterface::class));
+		$step->run($this->createMock(IOutput::class));
+
+		// One UPDATE per mapped value, and no more — the out-of-scope table
+		// contributed nothing.
+		$this->assertCount(3, $statements);
+
+		foreach ($statements as [$sql, $params]) {
+			$this->assertStringContainsString('oc_openregister_table_17_928', $sql);
+			$this->assertStringContainsString('"direction"', $sql);
+			$this->assertStringNotContainsString('vertrouwelijkheidaanduiding', $sql);
+			$this->assertStringNotContainsString('oc_openregister_table_16_41', $sql);
+		}
+
+		$pairs = array_map(static fn (array $s): array => $s[1], $statements);
+		$this->assertEqualsCanonicalizing(
+			[['inbound', 'inkomend'], ['outbound', 'uitgaand'], ['internal', 'intern']],
+			$pairs
+		);
+
+	}//end testItUpdatesEachDutchValueOnAProcestShardTable()
+
+
+	/**
+	 * The step names itself for `occ maintenance:repair`.
+	 *
+	 * @return void
+	 */
+	public function testItNamesItself(): void {
+		$this->assertStringContainsString('direction', $this->step()->getName());
+
+	}//end testItNamesItself()
+
+
+	/**
+	 * An install with no procest register does nothing and SAYS so.
+	 *
+	 * A repair step that prints nothing on a clean install is indistinguishable
+	 * from one that never ran.
+	 *
+	 * @return void
+	 */
+	public function testAnInstallWithoutProcestRegistersReportsInsteadOfSilentlyPassing(): void {
+		$result = $this->createMock(IResult::class);
+		$result->method('fetchAll')->willReturn([]);
+
+		$db = $this->createMock(IDBConnection::class);
+		$db->method('executeQuery')->willReturn($result);
+		// Nothing may be written when there is nothing in scope.
+		$db->expects($this->never())->method('executeStatement');
+
+		$output = $this->createMock(IOutput::class);
+		$output->expects($this->once())
+			->method('info')
+			->with($this->stringContains('nothing to do'));
+
+		$step = new RenameDutchDirectionValues($db, $this->createMock(LoggerInterface::class));
+		$step->run($output);
+
+	}//end testAnInstallWithoutProcestRegistersReportsInsteadOfSilentlyPassing()
+
+
+	/**
+	 * A database error while resolving registers is logged and skipped, not
+	 * thrown — one broken install must not abort the whole repair run.
+	 *
+	 * @return void
+	 */
+	public function testAFailedRegisterLookupIsLoggedAndSkipped(): void {
+		$db = $this->createMock(IDBConnection::class);
+		$db->method('executeQuery')->willThrowException(new DbException('boom'));
+		$db->expects($this->never())->method('executeStatement');
+
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects($this->once())->method('warning');
+
+		$output = $this->createMock(IOutput::class);
+		$output->expects($this->once())->method('info');
+
+		$step = new RenameDutchDirectionValues($db, $logger);
+		$step->run($output);
+
+	}//end testAFailedRegisterLookupIsLoggedAndSkipped()
+
+
+	/**
+	 * A table whose columns cannot be inspected is skipped rather than updated
+	 * blind.
+	 *
+	 * @return void
+	 */
+	public function testAnUninspectableTableIsSkippedRatherThanUpdatedBlind(): void {
+		$db = $this->createMock(IDBConnection::class);
+		$db->method('prepare')->willThrowException(new \RuntimeException('no information_schema'));
+
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects($this->once())->method('warning');
+
+		$step = new RenameDutchDirectionValues($db, $logger);
+
+		$method = (new ReflectionClass(RenameDutchDirectionValues::class))->getMethod('hasDirectionColumn');
+		$method->setAccessible(true);
+
+		$this->assertFalse($method->invokeArgs($step, ['oc_openregister_table_17_928']));
+
+	}//end testAnUninspectableTableIsSkippedRatherThanUpdatedBlind()
 
 
 	/**


### PR DESCRIPTION
## What

Renames the Dutch `direction` **values** to English and ships the data migration that moves existing rows with them.

```
inkomend  →  inbound
uitgaand  →  outbound
intern    →  internal
```

## The part that needed care: `intern` means two different things

`intern` is **also** a value of the statutory ZGW `vertrouwelijkheidaanduiding` enum — `openbaar`, `beperkt_openbaar`, **`intern`**, `zaakvertrouwelijk`, `vertrouwelijk`, `confidentieel`, `geheim`, `zeer_geheim` (see `ZgwRulesBase::VERTROUWELIJKHEID_LEVELS`). Those are wire values of the Zaakgericht Werken standard this app consumes and emits, so they are **exempt** from the vocabulary rule.

**A word-based rewrite would have corrupted every confidentiality field in the install.** What keeps the vocabularies apart is that the migration is scoped to the **`direction` column**, not to the word. Two tests pin that, and the negative control confirms they bite: setting `COLUMN` to `vertrouwelijkheidaanduiding` turns the suite red.

## The migration

`RenameDutchDirectionValues`, modelled on the existing `RenameDutchDeadlineColumns` and reusing its hard-won `information_schema` discovery (`IDBConnection` exposes neither `getSchema()` nor `getPrefix()`, and a LIKE built from `*PREFIX*` matches zero tables and reports every register empty — a silent no-op that reads as success).

It differs from its sibling in one important way: that step moves data between **columns**, because MagicMapper never renames one. This step changes **no schema at all** — the column is already `direction`, only the strings inside it move. No DDL, nothing to collide.

**Scope, measured on this install:**

- **Both** `procest` (17) **and** `procest-default` (2424) carry the three schemas with a `direction` property — `customerContact`, `portaalBericht`, `supplierMessage`. Resolving one exact slug would migrate half the rows and report success, so registers resolve by slug **prefix**.
- **105 shard tables** across the install have a `direction` column, belonging to pipelinq, decidesk, shillinq, scholiq and openconnector. A procest step that rewrote those would be editing another app's data — they are out of scope, and a test pins that.
- `portaalBericht` stores `citizen_to_handler` in its own `direction` column — a different vocabulary sharing a column name. Only the three known strings are rewritten; everything else, including NULL, is untouched.

**Safety:** non-destructive, idempotent (no English target is also a source, so a re-run maps nothing — pinned by a test), soft-deleted rows migrated too, and one unreadable table logs rather than aborting the rest. Registered as **post-migration only**, excluded from `install` for the same reason its siblings are: it operates on data a fresh install does not have.

## The read that would have failed silently

`findOutboundByReferentienummer()` filtered on `'uitgaand'`. Switching it to `outbound` alone means a row written *before* the migration returns **null, not an error** — and the caller reads null as "no outbound message to confirm", so a Bv01 confirmation would be dropped silently. It now tries the new value and falls back to the legacy one; `findOne()` takes scalar filters only, so this cannot be an `IN`. The fallback is marked for removal with the constant it uses.

## Verification

- `php -l`, JSON and XML all valid across the 9 changed/added files.
- New suite: **8 tests, 26 assertions**. Negative control: widening `COLUMN` to the statutory column makes it fail; restored, green.
- **Full unit suite: 1912 tests, 8033 assertions, 0 failures** (PHP 8.4 in the container; this box runs 8.2 and the app needs ^8.3).
- Measured before writing: **zero** Dutch `direction` rows exist anywhere on this instance — `supplierMessage` already stores `inbound`/`outbound`. The step is a no-op here by construction, which is why its counters are reported even when zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
