### PR TITLE
fix(e2e): de-race 9 test.skip() gates on the non-waiting isVisible()

### DIFF
--- a/tests/e2e/helpers/becomes-visible.js
+++ b/tests/e2e/helpers/becomes-visible.js
@@ -1,0 +1,59 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * A POLLING visibility probe, for use as a `test.skip()` condition.
+ *
+ * ⚠️ WHY THIS FILE EXISTS — `locator.isVisible()` DOES NOT WAIT.
+ * ------------------------------------------------------------------
+ * `Locator.isVisible()` is an *immediate* predicate: it answers "is this
+ * element visible on this tick". Its `timeout` option is **ignored** — passing
+ * `{ timeout: 10000 }` buys nothing at all, which is precisely why Playwright
+ * deprecated the option. Only `expect(...).toBeVisible()` and
+ * `locator.waitFor()` poll.
+ *
+ * So this shape, which this repo used in three spec files:
+ *
+ *     await page.goto('/index.php/apps/procest/workflow-board')
+ *     if (!(await heading.isVisible({ timeout: 10000 }).catch(() => false))) {
+ *         test.skip(true, 'Workflow Board surface not deployed in target instance')
+ *     }
+ *
+ * asks the question before the SPA has issued a single XHR. It answers "no"
+ * essentially always, and the test skips **with a reason that is false**.
+ *
+ * 🔑 And these reasons ARE false. `/workflow-board` is a declared route in
+ * `src/manifest.json` carrying the title "Workflow Board", and "Case Type
+ * Management" is a real heading rendered by `src/views/settings/AdminRoot.vue`.
+ * Both surfaces ship. The instrument looked too early and then blamed the
+ * deployment.
+ *
+ * A SKIP WHOSE STATED REASON IS UNTRUE IS AN INVISIBLE PASS — worse than a
+ * stub assertion, because it renders as "not applicable" rather than as a gap,
+ * the reason looks investigated, and it inflates the skip count, which is the
+ * number that separates a flake from a regression. procest skipped 38 of 128.
+ *
+ * `waitFor` polls. **The skip that survives it is a real one.**
+ *
+ * The `test.skip()` calls are deliberately KEPT: the fix is not to unskip, it
+ * is to make the gate tell the truth.
+ */
+
+/**
+ * Wait up to `timeout` for a locator to become visible; return whether it did.
+ *
+ * @param {import('@playwright/test').Locator} locator The locator to poll.
+ *        `.first()` is applied so a strict-mode violation on a multi-match
+ *        selector cannot masquerade as an absence.
+ * @param {number} [timeout] Milliseconds to poll for. Default 10s — enough for
+ *        a Nextcloud SPA route to mount and fetch.
+ * @return {Promise<boolean>} `true` when the element became visible within
+ *         `timeout`, else `false`. Never throws.
+ */
+export async function becomesVisible(locator, timeout = 10000) {
+	return await locator
+		.first()
+		.waitFor({ state: 'visible', timeout })
+		.then(() => true)
+		.catch(() => false)
+}

--- a/tests/e2e/helpers/becomes-visible.js
+++ b/tests/e2e/helpers/becomes-visible.js
@@ -22,18 +22,38 @@
  * asks the question before the SPA has issued a single XHR. It answers "no"
  * essentially always, and the test skips **with a reason that is false**.
  *
- * 🔑 And these reasons ARE false. `/workflow-board` is a declared route in
- * `src/manifest.json` carrying the title "Workflow Board", and "Case Type
- * Management" is a real heading rendered by `src/views/settings/AdminRoot.vue`.
- * Both surfaces ship. The instrument looked too early and then blamed the
- * deployment.
- *
  * A SKIP WHOSE STATED REASON IS UNTRUE IS AN INVISIBLE PASS — worse than a
  * stub assertion, because it renders as "not applicable" rather than as a gap,
  * the reason looks investigated, and it inflates the skip count, which is the
- * number that separates a flake from a regression. procest skipped 38 of 128.
+ * number that separates a flake from a regression. procest skips 38 of 128.
  *
  * `waitFor` polls. **The skip that survives it is a real one.**
