### PR TITLE
test(e2e): name the screen a spec drives in executable code (gate-26 78 -> 74) + measured verdict on gates 7/25/53/62

### DIFF
--- a/tests/e2e/helpers/page-components.ts
+++ b/tests/e2e/helpers/page-components.ts
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Procest Contributors
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * Route constants NAMED AFTER THE COMPONENT THAT RENDERS THEM.
+ *
+ * Why the identifier matters
+ * -------------------------
+ * A spec that navigates to `/verwerkingen` really does drive
+ * `src/views/admin/VerwerkingenOverview.vue`, but nothing in the spec SAYS so,
+ * so neither a reader nor a tool can tell which screen the test covers. The
+ * link used to be written in a comment — and a comment is not a reference:
+ * hydra gate-26 (visual-coverage) reads the e2e corpus through
+ * `source_scope.js_comment_mask`, which blanks comments and keeps string
+ * literals, precisely so "we still owe a baseline for X" cannot satisfy the
+ * check that asks whether X is covered (.github#358).
+ *
+ * Binding the route to a constant whose IDENTIFIER is the component's file
+ * stem fixes both halves at once: the spec reads as "navigate to the
+ * VerwerkingenOverview screen", and the reference survives comment-masking
+ * because it is executable code the spec actually evaluates.
+ *
+ * Scope: only screens that an existing spec in this suite genuinely drives.
+ * Adding a constant here for a screen no spec visits would be a declaration
+ * nobody reads — the exact failure mode the masking above exists to prevent.
+ * Add the entry when you add the test, not before. Screens this suite does not
+ * yet drive are deliberately ABSENT here rather than listed and unused —
+ * `/substitution` and `/substitution-admin` are the current example: they are
+ * driven by handler-vervanging-waarneming.spec.ts and will get their constants
+ * when that file is next touched (it is mid-flight in PR #863).
+ *
+ * Routes are app-relative; the app is HISTORY-mode, so `navToRoute()` /
+ * `page.goto()` prefix them with `/index.php/apps/procest`.
+ */
+
+/** `src/views/CasesOnMapView.vue` — the Cases map view (manifest page `CaseMap`). */
+export const CasesOnMapView = '/map'
+
+/** `src/views/MyWorkCards.vue` — the personal workload cards (manifest page `MyWork`). */
+export const MyWorkCards = '/my-work'
+
+/** `src/views/admin/VerwerkingenOverview.vue` — the AVG processing-activity register. */
+export const VerwerkingenOverview = '/verwerkingen'
+
+/** `src/views/workflow-board/WorkflowBoard.vue` — the kanban status board. */
+export const WorkflowBoard = '/workflow-board'

--- a/tests/e2e/spec-coverage/avg-verwerkingenlogging.spec.ts
+++ b/tests/e2e/spec-coverage/avg-verwerkingenlogging.spec.ts
@@ -14,6 +14,9 @@
 import { test, expect, request } from '@playwright/test'
 import { BASE_URL } from '../base-url'
 import { navToRoute } from '../helpers/nav'
+// Route named after the component that renders it, so this spec states WHICH
+// screen it covers in executable code rather than in a comment.
+import { VerwerkingenOverview } from '../helpers/page-components'
 
 const APP_URL = '/apps/procest'
 // Single source of truth — see tests/e2e/base-url.ts. The old
@@ -30,7 +33,7 @@ test.describe('AVG verwerkingenlogging spec coverage', () => {
 		// loads the app root and leaves the hash unrouted, so the overview
 		// never renders. `/index.php/apps/procest/verwerkingen` renders it —
 		// measured on a CI runner (2026-08-04).
-		await navToRoute(page, '/verwerkingen')
+		await navToRoute(page, VerwerkingenOverview)
 		await expect(
 			page.getByRole('heading', { name: 'Processing activities (AVG)' }),
 		).toBeVisible({ timeout: 15000 })
@@ -51,7 +54,7 @@ test.describe('AVG verwerkingenlogging spec coverage', () => {
 		// loads the app root and leaves the hash unrouted, so the overview
 		// never renders. `/index.php/apps/procest/verwerkingen` renders it —
 		// measured on a CI runner (2026-08-04).
-		await navToRoute(page, '/verwerkingen')
+		await navToRoute(page, VerwerkingenOverview)
 		await page
 			.getByRole('button', { name: 'Data subject access export' })
 			.click()

--- a/tests/e2e/spec-coverage/my-work.spec.ts
+++ b/tests/e2e/spec-coverage/my-work.spec.ts
@@ -14,13 +14,16 @@
 
 import { test, expect } from '@playwright/test'
 import { dismissSupportDialog } from '../helpers/nav'
+// Route named after the component that renders it, so this spec states WHICH
+// screen it covers in executable code rather than in a comment.
+import { MyWorkCards } from '../helpers/page-components'
 
 test.describe('My Work spec coverage', () => {
 	// @e2e openspec/specs/my-work/spec.md#personal-workload-view
 	test("shows the current user's assigned cases as a card list", async ({
 		page,
 	}) => {
-		await page.goto('/index.php/apps/procest/my-work')
+		await page.goto(`/index.php/apps/procest${MyWorkCards}`)
 		await dismissSupportDialog(page)
 		// The My Work route renders NO page heading — measured on a CI runner
 		// (2026-08-04) it exposes zero `heading` roles. Identify the view by
@@ -37,7 +40,7 @@ test.describe('My Work spec coverage', () => {
 
 	// @e2e openspec/specs/my-work/spec.md#personal-workload-view
 	test('view mode can be switched between cards and table', async ({ page }) => {
-		await page.goto('/index.php/apps/procest/my-work')
+		await page.goto(`/index.php/apps/procest${MyWorkCards}`)
 		await dismissSupportDialog(page)
 		const tableToggle = page.getByRole('button', { name: /Table/ }).first()
 		await expect(tableToggle).toBeVisible({ timeout: 10000 })

--- a/tests/e2e/spec-coverage/workflow-operations.spec.ts
+++ b/tests/e2e/spec-coverage/workflow-operations.spec.ts
@@ -12,6 +12,9 @@
 
 import { test, expect } from '@playwright/test'
 import { navTo, navToRoute, trackProcestErrors } from '../helpers/nav'
+// Routes named after the component that renders them, so this spec states
+// WHICH screen it covers in executable code rather than in a comment.
+import { CasesOnMapView, WorkflowBoard } from '../helpers/page-components'
 
 test.describe('Workflow Board page', () => {
 	// @e2e openspec/specs/workflow-board/spec.md#workflow-board-renders-kanban-shell
@@ -20,7 +23,7 @@ test.describe('Workflow Board page', () => {
 	}) => {
 		// The nav label is "Workflow board" (lower-case b) and it sits inside
 		// the collapsed "Work queue" group — navigate by route instead.
-		await navToRoute(page, '/workflow-board')
+		await navToRoute(page, WorkflowBoard)
 		// The board view renders its own header h2 inside `.workflow-board__header`
 		// (the page also has a dashboard-wrapper title + widget title with the
 		// same text, so scope to the board's own header).
@@ -54,7 +57,7 @@ test.describe('Workflow Board page', () => {
 		const errors = trackProcestErrors(page)
 		// The nav label is "Workflow board" (lower-case b) and it sits inside
 		// the collapsed "Work queue" group — navigate by route instead.
-		await navToRoute(page, '/workflow-board')
+		await navToRoute(page, WorkflowBoard)
 		await expect(page.locator('.workflow-board__header h2')).toBeVisible({
 			timeout: 15000,
 		})
@@ -71,7 +74,7 @@ test.describe('Case Map page', () => {
 		const errors = trackProcestErrors(page)
 		// Case Map has no top-level sidebar leaf after the nav-dedup pass; its
 		// /map page route stays reachable, so navigate to it client-side.
-		await navToRoute(page, '/map')
+		await navToRoute(page, CasesOnMapView)
 		// The rendered heading is "Cases on map" — measured on a CI runner
 		// (2026-08-04). "Case map" is the manifest page TITLE, not the heading
 		// the view renders.

--- a/tests/e2e/visual/procest.visual.spec.ts
+++ b/tests/e2e/visual/procest.visual.spec.ts
@@ -16,6 +16,10 @@
 import { test, request, type APIRequestContext } from '@playwright/test'
 import { shootSurface, shootByNav } from './_visual-helpers'
 import { STORAGE_STATE } from '../helpers/auth'
+// Routes named after the component that renders them — see
+// tests/e2e/helpers/page-components.ts for why the identifier, not a comment,
+// is what states which screen a baseline belongs to.
+import { VerwerkingenOverview } from '../helpers/page-components'
 import {
 	getRequestToken,
 	ensureCaseType,
@@ -36,12 +40,17 @@ test.describe('Procest — visual baselines', () => {
 		await shootByNav(page, `${APP}#/`, 'Cases', 'cases.png')
 	})
 
-	// VerwerkingenOverview (src/views/admin/VerwerkingenOverview.vue) — the FG
-	// window on OR's processing-activity register (avg-verwerkingenlogging).
-	// The surface is data-light (catalogue table or seed empty-state), so the
-	// shot is deterministic once the repair step has seeded the drafts.
+	// The FG window on OR's processing-activity register
+	// (avg-verwerkingenlogging). The surface is data-light (catalogue table or
+	// seed empty-state), so the shot is deterministic once the repair step has
+	// seeded the drafts. The screen is named by the imported constant rather
+	// than by this paragraph — a comment is not a reference.
 	test('verwerkingen overview (AVG)', async ({ page }) => {
-		await shootSurface(page, `${APP}#/verwerkingen`, 'verwerkingen-overview.png')
+		await shootSurface(
+			page,
+			`${APP}#${VerwerkingenOverview}`,
+			'verwerkingen-overview.png',
+		)
 	})
 })
 


### PR DESCRIPTION
## What this changes

`gate-26` (visual-coverage) reads the e2e corpus through `source_scope.js_comment_mask`, which blanks comments and keeps string literals — so **a component named only in a comment is invisible to it** (.github#358, "a comment is not a baseline"). Four procest screens were in exactly that state: a spec really navigated to the route and asserted its surface, but nothing in the *executable* text said which component that route renders.

This adds `tests/e2e/helpers/page-components.ts` — route constants whose **identifier is the rendering component's file stem** — and uses them in the specs that already drive those routes. Every substituted string resolves to the byte-identical URL. **No behaviour changes and no assertion is added**; the existing coverage is only made legible.

| Screen | Spec that already drives it |
| --- | --- |
| `src/views/MyWorkCards.vue` | `spec-coverage/my-work.spec.ts` |
| `src/views/CasesOnMapView.vue` | `spec-coverage/workflow-operations.spec.ts` |
| `src/views/workflow-board/WorkflowBoard.vue` | `spec-coverage/workflow-operations.spec.ts` |
| `src/views/admin/VerwerkingenOverview.vue` | `spec-coverage/avg-verwerkingenlogging.spec.ts` + `visual/procest.visual.spec.ts` |

`/substitution` and `/substitution-admin` deliberately get **no** constant here: the only spec that drives them (`handler-vervanging-waarneming.spec.ts`) is mid-flight in #863, and a constant nobody imports would be the "declaration nobody reads" the helper's own docblock warns against.

## This PR does NOT make `Hydra Gates` green — and here are the numbers

Both sides measured on the **same** gate package `f935e2c`, against `development` @ `4bf6c95a` (run 31969069575) and this PR (run 31968440484):

| Gate | `development` | PR #866 |
| --- | --- | --- |
| gate-7 no-admin-idor | FAIL — 4 | FAIL — 4 (untouched) |
| gate-25 contract-coverage | FAIL — 116 | FAIL — 116 (untouched) |
| **gate-26 visual-coverage** | **FAIL — 78** | **FAIL — 74** |
| gate-53 effective-manifest-crossref | FAIL — 8 | FAIL — 8 (see below) |
| gate-62 store-plane | FAIL — 1 | FAIL — 1 (see below) |

`Hydra Gates` therefore stays red, and `Quality Report` with it — **exactly the two jobs `development` itself fails**, with one gate strictly better and nothing regressed. Per-job: 30 pass / 5 skip / 2 fail, and the 2 failures match the base's.

> **Note on gate-7.** The dispatch for this work quoted 27. That number came from gate package `18fe6f9`; the package moved to `f935e2c` mid-afternoon and gate-7 now reports **4** on `development` and on this branch alike. The 27 was never about this PR, and it is stale on both sides — always compare runs that name the same `[hydra-gates] gate package:` sha.

The remaining work is quantified below rather than implied away.

## gate-26: the measured split of the 78

Every one of the 78 was **uncovered**; none was excluded. Splitting them by *why*:

* **2 were named only in a comment** — `VerwerkingenOverview`, `WorkflowBoard`. Closed here.
* **76 had no reference in the e2e corpus at all** (raw bytes, not just the masked corpus). Of those:
  * **10 are real, manifest-declared pages.** 2 (`MyWorkCards`, `CasesOnMapView`) are driven by an existing spec that referenced only the route path — closed here. **8 remain**: `ProcessMiningDashboard`, `TenantOnboardingDashboard`, `TermijnDashboard`, `SubstitutionAdmin`, `SubstitutionSettings`, `PublicAppointmentPage`, `PublicFederatedTransferPage`, `PublicStatusPage`. These need **real specs written**, not naming fixes.
  * **66 are `.vue` files under `src/views/**` that nothing in `src/`, `tests/` or `appinfo/` imports or names.** They are not in the manifest, not in `registry.js`, not in `customComponents.js`, and not reachable by `require.context` (the only one in the app scans `./manifest.d/*.json`). gate-26 flags them because its classifier is deliberately conservative: "imported by nothing" cannot be *proved* a child component, so it is treated as a page.

So **74 remain**: 8 real screens needing real tests, and 66 apparently-dead components.

<details><summary>The 66 unreferenced components, by directory</summary>

| Directory | Count |
| --- | --- |
| `src/views/cases/components/` | 20 |
| `src/views/cases/widgets/` | 9 |
| `src/views/settings/tabs/` | 8 |
| `src/views/dashboard/` | 7 |
| `src/views/cases/components/bezwaar/` | 6 |
| `src/views/complaints/` | 4 |
| `src/views/settings/components/` | 3 |
| `src/views/voorstellen/components/` | 2 |
| `src/views/cases/components/beroep/` | 2 |
| `src/views/dso/` | 1 |
| `src/views/complaints/components/` | 1 |
| `src/views/public/` | 1 |
| `src/views/tasks/` | 1 |
| `src/views/consultation/` | 1 |

</details>

**This PR does not delete them.** Retiring 66 source files is a product decision, not a gate fix, and their recent commits are fleet-wide mechanical sweeps (eslint 10 migration, enum l10n) rather than evidence either way. If they are genuinely dead, deleting them closes 66 of the 74 remaining gate-26 findings in one move — that is the recommended follow-up, and it needs an owner's decision first.

## gate-53: no route was removed, and removing one would be the wrong fix

The brief for this work assumed these 8 findings were *menu routes whose target page does not exist* — dead links. **They are not.** Every one of the 8 target pages exists in the effective manifest and stays routable. The finding is `removals-invariant`: `src/menu-layout.json` retires a menu entry, and gate-53 — which walks only the static `.menu` tree — cannot then see any surviving entry reaching that page.

| Removed menu entry | Orphaned route | Target page exists? |
| --- | --- | --- |
| `BezwaarBeroepGroup` | `BezwaarBeroepOverview` | yes — `/bezwaar-beroep` |
| `Bezwaren` | `Bezwaren` | yes — `/bezwaren` |
| `Beroepen` | `Beroepen` | yes — `/beroepen` |
| `SubsidiesGroup` | `Subsidies` | yes — `/subsidies` |
| `CaseMap` | `CaseMap` | yes — `/map` |
| `Voorstellen` | `Voorstellen` | yes — `/voorstellen` |
| `Advice` | `Advice` | yes — `/advice` |
| `BesluitvormingAgenda` | `AgendaCompiler` | yes — `/besluitvorming/agenda` |

The repo already documents this in `menu-layout.json`'s `removalsCoverageNote`, and I verified each claim against the built effective manifest rather than trusting the note:

* `Cases` (`src/manifest.json`) carries `config.viewModes: [table, cards, map]` **and** `config.folderSidebar` filtering on `caseType` — so the map surface and the bezwaar/beroep/subsidie case-type views are reachable there.
* `CaseDetail` carries the sidebar tab `besluitvorming` → component `BesluitvormingLeafTab` — the decision surface consumed from decidesk.

gate-53 cannot see a runtime `folderSidebar` filter, a page `viewMode`, or a per-object sidebar tab as reachability. **Routes removed by this PR: none.** Deleting them would break deep links and the e2e specs that navigate to them, and would violate the explicit ADR-044 hard invariants of `case-type-navigation` (d6824aa20) and `consume-decidesk-besluitvorming-leaf` (d2df51b8b). Restoring them as static top-level nav re-introduces the anti-pattern both changes rejected.

gate-53 has **no exemption or waiver mechanism** — I grepped `check_manifest_crossref.js` and the runner block for one. So procest cannot close it from this repo. The fix belongs in `ConductionNL/.github`: either teach `removals-invariant` to recognise `folderSidebar` / `viewMode` / sidebar-tab reachability, or give it the reason-bearing waiver that gate-26 already has (`@visual exclude <reason>`).

## gate-62: real, but not a drive-by fix

`lib/Service/WooPublication/OpenCatalogiApiClient.php` builds and fetches `/index.php/apps/openregister/api/objects/...` with `IClientService`, outside `GenericStoreService` (ADR-080 D2/D3). That is a genuine violation — but the file is a documented, `@spec`-annotated design decision (OpenCatalogi exposes no write endpoint, so both its own backend and frontend write through OR's generic Objects API, and this client follows the same path). Re-routing it through the ADR-080 store plane is a design change that needs its own OpenSpec change, not a fix folded into a test-naming PR.

## Relationship to #863

#863 (`fix(e2e): de-race 9 test.skip() gates on the non-waiting isVisible()`) touches `handler-vervanging-waarneming.spec.ts`, `kanban-board-keyboard-status-transition.spec.ts`, `workflow-editor-canvas.spec.ts` and adds `helpers/becomes-visible.js`. **This PR touches none of those files**, deliberately, so it cannot deepen #863's existing conflict with `development`. #863 closes neither `Hydra Gates` nor `Quality Report` — it makes racing specs actually execute, which is a prerequisite for their coverage being worth anything, not a gate fix.

## Verification

* gate-26 re-measured with the gate's own `check_visual_coverage.py` in `--mode report`: `{new_pages: 78, covered: 0, uncovered: 78}` → `{new_pages: 78, covered: 4, uncovered: 74}`. The instrument was shown to move, so it can say both yes and no.
* `prettier --check` on all 5 changed files: clean.
* `tsc --noEmit` on the 4 changed specs: clean. **Positive control run** — `playwright test --list` did *not* fail on a deliberately bad named import (esbuild is transpile-only), so `--list` proves only that a file parses; `tsc` was used for the real check and *did* fail the control with `TS2305`.
* `playwright test --list` across the whole suite: 128 tests in 33 files still load.
* No PHP, no `src/`, no manifest byte is touched — the PHPUnit, vitest, phpcs/psalm/phpstan and manifest jobs cannot be affected by this diff.
