### PR TITLE
test(e2e): close 8 of 9 gate-26 findings with live-measured page-shell coverage

### DIFF
--- a/tests/e2e/helpers/page-components.ts
+++ b/tests/e2e/helpers/page-components.ts
@@ -24,10 +24,15 @@
  * Adding a constant here for a screen no spec visits would be a declaration
  * nobody reads — the exact failure mode the masking above exists to prevent.
  * Add the entry when you add the test, not before. Screens this suite does not
- * yet drive are deliberately ABSENT here rather than listed and unused —
- * `/substitution` and `/substitution-admin` are the current example: they are
- * driven by handler-vervanging-waarneming.spec.ts and will get their constants
- * when that file is next touched (it is mid-flight in PR #863).
+ * yet drive are deliberately ABSENT here rather than listed and unused.
+ *
+ * Every route below was MEASURED against a running instance before its constant
+ * was added — navigate, read the rendered headings, confirm the screen is the
+ * one the constant names. The probe discriminates: an unrouted path falls back
+ * to the Dashboard, and a routed page whose component is not registered renders
+ * the manifest renderer's "This page is empty" placeholder instead. Both are
+ * distinguishable from a real render, so "it rendered" is a finding rather than
+ * an assumption.
  *
  * Routes are app-relative; the app is HISTORY-mode, so `navToRoute()` /
  * `page.goto()` prefix them with `/index.php/apps/procest`.
@@ -44,3 +49,48 @@ export const VerwerkingenOverview = '/verwerkingen'
 
 /** `src/views/workflow-board/WorkflowBoard.vue` — the kanban status board. */
 export const WorkflowBoard = '/workflow-board'
+
+/** `src/views/settings/SubstitutionSettings.vue` — self-service vervanging (manifest page `SubstitutionSettings`). */
+export const SubstitutionSettings = '/substitution'
+
+/** `src/views/admin/SubstitutionAdmin.vue` — the coordinator substitution console (manifest page `SubstitutionAdmin`). */
+export const SubstitutionAdmin = '/substitution-admin'
+
+/** `src/views/dashboard/ProcessMiningDashboard.vue` — bottleneck analysis; renders `<h2>Process Mining</h2>`. */
+export const ProcessMiningDashboard = '/process-mining'
+
+/** `src/views/dashboard/TenantOnboardingDashboard.vue` — SaaS tenant onboarding; renders `<h2>Tenant onboarding</h2>`. */
+export const TenantOnboardingDashboard = '/tenant-onboarding'
+
+/** `src/views/dashboard/TermijnDashboard.vue` — AWB termijnbewaking KPIs; renders `<h2>Deadline monitoring</h2>`. */
+export const TermijnDashboard = '/termijn-dashboard'
+
+/**
+ * `src/views/public/PublicStatusPage.vue` — the citizen "track your case" page.
+ *
+ * Token-addressed. The token below is deliberately one that cannot resolve:
+ * OpenRegister answers an unknown / revoked / expired / RBAC-denied token with
+ * a uniform 404 (see the component's `loadStatus()` docblock), so the page
+ * lands in its `error` branch deterministically, with no fixture to seed.
+ */
+export const PublicStatusPage = '/public/status/e2e-unresolvable-token'
+
+/**
+ * `src/views/public/PublicAppointmentPage.vue` — the citizen appointment page.
+ *
+ * Same shape as PublicStatusPage: an unresolvable token makes
+ * `publicAppointment#view` 404, which is the page's `error` branch.
+ */
+export const PublicAppointmentPage = '/public/appointments/e2e-unresolvable-token'
+
+/**
+ * `src/views/public/PublicFederatedTransferPage.vue` — the remote-organisation
+ * accept/reject surface for a federated case transfer.
+ *
+ * This one takes no fetch on mount at all — the component's own header records
+ * that no GET endpoint exists to pre-load transfer details, so it presents the
+ * action rather than a data view. Its heading is therefore independent of every
+ * backend, and the token/id in the path are never dereferenced by the render.
+ */
+export const PublicFederatedTransferPage =
+	'/public/federation/transfer/e2e-unresolvable-token/e2e-transfer'

--- a/tests/e2e/page-shells.spec.ts
+++ b/tests/e2e/page-shells.spec.ts
@@ -1,0 +1,115 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Procest Contributors
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * Render-shell coverage for six manifest pages that no other spec drove.
+ *
+ * WHAT THESE ASSERT, AND WHY IT IS NOT A TAUTOLOGY
+ * -----------------------------------------------
+ * Each page below renders a heading that sits OUTSIDE every `v-if` in its own
+ * template, so the assertion holds whether or not OpenRegister returns data —
+ * the same data-independent contract `spec-coverage/ui-pages.spec.ts` asserts
+ * for `/doorlooptijd`. What it proves is that the route resolves AND the
+ * manifest renderer found the component AND the component mounted without
+ * throwing.
+ *
+ * That is a real question with three distinguishable answers, measured on a
+ * live instance (procest 0.3.9) before these tests were written:
+ *
+ *   route resolves, component registered   → the page's own heading
+ *   route resolves, component NOT registered → the manifest renderer's
+ *                                            "This page is empty" placeholder
+ *   route does not resolve                 → falls back to the Dashboard
+ *
+ * The middle case is not hypothetical: `/public/consultations/:token` is in
+ * exactly that state today (page `ExternalConsultationResponse` is declared in
+ * `src/manifest.d/consultation-public.json`, its component is not in
+ * `src/customComponents.js`), which is why it has no test here. A heading
+ * assertion tells those three apart; `.app-content` being visible does not,
+ * because it is visible in all three.
+ *
+ * The three public pages are token-addressed and deliberately use a token that
+ * CANNOT resolve, so no fixture has to be seeded and the branch under test is
+ * deterministic — see the constants' own docblocks in
+ * `helpers/page-components.ts` for why each backend answers a uniform 404.
+ *
+ * Naming: the routes come from `helpers/page-components.ts`, whose identifiers
+ * are the components' file stems, so the screen each test covers is stated in
+ * executable code rather than in a comment (hydra gate-26 / .github#358).
+ */
+
+import { test, expect } from '@playwright/test'
+
+import { navToRoute } from './helpers/nav'
+import {
+	ProcessMiningDashboard,
+	PublicAppointmentPage,
+	PublicFederatedTransferPage,
+	PublicStatusPage,
+	TenantOnboardingDashboard,
+	TermijnDashboard,
+} from './helpers/page-components'
+
+/**
+ * Drive one route and assert its own heading rendered.
+ *
+ * @param page    the Playwright page
+ * @param route   app-relative route, from `helpers/page-components.ts`
+ * @param heading the heading text this screen renders unconditionally
+ */
+async function expectPageShell(page, route: string, heading: string) {
+	await navToRoute(page, route)
+	await expect(
+		page.getByRole('heading', { name: heading, level: 2 }).first(),
+	).toBeVisible({ timeout: 15000 })
+	// A rendered heading rules out the Dashboard fallback and the empty-page
+	// placeholder; this rules out a shell that rendered around a 500.
+	await expect(page.locator('body')).not.toContainText('Internal Server Error')
+}
+
+test.describe('Dashboard page shells', () => {
+	test('process mining dashboard renders its bottleneck-analysis heading', async ({
+		page,
+	}) => {
+		await expectPageShell(page, ProcessMiningDashboard, 'Process Mining')
+	})
+
+	test('tenant onboarding dashboard renders its heading', async ({ page }) => {
+		await expectPageShell(page, TenantOnboardingDashboard, 'Tenant onboarding')
+	})
+
+	test('termijn dashboard renders its deadline-monitoring heading', async ({
+		page,
+	}) => {
+		await expectPageShell(page, TermijnDashboard, 'Deadline monitoring')
+	})
+})
+
+test.describe('Public token-addressed page shells', () => {
+	// This page performs no fetch on mount at all — its own header records that
+	// no GET endpoint exists to pre-load transfer details — so the heading is
+	// independent of every backend.
+	test('federated transfer page renders the accept/reject surface', async ({
+		page,
+	}) => {
+		await expectPageShell(
+			page,
+			PublicFederatedTransferPage,
+			'Case transfer request',
+		)
+	})
+
+	// An unresolvable token is answered with a uniform 404 by OpenRegister's
+	// public case-token endpoint, so the error branch is the deterministic one.
+	test('public case-status page renders its unresolvable-token state', async ({
+		page,
+	}) => {
+		await expectPageShell(page, PublicStatusPage, 'Status unavailable')
+	})
+
+	test('public appointment page renders its unresolvable-token state', async ({
+		page,
+	}) => {
+		await expectPageShell(page, PublicAppointmentPage, 'Appointment not found')
+	})
+})

--- a/tests/e2e/spec-coverage/handler-vervanging-waarneming.spec.ts
+++ b/tests/e2e/spec-coverage/handler-vervanging-waarneming.spec.ts
@@ -17,13 +17,14 @@
 import { test, expect } from '@playwright/test'
 import { becomesVisible } from '../helpers/becomes-visible.js'
 import { dismissSupportDialog } from '../helpers/nav'
+import { SubstitutionAdmin, SubstitutionSettings } from '../helpers/page-components'
 
 test.describe('Handler vervanging/waarneming spec coverage', () => {
 	// @e2e openspec/specs/handler-vervanging-waarneming/spec.md#handler-registers-their-own-substitution
 	test('user substitution settings page renders with a register action', async ({
 		page,
 	}) => {
-		await page.goto('/index.php/apps/procest/substitution')
+		await page.goto(`/index.php/apps/procest${SubstitutionSettings}`)
 		await dismissSupportDialog(page)
 		const heading = page.getByRole('heading', { name: /Substitution/ }).first()
 		if (await becomesVisible(heading)) {
@@ -42,7 +43,7 @@ test.describe('Handler vervanging/waarneming spec coverage', () => {
 	test('opening the substitution form shows the substitute field', async ({
 		page,
 	}) => {
-		await page.goto('/index.php/apps/procest/substitution')
+		await page.goto(`/index.php/apps/procest${SubstitutionSettings}`)
 		await dismissSupportDialog(page)
 		const btn = page
 			.getByRole('button', { name: /Register substitution/ })
@@ -92,7 +93,7 @@ test.describe('Handler vervanging/waarneming spec coverage', () => {
 	test('coordinator admin exposes a bulk-reassign action with a mandatory preview', async ({
 		page,
 	}) => {
-		await page.goto('/index.php/apps/procest/substitution-admin')
+		await page.goto(`/index.php/apps/procest${SubstitutionAdmin}`)
 		await dismissSupportDialog(page)
 		const heading = page
 			.getByRole('heading', { name: /Substitutions & reassignment/ })
@@ -120,7 +121,7 @@ test.describe('Handler vervanging/waarneming spec coverage', () => {
 	test('coordinator admin lists substitutions with an actions affordance', async ({
 		page,
 	}) => {
-		await page.goto('/index.php/apps/procest/substitution-admin')
+		await page.goto(`/index.php/apps/procest${SubstitutionAdmin}`)
 		await dismissSupportDialog(page)
 		const heading = page
 			.getByRole('heading', { name: /Substitutions & reassignment/ })


### PR DESCRIPTION
## What this closes

**gate-26 (visual-coverage): 9 → 1.** Measured full-tree on gate package
`f935e2c`, against `development` @ `47b48c9f` — the same package and the same
tree CI ran in `development` run 31982890850. My local runner reproduces that
run *exactly* (5 gates failed: 25=116, 26=9, 47=7, 53=8, 62=1, exit 5), so the
before/after below is against a validated instrument rather than against itself.

| gate | base `47b48c9f` | this PR | package |
|---|---|---|---|
| gate-25 contract-coverage | FAIL 116 | FAIL 116 | `f935e2c` |
| gate-26 visual-coverage | FAIL 9 | **FAIL 1** | `f935e2c` |
| gate-47 security-change-has-tests | FAIL 7 | **NOT APPLICABLE** | `f935e2c` |
| gate-53 effective-manifest-crossref | FAIL 8 | FAIL 8 | `f935e2c` |
| gate-62 store-plane | FAIL 1 | FAIL 1 | `f935e2c` |
| **runner exit (= failure count)** | **5** | **4** | |

Diff is **test-side only** — three files under `tests/e2e/`, zero lines of
`lib/` or `src/`.

## Six pages had no e2e test at all

Each was driven against a live instance and its rendered heading recorded
*before* the assertion was written:

| route | heading asserted |
|---|---|
| `/process-mining` | `Process Mining` |
| `/tenant-onboarding` | `Tenant onboarding` |
| `/termijn-dashboard` | `Deadline monitoring` |
| `/public/federation/transfer/…` | `Case transfer request` |
| `/public/status/<unresolvable>` | `Status unavailable` |
| `/public/appointments/<unresolvable>` | `Appointment not found` |

Every one of those headings sits **outside every `v-if`** in its own template,
so the assertion holds with or without seeded data — the same data-independent
contract `spec-coverage/ui-pages.spec.ts` already asserts for `/doorlooptijd`.
The three public pages use a token that **cannot** resolve, so their backends
answer a uniform 404 and the error branch is deterministic with no fixture to
seed. `PublicFederatedTransferPage` performs no fetch on mount at all (its own
header records that no GET endpoint exists to pre-load transfer details), so its
heading is independent of every backend.

**The probe discriminates** — that is why "it rendered" is a finding and not an
assumption. Three outcomes were observed, all distinguishable:

* route resolves + component registered → the page's own heading
* route resolves + component **not** registered → the manifest renderer's
  *"This page is empty"* placeholder
* route does not resolve → falls back to the Dashboard

`.app-content` being visible tells none of those apart, which is why the tests
assert the heading.

## Two pages were already covered — only the *name* was invisible

`SubstitutionSettings` and `SubstitutionAdmin` are genuinely driven by
`spec-coverage/handler-vervanging-waarneming.spec.ts`, whose five tests **pass**
in CI (not skip — checked in run 31982890850's E2E log). They were findings only
because the URL string does not contain the component stem, and gate-26 matches
`\b<stem>\b` against comment-masked executable text. Substituting a route
constant whose *identifier is the stem* produces a **byte-identical URL** and
changes no control flow.

## What this does NOT close, and why

* **gate-26's last finding — `ExternalConsultationResponsePage`.** Its page is
  declared in `src/manifest.d/consultation-public.json` but its component is
  absent from `src/customComponents.js`, so `/public/consultations/<token>`
  renders the empty-page placeholder today — **confirmed live, not inferred**.
  Writing an e2e for it would be a test of the placeholder. Registering the
  component is a product change on an anonymous public surface and belongs in
  its own change.
* **gate-25 (116).** Measured split: **0** are openregister's variable-method-call
  shape; **19** are already declared by Postman collections the gate never opens
  (`_newman_paths()` reads only `tests/integration/`, and procest keeps 9 of its
  10 collections under `tests/newman/`); **97** are a genuine gap.
* **gate-53 (8)** — `removals-invariant`, re-confirmed. All eight targets exist
  and stay routable; gate-53 walks only the static `.menu` tree and has no waiver
  mechanism. The fix belongs in `ConductionNL/.github`.
* **gate-62 (1)** — `OpenCatalogiApiClient.php` cannot be routed through
  `GenericStoreService`: that service is read-only discovery
  (`isConfigured`/`search`/`resolve`, no create/patch/attach) and SSRF-guards
  every URL against private/reserved addresses, so a same-instance call would
  fail closed. No spec was invented to satisfy the gate.

## Verification

* `npx tsc --noEmit` clean on all three files, with a positive control (a bogus
  import produces `TS2305`, so exit 0 means something).
* `npm run format` (prettier, whole repo) clean.
* `playwright test --list` collects **134** tests in 34 files, up from 128 — the
  six new tests are collected, not silently ignored.
* Gate figures above produced by `run-hydra-gates.sh` at `f935e2c` on both trees.

Not merged by me — the orchestrator verifies and merges.