+ *
+ * ⚠️ AND HERE THEY ALL SURVIVED IT — READ THIS BEFORE REPEATING MY MISTAKE.
+ * ------------------------------------------------------------------------
+ * An earlier version of this comment asserted that procest's skip reasons were
+ * FALSE, reasoning that `/workflow-board` is a declared route in
+ * `src/manifest.json`, that `WorkflowBoardView` resolves in `src/registry.js`,
+ * and that `WorkflowBoard.vue` renders an **unconditional** `<h2>Workflow
+ * Board</h2>`. All three facts are true. **The conclusion drawn from them was
+ * not.**
+ *
+ * Measured: with these polling gates in place, the tally is **unchanged** —
+ * 128 collected, 90 passed, 38 skipped, byte-identical to the baseline, with
+ * the app's 3.1 MB bundle confirmed served (HTTP 200), so this is not the
+ * "e2e suite measuring an unbuilt app" trap either. The elements genuinely do
+ * not appear, and the skips are therefore **honest**.
+ *
+ * 🔑 SOURCE CODE PROVES A SURFACE IS DECLARED. IT DOES NOT PROVE IT RENDERS.
+ * A route can be declared, registered, and unreachable — the remaining suspect
+ * here is the server-side URL the specs navigate to
+ * (`/index.php/apps/procest/workflow-board`) versus where the SPA actually
+ * mounts that page. That is an app/routing question, not a Playwright one.
+ *
+ * So this file's value is NOT that it unskipped anything. It is that the 38
+ * skips are now **believable**: each survived a 10–15 s poll, so it reports a
+ * real absence rather than a race, and the next person to investigate can
+ * trust the number instead of re-deriving it.
  *
  * The `test.skip()` calls are deliberately KEPT: the fix is not to unskip, it
  * is to make the gate tell the truth.

--- a/tests/e2e/helpers/becomes-visible.js
+++ b/tests/e2e/helpers/becomes-visible.js
@@ -29,34 +29,52 @@
  *
  * `waitFor` polls. **The skip that survives it is a real one.**
  *
- * ⚠️ AND HERE THEY ALL SURVIVED IT — READ THIS BEFORE REPEATING MY MISTAKE.
- * ------------------------------------------------------------------------
- * An earlier version of this comment asserted that procest's skip reasons were
- * FALSE, reasoning that `/workflow-board` is a declared route in
- * `src/manifest.json`, that `WorkflowBoardView` resolves in `src/registry.js`,
- * and that `WorkflowBoard.vue` renders an **unconditional** `<h2>Workflow
- * Board</h2>`. All three facts are true. **The conclusion drawn from them was
- * not.**
+ * ⚠️ THE COUNT DID NOT MOVE — AND THAT IS NOT THE SAME AS "THE REASONS WERE TRUE".
+ * ---------------------------------------------------------------------------
+ * Measured with these polling gates in place: 128 collected, 90 passed,
+ * 38 skipped — byte-identical to the baseline. It is worth being precise about
+ * what that does and does not show, because I got it wrong twice.
  *
- * Measured: with these polling gates in place, the tally is **unchanged** —
- * 128 collected, 90 passed, 38 skipped, byte-identical to the baseline, with
- * the app's 3.1 MB bundle confirmed served (HTTP 200), so this is not the
- * "e2e suite measuring an unbuilt app" trap either. The elements genuinely do
- * not appear, and the skips are therefore **honest**.
+ * I first asserted the reasons were FALSE (reasoning from source: the route is
+ * declared, the component resolves, the `<h2>` is unconditional). I then
+ * over-corrected and wrote that they were all TRUE, because the count had not
+ * moved. **Both were wrong, because the question is PER GATE and the count
+ * cannot answer it.** The kanban test has two gates in series:
  *
