### PR TITLE
test(e2e): seed the Workflow Board so the two kanban tests actually run

### DIFF
--- a/tests/e2e/spec-coverage/kanban-board-keyboard-status-transition.spec.ts
+++ b/tests/e2e/spec-coverage/kanban-board-keyboard-status-transition.spec.ts
@@ -51,7 +51,6 @@ import { dismissSupportDialog } from '../helpers/nav'
 import {
 	RUN_PREFIX,
 	cleanupRunObjects,
-	deleteObject,
 	getRequestToken,
 	seedCase,
 	seedStateMachine,
@@ -66,8 +65,15 @@ let token: string
 let sm: StateMachine
 
 test.describe('Workflow Board keyboard status transition', () => {
-	test.describe.configure({ mode: 'serial' })
-
+	// ⚠️ DELIBERATELY NOT `test.describe.configure({ mode: 'serial' })`.
+	// These two tests share only the beforeAll fixture; neither depends on the
+	// other's side effects, so serial mode buys nothing — and it costs the one
+	// thing this file exists to fix. MEASURED, not assumed: with serial mode
+	// on, a failure in the first test marks the second `did not run`, which the
+	// report records as **outcome "skipped" with NO annotation at all** — a
+	// skip carrying no reason whatsoever, which is strictly worse than the
+	// false-reason skips this change removes. Off serial, a real failure
+	// reports as a failure in both.
 	test.beforeAll(async ({ baseURL }) => {
 		api = await request.newContext({ baseURL, storageState: STORAGE_STATE })
 		token = await getRequestToken(api)
@@ -84,12 +90,38 @@ test.describe('Workflow Board keyboard status transition', () => {
 	})
 
 	test.afterAll(async () => {
-		// Child-first: the cases (and any statusRecord a transition produced)
-		// before the machine they hang off.
-		await cleanupRunObjects(api, token, ['statusRecord', 'case'])
-		for (const [schema, id] of [...sm.created].reverse()) {
-			await deleteObject(api, token, schema, id)
-		}
+		// Any statusRecord this run produced is deletable and is swept.
+		await cleanupRunObjects(api, token, ['statusRecord'])
+
+		// ⚠️ THE SEEDED MACHINE IS DELIBERATELY LEFT IN PLACE. Deleting it
+		// breaks a LATER test, and this was MEASURED, not guessed.
+		//
+		// The `case` schema is archival (`x-openregister-archival`): a
+		// user-driven DELETE is refused with a 403 ArchivalImmutableException
+		// and the record persists — `workflows/cases-crud.spec.ts:225` asserts
+		// exactly that, and it passes. `helpers/fixtures.ts#deleteObject` never
+		// inspects the response, so `cleanupRunObjects(…, ['case'])` reports
+		// success and removes NOTHING. The seeded case therefore OUTLIVES this
+		// file whatever we do.
+		//
+		// Its caseType and statusTypes are NOT archival, so the obvious
+		// child-first cleanup deletes them out from under a case that is still
+		// live — leaving a DANGLING reference. Observed in CI run
+		// 31964165472: the dashboard's grouped aggregations
+		// (`aggregations/procest/case/grouped?groupBy=status|caseType`) still
+		// return the orphaned case's group keys, the chart widget resolves each
+		// key by id, and two of those lookups 404. That reddened
+		// `spec-coverage/ui-pages.spec.ts:55` ("dashboard mounts without
+		// procest console errors"), which is a test that was doing its job.
+		//
+		// So the referential integrity of the surviving case is what has to be
+		// preserved. The residue is small, RUN_PREFIX-tagged and consistent,
+		// and CI builds a throwaway instance per run.
+		//
+		// 📌 workflows/case-lifecycle.spec.ts carries the SAME latent defect —
+		// it deletes `sm.created` while its own cases survive. It is invisible
+		// today only because `workflows/` sorts after every spec that would
+		// notice. Recorded on the fleet board rather than changed here.
 		await api.dispose()
 	})
 

--- a/tests/e2e/spec-coverage/kanban-board-keyboard-status-transition.spec.ts
+++ b/tests/e2e/spec-coverage/kanban-board-keyboard-status-transition.spec.ts
@@ -4,50 +4,148 @@
  *
  * Gate-19 spec-coverage tests for kanban-board-keyboard-status-transition
  * (WCAG 2.1.1 Keyboard fix on the Workflow Board's status-move control).
- * Drives the real UI; skips gracefully when the board/data is not
- * available in the target instance rather than hard-failing the suite.
  *
- * Note: Use /apps/procest/<route> (not /index.php/...) so the Vue
- * history-mode router resolves the route.
+ * ⚠️ WHY THIS FILE SEEDS ITS OWN DATA
+ * -----------------------------------
+ * Both tests here used to open the board, look for a `.case-card`, find none,
+ * and `test.skip(true, 'No cases on the Workflow Board …')`. That reason was
+ * TRUE — and that is exactly the problem. The board is a data-dependent
+ * surface: `WorkflowBoard.fetchData()` builds one column per NON-FINAL
+ * statusType and then groups cases into a column by resolving `case.status`
+ * to that statusType's NAME. With no statusTypes and no cases in the target
+ * register there is nothing to render, so the assertions below never ran —
+ * on CI they had never run at all.
+ *
+ * A skip that is permanently true is an invisible pass under L8: the tests report
+ * "not applicable" rather than "untested", and the skip count hides them.
+ * The fix is therefore a FIXTURE change, not a timing change: seed the same
+ * shape `workflows/case-lifecycle.spec.ts` seeds — `seedStateMachine()` for a
+ * caseType + three ordered statusTypes + an active workflowTemplate, then
+ * `seedCase()` for the cards — and then ASSERT, with no escape hatch. If the
+ * board does not render the seeded card, that is a failure, and it should be.
+ *
+ * `case-lifecycle.spec.ts:185` ("the workflow board renders a column per
+ * status type with real case rows") passes in CI using precisely this fixture,
+ * so the shape is known-good; it is the one this file adopts rather than a
+ * new one.
+ *
+ * Every seeded object carries `RUN_PREFIX` in a human-visible field, so the
+ * assertions target THIS run's card (never another run's or an instance's
+ * demo data) and `afterAll` deletes exactly what this run created.
+ *
+ * Note: navigation is `page.goto('/index.php/apps/procest/workflow-board')` —
+ * the identical path `spec-coverage/workflow-operations.spec.ts:18` uses to
+ * reach the same board, and that test passes.
  */
 
-import { test, expect } from '@playwright/test'
+import {
+	test,
+	expect,
+	request,
+	type APIRequestContext,
+	type Locator,
+	type Page,
+} from '@playwright/test'
+import { STORAGE_STATE } from '../helpers/auth'
 import { dismissSupportDialog } from '../helpers/nav'
+import {
+	RUN_PREFIX,
+	cleanupRunObjects,
+	deleteObject,
+	getRequestToken,
+	seedCase,
+	seedStateMachine,
+	type StateMachine,
+} from '../helpers/fixtures'
+
+/** Title of the card both tests drive. Carries RUN_PREFIX for isolation. */
+const CARD_TITLE = `${RUN_PREFIX} Kanban card`
+
+let api: APIRequestContext
+let token: string
+let sm: StateMachine
 
 test.describe('Workflow Board keyboard status transition', () => {
+	test.describe.configure({ mode: 'serial' })
+
+	test.beforeAll(async ({ baseURL }) => {
+		api = await request.newContext({ baseURL, storageState: STORAGE_STATE })
+		token = await getRequestToken(api)
+		// caseType + Ontvangen/In behandeling (non-final) + Afgehandeld (final)
+		// + an active workflowTemplate. Two non-final statusTypes is the
+		// minimum the move control needs: CaseCard renders its NcActions only
+		// when `otherColumns.length > 0`, i.e. when a card has somewhere to go.
+		sm = await seedStateMachine(api, token)
+		await seedCase(api, token, {
+			title: CARD_TITLE,
+			caseType: sm.caseTypeId,
+			status: sm.statusReceived,
+		})
+	})
+
+	test.afterAll(async () => {
+		// Child-first: the cases (and any statusRecord a transition produced)
+		// before the machine they hang off.
+		await cleanupRunObjects(api, token, ['statusRecord', 'case'])
+		for (const [schema, id] of [...sm.created].reverse()) {
+			await deleteObject(api, token, schema, id)
+		}
+		await api.dispose()
+	})
+
+	/**
+	 * Open the Workflow Board and return the seeded case's card.
+	 *
+	 * Scoped by `hasText: CARD_TITLE` rather than `.case-card` first(): on an
+	 * instance that already holds cases, `.first()` would drive somebody
+	 * else's card and the test would be asserting about data it did not
+	 * create.
+	 * @param page The page.
+	 * @return The `.case-card` element rendering the seeded case.
+	 */
+	async function openBoardAndFindSeededCard(page: Page): Promise<Locator> {
+		await page.goto('/index.php/apps/procest/workflow-board')
+		await dismissSupportDialog(page)
+
+		// The board renders its heading unconditionally; the columns and cards
+		// arrive after fetchData() resolves three collections.
+		await expect(
+			page.getByRole('heading', { name: /Workflow Board/ }).first(),
+		).toBeVisible({ timeout: 15000 })
+		// The seeded non-final column must exist, or there is nowhere for a
+		// card to be grouped — assert it separately so a missing column does
+		// not present as "the card is missing".
+		await expect(
+			page.getByText(`${RUN_PREFIX} Ontvangen`, { exact: false }).first(),
+		).toBeVisible({ timeout: 15000 })
+
+		const card = page.locator('.case-card', { hasText: CARD_TITLE }).first()
+		await expect(card).toBeVisible({ timeout: 15000 })
+		return card
+	}
+
 	// @e2e openspec/changes/kanban-board-keyboard-status-transition/specs/dashboard/spec.md#scenario-dash-v1-006d-keyboard-only-status-transition-new
 	test('a case card exposes a keyboard-operable "Move to…" menu', async ({
 		page,
 	}) => {
-		await page.goto('/index.php/apps/procest/workflow-board')
-		await dismissSupportDialog(page)
-
-		const heading = page.getByRole('heading', { name: /Workflow Board/ }).first()
-		if (!(await heading.isVisible({ timeout: 10000 }).catch(() => false))) {
-			test.skip(true, 'Workflow Board surface not deployed in target instance')
-			return
-		}
-
-		const firstCard = page.locator('.case-card').first()
-		if (!(await firstCard.isVisible({ timeout: 8000 }).catch(() => false))) {
-			test.skip(
-				true,
-				'No cases on the Workflow Board to exercise the move control',
-			)
-			return
-		}
+		const card = await openBoardAndFindSeededCard(page)
 
 		// The move-target menu trigger is reachable independent of the card's
 		// own click-to-open handler (a separate focusable NcActions control).
-		const moveTrigger = firstCard
-			.locator('.case-card__move-actions button')
-			.first()
+		const moveTrigger = card.locator('.case-card__move-actions button').first()
 		await expect(moveTrigger).toBeVisible()
 
 		await moveTrigger.focus()
 		await page.keyboard.press('Enter')
 		const firstOption = page.getByRole('menuitem').first()
 		await expect(firstOption).toBeVisible({ timeout: 5000 })
+		// The offer is the OTHER seeded non-final column — proving the menu is
+		// populated from the board's real column model, not an empty shell.
+		await expect(
+			page.getByRole('menuitem', {
+				name: new RegExp(`${RUN_PREFIX} In behandeling`),
+			}),
+		).toBeVisible({ timeout: 5000 })
 
 		// Do not actually commit a status change against a live board's data —
 		// close the menu without selecting, proving the control opens via
@@ -57,18 +155,7 @@ test.describe('Workflow Board keyboard status transition', () => {
 
 	// @e2e openspec/changes/kanban-board-keyboard-status-transition/specs/dashboard/spec.md#scenario-dash-v1-006e-drag-path-unchanged-new
 	test('case cards remain draggable for mouse/touch users', async ({ page }) => {
-		await page.goto('/index.php/apps/procest/workflow-board')
-		await dismissSupportDialog(page)
-
-		const firstCard = page.locator('.case-card').first()
-		if (!(await firstCard.isVisible({ timeout: 8000 }).catch(() => false))) {
-			test.skip(
-				true,
-				'No cases on the Workflow Board to exercise the drag path',
-			)
-			return
-		}
-
-		await expect(firstCard).toHaveAttribute('draggable', 'true')
+		const card = await openBoardAndFindSeededCard(page)
+		await expect(card).toHaveAttribute('draggable', 'true')
 	})
 })


### PR DESCRIPTION
## What

`tests/e2e/spec-coverage/kanban-board-keyboard-status-transition.spec.ts` now **seeds its own Workflow Board data** instead of skipping when it finds none. **Both tests now run, and both pass.**

## Why — the reason was TRUE, and that is the problem

Both tests opened `/index.php/apps/procest/workflow-board`, looked for a `.case-card`, found none and skipped with

> `'No cases on the Workflow Board to exercise the move control'`

That reason is **correct**, which is exactly why the fix is a **fixture** change and not a timing change. The board is data-dependent: `WorkflowBoard.fetchData()` builds one column per **non-final** `statusType` and groups cases into a column by resolving `case.status` to that statusType's **name**. With no statusTypes and no cases in the target register there is nothing to render, so on CI these two assertions had **never executed at all** — an invisible pass under L8: they render as "not applicable" rather than as a gap, and the skip count hides them.

`workflows/case-lifecycle.spec.ts:185` is the **only** spec that has ever seen case cards, and it sees them because it **seeds two itself**. This file seeded nothing.

## What changed

- `beforeAll` calls the existing `helpers/fixtures.ts#seedStateMachine()` (a caseType, `Ontvangen`/`In behandeling` non-final + `Afgehandeld` final statusTypes, an active `workflowTemplate`) and one `seedCase()` in the `Ontvangen` status. Two non-final statusTypes is the **minimum the move control needs**: `CaseCard` renders its `NcActions` only when `otherColumns.length > 0`.
- Both `test.skip()` escape hatches are **removed** and replaced with hard `expect(...).toBeVisible()`.
- Assertions are scoped by `RUN_PREFIX` — the card is located as `.case-card` filtered on the seeded title, not `.first()`, so the tests never drive data they did not create.

The fixture is known-good rather than newly invented — `case-lifecycle.spec.ts:185` passes in CI using precisely this shape.

## Measured result

| run | collected | passed | failed | **skipped** |
|---|---|---|---|---|
| base `development` (run 31951083723) | 128 | 90 | 0 | **38** |
| **this branch** (run 31965150297, E2E `success`) | 128 | **92** | **0** | **36** |

**+2 passed, −2 skipped, 0 failed.** Both recovered tests pass.

Reason-set diff (not tally diff — a stable count is compatible with every reason underneath it changing), extracted from both runs' `playwright-report` artifacts:

```
runtime `skip` reasons: 13 tests / 6 reasons  ->  11 tests / 4 reasons
- kanban…spec.ts  was: No cases on the Workflow Board to exercise the move control
- kanban…spec.ts  was: No cases on the Workflow Board to exercise the drag path
(nothing else added, removed or changed; `test.fixme` count unchanged at 25)
```

## Two corrections found by running it, not by reading it

**1. `mode: 'serial'` turned a FAILURE into a REASON-LESS SKIP.** Measured locally: with serial on, a failure in the first test marks the second `did not run`, which the report records as **outcome `skipped` with no annotation at all** — a skip carrying no reason whatsoever, strictly worse than the false-reason skips this file removes. The two tests share only the `beforeAll` fixture, so serial bought nothing. Off serial, the same failing run reports **2 failed, 0 skipped**.

**2. Child-first cleanup left a DANGLING case and reddened another test.** The first push went red — honestly, and it is worth reading:

- The `case` schema is **archival**: a user-driven DELETE is refused **403 `ArchivalImmutableException`** and the record persists. `workflows/cases-crud.spec.ts:225` asserts exactly this and passes.
- `helpers/fixtures.ts#deleteObject` **never inspects the response**, so `cleanupRunObjects(…, ['case'])` reports success and **removes nothing**.
- `caseType` / `statusType` **are** deletable — so the textbook child-first cleanup deleted them out from under a case that was still live.

In run **31964165472** that surfaced four hops away, in a different file:

```
GET aggregations/procest/case/grouped?groupBy=status   -> groups: [26622fe5…, 62e4f28d…]
GET objects/procest/statusType/62e4f28d…               -> 404
GET objects/procest/caseType/29ae4029…                 -> 404
GET objects/procest/case?_order[startDate]=desc        -> [{"title":"E2EZAAK-… Kanban card",
                                                            "caseType":"29ae4029…","status":"62e4f28d…"}]
```

The "cleaned up" case is still in the list, still pointing at two objects that no longer exist; the dashboard chart resolves every group key by id and two of them 404 — reddening `spec-coverage/ui-pages.spec.ts:55` *"dashboard mounts without procest console errors"*. **That test was doing its job**, and this PR does not weaken it. `afterAll` now preserves the surviving case's referential integrity and sweeps only what is genuinely deletable.

📌 `workflows/case-lifecycle.spec.ts` carries the **same latent defect** (deletes `sm.created` while its cases survive). Deliberately **not** changed here — measure widely, change narrowly — and recorded on the fleet board for its own slot. Likewise `deleteObject` should throw on a non-2xx, but it is shared by every spec in the repo and that is a suite-wide change, not a two-test one.

## Parity — ZERO INTRODUCED

Both sides complete, untruncated, **0 pending** at the time of the verdict.

| | jobs | success | skipped | failure |
|---|---|---|---|---|
| base `development` @ `055d6f0a` (run 31964503054) | 37/37 | 30 | 5 | **2** |
| PR `75a0df97` (run 31965150297) | 37/37 | 30 | 5 | **2** |

Failing on **both** sides, identically: `quality / Hydra Gates`, `quality / Quality Report` — the §1 baseline. **Introduced: NONE.** Check-run level: base 49/49, PR 43/43, 0 pending either side, same two names.

## Verification notes

- `git archive HEAD` + `playwright test --list` → **`Total: 128 tests in 33 files`**, byte-identical to CI's `Running 128 tests`. Run from the archive, never the working tree.
- `prettier --check` on the changed file: clean.
- ⚠️ **A local run against the shared `:8080` dev instance is VOID for this surface and is not cited as evidence.** There, the CI-*passing* sibling `spec-coverage/workflow-operations.spec.ts:18` **also fails** (`.workflow-board__header h2` not found), so `:8080` cannot render the Workflow Board at all. Calibrating on the passing sibling is what showed that.

## Overlap

`#863` also edits this file (it substitutes a polling `becomesVisible()` for the two `isVisible({timeout})` gates). **This PR supersedes both gates in this file** — they are gone, replaced by assertions — so if `#863` lands first the resolution here is "take this version of this file". `#863`'s other two files are untouched by this PR.
