### PR TITLE
fix(gates): gate-24's checker could not see the direct integrations.register() form

### DIFF
--- a/scripts/check-integration-parity.js
+++ b/scripts/check-integration-parity.js
@@ -512,6 +512,37 @@ function resolveJs(expr, locals) {
 }
 
 /**
+ * Build the same-file `const NAME = { … }` table, keyed to the OBJECT LITERAL
+ * TEXT rather than a resolved scalar.
+ *
+ * `jsLocalConsts` below resolves constants to VALUES, and for a `{` it only
+ * reads to end-of-line, so a multi-line descriptor object never lands in its
+ * table. That is fine for `id: SOME_CONST`, but it cannot serve a registration
+ * whose whole descriptor is passed by name:
+ *
+ *   export const decisionsLeafDescriptor = { id: …, renderMode: 'mount', … }
+ *   …
+ *   OCA.OpenRegister.integrations.register(decisionsLeafDescriptor)
+ *
+ * The member parser in `collectJsRegistrations` needs the literal's TEXT, so
+ * this table keeps the balanced `{ … }` body verbatim for that one purpose.
+ *
+ * @param {string} src JS source text.
+ *
+ * @return {Object<string, string>} Constant name to object-literal inner text.
+ */
+function jsLocalObjectLiterals(src) {
+	const table = {}
+	const re = /\bconst\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*\{/g
+	let m
+	while ((m = re.exec(src)) !== null) {
+		const brace = m.index + m[0].length - 1
+		table[m[1]] = balanced(src, brace)
+	}
+	return table
+}
+
+/**
  * Build the same-file `const NAME = …` table for a JS/Vue source.
  *
  * @param {string} src JS source text.
@@ -560,12 +591,29 @@ function collectJsRegistrations() {
 		} catch (e) {
 			continue
 		}
-		if (src.includes('registerIntegration') === false) {
+		// BOTH SUPPORTED REGISTRATION APIs, NOT ONE.
+		//
+		// `registerIntegration(descriptor)` is the convenience wrapper exported
+		// from @conduction/nextcloud-vue. The registry object it wraps is
+		// equally canonical and is called directly as
+		// `OCA.OpenRegister.integrations.register(descriptor)` — including by
+		// nextcloud-vue's OWN built-in leaves. Matching only the wrapper made
+		// this checker report ZERO registrations for a repo that plainly has
+		// one, which the wrapper script then correctly refused to call a pass.
+		// gate-24's own selector probe was fixed for exactly this and reads
+		// both forms; this checker was a generation behind it.
+		if (
+			src.includes('registerIntegration') === false
+			&& src.includes('integrations.register') === false
+		) {
 			continue
 		}
 		const rel = path.relative(REPO_ROOT, file)
 		const locals = jsLocalConsts(src)
-		const re = /registerIntegration\s*\(/g
+		const objects = jsLocalObjectLiterals(src)
+		// `\s*\(` anchors both alternatives to a CALL, so neither
+		// `registerIntegrationIcons(` nor `installIntegrationRegistry(` matches.
+		const re = /(?:\bregisterIntegration|\bintegrations\s*\.\s*register)\s*\(/g
 		let m
 		while ((m = re.exec(src)) !== null) {
 			const before = src.slice(Math.max(0, m.index - 20), m.index)
@@ -573,9 +621,15 @@ function collectJsRegistrations() {
 				continue // the library's own `export function registerIntegration(`
 			}
 			const open = src.indexOf('(', m.index)
-			const argText = balanced(src, open).trim()
+			let argText = balanced(src, open).trim()
 			if (argText.startsWith('{') === false) {
-				continue
+				// A descriptor passed BY NAME is the same registration as an
+				// inline literal; resolve it to the literal's text or skip.
+				const ident = /^([A-Za-z_$][A-Za-z0-9_$]*)$/.exec(argText)
+				if (ident === null || objects[ident[1]] === undefined) {
+					continue
+				}
+				argText = '{' + objects[ident[1]] + '}'
 			}
 			const reg = { file: rel, fields: {}, keys: [], spreads: [] }
 			for (const member of splitTopLevel(balanced(argText, 0))) {


### PR DESCRIPTION
`scripts/check-integration-parity.js` (hydra gate-24) matched only the `registerIntegration(` convenience wrapper, and only an **inline** object literal. The registry object that wrapper wraps is equally canonical and is called directly as:

```js
OCA.OpenRegister.integrations.register(descriptor)
```

…including by `@conduction/nextcloud-vue`'s **own built-in leaves**. A repo using that form had every registration read as **zero** — the checker would correlate nothing and report success over an empty set.

**This is not hypothetical.** gate-24's own selector probe in `run-hydra-gates.sh` already matches *both* forms, and carries a comment recording why: probing for only the wrapper *"made this gate produce a FALSE ABSENCE CLAIM"*. The checker was a generation behind its own gate.

Found while porting this same file into **decidesk**, which uses the direct form — there the checker saw nothing, and (correctly) refused to report a pass over an empty set.

## Fixed

- match `integrations.register(` as well as `registerIntegration(`, anchored on `\s*\(` so neither `registerIntegrationIcons(` nor `installIntegrationRegistry(` can match;
- resolve a descriptor passed **by name** to its `const NAME = { … }` literal text (new `jsLocalObjectLiterals`). The existing `jsLocalConsts` resolves *values* and only reads to end-of-line when it meets a `{`, so a multi-line descriptor never entered its table.

## Control — additive, measured not assumed

Modified checker vs the original, run against **this repo** before the swap: **byte-identical stdout and identical exit code.** Nothing that passed before behaves differently; the only new capability is seeing a form that was previously invisible.

## Why land it if nothing changes here

This repo uses the wrapper form today, so the output is unchanged. It is **defensive**: adopting the direct form later would otherwise silently switch gate-24 off for this repo — and **an absence that reads as a pass is the exact failure this gate exists to prevent.**

Sibling PR: decidesk#519 (same fix, where the blind spot was live).