- * 🔑 SOURCE CODE PROVES A SURFACE IS DECLARED. IT DOES NOT PROVE IT RENDERS.
- * A route can be declared, registered, and unreachable — the remaining suspect
- * here is the server-side URL the specs navigate to
- * (`/index.php/apps/procest/workflow-board`) versus where the SPA actually
- * mounts that page. That is an app/routing question, not a Playwright one.
+ *   1. heading "Workflow Board"  → "Workflow Board surface not deployed in
+ *                                   target instance"        ← REASON IS FALSE
+ *   2. `.case-card`              → "No cases on the Workflow Board to
+ *                                   exercise the move control" ← REASON IS TRUE
  *
- * So this file's value is NOT that it unskipped anything. It is that the 38
- * skips are now **believable**: each survived a 10–15 s poll, so it reports a
- * real absence rather than a race, and the next person to investigate can
- * trust the number instead of re-deriving it.
+ * Gate 1's reason is false, and the proof is a SIBLING TEST THAT PASSES IN THE
+ * SAME RUN: `spec-coverage/workflow-operations.spec.ts:18` reaches
+ * `/index.php/apps/procest/workflow-board` by the identical navigation
+ * (`navToRoute` is literally `page.goto('/index.php/apps/procest'+route)` plus
+ * the same dialog dismissal) and asserts `.workflow-board__header h2` visible.
+ * The board renders.
  *
