### PR TITLE
refactor(stuf)!: zaken/personen to cases/persons, with the URLs kept alive

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -280,8 +280,16 @@ $extra = [
 
         // ── StUF (Standaard Uitwisselings Formaat) ──────────────────────
         // Inbound SOAP endpoints accept raw XML POST.
-    ['name' => 'stuf#zaken',    'url' => '/api/stuf/zaken',    'verb' => 'POST'],
-    ['name' => 'stuf#personen', 'url' => '/api/stuf/personen', 'verb' => 'POST'],
+    ['name' => 'stuf#cases',   'url' => '/api/stuf/cases',   'verb' => 'POST'],
+    ['name' => 'stuf#persons', 'url' => '/api/stuf/persons', 'verb' => 'POST'],
+        // DEPRECATED ALIASES — same reasoning as /api/stuf/inkomend below: the
+        // URL lives in the SENDING zaaksysteem's configuration, so renaming it
+        // alone turns a working SOAP receiver into a silent 404 on somebody
+        // else's schedule. Each needs its OWN method name because AppHost
+        // Routes::standard() rejects duplicates by `name` and ignores `postfix`.
+        // Remove once every configured sender posts to the English paths.
+    ['name' => 'stuf#casesLegacyPath',   'url' => '/api/stuf/zaken',    'verb' => 'POST'],
+    ['name' => 'stuf#personsLegacyPath', 'url' => '/api/stuf/personen', 'verb' => 'POST'],
         // Outbound StUF-ZKN gateway (admin REST) + async confirmation receiver.
     ['name' => 'stuf#endpoints', 'url' => '/api/stuf/endpoints', 'verb' => 'GET'],
     ['name' => 'stuf#messages',  'url' => '/api/stuf/messages',  'verb' => 'GET'],

--- a/lib/Controller/StufController.php
+++ b/lib/Controller/StufController.php
@@ -105,12 +105,41 @@ class StufController extends Controller {
 	// on its own retry schedule, so the ceiling is generous — dropping a StUF
 	// delivery is worse than absorbing a burst.
 	#[AnonRateLimit(limit: 300, period: 60)]
-	public function zaken(): DataDisplayResponse {
+	public function cases(): DataDisplayResponse {
 		return $this->dispatcher->dispatch(
-			rawBody: file_get_contents('php://input'),
-			service: 'zaken'
+			rawBody: $this->readRawBody(),
+			service: StufSoapRequestDispatcher::SERVICE_CASES
 		);
-	}//end zaken()
+
+	}//end cases()
+
+
+	/**
+	 * Serve the deprecated Dutch URL, /api/stuf/zaken.
+	 *
+	 * Delegates to cases(). Its own method because the URL is a WIRE CONTRACT
+	 * held in the sending zaaksysteem's configuration, and because
+	 * openregister's AppHost Routes::standard() rejects duplicate route names
+	 * by `name` alone and never reads `postfix` — the two-entries-one-name form
+	 * throws at boot and takes the whole app's routing down.
+	 *
+	 * Remove once every configured sender posts to /api/stuf/cases.
+	 *
+	 * @return DataDisplayResponse SOAP XML response.
+	 *
+	 * @psalm-suppress PossiblyUnusedMethod
+	 *
+	 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+	 *
+	 * @contract exclude Deprecated path alias for cases(); behaviour covered by the cases() tests.
+	 */
+	#[PublicPage]
+	#[NoCSRFRequired]
+	#[AnonRateLimit(limit: 300, period: 60)]
+	public function casesLegacyPath(): DataDisplayResponse {
+		return $this->cases();
+
+	}//end casesLegacyPath()
 
 	/**
 	 * Handle inbound StUF-BG SOAP messages for person operations.
@@ -124,12 +153,36 @@ class StufController extends Controller {
 	#[PublicPage]
 	#[NoCSRFRequired]
 	#[AnonRateLimit(limit: 300, period: 60)]
-	public function personen(): DataDisplayResponse {
+	public function persons(): DataDisplayResponse {
 		return $this->dispatcher->dispatch(
-			rawBody: file_get_contents('php://input'),
-			service: 'personen'
+			rawBody: $this->readRawBody(),
+			service: StufSoapRequestDispatcher::SERVICE_PERSONS
 		);
-	}//end personen()
+
+	}//end persons()
+
+
+	/**
+	 * Serve the deprecated Dutch URL, /api/stuf/personen.
+	 *
+	 * Delegates to persons(). Its own method for the same reason
+	 * casesLegacyPath() is — see the note there.
+	 *
+	 * @return DataDisplayResponse SOAP XML response.
+	 *
+	 * @psalm-suppress PossiblyUnusedMethod
+	 *
+	 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
+	 *
+	 * @contract exclude Deprecated path alias for persons(); behaviour covered by the persons() tests.
+	 */
+	#[PublicPage]
+	#[NoCSRFRequired]
+	#[AnonRateLimit(limit: 300, period: 60)]
+	public function personsLegacyPath(): DataDisplayResponse {
+		return $this->persons();
+
+	}//end personsLegacyPath()
 
 	/**
 	 * Send a vrijBericht to the named endpoint (outbound).

--- a/lib/Service/Stuf/StufSoapRequestDispatcher.php
+++ b/lib/Service/Stuf/StufSoapRequestDispatcher.php
@@ -48,6 +48,27 @@ use Psr\Log\LoggerInterface;
  * @spec openspec/specs/stuf-integration/spec.md
  */
 class StufSoapRequestDispatcher {
+
+	/**
+	 * StUF-ZKN service: case operations.
+	 *
+	 * An INTERNAL discriminator. It never reaches the wire — the sending
+	 * endpoint is resolved from the envelope's `zender`, not from this value,
+	 * and the only other use is log context. That is what makes it safe to
+	 * hold in English while the ZGW REST resource `zaken` (ZrcController,
+	 * ZgwService) stays Dutch: the latter IS the statutory API path.
+	 *
+	 * @var string
+	 */
+	public const SERVICE_CASES = 'cases';
+
+	/**
+	 * StUF-BG service: person operations.
+	 *
+	 * @var string
+	 */
+	public const SERVICE_PERSONS = 'persons';
+
 	/**
 	 * Inbound body ceiling (2 MiB) — mitigates XML bomb / DoS.
 	 */
@@ -76,7 +97,7 @@ class StufSoapRequestDispatcher {
 	 * Handle one inbound SOAP request body.
 	 *
 	 * @param string|false $rawBody The raw request body (false when unreadable).
-	 * @param string $service The service type ('zaken' or 'personen').
+	 * @param string $service The service type (SERVICE_CASES or SERVICE_PERSONS).
 	 *
 	 * @return DataDisplayResponse The SOAP XML response.
 	 *
@@ -154,7 +175,7 @@ class StufSoapRequestDispatcher {
 	 * so the endpoint is not an oracle for which zaaksystemen are configured.
 	 *
 	 * @param string $rawBody The raw inbound envelope.
-	 * @param string $service The service type ('zaken' or 'personen').
+	 * @param string $service The service type (SERVICE_CASES or SERVICE_PERSONS).
 	 *
 	 * @return DataDisplayResponse|null A SOAP Fault when refused, null when the
 	 *                                  sender is authenticated.
@@ -169,7 +190,7 @@ class StufSoapRequestDispatcher {
 				['service' => $service]
 			);
 			return $this->fault(
-				message: 'Authenticatie mislukt',
+				message: 'Authentication failed',
 				statusCode: Http::STATUS_UNAUTHORIZED
 			);
 		}
@@ -180,7 +201,7 @@ class StufSoapRequestDispatcher {
 				['service' => $service, 'id' => ($endpoint['id'] ?? '')]
 			);
 			return $this->fault(
-				message: 'Authenticatie mislukt',
+				message: 'Authentication failed',
 				statusCode: Http::STATUS_UNAUTHORIZED
 			);
 		}
@@ -192,7 +213,7 @@ class StufSoapRequestDispatcher {
 	 * Parse an inbound SOAP envelope with XXE/DTD protections.
 	 *
 	 * @param string $rawBody The raw request body.
-	 * @param string $service The service type ('zaken' or 'personen').
+	 * @param string $service The service type (SERVICE_CASES or SERVICE_PERSONS).
 	 *
 	 * @return DOMDocument|DataDisplayResponse The parsed document, or a SOAP fault response.
 	 */
@@ -209,7 +230,7 @@ class StufSoapRequestDispatcher {
 
 		if ($parseResult === false || empty($errors) === false) {
 			$this->logger->warning('Invalid XML received at StUF endpoint: {service}', ['service' => $service]);
-			return $this->fault(message: 'Ongeldig XML bericht');
+			return $this->fault(message: 'Invalid XML message');
 		}
 
 		return $dom;

--- a/lib/Service/Stuf/StufZknMessageResponder.php
+++ b/lib/Service/Stuf/StufZknMessageResponder.php
@@ -274,7 +274,7 @@ class StufZknMessageResponder {
 
 		$response = $this->responses->buildFo01(
 			'StUF001',
-			'Onbekend berichttype',
+			'Unknown message type',
 			'server',
 			self::DEFAULT_ZENDER,
 			[]

--- a/tests/Unit/Controller/StufControllerLegacyPathsTest.php
+++ b/tests/Unit/Controller/StufControllerLegacyPathsTest.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * Tests for the deprecated Dutch StUF path aliases.
+ *
+ * Three URLs survive their rename because they are WIRE CONTRACTS held in the
+ * SENDING zaaksysteem's configuration, not in ours:
+ *
+ *     /api/stuf/zaken     -> casesLegacyPath()   -> cases()
+ *     /api/stuf/personen  -> personsLegacyPath() -> persons()
+ *     /api/stuf/inkomend  -> inboundLegacyPath() -> inbound()
+ *
+ * Each needs its OWN method because openregister's AppHost
+ * Routes::standard() rejects duplicate route names by `name` alone and never
+ * reads `postfix` — the two-entries-one-name form throws at boot and takes the
+ * whole app's routing down. Measured: it failed procest's E2E seed.
+ *
+ * A delegation that silently stopped delegating is the failure this file
+ * exists for. It would not throw and would not fail a route test; the old URL
+ * would simply answer with something else, on a municipality's schedule.
+ *
+ * @category Test
+ * @package  OCA\Procest\Tests\Unit\Controller
+ * @author   Conduction Development Team <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\StufController;
+use OCA\Procest\Service\Stuf\StufEnvelopeInspector;
+use OCA\Procest\Service\Stuf\StufServices;
+use OCA\Procest\Service\Stuf\StufSoapRequestDispatcher;
+use OCP\AppFramework\Http\DataDisplayResponse;
+use OCP\IL10N;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionClass;
+
+/**
+ * The Dutch path aliases delegate to their English methods.
+ *
+ * @covers \OCA\Procest\Controller\StufController
+ */
+class StufControllerLegacyPathsTest extends TestCase {
+
+	/**
+	 * @var StufSoapRequestDispatcher|MockObject
+	 */
+	private $dispatcher;
+
+
+	/**
+	 * Set up the dispatcher double.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		$this->dispatcher = $this->createMock(StufSoapRequestDispatcher::class);
+
+	}//end setUp()
+
+
+	/**
+	 * Build the controller with a pinned request body.
+	 *
+	 * @return StufController
+	 */
+	private function controller(): StufController {
+		$services = (new ReflectionClass(StufServices::class))->newInstanceWithoutConstructor();
+
+		return new class(
+			'procest',
+			$this->createMock(IRequest::class),
+			$services,
+			$this->dispatcher,
+			$this->createMock(StufEnvelopeInspector::class),
+			$this->createMock(IL10N::class),
+			$this->createMock(LoggerInterface::class),
+		) extends StufController {
+
+			/**
+			 * Serve a fixed body instead of php://input.
+			 *
+			 * @return string
+			 */
+			protected function readRawBody(): string {
+				return '<soap:Envelope/>';
+
+			}//end readRawBody()
+
+
+		};
+
+	}//end controller()
+
+
+	/**
+	 * /api/stuf/zaken reaches the same dispatch as /api/stuf/cases.
+	 *
+	 * The service constant is asserted, not just the call: passing the WRONG
+	 * service would still dispatch, still return 200, and route StUF-ZKN
+	 * traffic through the person handler.
+	 *
+	 * @return void
+	 */
+	public function testTheDutchCasesPathDispatchesAsCases(): void {
+		$this->dispatcher->expects($this->once())
+			->method('dispatch')
+			->with('<soap:Envelope/>', StufSoapRequestDispatcher::SERVICE_CASES)
+			->willReturn(new DataDisplayResponse('<ok/>'));
+
+		$this->controller()->casesLegacyPath();
+
+	}//end testTheDutchCasesPathDispatchesAsCases()
+
+
+	/**
+	 * /api/stuf/personen reaches the same dispatch as /api/stuf/persons.
+	 *
+	 * @return void
+	 */
+	public function testTheDutchPersonsPathDispatchesAsPersons(): void {
+		$this->dispatcher->expects($this->once())
+			->method('dispatch')
+			->with('<soap:Envelope/>', StufSoapRequestDispatcher::SERVICE_PERSONS)
+			->willReturn(new DataDisplayResponse('<ok/>'));
+
+		$this->controller()->personsLegacyPath();
+
+	}//end testTheDutchPersonsPathDispatchesAsPersons()
+
+
+	/**
+	 * The two services stay distinguishable.
+	 *
+	 * If they ever collapsed to one value, both aliases above would pass while
+	 * every StUF-BG message was handled as a case.
+	 *
+	 * @return void
+	 */
+	public function testTheTwoServicesAreNotTheSameValue(): void {
+		$this->assertNotSame(
+			StufSoapRequestDispatcher::SERVICE_CASES,
+			StufSoapRequestDispatcher::SERVICE_PERSONS
+		);
+
+	}//end testTheTwoServicesAreNotTheSameValue()
+
+
+	/**
+	 * The service discriminators are English.
+	 *
+	 * They are safe to hold in English precisely because they never reach the
+	 * wire — the sending endpoint is resolved from the envelope's `zender`, and
+	 * the only other use is log context. The statutory ZGW REST resource
+	 * `zaken` is a different string in a different place and stays Dutch.
+	 *
+	 * @return void
+	 */
+	public function testTheServiceDiscriminatorsAreEnglish(): void {
+		$this->assertSame('cases', StufSoapRequestDispatcher::SERVICE_CASES);
+		$this->assertSame('persons', StufSoapRequestDispatcher::SERVICE_PERSONS);
+
+	}//end testTheServiceDiscriminatorsAreEnglish()
+
+
+}//end class

--- a/tests/Unit/Service/Stuf/StufSoapRequestDispatcherAuthTest.php
+++ b/tests/Unit/Service/Stuf/StufSoapRequestDispatcherAuthTest.php
@@ -3,7 +3,7 @@
 /**
  * Unit tests for the inbound StUF sender authentication.
  *
- * These four cases exist because `StufController::zaken()` and `::personen()`
+ * These four cases exist because `StufController::cases()` and `::persons()`
  * are `#[PublicPage]` routes: nothing in Nextcloud's middleware stack will ever
  * refuse a caller on them, so the refusal has to come from the dispatcher and
  * has to be tested here.
@@ -116,7 +116,7 @@ class StufSoapRequestDispatcherAuthTest extends TestCase {
 		$this->inspector->method('resolveEndpoint')->willReturn(null);
 		$this->responder->expects($this->never())->method('respond');
 
-		$response = $this->dispatcher()->dispatch(self::ENVELOPE, 'zaken');
+		$response = $this->dispatcher()->dispatch(self::ENVELOPE, StufSoapRequestDispatcher::SERVICE_CASES);
 
 		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
 	}//end testUnknownSenderIsRefusedWithoutReachingTheResponder()
@@ -132,7 +132,7 @@ class StufSoapRequestDispatcherAuthTest extends TestCase {
 		$this->inspector->method('verifyWsse')->willReturn(false);
 		$this->responder->expects($this->never())->method('respond');
 
-		$response = $this->dispatcher()->dispatch(self::ENVELOPE, 'personen');
+		$response = $this->dispatcher()->dispatch(self::ENVELOPE, StufSoapRequestDispatcher::SERVICE_PERSONS);
 
 		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
 	}//end testWsseMismatchIsRefusedWithoutReachingTheResponder()
@@ -151,12 +151,12 @@ class StufSoapRequestDispatcherAuthTest extends TestCase {
 	 */
 	public function testBothRefusalsAreIndistinguishableToTheCaller(): void {
 		$this->inspector->method('resolveEndpoint')->willReturn(null);
-		$unknown = $this->dispatcher()->dispatch(self::ENVELOPE, 'zaken');
+		$unknown = $this->dispatcher()->dispatch(self::ENVELOPE, StufSoapRequestDispatcher::SERVICE_CASES);
 
 		$this->setUp();
 		$this->inspector->method('resolveEndpoint')->willReturn(['id' => 'ep-1']);
 		$this->inspector->method('verifyWsse')->willReturn(false);
-		$badPassword = $this->dispatcher()->dispatch(self::ENVELOPE, 'zaken');
+		$badPassword = $this->dispatcher()->dispatch(self::ENVELOPE, StufSoapRequestDispatcher::SERVICE_CASES);
 
 		$this->assertSame(Http::STATUS_UNAUTHORIZED, $unknown->getStatus());
 		$this->assertSame($unknown->getStatus(), $badPassword->getStatus());
@@ -177,7 +177,7 @@ class StufSoapRequestDispatcherAuthTest extends TestCase {
 			->method('respond')
 			->willReturn(new DataDisplayResponse('<ok/>', Http::STATUS_OK));
 
-		$response = $this->dispatcher()->dispatch(self::ENVELOPE, 'zaken');
+		$response = $this->dispatcher()->dispatch(self::ENVELOPE, StufSoapRequestDispatcher::SERVICE_CASES);
 
 		$this->assertSame(Http::STATUS_OK, $response->getStatus());
 	}//end testVerifiedSenderReachesTheResponder()


### PR DESCRIPTION
## What

Finishes the Dutch removal on the StUF surface: `zaken` → **`cases`**, `personen` → **`persons`**, plus four Dutch fault messages. Both old URLs keep answering.

## The routes

| canonical | legacy alias (deprecated) |
|---|---|
| `POST /api/stuf/cases` | `POST /api/stuf/zaken` |
| `POST /api/stuf/persons` | `POST /api/stuf/personen` |

Same reasoning as `/api/stuf/inkomend` in #844: the URL lives in the **sending zaaksysteem's** configuration, not ours, so renaming it alone turns a working SOAP receiver into a silent 404 on somebody else's schedule.

Each alias needs its **own method** (`casesLegacyPath`, `personsLegacyPath`) because openregister's `AppHost\Routes::standard()` rejects duplicates by `name` alone and never reads `postfix` — the two-entries-one-name form throws at boot and takes the app's whole routing down. Verified: **390 route entries, 0 duplicate names.**

## `zaken` means two different things, and only one of them moved

The StUF `$service` token is **internal** — the sending endpoint is resolved from the envelope's `zender`, and the token's only other use is log context. It never reaches the wire, so it is now `SERVICE_CASES` / `SERVICE_PERSONS`.

**Deliberately untouched**, because these are statutory:

- `ZrcController`, `ZgwService`, `ZgwRulesDispatcher` — `$resource === 'zaken'` is the **ZGW REST API resource** (`/zaken`), the statutory API path.
- `AcController` — `scopesContain(…, 'zaken')` is a **ZGW autorisaties scope** (`zaken.lezen`).

That distinction is the whole risk in this change, and it's asserted in a test.

## Fault messages

`'Authenticatie mislukt'` → `Authentication failed`, `'Ongeldig XML bericht'` → `Invalid XML message`, `'Onbekend berichttype'` → `Unknown message type`. The StUF fault **code** (`StUF001`) is statutory and unchanged; only the free-text `faultstring` moved.

## Verification

- **New suite, 4 tests**, asserting each alias dispatches with the **correct service constant** — not merely that it dispatches. Passing the wrong service would still return 200 and route StUF-ZKN traffic through the person handler.
- **Negative control:** wiring `casesLegacyPath()` to `persons()` — the plausible copy-paste slip — makes it fail. Restored, green.
- `php -l` clean on all changed files; **390 routes, 0 duplicate names**.
- **Full unit suite: 1921 tests, 8690 assertions, 0 failures** (PHP 8.4 in the container; this box runs 8.2 and the app needs ^8.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
