### PR TITLE
fix(phpcs): clear 21 PHPCS errors

### DIFF
--- a/lib/Controller/CaseFederationController.php
+++ b/lib/Controller/CaseFederationController.php
@@ -106,6 +106,8 @@ class CaseFederationController extends Controller {
 	 * @param CaseTransferService $caseTransferService The transfer service
 	 * @param CaseCollaborationService $collabService The federated activity service
 	 * @param IUserSession $userSession The user session
+	 * @param IThrottler $throttler The brute-force throttler counting rejected share tokens
+	 * @param LoggerInterface $logger The logger
 	 *
 	 * @return void
 	 */

--- a/lib/Controller/ConsultationPublicController.php
+++ b/lib/Controller/ConsultationPublicController.php
@@ -116,6 +116,10 @@ class ConsultationPublicController extends Controller {
 	 *
 	 * Access is logged for BIO compliance.
 	 *
+	 * Rate-limit rationale: tight — this is an unauthenticated public
+	 * consultation response, so an unbounded caller can stuff the consultation
+	 * with fabricated submissions.
+	 *
 	 * @param string $token The secure access token
 	 *
 	 * @return JSONResponse Updated consultation or error
@@ -125,8 +129,6 @@ class ConsultationPublicController extends Controller {
 	 *
 	 * @spec openspec/changes/consultation-management/tasks.md#TASK-CN-04
 	 */
-	// Tight: this is an unauthenticated public consultation response, so an
-	// unbounded caller can stuff the consultation with fabricated submissions.
 	#[AnonRateLimit(limit: 20, period: 60)]
 	public function publicResponsePost(string $token): JSONResponse {
 		if (empty($token) === true) {

--- a/lib/Controller/DSOIntakeController.php
+++ b/lib/Controller/DSOIntakeController.php
@@ -88,6 +88,12 @@ class DSOIntakeController extends Controller {
 	 * OpenConnector. Payload signature is validated via HMAC-SHA256.
 	 * Invalid signatures result in 401; any other errors result in 500.
 	 *
+	 * Rate-limit rationale: DSO intake receiver — the caller is the Digitaal
+	 * Stelsel Omgevingswet, not a browser, and it authenticates by its own
+	 * credential. A generous ceiling against a delivery storm; too tight here
+	 * would DROP statutory submissions, which is a worse failure than
+	 * absorbing a burst.
+	 *
 	 * @return JSONResponse Created case data or error
 	 *
 	 * @PublicPage
@@ -97,10 +103,6 @@ class DSOIntakeController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
-	// DSO intake receiver — the caller is the Digitaal Stelsel Omgevingswet,
-	// not a browser, and it authenticates by its own credential. A generous
-	// ceiling against a delivery storm; too tight here would DROP statutory
-	// submissions, which is a worse failure than absorbing a burst.
 	#[AnonRateLimit(limit: 300, period: 60)]
 	public function intake(): JSONResponse {
 		// OCP\AppFramework\Http\Request::getContent() is marked protected, so

--- a/lib/Controller/DashboardController.php
+++ b/lib/Controller/DashboardController.php
@@ -137,15 +137,16 @@ class DashboardController extends Controller {
 	 * fell through to `Response.error()`. Any request the worker claimed with
 	 * `respondWith()` was therefore guaranteed to fail in the page.
 	 *
+	 * Rate-limit rationale: PWA assets — the browser fetches these on install
+	 * and on every update check, so the ceiling only exists to stop them being
+	 * used as a load generator. No credential, so no brute-force counter.
+	 *
 	 * @return DataDownloadResponse The service-worker JavaScript.
 	 *
 	 * @spec openspec/specs/mobiel-inspectie-offline/spec.md#requirement-offline-daily-planning-synchronization
 	 */
 	#[NoCSRFRequired]
 	#[PublicPage]
-	// PWA assets — the browser fetches these on install and on every update
-	// check, so the ceiling only exists to stop them being used as a load
-	// generator. No credential, so no brute-force counter.
 	#[AnonRateLimit(limit: 240, period: 60)]
 	public function serviceWorker(): DataDownloadResponse {
 		$body = $this->readPublicAsset(name: 'service-worker.js');

--- a/lib/Controller/DrcController.php
+++ b/lib/Controller/DrcController.php
@@ -582,6 +582,9 @@ class DrcController extends ZgwController {
 	/**
 	 * Download the binary file content for an EIO document.
 	 *
+	 * Rate-limit rationale: lower than the sibling reads — a download moves
+	 * file bytes.
+	 *
 	 * @param string $uuid The document UUID.
 	 *
 	 * @return DataDownloadResponse|JSONResponse
@@ -592,7 +595,6 @@ class DrcController extends ZgwController {
 	 *
 	 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
 	 */
-	// Lower than the sibling reads: a download moves file bytes.
 	#[AnonRateLimit(limit: 60, period: 60)]
 	public function download(string $uuid): DataDownloadResponse|JSONResponse {
 		$authError = $this->zgwService->validateJwtAuth($this->request);
@@ -1354,6 +1356,9 @@ class DrcController extends ZgwController {
 	 * Receives raw binary data for a single chunk and stores it.
 	 * When all chunks have been uploaded, merges them into the final file.
 	 *
+	 * Rate-limit rationale: tight — each call accepts a chunk of file bytes,
+	 * so this is the cheapest way for an anonymous caller to consume storage.
+	 *
 	 * @param string $uuid The document UUID.
 	 *
 	 * @return JSONResponse
@@ -1367,8 +1372,6 @@ class DrcController extends ZgwController {
 	 *
 	 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
 	 */
-	// Tight: each call accepts a chunk of file bytes, so this is the cheapest
-	// way for an anonymous caller to consume storage.
 	#[AnonRateLimit(limit: 30, period: 60)]
 	public function uploadChunk(string $uuid): JSONResponse {
 		$authError = $this->zgwService->validateJwtAuth($this->request);

--- a/lib/Controller/DwangsomPaymentCallbackController.php
+++ b/lib/Controller/DwangsomPaymentCallbackController.php
@@ -73,15 +73,16 @@ class DwangsomPaymentCallbackController extends Controller {
 	/**
 	 * Handle a payment callback.
 	 *
+	 * Rate-limit rationale: payment provider callback. Same reasoning as the
+	 * DSO receiver — the caller is a provider retrying on its own schedule,
+	 * and dropping a payment notification is worse than absorbing a burst.
+	 *
 	 * @return JSONResponse
 	 *
 	 * @spec openspec/changes/termijnbewaking-dwangsom-engine-07-financial-integration/tasks.md
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
-	// Payment provider callback. Same reasoning as the DSO receiver: the
-	// caller is a provider retrying on its own schedule, and dropping a
-	// payment notification is worse than absorbing a burst.
 	#[AnonRateLimit(limit: 300, period: 60)]
 	public function callback(): JSONResponse {
 		// The OCP IRequest::getContent() method is marked protected in

--- a/lib/Controller/InspectionChecklistController.php
+++ b/lib/Controller/InspectionChecklistController.php
@@ -59,6 +59,7 @@ class InspectionChecklistController extends Controller {
 	 * @param IUserSession $userSession User session
 	 * @param IGroupManager $groupManager Group manager
 	 * @param LoggerInterface $logger Logger
+	 * @param CaseAccessGuard $caseAccessGuard Per-case read-access guard
 	 *
 	 * @spec openspec/changes/vth-module/tasks.md#task-4
 	 */

--- a/lib/Controller/NrcController.php
+++ b/lib/Controller/NrcController.php
@@ -252,6 +252,10 @@ class NrcController extends ZgwController {
 	 *
 	 * This endpoint receives incoming ZGW notifications and acknowledges them.
 	 *
+	 * Rate-limit rationale: tight — a notification fans out to every
+	 * subscribed channel, so one cheap call can generate a lot of downstream
+	 * delivery work.
+	 *
 	 * @return JSONResponse
 	 *
 	 * @NoCSRFRequired
@@ -260,8 +264,6 @@ class NrcController extends ZgwController {
 	 *
 	 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
 	 */
-	// Tight: a notification fans out to every subscribed channel, so one cheap
-	// call can generate a lot of downstream delivery work.
 	#[AnonRateLimit(limit: 30, period: 60)]
 	public function notificatieCreate(): JSONResponse {
 		$authError = $this->zgwService->validateJwtAuth($this->request);

--- a/lib/Controller/PublicAppointmentController.php
+++ b/lib/Controller/PublicAppointmentController.php
@@ -84,6 +84,9 @@ class PublicAppointmentController extends Controller {
 	/**
 	 * Cancel an appointment via its public token.
 	 *
+	 * Rate-limit rationale: tight — cancelling is destructive and reachable
+	 * without authentication, so the token in the link is the only barrier.
+	 *
 	 * @param string $token The appointment public token.
 	 *
 	 * @return JSONResponse
@@ -93,8 +96,6 @@ class PublicAppointmentController extends Controller {
 	 *
 	 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
 	 */
-	// Tight: cancelling is destructive and reachable without authentication,
-	// so the token in the link is the only barrier.
 	#[AnonRateLimit(limit: 20, period: 60)]
 	public function cancel(string $token): JSONResponse {
 		$appointment = $this->appointmentService->getAppointmentByToken($token);

--- a/lib/Controller/RaadsinformatieFeedController.php
+++ b/lib/Controller/RaadsinformatieFeedController.php
@@ -85,6 +85,10 @@ class RaadsinformatieFeedController extends Controller {
 	/**
 	 * Serve the Atom feed for vergaderingen.
 	 *
+	 * Rate-limit rationale: raadsinformatie is a published open-data feed —
+	 * public access is the statutory point of it, so these are runaway
+	 * ceilings, not gates, and carry no brute-force counter.
+	 *
 	 * @param string $organisation Optional organisatie filter
 	 *
 	 * @return DataDisplayResponse Atom XML feed
@@ -93,9 +97,6 @@ class RaadsinformatieFeedController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
-	// Raadsinformatie is a published open-data feed — public access is the
-	// statutory point of it, so these are runaway ceilings, not gates, and
-	// carry no brute-force counter.
 	#[AnonRateLimit(limit: 120, period: 60)]
 	public function vergaderingen(string $organisation = ''): DataDisplayResponse {
 		return $this->buildFeed(

--- a/lib/Controller/StufController.php
+++ b/lib/Controller/StufController.php
@@ -93,6 +93,10 @@ class StufController extends Controller {
 	/**
 	 * Handle inbound StUF-ZKN SOAP messages for case operations.
 	 *
+	 * Rate-limit rationale: StUF-ZKN SOAP receivers. The caller is a municipal
+	 * middleware component on its own retry schedule, so the ceiling is
+	 * generous — dropping a StUF delivery is worse than absorbing a burst.
+	 *
 	 * @return DataDisplayResponse SOAP XML response.
 	 *
 	 * @psalm-suppress PossiblyUnusedMethod
@@ -101,9 +105,6 @@ class StufController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
-	// StUF-ZKN SOAP receivers. The caller is a municipal middleware component
-	// on its own retry schedule, so the ceiling is generous — dropping a StUF
-	// delivery is worse than absorbing a burst.
 	#[AnonRateLimit(limit: 300, period: 60)]
 	public function cases(): DataDisplayResponse {
 		return $this->dispatcher->dispatch(

--- a/lib/Controller/SubsidieRegisterController.php
+++ b/lib/Controller/SubsidieRegisterController.php
@@ -63,6 +63,9 @@ class SubsidieRegisterController extends Controller {
 	/**
 	 * Export the public subsidieregister feed (anonymised, published only).
 	 *
+	 * Rate-limit rationale: tight — an export is a cheap request that buys a
+	 * lot of server work.
+	 *
 	 * @return JSONResponse
 	 *
 	 * @PublicPage
@@ -72,7 +75,6 @@ class SubsidieRegisterController extends Controller {
 	 *
 	 * @spec openspec/changes/subsidieverlening-keten/tasks.md#TASK-SUB-39
 	 */
-	// Tight: an export is a cheap request that buys a lot of server work.
 	#[AnonRateLimit(limit: 20, period: 60)]
 	public function export(): JSONResponse {
 		$limit = (int)$this->request->getParam('limit', 100);

--- a/lib/Controller/ZgwOpenApiController.php
+++ b/lib/Controller/ZgwOpenApiController.php
@@ -108,6 +108,10 @@ class ZgwOpenApiController extends Controller {
 	 * The `$api` segment is checked against a strict allow-list (self::APIS)
 	 * before touching the filesystem — no path traversal is possible.
 	 *
+	 * Rate-limit rationale: generous — the OpenAPI document is fetched by
+	 * tooling and client generators, which a tight ceiling would break rather
+	 * than protect.
+	 *
 	 * @param string $api The ZGW API id (zaken, documenten, catalogi, besluiten, autorisaties, notificaties)
 	 *
 	 * @return DataDisplayResponse|JSONResponse
@@ -118,8 +122,6 @@ class ZgwOpenApiController extends Controller {
 	 *
 	 * @spec openspec/specs/zgw-openapi-publication/spec.md
 	 */
-	// Generous: the OpenAPI document is fetched by tooling and client
-	// generators, which a tight ceiling would break rather than protect.
 	#[AnonRateLimit(limit: 240, period: 60)]
 	public function spec(string $api): DataDisplayResponse|JSONResponse {
 		if (isset(self::APIS[$api]) === false) {

--- a/lib/Controller/ZrcController.php
+++ b/lib/Controller/ZrcController.php
@@ -774,6 +774,9 @@ class ZrcController extends ZgwController {
 	 *
 	 * Delegates to index and returns HTTP 201 per the ZGW specification.
 	 *
+	 * Rate-limit rationale: lower than a plain read — zoek is the most
+	 * expensive query in this controller, and it is reachable anonymously.
+	 *
 	 * @return JSONResponse
 	 *
 	 * @NoCSRFRequired
@@ -782,8 +785,6 @@ class ZrcController extends ZgwController {
 	 *
 	 * @spec openspec/changes/retrofit-2026-05-24-case-management/tasks.md
 	 */
-	// Lower than a plain read: zoek is the most expensive query in this
-	// controller, and it is reachable anonymously.
 	#[AnonRateLimit(limit: 60, period: 60)]
 	public function zoek(): JSONResponse {
 		$indexResponse = $this->index(resource: 'zaken');

--- a/lib/Service/DsoCaseService.php
+++ b/lib/Service/DsoCaseService.php
@@ -92,6 +92,7 @@ class DsoCaseService {
 	 * @param ContainerInterface $container The DI container (ObjectService resolved lazily)
 	 * @param DsoStatusChangeNotifier $notifier Emits the VergunningStatusChanged domain event
 	 * @param LoggerInterface $logger The logger
+	 * @param ObjectServiceInterface $objectService The OpenRegister object service (ADR-084)
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,
@@ -175,9 +176,9 @@ class DsoCaseService {
 			],
 		];
 
-		// saveObject() returns an ObjectEntityInterface (ADR-084); this method
-		// declares `: array`. Normalise, exactly as findObjectAsArray() does on
-		// the read side.
+		// The saveObject() call returns an ObjectEntityInterface (ADR-084); this
+		// method declares `: array`. Normalise, exactly as findObjectAsArray()
+		// does on the read side.
 		$created = $this->saveObjectAsArray(
 			objectService: $objectService,
 			register: $register,

--- a/lib/Service/SamenwerkverzoekService.php
+++ b/lib/Service/SamenwerkverzoekService.php
@@ -56,6 +56,7 @@ class SamenwerkverzoekService {
 	 * @param ContainerInterface $container The DI container
 	 * @param IEventDispatcher $eventDispatcher The event dispatcher
 	 * @param LoggerInterface $logger The logger
+	 * @param ObjectServiceInterface $objectService The OpenRegister object service (ADR-084)
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,
@@ -128,7 +129,7 @@ class SamenwerkverzoekService {
 			'requestedOn' => date('c'),
 		];
 
-		// saveObject() returns an ObjectEntityInterface (which extends
+		// The saveObject() call returns an ObjectEntityInterface (which extends
 		// JsonSerializable), never an array — returning it straight out of a
 		// method declared `: array` is a TypeError.
 		$created = $objectService->saveObject(

--- a/lib/Service/Stuf/StufRegisterAccess.php
+++ b/lib/Service/Stuf/StufRegisterAccess.php
@@ -51,6 +51,7 @@ class StufRegisterAccess {
 	 * @param IAppContainer $container The DI container.
 	 * @param IAppConfig $appConfig The app config (register id lookup).
 	 * @param LoggerInterface $logger The logger.
+	 * @param IAppManager $appManager The app manager (checks openregister is installed).
 	 */
 	public function __construct(
 		private IAppContainer $container,


### PR DESCRIPTION
## What

`phpcs` reported **21 errors and 505 warnings** on `development`. This clears the errors to **0**. Warnings are deliberately left alone.

The errors have been invisible: the shared quality workflow (`ConductionNL/.github/.github/workflows/quality.yml@main`) maps `phpcs` exit 1 to success, so a red `phpcs` has been shipping as a green gate. This clears procest's share of that fleet-wide debt **before** the gate is corrected to fail on errors, so the correction lands on an already-clean tree.

## Errors cleared, by category

| Sniff | Count |
|---|---|
| `PEAR.Commenting.FunctionComment.WrongStyle` | 13 |
| `PEAR.Commenting.FunctionComment.MissingParamTag` | 6 |
| `Squiz.Commenting.InlineComment.NotCapital` | 2 |
| **Total** | **21** |

**`WrongStyle` (13).** Every site had the same shape: a correct `/** */` docblock, then a `//` block explaining the `#[AnonRateLimit]` ceiling, then the attribute, then the function. That `//` block is what the sniff reads as "the function comment". The rationale is **folded into the docblock** as a `Rate-limit rationale:` paragraph — not deleted. Sites: `StufController::cases`, `DashboardController::serviceWorker`, `ZrcController::zoek`, `SubsidieRegisterController::export`, `RaadsinformatieFeedController::vergaderingen`, `ConsultationPublicController::publicResponsePost`, `ZgwOpenApiController::spec`, `DSOIntakeController::intake`, `DwangsomPaymentCallbackController::callback`, `PublicAppointmentController::cancel`, `DrcController::download`, `DrcController::uploadChunk`, `NrcController::notificatieCreate`.

**`MissingParamTag` (6).** Constructor promoted properties added without their `@param` line. Tags written against the actual signature, in signature order: `$caseAccessGuard` (InspectionChecklistController), `$throttler` + `$logger` (CaseFederationController), `$objectService` (SamenwerkverzoekService, DsoCaseService), `$appManager` (StufRegisterAccess).

**`NotCapital` (2).** Two inline comments opened with the lowercase `saveObject()`. Reworded to open with a capital; meaning preserved.

## Side effect worth recording: 13 hidden `@spec` warnings

13 `CustomSniffs.Commenting.SpecTag.MissingMethodSpec` warnings also disappeared (505 → 492). **None were suppressed.** Those 13 methods each carried a correct `@spec` tag all along — the intervening `//` block hid the docblock from the `@spec` sniff exactly as it hid it from the `WrongStyle` sniff.

So one comment misplacement was breaking **ADR-003 traceability reporting on 13 public endpoints**, and the `@spec` gate was reporting them as untagged when they were tagged. Diffed warning-set base vs head by `(file, sniff, message)`: **13 gone, 0 new**.

## Method

- Fixed **by hand**. No `phpcbf`, no `--fix`, no `phpcs:ignore`, no `<exclude>` rules, no ruleset changes.
- No genuine false positives found — nothing recorded as debt, nothing switched off.
- **Every changed line is a comment line.** No executable code is touched (`git diff` filtered for non-comment changes returns empty).

## Verification

Measured on PHP 8.3 in Docker against base `development` (`d53e321f`). Positive control: a pristine worktree of the base commit reproduces 21 errors / 505 warnings / exit 1, so the instrument can still show failure.

| Check | Before | After |
|---|---|---|
| `lint` | 934 files, 0 syntax errors | unchanged |
| `phpcs` | 21 errors, 505 warnings, **exit 1** | **0 errors**, 492 warnings, **exit 0** |
| `phpmd` (both rulesets) | clean | clean |
| `psalm` | 25 errors | 25 errors — **identical by type/file/line** |
| `phpstan` | `[OK] No errors` | `[OK] No errors` |
| `phpunit` | 1925 tests, 9288 assertions, 8 errors, 2 failures, 1 warning, 5 skipped | **identical**, same 10 test names |

`composer check:strict` is **already RED on `development`** — psalm (25 `UndefinedClass` in `CaseDefinitionExportService`, `CaseDefinitionImportService`, `ZipManifestBuilder`) and phpunit (10 failing tests in `DashboardControllerServiceWorkerTest`, `ZaakdossierDownloadControllerGuardTest`, `BeschikkingServiceTest`, `ZipManifestBuilderTest`, `AiAuditExportControllerTest`). Those are pre-existing and untouched by this PR. Both were compared **by identity, not by count** — psalm errors match exactly on type/file/line, and the failing-test set matches exactly by name (execution order differs between runs, membership does not).

**This PR introduces nothing new in any check.**
