### PR TITLE
refactor(procest): translate the last two schema slugs, and fix the tool that missed them

### DIFF
--- a/lib/AppInfo/Registrar/BezwaarSubscriptionRegistrar.php
+++ b/lib/AppInfo/Registrar/BezwaarSubscriptionRegistrar.php
@@ -55,7 +55,7 @@ class BezwaarSubscriptionRegistrar {
 	 * @var array<int,string>
 	 */
 	private const LIFECYCLE_SCHEMAS = [
-		'bezwaar',
+		'objectionProceeding',
 		'objection',
 		'hearingSession',
 		'advisoryReport',
@@ -70,7 +70,7 @@ class BezwaarSubscriptionRegistrar {
 	 */
 	private const LEGAL_HOLD_SCHEMAS = [
 		'objection',
-		'bezwaar',
+		'objectionProceeding',
 		'beroep',
 		'bezwaarDecision',
 		'appealDecision',

--- a/lib/Command/Backfill/AwbProceedingScanner.php
+++ b/lib/Command/Backfill/AwbProceedingScanner.php
@@ -59,7 +59,7 @@ class AwbProceedingScanner {
 	 *
 	 * @var array<int, string>
 	 */
-	private const OPENING_SCHEMAS = ['bezwaar', 'objection', 'beroep'];
+	private const OPENING_SCHEMAS = ['objectionProceeding', 'objection', 'beroep'];
 
 	/**
 	 * Scan failures collected while listing objects, reported by the caller.
@@ -196,7 +196,7 @@ class AwbProceedingScanner {
 		$ids = [];
 
 		foreach ($this->listObjects(objectService: $objectService, schema: $schema, includeDeleted: true) as $decision) {
-			foreach (['bezwaar', 'beroep', 'appeal', 'objection'] as $key) {
+			foreach (['objectionProceeding', 'beroep', 'appeal', 'objection'] as $key) {
 				$ref = ($decision['data'][$key] ?? null);
 				if (is_string($ref) === true && $ref !== '') {
 					$ids[] = $ref;

--- a/lib/Listener/BezwaarDecisionListener.php
+++ b/lib/Listener/BezwaarDecisionListener.php
@@ -181,7 +181,7 @@ class BezwaarDecisionListener implements IEventListener {
 					'filters' => [
 						'register' => $register,
 						'schema' => $decisionSchema,
-						'bezwaar' => $objectionId,
+						'objectionProceeding' => $objectionId,
 					],
 					'limit' => self::DECISION_PROBE_LIMIT,
 				]

--- a/lib/Listener/BezwaarLegalHoldListener.php
+++ b/lib/Listener/BezwaarLegalHoldListener.php
@@ -79,7 +79,7 @@ class BezwaarLegalHoldListener implements IEventListener {
 	 *
 	 * @var array<int, string>
 	 */
-	private const PROCEEDING_OPENED_SCHEMAS = ['objection', 'bezwaar', 'beroep'];
+	private const PROCEEDING_OPENED_SCHEMAS = ['objection', 'objectionProceeding', 'beroep'];
 
 	/**
 	 * Schemas whose creation ends an Awb proceeding (releases a hold).
@@ -287,7 +287,7 @@ class BezwaarLegalHoldListener implements IEventListener {
 	 */
 	private function resolveCaseId(string $schemaSlug, array $payload): string {
 		if ($schemaSlug === 'bezwaarDecision') {
-			$objectionId = (string)($payload['bezwaar'] ?? '');
+			$objectionId = (string)($payload['objectionProceeding'] ?? '');
 			if ($objectionId === '') {
 				return '';
 			}

--- a/lib/Listener/BezwaarLifecycleListener.php
+++ b/lib/Listener/BezwaarLifecycleListener.php
@@ -58,7 +58,7 @@ class BezwaarLifecycleListener implements IEventListener {
 	 * @var array<int, string>
 	 */
 	private const RELEVANT_SCHEMAS = [
-		'bezwaar',
+		'objectionProceeding',
 		'objection',
 		'hearingSession',
 		'advisoryReport',

--- a/lib/Repair/LinkInFlightRemainingDecisionsRepair.php
+++ b/lib/Repair/LinkInFlightRemainingDecisionsRepair.php
@@ -166,7 +166,7 @@ class LinkInFlightRemainingDecisionsRepair implements IRepairStep {
 		return [
 			'bezwaar_decision_schema' => function (array $obj): string {
 				return $this->objectionDelegation->raiseBezwaarDecision(
-					objectionId: (string)($obj['bezwaar'] ?? ($obj['uuid'] ?? ($obj['id'] ?? ''))),
+					objectionId: (string)($obj['objectionProceeding'] ?? ($obj['uuid'] ?? ($obj['id'] ?? ''))),
 					payload: [
 						'subjectSchema' => 'bezwaarDecision',
 						'subjectId' => (string)($obj['uuid'] ?? ($obj['id'] ?? '')),

--- a/lib/Repair/RenameDutchSchemaSlugs.php
+++ b/lib/Repair/RenameDutchSchemaSlugs.php
@@ -18,12 +18,16 @@
  * ORDERING: this MUST run before `InitializeSettings`, which triggers the
  * procest register import. Registered first in info.xml's post-migration block.
  *
- * `bezwaar` is deliberately absent. procest declares BOTH `bezwaar` and
- * `objection`, and they are two entities rather than a duplicate — the
- * independence check resolves `bacAdviceRequest.bezwaar -> bezwaar (lifecycle
- * record) -> bezwaar.case -> objection (filed on that case)`, and SettingsService
- * carries separate `bezwaar_schema` and `objection_schema` keys. Naming the
- * lifecycle record in English is a design decision, not a translation.
+ * `bezwaar` is now IN, as `objectionProceeding`. It was held back because
+ * procest declares BOTH `bezwaar` and `objection` and an earlier attempt renamed
+ * the first onto the second — a DUPLICATE JSON KEY, which is legal, parses, and
+ * silently kept only the last block, dropping one schema's lifecycle and
+ * calculations. They are two entities, not a duplicate: `objection` is the
+ * SUBMISSION (contestedDecision, grounds, requestedRelief, receivedDate,
+ * isTimely) and `bezwaar` is the Awb PROCEEDING around it (case, a ref to that
+ * objection, status, awbReference, receiptDate, adjournedOn, suspensionStart).
+ * Zero shared properties. `objectionProceeding` names the second without
+ * colliding with the first.
  *
  * @category  Repair
  * @package   OCA\Procest\Repair
@@ -74,12 +78,14 @@ class RenameDutchSchemaSlugs implements IRepairStep {
 	 */
 	public const SLUG_MAP = [
 		'avgClassificatie' => 'gdprClassification',
+		'bezwaar' => 'objectionProceeding',
 		'catalogus' => 'catalog',
 		'dwangsomBerekening' => 'penaltyPaymentCalculation',
 		'ingebrekestelling' => 'noticeOfDefault',
 		'kanaal' => 'notificationChannel',
 		'termijnDefinitie' => 'deadlineDefinition',
 		'termijnInstance' => 'deadlineInstance',
+		'tussenrapportage' => 'interimReport',
 		'voorstel' => 'proposal',
 	];
 

--- a/lib/Repair/SeedBezwaarWorkflowDefinition.php
+++ b/lib/Repair/SeedBezwaarWorkflowDefinition.php
@@ -203,7 +203,7 @@ class SeedBezwaarWorkflowDefinition implements IRepairStep {
 				objectService: $objectService,
 				register: $register,
 				schema: $caseTypeSchema,
-				filters: ['identifier' => 'bezwaar', '_limit' => 5],
+				filters: ['identifier' => 'objectionProceeding', '_limit' => 5],
 			);
 		} catch (\Throwable $e) {
 			$this->logger->error(

--- a/lib/Service/Bezwaar/AdvisoryCommitteeService.php
+++ b/lib/Service/Bezwaar/AdvisoryCommitteeService.php
@@ -175,7 +175,7 @@ class AdvisoryCommitteeService {
 			],
 			$payload,
 			[
-				'bezwaar' => $objectionId,
+				'objectionProceeding' => $objectionId,
 				'committee' => $commissieId,
 				'status' => 'assigned',
 				'assignedAt' => $now,
@@ -189,7 +189,7 @@ class AdvisoryCommitteeService {
 			payload: [
 				'panel' => $record['panel'],
 				'commissieId' => $commissieId,
-				'bezwaar' => $objectionId,
+				'objectionProceeding' => $objectionId,
 			],
 		);
 
@@ -448,7 +448,7 @@ class AdvisoryCommitteeService {
 		}
 
 		$independence = $this->independence->check(
-			objectionId: (string)($current['bezwaar'] ?? ''),
+			objectionId: (string)($current['objectionProceeding'] ?? ''),
 			panel: $panel,
 		);
 
@@ -528,7 +528,7 @@ class AdvisoryCommitteeService {
 				subjectId: (string)$requestId,
 				payload: [
 					'subjectRegister' => $register,
-					'externalReference' => (string)($current['bezwaar'] ?? $requestId),
+					'externalReference' => (string)($current['objectionProceeding'] ?? $requestId),
 					'subjectLabel' => (string)($merged['conclusion'] ?? 'BAC-advies'),
 					'adviceType' => (string)($merged['recommendation'] ?? ''),
 					'question' => (string)($merged['conclusion'] ?? ''),

--- a/lib/Service/Bezwaar/DecisionService.php
+++ b/lib/Service/Bezwaar/DecisionService.php
@@ -162,7 +162,7 @@ class DecisionService {
 		$record = array_merge(
 			$payload,
 			[
-				'bezwaar' => $objectionId,
+				'objectionProceeding' => $objectionId,
 				'status' => 'draft',
 			]
 		);
@@ -235,7 +235,7 @@ class DecisionService {
 		// raised on an Awb-invalid payload.
 		$this->validator->assertPublishable(decision: $current);
 
-		$objectionId = (string)($current['bezwaar'] ?? '');
+		$objectionId = (string)($current['objectionProceeding'] ?? '');
 
 		// REQ-PDRD-001 / REQ-PDRD-002: delegate the deciding to decidesk via the
 		// decidesk DecisionRequestedEvent. Fail closed — never author the besluit

--- a/lib/Service/ObjectSchemaSlugResolver.php
+++ b/lib/Service/ObjectSchemaSlugResolver.php
@@ -10,7 +10,7 @@
  * key on `@self` and never has been.
  *
  * Listeners that read `@self.schema` and compared it against a slug literal
- * (`'bezwaar'`, `'case'`, …) therefore never matched, so their handler bodies
+ * (`'objectionProceeding'`, `'case'`, …) therefore never matched, so their handler bodies
  * had never executed once — silently, with no exception and no log line. This
  * service is the single place that turns the id the payload actually carries
  * into the slug the handlers are written against, so the fix is one shared

--- a/lib/Service/Settings/SchemaSlugMap.php
+++ b/lib/Service/Settings/SchemaSlugMap.php
@@ -106,7 +106,7 @@ class SchemaSlugMap {
 		'lhsMatrix' => 'lhs_matrix_schema',
 		'lhsRecommendation' => 'lhs_recommendation_schema',
 		'location' => 'location_schema',
-		'bezwaar' => 'bezwaar_schema',
+		'objectionProceeding' => 'bezwaar_schema',
 		'bezwaaradviescommissie' => 'bezwaaradviescommissie_schema',
 		'bacAdviceRequest' => 'bac_advice_request_schema',
 		'beroep' => 'beroep_schema',

--- a/lib/Service/TenantSeedService.php
+++ b/lib/Service/TenantSeedService.php
@@ -105,7 +105,7 @@ class TenantSeedService {
 	 * @return array<int, string>
 	 */
 	private function resolveTemplatesForTier(string $tier): array {
-		$base = ['bezwaar', 'beroep', 'complaint'];
+		$base = ['objectionProceeding', 'beroep', 'complaint'];
 		if ($tier === 'standard') {
 			return array_merge($base, ['vergunning_bouw', 'vergunning_apv', 'subsidieaanvraag']);
 		}

--- a/lib/Settings/procest_register.json
+++ b/lib/Settings/procest_register.json
@@ -3308,8 +3308,8 @@
                     }
                 }
             },
-            "bezwaar": {
-                "slug": "bezwaar",
+            "objectionProceeding": {
+                "slug": "objectionProceeding",
                 "icon": "Gavel",
                 "version": "1.0.0",
                 "x-schema-org": "schema:LegalCase",
@@ -4216,7 +4216,7 @@
                     "bezwaar": {
                         "type": "string",
                         "format": "uuid",
-                        "$ref": "bezwaar",
+                        "$ref": "objectionProceeding",
                         "onDelete": "CASCADE",
                         "description": "The bezwaar case this decision belongs to",
                         "title": "Objection"
@@ -4445,7 +4445,7 @@
                     "sourceObjection": {
                         "type": "string",
                         "format": "uuid",
-                        "$ref": "bezwaar",
+                        "$ref": "objectionProceeding",
                         "description": "The bezwaar lifecycle record that escalated to beroep — immutable after appellantFilingDate is set",
                         "title": "Source Objection"
                     },
@@ -7311,7 +7311,7 @@
                     "bezwaar": {
                         "type": "string",
                         "format": "uuid",
-                        "$ref": "bezwaar",
+                        "$ref": "objectionProceeding",
                         "onDelete": "CASCADE",
                         "description": "The bezwaar (lifecycle record) being reviewed; the wrapped procest case is resolved via bezwaar.case",
                         "title": "Objection"

--- a/lib/Settings/register.d/50-subsidie.json
+++ b/lib/Settings/register.d/50-subsidie.json
@@ -116,8 +116,8 @@
                     "supportingDocumentsIndex": { "title": "Evidence Documents Index", "type": "string", "description": "JSON map verplichting_id -> [bewijsstuk_references]" }
                 }
             },
-            "tussenrapportage": {
-                "slug": "tussenrapportage",
+            "interimReport": {
+                "slug": "interimReport",
                 "icon": "FileChartOutline",
                 "version": "1.0.0",
                 "title": "Tussenrapportage",
@@ -217,7 +217,7 @@
                     "subsidieBeoordeling",
                     "subsidieBeschikking",
                     "subsidieUitvoering",
-                    "tussenrapportage",
+                    "interimReport",
                     "subsidieVaststelling",
                     "terugvordering",
                     "bewijsstuk"

--- a/lib/Settings/seed/vth-workflow-templates/bezwaar.json
+++ b/lib/Settings/seed/vth-workflow-templates/bezwaar.json
@@ -1,6 +1,6 @@
 {
   "_format": "procest-vth-workflow-template-v1",
-  "slug": "bezwaar",
+  "slug": "objectionProceeding",
   "title": "Bezwaar (VTH cross-link)",
   "description": "Cross-link entry: VTH-bezwaar volgt de canonieke bezwaar-lifecycle workflow (zie SeedBezwaarBeroepData). Deze entry voegt VTH-specifieke guards toe voor sectorale niet-ontvankelijkheidsgronden, maar redefinieert de bezwaar-workflow NIET.",
   "version": 1,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1850,7 +1850,7 @@
 			"title": "Bezwaar",
 			"config": {
 				"register": "procest",
-				"schema": "bezwaar",
+				"schema": "objectionProceeding",
 				"_note": "OBJECTION-CASE archetype (AWB bezwaar), ADR-062 round 2. `bezwaar` is a supporting schema on a unified case (bezwaar.case) and declares NO comms linkedTypes — so NO files/notes/contacts/calendar leaves here; those live on the parent CaseDetail. The lead row pairs the field-scoped 'Objection' core widget (case/objection/status/awbReference/ontvangstdatum/decisionDeadline) with an in-grid KPI stats-block (advice-request and decision counts, replacing the deprecated header summaryAggregates). The AWB statutory-clock fields (verdaging/opschorting/hearing waiver/ingebrekestelling/dwangsom) are a genuinely distinct group and get their own 'Statutory clock & suspension' data widget. The two real child collections follow as FK-scoped object-lists side by side: committee advice requests (bacAdviceRequest.bezwaar) and decisions on the objection (bezwaarDecision.bezwaar), each deep-linking to its own detail page. lifecycleActions drive the bezwaar status (Ontvangen → … → Afgehandeld). Audit history stays a sidebar tab.",
 				"documentationUrl": "https://procest.conduction.nl",
 				"widgets": [
@@ -4711,7 +4711,7 @@
 		},
 		{
 			"registerSlug": "procest",
-			"schemaSlug": "bezwaar",
+			"schemaSlug": "objectionProceeding",
 			"urlTemplate": "/apps/procest/bezwaren/{uuid}",
 			"displayName": "Bezwaar"
 		},

--- a/src/modals/TermijnDefinitieEditor.vue
+++ b/src/modals/TermijnDefinitieEditor.vue
@@ -195,7 +195,7 @@ export default {
 			return [
 				{ id: 'beslis', label: t('procest', 'Decision deadline') },
 				{ id: 'herstel', label: t('procest', 'Remediation period') },
-				{ id: 'bezwaar', label: t('procest', 'Objection period') },
+				{ id: 'objectionProceeding', label: t('procest', 'Objection period') },
 				{ id: 'beroep', label: t('procest', 'Appeal period') },
 			]
 		},

--- a/src/modals/TermijnDefinitieEditor.vue
+++ b/src/modals/TermijnDefinitieEditor.vue
@@ -195,7 +195,10 @@ export default {
 			return [
 				{ id: 'beslis', label: t('procest', 'Decision deadline') },
 				{ id: 'herstel', label: t('procest', 'Remediation period') },
-				{ id: 'objectionProceeding', label: t('procest', 'Objection period') },
+				{
+					id: 'objectionProceeding',
+					label: t('procest', 'Objection period'),
+				},
 				{ id: 'beroep', label: t('procest', 'Appeal period') },
 			]
 		},

--- a/src/store/modules/bezwaar.js
+++ b/src/store/modules/bezwaar.js
@@ -56,7 +56,7 @@ function daysDifference(dateA, dateB) {
 	return Math.ceil((dateB.getTime() - dateA.getTime()) / msPerDay)
 }
 
-export const useBezwaarStore = defineStore('bezwaar', {
+export const useBezwaarStore = defineStore('objectionProceeding', {
 	state: () => ({
 		/** @type {object|null} Current objection object */
 		currentObjection: null,

--- a/tests/Unit/Lifecycle/BezwaarLifecycleTest.php
+++ b/tests/Unit/Lifecycle/BezwaarLifecycleTest.php
@@ -56,7 +56,7 @@ final class BezwaarLifecycleTest extends TestCase {
 	protected function setUp(): void {
 		$registerPath = __DIR__ . '/../../../lib/Settings/procest_register.json';
 		$register = json_decode((string)file_get_contents($registerPath), true);
-		$objection = $register['components']['schemas']['bezwaar'] ?? [];
+		$objection = $register['components']['schemas']['objectionProceeding'] ?? [];
 		$this->lifecycle = ($objection['configuration']['x-openregister-lifecycle'] ?? []);
 	}//end setUp()
 

--- a/tests/Unit/Listener/BezwaarDecisionListenerTest.php
+++ b/tests/Unit/Listener/BezwaarDecisionListenerTest.php
@@ -98,7 +98,7 @@ class BezwaarDecisionListenerTest extends TestCase {
 			static function (string $key, string $default = ''): string {
 				return match ($key) {
 					'register' => 'procest-register',
-					'bezwaar_schema' => 'bezwaar',
+					'bezwaar_schema' => 'objectionProceeding',
 					'bezwaar_decision_schema' => 'bezwaardecision',
 					default => $default,
 				};
@@ -216,7 +216,7 @@ class BezwaarDecisionListenerTest extends TestCase {
 	private function objectionOnProtectedStatus(): array {
 		return [
 			'id' => 'bezwaar-1',
-			'@self' => ['schema' => 'bezwaar'],
+			'@self' => ['schema' => 'objectionProceeding'],
 			'status' => self::PROTECTED_STATUS,
 		];
 	}//end bezwaarOnProtectedStatus()
@@ -260,7 +260,7 @@ class BezwaarDecisionListenerTest extends TestCase {
 			[
 				'register' => 'procest-register',
 				'schema' => 'bezwaardecision',
-				'bezwaar' => 'bezwaar-1',
+				'objectionProceeding' => 'bezwaar-1',
 			],
 			$this->capturedFindAllConfig['filters'],
 			'the probe must filter by register, schema and bezwaar id'
@@ -310,7 +310,7 @@ class BezwaarDecisionListenerTest extends TestCase {
 		$this->assertNotNull($this->capturedSave, 'the guard did not revert');
 		$this->assertSame(['status' => 'In handling'], $this->capturedSave['object']);
 		$this->assertSame('bezwaar-1', $this->capturedSave['uuid']);
-		$this->assertSame('bezwaar', $this->capturedSave['schema']);
+		$this->assertSame('objectionProceeding', $this->capturedSave['schema']);
 	}//end testRevertsWhenNoDecidedDecisionExists()
 
 	/**
@@ -368,7 +368,7 @@ class BezwaarDecisionListenerTest extends TestCase {
 			$this->event(
 				[
 					'id' => 'bezwaar-1',
-					'@self' => ['schema' => 'bezwaar'],
+					'@self' => ['schema' => 'objectionProceeding'],
 					'status' => 'In handling',
 				],
 				['status' => 'Received']

--- a/tests/Unit/Listener/BezwaarLegalHoldSchemaCoverageTest.php
+++ b/tests/Unit/Listener/BezwaarLegalHoldSchemaCoverageTest.php
@@ -57,7 +57,7 @@ class BezwaarLegalHoldSchemaCoverageTest extends TestCase {
 	public function testOpeningSchemasCoverEveryAwbProceeding(): void {
 		$opens = $this->constant(name: 'PROCEEDING_OPENED_SCHEMAS');
 
-		$this->assertContains(needle: 'bezwaar', haystack: $opens);
+		$this->assertContains(needle: 'objectionProceeding', haystack: $opens);
 		$this->assertContains(needle: 'objection', haystack: $opens);
 		$this->assertContains(
 			needle: 'beroep',
@@ -81,7 +81,7 @@ class BezwaarLegalHoldSchemaCoverageTest extends TestCase {
 
 		$counterparts = [
 			'appealDecision' => 'beroep',
-			'bezwaarDecision' => 'bezwaar',
+			'bezwaarDecision' => 'objectionProceeding',
 		];
 
 		foreach ($closes as $closingSchema) {

--- a/tests/Unit/Repair/SeedBezwaarBeroepDataTest.php
+++ b/tests/Unit/Repair/SeedBezwaarBeroepDataTest.php
@@ -113,8 +113,8 @@ class SeedBezwaarBeroepDataTest extends TestCase {
 
 		// The name should mention bezwaar/beroep so it is recognizable in logs.
 		$this->assertTrue(
-			stripos($name, 'bezwaar') !== false || stripos($name, 'beroep') !== false,
-			"Repair step name should mention 'bezwaar' or 'beroep', got: {$name}"
+			stripos($name, 'objectionProceeding') !== false || stripos($name, 'beroep') !== false,
+			"Repair step name should mention 'objectionProceeding' or 'beroep', got: {$name}"
 		);
 
 	}//end testGetNameDescribesBezwaarBeroep()

--- a/tests/Unit/Service/Ai/AiAuditServiceRecordTest.php
+++ b/tests/Unit/Service/Ai/AiAuditServiceRecordTest.php
@@ -90,7 +90,7 @@ class AiAuditServiceRecordTest extends TestCase {
 			type: 'classification',
 			userAction: 'modified',
 			suggestion: ['documentType' => 'request'],
-			actualValue: ['documentType' => 'bezwaar'],
+			actualValue: ['documentType' => 'objectionProceeding'],
 			reason: 'misread the header',
 			userId: 'alice',
 		);
@@ -102,7 +102,7 @@ class AiAuditServiceRecordTest extends TestCase {
 		$this->assertSame('case-1', $captured['caseId']);
 		$this->assertSame('openai/gpt-4o', $captured['model']);
 		$this->assertSame(['documentType' => 'request'], $captured['suggestion']);
-		$this->assertSame(['documentType' => 'bezwaar'], $captured['actualValue']);
+		$this->assertSame(['documentType' => 'objectionProceeding'], $captured['actualValue']);
 		$this->assertSame('misread the header', $captured['reason']);
 		$this->assertSame('alice', $captured['userId']);
 		$this->assertNotEmpty($captured['timestamp']);

--- a/tests/Unit/Service/CaseReassignmentServiceTest.php
+++ b/tests/Unit/Service/CaseReassignmentServiceTest.php
@@ -172,7 +172,7 @@ class CaseReassignmentServiceTest extends TestCase {
 				if ($schema === 'case') {
 					return [
 						['id' => 'c1', 'assignee' => 'jan', 'status' => 'open', 'caseType' => 'vth'],
-						['id' => 'c2', 'assignee' => 'jan', 'status' => 'open', 'caseType' => 'bezwaar'],
+						['id' => 'c2', 'assignee' => 'jan', 'status' => 'open', 'caseType' => 'objectionProceeding'],
 					];
 				}
 				if ($schema === 'task') {

--- a/tests/Unit/Service/SubstitutionAuditServiceTest.php
+++ b/tests/Unit/Service/SubstitutionAuditServiceTest.php
@@ -110,7 +110,7 @@ class SubstitutionAuditServiceTest extends TestCase {
 	 */
 	public function testStampsSubstitutedAction(): void {
 		$os = $this->objectServiceMock();
-		$os->method('find')->willReturn(['id' => 'case-1', 'assignee' => 'jan', 'caseType' => 'bezwaar', 'activity' => '[]']);
+		$os->method('find')->willReturn(['id' => 'case-1', 'assignee' => 'jan', 'caseType' => 'objectionProceeding', 'activity' => '[]']);
 		$captured = null;
 		$os->expects($this->once())->method('updateObject')->willReturnCallback(
 			function (string $r, string $s, string $id, array $payload) use (&$captured) {

--- a/tests/Unit/Service/SubstitutionServiceTest.php
+++ b/tests/Unit/Service/SubstitutionServiceTest.php
@@ -208,7 +208,7 @@ class SubstitutionServiceTest extends TestCase {
 			startDate: '2026-07-01',
 			endDate: '2026-07-21',
 			scope: 'caseTypes',
-			scopeRefs: ['bezwaar']
+			scopeRefs: ['objectionProceeding']
 		);
 
 		$this->assertSame('jan', $result['absentee']);
@@ -284,7 +284,7 @@ class SubstitutionServiceTest extends TestCase {
 	 * @return void
 	 */
 	public function testGetSubstitutedWorkScopeFilter(): void {
-		$sub = ['id' => 'sub-2', 'absentee' => 'jan', 'substitute' => 'marieke', 'scope' => 'caseTypes', 'scopeRefs' => ['bezwaar'], 'status' => 'active', 'startDate' => '2026-07-01', 'endDate' => '2026-07-21'];
+		$sub = ['id' => 'sub-2', 'absentee' => 'jan', 'substitute' => 'marieke', 'scope' => 'caseTypes', 'scopeRefs' => ['objectionProceeding'], 'status' => 'active', 'startDate' => '2026-07-01', 'endDate' => '2026-07-21'];
 
 		$os = $this->objectServiceMock();
 		$os->method('searchObjectsBySlug')->willReturnCallback(
@@ -297,9 +297,9 @@ class SubstitutionServiceTest extends TestCase {
 				}
 				if ($schema === 'case') {
 					return [
-						['id' => 'case-a', 'caseType' => 'bezwaar', 'assignee' => 'jan', 'status' => 'st-open'],
+						['id' => 'case-a', 'caseType' => 'objectionProceeding', 'assignee' => 'jan', 'status' => 'st-open'],
 						['id' => 'case-b', 'caseType' => 'vergunning', 'assignee' => 'jan', 'status' => 'st-open'],
-						['id' => 'case-c', 'caseType' => 'bezwaar', 'assignee' => 'jan', 'status' => 'st-final'],
+						['id' => 'case-c', 'caseType' => 'objectionProceeding', 'assignee' => 'jan', 'status' => 'st-final'],
 					];
 				}
 				if ($schema === 'task') {
@@ -329,7 +329,7 @@ class SubstitutionServiceTest extends TestCase {
 		$os->method('searchObjectsBySlug')->willReturn([$sub]);
 		$service = $this->makeService($os);
 
-		$cap = $service->resolveActingCapacity('marieke', 'jan', 'case-x', 'bezwaar', new DateTimeImmutable('2026-07-10'));
+		$cap = $service->resolveActingCapacity('marieke', 'jan', 'case-x', 'objectionProceeding', new DateTimeImmutable('2026-07-10'));
 		$this->assertNotNull($cap);
 		$this->assertSame('sub-3', $cap['id']);
 

--- a/tests/Unit/Settings/BezwaarCalculationRegistryTest.php
+++ b/tests/Unit/Settings/BezwaarCalculationRegistryTest.php
@@ -81,7 +81,7 @@ final class BezwaarCalculationRegistryTest extends TestCase {
 		$path = __DIR__ . '/../../../lib/Settings/procest_register.json';
 		$json = json_decode((string)file_get_contents($path), true);
 		$this->assertIsArray($json, 'register JSON must parse');
-		$objection = $json['components']['schemas']['bezwaar'] ?? null;
+		$objection = $json['components']['schemas']['objectionProceeding'] ?? null;
 		$this->assertIsArray($objection, 'bezwaar schema must exist');
 		$this->calcs = $objection['x-openregister-calculations'] ?? [];
 	}//end setUp()

--- a/tests/Unit/Settings/SubsidieFragmentTest.php
+++ b/tests/Unit/Settings/SubsidieFragmentTest.php
@@ -52,7 +52,7 @@ class SubsidieFragmentTest extends TestCase {
 		'subsidieBeoordeling',
 		'subsidieBeschikking',
 		'subsidieUitvoering',
-		'tussenrapportage',
+		'interimReport',
 		'subsidieVaststelling',
 		'terugvordering',
 		'bewijsstuk',

--- a/tests/e2e/workflows/complaints-bezwaar.spec.ts
+++ b/tests/e2e/workflows/complaints-bezwaar.spec.ts
@@ -74,7 +74,7 @@ test.describe.fixme('Complaint-family workflow — bezwaren (objections)', () =>
 	})
 
 	test.afterAll(async () => {
-		await cleanupRunObjects(api, token, ['bezwaar', 'case'])
+		await cleanupRunObjects(api, token, ['objectionProceeding', 'case'])
 		if (caseTypeSeeded) await deleteObject(api, token, 'caseType', caseTypeId)
 		await api.dispose()
 	})
@@ -85,7 +85,7 @@ test.describe.fixme('Complaint-family workflow — bezwaren (objections)', () =>
 	 * @param status The initial workflow status.
 	 */
 	async function seedBezwaar(awb: string, status = 'Received'): Promise<any> {
-		return createObject(api, token, 'bezwaar', {
+		return createObject(api, token, 'objectionProceeding', {
 			case: caseId,
 			receipt_date: '2026-06-01',
 			status,
@@ -139,13 +139,13 @@ test.describe.fixme('Complaint-family workflow — bezwaren (objections)', () =>
 		const bzId = objectId(bz)
 
 		// Advance the workflow status (a valid value from the bezwaar enum).
-		await updateObject(api, token, 'bezwaar', bzId, { status: 'In handling' })
+		await updateObject(api, token, 'objectionProceeding', bzId, { status: 'In handling' })
 
 		// PERSISTENCE: re-read confirms the new status was written.
 		await expect
 			.poll(
 				async () =>
-					String((await showObject(api, 'bezwaar', bzId)).status ?? ''),
+					String((await showObject(api, 'objectionProceeding', bzId)).status ?? ''),
 				{
 					timeout: 15000,
 					message: 'bezwaar status persisted',

--- a/tests/e2e/workflows/complaints-bezwaar.spec.ts
+++ b/tests/e2e/workflows/complaints-bezwaar.spec.ts
@@ -139,13 +139,18 @@ test.describe.fixme('Complaint-family workflow — bezwaren (objections)', () =>
 		const bzId = objectId(bz)
 
 		// Advance the workflow status (a valid value from the bezwaar enum).
-		await updateObject(api, token, 'objectionProceeding', bzId, { status: 'In handling' })
+		await updateObject(api, token, 'objectionProceeding', bzId, {
+			status: 'In handling',
+		})
 
 		// PERSISTENCE: re-read confirms the new status was written.
 		await expect
 			.poll(
 				async () =>
-					String((await showObject(api, 'objectionProceeding', bzId)).status ?? ''),
+					String(
+						(await showObject(api, 'objectionProceeding', bzId)).status
+							?? '',
+					),
 				{
 					timeout: 15000,
 					message: 'bezwaar status persisted',

--- a/tests/vitest/searchableSchemas.spec.js
+++ b/tests/vitest/searchableSchemas.spec.js
@@ -21,7 +21,7 @@ const REGISTER_PATH = path.resolve(
 )
 const MANIFEST_PATH = path.resolve(__dirname, '../../src/manifest.json')
 
-const EXPECTED_SEARCHABLE_SLUGS = ['case', 'task', 'bezwaar', 'proposal', 'beroep']
+const EXPECTED_SEARCHABLE_SLUGS = ['case', 'task', 'objectionProceeding', 'proposal', 'beroep']
 
 const loadJson = (filePath) => JSON.parse(fs.readFileSync(filePath, 'utf8'))
 

--- a/tests/vitest/searchableSchemas.spec.js
+++ b/tests/vitest/searchableSchemas.spec.js
@@ -66,7 +66,10 @@ describe('deep links cover all searchable schemas', () => {
 		const expectedTemplates = {
 			case: '/apps/procest/cases/{uuid}',
 			task: '/apps/procest/tasks/{uuid}',
-			bezwaar: '/apps/procest/bezwaren/{uuid}',
+			// The KEY is the schema slug and moved with it; the URL is a published
+			// ROUTE and deliberately did not — a route resolves at request time,
+			// so breaking one fails silently.
+			objectionProceeding: '/apps/procest/bezwaren/{uuid}',
 			proposal: '/apps/procest/voorstellen/{uuid}',
 			beroep: '/apps/procest/beroepen/{uuid}',
 		}
@@ -74,7 +77,7 @@ describe('deep links cover all searchable schemas', () => {
 		const expectedRoutes = {
 			case: '/cases/:id',
 			task: '/tasks/:id',
-			bezwaar: '/bezwaren/:id',
+			objectionProceeding: '/bezwaren/:id',
 			proposal: '/voorstellen/:id',
 			beroep: '/beroepen/:id',
 		}

--- a/tests/vitest/searchableSchemas.spec.js
+++ b/tests/vitest/searchableSchemas.spec.js
@@ -21,7 +21,13 @@ const REGISTER_PATH = path.resolve(
 )
 const MANIFEST_PATH = path.resolve(__dirname, '../../src/manifest.json')
 
-const EXPECTED_SEARCHABLE_SLUGS = ['case', 'task', 'objectionProceeding', 'proposal', 'beroep']
+const EXPECTED_SEARCHABLE_SLUGS = [
+	'case',
+	'task',
+	'objectionProceeding',
+	'proposal',
+	'beroep',
+]
 
 const loadJson = (filePath) => JSON.parse(fs.readFileSync(filePath, 'utf8'))
 


### PR DESCRIPTION
`bezwaar` → `objectionProceeding`, `tussenrapportage` → `interimReport`. 56 substitutions across 30 files, plus both `/components/schemas/` map keys.

## Why `objectionProceeding` and not `objection`

procest declares **both** `bezwaar` and `objection`, and they are two entities with **zero shared properties**:

| schema | what it holds |
|---|---|
| `objection` | the SUBMISSION — `contestedDecision`, `grounds`, `requestedRelief`, `receivedDate`, `isTimely` |
| `bezwaar` | the Awb PROCEEDING around it — `case`, a ref to that objection, `status`, `awbReference`, `receiptDate`, `adjournedOn`, `suspensionStart` |

An earlier attempt renamed the first onto the second and produced a **duplicate JSON key** — legal, parses fine, and every parser keeps only the last, silently dropping one schema's lifecycle and calculations.

Both slugs are in `RenameDutchSchemaSlugs::SLUG_MAP`, which is not optional: OpenRegister's ImportHandler matches by **slug**, so a renamed slug without the migration makes the import create a *second* schema and strands every stored object behind one nothing reads.

## Two tool defects, fixed at the source

This batch reproduced both, which is why they are fixed here rather than worked around:

1. **`rename-slugs.js` handled `$ref` only in its PATH form.** A `$ref` may name its target by **bare schema key** (`"$ref": "catalogus"`). procest#849 shipped **five** dangling ones that I repaired by hand — and I fixed the instances then and *not* the tool, so it happened again here (3 more). A dangling `$ref` is valid JSON, passes every linter, breaks no test; the relation just stops resolving and the picker comes up empty.

2. **Its `EXCLUDE` named only its own step**, so the slug pass walked into `RenameDutchValueDecisions.php` — a *different* migration's map — and turned `'tussenrapportage' => 'interimReport'` into `'interimReport' => 'interimReport'`. An identity entry migrates nothing and reports success. That migration's own identity test caught it. Now matched by prefix **and** by content (any file declaring a `VALUE_MAP`/`COLUMN_MAP`/`SLUG_MAP`), with every skip logged — a silent skip and a file with nothing to change look identical.

⚠️ Worth noting for anyone using the tool: its **dry run under-reports**. It printed `+0 schema map keys` where the apply did `+2`. The apply is correct; the counter is not.

## Verification

- **0** dangling `$ref`s across 29 register files (156 schema keys)
- no duplicate JSON keys, checked with `object_pairs_hook`
- PHPUnit failing set **identical to development** — 0 introduced