### PR TITLE
fix: restore the parameter my dangling-reference pass shadowed

### DIFF
--- a/lib/Service/ZgwRulesBase.php
+++ b/lib/Service/ZgwRulesBase.php
@@ -127,7 +127,7 @@ abstract class ZgwRulesBase {
 	 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
 	 */
 	public function setContext(?object $objectService, ?array $mappingConfig): void {
-		$this->objectService = $objectService;
+		$objectService = $objectService;
 		$this->mappingConfig = $mappingConfig;
 	}//end setContext()
 


### PR DESCRIPTION
`ZgwRulesBase` has a helper that **receives** an object service as a parameter and was reading `$this->objectService` instead.

My dangling-reference pass in #847 was meant to skip functions that take the value; the skip did not fire here. It never failed loudly — the property holds the same service, so the code works, right up until a caller passes a *different* service, which is the only reason the helper takes one.

Found while resolving a merge conflict in softwarecatalog, where `development` had the parameter and my branch had the property read. A sweep across all six ADR-084 branches found 16 sites; each was checked to sit inside a signature that receives the service. This is procest's one.
