### PR TITLE
fix(register): gate-54 — statustype's relation filter still names the pre-rename `zaaktype` property

### DIFF
--- a/lib/Settings/procest_register.json
+++ b/lib/Settings/procest_register.json
@@ -2355,7 +2355,7 @@
                         "format": "uuid",
                         "$ref": "statusType",
                         "x-relation-filter": {
-                            "caseType": "@object.zaaktype"
+                            "caseType": "@object.caseType"
                         },
                         "description": "Reference to a status type",
                         "title": "Status Type Reference"


### PR DESCRIPTION
## What

`zaaktypeInformatieobjecttype.statustype` carries `x-relation-filter: { "caseType": "@object.zaaktype" }`, but that schema has no `zaaktype` property — it has `caseType`. Repointed to `@object.caseType`.

## This one is INTRODUCED, not legacy debt

The CI verdict said *"this run knew no base, so NONE of these could be classified as introduced or inherited"*, so the first job was to establish which it was. `git log -S` answers it:

`75f578d2` — **refactor(procest): translate Dutch vocabulary to English, with migration (#832)** — renamed `zaaktype` → `caseType`. The **two sibling tokens on the same register were updated** (`procest_register.json:1055` and `:1274` both read `@object.caseType` today); this third one was missed. So it is a rename miss, not historical backlog.

Same shape as softwarecatalog #526, found in the same sweep: a Dutch→English codemod that reaches bare identifier keys but not a quoted compound token embedding the same name behind an `@object.` prefix. Two of the fleet's three gate-54 repos have it.

## Effect of the defect (it was not cosmetic)

ADR-062 rule 6: *"Unresolved tokens drop their entry: an unfiltered picker beats an empty one."* So since #832 the status-type picker on a zaaktype-informatieobjecttype row has been offering **every** `statusType` in the register, instead of only those belonging to that row's case type. This is precisely the per-caseType status-graph scoping that ADR-062 rule 10 cites procest as the reference implementation for.

## Not a data migration

`x-relation-filter` is picker-scoping metadata naming a sibling property. No property is renamed and no stored value changes — #832 already carried the data migration.

## Both sides of the token verified by hand

Gate check (d) validates only the **value** side (`@object.<field>` must exist on the same schema). The **key** side (must be a property of the *target* schema) is unchecked, so it was verified manually:

| | resolves? |
|---|---|
| filter key `caseType` on target `statusType` | `statusType.caseType` ✔ |
| token `@object.caseType` on self | `zaaktypeInformatieobjecttype.caseType` ✔ |

All five `@object.` tokens in `lib/Settings/` were audited; the other four already resolve.

## Evidence — gate-54's own script, on its own paths

Instrument: `check_relation_dialect.py` from the vendored `conduction/hydra-gates` package, blob `3d4c81ca` — **byte-identical to `ConductionNL/.github@main`**, i.e. the copy CI actually runs (`openregister`'s vendored copy is v1.7.0 and stale; this is v1.7.3).

File enumeration reproduces the runner's own `_enum_tracked` exactly: `git ls-files -- lib/Settings` filtered to `(register[^/]*\.json|/register\.d/[^/]*\.json)$`.

```
BEFORE:  FILES_IN_SCOPE=22   FAIL=1  WARN=0   HELPER_EXIT=0
AFTER:   FILES_IN_SCOPE=22   FAIL=0  WARN=0   HELPER_EXIT=0
```

**1 finding over 22 files → 0 findings over 22 files.** The 1 reproduces baseline run `31931239578` exactly, so the instrument is measuring the same thing CI did. 22 files were actually opened — this is a verdict, not an empty scope.

JSON re-parsed clean after the edit. No test in `tests/` asserts `x-relation-filter`.

## Known adjacent debt, deliberately NOT touched

The property is still named `statustype` (lowercase, Dutch) while its `$ref` correctly targets `statusType`. Renaming the **property** would rewrite the key on every stored object — that is a data migration and belongs with a `Repair` step, not in a filter-token repair. Left as-is and recorded on the fleet board.

## Checks

- `composer check:strict` — **not run, and it cannot be affected**: this PR changes one `.json` file and zero PHP. PHPCS/PHPMD/Psalm/PHPStan have no input here, so there is no L10 debt to inherit.
- Edit made with the Edit tool. No `sed`, no codemod — this finding *is* what a codemod did.

## Baseline parity

Baseline for this repo (§1) is run `31931239578` at `67952ad1`, which this branch is cut from. It is red on **Hydra Gates** (9 gates) and **Quality Report**. This PR should clear gate-54 and change nothing else; the other 8 gates are owned by S3 and S5.