- * The `test.skip()` calls are deliberately KEPT: the fix is not to unskip, it
- * is to make the gate tell the truth.
+ * Gate 2's reason is true, and the proof is also a passing test:
+ * `workflows/case-lifecycle.spec.ts:185` is the only spec that sees case cards
+ * — and it **seeds two cases itself** before looking. This file's specs seed
+ * nothing, so there are no cards, and "no cases on the board" is exactly right.
+ *
+ * 🔑 SO THE SKIP MOVED FROM A FALSE REASON TO A TRUE ONE, AND THE COUNT — the
+ * only thing CI reports — COULD NOT SHOW IT. De-racing gate 1 simply hands
+ * control to gate 2. A stable skip count is compatible with every reason
+ * underneath it changing.
+ *
+ * 🔑 AND SOURCE CODE PROVES A SURFACE IS DECLARED, NOT THAT IT RENDERS. What
+ * settled both gates was not reading the app — it was finding a PASSING TEST
+ * that already exercised the same thing. Prefer that evidence.
+ *
+ * ➡️ FOLLOW-UP, EVIDENCED AND NOT DONE HERE: to actually recover these tests,
+ * seed cases the way `case-lifecycle.spec.ts` does rather than hoping the
+ * shared fixture has some. That is a fixture change, not a timing change, and
+ * it belongs in its own reviewed commit.
+ *
+ * So this file's value is NOT that it unskipped anything. It is that each
+ * surviving skip now reports a real absence rather than a race, so the next
+ * person can trust it instead of re-deriving it — as I had to, twice.
  */
 
 /**

--- a/tests/e2e/helpers/becomes-visible.js
+++ b/tests/e2e/helpers/becomes-visible.js
@@ -29,52 +29,55 @@
  *
  * `waitFor` polls. **The skip that survives it is a real one.**
  *
- * ⚠️ THE COUNT DID NOT MOVE — AND THAT IS NOT THE SAME AS "THE REASONS WERE TRUE".
- * ---------------------------------------------------------------------------
- * Measured with these polling gates in place: 128 collected, 90 passed,
- * 38 skipped — byte-identical to the baseline. It is worth being precise about
- * what that does and does not show, because I got it wrong twice.
+ * ⚠️ NOTHING MOVED — AND THE RECORDED REASONS SAY WHY. READ THIS FIRST.
+ * ---------------------------------------------------------------------
+ * Measured base vs branch: 128 collected, 90 passed, 38 skipped on BOTH, and —
+ * decisively — the SKIP REASONS THEMSELVES ARE IDENTICAL on both sides. They
+ * are recoverable from the `playwright-report` artifact (recipe at the bottom).
  *
- * I first asserted the reasons were FALSE (reasoning from source: the route is
- * declared, the component resolves, the `<h2>` is unconditional). I then
- * over-corrected and wrote that they were all TRUE, because the count had not
- * moved. **Both were wrong, because the question is PER GATE and the count
- * cannot answer it.** The kanban test has two gates in series:
+ * The reasons actually recorded, base and branch alike:
  *
- *   1. heading "Workflow Board"  → "Workflow Board surface not deployed in
- *                                   target instance"        ← REASON IS FALSE
- *   2. `.case-card`              → "No cases on the Workflow Board to
- *                                   exercise the move control" ← REASON IS TRUE
+ *    12  Sub-cases tab not present in the deployed build (deploy mismatch).
+ *     9  Related cases sidebar tab not present in the deployed build (…).
+ *     9  No case types in the deployed/seeded register — the Workflow tab is
+ *        data-dependent.
+ *     3  No cases on the Workflow Board to exercise the move control
+ *     3  No cases on the Workflow Board to exercise the drag path
+ *     3  OR addresses register not installed (sibling change not shipped)
  *
- * Gate 1's reason is false, and the proof is a SIBLING TEST THAT PASSES IN THE
- * SAME RUN: `spec-coverage/workflow-operations.spec.ts:18` reaches
- * `/index.php/apps/procest/workflow-board` by the identical navigation
- * (`navToRoute` is literally `page.goto('/index.php/apps/procest'+route)` plus
- * the same dialog dismissal) and asserts `.workflow-board__header h2` visible.
- * The board renders.
+ * 🔑 NOTE WHAT IS ABSENT: "Workflow Board surface not deployed in target
+ * instance" — the reason I twice argued about — **never fires, on either side.**
+ * That gate was already passing before this change; the non-waiting probe
+ * happened to win. The gates that actually fire are the SECOND ones in each
+ * chain, and their reasons are true: these specs seed nothing, and the only
+ * spec that ever sees case cards (`workflows/case-lifecycle.spec.ts:185`)
+ * **seeds two cases itself** first.
  *
- * Gate 2's reason is true, and the proof is also a passing test:
- * `workflows/case-lifecycle.spec.ts:185` is the only spec that sees case cards
- * — and it **seeds two cases itself** before looking. This file's specs seed
- * nothing, so there are no cards, and "no cases on the board" is exactly right.
+ * So the honest verdict for these nine gates is: **they were latent, not
+ * false.** Nothing here was an invisible pass. The value of this change is that
+ * each surviving skip now reports a real absence instead of depending on a
+ * probe that could not have known — not that any test was recovered.
  *
- * 🔑 SO THE SKIP MOVED FROM A FALSE REASON TO A TRUE ONE, AND THE COUNT — the
- * only thing CI reports — COULD NOT SHOW IT. De-racing gate 1 simply hands
- * control to gate 2. A stable skip count is compatible with every reason
- * underneath it changing.
+ * ➡️ WHERE THE REAL SUSPECTS ARE, AND THEY ARE NOT `isVisible()`:
+ * The two largest clusters above (21 of 39 records) come from
+ * `spec-coverage/deelzaak-support.spec.ts` and
+ * `spec-coverage/related-case-linking.spec.ts`, which gate on
+ * **`(await tab.count()) === 0`** after a bare `waitForTimeout(1000)`.
+ * `count()` DOES NOT WAIT EITHER — it is the same defect with a different
+ * method name, invisible to any `isVisible` grep — and the reason blames the
+ * DEPLOYMENT ("deploy mismatch"), which is the tell. "Sub-cases" is declared in
+ * `src/manifest.json`. **Unverified**, deliberately: declaration is not
+ * rendering, and this file has already been wrong about that once.
  *
- * 🔑 AND SOURCE CODE PROVES A SURFACE IS DECLARED, NOT THAT IT RENDERS. What
- * settled both gates was not reading the app — it was finding a PASSING TEST
- * that already exercised the same thing. Prefer that evidence.
- *
- * ➡️ FOLLOW-UP, EVIDENCED AND NOT DONE HERE: to actually recover these tests,
- * seed cases the way `case-lifecycle.spec.ts` does rather than hoping the
- * shared fixture has some. That is a fixture change, not a timing change, and
- * it belongs in its own reviewed commit.
- *
- * So this file's value is NOT that it unskipped anything. It is that each
- * surviving skip now reports a real absence rather than a race, so the next
- * person can trust it instead of re-deriving it — as I had to, twice.
+ * 🔑 HOW TO CHECK A SKIP REASON (this is the instrument, and it is cheap):
+ *   1. download the run's `playwright-report` artifact and unzip it;
+ *   2. the report data is base64 inside index.html:
+ *      `<script id="playwrightReportBase64">data:application/zip;base64,…`
+ *   3. b64-decode → it is a ZIP of JSON → collect every
+ *      `{"type":"skip","description":…}`.
+ * The `list` reporter drops reasons entirely, so the CI log CANNOT answer this.
+ * Compare the reason SETS between base and branch — the skip COUNT is the one
+ * number that cannot tell you whether a reason changed.
  */
 
 /**

--- a/tests/e2e/spec-coverage/handler-vervanging-waarneming.spec.ts
+++ b/tests/e2e/spec-coverage/handler-vervanging-waarneming.spec.ts
@@ -15,6 +15,7 @@
  */
 
 import { test, expect } from '@playwright/test'
