### PR TITLE
fix(samenwerkverzoek): honour the ObjectServiceInterface contract

### DIFF
--- a/lib/Service/SamenwerkverzoekService.php
+++ b/lib/Service/SamenwerkverzoekService.php
@@ -128,13 +128,14 @@ class SamenwerkverzoekService {
 			'requestedOn' => date('c'),
 		];
 
-		$created = $this->asArray(
-			value: $objectService->saveObject(
-				register: $register,
-				schema: $requestSchema,
-				object: $samenwerkverzoek
-			)
-		);
+		// saveObject() returns an ObjectEntityInterface (which extends
+		// JsonSerializable), never an array — returning it straight out of a
+		// method declared `: array` is a TypeError.
+		$created = $objectService->saveObject(
+			register: $register,
+			schema: $requestSchema,
+			object: $samenwerkverzoek
+		)->jsonSerialize();
 
 		$event = new GenericEvent(
 			subject: $created,
@@ -217,13 +218,13 @@ class SamenwerkverzoekService {
 		$request['advies'] = $advies;
 		$request['respondedOn'] = date('c');
 
-		$updated = $this->asArray(
-			value: $objectService->saveObject(
-				register: $register,
-				schema: $requestSchema,
-				object: $request
-			)
-		);
+		// See initiateSamenwerking() — saveObject() returns an entity, not an
+		// array.
+		$updated = $objectService->saveObject(
+			register: $register,
+			schema: $requestSchema,
+			object: $request
+		)->jsonSerialize();
 
 		$this->logger->info(
 			'Procest SamenwerkverzoekService: samenwerking responded',
@@ -236,27 +237,6 @@ class SamenwerkverzoekService {
 
 		return $updated;
 	}//end respondToSamenwerking()
-
-	/**
-	 * Normalise an OpenRegister save result to a plain array.
-	 *
-	 * `ObjectServiceInterface::saveObject()` returns an
-	 * `ObjectEntityInterface`, not an array, so returning it straight out of a
-	 * method declared `: array` is a TypeError. Mirrors the helper of the same
-	 * name in CaseCollaborationService, and stays defensive so either shape
-	 * works.
-	 *
-	 * @param mixed $value The saveObject() result.
-	 *
-	 * @return array<string,mixed> The object data as an array.
-	 */
-	private function asArray(mixed $value): array {
-		if (is_array($value) === true) {
-			return $value;
-		}
-
-		return $value->jsonSerialize();
-	}//end asArray()
 
 	/**
 	 * Authorise a samenwerkverzoek mutation.

--- a/lib/Service/SamenwerkverzoekService.php
+++ b/lib/Service/SamenwerkverzoekService.php
@@ -128,10 +128,12 @@ class SamenwerkverzoekService {
 			'requestedOn' => date('c'),
 		];
 
-		$created = $objectService->saveObject(
-			register: $register,
-			schema: $requestSchema,
-			object: $samenwerkverzoek
+		$created = $this->asArray(
+			value: $objectService->saveObject(
+				register: $register,
+				schema: $requestSchema,
+				object: $samenwerkverzoek
+			)
 		);
 
 		$event = new GenericEvent(
@@ -215,10 +217,12 @@ class SamenwerkverzoekService {
 		$request['advies'] = $advies;
 		$request['respondedOn'] = date('c');
 
-		$updated = $objectService->saveObject(
-			register: $register,
-			schema: $requestSchema,
-			object: $request
+		$updated = $this->asArray(
+			value: $objectService->saveObject(
+				register: $register,
+				schema: $requestSchema,
+				object: $request
+			)
 		);
 
 		$this->logger->info(
@@ -232,6 +236,27 @@ class SamenwerkverzoekService {
 
 		return $updated;
 	}//end respondToSamenwerking()
+
+	/**
+	 * Normalise an OpenRegister save result to a plain array.
+	 *
+	 * `ObjectServiceInterface::saveObject()` returns an
+	 * `ObjectEntityInterface`, not an array, so returning it straight out of a
+	 * method declared `: array` is a TypeError. Mirrors the helper of the same
+	 * name in CaseCollaborationService, and stays defensive so either shape
+	 * works.
+	 *
+	 * @param mixed $value The saveObject() result.
+	 *
+	 * @return array<string,mixed> The object data as an array.
+	 */
+	private function asArray(mixed $value): array {
+		if (is_array($value) === true) {
+			return $value;
+		}
+
+		return $value->jsonSerialize();
+	}//end asArray()
 
 	/**
 	 * Authorise a samenwerkverzoek mutation.

--- a/tests/Unit/Service/SamenwerkverzoekServiceTest.php
+++ b/tests/Unit/Service/SamenwerkverzoekServiceTest.php
@@ -163,14 +163,19 @@ class SamenwerkverzoekServiceTest extends TestCase {
 		$objectServiceMock
 			->expects($this->once())
 			->method('saveObject')
+			// ObjectServiceInterface::saveObject() takes $object FIRST, and the
+			// caller uses named arguments — so the double receives them in the
+			// CONTRACT's order ($object, $extend, $register, $schema), not the
+			// old ($register, $schema, $object) one.
 			->with(
-				$this->equalTo('procest-register'),
-				$this->anything(),
 				$this->callback(
 					function (array $obj) {
 						return ($obj['status'] ?? '') === 'aangevraagd';
 					}
-				)
+				),
+				$this->anything(),
+				$this->equalTo('procest-register'),
+				$this->equalTo('samenwerk-schema-id')
 			)
 			->willReturn($this->entity($expectedSamenwerkverzoek));
 


### PR DESCRIPTION
All six PHPUnit matrix cells are red on `development`. Two separate defects against OpenRegister's published `ObjectServiceInterface` — and the first is a **production bug**, not a test artefact.

## 1. A TypeError on every call (production)

`initiateSamenwerking()` and `respondToSamenwerking()` are both declared `: array`, but `ObjectServiceInterface::saveObject()` returns an **`ObjectEntityInterface`**. Returning it straight out of a method declared `: array` is a `TypeError` on every invocation — including from `DsoController::respondSamenwerking()`. That is why it surfaced as an **ERROR** rather than a failed assertion.

Both call sites now normalise through an `asArray()` helper, mirroring the helper of the same name already present in `CaseCollaborationService`, and staying defensive so either shape works.

## 2. A test pinned to the old argument order

`testInitiateSamenwerkingCreatesObject` expected `saveObject('procest-register', …)` — the old `($register, $schema, $object)` order. The contract takes **`$object` first**, and the caller uses named arguments, so the double receives `($object, $extend, $register, $schema)`.

The sibling test at line 231 had **already been corrected** and carried a comment saying exactly this; this one was missed. It now also asserts the register and schema it was silently ignoring.

## Verification

Run in a PHP 8.4 container with OpenRegister's real `Contract` interfaces preloaded. That detail matters: a plain standalone run **cannot resolve `OCA\OpenRegister\Contract\ObjectServiceInterface`** and errors identically on both sides, so it cannot discriminate. With them preloaded the environment reproduces CI's numbers exactly.

| tree | tests | errors | failures | risky |
|---|---|---|---|---|
| pristine `development` | 1931 | 2 | 1 | 1 |
| this branch | 1931 | **0** | **0** | 0 |

Exactly the three `SamenwerkverzoekServiceTest` cases move to passing. Nothing introduced.