+import { becomesVisible } from '../helpers/becomes-visible.js'
 import { dismissSupportDialog } from '../helpers/nav'
 
 test.describe('Handler vervanging/waarneming spec coverage', () => {
@@ -25,7 +26,7 @@ test.describe('Handler vervanging/waarneming spec coverage', () => {
 		await page.goto('/index.php/apps/procest/substitution')
 		await dismissSupportDialog(page)
 		const heading = page.getByRole('heading', { name: /Substitution/ }).first()
-		if (await heading.isVisible({ timeout: 10000 }).catch(() => false)) {
+		if (await becomesVisible(heading)) {
 			await expect(
 				page.getByRole('button', { name: /Register substitution/ }).first(),
 			).toBeVisible()
@@ -46,7 +47,7 @@ test.describe('Handler vervanging/waarneming spec coverage', () => {
 		const btn = page
 			.getByRole('button', { name: /Register substitution/ })
 			.first()
-		if (await btn.isVisible({ timeout: 10000 }).catch(() => false)) {
+		if (await becomesVisible(btn)) {
 			await btn.click()
 			await expect(
 				page.getByText(/Substitute \(user id\)/).first(),
@@ -77,7 +78,7 @@ test.describe('Handler vervanging/waarneming spec coverage', () => {
 		// active waarnemer; its presence (or graceful absence) must not error.
 		await expect(page.locator('body')).not.toContainText('Internal Server Error')
 		const toggle = page.getByTestId('substituted-toggle')
-		if (await toggle.isVisible({ timeout: 3000 }).catch(() => false)) {
+		if (await becomesVisible(toggle, 3000)) {
 			await toggle.locator('input').click()
 			await expect(page.locator('body')).not.toContainText(
 				'Internal Server Error',
@@ -96,7 +97,7 @@ test.describe('Handler vervanging/waarneming spec coverage', () => {
 		const heading = page
 			.getByRole('heading', { name: /Substitutions & reassignment/ })
 			.first()
-		if (await heading.isVisible({ timeout: 10000 }).catch(() => false)) {
+		if (await becomesVisible(heading)) {
 			const reassign = page
 				.getByRole('button', { name: /Bulk reassign/ })
 				.first()
@@ -124,7 +125,7 @@ test.describe('Handler vervanging/waarneming spec coverage', () => {
 		const heading = page
 			.getByRole('heading', { name: /Substitutions & reassignment/ })
 			.first()
-		if (await heading.isVisible({ timeout: 10000 }).catch(() => false)) {
+		if (await becomesVisible(heading)) {
 			await expect(page.locator('body')).not.toContainText(
 				'Internal Server Error',
 			)

--- a/tests/e2e/spec-coverage/kanban-board-keyboard-status-transition.spec.ts
+++ b/tests/e2e/spec-coverage/kanban-board-keyboard-status-transition.spec.ts
@@ -12,6 +12,7 @@
  */
 
 import { test, expect } from '@playwright/test'
+import { becomesVisible } from '../helpers/becomes-visible.js'
 import { dismissSupportDialog } from '../helpers/nav'
 
 test.describe('Workflow Board keyboard status transition', () => {
@@ -23,13 +24,13 @@ test.describe('Workflow Board keyboard status transition', () => {
 		await dismissSupportDialog(page)
 
 		const heading = page.getByRole('heading', { name: /Workflow Board/ }).first()
-		if (!(await heading.isVisible({ timeout: 10000 }).catch(() => false))) {
+		if (!(await becomesVisible(heading))) {
 			test.skip(true, 'Workflow Board surface not deployed in target instance')
 			return
 		}
 
 		const firstCard = page.locator('.case-card').first()
-		if (!(await firstCard.isVisible({ timeout: 8000 }).catch(() => false))) {
+		if (!(await becomesVisible(firstCard, 8000))) {
 			test.skip(
 				true,
 				'No cases on the Workflow Board to exercise the move control',
@@ -61,7 +62,7 @@ test.describe('Workflow Board keyboard status transition', () => {
 		await dismissSupportDialog(page)
 
 		const firstCard = page.locator('.case-card').first()
-		if (!(await firstCard.isVisible({ timeout: 8000 }).catch(() => false))) {
+		if (!(await becomesVisible(firstCard, 8000))) {
 			test.skip(
 				true,
 				'No cases on the Workflow Board to exercise the drag path',

--- a/tests/e2e/spec-coverage/workflow-editor-canvas.spec.ts
+++ b/tests/e2e/spec-coverage/workflow-editor-canvas.spec.ts
@@ -38,6 +38,7 @@
  */
 
 import { test, expect } from '@playwright/test'
+import { becomesVisible } from '../helpers/becomes-visible.js'
 
 const ADMIN_SETTINGS_URL = '/settings/admin/procest'
 
@@ -52,7 +53,7 @@ const ADMIN_SETTINGS_URL = '/settings/admin/procest'
 async function openFirstCaseTypeWorkflowTabOrSkip(page): Promise<boolean> {
 	await page.goto(ADMIN_SETTINGS_URL)
 	const heading = page.getByRole('heading', { name: 'Case Type Management' })
-	if (!(await heading.isVisible({ timeout: 15000 }).catch(() => false))) {
+	if (!(await becomesVisible(heading, 15000))) {
 		test.skip(
 			true,
 			'Case Type Management admin section not present in the deployed build',
@@ -61,7 +62,7 @@ async function openFirstCaseTypeWorkflowTabOrSkip(page): Promise<boolean> {
 	}
 
 	const row = page.locator('.viewTableRow, tr[role="row"], .list-item').first()
-	if (!(await row.isVisible({ timeout: 10000 }).catch(() => false))) {
+	if (!(await becomesVisible(row))) {
 		test.skip(
 			true,
 			'No case types in the deployed/seeded register — the Workflow tab is data-dependent.',
@@ -73,7 +74,7 @@ async function openFirstCaseTypeWorkflowTabOrSkip(page): Promise<boolean> {
 	const workflowTab = page
 		.locator('.case-type-detail__tab', { hasText: 'Workflow' })
 		.first()
-	if (!(await workflowTab.isVisible({ timeout: 10000 }).catch(() => false))) {
+	if (!(await becomesVisible(workflowTab))) {
 		test.skip(
 			true,
 			'Workflow tab not present on the case type detail page (deploy mismatch).',
@@ -111,7 +112,7 @@ test.describe('Visual workflow editor canvas (workflow-editor-integration)', () 
 		if (!opened) return
 
 		const node = page.locator('.workflow-node').first()
-		if (!(await node.isVisible({ timeout: 5000 }).catch(() => false))) {
+		if (!(await becomesVisible(node, 5000))) {
 			test.skip(
 				true,
 				'No workflow definition with status nodes for this case type — canvas keyboard interaction is data-dependent.',
@@ -144,7 +145,7 @@ test.describe('Visual workflow editor canvas (workflow-editor-integration)', () 
 		if (!opened) return
 
 		const canvas = page.locator('.workflow-editor')
-		if (!(await canvas.isVisible({ timeout: 5000 }).catch(() => false))) {
+		if (!(await becomesVisible(canvas, 5000))) {
 			test.skip(
 				true,
 				'No workflow defined for this case type yet — the palette only renders alongside the canvas.',


### PR DESCRIPTION
## What this does

De-races **9 `test.skip()` gates** built on `locator.isVisible()`, an IMMEDIATE predicate whose `timeout` option is **ignored** — so `{ timeout: 10000 }` bought nothing. Adds `tests/e2e/helpers/becomes-visible.js`, a polling probe on `waitFor`. **Every `test.skip()` is KEPT**: the fix is to make the gate tell the truth, not to unskip.

| file | gates |
|---|---|
| `workflow-editor-canvas` | 5 (3 in the shared `openFirstCaseTypeWorkflowTabOrSkip()` helper) |
| `handler-vervanging-waarneming` | 3 |
| `kanban-board-keyboard-status-transition` | 3 |

## ⚠️ procest was scored ZERO for this defect

The sweep that dispatched this workstream matched the literal `isVisible()` with **empty parens** — and *every* procest gate is `isVisible({ timeout: N })`. procest scored 13 in one column and 0 in the other, when most of those 13 **are** skip gates.

## 📊 RESULT: nothing moved — verified at the REASON level, not just the count

```
BASE (862c8f8c)   Running 128 tests → 90 passed  0 failed  38 skipped
PR   (d0ac5976)   Running 128 tests → 90 passed  0 failed  38 skipped
```

Skip **reasons** extracted from the `playwright-report` artifact on both sides — **identical sets**:

```
12  Sub-cases tab not present in the deployed build (deploy mismatch).
 9  Related cases sidebar tab not present in the deployed build (…).
 9  No case types in the deployed/seeded register — …
 3  No cases on the Workflow Board to exercise the move control
 3  No cases on the Workflow Board to exercise the drag path
 3  OR addresses register not installed (…)
```

🔑 **`"Workflow Board surface not deployed in target instance"` never fires, on either side.** That gate was already passing — the non-waiting probe happened to win. The gates that actually fire are the *second* ones in each chain, and their reasons are **true**: these specs seed nothing, while the only spec that ever sees case cards (`workflows/case-lifecycle.spec.ts:185`) **seeds two cases itself** first.

⇒ **These nine gates were latent trip-wires, not invisible passes.** I argued twice that the reasons were false (from `manifest.json`, from the count) and was wrong both times; the recorded reasons settled it. Those retractions are in the commit log rather than edited away.

**So why land it?** A latent trip-wire fires the day the runner slows — shillinq had eleven tests on one such helper. Each surviving skip now reports a real absence instead of depending on a probe that could not have known. But **no green-number improvement is claimed.**

## ➡️ The real suspects here are `count()`, not `isVisible()`

The two largest clusters above — **21 of 39 records** — come from `deelzaak-support.spec.ts` and `related-case-linking.spec.ts`:

```js
await page.waitForTimeout(1000)                    // a FIXED 1s, then…
if ((await subCasesTab.count()) === 0) {           // …an IMMEDIATE predicate
    test.skip(true, 'Sub-cases tab not present in the deployed build (deploy mismatch).')
```

**`count()` does not wait either** — same defect, different method, invisible to every `isVisible` grep — and the reason **blames the deployment**, which is the tell. `"Sub-cases"` *is* declared in `src/manifest.json`. **Left UNVERIFIED on purpose**: declaration is not rendering, and this PR has already been wrong about that twice. Worth its own slot.

## Verification

`git archive HEAD` extracted to a clean dir, `playwright --list` run **there**: **128 tests in 33 files**, matching CI's `Running 128 tests` exactly. (Adopted after a working-tree check missed a staging error that made decidesk#509 run zero tests.)

- eslint on the 3 changed specs: **5 → 5, zero introduced**
- prettier: clean
- parity vs `development@862c8f8c`: **INTRODUCED = empty**

🤖 Generated with [Claude Code](https://claude.com/claude-code)