### PR TITLE
test(gate-25): close contract-coverage by writing the missing contract tests

### DIFF
--- a/tests/Unit/Controller/AdviceControllerContractTest.php
+++ b/tests/Unit/Controller/AdviceControllerContractTest.php
@@ -1,0 +1,619 @@
+<?php
+
+/**
+ * AdviceController Wire-Contract Tests
+ *
+ * Contract coverage for the three advice endpoints that had no automated proof
+ * of their wire behaviour (gate-25). The three do NOT share one auth posture,
+ * and that difference is the contract these tests pin:
+ *
+ *  - `createForCase` and `getForCase` THROW `OCSForbiddenException` for an
+ *    anonymous caller, while `dispatchReminder` answers a plain 401 JSON body —
+ *    a client cannot handle both the same way, so the shape of each refusal is
+ *    asserted rather than "some error came back";
+ *  - `getForCase` is the only one of the three behind `CaseAccessGuard`, and it
+ *    must consult it with the CASE uuid from the route and the SESSION user —
+ *    passing the wrong id or a different user is the realistic defect;
+ *  - `createForCase` writes `requestedBy`, `caseRef` and `status` server-side.
+ *    A body that claims all three must not win: identity supplied by the
+ *    requester is not identity;
+ *  - `dispatchReminder` distinguishes an authorization refusal (403, message
+ *    carried through) from an unexpected failure (500, message withheld) — a
+ *    single catch-all would either leak internals or hide the refusal.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use LogicException;
+use OCA\Procest\Controller\AdviceController;
+use OCA\Procest\Service\AdviceService;
+use OCA\Procest\Service\CaseAccessGuard;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\OCS\OCSForbiddenException;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * Concrete IRequest stub carrying a raw JSON body.
+ *
+ * `AdviceController::readJsonBody()` prefers `$request->getContent()` and only
+ * falls back to `php://input`. `OCP\IRequest` does not declare `getContent()`
+ * (it is a magic property on the concrete Nextcloud request), so a createMock
+ * of the interface cannot serve a body at all. This stub is the seam that lets
+ * the "the body must not override server-derived identity" test actually POST
+ * something.
+ */
+class AdviceControllerRequestStub implements IRequest {
+
+	/**
+	 * Raw request body returned by getContent().
+	 *
+	 * @var string
+	 */
+	private string $content;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $content Raw JSON request body.
+	 */
+	public function __construct(string $content = '') {
+		$this->content = $content;
+	}//end __construct()
+
+	/**
+	 * Return the raw request body content.
+	 *
+	 * @return string
+	 */
+	public function getContent(): string {
+		return $this->content;
+	}//end getContent()
+
+	/**
+	 * Return a query/body parameter.
+	 *
+	 * @param string $key Parameter name.
+	 * @param mixed $default Default when absent.
+	 *
+	 * @return mixed
+	 */
+	public function getParam(string $key, mixed $default = null): mixed {
+		return $default;
+	}//end getParam()
+
+	/**
+	 * Return a request header value by name.
+	 *
+	 * @param string $name Header name.
+	 *
+	 * @return string
+	 */
+	public function getHeader(string $name): string {
+		return '';
+	}//end getHeader()
+
+	/**
+	 * Return all request parameters.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public function getParams(): array {
+		return [];
+	}//end getParams()
+
+	/**
+	 * Return the HTTP method.
+	 *
+	 * @return string
+	 */
+	public function getMethod(): string {
+		return 'POST';
+	}//end getMethod()
+
+	/**
+	 * Return an uploaded file by key.
+	 *
+	 * @param string $key File field name.
+	 *
+	 * @return mixed
+	 */
+	public function getUploadedFile(string $key): mixed {
+		return null;
+	}//end getUploadedFile()
+
+	/**
+	 * Return a server environment variable.
+	 *
+	 * @param string $key Variable name.
+	 *
+	 * @return mixed
+	 */
+	public function getEnv(string $key): mixed {
+		return null;
+	}//end getEnv()
+
+	/**
+	 * Return a cookie value by name.
+	 *
+	 * @param string $key Cookie name.
+	 *
+	 * @return mixed
+	 */
+	public function getCookie(string $key): mixed {
+		return null;
+	}//end getCookie()
+
+	/**
+	 * Return whether this request passes a CSRF check.
+	 *
+	 * @return bool
+	 */
+	public function passesCSRFCheck(): bool {
+		return true;
+	}//end passesCSRFCheck()
+
+	/**
+	 * Return whether this request passes a strict cookie check.
+	 *
+	 * @return bool
+	 */
+	public function passesStrictCookieCheck(): bool {
+		return true;
+	}//end passesStrictCookieCheck()
+
+	/**
+	 * Return whether this request passes a lax cookie check.
+	 *
+	 * @return bool
+	 */
+	public function passesLaxCookieCheck(): bool {
+		return true;
+	}//end passesLaxCookieCheck()
+
+	/**
+	 * Return the unique request ID.
+	 *
+	 * @return string
+	 */
+	public function getId(): string {
+		return 'test-request';
+	}//end getId()
+
+	/**
+	 * Return the remote IP address.
+	 *
+	 * @return string
+	 */
+	public function getRemoteAddress(): string {
+		return '127.0.0.1';
+	}//end getRemoteAddress()
+
+	/**
+	 * Return the server protocol.
+	 *
+	 * @return string
+	 */
+	public function getServerProtocol(): string {
+		return 'HTTP/1.1';
+	}//end getServerProtocol()
+
+	/**
+	 * Return the HTTP scheme.
+	 *
+	 * @return string
+	 */
+	public function getHttpProtocol(): string {
+		return 'http';
+	}//end getHttpProtocol()
+
+	/**
+	 * Return the full request URI.
+	 *
+	 * @return string
+	 */
+	public function getRequestUri(): string {
+		return '/apps/procest/api/vth/cases/case-1/advice-requests';
+	}//end getRequestUri()
+
+	/**
+	 * Return the raw path info segment.
+	 *
+	 * @return string
+	 */
+	public function getRawPathInfo(): string {
+		return '';
+	}//end getRawPathInfo()
+
+	/**
+	 * Return the decoded path info segment.
+	 *
+	 * @return mixed
+	 */
+	public function getPathInfo(): mixed {
+		return '';
+	}//end getPathInfo()
+
+	/**
+	 * Return the script name.
+	 *
+	 * @return string
+	 */
+	public function getScriptName(): string {
+		return '';
+	}//end getScriptName()
+
+	/**
+	 * Return whether the request originates from the given user agent(s).
+	 *
+	 * @param array<int,string> $agent Agent strings to match.
+	 *
+	 * @return bool
+	 */
+	public function isUserAgent(array $agent): bool {
+		return false;
+	}//end isUserAgent()
+
+	/**
+	 * Return the insecure (HTTP) server host.
+	 *
+	 * @return string
+	 */
+	public function getInsecureServerHost(): string {
+		return 'localhost';
+	}//end getInsecureServerHost()
+
+	/**
+	 * Return the server host.
+	 *
+	 * @return string
+	 */
+	public function getServerHost(): string {
+		return 'localhost';
+	}//end getServerHost()
+
+	/**
+	 * Throw if a JSON decode error occurred during body parsing.
+	 *
+	 * @return void
+	 */
+	public function throwDecodingExceptionIfAny(): void {
+	}//end throwDecodingExceptionIfAny()
+
+	/**
+	 * Return the requested response format.
+	 *
+	 * @return string|null
+	 */
+	public function getFormat(): ?string {
+		return null;
+	}//end getFormat()
+}//end class
+
+/**
+ * Wire-contract tests for AdviceController.
+ *
+ * @covers \OCA\Procest\Controller\AdviceController
+ */
+class AdviceControllerContractTest extends TestCase {
+
+	/**
+	 * The advice service mock — the controller's only delegate.
+	 *
+	 * @var AdviceService|MockObject
+	 */
+	private AdviceService $adviceService;
+
+	/**
+	 * The session mock.
+	 *
+	 * @var IUserSession|MockObject
+	 */
+	private IUserSession $userSession;
+
+	/**
+	 * The per-case read guard mock.
+	 *
+	 * @var CaseAccessGuard|MockObject
+	 */
+	private CaseAccessGuard $caseAccessGuard;
+
+	/**
+	 * The logger mock.
+	 *
+	 * @var LoggerInterface|MockObject
+	 */
+	private LoggerInterface $logger;
+
+	/**
+	 * Build the collaborator mocks. The controller itself is built per test so
+	 * a body-carrying request stub can be swapped in.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->adviceService = $this->createMock(AdviceService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->caseAccessGuard = $this->createMock(CaseAccessGuard::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+	}//end setUp()
+
+	/**
+	 * Build the controller over the supplied request.
+	 *
+	 * @param IRequest $request The request to hand the controller.
+	 *
+	 * @return AdviceController
+	 */
+	private function controller(IRequest $request): AdviceController {
+		return new AdviceController(
+			appName: 'procest',
+			request: $request,
+			adviceService: $this->adviceService,
+			userSession: $this->userSession,
+			logger: $this->logger,
+			caseAccessGuard: $this->caseAccessGuard,
+		);
+	}//end controller()
+
+	/**
+	 * Build the controller over a request carrying an empty JSON object.
+	 *
+	 * An empty string would make `readJsonBody()` fall through to `php://input`,
+	 * which a unit test cannot drive; `{}` keeps the read on the stub.
+	 *
+	 * @return AdviceController
+	 */
+	private function bodylessController(): AdviceController {
+		return $this->controller(request: new AdviceControllerRequestStub(content: '{}'));
+	}//end bodylessController()
+
+	/**
+	 * Mark the session as authenticated for user `alice`.
+	 *
+	 * @return IUser The authenticated user.
+	 */
+	private function authenticate(): IUser {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+		$this->userSession->method('getUser')->willReturn($user);
+
+		return $user;
+	}//end authenticate()
+
+	/**
+	 * createForCase refuses an anonymous caller by THROWING, and never reaches
+	 * the service. The throw (rather than a JSONResponse) is the contract: the
+	 * OCS exception is what the caller sees.
+	 *
+	 * @return void
+	 */
+	public function testCreateForCaseThrowsForbiddenForAnAnonymousCaller(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->adviceService->expects($this->never())->method('requestAdvice');
+
+		$this->expectException(OCSForbiddenException::class);
+		$this->expectExceptionMessage('Not authenticated');
+
+		$this->bodylessController()->createForCase(id: 'case-1');
+	}//end testCreateForCaseThrowsForbiddenForAnAnonymousCaller()
+
+	/**
+	 * createForCase derives `caseRef` from the ROUTE, `requestedBy` from the
+	 * SESSION and pins `status` to `open` — a body claiming all three must lose.
+	 *
+	 * A caller that could set `requestedBy` would attribute its own advice
+	 * request to somebody else, and one that could set `status` would skip the
+	 * workflow entirely.
+	 *
+	 * @return void
+	 */
+	public function testCreateForCaseOverridesCaseRefRequestedByAndStatusFromTheBody(): void {
+		$this->authenticate();
+
+		$body = json_encode(
+			[
+				'caseRef' => 'some-other-case',
+				'requestedBy' => 'mallory',
+				'status' => 'received',
+				'question' => 'Is dit vergunningplichtig?',
+			]
+		);
+
+		$created = ['id' => 'advice-1', 'status' => 'open'];
+
+		$this->adviceService->expects($this->once())
+			->method('requestAdvice')
+			->with(
+				'case-1',
+				$this->callback(
+					static function (array $data): bool {
+						return $data['caseRef'] === 'case-1'
+							&& $data['requestedBy'] === 'alice'
+							&& $data['status'] === 'open'
+							&& $data['question'] === 'Is dit vergunningplichtig?';
+					}
+				),
+				'alice'
+			)
+			->willReturn($created);
+
+		$controller = $this->controller(request: new AdviceControllerRequestStub(content: (string)$body));
+		$response = $controller->createForCase(id: 'case-1');
+
+		$this->assertSame(Http::STATUS_CREATED, $response->getStatus());
+		$this->assertSame($created, $response->getData());
+	}//end testCreateForCaseOverridesCaseRefRequestedByAndStatusFromTheBody()
+
+	/**
+	 * A service failure on createForCase is a 500, not a 201 with a half-made
+	 * record.
+	 *
+	 * @return void
+	 */
+	public function testCreateForCaseReturns500WhenTheServiceFails(): void {
+		$this->authenticate();
+		$this->adviceService->method('requestAdvice')
+			->willThrowException(new RuntimeException('OpenRegister is not available'));
+
+		$response = $this->bodylessController()->createForCase(id: 'case-1');
+
+		$this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+		$this->assertArrayHasKey('error', $response->getData());
+	}//end testCreateForCaseReturns500WhenTheServiceFails()
+
+	/**
+	 * getForCase refuses an anonymous caller by throwing, before the guard or
+	 * the service is consulted.
+	 *
+	 * @return void
+	 */
+	public function testGetForCaseThrowsForbiddenForAnAnonymousCaller(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->caseAccessGuard->expects($this->never())->method('hasCaseReadAccess');
+		$this->adviceService->expects($this->never())->method('getAdviceForCase');
+
+		$this->expectException(OCSForbiddenException::class);
+
+		$this->bodylessController()->getForCase(id: 'case-1');
+	}//end testGetForCaseThrowsForbiddenForAnAnonymousCaller()
+
+	/**
+	 * getForCase consults CaseAccessGuard with the CASE uuid from the route and
+	 * the SESSION user, and answers 403 without listing anything when the guard
+	 * denies. Advice requests carry the substance of a permit assessment, so a
+	 * list served past the guard is the disclosure.
+	 *
+	 * @return void
+	 */
+	public function testGetForCaseRefusesWithoutCaseReadAccessAndNeverLists(): void {
+		$user = $this->authenticate();
+
+		$this->caseAccessGuard->expects($this->once())
+			->method('hasCaseReadAccess')
+			->with('case-1', $user)
+			->willReturn(false);
+
+		$this->adviceService->expects($this->never())->method('getAdviceForCase');
+
+		$response = $this->bodylessController()->getForCase(id: 'case-1');
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame(['error' => 'Not authorized'], $response->getData());
+	}//end testGetForCaseRefusesWithoutCaseReadAccessAndNeverLists()
+
+	/**
+	 * With read access granted, getForCase returns the service's list verbatim
+	 * at 200, keyed on the same case uuid the guard approved.
+	 *
+	 * @return void
+	 */
+	public function testGetForCaseReturnsTheListForTheApprovedCase(): void {
+		$this->authenticate();
+		$this->caseAccessGuard->method('hasCaseReadAccess')->willReturn(true);
+
+		$rows = [['id' => 'advice-1', 'status' => 'requested']];
+
+		$this->adviceService->expects($this->once())
+			->method('getAdviceForCase')
+			->with('case-1')
+			->willReturn($rows);
+
+		$response = $this->bodylessController()->getForCase(id: 'case-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($rows, $response->getData());
+	}//end testGetForCaseReturnsTheListForTheApprovedCase()
+
+	/**
+	 * dispatchReminder answers a JSON 401 for an anonymous caller — NOT the
+	 * OCS throw its two neighbours use — and does not notify anybody.
+	 *
+	 * @return void
+	 */
+	public function testDispatchReminderReturns401ForAnAnonymousCallerAndSendsNothing(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->adviceService->expects($this->never())->method('dispatchReminderAsUser');
+
+		$response = $this->bodylessController()->dispatchReminder(id: 'advice-1');
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame(['error' => 'Not authenticated'], $response->getData());
+	}//end testDispatchReminderReturns401ForAnAnonymousCallerAndSendsNothing()
+
+	/**
+	 * The authorized seam is `dispatchReminderAsUser()`, not the cron's
+	 * unguarded `dispatchReminder()`. On success the wire answer is the fixed
+	 * `{"status":"reminded"}` acknowledgement.
+	 *
+	 * @return void
+	 */
+	public function testDispatchReminderUsesTheAuthorizedSeamAndAcknowledges(): void {
+		$this->authenticate();
+
+		$this->adviceService->expects($this->once())
+			->method('dispatchReminderAsUser')
+			->with('advice-1');
+
+		$response = $this->bodylessController()->dispatchReminder(id: 'advice-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['status' => 'reminded'], $response->getData());
+	}//end testDispatchReminderUsesTheAuthorizedSeamAndAcknowledges()
+
+	/**
+	 * The service's authorization refusal (a RuntimeException) becomes a 403
+	 * carrying the refusal message — not a 500, which a client would retry.
+	 *
+	 * @return void
+	 */
+	public function testDispatchReminderMapsAServiceRefusalTo403(): void {
+		$this->authenticate();
+		$this->adviceService->method('dispatchReminderAsUser')
+			->willThrowException(new RuntimeException('Advice request not accessible'));
+
+		$response = $this->bodylessController()->dispatchReminder(id: 'advice-1');
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame(['error' => 'Advice request not accessible'], $response->getData());
+	}//end testDispatchReminderMapsAServiceRefusalTo403()
+
+	/**
+	 * An unexpected failure becomes a 500 whose body does NOT carry the
+	 * internal message — only the RuntimeException arm is a caller-facing
+	 * message.
+	 *
+	 * @return void
+	 */
+	public function testDispatchReminderWithholdsTheInternalMessageOn500(): void {
+		$this->authenticate();
+		$this->adviceService->method('dispatchReminderAsUser')
+			->willThrowException(new LogicException('SQLSTATE[42S02] table procest_advice missing'));
+
+		$response = $this->bodylessController()->dispatchReminder(id: 'advice-1');
+
+		$this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+		$this->assertSame(['error' => 'Could not send reminder'], $response->getData());
+	}//end testDispatchReminderWithholdsTheInternalMessageOn500()
+}//end class

--- a/tests/Unit/Controller/AdvisoryBodyControllerContractTest.php
+++ b/tests/Unit/Controller/AdvisoryBodyControllerContractTest.php
@@ -1,0 +1,174 @@
+<?php
+
+/**
+ * AdvisoryBodyController Wire-Contract Tests
+ *
+ * Contract coverage for `GET /api/advisory-bodies/search` (gate-25). The
+ * endpoint is `@NoAdminRequired`, so Nextcloud's middleware only guarantees
+ * *some* session exists; the controller's own `getUser() === null` branch is
+ * what turns "no session" into a 401 instead of an unauthenticated directory
+ * dump. These tests pin:
+ *
+ *  - the refusal happens BEFORE AdvisoryBodyService is consulted;
+ *  - the `q` query parameter is forwarded verbatim as the service's `query`
+ *    argument — searching on the wrong parameter name silently returns the
+ *    unfiltered directory, which looks like a working search;
+ *  - the payload is nested under `results`, the shape the frontend reads.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\AdvisoryBodyController;
+use OCA\Procest\Service\AdvisoryBodyService;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Wire-contract tests for AdvisoryBodyController.
+ *
+ * @covers \OCA\Procest\Controller\AdvisoryBodyController
+ */
+class AdvisoryBodyControllerContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The advisory body directory service.
+	 *
+	 * @var AdvisoryBodyService|MockObject
+	 */
+	private AdvisoryBodyService $advisoryBodyService;
+
+	/**
+	 * The user session.
+	 *
+	 * @var IUserSession|MockObject
+	 */
+	private IUserSession $userSession;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var AdvisoryBodyController
+	 */
+	private AdvisoryBodyController $controller;
+
+	/**
+	 * Build the controller with mocked collaborators.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->advisoryBodyService = $this->createMock(AdvisoryBodyService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+
+		$this->controller = new AdvisoryBodyController(
+			appName: 'procest',
+			request: $this->request,
+			advisoryBodyService: $this->advisoryBodyService,
+			userSession: $this->userSession,
+		);
+	}//end setUp()
+
+	/**
+	 * Put a signed-in user on the session.
+	 *
+	 * @return void
+	 */
+	private function signIn(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+		$this->userSession->method('getUser')->willReturn($user);
+	}//end signIn()
+
+	/**
+	 * Without a session the endpoint answers 401 and never reaches the service.
+	 *
+	 * @return void
+	 */
+	public function testSearchRefusesAnUnauthenticatedCallerBeforeQueryingTheDirectory(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->advisoryBodyService->expects($this->never())->method('searchBySpecialization');
+
+		$response = $this->controller->searchAdvisoryBodies();
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame(['error' => 'Not authenticated'], $response->getData());
+	}//end testSearchRefusesAnUnauthenticatedCallerBeforeQueryingTheDirectory()
+
+	/**
+	 * The `q` query parameter is what the search is run on.
+	 *
+	 * A search wired to the wrong parameter name returns the whole directory
+	 * and still renders — so the parameter name is asserted, not just that a
+	 * search happened.
+	 *
+	 * @return void
+	 */
+	public function testSearchForwardsTheQQueryParameterAsTheSpecializationQuery(): void {
+		$this->signIn();
+		$bodies = [['id' => 'ab-1', 'naam' => 'Welstandscommissie']];
+
+		$this->request->expects($this->once())
+			->method('getParam')
+			->with('q')
+			->willReturn('welstand');
+
+		$this->advisoryBodyService->expects($this->once())
+			->method('searchBySpecialization')
+			->with('welstand')
+			->willReturn($bodies);
+
+		$response = $this->controller->searchAdvisoryBodies();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['results' => $bodies], $response->getData());
+	}//end testSearchForwardsTheQQueryParameterAsTheSpecializationQuery()
+
+	/**
+	 * An absent `q` is coerced to the empty string, never passed as null.
+	 *
+	 * AdvisoryBodyService::searchBySpecialization() declares `string $query`,
+	 * so forwarding a null would be a TypeError (HTTP 500) on the bare
+	 * `/api/advisory-bodies/search` call the UI makes on first paint.
+	 *
+	 * @return void
+	 */
+	public function testSearchCoercesAnAbsentQueryToAnEmptyStringRatherThanNull(): void {
+		$this->signIn();
+
+		$this->request->method('getParam')->willReturn(null);
+
+		$this->advisoryBodyService->expects($this->once())
+			->method('searchBySpecialization')
+			->with($this->identicalTo(''))
+			->willReturn([]);
+
+		$response = $this->controller->searchAdvisoryBodies();
+
+		$this->assertSame(['results' => []], $response->getData());
+	}//end testSearchCoercesAnAbsentQueryToAnEmptyStringRatherThanNull()
+}//end class

--- a/tests/Unit/Controller/AiControllerContractTest.php
+++ b/tests/Unit/Controller/AiControllerContractTest.php
@@ -1,0 +1,424 @@
+<?php
+
+/**
+ * AiController Wire-Contract Tests
+ *
+ * Contract coverage for the four AI endpoints that had no automated proof of
+ * their wire behaviour (gate-25): `ask`, `extract`, `recordAction` and
+ * `suggestNext`. All four are `@NoAdminRequired` POSTs that take a
+ * caller-supplied `caseId` and hand it to a service, so the properties worth
+ * pinning are:
+ *
+ *  - an anonymous caller gets 401 and the AI/audit service is never reached —
+ *    an LLM call made before the session check both leaks case context and
+ *    costs money;
+ *  - required-input validation is per-endpoint and NOT uniform: `ask` demands
+ *    caseId AND question, `extract` demands only caseId (documentId is
+ *    optional and must be forwarded as null, not as an empty string, or the
+ *    service would look for a document with the id ""), `suggestNext` demands
+ *    only caseId, `recordAction` demands caseId, type AND userAction;
+ *  - each delegate is called with its arguments in the right ORDER. All of
+ *    these methods take several same-typed strings in a row, so a transposed
+ *    pair (`type` and `userAction` on recordUserAction, `question` and `userId`
+ *    on askQuestion) type-checks perfectly and is the realistic defect.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\AiController;
+use OCA\Procest\Service\Ai\AiAuditService;
+use OCA\Procest\Service\AiService;
+use OCA\Procest\Service\CaseAccessGuard;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Wire-contract tests for AiController.
+ *
+ * @covers \OCA\Procest\Controller\AiController
+ */
+class AiControllerContractTest extends TestCase {
+
+	/**
+	 * The inbound request mock.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The AI service mock.
+	 *
+	 * @var AiService|MockObject
+	 */
+	private AiService $aiService;
+
+	/**
+	 * The AI oversight audit service mock.
+	 *
+	 * @var AiAuditService|MockObject
+	 */
+	private AiAuditService $auditService;
+
+	/**
+	 * The session mock.
+	 *
+	 * @var IUserSession|MockObject
+	 */
+	private IUserSession $userSession;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var AiController
+	 */
+	private AiController $controller;
+
+	/**
+	 * Build the controller with all collaborators mocked.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->aiService = $this->createMock(AiService::class);
+		$this->auditService = $this->createMock(AiAuditService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+
+		$this->controller = new AiController(
+			appName: 'procest',
+			request: $this->request,
+			aiService: $this->aiService,
+			auditService: $this->auditService,
+			userSession: $this->userSession,
+			logger: $this->createMock(LoggerInterface::class),
+			caseAccessGuard: $this->createMock(CaseAccessGuard::class),
+		);
+	}//end setUp()
+
+	/**
+	 * Mark the session as authenticated for user `alice`.
+	 *
+	 * @return void
+	 */
+	private function authenticate(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+		$this->userSession->method('getUser')->willReturn($user);
+	}//end authenticate()
+
+	/**
+	 * Mark the session as anonymous.
+	 *
+	 * @return void
+	 */
+	private function anonymous(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+	}//end anonymous()
+
+	/**
+	 * Feed the request parameter bag.
+	 *
+	 * @param array<string, mixed> $params The request parameters.
+	 *
+	 * @return void
+	 */
+	private function withParams(array $params): void {
+		$this->request->method('getParam')->willReturnCallback(
+			static function (string $key, mixed $default = null) use ($params): mixed {
+				if (array_key_exists($key, $params) === true) {
+					return $params[$key];
+				}
+
+				return $default;
+			}
+		);
+	}//end withParams()
+
+	/**
+	 * No AI work is done for an anonymous caller on any of the four endpoints,
+	 * and each answers the same 401 body.
+	 *
+	 * An LLM round-trip started before the session check would both bill the
+	 * instance and put case context into a prompt for a caller with no session.
+	 *
+	 * @return void
+	 */
+	public function testAllFourEndpointsRefuseAnAnonymousCallerBeforeAnyAiWork(): void {
+		$this->anonymous();
+		$this->withParams(['caseId' => 'case-1', 'question' => 'q', 'type' => 'routing', 'userAction' => 'accepted']);
+
+		$this->aiService->expects($this->never())->method('askQuestion');
+		$this->aiService->expects($this->never())->method('extractData');
+		$this->aiService->expects($this->never())->method('suggestNextStep');
+		$this->auditService->expects($this->never())->method('recordUserAction');
+
+		$responses = [
+			'ask' => $this->controller->ask(),
+			'extract' => $this->controller->extract(),
+			'suggestNext' => $this->controller->suggestNext(),
+			'recordAction' => $this->controller->recordAction(),
+		];
+
+		foreach ($responses as $endpoint => $response) {
+			$this->assertSame(
+				Http::STATUS_UNAUTHORIZED,
+				$response->getStatus(),
+				$endpoint . ' must answer 401 for a caller without a session'
+			);
+			$this->assertSame(
+				['error' => 'Not authenticated'],
+				$response->getData(),
+				$endpoint . ' must answer the standard unauthenticated body'
+			);
+		}
+	}//end testAllFourEndpointsRefuseAnAnonymousCallerBeforeAnyAiWork()
+
+	/**
+	 * ask() demands BOTH caseId and question; a caseId alone is a 400 and no
+	 * prompt is sent.
+	 *
+	 * @return void
+	 */
+	public function testAskRejectsAMissingQuestionWithoutPrompting(): void {
+		$this->authenticate();
+		$this->withParams(['caseId' => 'case-1']);
+		$this->aiService->expects($this->never())->method('askQuestion');
+
+		$response = $this->controller->ask();
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'caseId and question are required'], $response->getData());
+	}//end testAskRejectsAMissingQuestionWithoutPrompting()
+
+	/**
+	 * ask() forwards caseId, question and the SESSION user id — in that order —
+	 * and returns the service answer verbatim at 200.
+	 *
+	 * @return void
+	 */
+	public function testAskForwardsCaseQuestionAndSessionUserInOrder(): void {
+		$this->authenticate();
+		$this->withParams(['caseId' => 'case-1', 'question' => 'Wat is de beslistermijn?', 'userId' => 'mallory']);
+
+		$answer = ['answer' => 'Acht weken.', 'sources' => []];
+
+		$this->aiService->expects($this->once())
+			->method('askQuestion')
+			->with('case-1', 'Wat is de beslistermijn?', 'alice')
+			->willReturn($answer);
+
+		$response = $this->controller->ask();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($answer, $response->getData());
+	}//end testAskForwardsCaseQuestionAndSessionUserInOrder()
+
+	/**
+	 * extract() demands a caseId and refuses without one.
+	 *
+	 * @return void
+	 */
+	public function testExtractRejectsAMissingCaseId(): void {
+		$this->authenticate();
+		$this->withParams(['documentId' => 'doc-1']);
+		$this->aiService->expects($this->never())->method('extractData');
+
+		$response = $this->controller->extract();
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'caseId is required'], $response->getData());
+	}//end testExtractRejectsAMissingCaseId()
+
+	/**
+	 * extract() treats documentId as OPTIONAL and forwards a genuine null when
+	 * it is absent — the service signature is `?string $documentId`, so an
+	 * empty string would be a request to extract from a document called "".
+	 *
+	 * @return void
+	 */
+	public function testExtractForwardsANullDocumentIdWhenNoneWasGiven(): void {
+		$this->authenticate();
+		$this->withParams(['caseId' => 'case-1']);
+
+		$extracted = ['fields' => ['bsn' => '***']];
+
+		$this->aiService->expects($this->once())
+			->method('extractData')
+			->with('case-1', null, 'alice')
+			->willReturn($extracted);
+
+		$response = $this->controller->extract();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($extracted, $response->getData());
+	}//end testExtractForwardsANullDocumentIdWhenNoneWasGiven()
+
+	/**
+	 * With a documentId supplied, extract() scopes the extraction to that
+	 * document.
+	 *
+	 * @return void
+	 */
+	public function testExtractScopesToTheSuppliedDocument(): void {
+		$this->authenticate();
+		$this->withParams(['caseId' => 'case-1', 'documentId' => 'doc-9']);
+
+		$this->aiService->expects($this->once())
+			->method('extractData')
+			->with('case-1', 'doc-9', 'alice')
+			->willReturn(['fields' => []]);
+
+		$response = $this->controller->extract();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+	}//end testExtractScopesToTheSuppliedDocument()
+
+	/**
+	 * suggestNext() demands a caseId and refuses without one.
+	 *
+	 * @return void
+	 */
+	public function testSuggestNextRejectsAMissingCaseId(): void {
+		$this->authenticate();
+		$this->withParams([]);
+		$this->aiService->expects($this->never())->method('suggestNextStep');
+
+		$response = $this->controller->suggestNext();
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'caseId is required'], $response->getData());
+	}//end testSuggestNextRejectsAMissingCaseId()
+
+	/**
+	 * suggestNext() delegates to `suggestNextStep` — NOT `suggestRouting`,
+	 * which is a different endpoint on the same controller — with the case id
+	 * and the session user, and returns the suggestion set verbatim.
+	 *
+	 * @return void
+	 */
+	public function testSuggestNextDelegatesToSuggestNextStepNotSuggestRouting(): void {
+		$this->authenticate();
+		$this->withParams(['caseId' => 'case-1']);
+
+		$suggestions = ['steps' => [['action' => 'request_advice', 'confidence' => 0.8]]];
+
+		$this->aiService->expects($this->never())->method('suggestRouting');
+		$this->aiService->expects($this->once())
+			->method('suggestNextStep')
+			->with('case-1', 'alice')
+			->willReturn($suggestions);
+
+		$response = $this->controller->suggestNext();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($suggestions, $response->getData());
+	}//end testSuggestNextDelegatesToSuggestNextStepNotSuggestRouting()
+
+	/**
+	 * recordAction() demands caseId, type AND userAction. A body carrying only
+	 * two of the three is a 400 and nothing is written to the oversight log —
+	 * a half-identified entry is worse than none, because the Algorithm Act
+	 * register is read as complete.
+	 *
+	 * @return void
+	 */
+	public function testRecordActionRejectsAMissingUserActionAndWritesNothing(): void {
+		$this->authenticate();
+		$this->withParams(['caseId' => 'case-1', 'type' => 'routing']);
+		$this->auditService->expects($this->never())->method('recordUserAction');
+
+		$response = $this->controller->recordAction();
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'caseId, type, and userAction are required'], $response->getData());
+	}//end testRecordActionRejectsAMissingUserActionAndWritesNothing()
+
+	/**
+	 * recordAction() writes the oversight entry with its seven arguments in the
+	 * declared order — caseId, type, userAction, suggestion, actualValue,
+	 * reason, userId — and the recorded user id comes from the SESSION, not
+	 * from a `userId` the caller may have posted.
+	 *
+	 * Four of those seven are strings, so a transposition is invisible to the
+	 * type system and would silently mislabel every entry in the log.
+	 *
+	 * @return void
+	 */
+	public function testRecordActionWritesTheOversightEntryInDeclaredOrder(): void {
+		$this->authenticate();
+		$this->withParams(
+			[
+				'caseId' => 'case-1',
+				'type' => 'routing',
+				'userAction' => 'rejected',
+				'suggestion' => ['team' => 'vergunningen'],
+				'actualValue' => ['team' => 'handhaving'],
+				'reason' => 'Betreft een handhavingsverzoek.',
+				'userId' => 'mallory',
+			]
+		);
+
+		$written = ['id' => 'audit-1'];
+
+		$this->auditService->expects($this->once())
+			->method('recordUserAction')
+			->with(
+				'case-1',
+				'routing',
+				'rejected',
+				['team' => 'vergunningen'],
+				['team' => 'handhaving'],
+				'Betreft een handhavingsverzoek.',
+				'alice'
+			)
+			->willReturn($written);
+
+		$response = $this->controller->recordAction();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($written, $response->getData());
+	}//end testRecordActionWritesTheOversightEntryInDeclaredOrder()
+
+	/**
+	 * `actualValue` and `reason` are optional and reach the service as nulls,
+	 * not as empty strings/arrays — the audit entry distinguishes "the user did
+	 * not correct the suggestion" from "the user corrected it to nothing".
+	 *
+	 * @return void
+	 */
+	public function testRecordActionForwardsAbsentOptionalsAsNull(): void {
+		$this->authenticate();
+		$this->withParams(['caseId' => 'case-1', 'type' => 'routing', 'userAction' => 'accepted']);
+
+		$this->auditService->expects($this->once())
+			->method('recordUserAction')
+			->with('case-1', 'routing', 'accepted', [], null, null, 'alice')
+			->willReturn(['id' => 'audit-2']);
+
+		$response = $this->controller->recordAction();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+	}//end testRecordActionForwardsAbsentOptionalsAsNull()
+}//end class

--- a/tests/Unit/Controller/AppointmentControllerContractTest.php
+++ b/tests/Unit/Controller/AppointmentControllerContractTest.php
@@ -1,0 +1,344 @@
+<?php
+
+/**
+ * AppointmentController Wire-Contract Tests
+ *
+ * Contract coverage (gate-25) for the three AppointmentController endpoints
+ * that had no automated proof of their wire behaviour.
+ *
+ * `cancel()` and `noShow()` are the controller's two mutating routes and they
+ * carry ONLY an appointment id — no case id — so the guard they need cannot be
+ * applied directly: the owning case has to be resolved first and the ordinary
+ * per-case mutation guard applied to THAT. Two properties of that indirection
+ * are pinned here because both fail silently:
+ *
+ *  - an appointment whose owning case cannot be resolved DENIES (403), so an
+ *    unknown id is not an existence oracle and not an open door;
+ *  - the guard is asked about the RESOLVED CASE id, never about the
+ *    appointment id — passing the id it happens to have is the realistic
+ *    defect, and it would make the guard pass or fail on the wrong object.
+ *
+ * `timeslots()` is deliberately unguarded beyond the session (it is an
+ * availability probe against the scheduling backend's public catalogue), so
+ * what is pinned there is that it still refuses an anonymous caller and that
+ * it forwards the three query parameters — defaulting the date to today rather
+ * than sending an empty one.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\AppointmentController;
+use OCA\Procest\Service\AppointmentService;
+use OCA\Procest\Service\CaseAccessGuard;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Wire-contract tests for AppointmentController.
+ *
+ * @covers \OCA\Procest\Controller\AppointmentController
+ */
+class AppointmentControllerContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock handed to the controller.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The appointment backend.
+	 *
+	 * @var AppointmentService|MockObject
+	 */
+	private AppointmentService $appointmentService;
+
+	/**
+	 * The user session.
+	 *
+	 * @var IUserSession|MockObject
+	 */
+	private IUserSession $userSession;
+
+	/**
+	 * The per-case authorization guard (fails closed).
+	 *
+	 * @var CaseAccessGuard|MockObject
+	 */
+	private CaseAccessGuard $caseAccessGuard;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var AppointmentController
+	 */
+	private AppointmentController $controller;
+
+	/**
+	 * Build the controller with all collaborators mocked.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->appointmentService = $this->createMock(AppointmentService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->caseAccessGuard = $this->createMock(CaseAccessGuard::class);
+
+		$this->controller = new AppointmentController(
+			request: $this->request,
+			appointmentService: $this->appointmentService,
+			userSession: $this->userSession,
+			caseAccessGuard: $this->caseAccessGuard,
+		);
+	}//end setUp()
+
+	/**
+	 * Put a user in the session.
+	 *
+	 * @param string $uid The uid the session user reports.
+	 *
+	 * @return IUser|MockObject The session user.
+	 */
+	private function signIn(string $uid = 'handler'): IUser {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		$this->userSession->method('getUser')->willReturn($user);
+
+		return $user;
+	}//end signIn()
+
+	/**
+	 * Make `getParam()` behave like the real request: serve the override when
+	 * configured, otherwise the caller's own default.
+	 *
+	 * @param array<string, mixed> $overrides Parameter values to serve.
+	 *
+	 * @return void
+	 */
+	private function withRequestParams(array $overrides): void {
+		$this->request->method('getParam')->willReturnCallback(
+			static function (string $key, mixed $default = null) use ($overrides): mixed {
+				return ($overrides[$key] ?? $default);
+			}
+		);
+	}//end withRequestParams()
+
+	/**
+	 * All three endpoints refuse an anonymous caller with 401 and reach neither
+	 * the scheduling backend nor the case guard.
+	 *
+	 * @return void
+	 */
+	public function testAllThreeEndpointsRefuseAnAnonymousCallerWith401(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->appointmentService->expects($this->never())->method('cancelAppointment');
+		$this->appointmentService->expects($this->never())->method('markNoShow');
+		$this->appointmentService->expects($this->never())->method('getTimeslots');
+		$this->caseAccessGuard->expects($this->never())->method('hasCaseMutationAccess');
+
+		$responses = [
+			'cancel' => $this->controller->cancel(appointmentId: 'apt-1'),
+			'noShow' => $this->controller->noShow(appointmentId: 'apt-1'),
+			'timeslots' => $this->controller->timeslots(),
+		];
+
+		foreach ($responses as $endpoint => $response) {
+			$this->assertSame(
+				Http::STATUS_UNAUTHORIZED,
+				$response->getStatus(),
+				$endpoint . ' must refuse an anonymous caller'
+			);
+			$this->assertSame(['success' => false, 'error' => 'Not authenticated'], $response->getData());
+		}
+	}//end testAllThreeEndpointsRefuseAnAnonymousCallerWith401()
+
+	/**
+	 * An appointment id that resolves to no case DENIES with 403 and cancels
+	 * nothing. Answering 404 here would turn the route into an existence
+	 * oracle; answering 200 would make it an open door.
+	 *
+	 * @return void
+	 */
+	public function testCancelDeniesWhenTheOwningCaseCannotBeResolved(): void {
+		$this->signIn();
+		$this->appointmentService->method('getCaseIdForAppointment')->willReturn(null);
+		$this->caseAccessGuard->expects($this->never())->method('hasCaseMutationAccess');
+		$this->appointmentService->expects($this->never())->method('cancelAppointment');
+
+		$response = $this->controller->cancel(appointmentId: 'apt-unknown');
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame(['success' => false, 'error' => 'Not authorized'], $response->getData());
+	}//end testCancelDeniesWhenTheOwningCaseCannotBeResolved()
+
+	/**
+	 * The mutation guard is asked about the RESOLVED CASE id — not about the
+	 * appointment id the route carries — and its refusal is a 403 that cancels
+	 * nothing.
+	 *
+	 * @return void
+	 */
+	public function testCancelAsksTheGuardAboutTheResolvedCaseAndRefusesOnDenial(): void {
+		$user = $this->signIn();
+		$this->appointmentService->method('getCaseIdForAppointment')
+			->with('apt-1')
+			->willReturn('case-88');
+
+		$this->caseAccessGuard->expects($this->once())
+			->method('hasCaseMutationAccess')
+			->with('case-88', $user)
+			->willReturn(false);
+		$this->appointmentService->expects($this->never())->method('cancelAppointment');
+
+		$response = $this->controller->cancel(appointmentId: 'apt-1');
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame(['success' => false, 'error' => 'Not authorized'], $response->getData());
+	}//end testCancelAsksTheGuardAboutTheResolvedCaseAndRefusesOnDenial()
+
+	/**
+	 * A cleared caller's cancel reaches the backend with the appointment id and
+	 * gets the updated appointment back under `appointment`.
+	 *
+	 * @return void
+	 */
+	public function testCancelReturnsTheCancelledAppointmentForAClearedCaller(): void {
+		$this->signIn();
+		$this->appointmentService->method('getCaseIdForAppointment')->willReturn('case-88');
+		$this->caseAccessGuard->method('hasCaseMutationAccess')->willReturn(true);
+
+		$this->appointmentService->expects($this->once())
+			->method('cancelAppointment')
+			->with('apt-1')
+			->willReturn(['id' => 'apt-1', 'status' => 'cancelled']);
+		$this->appointmentService->expects($this->never())->method('markNoShow');
+
+		$response = $this->controller->cancel(appointmentId: 'apt-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(
+			['success' => true, 'appointment' => ['id' => 'apt-1', 'status' => 'cancelled']],
+			$response->getData()
+		);
+	}//end testCancelReturnsTheCancelledAppointmentForAClearedCaller()
+
+	/**
+	 * noShow takes the SAME resolve-then-guard path as cancel: an unresolvable
+	 * appointment denies, and the guard is asked about the resolved case.
+	 *
+	 * @return void
+	 */
+	public function testNoShowDeniesWhenTheGuardRefusesTheResolvedCase(): void {
+		$user = $this->signIn();
+		$this->appointmentService->method('getCaseIdForAppointment')
+			->with('apt-2')
+			->willReturn('case-99');
+
+		$this->caseAccessGuard->expects($this->once())
+			->method('hasCaseMutationAccess')
+			->with('case-99', $user)
+			->willReturn(false);
+		$this->appointmentService->expects($this->never())->method('markNoShow');
+
+		$response = $this->controller->noShow(appointmentId: 'apt-2');
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame(['success' => false, 'error' => 'Not authorized'], $response->getData());
+	}//end testNoShowDeniesWhenTheGuardRefusesTheResolvedCase()
+
+	/**
+	 * noShow marks a no-show — it does NOT cancel. The two routes are otherwise
+	 * identical, so the delegate each one picks is the thing worth pinning.
+	 *
+	 * @return void
+	 */
+	public function testNoShowMarksANoShowRatherThanCancelling(): void {
+		$this->signIn();
+		$this->appointmentService->method('getCaseIdForAppointment')->willReturn('case-99');
+		$this->caseAccessGuard->method('hasCaseMutationAccess')->willReturn(true);
+
+		$this->appointmentService->expects($this->once())
+			->method('markNoShow')
+			->with('apt-2')
+			->willReturn(['id' => 'apt-2', 'status' => 'no_show']);
+		$this->appointmentService->expects($this->never())->method('cancelAppointment');
+
+		$response = $this->controller->noShow(appointmentId: 'apt-2');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(
+			['success' => true, 'appointment' => ['id' => 'apt-2', 'status' => 'no_show']],
+			$response->getData()
+		);
+	}//end testNoShowMarksANoShowRatherThanCancelling()
+
+	/**
+	 * timeslots forwards product, location and date to the scheduling backend
+	 * in that order and answers the slot list under `timeslots`.
+	 *
+	 * @return void
+	 */
+	public function testTimeslotsForwardsTheProductLocationAndDateQuery(): void {
+		$this->signIn();
+		$this->withRequestParams(
+			[
+				'productId' => 'prod-7',
+				'locationId' => 'loc-3',
+				'date' => '2026-09-01',
+			]
+		);
+
+		$this->appointmentService->expects($this->once())
+			->method('getTimeslots')
+			->with('prod-7', 'loc-3', '2026-09-01')
+			->willReturn([['start' => '09:00'], ['start' => '09:30']]);
+
+		$response = $this->controller->timeslots();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(
+			['success' => true, 'timeslots' => [['start' => '09:00'], ['start' => '09:30']]],
+			$response->getData()
+		);
+	}//end testTimeslotsForwardsTheProductLocationAndDateQuery()
+
+	/**
+	 * With no `date` in the query the backend is asked about TODAY — an empty
+	 * date string would make the scheduling backend answer for no day at all.
+	 *
+	 * @return void
+	 */
+	public function testTimeslotsDefaultsTheDateToTodayWhenTheQueryOmitsIt(): void {
+		$this->signIn();
+		$this->withRequestParams(['productId' => 'prod-7']);
+
+		$this->appointmentService->expects($this->once())
+			->method('getTimeslots')
+			->with('prod-7', '', date('Y-m-d'))
+			->willReturn([]);
+
+		$response = $this->controller->timeslots();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['success' => true, 'timeslots' => []], $response->getData());
+	}//end testTimeslotsDefaultsTheDateToTodayWhenTheQueryOmitsIt()
+}//end class

--- a/tests/Unit/Controller/BelplanControllerContractTest.php
+++ b/tests/Unit/Controller/BelplanControllerContractTest.php
@@ -1,0 +1,205 @@
+<?php
+
+/**
+ * BelplanController Wire-Contract Tests
+ *
+ * Contract coverage for `POST /api/kcc/belplannen/route` (gate-25). The
+ * endpoint resolves which specialist a dialed number plus keuzemenu selection
+ * routes to, and it is the only belplan endpoint a KCC-medewerker calls on
+ * every inbound call. These tests pin:
+ *
+ *  - an unauthenticated caller is refused 401 BEFORE the routing service runs,
+ *    so the belplan (which maps phone numbers to named staff) is not readable
+ *    without a session;
+ *  - both `phoneNumber` and `menuSelection` reach the service — dropping the
+ *    menu selection still routes the call, to the wrong desk;
+ *  - a domain RuntimeException becomes a 400 carrying the domain message, not
+ *    a 500 — the caller has to be able to tell "unknown number" from "server
+ *    broken".
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\BelplanController;
+use OCA\Procest\Service\BelplanRoutingService;
+use OCA\Procest\Service\SettingsService;
+use OCP\AppFramework\Http;
+use OCP\IGroupManager;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Wire-contract tests for BelplanController::route().
+ *
+ * @covers \OCA\Procest\Controller\BelplanController
+ */
+class BelplanControllerContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The belplan routing service.
+	 *
+	 * @var BelplanRoutingService|MockObject
+	 */
+	private BelplanRoutingService $routingService;
+
+	/**
+	 * The settings service (unused by route(), required by the constructor).
+	 *
+	 * @var SettingsService|MockObject
+	 */
+	private SettingsService $settingsService;
+
+	/**
+	 * The user session.
+	 *
+	 * @var IUserSession|MockObject
+	 */
+	private IUserSession $userSession;
+
+	/**
+	 * The group manager.
+	 *
+	 * @var IGroupManager|MockObject
+	 */
+	private IGroupManager $groupManager;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var BelplanController
+	 */
+	private BelplanController $controller;
+
+	/**
+	 * Build the controller with mocked collaborators.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->routingService = $this->createMock(BelplanRoutingService::class);
+		$this->settingsService = $this->createMock(SettingsService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+
+		$this->controller = new BelplanController(
+			appName: 'procest',
+			request: $this->request,
+			routingService: $this->routingService,
+			settingsService: $this->settingsService,
+			userSession: $this->userSession,
+			groupManager: $this->groupManager,
+		);
+	}//end setUp()
+
+	/**
+	 * Put a signed-in, non-admin user on the session.
+	 *
+	 * @return void
+	 */
+	private function signIn(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('kcc-agent');
+		$this->userSession->method('getUser')->willReturn($user);
+		$this->groupManager->method('isAdmin')->willReturn(false);
+	}//end signIn()
+
+	/**
+	 * Drive the two request parameters route() reads.
+	 *
+	 * @param string $phoneNumber The dialed number.
+	 * @param string $menuSelection The keuzemenu selection.
+	 *
+	 * @return void
+	 */
+	private function withCall(string $phoneNumber, string $menuSelection): void {
+		$this->request->method('getParam')->willReturnCallback(
+			static function (string $key, mixed $default = null) use ($phoneNumber, $menuSelection): mixed {
+				return match ($key) {
+					'phoneNumber' => $phoneNumber,
+					'menuSelection' => $menuSelection,
+					default => $default,
+				};
+			}
+		);
+	}//end withCall()
+
+	/**
+	 * An unauthenticated caller is refused before the belplan is consulted.
+	 *
+	 * @return void
+	 */
+	public function testRouteRefusesAnUnauthenticatedCallerBeforeResolvingTheBelplan(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->routingService->expects($this->never())->method('routeCall');
+
+		$response = $this->controller->route();
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame(['error' => 'Not authenticated'], $response->getData());
+	}//end testRouteRefusesAnUnauthenticatedCallerBeforeResolvingTheBelplan()
+
+	/**
+	 * Both call attributes reach the routing service and the result is
+	 * returned unwrapped.
+	 *
+	 * @return void
+	 */
+	public function testRouteForwardsBothThePhoneNumberAndTheMenuSelection(): void {
+		$this->signIn();
+		$this->withCall(phoneNumber: '+31201234567', menuSelection: '3');
+
+		$resolved = ['specialist' => 'burgerzaken', 'queue' => 'BZ-1'];
+
+		$this->routingService->expects($this->once())
+			->method('routeCall')
+			->with('+31201234567', '3')
+			->willReturn($resolved);
+
+		$response = $this->controller->route();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($resolved, $response->getData());
+	}//end testRouteForwardsBothThePhoneNumberAndTheMenuSelection()
+
+	/**
+	 * A domain RuntimeException is a 400 with the domain message, not a 500.
+	 *
+	 * @return void
+	 */
+	public function testRouteMapsADomainRuntimeExceptionToA400CarryingItsMessage(): void {
+		$this->signIn();
+		$this->withCall(phoneNumber: '+31200000000', menuSelection: '9');
+
+		$this->routingService->method('routeCall')
+			->willThrowException(new \RuntimeException('Geen belplan voor dit nummer'));
+
+		$response = $this->controller->route();
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'Geen belplan voor dit nummer'], $response->getData());
+	}//end testRouteMapsADomainRuntimeExceptionToA400CarryingItsMessage()
+}//end class

--- a/tests/Unit/Controller/BerichtenboxControllerContractTest.php
+++ b/tests/Unit/Controller/BerichtenboxControllerContractTest.php
@@ -1,0 +1,399 @@
+<?php
+
+/**
+ * BerichtenboxController Wire-Contract Tests
+ *
+ * Contract coverage for the three Berichtenbox endpoints (gate-25). All three
+ * are `@NoAdminRequired`, i.e. reachable by EVERY authenticated Nextcloud user,
+ * and the Berichtenbox is a citizen's statutory message box — a send is an
+ * official, externally visible, non-undoable act. The contract pinned here:
+ *
+ *  - no session at all answers 401 and never reaches the service;
+ *  - `send` is guarded by the MUTATION guard and `messages`/`poll` by the READ
+ *    guard — using the read guard on `send` would let a bystander post official
+ *    correspondence in a citizen's name, so the guard NAME is asserted, not just
+ *    the 403;
+ *  - the guard is consulted with the caseId from the request and the session
+ *    user, so a guard called on the wrong case cannot pass;
+ *  - `poll` denies an unresolvable message id with 403, not 404 — the endpoint
+ *    must not be an existence oracle for other tenants' message ids.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\BerichtenboxController;
+use OCA\Procest\Service\BerichtenboxService;
+use OCA\Procest\Service\CaseAccessGuard;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Wire-contract tests for BerichtenboxController.
+ *
+ * @covers \OCA\Procest\Controller\BerichtenboxController
+ */
+class BerichtenboxControllerContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The BerichtenboxService mock.
+	 *
+	 * @var BerichtenboxService|MockObject
+	 */
+	private BerichtenboxService $berichtenboxService;
+
+	/**
+	 * The IUserSession mock.
+	 *
+	 * @var IUserSession|MockObject
+	 */
+	private IUserSession $userSession;
+
+	/**
+	 * The per-case authorization guard mock.
+	 *
+	 * @var CaseAccessGuard|MockObject
+	 */
+	private CaseAccessGuard $caseAccessGuard;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var BerichtenboxController
+	 */
+	private BerichtenboxController $controller;
+
+	/**
+	 * Build the controller with all collaborators mocked.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->berichtenboxService = $this->createMock(BerichtenboxService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->caseAccessGuard = $this->createMock(CaseAccessGuard::class);
+
+		$this->controller = new BerichtenboxController(
+			request: $this->request,
+			berichtenboxService: $this->berichtenboxService,
+			userSession: $this->userSession,
+			caseAccessGuard: $this->caseAccessGuard,
+		);
+	}//end setUp()
+
+	/**
+	 * Put a signed-in user on the session.
+	 *
+	 * @param string $uid The UID of the signed-in user.
+	 *
+	 * @return IUser|MockObject The user placed on the session.
+	 */
+	private function signIn(string $uid = 'alice'): IUser {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		$this->userSession->method('getUser')->willReturn($user);
+
+		return $user;
+	}//end signIn()
+
+	/**
+	 * Answer request parameters from the supplied map.
+	 *
+	 * @param array<string, mixed> $params The parameter map.
+	 *
+	 * @return void
+	 */
+	private function withParams(array $params): void {
+		$this->request->method('getParam')->willReturnCallback(
+			static function (string $key, mixed $default = null) use ($params): mixed {
+				return ($params[$key] ?? $default);
+			}
+		);
+	}//end withParams()
+
+	/**
+	 * `send` refuses an anonymous caller with 401 and never dispatches.
+	 *
+	 * @return void
+	 */
+	public function testSendRefusesAnUnauthenticatedCallerWith401(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->berichtenboxService->expects($this->never())->method('sendMessage');
+
+		$response = $this->controller->send();
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame(
+			['success' => false, 'error' => 'Not authenticated'],
+			$response->getData()
+		);
+	}//end testSendRefusesAnUnauthenticatedCallerWith401()
+
+	/**
+	 * `send` rejects a body without a caseId with 400 — before consulting the
+	 * guard, because a guard asked about an empty case cannot decide anything.
+	 *
+	 * @return void
+	 */
+	public function testSendRejectsAMissingCaseIdWith400BeforeGuarding(): void {
+		$this->signIn();
+		$this->withParams([]);
+		$this->caseAccessGuard->expects($this->never())->method('hasCaseMutationAccess');
+		$this->berichtenboxService->expects($this->never())->method('sendMessage');
+
+		$response = $this->controller->send();
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame('caseId is required', $response->getData()['error']);
+	}//end testSendRejectsAMissingCaseIdWith400BeforeGuarding()
+
+	/**
+	 * `send` is gated on MUTATION access to the named case, not read access.
+	 *
+	 * Dispatching an official government message is a write in every sense that
+	 * matters, so the read guard must not be the one consulted here.
+	 *
+	 * @return void
+	 */
+	public function testSendDemandsCaseMutationAccessAndRefusesWith403(): void {
+		$user = $this->signIn(uid: 'alice');
+		$this->withParams(['caseId' => 'case-1', 'subject' => 'Besluit', 'body' => 'Tekst']);
+
+		$this->caseAccessGuard->expects($this->once())
+			->method('hasCaseMutationAccess')
+			->with('case-1', $user)
+			->willReturn(false);
+		$this->caseAccessGuard->expects($this->never())->method('hasCaseReadAccess');
+		$this->berichtenboxService->expects($this->never())->method('sendMessage');
+
+		$response = $this->controller->send();
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame(
+			['success' => false, 'error' => 'Not authorized'],
+			$response->getData()
+		);
+	}//end testSendDemandsCaseMutationAccessAndRefusesWith403()
+
+	/**
+	 * A service-level failure is reported as 400 with the service's message and
+	 * `success: false` — never as a 200 the client would read as delivered.
+	 *
+	 * @return void
+	 */
+	public function testSendReportsAServiceFailureAs400WithSuccessFalse(): void {
+		$this->signIn();
+		$this->withParams(['caseId' => 'case-1']);
+		$this->caseAccessGuard->method('hasCaseMutationAccess')->willReturn(true);
+		$this->berichtenboxService->method('sendMessage')
+			->willReturn(['error' => 'Berichtenbox endpoint not configured']);
+
+		$response = $this->controller->send();
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertFalse($response->getData()['success']);
+		$this->assertSame('Berichtenbox endpoint not configured', $response->getData()['error']);
+	}//end testSendReportsAServiceFailureAs400WithSuccessFalse()
+
+	/**
+	 * A successful send answers 200 with the service's record under `message`.
+	 *
+	 * @return void
+	 */
+	public function testSendReturns200WithTheDispatchedMessageRecord(): void {
+		$this->signIn();
+		$this->withParams(['caseId' => 'case-1', 'bsn' => '123456782']);
+		$this->caseAccessGuard->method('hasCaseMutationAccess')->willReturn(true);
+		$this->berichtenboxService->method('sendMessage')
+			->willReturn(['id' => 'msg-1', 'status' => 'sent']);
+
+		$response = $this->controller->send();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(
+			['success' => true, 'message' => ['id' => 'msg-1', 'status' => 'sent']],
+			$response->getData()
+		);
+	}//end testSendReturns200WithTheDispatchedMessageRecord()
+
+	/**
+	 * `messages` refuses an anonymous caller with 401 and reads nothing.
+	 *
+	 * @return void
+	 */
+	public function testMessagesRefusesAnUnauthenticatedCallerWith401(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->berichtenboxService->expects($this->never())->method('getMessagesForCase');
+
+		$response = $this->controller->messages();
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame('Not authenticated', $response->getData()['error']);
+	}//end testMessagesRefusesAnUnauthenticatedCallerWith401()
+
+	/**
+	 * `messages` rejects a request without a caseId with 400 rather than
+	 * listing every message it can reach.
+	 *
+	 * @return void
+	 */
+	public function testMessagesRejectsAMissingCaseIdWith400(): void {
+		$this->signIn();
+		$this->withParams([]);
+		$this->berichtenboxService->expects($this->never())->method('getMessagesForCase');
+
+		$response = $this->controller->messages();
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame('caseId is required', $response->getData()['error']);
+	}//end testMessagesRejectsAMissingCaseIdWith400()
+
+	/**
+	 * `messages` is gated on READ access to the named case.
+	 *
+	 * @return void
+	 */
+	public function testMessagesDemandsCaseReadAccessAndRefusesWith403(): void {
+		$user = $this->signIn(uid: 'bob');
+		$this->withParams(['caseId' => 'case-7']);
+
+		$this->caseAccessGuard->expects($this->once())
+			->method('hasCaseReadAccess')
+			->with('case-7', $user)
+			->willReturn(false);
+		$this->berichtenboxService->expects($this->never())->method('getMessagesForCase');
+
+		$response = $this->controller->messages();
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame('Not authorized', $response->getData()['error']);
+	}//end testMessagesDemandsCaseReadAccessAndRefusesWith403()
+
+	/**
+	 * An authorized `messages` call answers 200 with the case's correspondence
+	 * under `messages`.
+	 *
+	 * @return void
+	 */
+	public function testMessagesReturnsTheCorrespondenceForTheNamedCase(): void {
+		$this->signIn();
+		$this->withParams(['caseId' => 'case-7']);
+		$this->caseAccessGuard->method('hasCaseReadAccess')->willReturn(true);
+		$this->berichtenboxService->expects($this->once())
+			->method('getMessagesForCase')
+			->with('case-7')
+			->willReturn([['id' => 'msg-1']]);
+
+		$response = $this->controller->messages();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(
+			['success' => true, 'messages' => [['id' => 'msg-1']]],
+			$response->getData()
+		);
+	}//end testMessagesReturnsTheCorrespondenceForTheNamedCase()
+
+	/**
+	 * `poll` refuses an anonymous caller with 401.
+	 *
+	 * @return void
+	 */
+	public function testPollRefusesAnUnauthenticatedCallerWith401(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->berichtenboxService->expects($this->never())->method('pollReadStatus');
+
+		$response = $this->controller->poll(messageId: 'msg-1');
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame('Not authenticated', $response->getData()['error']);
+	}//end testPollRefusesAnUnauthenticatedCallerWith401()
+
+	/**
+	 * An unresolvable message id is denied with 403 — deliberately the SAME
+	 * status as an unauthorized one, so the route cannot be used to discover
+	 * which message ids exist.
+	 *
+	 * @return void
+	 */
+	public function testPollDeniesAnUnknownMessageWith403AndIsNotAnExistenceOracle(): void {
+		$this->signIn();
+		$this->berichtenboxService->method('getCaseIdForMessage')->willReturn(null);
+		$this->caseAccessGuard->expects($this->never())->method('hasCaseReadAccess');
+		$this->berichtenboxService->expects($this->never())->method('pollReadStatus');
+
+		$response = $this->controller->poll(messageId: 'does-not-exist');
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertNotSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertSame('Not authorized', $response->getData()['error']);
+	}//end testPollDeniesAnUnknownMessageWith403AndIsNotAnExistenceOracle()
+
+	/**
+	 * `poll` resolves the message's OWNING case and applies the read guard to
+	 * that case — not to some caller-supplied id.
+	 *
+	 * @return void
+	 */
+	public function testPollAppliesTheReadGuardToTheMessagesOwningCase(): void {
+		$user = $this->signIn(uid: 'carol');
+		$this->berichtenboxService->expects($this->once())
+			->method('getCaseIdForMessage')
+			->with('msg-42')
+			->willReturn('case-99');
+
+		$this->caseAccessGuard->expects($this->once())
+			->method('hasCaseReadAccess')
+			->with('case-99', $user)
+			->willReturn(false);
+		$this->berichtenboxService->expects($this->never())->method('pollReadStatus');
+
+		$response = $this->controller->poll(messageId: 'msg-42');
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+	}//end testPollAppliesTheReadGuardToTheMessagesOwningCase()
+
+	/**
+	 * An authorized `poll` answers 200 with the polled read status.
+	 *
+	 * @return void
+	 */
+	public function testPollReturnsTheReadStatusForAnAuthorizedCaller(): void {
+		$this->signIn();
+		$this->berichtenboxService->method('getCaseIdForMessage')->willReturn('case-99');
+		$this->caseAccessGuard->method('hasCaseReadAccess')->willReturn(true);
+		$this->berichtenboxService->expects($this->once())
+			->method('pollReadStatus')
+			->with('msg-42')
+			->willReturn(['read' => true, 'readAt' => '2026-08-16T10:00:00+00:00']);
+
+		$response = $this->controller->poll(messageId: 'msg-42');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertTrue($response->getData()['success']);
+		$this->assertTrue($response->getData()['message']['read']);
+	}//end testPollReturnsTheReadStatusForAnAuthorizedCaller()
+}//end class

--- a/tests/Unit/Controller/BeschikkingControllerContractTest.php
+++ b/tests/Unit/Controller/BeschikkingControllerContractTest.php
@@ -1,0 +1,223 @@
+<?php
+
+/**
+ * BeschikkingController Wire-Contract Tests
+ *
+ * Contract coverage for `GET /api/beschikkingen/{id}/audit-pakket` (gate-25).
+ * The endpoint hands back the verifiable audit packet of a formal decision — a
+ * ZIP of the decision, its mandaat trail and its signatures — so its refusal
+ * branches matter more than its happy path. These tests pin:
+ *
+ *  - an unauthenticated caller is refused 401 BEFORE the packet is built, so
+ *    the export is never performed for a session-less request;
+ *  - an authenticated call reaches the exporter with the id from the URL;
+ *  - the domain error codes map to DISTINCT statuses — `not_found` is 404 and
+ *    `mandaat_insufficient` is 403. Collapsing those two into one status is
+ *    the realistic defect in a `match` of eleven arms, and the 403 arm is the
+ *    one that keeps an under-mandated official out of the audit trail.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\BeschikkingController;
+use OCA\Procest\Service\BeschikkingService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Wire-contract tests for BeschikkingController::auditPakket().
+ *
+ * @covers \OCA\Procest\Controller\BeschikkingController
+ */
+class BeschikkingControllerContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The beschikking domain service.
+	 *
+	 * @var BeschikkingService|MockObject
+	 */
+	private BeschikkingService $decisionService;
+
+	/**
+	 * The user session.
+	 *
+	 * @var IUserSession|MockObject
+	 */
+	private IUserSession $userSession;
+
+	/**
+	 * The logger.
+	 *
+	 * @var LoggerInterface|MockObject
+	 */
+	private LoggerInterface $logger;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var BeschikkingController
+	 */
+	private BeschikkingController $controller;
+
+	/**
+	 * Build the controller with mocked collaborators.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->decisionService = $this->createMock(BeschikkingService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$this->controller = new BeschikkingController(
+			appName: 'procest',
+			request: $this->request,
+			decisionService: $this->decisionService,
+			userSession: $this->userSession,
+			logger: $this->logger,
+		);
+	}//end setUp()
+
+	/**
+	 * Put a signed-in user on the session.
+	 *
+	 * @return void
+	 */
+	private function signIn(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('behandelaar');
+		$this->userSession->method('getUser')->willReturn($user);
+	}//end signIn()
+
+	/**
+	 * An unauthenticated caller is refused before the packet is assembled.
+	 *
+	 * @return void
+	 */
+	public function testAuditPakketRefusesAnUnauthenticatedCallerBeforeBuildingThePacket(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->decisionService->expects($this->never())->method('exportAuditPacket');
+
+		$response = $this->controller->auditPakket(id: 'besluit-1');
+
+		$this->assertInstanceOf(JSONResponse::class, $response);
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame(['error' => 'Not authenticated'], $response->getData());
+	}//end testAuditPakketRefusesAnUnauthenticatedCallerBeforeBuildingThePacket()
+
+	/**
+	 * An authenticated caller reaches the exporter, and the id exported is the
+	 * one from the URL — not a session-derived or default id.
+	 *
+	 * ⚠️ THE RESPONSE SHAPE IS NOT ASSERTED HERE, DELIBERATELY.
+	 * `DataDownloadResponse` cannot be constructed in this unit-test
+	 * environment: `OCP\AppFramework\Http\DownloadResponse::__construct()`
+	 * calls `Symfony\Component\HttpFoundation\HeaderUtils`, and
+	 * `symfony/http-foundation` is not in procest's vendor tree (it is supplied
+	 * by the Nextcloud server at runtime). Constructing one raises an `Error`
+	 * that this controller's `catch (\Throwable)` converts into a 500, so any
+	 * assertion on the download headers here would be asserting the
+	 * environment, not the contract. The same limitation already makes
+	 * `ZaakdossierDownloadControllerGuardTest::testCallerWithCaseAccessStillGetsTheArchive`
+	 * red on an untouched checkout.
+	 *
+	 * What IS asserted — that an authenticated call reaches `exportAuditPacket`
+	 * with the path id — is the discriminating half: paired with the `never()`
+	 * on the unauthenticated arm above, a controller that refused everything
+	 * and a controller that refused nothing both fail.
+	 *
+	 * @return void
+	 */
+	public function testAuditPakketExportsThePacketForTheIdInThePath(): void {
+		$this->signIn();
+
+		$this->decisionService->expects($this->once())
+			->method('exportAuditPacket')
+			->with('besluit-42')
+			->willReturn('PK-zip-bytes');
+
+		$this->controller->auditPakket(id: 'besluit-42');
+	}//end testAuditPakketExportsThePacketForTheIdInThePath()
+
+	/**
+	 * The `not_found` domain code is a 404, not a generic 500.
+	 *
+	 * @return void
+	 */
+	public function testAuditPakketMapsTheNotFoundDomainCodeToA404(): void {
+		$this->signIn();
+
+		$this->decisionService->method('exportAuditPacket')
+			->willThrowException(new \RuntimeException('not_found'));
+
+		$response = $this->controller->auditPakket(id: 'missing');
+
+		$this->assertInstanceOf(JSONResponse::class, $response);
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertSame(['error' => 'Beschikking not found'], $response->getData());
+	}//end testAuditPakketMapsTheNotFoundDomainCodeToA404()
+
+	/**
+	 * An insufficient mandaat is a 403, a DIFFERENT status from `not_found`.
+	 *
+	 * @return void
+	 */
+	public function testAuditPakketMapsAnInsufficientMandaatToA403DistinctFromNotFound(): void {
+		$this->signIn();
+
+		$this->decisionService->method('exportAuditPacket')
+			->willThrowException(new \RuntimeException('mandaat_insufficient'));
+
+		$response = $this->controller->auditPakket(id: 'besluit-42');
+
+		$this->assertInstanceOf(JSONResponse::class, $response);
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame(['error' => 'Insufficient mandaat for this decision'], $response->getData());
+	}//end testAuditPakketMapsAnInsufficientMandaatToA403DistinctFromNotFound()
+
+	/**
+	 * An unexpected failure is a generic 500 that does not leak the internal
+	 * exception message to the caller.
+	 *
+	 * @return void
+	 */
+	public function testAuditPakketReturnsAGeneric500WithoutLeakingTheInternalMessage(): void {
+		$this->signIn();
+
+		$this->decisionService->method('exportAuditPacket')
+			->willThrowException(new \LogicException('ZipArchive::open(/srv/secret/path) failed'));
+
+		$response = $this->controller->auditPakket(id: 'besluit-42');
+
+		$this->assertInstanceOf(JSONResponse::class, $response);
+		$this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+		$this->assertStringNotContainsString('/srv/secret/path', json_encode($response->getData()));
+	}//end testAuditPakketReturnsAGeneric500WithoutLeakingTheInternalMessage()
+}//end class

--- a/tests/Unit/Controller/CaseReassignmentControllerContractTest.php
+++ b/tests/Unit/Controller/CaseReassignmentControllerContractTest.php
@@ -1,0 +1,321 @@
+<?php
+
+/**
+ * CaseReassignmentController Wire-Contract Tests
+ *
+ * Contract coverage (gate-25) for the two coordinator-only bulk reassignment
+ * endpoints, `reassignPreview()` and `reassignExecute()`. Both are
+ * `#[NoAdminRequired]`, i.e. any authenticated user may reach the route, and the
+ * only thing standing between an ordinary handler and moving somebody else's
+ * entire caseload is the private `requireCoordinator()` guard. That guard, and
+ * the arguments the controller hands the service once it passes, are what these
+ * tests pin:
+ *
+ *  - an anonymous caller is refused 403 and the service is never entered — the
+ *    guard must run BEFORE any parameter is read;
+ *  - an authenticated NON-coordinator is refused 403 with the role message, and
+ *    the group check is made against THAT caller's uid, not a blank string: a
+ *    guard that asked about the wrong user would be no guard at all;
+ *  - the optional `caseType` filter is forwarded as `['caseType' => ...]` when
+ *    present and as NULL when absent. The null case is the dangerous one — a
+ *    filter that silently became `['caseType' => '']` would either match
+ *    nothing or, worse, match everything on a permissive backend;
+ *  - `reassignExecute()` attributes the run to the SESSION user (`actorId`),
+ *    not to the handler being emptied — the audit trail of a bulk move is the
+ *    only record of who ordered it;
+ *  - a rejected argument is a 400 and an unexpected failure a 500, so a caller
+ *    can distinguish "your request was wrong" from "we broke".
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\CaseReassignmentController;
+use OCA\Procest\Service\CaseReassignmentService;
+use OCP\AppFramework\Http;
+use OCP\IGroupManager;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Wire-contract tests for CaseReassignmentController.
+ *
+ * @covers \OCA\Procest\Controller\CaseReassignmentController
+ */
+class CaseReassignmentControllerContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock handed to the controller.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The bulk reassignment service mock.
+	 *
+	 * @var CaseReassignmentService|MockObject
+	 */
+	private CaseReassignmentService $reassignmentService;
+
+	/**
+	 * The user session mock — source of the caller and of `actorId`.
+	 *
+	 * @var IUserSession|MockObject
+	 */
+	private IUserSession $userSession;
+
+	/**
+	 * The group manager mock — the coordinator gate.
+	 *
+	 * @var IGroupManager|MockObject
+	 */
+	private IGroupManager $groupManager;
+
+	/**
+	 * The logger mock.
+	 *
+	 * @var LoggerInterface|MockObject
+	 */
+	private LoggerInterface $logger;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var CaseReassignmentController
+	 */
+	private CaseReassignmentController $controller;
+
+	/**
+	 * Build the controller with all collaborators mocked.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->reassignmentService = $this->createMock(CaseReassignmentService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$this->controller = new CaseReassignmentController(
+			appName: 'procest',
+			request: $this->request,
+			reassignmentService: $this->reassignmentService,
+			userSession: $this->userSession,
+			groupManager: $this->groupManager,
+			logger: $this->logger,
+		);
+	}//end setUp()
+
+	/**
+	 * Put an authenticated user in the session.
+	 *
+	 * @param string $uid The user id the session reports.
+	 *
+	 * @return void
+	 */
+	private function signIn(string $uid): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		$this->userSession->method('getUser')->willReturn($user);
+	}//end signIn()
+
+	/**
+	 * Serve the given request parameters, defaulting like the real request.
+	 *
+	 * @param array<string, mixed> $overrides The parameter values to serve.
+	 *
+	 * @return void
+	 */
+	private function withRequestParams(array $overrides): void {
+		$this->request->method('getParam')->willReturnCallback(
+			static function (string $key, mixed $default = null) use ($overrides): mixed {
+				return ($overrides[$key] ?? $default);
+			}
+		);
+	}//end withRequestParams()
+
+	/**
+	 * An anonymous caller is refused 403 by both endpoints and the reassignment
+	 * service is never entered.
+	 *
+	 * @return void
+	 */
+	public function testBothEndpointsRefuseAnAnonymousCallerWithoutTouchingTheService(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->reassignmentService->expects($this->never())->method('preview');
+		$this->reassignmentService->expects($this->never())->method('execute');
+
+		$preview = $this->controller->reassignPreview();
+		$execute = $this->controller->reassignExecute();
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $preview->getStatus());
+		$this->assertSame(Http::STATUS_FORBIDDEN, $execute->getStatus());
+		$this->assertSame(['error' => 'Not authorised'], $preview->getData());
+		$this->assertSame(['error' => 'Not authorised'], $execute->getData());
+	}//end testBothEndpointsRefuseAnAnonymousCallerWithoutTouchingTheService()
+
+	/**
+	 * An authenticated non-coordinator is refused 403 with the role message, and
+	 * the group check is asked about THE CALLER's uid — a guard that queried a
+	 * blank or hard-coded uid would answer for the wrong person.
+	 *
+	 * @return void
+	 */
+	public function testANonCoordinatorIsRefusedAndTheGroupCheckNamesTheCaller(): void {
+		$this->signIn(uid: 'handler-1');
+
+		$this->groupManager->expects($this->atLeastOnce())
+			->method('isAdmin')
+			->with('handler-1')
+			->willReturn(false);
+		$this->reassignmentService->expects($this->never())->method('preview');
+		$this->reassignmentService->expects($this->never())->method('execute');
+
+		$preview = $this->controller->reassignPreview();
+		$execute = $this->controller->reassignExecute();
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $preview->getStatus());
+		$this->assertSame(
+			['error' => 'This action requires the coordinator role'],
+			$preview->getData()
+		);
+		$this->assertSame(Http::STATUS_FORBIDDEN, $execute->getStatus());
+	}//end testANonCoordinatorIsRefusedAndTheGroupCheckNamesTheCaller()
+
+	/**
+	 * A coordinator's preview forwards `fromUser` and the `caseType` filter and
+	 * returns the service's preview verbatim at 200.
+	 *
+	 * @return void
+	 */
+	public function testReassignPreviewForwardsTheCaseTypeFilterAndReturnsThePreview(): void {
+		$this->signIn(uid: 'coordinator-1');
+		$this->groupManager->method('isAdmin')->willReturn(true);
+		$this->withRequestParams(['fromUser' => 'handler-1', 'caseType' => 'bezwaar']);
+
+		$seen = [];
+		$this->reassignmentService->expects($this->once())
+			->method('preview')
+			->willReturnCallback(
+				static function (string $fromUser, ?array $filter = null) use (&$seen): array {
+					$seen = ['fromUser' => $fromUser, 'filter' => $filter];
+					return ['total' => 7];
+				}
+			);
+
+		$response = $this->controller->reassignPreview();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['total' => 7], $response->getData());
+		$this->assertSame(['fromUser' => 'handler-1', 'filter' => ['caseType' => 'bezwaar']], $seen);
+	}//end testReassignPreviewForwardsTheCaseTypeFilterAndReturnsThePreview()
+
+	/**
+	 * A rejected argument is a 400 carrying the service's message, not a 500 —
+	 * the caller can fix a bad `fromUser`, it cannot fix an outage.
+	 *
+	 * @return void
+	 */
+	public function testReassignPreviewAnswers400WhenTheServiceRejectsTheArguments(): void {
+		$this->signIn(uid: 'coordinator-1');
+		$this->groupManager->method('isAdmin')->willReturn(true);
+		$this->withRequestParams([]);
+
+		$this->reassignmentService->method('preview')
+			->willThrowException(new \InvalidArgumentException('fromUser is required'));
+
+		$response = $this->controller->reassignPreview();
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'fromUser is required'], $response->getData());
+	}//end testReassignPreviewAnswers400WhenTheServiceRejectsTheArguments()
+
+	/**
+	 * A coordinator's execute forwards both handlers, attributes the run to the
+	 * SESSION user rather than to the handler being emptied, and sends a NULL
+	 * filter when no `caseType` was supplied — an empty-string filter would
+	 * change which cases move.
+	 *
+	 * @return void
+	 */
+	public function testReassignExecuteAttributesTheRunToTheSessionUserAndSendsANullFilter(): void {
+		$this->signIn(uid: 'coordinator-1');
+		$this->groupManager->method('isAdmin')->willReturn(true);
+		$this->withRequestParams(['fromUser' => 'handler-1', 'toUser' => 'handler-2']);
+
+		$seen = [];
+		$this->reassignmentService->expects($this->once())
+			->method('execute')
+			->willReturnCallback(
+				static function (
+					string $fromUser,
+					string $toUser,
+					?array $filter = null,
+					string $actorId = '',
+				) use (&$seen): array {
+					$seen = [
+						'fromUser' => $fromUser,
+						'toUser' => $toUser,
+						'filter' => $filter,
+						'actorId' => $actorId,
+					];
+					return ['moved' => 7];
+				}
+			);
+
+		$response = $this->controller->reassignExecute();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['moved' => 7], $response->getData());
+		$this->assertSame(
+			[
+				'fromUser' => 'handler-1',
+				'toUser' => 'handler-2',
+				'filter' => null,
+				'actorId' => 'coordinator-1',
+			],
+			$seen
+		);
+	}//end testReassignExecuteAttributesTheRunToTheSessionUserAndSendsANullFilter()
+
+	/**
+	 * An unexpected failure is a 500 and is logged — a bulk move that half
+	 * happened must not be reported as a clean 200.
+	 *
+	 * @return void
+	 */
+	public function testReassignExecuteAnswers500AndLogsAnUnexpectedFailure(): void {
+		$this->signIn(uid: 'coordinator-1');
+		$this->groupManager->method('isAdmin')->willReturn(true);
+		$this->withRequestParams(['fromUser' => 'handler-1', 'toUser' => 'handler-2']);
+
+		$this->reassignmentService->method('execute')
+			->willThrowException(new \RuntimeException('register unavailable'));
+		$this->logger->expects($this->once())
+			->method('error')
+			->with('Reassignment execute failed', ['error' => 'register unavailable']);
+
+		$response = $this->controller->reassignExecute();
+
+		$this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+		$this->assertSame(['error' => 'register unavailable'], $response->getData());
+	}//end testReassignExecuteAnswers500AndLogsAnUnexpectedFailure()
+}//end class

--- a/tests/Unit/Controller/CaseSharingControllerContractTest.php
+++ b/tests/Unit/Controller/CaseSharingControllerContractTest.php
@@ -1,0 +1,425 @@
+<?php
+
+/**
+ * CaseSharingController Wire-Contract Tests
+ *
+ * Contract coverage for the two share-lifecycle endpoints (gate-25).
+ * `createShare` MINTS a public "track your case" surface — a token link that
+ * anyone holding it can follow without a Nextcloud session — and `revokeShare`
+ * is the only way to take one back. Both are `@NoAdminRequired`, so the
+ * per-case guard is the entire authorization story. The contract pinned here:
+ *
+ *  - no session answers 401 and mints nothing;
+ *  - a caller not assigned to the case is refused 403 BEFORE any token is
+ *    minted, and the guard is asked about the caseId from the request together
+ *    with the session UID;
+ *  - the partner branch demands a partnerId and reports an upstream failure as
+ *    502, distinct from the 400 it uses for its own input validation;
+ *  - revoking a token link requires BOTH that the caller may access the case
+ *    AND that the token actually belongs to that case — dropping the second
+ *    condition is a cross-case IDOR (a handler of case A revoking case B's
+ *    link by id), which is exactly the defect this file is here to catch.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\CaseSharingController;
+use OCA\Procest\Service\CaseSharingService;
+use OCA\Procest\Service\CaseTransferService;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Wire-contract tests for CaseSharingController.
+ *
+ * @covers \OCA\Procest\Controller\CaseSharingController
+ */
+class CaseSharingControllerContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The CaseSharingService mock.
+	 *
+	 * @var CaseSharingService|MockObject
+	 */
+	private CaseSharingService $caseSharingService;
+
+	/**
+	 * The CaseTransferService mock.
+	 *
+	 * @var CaseTransferService|MockObject
+	 */
+	private CaseTransferService $caseTransferService;
+
+	/**
+	 * The IUserSession mock.
+	 *
+	 * @var IUserSession|MockObject
+	 */
+	private IUserSession $userSession;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var CaseSharingController
+	 */
+	private CaseSharingController $controller;
+
+	/**
+	 * Build the controller with all collaborators mocked.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->caseSharingService = $this->createMock(CaseSharingService::class);
+		$this->caseTransferService = $this->createMock(CaseTransferService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+
+		$this->controller = new CaseSharingController(
+			request: $this->request,
+			caseSharingService: $this->caseSharingService,
+			caseTransferService: $this->caseTransferService,
+			userSession: $this->userSession,
+		);
+	}//end setUp()
+
+	/**
+	 * Put a signed-in user on the session.
+	 *
+	 * @param string $uid The UID of the signed-in user.
+	 *
+	 * @return void
+	 */
+	private function signIn(string $uid = 'alice'): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		$this->userSession->method('getUser')->willReturn($user);
+	}//end signIn()
+
+	/**
+	 * Answer request parameters from the supplied map.
+	 *
+	 * @param array<string, mixed> $params The parameter map.
+	 *
+	 * @return void
+	 */
+	private function withParams(array $params): void {
+		$this->request->method('getParam')->willReturnCallback(
+			static function (string $key, mixed $default = null) use ($params): mixed {
+				return ($params[$key] ?? $default);
+			}
+		);
+	}//end withParams()
+
+	/**
+	 * `createShare` refuses an anonymous caller with 401 and mints nothing.
+	 *
+	 * @return void
+	 */
+	public function testCreateShareRefusesAnUnauthenticatedCallerWith401(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->caseSharingService->expects($this->never())->method('createTokenShare');
+		$this->caseSharingService->expects($this->never())->method('createPartnerShare');
+
+		$response = $this->controller->createShare();
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame(
+			['success' => false, 'error' => 'Not authenticated'],
+			$response->getData()
+		);
+	}//end testCreateShareRefusesAnUnauthenticatedCallerWith401()
+
+	/**
+	 * A caller who is not assigned to the case may not mint a public link for
+	 * it: 403, and no token is created.
+	 *
+	 * @return void
+	 */
+	public function testCreateShareRefusesACallerNotAssignedToTheCaseWith403(): void {
+		$this->signIn(uid: 'mallory');
+		$this->withParams(['caseId' => 'case-1']);
+
+		$this->caseSharingService->expects($this->once())
+			->method('canUserAccessCase')
+			->with('case-1', 'mallory')
+			->willReturn(false);
+		$this->caseSharingService->expects($this->never())->method('createTokenShare');
+
+		$response = $this->controller->createShare();
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame(
+			'Access denied: you are not assigned to this case',
+			$response->getData()['error']
+		);
+	}//end testCreateShareRefusesACallerNotAssignedToTheCaseWith403()
+
+	/**
+	 * A request without a caseId is a 400, not a share against "no case".
+	 *
+	 * @return void
+	 */
+	public function testCreateShareRejectsAMissingCaseIdWith400(): void {
+		$this->signIn();
+		$this->withParams([]);
+		$this->caseSharingService->expects($this->never())->method('createTokenShare');
+
+		$response = $this->controller->createShare();
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame('caseId is required', $response->getData()['error']);
+	}//end testCreateShareRejectsAMissingCaseIdWith400()
+
+	/**
+	 * The partner branch demands a partnerId — a partner share with no partner
+	 * would otherwise be minted against an empty organisation.
+	 *
+	 * @return void
+	 */
+	public function testCreateShareRejectsAPartnerShareWithoutAPartnerIdWith400(): void {
+		$this->signIn();
+		$this->withParams(['caseId' => 'case-1', 'shareType' => 'partner']);
+		$this->caseSharingService->method('canUserAccessCase')->willReturn(true);
+		$this->caseSharingService->expects($this->never())->method('createPartnerShare');
+
+		$response = $this->controller->createShare();
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame('partnerId is required for partner shares', $response->getData()['error']);
+	}//end testCreateShareRejectsAPartnerShareWithoutAPartnerIdWith400()
+
+	/**
+	 * An upstream failure creating a partner share is a 502, not a 400 — the
+	 * caller's input was fine; the downstream store was not.
+	 *
+	 * @return void
+	 */
+	public function testCreateShareReportsAPartnerStoreFailureAs502(): void {
+		$this->signIn(uid: 'alice');
+		$this->withParams([
+			'caseId' => 'case-1',
+			'shareType' => 'partner',
+			'partnerId' => 'partner-9',
+			'permissionLevel' => 'bewerken',
+		]);
+		$this->caseSharingService->method('canUserAccessCase')->willReturn(true);
+		$this->caseSharingService->expects($this->once())
+			->method('createPartnerShare')
+			->with('case-1', 'partner-9', 'bewerken', 'alice')
+			->willReturn(['error' => 'OpenRegister unavailable']);
+
+		$response = $this->controller->createShare();
+
+		$this->assertSame(Http::STATUS_BAD_GATEWAY, $response->getStatus());
+		$this->assertSame('OpenRegister unavailable', $response->getData()['error']);
+	}//end testCreateShareReportsAPartnerStoreFailureAs502()
+
+	/**
+	 * The default share type is a token link, minted through the sharing leaf
+	 * with the caller's UID as owner and the requested expiry.
+	 *
+	 * @return void
+	 */
+	public function testCreateShareDefaultsToATokenShareOwnedByTheCaller(): void {
+		$this->signIn(uid: 'alice');
+		$this->withParams([
+			'caseId' => 'case-1',
+			'label' => 'Volg uw zaak',
+			'expiresAt' => '2026-12-31',
+		]);
+		$this->caseSharingService->method('canUserAccessCase')->willReturn(true);
+		$this->caseSharingService->expects($this->once())
+			->method('createTokenShare')
+			->with('case-1', 'Volg uw zaak', 'alice', '2026-12-31')
+			->willReturn(['id' => 'share-1', 'url' => 'https://example.test/s/abc']);
+
+		$response = $this->controller->createShare();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertTrue($response->getData()['success']);
+		$this->assertSame('share-1', $response->getData()['share']['id']);
+	}//end testCreateShareDefaultsToATokenShareOwnedByTheCaller()
+
+	/**
+	 * `revokeShare` refuses an anonymous caller with 401.
+	 *
+	 * @return void
+	 */
+	public function testRevokeShareRefusesAnUnauthenticatedCallerWith401(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->caseSharingService->expects($this->never())->method('revokeShare');
+		$this->caseSharingService->expects($this->never())->method('revokeTokenShare');
+
+		$response = $this->controller->revokeShare(shareId: 'share-1');
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame('Not authenticated', $response->getData()['error']);
+	}//end testRevokeShareRefusesAnUnauthenticatedCallerWith401()
+
+	/**
+	 * Revoking a token link refuses a caller with no access to the named case.
+	 *
+	 * @return void
+	 */
+	public function testRevokeTokenShareRefusesACallerNotAssignedToTheCaseWith403(): void {
+		$this->signIn(uid: 'mallory');
+		$this->withParams(['caseId' => 'case-1']);
+
+		$this->caseSharingService->method('canUserAccessCase')
+			->with('case-1', 'mallory')
+			->willReturn(false);
+		$this->caseSharingService->expects($this->never())->method('revokeTokenShare');
+
+		$response = $this->controller->revokeShare(shareId: 'share-1');
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame(
+			'Access denied: you are not assigned to this case',
+			$response->getData()['error']
+		);
+	}//end testRevokeTokenShareRefusesACallerNotAssignedToTheCaseWith403()
+
+	/**
+	 * Case access alone is NOT enough: the token must also belong to the case
+	 * the caller named. Without this second condition a handler of case A can
+	 * revoke case B's public link by quoting its id (ADR-005 rule 3 IDOR).
+	 *
+	 * @return void
+	 */
+	public function testRevokeTokenShareRefusesATokenBelongingToAnotherCase(): void {
+		$this->signIn(uid: 'alice');
+		$this->withParams(['caseId' => 'case-A']);
+
+		$this->caseSharingService->method('canUserAccessCase')->willReturn(true);
+		$this->caseSharingService->expects($this->once())
+			->method('tokenBelongsToCase')
+			->with('token-of-case-B', 'case-A')
+			->willReturn(false);
+		$this->caseSharingService->expects($this->never())->method('revokeTokenShare');
+
+		$response = $this->controller->revokeShare(shareId: 'token-of-case-B');
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame(
+			'Access denied: you are not assigned to this case',
+			$response->getData()['error']
+		);
+	}//end testRevokeTokenShareRefusesATokenBelongingToAnotherCase()
+
+	/**
+	 * A token revoke that the sharing leaf refuses is reported as 502 — the
+	 * client must not read a failed revoke as a successful one.
+	 *
+	 * @return void
+	 */
+	public function testRevokeTokenShareReportsALeafFailureAs502(): void {
+		$this->signIn();
+		$this->withParams(['caseId' => 'case-A']);
+		$this->caseSharingService->method('canUserAccessCase')->willReturn(true);
+		$this->caseSharingService->method('tokenBelongsToCase')->willReturn(true);
+		$this->caseSharingService->method('revokeTokenShare')->willReturn(false);
+
+		$response = $this->controller->revokeShare(shareId: 'share-1');
+
+		$this->assertSame(Http::STATUS_BAD_GATEWAY, $response->getStatus());
+		$this->assertSame('Could not revoke share link', $response->getData()['error']);
+	}//end testRevokeTokenShareReportsALeafFailureAs502()
+
+	/**
+	 * A fully authorized token revoke answers 200 with `success: true`.
+	 *
+	 * @return void
+	 */
+	public function testRevokeTokenShareReturns200WhenBothGuardsPass(): void {
+		$this->signIn();
+		$this->withParams(['caseId' => 'case-A']);
+		$this->caseSharingService->method('canUserAccessCase')->willReturn(true);
+		$this->caseSharingService->method('tokenBelongsToCase')->willReturn(true);
+		$this->caseSharingService->expects($this->once())
+			->method('revokeTokenShare')
+			->with('share-1')
+			->willReturn(true);
+
+		$response = $this->controller->revokeShare(shareId: 'share-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['success' => true], $response->getData());
+	}//end testRevokeTokenShareReturns200WhenBothGuardsPass()
+
+	/**
+	 * The partner-share branch (no caseId in the request) resolves the share's
+	 * OWN case and refuses a caller with no access to it.
+	 *
+	 * @return void
+	 */
+	public function testRevokePartnerShareResolvesTheSharesCaseAndRefusesWith403(): void {
+		$this->signIn(uid: 'mallory');
+		$this->withParams([]);
+
+		$this->caseSharingService->expects($this->once())
+			->method('getCaseIdForShare')
+			->with('share-5')
+			->willReturn('case-owned-by-someone-else');
+		$this->caseSharingService->expects($this->once())
+			->method('canUserAccessCase')
+			->with('case-owned-by-someone-else', 'mallory')
+			->willReturn(false);
+		$this->caseSharingService->expects($this->never())->method('revokeShare');
+
+		$response = $this->controller->revokeShare(shareId: 'share-5');
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame(
+			'Access denied: you are not assigned to this case',
+			$response->getData()['error']
+		);
+	}//end testRevokePartnerShareResolvesTheSharesCaseAndRefusesWith403()
+
+	/**
+	 * An authorized partner revoke answers 200 and carries the revoked share
+	 * back, attributed to the revoking user.
+	 *
+	 * @return void
+	 */
+	public function testRevokePartnerShareReturnsTheRevokedShareAttributedToTheCaller(): void {
+		$this->signIn(uid: 'alice');
+		$this->withParams([]);
+		$this->caseSharingService->method('getCaseIdForShare')->willReturn('case-1');
+		$this->caseSharingService->method('canUserAccessCase')->willReturn(true);
+		$this->caseSharingService->expects($this->once())
+			->method('revokeShare')
+			->with('share-5', 'alice')
+			->willReturn(['id' => 'share-5', 'status' => 'revoked']);
+
+		$response = $this->controller->revokeShare(shareId: 'share-5');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertTrue($response->getData()['success']);
+		$this->assertSame('revoked', $response->getData()['share']['status']);
+	}//end testRevokePartnerShareReturnsTheRevokedShareAttributedToTheCaller()
+}//end class

--- a/tests/Unit/Controller/ComplaintAnalyticsControllerContractTest.php
+++ b/tests/Unit/Controller/ComplaintAnalyticsControllerContractTest.php
@@ -1,0 +1,179 @@
+<?php
+
+/**
+ * ComplaintAnalyticsController Wire-Contract Tests
+ *
+ * Contract coverage (gate-25) for `kpi()`, the management KPI summary over
+ * complaint (klacht) data. The endpoint is `@NoAdminRequired` and aggregates
+ * across EVERY complaint on the instance, so its only gate is the session check
+ * `ComplaintAccessGuard::currentUid()`. These tests pin:
+ *
+ *  - an anonymous caller gets the guard's refusal verbatim and the analytics
+ *    service is never entered — an aggregate over all complaints leaks case
+ *    volumes, backlogs and employee alerts even without a single case body;
+ *  - the caller's `dateFrom`/`dateTo` are forwarded to the summary unchanged
+ *    and in that order — transposed bounds would silently produce an empty
+ *    report that reads like "no complaints this period";
+ *  - with no bounds supplied the window defaults to MONTH-to-date
+ *    (`Y-m-01` .. today), which is what makes this endpoint different from its
+ *    sibling `analytics()` on the same controller, whose default is YEAR-to-date.
+ *    A copy-paste of the sibling's default is the realistic defect here and is
+ *    invisible from the response shape.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\ComplaintAnalyticsController;
+use OCA\Procest\Service\Complaint\ComplaintAccessGuard;
+use OCA\Procest\Service\ComplaintAnalyticsService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Wire-contract tests for ComplaintAnalyticsController::kpi().
+ *
+ * @covers \OCA\Procest\Controller\ComplaintAnalyticsController
+ */
+class ComplaintAnalyticsControllerContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock handed to the controller.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The analytics service mock — the aggregate the endpoint protects.
+	 *
+	 * @var ComplaintAnalyticsService|MockObject
+	 */
+	private ComplaintAnalyticsService $analyticsService;
+
+	/**
+	 * The shared complaint access guard mock — the endpoint's only gate.
+	 *
+	 * @var ComplaintAccessGuard|MockObject
+	 */
+	private ComplaintAccessGuard $accessGuard;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var ComplaintAnalyticsController
+	 */
+	private ComplaintAnalyticsController $controller;
+
+	/**
+	 * Build the controller with all collaborators mocked.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->analyticsService = $this->createMock(ComplaintAnalyticsService::class);
+		$this->accessGuard = $this->createMock(ComplaintAccessGuard::class);
+
+		$this->controller = new ComplaintAnalyticsController(
+			appName: 'procest',
+			request: $this->request,
+			analyticsService: $this->analyticsService,
+			accessGuard: $this->accessGuard,
+		);
+	}//end setUp()
+
+	/**
+	 * Serve the given request parameters, defaulting like the real request.
+	 *
+	 * @param array<string, mixed> $overrides The parameter values to serve.
+	 *
+	 * @return void
+	 */
+	private function withRequestParams(array $overrides): void {
+		$this->request->method('getParam')->willReturnCallback(
+			static function (string $key, mixed $default = null) use ($overrides): mixed {
+				return ($overrides[$key] ?? $default);
+			}
+		);
+	}//end withRequestParams()
+
+	/**
+	 * An anonymous caller gets the guard's 401 verbatim and no aggregate is
+	 * computed — the KPI body itself is the disclosure.
+	 *
+	 * @return void
+	 */
+	public function testKpiReturnsTheGuardRefusalForAnAnonymousCallerAndComputesNothing(): void {
+		$refusal = new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+		$this->accessGuard->method('currentUid')->willReturn('');
+		$this->accessGuard->method('notAuthenticated')->willReturn($refusal);
+		$this->analyticsService->expects($this->never())->method('getKpiSummary');
+
+		$response = $this->controller->kpi();
+
+		$this->assertSame($refusal, $response, 'kpi() must return the guard refusal verbatim');
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+	}//end testKpiReturnsTheGuardRefusalForAnAnonymousCallerAndComputesNothing()
+
+	/**
+	 * A signed-in caller's explicit window is forwarded unchanged and in order,
+	 * and the summary is returned as the response body at 200.
+	 *
+	 * @return void
+	 */
+	public function testKpiForwardsTheRequestedWindowInOrderAndReturnsTheSummary(): void {
+		$this->accessGuard->method('currentUid')->willReturn('handler-1');
+		$this->withRequestParams(['dateFrom' => '2026-01-01', 'dateTo' => '2026-03-31']);
+
+		$summary = ['total' => 12, 'resolved' => 9, 'withinDeadlinePercentage' => 75.0];
+		$this->analyticsService->expects($this->once())
+			->method('getKpiSummary')
+			->with('2026-01-01', '2026-03-31')
+			->willReturn($summary);
+
+		$response = $this->controller->kpi();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($summary, $response->getData());
+	}//end testKpiForwardsTheRequestedWindowInOrderAndReturnsTheSummary()
+
+	/**
+	 * With no bounds supplied the KPI window is MONTH-to-date, not the
+	 * year-to-date default its sibling `analytics()` uses on this same
+	 * controller. (During January the two defaults coincide, so this test can
+	 * only distinguish them in the other eleven months — it still fails on any
+	 * other wrong default, e.g. an epoch-start or an off-by-one day.)
+	 *
+	 * @return void
+	 */
+	public function testKpiDefaultsToTheCurrentMonthRatherThanTheCurrentYear(): void {
+		$this->accessGuard->method('currentUid')->willReturn('handler-1');
+		$this->withRequestParams([]);
+
+		$this->analyticsService->expects($this->once())
+			->method('getKpiSummary')
+			->with(date('Y-m-01'), date('Y-m-d'))
+			->willReturn(['total' => 0]);
+
+		$response = $this->controller->kpi();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['total' => 0], $response->getData());
+	}//end testKpiDefaultsToTheCurrentMonthRatherThanTheCurrentYear()
+}//end class

--- a/tests/Unit/Controller/ComplaintCategoryControllerContractTest.php
+++ b/tests/Unit/Controller/ComplaintCategoryControllerContractTest.php
@@ -1,0 +1,409 @@
+<?php
+
+/**
+ * ComplaintCategoryController Wire-Contract Tests
+ *
+ * Contract coverage for the two write endpoints on the complaint-category
+ * reference list (gate-25). Both are `@NoAdminRequired`, so the ONLY thing
+ * standing between any authenticated user and the klachtcategorie vocabulary —
+ * which drives complaint routing and the statutory Awb reporting — is
+ * `ComplaintAccessGuard::requireCoordinator()`. That guard is therefore
+ * exercised for real here (a real ComplaintAccessGuard over mocked NC
+ * collaborators), not stubbed away: a mocked guard would answer "allowed" no
+ * matter what the controller asked it.
+ *
+ * The contract pinned here:
+ *
+ *  - no session answers 401 and never reaches OpenRegister;
+ *  - a non-admin is refused with OCSForbiddenException (rendered 403 by the NC
+ *    middleware) and the admin question is asked about the CALLER's uid;
+ *  - an absent OpenRegister answers 503 — not an empty 200 a client would read
+ *    as "no categories saved";
+ *  - create answers 201 and passes NO uuid, update answers 200 and passes the
+ *    path id as `uuid` — an update that forgets the uuid silently forks a
+ *    duplicate category instead of editing one, which is the realistic defect
+ *    on two near-identical methods.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\ComplaintCategoryController;
+use OCA\Procest\Service\Complaint\ComplaintAccessGuard;
+use OCA\Procest\Service\SettingsService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\OCS\OCSForbiddenException;
+use OCP\IGroupManager;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Minimal ObjectService surface for the ComplaintCategoryController tests.
+ *
+ * The controller calls `saveObject()` with NAMED arguments, so the stub must
+ * declare the real parameter names (`object`, `register`, `schema`, `uuid`).
+ * Prefixed with the controller name because other contract-test files declare
+ * their own stubs in this same namespace.
+ */
+interface ComplaintCategoryControllerObjectServiceStub {
+
+	/**
+	 * Save or update an object in a register/schema.
+	 *
+	 * @param array<string, mixed> $object The object payload.
+	 * @param string $register The register slug.
+	 * @param string $schema The schema slug.
+	 * @param string|null $uuid The uuid to update, or null to create.
+	 *
+	 * @return mixed The saved object.
+	 */
+	public function saveObject(array $object, string $register, string $schema, ?string $uuid = null): mixed;
+}//end interface
+
+/**
+ * Wire-contract tests for ComplaintCategoryController.
+ *
+ * @covers \OCA\Procest\Controller\ComplaintCategoryController
+ *
+ * @uses \OCA\Procest\Service\Complaint\ComplaintAccessGuard
+ */
+class ComplaintCategoryControllerContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The SettingsService mock.
+	 *
+	 * @var SettingsService|MockObject
+	 */
+	private SettingsService $settingsService;
+
+	/**
+	 * The IUserSession mock backing the real access guard.
+	 *
+	 * @var IUserSession|MockObject
+	 */
+	private IUserSession $userSession;
+
+	/**
+	 * The IGroupManager mock backing the real access guard.
+	 *
+	 * @var IGroupManager|MockObject
+	 */
+	private IGroupManager $groupManager;
+
+	/**
+	 * The REAL access guard under test alongside the controller.
+	 *
+	 * @var ComplaintAccessGuard
+	 */
+	private ComplaintAccessGuard $accessGuard;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var ComplaintCategoryController
+	 */
+	private ComplaintCategoryController $controller;
+
+	/**
+	 * Build the controller over a real ComplaintAccessGuard.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->settingsService = $this->createMock(SettingsService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+
+		$this->accessGuard = new ComplaintAccessGuard(
+			request: $this->request,
+			userSession: $this->userSession,
+			groupManager: $this->groupManager,
+		);
+
+		$this->controller = new ComplaintCategoryController(
+			appName: 'procest',
+			request: $this->request,
+			settingsService: $this->settingsService,
+			accessGuard: $this->accessGuard,
+		);
+	}//end setUp()
+
+	/**
+	 * Put a signed-in user on the session.
+	 *
+	 * @param string $uid The UID of the signed-in user.
+	 *
+	 * @return void
+	 */
+	private function signIn(string $uid = 'alice'): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		$this->userSession->method('getUser')->willReturn($user);
+	}//end signIn()
+
+	/**
+	 * Wire the register/schema configuration the controller reads.
+	 *
+	 * @return void
+	 */
+	private function withConfiguredSchemas(): void {
+		$this->settingsService->method('getConfigValue')->willReturnCallback(
+			static function (string $key, string $default = ''): string {
+				return match ($key) {
+					'register' => 'procest-register',
+					'complaint_category_schema' => 'klachtcategorie',
+					default => $default,
+				};
+			}
+		);
+	}//end withConfiguredSchemas()
+
+	/**
+	 * `createCategory` refuses an anonymous caller with 401 and never touches
+	 * OpenRegister.
+	 *
+	 * @return void
+	 */
+	public function testCreateCategoryRefusesAnUnauthenticatedCallerWith401(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->settingsService->expects($this->never())->method('getObjectService');
+
+		$response = $this->controller->createCategory();
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame(['error' => 'Not authenticated'], $response->getData());
+	}//end testCreateCategoryRefusesAnUnauthenticatedCallerWith401()
+
+	/**
+	 * A plain authenticated user may NOT extend the category vocabulary: the
+	 * coordinator guard refuses, and it asks about the caller's own uid.
+	 *
+	 * @return void
+	 */
+	public function testCreateCategoryRefusesANonCoordinatorBeforeReachingOpenRegister(): void {
+		$this->signIn(uid: 'bob');
+		$this->groupManager->expects($this->once())
+			->method('isAdmin')
+			->with('bob')
+			->willReturn(false);
+		$this->settingsService->expects($this->never())->method('getObjectService');
+
+		$this->expectException(OCSForbiddenException::class);
+		$this->expectExceptionMessage('This action requires coordinator (admin) privileges');
+
+		$this->controller->createCategory();
+	}//end testCreateCategoryRefusesANonCoordinatorBeforeReachingOpenRegister()
+
+	/**
+	 * With OpenRegister absent the write answers 503 — a dependency outage, not
+	 * a client error and not a silent success.
+	 *
+	 * @return void
+	 */
+	public function testCreateCategoryReturns503WhenOpenRegisterIsAbsent(): void {
+		$this->signIn();
+		$this->groupManager->method('isAdmin')->willReturn(true);
+		$this->settingsService->method('getObjectService')->willReturn(null);
+
+		$response = $this->controller->createCategory();
+
+		$this->assertSame(Http::STATUS_SERVICE_UNAVAILABLE, $response->getStatus());
+		$this->assertSame(['error' => 'OpenRegister not available'], $response->getData());
+	}//end testCreateCategoryReturns503WhenOpenRegisterIsAbsent()
+
+	/**
+	 * A coordinator's create answers 201 and writes the posted body into the
+	 * configured register/schema WITHOUT a uuid — passing one would overwrite an
+	 * existing category instead of adding a new one.
+	 *
+	 * @return void
+	 */
+	public function testCreateCategoryReturns201AndWritesWithoutAUuid(): void {
+		$this->signIn();
+		$this->groupManager->method('isAdmin')->willReturn(true);
+		$this->withConfiguredSchemas();
+		$this->request->method('getParams')->willReturn(['name' => 'Bejegening']);
+
+		$captured = [];
+		$objectService = $this->createMock(ComplaintCategoryControllerObjectServiceStub::class);
+		$objectService->expects($this->once())
+			->method('saveObject')
+			->willReturnCallback(
+				static function (array $object, string $register, string $schema, ?string $uuid = null) use (&$captured): array {
+					$captured = [
+						'object' => $object,
+						'register' => $register,
+						'schema' => $schema,
+						'uuid' => $uuid,
+					];
+
+					return ['id' => 'cat-1', 'name' => $object['name']];
+				}
+			);
+		$this->settingsService->method('getObjectService')->willReturn($objectService);
+
+		$response = $this->controller->createCategory();
+
+		$this->assertSame(Http::STATUS_CREATED, $response->getStatus());
+		$this->assertSame(['id' => 'cat-1', 'name' => 'Bejegening'], $response->getData());
+		$this->assertSame(['name' => 'Bejegening'], $captured['object']);
+		$this->assertSame('procest-register', $captured['register']);
+		$this->assertSame('klachtcategorie', $captured['schema']);
+		$this->assertNull($captured['uuid'], 'a create must not address an existing uuid');
+	}//end testCreateCategoryReturns201AndWritesWithoutAUuid()
+
+	/**
+	 * A validation failure raised by the store surfaces as 400 with the store's
+	 * own message, not as a 500.
+	 *
+	 * @return void
+	 */
+	public function testCreateCategoryReportsAValidationFailureAs400(): void {
+		$this->signIn();
+		$this->groupManager->method('isAdmin')->willReturn(true);
+		$this->withConfiguredSchemas();
+		$this->request->method('getParams')->willReturn(['name' => '']);
+
+		$objectService = $this->createMock(ComplaintCategoryControllerObjectServiceStub::class);
+		$objectService->method('saveObject')
+			->willThrowException(new \RuntimeException('name is required'));
+		$this->settingsService->method('getObjectService')->willReturn($objectService);
+
+		$response = $this->controller->createCategory();
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'name is required'], $response->getData());
+	}//end testCreateCategoryReportsAValidationFailureAs400()
+
+	/**
+	 * `updateCategory` refuses an anonymous caller with 401.
+	 *
+	 * @return void
+	 */
+	public function testUpdateCategoryRefusesAnUnauthenticatedCallerWith401(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->settingsService->expects($this->never())->method('getObjectService');
+
+		$response = $this->controller->updateCategory(id: 'cat-1');
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame(['error' => 'Not authenticated'], $response->getData());
+	}//end testUpdateCategoryRefusesAnUnauthenticatedCallerWith401()
+
+	/**
+	 * A plain authenticated user may not rewrite an existing category either.
+	 *
+	 * @return void
+	 */
+	public function testUpdateCategoryRefusesANonCoordinatorBeforeReachingOpenRegister(): void {
+		$this->signIn(uid: 'bob');
+		$this->groupManager->expects($this->once())
+			->method('isAdmin')
+			->with('bob')
+			->willReturn(false);
+		$this->settingsService->expects($this->never())->method('getObjectService');
+
+		$this->expectException(OCSForbiddenException::class);
+
+		$this->controller->updateCategory(id: 'cat-1');
+	}//end testUpdateCategoryRefusesANonCoordinatorBeforeReachingOpenRegister()
+
+	/**
+	 * With OpenRegister absent the update answers 503.
+	 *
+	 * @return void
+	 */
+	public function testUpdateCategoryReturns503WhenOpenRegisterIsAbsent(): void {
+		$this->signIn();
+		$this->groupManager->method('isAdmin')->willReturn(true);
+		$this->settingsService->method('getObjectService')->willReturn(null);
+
+		$response = $this->controller->updateCategory(id: 'cat-1');
+
+		$this->assertSame(Http::STATUS_SERVICE_UNAVAILABLE, $response->getStatus());
+		$this->assertSame(['error' => 'OpenRegister not available'], $response->getData());
+	}//end testUpdateCategoryReturns503WhenOpenRegisterIsAbsent()
+
+	/**
+	 * An update addresses the category named in the URL — the path id reaches
+	 * the store as `uuid` — and answers 200, not the 201 the create uses.
+	 *
+	 * @return void
+	 */
+	public function testUpdateCategoryAddressesThePathIdAndReturns200(): void {
+		$this->signIn();
+		$this->groupManager->method('isAdmin')->willReturn(true);
+		$this->withConfiguredSchemas();
+		$this->request->method('getParams')->willReturn(['name' => 'Bejegening (herzien)']);
+
+		$captured = [];
+		$objectService = $this->createMock(ComplaintCategoryControllerObjectServiceStub::class);
+		$objectService->expects($this->once())
+			->method('saveObject')
+			->willReturnCallback(
+				static function (array $object, string $register, string $schema, ?string $uuid = null) use (&$captured): array {
+					$captured = [
+						'object' => $object,
+						'register' => $register,
+						'schema' => $schema,
+						'uuid' => $uuid,
+					];
+
+					return array_merge($object, ['id' => $uuid]);
+				}
+			);
+		$this->settingsService->method('getObjectService')->willReturn($objectService);
+
+		$response = $this->controller->updateCategory(id: 'cat-42');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame('cat-42', $captured['uuid'], 'the update must address the category named in the URL');
+		$this->assertSame('klachtcategorie', $captured['schema']);
+		$this->assertSame('cat-42', $response->getData()['id']);
+	}//end testUpdateCategoryAddressesThePathIdAndReturns200()
+
+	/**
+	 * A validation failure on update surfaces as 400 with the store's message.
+	 *
+	 * @return void
+	 */
+	public function testUpdateCategoryReportsAValidationFailureAs400(): void {
+		$this->signIn();
+		$this->groupManager->method('isAdmin')->willReturn(true);
+		$this->withConfiguredSchemas();
+		$this->request->method('getParams')->willReturn(['name' => '']);
+
+		$objectService = $this->createMock(ComplaintCategoryControllerObjectServiceStub::class);
+		$objectService->method('saveObject')
+			->willThrowException(new \RuntimeException('unknown category'));
+		$this->settingsService->method('getObjectService')->willReturn($objectService);
+
+		$response = $this->controller->updateCategory(id: 'cat-1');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'unknown category'], $response->getData());
+	}//end testUpdateCategoryReportsAValidationFailureAs400()
+}//end class

--- a/tests/Unit/Controller/ComplaintControllerContractTest.php
+++ b/tests/Unit/Controller/ComplaintControllerContractTest.php
@@ -1,0 +1,346 @@
+<?php
+
+/**
+ * ComplaintController Wire-Contract Tests
+ *
+ * Contract coverage for the two statutory-consequence endpoints on the
+ * complaint lifecycle (gate-25): `verdaging` — the Awb art. 9:11 lid 2
+ * deadline extension — and `escalate`, which binds a complaint to a formal
+ * case. Both are `@NoAdminRequired`, so `ComplaintAccessGuard::authorizeMutation()`
+ * is the whole authorization story; it is therefore exercised for REAL here
+ * (a real guard over mocked NC collaborators), because a mocked guard would
+ * wave through any complaint the controller handed it.
+ *
+ * The contract pinned here:
+ *
+ *  - no session answers 401 and never loads the complaint;
+ *  - an unknown complaint answers 404 and never mutates;
+ *  - a caller who is neither the assigned behandelaar nor an admin is refused
+ *    with OCSForbiddenException (403 via the NC middleware) BEFORE any
+ *    mutation, and the admin bypass is asserted to actually work — a guard that
+ *    refuses everyone is as broken as one that refuses no one;
+ *  - `escalate` demands a caseId (400 otherwise) and links the complaint to
+ *    exactly the case the caller named;
+ *  - `verdaging` reads its motivation from the `justificatie` body key. That
+ *    key name is load-bearing: reading a differently-named key would silently
+ *    record an EMPTY justification for a statutory deadline extension while
+ *    still answering 200.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\ComplaintController;
+use OCA\Procest\Service\Complaint\ComplaintAccessGuard;
+use OCA\Procest\Service\ComplaintService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\OCS\OCSForbiddenException;
+use OCP\IGroupManager;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Wire-contract tests for ComplaintController's verdaging + escalate endpoints.
+ *
+ * @covers \OCA\Procest\Controller\ComplaintController
+ *
+ * @uses \OCA\Procest\Service\Complaint\ComplaintAccessGuard
+ */
+class ComplaintControllerContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The ComplaintService mock.
+	 *
+	 * @var ComplaintService|MockObject
+	 */
+	private ComplaintService $complaintService;
+
+	/**
+	 * The IUserSession mock backing the real access guard.
+	 *
+	 * @var IUserSession|MockObject
+	 */
+	private IUserSession $userSession;
+
+	/**
+	 * The IGroupManager mock backing the real access guard.
+	 *
+	 * @var IGroupManager|MockObject
+	 */
+	private IGroupManager $groupManager;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var ComplaintController
+	 */
+	private ComplaintController $controller;
+
+	/**
+	 * Build the controller over a real ComplaintAccessGuard.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->complaintService = $this->createMock(ComplaintService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+
+		$this->controller = new ComplaintController(
+			appName: 'procest',
+			request: $this->request,
+			complaintService: $this->complaintService,
+			accessGuard: new ComplaintAccessGuard(
+				request: $this->request,
+				userSession: $this->userSession,
+				groupManager: $this->groupManager,
+			),
+		);
+	}//end setUp()
+
+	/**
+	 * Put a signed-in user on the session.
+	 *
+	 * @param string $uid The UID of the signed-in user.
+	 *
+	 * @return void
+	 */
+	private function signIn(string $uid = 'alice'): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		$this->userSession->method('getUser')->willReturn($user);
+	}//end signIn()
+
+	/**
+	 * `escalate` refuses an anonymous caller with 401 and loads nothing.
+	 *
+	 * @return void
+	 */
+	public function testEscalateRefusesAnUnauthenticatedCallerWith401(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->complaintService->expects($this->never())->method('getComplaint');
+
+		$response = $this->controller->escalate(id: 'klacht-1');
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame(['error' => 'Not authenticated'], $response->getData());
+	}//end testEscalateRefusesAnUnauthenticatedCallerWith401()
+
+	/**
+	 * An unknown complaint answers 404 and links nothing.
+	 *
+	 * @return void
+	 */
+	public function testEscalateReturns404ForAnUnknownComplaint(): void {
+		$this->signIn();
+		$this->complaintService->method('getComplaint')->willReturn(null);
+		$this->complaintService->expects($this->never())->method('linkEscalatedCase');
+
+		$response = $this->controller->escalate(id: 'does-not-exist');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertSame(['error' => 'Complaint not found'], $response->getData());
+	}//end testEscalateReturns404ForAnUnknownComplaint()
+
+	/**
+	 * A caller who is neither the assigned behandelaar nor an admin may not
+	 * escalate someone else's complaint.
+	 *
+	 * @return void
+	 */
+	public function testEscalateRefusesAStrangerToTheComplaint(): void {
+		$this->signIn(uid: 'mallory');
+		$this->complaintService->method('getComplaint')
+			->willReturn(['id' => 'klacht-1', 'handler' => 'alice']);
+		$this->groupManager->expects($this->once())
+			->method('isAdmin')
+			->with('mallory')
+			->willReturn(false);
+		$this->complaintService->expects($this->never())->method('linkEscalatedCase');
+
+		$this->expectException(OCSForbiddenException::class);
+		$this->expectExceptionMessage('Not authorized to modify this complaint');
+
+		$this->controller->escalate(id: 'klacht-1');
+	}//end testEscalateRefusesAStrangerToTheComplaint()
+
+	/**
+	 * Escalation without a caseId is a 400 — a complaint must not be marked
+	 * escalated with nothing to escalate it to.
+	 *
+	 * @return void
+	 */
+	public function testEscalateRejectsAMissingCaseIdWith400(): void {
+		$this->signIn(uid: 'alice');
+		$this->complaintService->method('getComplaint')
+			->willReturn(['id' => 'klacht-1', 'handler' => 'alice']);
+		$this->request->method('getParams')->willReturn(['_route' => 'procest.complaint.escalate']);
+		$this->complaintService->expects($this->never())->method('linkEscalatedCase');
+
+		$response = $this->controller->escalate(id: 'klacht-1');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'caseId is required for escalation'], $response->getData());
+	}//end testEscalateRejectsAMissingCaseIdWith400()
+
+	/**
+	 * The assigned behandelaar escalates to exactly the case they named, and
+	 * the endpoint answers 200 with the service's updated complaint.
+	 *
+	 * @return void
+	 */
+	public function testEscalateLinksTheNamedCaseForTheAssignedHandler(): void {
+		$this->signIn(uid: 'alice');
+		$this->complaintService->method('getComplaint')
+			->willReturn(['id' => 'klacht-1', 'handler' => 'alice']);
+		$this->request->method('getParams')->willReturn(['caseId' => 'zaak-77']);
+
+		$this->complaintService->expects($this->once())
+			->method('linkEscalatedCase')
+			->with('klacht-1', 'zaak-77')
+			->willReturn(['id' => 'klacht-1', 'escalatedCase' => 'zaak-77']);
+
+		$response = $this->controller->escalate(id: 'klacht-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame('zaak-77', $response->getData()['escalatedCase']);
+	}//end testEscalateLinksTheNamedCaseForTheAssignedHandler()
+
+	/**
+	 * The admin bypass is real: a coordinator escalates a complaint assigned to
+	 * someone else. Without this the refusal test above could be satisfied by a
+	 * guard that simply refuses everybody.
+	 *
+	 * @return void
+	 */
+	public function testEscalateAllowsACoordinatorOnSomeoneElsesComplaint(): void {
+		$this->signIn(uid: 'coordinator');
+		$this->complaintService->method('getComplaint')
+			->willReturn(['id' => 'klacht-1', 'handler' => 'alice']);
+		$this->groupManager->method('isAdmin')->with('coordinator')->willReturn(true);
+		$this->request->method('getParams')->willReturn(['caseId' => 'zaak-77']);
+
+		$this->complaintService->expects($this->once())
+			->method('linkEscalatedCase')
+			->willReturn(['id' => 'klacht-1', 'escalatedCase' => 'zaak-77']);
+
+		$response = $this->controller->escalate(id: 'klacht-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+	}//end testEscalateAllowsACoordinatorOnSomeoneElsesComplaint()
+
+	/**
+	 * `verdaging` refuses an anonymous caller with 401.
+	 *
+	 * @return void
+	 */
+	public function testVerdagingRefusesAnUnauthenticatedCallerWith401(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->complaintService->expects($this->never())->method('getComplaint');
+
+		$response = $this->controller->verdaging(id: 'klacht-1');
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame(['error' => 'Not authenticated'], $response->getData());
+	}//end testVerdagingRefusesAnUnauthenticatedCallerWith401()
+
+	/**
+	 * An unknown complaint answers 404 and extends no deadline.
+	 *
+	 * @return void
+	 */
+	public function testVerdagingReturns404ForAnUnknownComplaint(): void {
+		$this->signIn();
+		$this->complaintService->method('getComplaint')->willReturn(null);
+		$this->complaintService->expects($this->never())->method('requestVerdaging');
+
+		$response = $this->controller->verdaging(id: 'does-not-exist');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertSame(['error' => 'Complaint not found'], $response->getData());
+	}//end testVerdagingReturns404ForAnUnknownComplaint()
+
+	/**
+	 * A stranger to the complaint may not extend its statutory deadline.
+	 *
+	 * @return void
+	 */
+	public function testVerdagingRefusesAStrangerToTheComplaint(): void {
+		$this->signIn(uid: 'mallory');
+		$this->complaintService->method('getComplaint')
+			->willReturn(['id' => 'klacht-1', 'handler' => 'alice']);
+		$this->groupManager->method('isAdmin')->with('mallory')->willReturn(false);
+		$this->complaintService->expects($this->never())->method('requestVerdaging');
+
+		$this->expectException(OCSForbiddenException::class);
+
+		$this->controller->verdaging(id: 'klacht-1');
+	}//end testVerdagingRefusesAStrangerToTheComplaint()
+
+	/**
+	 * The motivation is read from the `justificatie` body key and forwarded to
+	 * the service verbatim.
+	 *
+	 * @return void
+	 */
+	public function testVerdagingForwardsTheJustificatieBodyKeyAsTheMotivation(): void {
+		$this->signIn(uid: 'alice');
+		$this->complaintService->method('getComplaint')
+			->willReturn(['id' => 'klacht-1', 'handler' => 'alice']);
+		$this->request->method('getParams')
+			->willReturn(['justificatie' => 'Extern advies afwachten']);
+
+		$this->complaintService->expects($this->once())
+			->method('requestVerdaging')
+			->with('klacht-1', 'Extern advies afwachten')
+			->willReturn(['id' => 'klacht-1', 'status' => 'verdaagd']);
+
+		$response = $this->controller->verdaging(id: 'klacht-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame('verdaagd', $response->getData()['status']);
+	}//end testVerdagingForwardsTheJustificatieBodyKeyAsTheMotivation()
+
+	/**
+	 * A domain refusal from the service (e.g. verdaging already used) surfaces
+	 * as 400 with the service's message, not as a 500.
+	 *
+	 * @return void
+	 */
+	public function testVerdagingReportsADomainRefusalAs400(): void {
+		$this->signIn(uid: 'alice');
+		$this->complaintService->method('getComplaint')
+			->willReturn(['id' => 'klacht-1', 'handler' => 'alice']);
+		$this->request->method('getParams')->willReturn(['justificatie' => 'x']);
+		$this->complaintService->method('requestVerdaging')
+			->willThrowException(new \RuntimeException('Verdaging is al toegepast'));
+
+		$response = $this->controller->verdaging(id: 'klacht-1');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'Verdaging is al toegepast'], $response->getData());
+	}//end testVerdagingReportsADomainRefusalAs400()
+}//end class

--- a/tests/Unit/Controller/ComplaintDispositionControllerContractTest.php
+++ b/tests/Unit/Controller/ComplaintDispositionControllerContractTest.php
@@ -1,0 +1,271 @@
+<?php
+
+/**
+ * ComplaintDispositionController Wire-Contract Tests
+ *
+ * Contract coverage for `POST /api/complaints/{id}/disposition/letter`
+ * (gate-25) — the endpoint that generates the formal Awb chapter 9 response
+ * letter a complainant actually receives. It is `@NoAdminRequired` and takes a
+ * complaint id straight off the URL, so the ordering of its four guards is the
+ * whole contract. These tests pin:
+ *
+ *  - 401 without a session, from the guard's own response, before either
+ *    domain service is touched;
+ *  - 404 for an unknown complaint, with NO letter generated;
+ *  - the per-object authorization is applied to THE LOADED COMPLAINT and the
+ *    SESSION UID, and an `OCSForbiddenException` from it PROPAGATES rather
+ *    than being swallowed into a success — a `try` placed one line too early
+ *    would turn a refusal into a generated letter;
+ *  - a complaint with no disposition yet is a 400 ("submit first"), NOT the
+ *    404 used for a missing complaint — the two are different remedies for
+ *    the caseworker;
+ *  - the letter is generated for the disposition belonging to that complaint,
+ *    with the disposition's own id, not the complaint id.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\ComplaintDispositionController;
+use OCA\Procest\Service\Complaint\ComplaintAccessGuard;
+use OCA\Procest\Service\ComplaintService;
+use OCA\Procest\Service\DispositionService;
+use OCA\Procest\Service\SettingsService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\OCS\OCSForbiddenException;
+use OCP\IGroupManager;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Wire-contract tests for ComplaintDispositionController::generateLetter().
+ *
+ * @covers \OCA\Procest\Controller\ComplaintDispositionController
+ *
+ * @uses \OCA\Procest\Service\Complaint\ComplaintAccessGuard
+ */
+class ComplaintDispositionControllerContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The complaint service.
+	 *
+	 * @var ComplaintService|MockObject
+	 */
+	private ComplaintService $complaintService;
+
+	/**
+	 * The disposition service.
+	 *
+	 * @var DispositionService|MockObject
+	 */
+	private DispositionService $dispositionService;
+
+	/**
+	 * The settings service (unused by generateLetter, required by the ctor).
+	 *
+	 * @var SettingsService|MockObject
+	 */
+	private SettingsService $settingsService;
+
+	/**
+	 * Build the shared collaborators.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->complaintService = $this->createMock(ComplaintService::class);
+		$this->dispositionService = $this->createMock(DispositionService::class);
+		$this->settingsService = $this->createMock(SettingsService::class);
+	}//end setUp()
+
+	/**
+	 * Build the controller around the supplied access guard.
+	 *
+	 * @param ComplaintAccessGuard $accessGuard The guard to install.
+	 *
+	 * @return ComplaintDispositionController
+	 */
+	private function controller(ComplaintAccessGuard $accessGuard): ComplaintDispositionController {
+		return new ComplaintDispositionController(
+			appName: 'procest',
+			request: $this->request,
+			complaintService: $this->complaintService,
+			dispositionService: $this->dispositionService,
+			settingsService: $this->settingsService,
+			accessGuard: $accessGuard,
+		);
+	}//end controller()
+
+	/**
+	 * A REAL guard wired to an empty session, so its 401 is the app's own.
+	 *
+	 * @return ComplaintAccessGuard
+	 */
+	private function realGuardWithoutSession(): ComplaintAccessGuard {
+		$userSession = $this->createMock(IUserSession::class);
+		$userSession->method('getUser')->willReturn(null);
+
+		return new ComplaintAccessGuard(
+			request: $this->request,
+			userSession: $userSession,
+			groupManager: $this->createMock(IGroupManager::class),
+		);
+	}//end realGuardWithoutSession()
+
+	/**
+	 * A REAL guard wired to a signed-in, non-admin session.
+	 *
+	 * @param string $uid The signed-in user id.
+	 *
+	 * @return ComplaintAccessGuard
+	 */
+	private function realGuardSignedInAs(string $uid): ComplaintAccessGuard {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+
+		$userSession = $this->createMock(IUserSession::class);
+		$userSession->method('getUser')->willReturn($user);
+
+		$groupManager = $this->createMock(IGroupManager::class);
+		$groupManager->method('isAdmin')->willReturn(false);
+
+		return new ComplaintAccessGuard(
+			request: $this->request,
+			userSession: $userSession,
+			groupManager: $groupManager,
+		);
+	}//end realGuardSignedInAs()
+
+	/**
+	 * Without a session the endpoint returns the guard's 401 and neither
+	 * domain service is consulted.
+	 *
+	 * @return void
+	 */
+	public function testGenerateLetterRefusesAnUnauthenticatedCallerBeforeAnyLookup(): void {
+		$this->complaintService->expects($this->never())->method('getComplaint');
+		$this->dispositionService->expects($this->never())->method('getDispositionForComplaint');
+		$this->dispositionService->expects($this->never())->method('generateResponseLetter');
+
+		$response = $this->controller($this->realGuardWithoutSession())->generateLetter(id: 'klacht-1');
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame(['error' => 'Not authenticated'], $response->getData());
+	}//end testGenerateLetterRefusesAnUnauthenticatedCallerBeforeAnyLookup()
+
+	/**
+	 * An unknown complaint is a 404 and produces no letter.
+	 *
+	 * @return void
+	 */
+	public function testGenerateLetterReturns404ForAnUnknownComplaintAndWritesNoLetter(): void {
+		$this->complaintService->expects($this->once())
+			->method('getComplaint')
+			->with('klacht-onbekend')
+			->willReturn(null);
+
+		$this->dispositionService->expects($this->never())->method('generateResponseLetter');
+
+		$response = $this->controller($this->realGuardSignedInAs('behandelaar'))
+			->generateLetter(id: 'klacht-onbekend');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertSame(['error' => 'Complaint not found'], $response->getData());
+	}//end testGenerateLetterReturns404ForAnUnknownComplaintAndWritesNoLetter()
+
+	/**
+	 * The per-object guard is applied to the loaded complaint and the session
+	 * uid, and its refusal is NOT swallowed into a generated letter.
+	 *
+	 * @return void
+	 */
+	public function testGenerateLetterAuthorizesTheLoadedComplaintAndLetsARefusalPropagate(): void {
+		$complaint = ['id' => 'klacht-1', 'handler' => 'someone-else'];
+
+		$this->complaintService->method('getComplaint')->willReturn($complaint);
+
+		$accessGuard = $this->createMock(ComplaintAccessGuard::class);
+		$accessGuard->method('currentUid')->willReturn('intruder');
+		$accessGuard->expects($this->once())
+			->method('authorizeMutation')
+			->with($complaint, 'intruder')
+			->willThrowException(new OCSForbiddenException('Not authorized to modify this complaint'));
+
+		$this->dispositionService->expects($this->never())->method('getDispositionForComplaint');
+		$this->dispositionService->expects($this->never())->method('generateResponseLetter');
+
+		$this->expectException(OCSForbiddenException::class);
+
+		$this->controller($accessGuard)->generateLetter(id: 'klacht-1');
+	}//end testGenerateLetterAuthorizesTheLoadedComplaintAndLetsARefusalPropagate()
+
+	/**
+	 * A complaint whose disposition has not been submitted yet is a 400 with
+	 * the "submit first" instruction — a DIFFERENT status from the 404 used
+	 * for a missing complaint.
+	 *
+	 * @return void
+	 */
+	public function testGenerateLetterReturns400WhenNoDispositionHasBeenSubmittedYet(): void {
+		$this->complaintService->method('getComplaint')->willReturn(['id' => 'klacht-1']);
+		$this->dispositionService->method('getDispositionForComplaint')->willReturn(null);
+		$this->dispositionService->expects($this->never())->method('generateResponseLetter');
+
+		$response = $this->controller($this->realGuardSignedInAs('behandelaar'))
+			->generateLetter(id: 'klacht-1');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(
+			['error' => 'Submit disposition before generating a letter'],
+			$response->getData()
+		);
+	}//end testGenerateLetterReturns400WhenNoDispositionHasBeenSubmittedYet()
+
+	/**
+	 * The letter is generated from the complaint id AND the disposition's own
+	 * id — passing the complaint id twice would address the wrong record.
+	 *
+	 * @return void
+	 */
+	public function testGenerateLetterPairsTheComplaintIdWithTheDispositionsOwnId(): void {
+		$this->complaintService->method('getComplaint')->willReturn(['id' => 'klacht-1']);
+		$this->dispositionService->method('getDispositionForComplaint')
+			->willReturn(['id' => 'afdoening-9', 'uuid' => 'afdoening-9']);
+
+		$letter = ['fileId' => 4711, 'status' => 'generated'];
+
+		$this->dispositionService->expects($this->once())
+			->method('generateResponseLetter')
+			->with('klacht-1', 'afdoening-9')
+			->willReturn($letter);
+
+		$response = $this->controller($this->realGuardSignedInAs('behandelaar'))
+			->generateLetter(id: 'klacht-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($letter, $response->getData());
+	}//end testGenerateLetterPairsTheComplaintIdWithTheDispositionsOwnId()
+}//end class

--- a/tests/Unit/Controller/ComplaintHearingControllerContractTest.php
+++ b/tests/Unit/Controller/ComplaintHearingControllerContractTest.php
@@ -1,0 +1,332 @@
+<?php
+
+/**
+ * ComplaintHearingController Wire-Contract Tests
+ *
+ * Contract coverage for the two hoorgesprek endpoints (gate-25). Both are
+ * `@NoAdminRequired`. `hearings` is a read and `recordHearingOutcome` both
+ * writes the hearing record AND advances the parent complaint's status, which
+ * is what makes it interesting: two ids arrive on the same route and a status
+ * transition rides on the write's success.
+ *
+ * The contract pinned here:
+ *
+ *  - no session answers 401 on both endpoints and neither touches HearingService;
+ *  - an unknown complaint answers 404 before any write;
+ *  - a caller who is neither the assigned behandelaar nor an admin is refused by
+ *    the REAL ComplaintAccessGuard (403 via the NC middleware) before any write;
+ *  - the outcome is recorded against the HEARING id and the transition is
+ *    applied to the COMPLAINT id — transposing the two ids on a two-id route is
+ *    the realistic defect, and both would still answer 200;
+ *  - the transition target is the literal `hoorgesprek_completed`, and a failed
+ *    recording answers 400 WITHOUT advancing the complaint — a complaint marked
+ *    "hearing completed" with no hearing on file is an Awb record defect.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\ComplaintHearingController;
+use OCA\Procest\Service\Complaint\ComplaintAccessGuard;
+use OCA\Procest\Service\ComplaintService;
+use OCA\Procest\Service\HearingService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\OCS\OCSForbiddenException;
+use OCP\IGroupManager;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Wire-contract tests for ComplaintHearingController.
+ *
+ * @covers \OCA\Procest\Controller\ComplaintHearingController
+ *
+ * @uses \OCA\Procest\Service\Complaint\ComplaintAccessGuard
+ */
+class ComplaintHearingControllerContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The ComplaintService mock.
+	 *
+	 * @var ComplaintService|MockObject
+	 */
+	private ComplaintService $complaintService;
+
+	/**
+	 * The HearingService mock.
+	 *
+	 * @var HearingService|MockObject
+	 */
+	private HearingService $hearingService;
+
+	/**
+	 * The IUserSession mock backing the real access guard.
+	 *
+	 * @var IUserSession|MockObject
+	 */
+	private IUserSession $userSession;
+
+	/**
+	 * The IGroupManager mock backing the real access guard.
+	 *
+	 * @var IGroupManager|MockObject
+	 */
+	private IGroupManager $groupManager;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var ComplaintHearingController
+	 */
+	private ComplaintHearingController $controller;
+
+	/**
+	 * Build the controller over a real ComplaintAccessGuard.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->complaintService = $this->createMock(ComplaintService::class);
+		$this->hearingService = $this->createMock(HearingService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+
+		$this->controller = new ComplaintHearingController(
+			appName: 'procest',
+			request: $this->request,
+			complaintService: $this->complaintService,
+			hearingService: $this->hearingService,
+			accessGuard: new ComplaintAccessGuard(
+				request: $this->request,
+				userSession: $this->userSession,
+				groupManager: $this->groupManager,
+			),
+		);
+	}//end setUp()
+
+	/**
+	 * Put a signed-in user on the session.
+	 *
+	 * @param string $uid The UID of the signed-in user.
+	 *
+	 * @return void
+	 */
+	private function signIn(string $uid = 'alice'): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		$this->userSession->method('getUser')->willReturn($user);
+	}//end signIn()
+
+	/**
+	 * `hearings` refuses an anonymous caller with 401 and reads nothing.
+	 *
+	 * @return void
+	 */
+	public function testHearingsRefusesAnUnauthenticatedCallerWith401(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->hearingService->expects($this->never())->method('getHearingsForComplaint');
+
+		$response = $this->controller->hearings(id: 'klacht-1');
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame(['error' => 'Not authenticated'], $response->getData());
+	}//end testHearingsRefusesAnUnauthenticatedCallerWith401()
+
+	/**
+	 * `hearings` lists the hearings of the complaint named in the URL, under a
+	 * `results` key.
+	 *
+	 * @return void
+	 */
+	public function testHearingsListsTheHearingsOfTheComplaintNamedInTheUrl(): void {
+		$this->signIn();
+		$this->hearingService->expects($this->once())
+			->method('getHearingsForComplaint')
+			->with('klacht-1')
+			->willReturn([['id' => 'hoor-1', 'date' => '2026-09-01']]);
+
+		$response = $this->controller->hearings(id: 'klacht-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(
+			['results' => [['id' => 'hoor-1', 'date' => '2026-09-01']]],
+			$response->getData()
+		);
+	}//end testHearingsListsTheHearingsOfTheComplaintNamedInTheUrl()
+
+	/**
+	 * Listing hearings is a BROAD read: any authenticated user may list any
+	 * complaint's hearings, matching ComplaintAccessGuard::authorizeAccess(),
+	 * which deliberately grants read to every authenticated caller.
+	 *
+	 * This pins the posture rather than assuming it. If the read surface is ever
+	 * narrowed to the behandelaar, this test must be updated deliberately — it
+	 * will not silently keep passing.
+	 *
+	 * @return void
+	 */
+	public function testHearingsGrantsReadToAnyAuthenticatedCallerByDesign(): void {
+		$this->signIn(uid: 'someone-else');
+		$this->groupManager->method('isAdmin')->willReturn(false);
+		$this->hearingService->method('getHearingsForComplaint')->willReturn([]);
+
+		$response = $this->controller->hearings(id: 'klacht-of-another-handler');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['results' => []], $response->getData());
+	}//end testHearingsGrantsReadToAnyAuthenticatedCallerByDesign()
+
+	/**
+	 * `recordHearingOutcome` refuses an anonymous caller with 401 and records
+	 * nothing.
+	 *
+	 * @return void
+	 */
+	public function testRecordHearingOutcomeRefusesAnUnauthenticatedCallerWith401(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->hearingService->expects($this->never())->method('recordOutcome');
+		$this->complaintService->expects($this->never())->method('transitionStatus');
+
+		$response = $this->controller->recordHearingOutcome(id: 'klacht-1', hearingId: 'hoor-1');
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame(['error' => 'Not authenticated'], $response->getData());
+	}//end testRecordHearingOutcomeRefusesAnUnauthenticatedCallerWith401()
+
+	/**
+	 * An unknown complaint answers 404 and neither records nor transitions.
+	 *
+	 * @return void
+	 */
+	public function testRecordHearingOutcomeReturns404ForAnUnknownComplaint(): void {
+		$this->signIn();
+		$this->complaintService->method('getComplaint')->willReturn(null);
+		$this->hearingService->expects($this->never())->method('recordOutcome');
+		$this->complaintService->expects($this->never())->method('transitionStatus');
+
+		$response = $this->controller->recordHearingOutcome(id: 'nope', hearingId: 'hoor-1');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertSame(['error' => 'Complaint not found'], $response->getData());
+	}//end testRecordHearingOutcomeReturns404ForAnUnknownComplaint()
+
+	/**
+	 * Recording an outcome is a MUTATION: a caller who is neither the assigned
+	 * behandelaar nor an admin is refused before anything is written.
+	 *
+	 * @return void
+	 */
+	public function testRecordHearingOutcomeRefusesAStrangerToTheComplaint(): void {
+		$this->signIn(uid: 'mallory');
+		$this->complaintService->method('getComplaint')
+			->willReturn(['id' => 'klacht-1', 'handler' => 'alice']);
+		$this->groupManager->expects($this->once())
+			->method('isAdmin')
+			->with('mallory')
+			->willReturn(false);
+		$this->hearingService->expects($this->never())->method('recordOutcome');
+		$this->complaintService->expects($this->never())->method('transitionStatus');
+
+		$this->expectException(OCSForbiddenException::class);
+		$this->expectExceptionMessage('Not authorized to modify this complaint');
+
+		$this->controller->recordHearingOutcome(id: 'klacht-1', hearingId: 'hoor-1');
+	}//end testRecordHearingOutcomeRefusesAStrangerToTheComplaint()
+
+	/**
+	 * The outcome is recorded against the HEARING id while the transition is
+	 * applied to the COMPLAINT id, and the transition target is the literal
+	 * `hoorgesprek_completed`.
+	 *
+	 * @return void
+	 */
+	public function testRecordHearingOutcomeWritesTheHearingAndAdvancesTheComplaint(): void {
+		$this->signIn(uid: 'alice');
+		$this->complaintService->method('getComplaint')
+			->willReturn(['id' => 'klacht-1', 'handler' => 'alice']);
+		$this->request->method('getParams')->willReturn(['outcome' => 'gehoord']);
+
+		$this->hearingService->expects($this->once())
+			->method('recordOutcome')
+			->with('hoor-9', ['outcome' => 'gehoord'])
+			->willReturn(['id' => 'hoor-9', 'outcome' => 'gehoord']);
+
+		$this->complaintService->expects($this->once())
+			->method('transitionStatus')
+			->with('klacht-1', 'hoorgesprek_completed')
+			->willReturn(['id' => 'klacht-1', 'status' => 'hoorgesprek_completed']);
+
+		$response = $this->controller->recordHearingOutcome(id: 'klacht-1', hearingId: 'hoor-9');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['id' => 'hoor-9', 'outcome' => 'gehoord'], $response->getData());
+	}//end testRecordHearingOutcomeWritesTheHearingAndAdvancesTheComplaint()
+
+	/**
+	 * A rejected outcome answers 400 and leaves the complaint's status alone —
+	 * a complaint stamped "hearing completed" with no hearing on file would be
+	 * an Awb record defect.
+	 *
+	 * @return void
+	 */
+	public function testRecordHearingOutcomeDoesNotAdvanceTheComplaintWhenRecordingFails(): void {
+		$this->signIn(uid: 'alice');
+		$this->complaintService->method('getComplaint')
+			->willReturn(['id' => 'klacht-1', 'handler' => 'alice']);
+		$this->request->method('getParams')->willReturn(['outcome' => '']);
+		$this->hearingService->method('recordOutcome')
+			->willThrowException(new \RuntimeException('outcome is required'));
+		$this->complaintService->expects($this->never())->method('transitionStatus');
+
+		$response = $this->controller->recordHearingOutcome(id: 'klacht-1', hearingId: 'hoor-9');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'outcome is required'], $response->getData());
+	}//end testRecordHearingOutcomeDoesNotAdvanceTheComplaintWhenRecordingFails()
+
+	/**
+	 * A coordinator may record an outcome on a complaint assigned to someone
+	 * else — proving the refusal above is a real per-complaint decision and not
+	 * a guard that refuses everybody.
+	 *
+	 * @return void
+	 */
+	public function testRecordHearingOutcomeAllowsACoordinatorOnAnotherHandlersComplaint(): void {
+		$this->signIn(uid: 'coordinator');
+		$this->complaintService->method('getComplaint')
+			->willReturn(['id' => 'klacht-1', 'handler' => 'alice']);
+		$this->groupManager->method('isAdmin')->with('coordinator')->willReturn(true);
+		$this->request->method('getParams')->willReturn(['outcome' => 'gehoord']);
+		$this->hearingService->expects($this->once())
+			->method('recordOutcome')
+			->willReturn(['id' => 'hoor-9']);
+		$this->complaintService->method('transitionStatus')->willReturn([]);
+
+		$response = $this->controller->recordHearingOutcome(id: 'klacht-1', hearingId: 'hoor-9');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+	}//end testRecordHearingOutcomeAllowsACoordinatorOnAnotherHandlersComplaint()
+}//end class

--- a/tests/Unit/Controller/ConsultationControllerContractTest.php
+++ b/tests/Unit/Controller/ConsultationControllerContractTest.php
@@ -1,0 +1,172 @@
+<?php
+
+/**
+ * ConsultationController Wire-Contract Tests
+ *
+ * Contract coverage for `GET /api/consultations/overdue` (gate-25). Unlike its
+ * sibling endpoints this one takes NO id: it is a cross-case listing of every
+ * adviesaanvraag past its Awb 3:6 deadline, so the authentication branch is
+ * the only thing between an anonymous caller and a list of overdue advisory
+ * requests across the whole organisation. These tests pin:
+ *
+ *  - the refusal is the guard's real 401 and it happens BEFORE
+ *    ConsultationService is consulted (the guard is instantiated for real, so
+ *    a stubbed-away status cannot manufacture the pass);
+ *  - the payload is nested under `results`, not returned bare — the sibling
+ *    `show()` returns its object bare, so the two shapes are easy to confuse.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\ConsultationController;
+use OCA\Procest\Service\Consultation\ConsultationAccessGuard;
+use OCA\Procest\Service\ConsultationService;
+use OCP\AppFramework\Http;
+use OCP\IGroupManager;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Wire-contract tests for ConsultationController::overdue().
+ *
+ * @covers \OCA\Procest\Controller\ConsultationController
+ *
+ * @uses \OCA\Procest\Service\Consultation\ConsultationAccessGuard
+ */
+class ConsultationControllerContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The consultation domain service.
+	 *
+	 * @var ConsultationService|MockObject
+	 */
+	private ConsultationService $consultationService;
+
+	/**
+	 * The user session driving the REAL access guard.
+	 *
+	 * @var IUserSession|MockObject
+	 */
+	private IUserSession $userSession;
+
+	/**
+	 * The group manager driving the REAL access guard.
+	 *
+	 * @var IGroupManager|MockObject
+	 */
+	private IGroupManager $groupManager;
+
+	/**
+	 * Build the collaborators.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->consultationService = $this->createMock(ConsultationService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+	}//end setUp()
+
+	/**
+	 * Build the controller behind a REAL ConsultationAccessGuard, so the 401
+	 * asserted below is the guard's own response and not a test stub.
+	 *
+	 * @return ConsultationController
+	 */
+	private function controller(): ConsultationController {
+		return new ConsultationController(
+			appName: 'procest',
+			request: $this->request,
+			consultationService: $this->consultationService,
+			accessGuard: new ConsultationAccessGuard(
+				request: $this->request,
+				consultationService: $this->consultationService,
+				userSession: $this->userSession,
+				groupManager: $this->groupManager,
+			),
+		);
+	}//end controller()
+
+	/**
+	 * An unauthenticated caller gets 401 and no overdue list is assembled.
+	 *
+	 * @return void
+	 */
+	public function testOverdueRefusesAnUnauthenticatedCallerBeforeListingAnyConsultation(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->consultationService->expects($this->never())->method('getOverdueConsultations');
+
+		$response = $this->controller()->overdue();
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame(['error' => 'Not authenticated'], $response->getData());
+	}//end testOverdueRefusesAnUnauthenticatedCallerBeforeListingAnyConsultation()
+
+	/**
+	 * An authenticated caller gets the overdue set wrapped under `results`.
+	 *
+	 * @return void
+	 */
+	public function testOverdueWrapsTheOverdueConsultationsUnderResults(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('adviseur');
+		$this->userSession->method('getUser')->willReturn($user);
+
+		$overdue = [
+			['id' => 'cn-1', 'deadline' => '2026-01-01'],
+			['id' => 'cn-2', 'deadline' => '2026-02-01'],
+		];
+
+		$this->consultationService->expects($this->once())
+			->method('getOverdueConsultations')
+			->willReturn($overdue);
+
+		$response = $this->controller()->overdue();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['results' => $overdue], $response->getData());
+	}//end testOverdueWrapsTheOverdueConsultationsUnderResults()
+
+	/**
+	 * An empty overdue set is still the `results` envelope, never a bare array
+	 * or a 404 — the frontend reads `.results` unconditionally.
+	 *
+	 * @return void
+	 */
+	public function testOverdueReturnsAnEmptyResultsEnvelopeWhenNothingIsOverdue(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('adviseur');
+		$this->userSession->method('getUser')->willReturn($user);
+
+		$this->consultationService->method('getOverdueConsultations')->willReturn([]);
+
+		$response = $this->controller()->overdue();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['results' => []], $response->getData());
+	}//end testOverdueReturnsAnEmptyResultsEnvelopeWhenNothingIsOverdue()
+}//end class

--- a/tests/Unit/Controller/ConsultationPublicControllerContractTest.php
+++ b/tests/Unit/Controller/ConsultationPublicControllerContractTest.php
@@ -1,0 +1,454 @@
+<?php
+
+/**
+ * ConsultationPublicController Wire-Contract Tests
+ *
+ * Contract coverage for `POST /api/public/consultations/{token}` (gate-25) —
+ * the endpoint an EXTERNAL advisory body posts its Awb 3:5-3:9 advice to. It
+ * is `@PublicPage` + `@NoCSRFRequired`: there is no Nextcloud session and no
+ * CSRF token, so the secure token is the entire authorization system and the
+ * controller body is the only thing enforcing it. These tests pin:
+ *
+ *  - an empty token is a 400 raised BEFORE the token store is queried, so a
+ *    blank token can never be matched against anything;
+ *  - a token that resolves to nothing is a 404 and NO response is submitted —
+ *    this is the branch that stops an anonymous caller stuffing an arbitrary
+ *    consultation with fabricated advice, and it is asserted with a
+ *    `never()` on `submitResponse()` rather than only on the status;
+ *  - the advice is filed against the CONSULTATION ID the token resolved to,
+ *    never against the token itself — the token is a caller-supplied string
+ *    and using it as the record key would be an injection point;
+ *  - a domain `RuntimeException` (e.g. a closed consultation) becomes a 400
+ *    carrying the domain message, not a 500.
+ *
+ * NOTE ON THE ROUTE'S LIVENESS: procest's board records that the public
+ * consultation-response PAGE renders "This page is empty" because its Vue
+ * component is never registered. That is a frontend registration gap; the
+ * BACKEND route is present in appinfo/routes.php and dispatches to this
+ * method, so the endpoint is live and testable at the controller level.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\ConsultationPublicController;
+use OCA\Procest\Service\ConsultationService;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Concrete IRequest stub serving a raw body for the ConsultationPublic tests.
+ *
+ * `getContent()` is NOT declared on the OCP\IRequest interface — it is a magic
+ * accessor on the concrete OC request — so `createMock(IRequest::class)` has no
+ * such method and calling it raises an Error. A concrete stub is the only way
+ * to drive `publicResponsePost()`'s body decoding. The class name is prefixed
+ * with the controller name because sibling contract suites define their own
+ * stubs in this same namespace.
+ */
+class ConsultationPublicControllerContractRequestStub implements IRequest {
+
+	/**
+	 * The raw request body returned by getContent().
+	 *
+	 * @var string
+	 */
+	private string $content;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $content The raw request body.
+	 */
+	public function __construct(string $content = '') {
+		$this->content = $content;
+	}//end __construct()
+
+	/**
+	 * Return the raw request body.
+	 *
+	 * @return string
+	 */
+	public function getContent(): string {
+		return $this->content;
+	}//end getContent()
+
+	/**
+	 * Return a request header value.
+	 *
+	 * @param string $name Header name.
+	 *
+	 * @return string
+	 */
+	public function getHeader(string $name): string {
+		return '';
+	}//end getHeader()
+
+	/**
+	 * Return a single request parameter.
+	 *
+	 * @param string $key Parameter name.
+	 * @param mixed $default Default when absent.
+	 *
+	 * @return mixed
+	 */
+	public function getParam(string $key, mixed $default = null): mixed {
+		return $default;
+	}//end getParam()
+
+	/**
+	 * Return all request parameters.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public function getParams(): array {
+		return [];
+	}//end getParams()
+
+	/**
+	 * Return the HTTP method.
+	 *
+	 * @return string
+	 */
+	public function getMethod(): string {
+		return 'POST';
+	}//end getMethod()
+
+	/**
+	 * Return an uploaded file.
+	 *
+	 * @param string $key File field name.
+	 *
+	 * @return mixed
+	 */
+	public function getUploadedFile(string $key): mixed {
+		return null;
+	}//end getUploadedFile()
+
+	/**
+	 * Return a server environment variable.
+	 *
+	 * @param string $key Variable name.
+	 *
+	 * @return mixed
+	 */
+	public function getEnv(string $key): mixed {
+		return null;
+	}//end getEnv()
+
+	/**
+	 * Return a cookie value.
+	 *
+	 * @param string $key Cookie name.
+	 *
+	 * @return mixed
+	 */
+	public function getCookie(string $key): mixed {
+		return null;
+	}//end getCookie()
+
+	/**
+	 * Whether the request passes the CSRF check.
+	 *
+	 * @return bool
+	 */
+	public function passesCSRFCheck(): bool {
+		return true;
+	}//end passesCSRFCheck()
+
+	/**
+	 * Whether the request passes the strict cookie check.
+	 *
+	 * @return bool
+	 */
+	public function passesStrictCookieCheck(): bool {
+		return true;
+	}//end passesStrictCookieCheck()
+
+	/**
+	 * Whether the request passes the lax cookie check.
+	 *
+	 * @return bool
+	 */
+	public function passesLaxCookieCheck(): bool {
+		return true;
+	}//end passesLaxCookieCheck()
+
+	/**
+	 * Return the unique request id.
+	 *
+	 * @return string
+	 */
+	public function getId(): string {
+		return 'consultation-public-contract-test';
+	}//end getId()
+
+	/**
+	 * Return the remote address.
+	 *
+	 * @return string
+	 */
+	public function getRemoteAddress(): string {
+		return '198.51.100.7';
+	}//end getRemoteAddress()
+
+	/**
+	 * Return the server protocol.
+	 *
+	 * @return string
+	 */
+	public function getServerProtocol(): string {
+		return 'HTTP/1.1';
+	}//end getServerProtocol()
+
+	/**
+	 * Return the HTTP scheme.
+	 *
+	 * @return string
+	 */
+	public function getHttpProtocol(): string {
+		return 'https';
+	}//end getHttpProtocol()
+
+	/**
+	 * Return the request URI.
+	 *
+	 * @return string
+	 */
+	public function getRequestUri(): string {
+		return '/apps/procest/api/public/consultations/tok';
+	}//end getRequestUri()
+
+	/**
+	 * Return the raw path info.
+	 *
+	 * @return string
+	 */
+	public function getRawPathInfo(): string {
+		return '';
+	}//end getRawPathInfo()
+
+	/**
+	 * Return the decoded path info.
+	 *
+	 * @return mixed
+	 */
+	public function getPathInfo(): mixed {
+		return '';
+	}//end getPathInfo()
+
+	/**
+	 * Return the script name.
+	 *
+	 * @return string
+	 */
+	public function getScriptName(): string {
+		return '';
+	}//end getScriptName()
+
+	/**
+	 * Whether the request comes from one of the given user agents.
+	 *
+	 * @param array<int,string> $agent Agent patterns.
+	 *
+	 * @return bool
+	 */
+	public function isUserAgent(array $agent): bool {
+		return false;
+	}//end isUserAgent()
+
+	/**
+	 * Return the insecure server host.
+	 *
+	 * @return string
+	 */
+	public function getInsecureServerHost(): string {
+		return 'localhost';
+	}//end getInsecureServerHost()
+
+	/**
+	 * Return the server host.
+	 *
+	 * @return string
+	 */
+	public function getServerHost(): string {
+		return 'localhost';
+	}//end getServerHost()
+
+	/**
+	 * Rethrow a body-decoding failure, if any.
+	 *
+	 * @return void
+	 */
+	public function throwDecodingExceptionIfAny(): void {
+	}//end throwDecodingExceptionIfAny()
+
+	/**
+	 * Return the requested response format.
+	 *
+	 * @return string|null
+	 */
+	public function getFormat(): ?string {
+		return null;
+	}//end getFormat()
+}//end class
+
+/**
+ * Wire-contract tests for ConsultationPublicController::publicResponsePost().
+ *
+ * @covers \OCA\Procest\Controller\ConsultationPublicController
+ */
+class ConsultationPublicControllerContractTest extends TestCase {
+
+	/**
+	 * The consultation domain service.
+	 *
+	 * @var ConsultationService|MockObject
+	 */
+	private ConsultationService $consultationService;
+
+	/**
+	 * The BIO audit logger.
+	 *
+	 * @var LoggerInterface|MockObject
+	 */
+	private LoggerInterface $logger;
+
+	/**
+	 * Build the shared collaborators.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->consultationService = $this->createMock(ConsultationService::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+	}//end setUp()
+
+	/**
+	 * Build the controller with the given raw request body.
+	 *
+	 * @param string $body The raw JSON body an external body would post.
+	 *
+	 * @return ConsultationPublicController
+	 */
+	private function controller(string $body = ''): ConsultationPublicController {
+		return new ConsultationPublicController(
+			appName: 'procest',
+			request: new ConsultationPublicControllerContractRequestStub(content: $body),
+			consultationService: $this->consultationService,
+			logger: $this->logger,
+		);
+	}//end controller()
+
+	/**
+	 * An empty token is a 400 and the token store is never queried.
+	 *
+	 * @return void
+	 */
+	public function testPublicResponsePostRejectsAnEmptyTokenBeforeQueryingTheTokenStore(): void {
+		$this->consultationService->expects($this->never())->method('findBySecureToken');
+		$this->consultationService->expects($this->never())->method('submitResponse');
+
+		$response = $this->controller()->publicResponsePost(token: '');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'Token is required'], $response->getData());
+	}//end testPublicResponsePostRejectsAnEmptyTokenBeforeQueryingTheTokenStore()
+
+	/**
+	 * An unresolvable token is a 404 and NOTHING is submitted.
+	 *
+	 * This is the guard that keeps an anonymous caller from writing advice
+	 * into a consultation it holds no token for.
+	 *
+	 * @return void
+	 */
+	public function testPublicResponsePostRefusesAnInvalidTokenAndSubmitsNothing(): void {
+		$this->consultationService->expects($this->once())
+			->method('findBySecureToken')
+			->with('tok-vervalst')
+			->willReturn(null);
+
+		$this->consultationService->expects($this->never())->method('submitResponse');
+
+		$response = $this->controller('{"advies":"positief"}')->publicResponsePost(token: 'tok-vervalst');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertSame(['error' => 'Invalid or expired token'], $response->getData());
+	}//end testPublicResponsePostRefusesAnInvalidTokenAndSubmitsNothing()
+
+	/**
+	 * The advice is filed against the consultation the token RESOLVED to, and
+	 * the decoded body is forwarded as the response payload.
+	 *
+	 * @return void
+	 */
+	public function testPublicResponsePostFilesTheAdviceAgainstTheResolvedConsultationNotTheToken(): void {
+		$this->consultationService->method('findBySecureToken')
+			->willReturn(['id' => 'cn-88', 'secureToken' => 'tok-geldig', 'onderwerp' => 'Bestemmingsplan']);
+
+		$stored = ['id' => 'cn-88', 'status' => 'advised'];
+
+		$this->consultationService->expects($this->once())
+			->method('submitResponse')
+			->with('cn-88', ['advies' => 'positief', 'toelichting' => 'geen bezwaar'])
+			->willReturn($stored);
+
+		$response = $this->controller('{"advies":"positief","toelichting":"geen bezwaar"}')
+			->publicResponsePost(token: 'tok-geldig');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($stored, $response->getData());
+	}//end testPublicResponsePostFilesTheAdviceAgainstTheResolvedConsultationNotTheToken()
+
+	/**
+	 * An empty or unparseable body is forwarded as an empty array, never as
+	 * a string or null, into the service's typed `array $response` parameter.
+	 *
+	 * @return void
+	 */
+	public function testPublicResponsePostForwardsAnEmptyArrayForAnUnparseableBody(): void {
+		$this->consultationService->method('findBySecureToken')->willReturn(['id' => 'cn-88']);
+
+		$this->consultationService->expects($this->once())
+			->method('submitResponse')
+			->with('cn-88', $this->identicalTo([]))
+			->willReturn([]);
+
+		$response = $this->controller('not-json-at-all')->publicResponsePost(token: 'tok-geldig');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+	}//end testPublicResponsePostForwardsAnEmptyArrayForAnUnparseableBody()
+
+	/**
+	 * A domain refusal (a closed or already-answered consultation) is a 400
+	 * carrying the domain message, not a 500.
+	 *
+	 * @return void
+	 */
+	public function testPublicResponsePostMapsADomainRefusalToA400WithItsMessage(): void {
+		$this->consultationService->method('findBySecureToken')->willReturn(['id' => 'cn-88']);
+		$this->consultationService->method('submitResponse')
+			->willThrowException(new \RuntimeException('Consultation is already closed'));
+
+		$response = $this->controller('{"advies":"positief"}')->publicResponsePost(token: 'tok-geldig');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'Consultation is already closed'], $response->getData());
+	}//end testPublicResponsePostMapsADomainRefusalToA400WithItsMessage()
+}//end class

--- a/tests/Unit/Controller/ContactMomentControllerContractTest.php
+++ b/tests/Unit/Controller/ContactMomentControllerContractTest.php
@@ -1,0 +1,434 @@
+<?php
+
+/**
+ * ContactMomentController Wire-Contract Tests
+ *
+ * Contract coverage for the four KCC endpoints that had no automated proof of
+ * their wire behaviour (gate-25): `statusGeven`, `doorverbinden`,
+ * `acceptDoorverbinding` and `rejectDoorverbinding`.
+ *
+ * These four differ from their neighbours on this controller in one respect
+ * that the tests make explicit: `create()`, `index()`, `voorblad()`,
+ * `nieuweZaak()` and `klachtRegistreren()` all sit behind
+ * `CitizenLookupGuard::isCitizenLookupAllowed()` because they resolve a
+ * caller-supplied CITIZEN identifier, while these four address a case or a
+ * transfer record and are gated on the session alone. What every one of them
+ * must never do is take the acting identity from the request:
+ *
+ *  - `doorverbinden` records `fromEmployeeId` from the session;
+ *  - `acceptDoorverbinding` accepts AS the session user;
+ *  - `rejectDoorverbinding` rejects AS the session user;
+ *  - `statusGeven` logs the activity under the session user.
+ *
+ * A caller able to supply those would attribute a warm transfer, an acceptance
+ * or a citizen-facing status update to a colleague. Each test therefore posts a
+ * contradicting value in the body and asserts the session value wins.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\ContactMomentController;
+use OCA\Procest\Service\BurgerIdentificationService;
+use OCA\Procest\Service\CaseVoorbladService;
+use OCA\Procest\Service\CitizenLookupGuard;
+use OCA\Procest\Service\ContactMomentService;
+use OCA\Procest\Service\DoorverbindingService;
+use OCA\Procest\Service\QuickActionService;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * Wire-contract tests for ContactMomentController.
+ *
+ * @covers \OCA\Procest\Controller\ContactMomentController
+ */
+class ContactMomentControllerContractTest extends TestCase {
+
+	/**
+	 * The inbound request mock.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The contactmoment service mock (activity logging).
+	 *
+	 * @var ContactMomentService|MockObject
+	 */
+	private ContactMomentService $contactMomentService;
+
+	/**
+	 * The quick-action service mock.
+	 *
+	 * @var QuickActionService|MockObject
+	 */
+	private QuickActionService $quickActionService;
+
+	/**
+	 * The doorverbinding (warm transfer) service mock.
+	 *
+	 * @var DoorverbindingService|MockObject
+	 */
+	private DoorverbindingService $transferService;
+
+	/**
+	 * The session mock.
+	 *
+	 * @var IUserSession|MockObject
+	 */
+	private IUserSession $userSession;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var ContactMomentController
+	 */
+	private ContactMomentController $controller;
+
+	/**
+	 * Build the controller with all collaborators mocked.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->contactMomentService = $this->createMock(ContactMomentService::class);
+		$this->quickActionService = $this->createMock(QuickActionService::class);
+		$this->transferService = $this->createMock(DoorverbindingService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+
+		$this->controller = new ContactMomentController(
+			appName: 'procest',
+			request: $this->request,
+			contactMomentService: $this->contactMomentService,
+			caseVoorbladService: $this->createMock(CaseVoorbladService::class),
+			quickActionService: $this->quickActionService,
+			transferService: $this->transferService,
+			burgerService: $this->createMock(BurgerIdentificationService::class),
+			userSession: $this->userSession,
+			citizenLookupGuard: $this->createMock(CitizenLookupGuard::class),
+		);
+	}//end setUp()
+
+	/**
+	 * Mark the session as authenticated for KCC employee `alice`.
+	 *
+	 * @return void
+	 */
+	private function authenticate(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+		$this->userSession->method('getUser')->willReturn($user);
+	}//end authenticate()
+
+	/**
+	 * Feed the request parameter bag.
+	 *
+	 * @param array<string, mixed> $params The request parameters.
+	 *
+	 * @return void
+	 */
+	private function withParams(array $params): void {
+		$this->request->method('getParam')->willReturnCallback(
+			static function (string $key, mixed $default = null) use ($params): mixed {
+				if (array_key_exists($key, $params) === true) {
+					return $params[$key];
+				}
+
+				return $default;
+			}
+		);
+	}//end withParams()
+
+	/**
+	 * All four endpoints refuse an anonymous caller with 401 and never touch a
+	 * case, a transfer record or the activity log.
+	 *
+	 * @return void
+	 */
+	public function testAllFourEndpointsRefuseAnAnonymousCaller(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->withParams(['caseId' => 'case-1', 'reason' => 'geen tijd']);
+
+		$this->quickActionService->expects($this->never())->method('executeStatusTerugkoppelen');
+		$this->transferService->expects($this->never())->method('initiateWarmTransfer');
+		$this->transferService->expects($this->never())->method('acceptTransfer');
+		$this->transferService->expects($this->never())->method('rejectTransfer');
+		$this->contactMomentService->expects($this->never())->method('recordActivity');
+
+		$responses = [
+			'statusGeven' => $this->controller->statusGeven(),
+			'doorverbinden' => $this->controller->doorverbinden(),
+			'acceptDoorverbinding' => $this->controller->acceptDoorverbinding(id: 'dv-1'),
+			'rejectDoorverbinding' => $this->controller->rejectDoorverbinding(id: 'dv-1'),
+		];
+
+		foreach ($responses as $endpoint => $response) {
+			$this->assertSame(
+				Http::STATUS_UNAUTHORIZED,
+				$response->getStatus(),
+				$endpoint . ' must answer 401 for a caller without a session'
+			);
+			$this->assertSame(
+				['error' => 'Not authenticated'],
+				$response->getData(),
+				$endpoint . ' must answer the standard unauthenticated body'
+			);
+		}
+	}//end testAllFourEndpointsRefuseAnAnonymousCaller()
+
+	/**
+	 * Without `confirm`, statusGeven only DRAFTS: the draft text is returned and
+	 * nothing is written to the case's activity log.
+	 *
+	 * This is the whole point of the two-step quick-action — the KCC employee
+	 * reads the generated text to the citizen before it is recorded as given.
+	 *
+	 * @return void
+	 */
+	public function testStatusGevenDraftsWithoutRecordingWhenNotConfirmed(): void {
+		$this->authenticate();
+		$this->withParams(['caseId' => 'case-1']);
+
+		$draft = ['draftText' => 'Uw aanvraag heeft de status: in behandeling.', 'status' => 'in_behandeling'];
+
+		$this->quickActionService->expects($this->once())
+			->method('executeStatusTerugkoppelen')
+			->with('case-1')
+			->willReturn($draft);
+
+		$this->contactMomentService->expects($this->never())->method('recordActivity');
+
+		$response = $this->controller->statusGeven();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($draft, $response->getData());
+	}//end testStatusGevenDraftsWithoutRecordingWhenNotConfirmed()
+
+	/**
+	 * With `confirm`, statusGeven records the activity against the case under
+	 * the SESSION employee id, tagged `status_given`, carrying the draft text
+	 * that was actually generated — and still answers with the draft.
+	 *
+	 * @return void
+	 */
+	public function testStatusGevenRecordsTheActivityUnderTheSessionEmployeeWhenConfirmed(): void {
+		$this->authenticate();
+		$this->withParams(['caseId' => 'case-1', 'confirm' => true, 'kccEmployeeId' => 'mallory']);
+
+		$draft = ['draftText' => 'Uw aanvraag heeft de status: in behandeling.'];
+
+		$this->quickActionService->method('executeStatusTerugkoppelen')->willReturn($draft);
+
+		$this->contactMomentService->expects($this->once())
+			->method('recordActivity')
+			->with('case-1', '', 'status_given', 'alice', 'Uw aanvraag heeft de status: in behandeling.')
+			->willReturn(true);
+
+		$response = $this->controller->statusGeven();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($draft, $response->getData());
+	}//end testStatusGevenRecordsTheActivityUnderTheSessionEmployeeWhenConfirmed()
+
+	/**
+	 * An unresolvable case makes statusGeven a 400 carrying the service reason,
+	 * not a 500 and not an empty draft the employee would read out loud.
+	 *
+	 * @return void
+	 */
+	public function testStatusGevenMapsAnUnresolvableCaseTo400(): void {
+		$this->authenticate();
+		$this->withParams(['caseId' => 'case-missing', 'confirm' => true]);
+
+		$this->quickActionService->method('executeStatusTerugkoppelen')
+			->willThrowException(new RuntimeException('Case not found'));
+
+		$this->contactMomentService->expects($this->never())->method('recordActivity');
+
+		$response = $this->controller->statusGeven();
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'Case not found'], $response->getData());
+	}//end testStatusGevenMapsAnUnresolvableCaseTo400()
+
+	/**
+	 * doorverbinden builds the transfer payload from the request but takes
+	 * `fromEmployeeId` from the SESSION, and maps the request's `reason`
+	 * parameter onto the service's `transferReason` key.
+	 *
+	 * The body here supplies a contradicting `fromEmployeeId` — it must not
+	 * appear in the payload.
+	 *
+	 * @return void
+	 */
+	public function testDoorverbindenTakesTheOriginatingEmployeeFromTheSession(): void {
+		$this->authenticate();
+		$this->withParams(
+			[
+				'interactionId' => 'cm-1',
+				'fromEmployeeId' => 'mallory',
+				'toEmployeeId' => 'bob',
+				'toQueue' => null,
+				'reason' => 'Specialistische vraag',
+				'contextSnapshot' => '{"caseId":"case-1"}',
+			]
+		);
+
+		$initiated = ['id' => 'dv-1', 'status' => 'initiated'];
+
+		$this->transferService->expects($this->once())
+			->method('initiateWarmTransfer')
+			->with(
+				[
+					'interactionId' => 'cm-1',
+					'fromEmployeeId' => 'alice',
+					'toEmployeeId' => 'bob',
+					'toQueue' => null,
+					'transferReason' => 'Specialistische vraag',
+					'contextSnapshot' => '{"caseId":"case-1"}',
+				]
+			)
+			->willReturn($initiated);
+
+		$response = $this->controller->doorverbinden();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($initiated, $response->getData());
+	}//end testDoorverbindenTakesTheOriginatingEmployeeFromTheSession()
+
+	/**
+	 * A transfer the service rejects (e.g. no interaction id) is a 400 carrying
+	 * the service reason.
+	 *
+	 * @return void
+	 */
+	public function testDoorverbindenMapsAServiceRefusalTo400(): void {
+		$this->authenticate();
+		$this->withParams([]);
+
+		$this->transferService->method('initiateWarmTransfer')
+			->willThrowException(new RuntimeException('contactmomentId and vanMedewerkerId are required'));
+
+		$response = $this->controller->doorverbinden();
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(
+			['error' => 'contactmomentId and vanMedewerkerId are required'],
+			$response->getData()
+		);
+	}//end testDoorverbindenMapsAServiceRefusalTo400()
+
+	/**
+	 * acceptDoorverbinding accepts the transfer named in the ROUTE as the
+	 * SESSION user — the caller uid is what the service checks the assignment
+	 * against, so a body-supplied uid would let anybody accept anybody's
+	 * transfer.
+	 *
+	 * @return void
+	 */
+	public function testAcceptDoorverbindingAcceptsAsTheSessionUser(): void {
+		$this->authenticate();
+		$this->withParams(['callerUid' => 'mallory', 'id' => 'dv-other']);
+
+		$accepted = ['id' => 'dv-1', 'accepted' => true];
+
+		$this->transferService->expects($this->once())
+			->method('acceptTransfer')
+			->with('dv-1', 'alice')
+			->willReturn($accepted);
+
+		$response = $this->controller->acceptDoorverbinding(id: 'dv-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($accepted, $response->getData());
+	}//end testAcceptDoorverbindingAcceptsAsTheSessionUser()
+
+	/**
+	 * A transfer that was already answered cannot be accepted twice: the
+	 * service's refusal surfaces as a 400 with its reason, not a 200 that would
+	 * make the second specialist believe the call is theirs.
+	 *
+	 * @return void
+	 */
+	public function testAcceptDoorverbindingMapsAnAlreadyAnsweredTransferTo400(): void {
+		$this->authenticate();
+		$this->withParams([]);
+
+		$this->transferService->method('acceptTransfer')
+			->willThrowException(new RuntimeException('Doorverbinding already answered'));
+
+		$response = $this->controller->acceptDoorverbinding(id: 'dv-1');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'Doorverbinding already answered'], $response->getData());
+	}//end testAcceptDoorverbindingMapsAnAlreadyAnsweredTransferTo400()
+
+	/**
+	 * rejectDoorverbinding forwards the route id, the `reason` parameter and
+	 * the SESSION uid — in that order. `acceptTransfer` and `rejectTransfer`
+	 * both end with the caller uid, so a reason/uid transposition here would
+	 * record the rejecting employee as the reason.
+	 *
+	 * @return void
+	 */
+	public function testRejectDoorverbindingForwardsReasonAndSessionUserInOrder(): void {
+		$this->authenticate();
+		$this->withParams(['reason' => 'Geen capaciteit', 'callerUid' => 'mallory']);
+
+		$rejected = ['id' => 'dv-1', 'accepted' => false, 'rejectionReason' => 'Geen capaciteit'];
+
+		$this->transferService->expects($this->once())
+			->method('rejectTransfer')
+			->with('dv-1', 'Geen capaciteit', 'alice')
+			->willReturn($rejected);
+
+		$response = $this->controller->rejectDoorverbinding(id: 'dv-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($rejected, $response->getData());
+	}//end testRejectDoorverbindingForwardsReasonAndSessionUserInOrder()
+
+	/**
+	 * A rejection without a reason is refused by the service and surfaces as a
+	 * 400 — a doorverbinding may not be bounced back to the KCC unexplained.
+	 *
+	 * @return void
+	 */
+	public function testRejectDoorverbindingRequiresAReason(): void {
+		$this->authenticate();
+		$this->withParams([]);
+
+		$this->transferService->expects($this->once())
+			->method('rejectTransfer')
+			->with('dv-1', '', 'alice')
+			->willThrowException(new RuntimeException('Rejection reason is required'));
+
+		$response = $this->controller->rejectDoorverbinding(id: 'dv-1');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'Rejection reason is required'], $response->getData());
+	}//end testRejectDoorverbindingRequiresAReason()
+}//end class

--- a/tests/Unit/Controller/DashboardControllerContractTest.php
+++ b/tests/Unit/Controller/DashboardControllerContractTest.php
@@ -1,0 +1,177 @@
+<?php
+
+/**
+ * DashboardController Wire-Contract Tests
+ *
+ * Contract coverage for the two SPA-shell endpoints (gate-25): `page` (`GET /`)
+ * and `catchAll` (`GET /{path}`, the Vue history-mode deep-link route).
+ *
+ * These two carry no service call to assert, so the contract IS the response
+ * envelope and the auth posture — and both are load-bearing:
+ *
+ *  - the class docblock records that `#[NoAdminRequired]` / `#[NoCSRFRequired]`
+ *    used to be INHERITED from the OpenRegister AppHost generic and were
+ *    re-declared locally when the inheritance was dropped. Nothing else proves
+ *    they survived that edit, and an endpoint that loses `#[NoAdminRequired]`
+ *    silently becomes admin-only — the SPA would 403 for every ordinary user
+ *    while every unit test still passed;
+ *  - neither may be `#[PublicPage]`: the shell must require a Nextcloud
+ *    session. Adding `#[PublicPage]` here would serve the whole procest SPA
+ *    chrome anonymously;
+ *  - `catchAll` must render the SAME template as `page` and render it AS A USER
+ *    (`RENDER_AS_USER`) with a 200 — a deep link that answered 404, redirected,
+ *    or rendered the guest/public chrome would break every bookmarked URL in
+ *    the app.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\DashboardController;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
+use OCP\AppFramework\Http\Attribute\PublicPage;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Wire-contract tests for DashboardController's SPA shell endpoints.
+ *
+ * @covers \OCA\Procest\Controller\DashboardController
+ */
+class DashboardControllerContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var DashboardController
+	 */
+	private DashboardController $controller;
+
+	/**
+	 * Build the controller.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->controller = new DashboardController(request: $this->request);
+	}//end setUp()
+
+	/**
+	 * Collect the attribute class names declared on a controller method.
+	 *
+	 * @param string $method The method name.
+	 *
+	 * @return array<int, string> The attribute class names.
+	 */
+	private function attributeNamesOf(string $method): array {
+		$reflection = new \ReflectionMethod(DashboardController::class, $method);
+
+		return array_map(
+			static function (\ReflectionAttribute $attribute): string {
+				return $attribute->getName();
+			},
+			$reflection->getAttributes()
+		);
+	}//end attributeNamesOf()
+
+	/**
+	 * `page` renders the procest `index` template as a signed-in user, with 200.
+	 *
+	 * @return void
+	 */
+	public function testPageRendersTheProcestIndexTemplateAsAUser(): void {
+		$response = $this->controller->page();
+
+		$this->assertInstanceOf(TemplateResponse::class, $response);
+		$this->assertSame('procest', $response->getApp());
+		$this->assertSame('index', $response->getTemplateName());
+		$this->assertSame(TemplateResponse::RENDER_AS_USER, $response->getRenderAs());
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+	}//end testPageRendersTheProcestIndexTemplateAsAUser()
+
+	/**
+	 * `catchAll` serves the SAME shell as `page` — a deep link must reach the
+	 * Vue router, not a 404 or a different chrome.
+	 *
+	 * @return void
+	 */
+	public function testCatchAllServesTheSameShellAsPageSoDeepLinksResolve(): void {
+		$page = $this->controller->page();
+		$deepLink = $this->controller->catchAll();
+
+		$this->assertInstanceOf(TemplateResponse::class, $deepLink);
+		$this->assertSame($page->getApp(), $deepLink->getApp());
+		$this->assertSame($page->getTemplateName(), $deepLink->getTemplateName());
+		$this->assertSame($page->getRenderAs(), $deepLink->getRenderAs());
+		$this->assertSame(Http::STATUS_OK, $deepLink->getStatus());
+	}//end testCatchAllServesTheSameShellAsPageSoDeepLinksResolve()
+
+	/**
+	 * Both shell endpoints keep the `#[NoAdminRequired]` / `#[NoCSRFRequired]`
+	 * posture they used to inherit from the AppHost generic.
+	 *
+	 * Losing `#[NoAdminRequired]` turns the whole SPA admin-only; losing
+	 * `#[NoCSRFRequired]` makes a plain browser navigation to `/` fail its CSRF
+	 * check. Neither shows up in any behavioural assertion.
+	 *
+	 * @return void
+	 */
+	public function testBothShellEndpointsKeepTheirDeclaredAuthPosture(): void {
+		foreach (['page', 'catchAll'] as $method) {
+			$attributes = $this->attributeNamesOf(method: $method);
+
+			$this->assertContains(
+				NoAdminRequired::class,
+				$attributes,
+				$method . ' must stay reachable by non-admin users'
+			);
+			$this->assertContains(
+				NoCSRFRequired::class,
+				$attributes,
+				$method . ' is a browser navigation and carries no CSRF token'
+			);
+		}
+	}//end testBothShellEndpointsKeepTheirDeclaredAuthPosture()
+
+	/**
+	 * Neither shell endpoint may be public: the procest SPA requires a session.
+	 *
+	 * @return void
+	 */
+	public function testNeitherShellEndpointIsAPublicPage(): void {
+		$this->assertNotContains(
+			PublicPage::class,
+			$this->attributeNamesOf(method: 'page'),
+			'the SPA shell must not be reachable without a Nextcloud session'
+		);
+		$this->assertNotContains(
+			PublicPage::class,
+			$this->attributeNamesOf(method: 'catchAll'),
+			'the SPA deep-link route must not be reachable without a Nextcloud session'
+		);
+	}//end testNeitherShellEndpointIsAPublicPage()
+}//end class

--- a/tests/Unit/Controller/DeadlineReportingControllerContractTest.php
+++ b/tests/Unit/Controller/DeadlineReportingControllerContractTest.php
@@ -1,0 +1,394 @@
+<?php
+
+/**
+ * DeadlineReportingController Wire-Contract Tests
+ *
+ * Contract coverage for the three termijnbewaking reporting endpoints
+ * (gate-25): the KPI dashboard, the quarterly report and the annual dwangsom
+ * audit statement. All three are `@NoAdminRequired`.
+ *
+ * The contract pinned here:
+ *
+ *  - an anonymous caller is refused with 403 — NOT the 401 the rest of the app
+ *    uses. That is what `ensureAuthenticated()` actually returns, and a client
+ *    that retries on 401 must not be told to retry here; the test asserts the
+ *    real code so a "tidy-up" to 401 is a visible, deliberate change;
+ *  - `dashboard` MASKS an internal failure as a 500 with a fixed message while
+ *    `quarterlyReport` / `annualStatement` REPORT the exception message with a
+ *    400. That asymmetry is the actual behaviour and is asserted on both sides;
+ *  - the period/year arrive either as a route argument or via the Dutch query
+ *    parameters `periode` / `jaar` — those literal parameter names are the wire
+ *    contract, and reading a differently-named key would make every query-string
+ *    call answer 400;
+ *  - the year is bounded to 2020..2100 inclusive, asserted at both boundaries
+ *    (2019 refused, 2020 accepted) rather than at one arbitrary value.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\DeadlineReportingController;
+use OCA\Procest\Service\DeadlineReportingService;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Wire-contract tests for DeadlineReportingController.
+ *
+ * @covers \OCA\Procest\Controller\DeadlineReportingController
+ */
+class DeadlineReportingControllerContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The reporting service mock.
+	 *
+	 * @var DeadlineReportingService|MockObject
+	 */
+	private DeadlineReportingService $service;
+
+	/**
+	 * The IUserSession mock.
+	 *
+	 * @var IUserSession|MockObject
+	 */
+	private IUserSession $userSession;
+
+	/**
+	 * The LoggerInterface mock.
+	 *
+	 * @var LoggerInterface|MockObject
+	 */
+	private LoggerInterface $logger;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var DeadlineReportingController
+	 */
+	private DeadlineReportingController $controller;
+
+	/**
+	 * Build the controller with all collaborators mocked.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->service = $this->createMock(DeadlineReportingService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$this->controller = new DeadlineReportingController(
+			appName: 'procest',
+			request: $this->request,
+			service: $this->service,
+			userSession: $this->userSession,
+			logger: $this->logger,
+		);
+	}//end setUp()
+
+	/**
+	 * Put a signed-in user on the session.
+	 *
+	 * @return void
+	 */
+	private function signIn(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+		$this->userSession->method('getUser')->willReturn($user);
+	}//end signIn()
+
+	/**
+	 * Answer request parameters from the supplied map.
+	 *
+	 * @param array<string, mixed> $params The parameter map.
+	 *
+	 * @return void
+	 */
+	private function withParams(array $params): void {
+		$this->request->method('getParam')->willReturnCallback(
+			static function (string $key, mixed $default = null) use ($params): mixed {
+				return ($params[$key] ?? $default);
+			}
+		);
+	}//end withParams()
+
+	/**
+	 * `dashboard` refuses an anonymous caller with 403 and computes no KPI.
+	 *
+	 * @return void
+	 */
+	public function testDashboardRefusesAnUnauthenticatedCallerWith403(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->service->expects($this->never())->method('getTermijnKpi');
+
+		$response = $this->controller->dashboard();
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame(['message' => 'Not authenticated'], $response->getData());
+	}//end testDashboardRefusesAnUnauthenticatedCallerWith403()
+
+	/**
+	 * An authenticated `dashboard` answers 200 with the service's KPI row
+	 * unchanged.
+	 *
+	 * @return void
+	 */
+	public function testDashboardReturnsTheKpiRowUnchanged(): void {
+		$this->signIn();
+		$this->service->expects($this->once())
+			->method('getTermijnKpi')
+			->willReturn(['overdue' => 4, 'dwangsomTotal' => 1442.0]);
+
+		$response = $this->controller->dashboard();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['overdue' => 4, 'dwangsomTotal' => 1442.0], $response->getData());
+	}//end testDashboardReturnsTheKpiRowUnchanged()
+
+	/**
+	 * `dashboard` masks an internal failure as a 500 with a fixed message and
+	 * logs the real one — the KPI query touches the whole case store, so its
+	 * error text must not reach the browser.
+	 *
+	 * @return void
+	 */
+	public function testDashboardMasksAnInternalFailureAs500AndLogsIt(): void {
+		$this->signIn();
+		$this->service->method('getTermijnKpi')
+			->willThrowException(new \RuntimeException('SQLSTATE[42S02] table procest_cases missing'));
+		$this->logger->expects($this->once())->method('error');
+
+		$response = $this->controller->dashboard();
+
+		$this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+		$this->assertSame(['message' => 'Internal error'], $response->getData());
+		$this->assertStringNotContainsString(
+			'SQLSTATE',
+			json_encode($response->getData()),
+			'the internal error text must not reach the client'
+		);
+	}//end testDashboardMasksAnInternalFailureAs500AndLogsIt()
+
+	/**
+	 * `quarterlyReport` refuses an anonymous caller with 403.
+	 *
+	 * @return void
+	 */
+	public function testQuarterlyReportRefusesAnUnauthenticatedCallerWith403(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->service->expects($this->never())->method('generateQuarterlyReport');
+
+		$response = $this->controller->quarterlyReport();
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame(['message' => 'Not authenticated'], $response->getData());
+	}//end testQuarterlyReportRefusesAnUnauthenticatedCallerWith403()
+
+	/**
+	 * With no period anywhere the endpoint answers 400 rather than reporting on
+	 * an unnamed quarter.
+	 *
+	 * @return void
+	 */
+	public function testQuarterlyReportRejectsAMissingPeriodWith400(): void {
+		$this->signIn();
+		$this->withParams([]);
+		$this->service->expects($this->never())->method('generateQuarterlyReport');
+
+		$response = $this->controller->quarterlyReport();
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['message' => 'periode is required'], $response->getData());
+	}//end testQuarterlyReportRejectsAMissingPeriodWith400()
+
+	/**
+	 * When the route argument is empty the period is taken from the `periode`
+	 * query parameter — that literal Dutch key is the wire contract.
+	 *
+	 * @return void
+	 */
+	public function testQuarterlyReportFallsBackToThePeriodeQueryParameter(): void {
+		$this->signIn();
+		$this->withParams(['periode' => '2026-Q2']);
+
+		$this->service->expects($this->once())
+			->method('generateQuarterlyReport')
+			->with('2026-Q2', null)
+			->willReturn(['periode' => '2026-Q2', 'onTime' => 91]);
+
+		$response = $this->controller->quarterlyReport();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['periode' => '2026-Q2', 'onTime' => 91], $response->getData());
+	}//end testQuarterlyReportFallsBackToThePeriodeQueryParameter()
+
+	/**
+	 * An explicit route argument wins over the query parameter, and the
+	 * department filter is forwarded as given.
+	 *
+	 * @return void
+	 */
+	public function testQuarterlyReportPrefersTheRouteArgumentAndForwardsTheDepartment(): void {
+		$this->signIn();
+		$this->withParams(['periode' => '2026-Q2']);
+
+		$this->service->expects($this->once())
+			->method('generateQuarterlyReport')
+			->with('2026-Q4', 'Vergunningen')
+			->willReturn(['periode' => '2026-Q4']);
+
+		$response = $this->controller->quarterlyReport(period: '2026-Q4', department: 'Vergunningen');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame('2026-Q4', $response->getData()['periode']);
+	}//end testQuarterlyReportPrefersTheRouteArgumentAndForwardsTheDepartment()
+
+	/**
+	 * A rejected period is reported as 400 carrying the service's own message —
+	 * unlike `dashboard`, this endpoint does not mask it.
+	 *
+	 * @return void
+	 */
+	public function testQuarterlyReportReportsAServiceRefusalAs400WithItsMessage(): void {
+		$this->signIn();
+		$this->withParams([]);
+		$this->service->method('generateQuarterlyReport')
+			->willThrowException(new \RuntimeException('Onbekende periode 2026-Q9'));
+
+		$response = $this->controller->quarterlyReport(period: '2026-Q9');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['message' => 'Onbekende periode 2026-Q9'], $response->getData());
+	}//end testQuarterlyReportReportsAServiceRefusalAs400WithItsMessage()
+
+	/**
+	 * `annualStatement` refuses an anonymous caller with 403.
+	 *
+	 * @return void
+	 */
+	public function testAnnualStatementRefusesAnUnauthenticatedCallerWith403(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->service->expects($this->never())->method('generateDwangsomAuditReport');
+
+		$response = $this->controller->annualStatement();
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame(['message' => 'Not authenticated'], $response->getData());
+	}//end testAnnualStatementRefusesAnUnauthenticatedCallerWith403()
+
+	/**
+	 * The year is bounded to 2020..2100: 2019 is refused with 400 and the audit
+	 * report is not generated.
+	 *
+	 * @return void
+	 */
+	public function testAnnualStatementRefusesAYearBelowTheLowerBound(): void {
+		$this->signIn();
+		$this->withParams([]);
+		$this->service->expects($this->never())->method('generateDwangsomAuditReport');
+
+		$response = $this->controller->annualStatement(year: 2019);
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(
+			['message' => 'jaar is required and must be between 2020 and 2100'],
+			$response->getData()
+		);
+	}//end testAnnualStatementRefusesAYearBelowTheLowerBound()
+
+	/**
+	 * ...and 2101 above it. Asserting both ends proves the bound is a range and
+	 * not an accidental single-value check.
+	 *
+	 * @return void
+	 */
+	public function testAnnualStatementRefusesAYearAboveTheUpperBound(): void {
+		$this->signIn();
+		$this->withParams([]);
+		$this->service->expects($this->never())->method('generateDwangsomAuditReport');
+
+		$response = $this->controller->annualStatement(year: 2101);
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+	}//end testAnnualStatementRefusesAYearAboveTheUpperBound()
+
+	/**
+	 * 2020 — the lower boundary itself — is accepted, so the guard is inclusive.
+	 *
+	 * @return void
+	 */
+	public function testAnnualStatementAcceptsTheInclusiveLowerBoundYear(): void {
+		$this->signIn();
+		$this->withParams([]);
+		$this->service->expects($this->once())
+			->method('generateDwangsomAuditReport')
+			->with(2020)
+			->willReturn(['jaar' => 2020, 'dwangsommen' => []]);
+
+		$response = $this->controller->annualStatement(year: 2020);
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(2020, $response->getData()['jaar']);
+	}//end testAnnualStatementAcceptsTheInclusiveLowerBoundYear()
+
+	/**
+	 * With no route argument the year is taken from the `jaar` query parameter.
+	 *
+	 * @return void
+	 */
+	public function testAnnualStatementFallsBackToTheJaarQueryParameter(): void {
+		$this->signIn();
+		$this->withParams(['jaar' => '2025']);
+		$this->service->expects($this->once())
+			->method('generateDwangsomAuditReport')
+			->with(2025)
+			->willReturn(['jaar' => 2025, 'total' => 3]);
+
+		$response = $this->controller->annualStatement();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(3, $response->getData()['total']);
+	}//end testAnnualStatementFallsBackToTheJaarQueryParameter()
+
+	/**
+	 * A service refusal on the annual statement is a 400 carrying its message.
+	 *
+	 * @return void
+	 */
+	public function testAnnualStatementReportsAServiceRefusalAs400WithItsMessage(): void {
+		$this->signIn();
+		$this->withParams([]);
+		$this->service->method('generateDwangsomAuditReport')
+			->willThrowException(new \RuntimeException('Geen dwangsomregister geconfigureerd'));
+
+		$response = $this->controller->annualStatement(year: 2026);
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['message' => 'Geen dwangsomregister geconfigureerd'], $response->getData());
+	}//end testAnnualStatementReportsAServiceRefusalAs400WithItsMessage()
+}//end class

--- a/tests/Unit/Controller/DeelzaakControllerContractTest.php
+++ b/tests/Unit/Controller/DeelzaakControllerContractTest.php
@@ -1,0 +1,317 @@
+<?php
+
+/**
+ * DeelzaakController Wire-Contract Tests
+ *
+ * Contract coverage (gate-25) for `parent()` and `counts()` — the two sub-case
+ * endpoints with no executed proof of their wire behaviour. Both are
+ * `@NoAdminRequired`, so any authenticated user reaches them, and what separates
+ * them is the authorization they apply. These tests pin:
+ *
+ *  - `parent()` refuses an anonymous caller 401 and a caller without read
+ *    access to the named CHILD case 403 — in both cases without asking the
+ *    service for the parent, because the parent object IS the answer;
+ *  - `parent()` guards on the caseId the CALLER named, not on the parent it
+ *    resolves to (the controller documents this as deliberate; a guard on the
+ *    resolved parent would be circular);
+ *  - a child with no parent is 404 `not_found`, distinct from the 403 above —
+ *    collapsing the two would turn the endpoint into a hierarchy oracle;
+ *  - `counts()` refuses an anonymous caller 401, requires a non-empty `ids`
+ *    parameter (400), and accepts it both as a comma-separated string and as an
+ *    array, trimming and dropping blanks — a trailing comma must not become a
+ *    lookup for the empty uuid;
+ *  - and one TRIPWIRE (see its docblock): `counts()` applies NO per-case guard,
+ *    unlike every one of its siblings in this controller.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\DeelzaakController;
+use OCA\Procest\Service\CaseAccessGuard;
+use OCA\Procest\Service\DeelzaakService;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Wire-contract tests for DeelzaakController::parent() and ::counts().
+ *
+ * @covers \OCA\Procest\Controller\DeelzaakController
+ */
+class DeelzaakControllerContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock handed to the controller.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The sub-case service mock.
+	 *
+	 * @var DeelzaakService|MockObject
+	 */
+	private DeelzaakService $deelzaakService;
+
+	/**
+	 * The user session mock.
+	 *
+	 * @var IUserSession|MockObject
+	 */
+	private IUserSession $userSession;
+
+	/**
+	 * The per-case authorization guard mock.
+	 *
+	 * @var CaseAccessGuard|MockObject
+	 */
+	private CaseAccessGuard $caseAccessGuard;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var DeelzaakController
+	 */
+	private DeelzaakController $controller;
+
+	/**
+	 * Build the controller with all collaborators mocked.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->deelzaakService = $this->createMock(DeelzaakService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->caseAccessGuard = $this->createMock(CaseAccessGuard::class);
+
+		$this->controller = new DeelzaakController(
+			request: $this->request,
+			deelzaakService: $this->deelzaakService,
+			userSession: $this->userSession,
+			caseAccessGuard: $this->caseAccessGuard,
+		);
+	}//end setUp()
+
+	/**
+	 * Put an authenticated user in the session.
+	 *
+	 * @param string $uid The user id the session reports.
+	 *
+	 * @return IUser|MockObject The signed-in user.
+	 */
+	private function signIn(string $uid = 'handler-1'): IUser {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		$this->userSession->method('getUser')->willReturn($user);
+
+		return $user;
+	}//end signIn()
+
+	/**
+	 * Serve the given request parameters, defaulting like the real request.
+	 *
+	 * @param array<string, mixed> $overrides The parameter values to serve.
+	 *
+	 * @return void
+	 */
+	private function withRequestParams(array $overrides): void {
+		$this->request->method('getParam')->willReturnCallback(
+			static function (string $key, mixed $default = null) use ($overrides): mixed {
+				return ($overrides[$key] ?? $default);
+			}
+		);
+	}//end withRequestParams()
+
+	/**
+	 * Both endpoints refuse an anonymous caller with 401 and read nothing.
+	 *
+	 * @return void
+	 */
+	public function testBothEndpointsRefuseAnAnonymousCallerWith401(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->deelzaakService->expects($this->never())->method('getParentCase');
+		$this->deelzaakService->expects($this->never())->method('getSubCaseCounts');
+
+		$parent = $this->controller->parent(caseId: 'case-1');
+		$counts = $this->controller->counts();
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $parent->getStatus());
+		$this->assertSame(['message' => 'unauthenticated'], $parent->getData());
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $counts->getStatus());
+		$this->assertSame(['message' => 'unauthenticated'], $counts->getData());
+	}//end testBothEndpointsRefuseAnAnonymousCallerWith401()
+
+	/**
+	 * `parent()` refuses 403 when the caller has no read access to the CHILD
+	 * case it named, and never resolves the parent — the parent object would
+	 * itself be the leak.
+	 *
+	 * @return void
+	 */
+	public function testParentRefusesACallerWithoutReadAccessToTheNamedChildCase(): void {
+		$this->signIn(uid: 'handler-1');
+		$this->deelzaakService->expects($this->never())->method('getParentCase');
+
+		$seen = [];
+		$this->caseAccessGuard->expects($this->once())
+			->method('hasCaseReadAccess')
+			->willReturnCallback(
+				static function (string $caseId, IUser $user) use (&$seen): bool {
+					$seen = ['caseId' => $caseId, 'uid' => $user->getUID()];
+					return false;
+				}
+			);
+
+		$response = $this->controller->parent(caseId: 'child-9');
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame(['message' => 'forbidden'], $response->getData());
+		$this->assertSame(
+			['caseId' => 'child-9', 'uid' => 'handler-1'],
+			$seen,
+			'the guard must be asked about the CHILD case the caller named, for the calling user'
+		);
+	}//end testParentRefusesACallerWithoutReadAccessToTheNamedChildCase()
+
+	/**
+	 * A cleared caller gets the parent case resolved from the CHILD uuid, and a
+	 * child with no parent is a 404 rather than an empty 200 body a client
+	 * cannot distinguish from a parent with no fields.
+	 *
+	 * @return void
+	 */
+	public function testParentResolvesTheParentFromTheChildUuidAndAnswers404WhenThereIsNone(): void {
+		$this->signIn(uid: 'handler-1');
+		$this->caseAccessGuard->method('hasCaseReadAccess')->willReturn(true);
+
+		$asked = [];
+		$this->deelzaakService->expects($this->exactly(2))
+			->method('getParentCase')
+			->willReturnCallback(
+				static function (string $childCaseUuid) use (&$asked): ?array {
+					$asked[] = $childCaseUuid;
+					if ($childCaseUuid === 'orphan-1') {
+						return null;
+					}
+
+					return ['id' => 'parent-1', 'identificatie' => 'ZAAK-2026-0001'];
+				}
+			);
+
+		$found = $this->controller->parent(caseId: 'child-9');
+		$missing = $this->controller->parent(caseId: 'orphan-1');
+
+		$this->assertSame(Http::STATUS_OK, $found->getStatus());
+		$this->assertSame(['id' => 'parent-1', 'identificatie' => 'ZAAK-2026-0001'], $found->getData());
+		$this->assertSame(Http::STATUS_NOT_FOUND, $missing->getStatus());
+		$this->assertSame(['message' => 'not_found'], $missing->getData());
+		$this->assertSame(['child-9', 'orphan-1'], $asked, 'the CHILD uuid is what gets resolved');
+	}//end testParentResolvesTheParentFromTheChildUuidAndAnswers404WhenThereIsNone()
+
+	/**
+	 * `counts()` demands a non-empty `ids` parameter: a missing one, and one
+	 * that reduces to nothing after trimming, are both 400 — never a batch
+	 * lookup for the empty uuid.
+	 *
+	 * @return void
+	 */
+	public function testCountsRefusesAnIdsParameterThatReducesToNothing(): void {
+		$this->signIn();
+		$this->withRequestParams(['ids' => ' , , ']);
+		$this->deelzaakService->expects($this->never())->method('getSubCaseCounts');
+
+		$response = $this->controller->counts();
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['message' => 'ids parameter is required'], $response->getData());
+	}//end testCountsRefusesAnIdsParameterThatReducesToNothing()
+
+	/**
+	 * A comma-separated `ids` string is split, trimmed and stripped of blanks
+	 * before it reaches the service, and the counts are returned under `counts`.
+	 *
+	 * @return void
+	 */
+	public function testCountsSplitsTrimsAndCompactsACommaSeparatedIdsString(): void {
+		$this->signIn();
+		$this->withRequestParams(['ids' => ' case-1 , case-2 ,, case-3,']);
+
+		$seen = [];
+		$this->deelzaakService->expects($this->once())
+			->method('getSubCaseCounts')
+			->willReturnCallback(
+				static function (array $parentUuids) use (&$seen): array {
+					$seen = $parentUuids;
+					return ['case-1' => 2, 'case-2' => 0, 'case-3' => 1];
+				}
+			);
+
+		$response = $this->controller->counts();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['case-1', 'case-2', 'case-3'], $seen);
+		$this->assertSame(['counts' => ['case-1' => 2, 'case-2' => 0, 'case-3' => 1]], $response->getData());
+	}//end testCountsSplitsTrimsAndCompactsACommaSeparatedIdsString()
+
+	/**
+	 * TRIPWIRE — pins CURRENT behaviour, which is NOT asserted to be correct.
+	 *
+	 * `counts()` applies no per-case authorization at all: it checks only that
+	 * SOMEONE is signed in, then answers with the sub-case count of every uuid
+	 * the caller cares to name. Every one of its siblings on this controller —
+	 * `list()`, `parent()`, `validate()`, `unlink()` — calls
+	 * `CaseAccessGuard::hasCaseReadAccess()` (or the mutation equivalent) first,
+	 * and `validate()` carries an explicit comment about not becoming an
+	 * "existence oracle over every case on the instance". `counts()` is exactly
+	 * that oracle at a lower resolution: a count of 0 for an unknown uuid and a
+	 * count of N for a real one are distinguishable, so any authenticated user
+	 * can confirm a case exists and learn how many sub-cases hang off it.
+	 *
+	 * The test asserts the guard is NEVER consulted. If it goes RED, a guard was
+	 * ADDED — that is the fix, not a regression: update this test to assert the
+	 * new 403 branch and delete the tripwire. Do not weaken the controller to
+	 * make it pass again.
+	 *
+	 * @return void
+	 */
+	public function testTripwireCountsAnswersForArbitraryCaseUuidsWithoutAnyPerCaseGuard(): void {
+		$this->signIn(uid: 'unrelated-user');
+		$this->withRequestParams(['ids' => 'someone-elses-case,another-tenants-case']);
+
+		$this->caseAccessGuard->expects($this->never())->method('hasCaseReadAccess');
+		$this->caseAccessGuard->expects($this->never())->method('hasCaseMutationAccess');
+		$this->deelzaakService->method('getSubCaseCounts')->willReturn(
+			['someone-elses-case' => 4, 'another-tenants-case' => 0]
+		);
+
+		$response = $this->controller->counts();
+
+		$this->assertSame(
+			Http::STATUS_OK,
+			$response->getStatus(),
+			'current behaviour: an unrelated user is served, no per-case guard exists'
+		);
+		$this->assertSame(
+			['counts' => ['someone-elses-case' => 4, 'another-tenants-case' => 0]],
+			$response->getData()
+		);
+	}//end testTripwireCountsAnswersForArbitraryCaseUuidsWithoutAnyPerCaseGuard()
+}//end class

--- a/tests/Unit/Controller/DoorlooptijdControllerContractTest.php
+++ b/tests/Unit/Controller/DoorlooptijdControllerContractTest.php
@@ -1,0 +1,233 @@
+<?php
+
+/**
+ * DoorlooptijdController Wire-Contract Tests
+ *
+ * Contract coverage for `GET /api/doorlooptijd/metrics` (gate-25). The
+ * controller is a parameter validator in front of DoorlooptijdService: every
+ * branch it owns is either a refusal or a coercion, and each one is asserted
+ * here rather than only the happy path. These tests pin:
+ *
+ *  - 401 without a session, before any metric is computed;
+ *  - each of the three 400 branches SEPARATELY, with its own message — a
+ *    `match`-free chain of three `if`s is exactly where a copy-pasted message
+ *    or a mis-ordered guard hides;
+ *  - the defaults the service actually receives: `period` = '12m',
+ *    `atRiskDays` = int 5, and NO `caseType` key at all when the caller did
+ *    not supply one. An empty-string caseType leaking into the params array
+ *    would filter the dashboard down to zero cases while still rendering.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\DoorlooptijdController;
+use OCA\Procest\Service\DoorlooptijdService;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Wire-contract tests for DoorlooptijdController::metrics().
+ *
+ * @covers \OCA\Procest\Controller\DoorlooptijdController
+ */
+class DoorlooptijdControllerContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The metrics service.
+	 *
+	 * @var DoorlooptijdService|MockObject
+	 */
+	private DoorlooptijdService $leadTimeService;
+
+	/**
+	 * The user session.
+	 *
+	 * @var IUserSession|MockObject
+	 */
+	private IUserSession $userSession;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var DoorlooptijdController
+	 */
+	private DoorlooptijdController $controller;
+
+	/**
+	 * Build the controller with mocked collaborators.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->leadTimeService = $this->createMock(DoorlooptijdService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+
+		$this->controller = new DoorlooptijdController(
+			request: $this->request,
+			leadTimeService: $this->leadTimeService,
+			userSession: $this->userSession,
+		);
+	}//end setUp()
+
+	/**
+	 * Put a signed-in user on the session.
+	 *
+	 * @return void
+	 */
+	private function signIn(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('analist');
+		$this->userSession->method('getUser')->willReturn($user);
+	}//end signIn()
+
+	/**
+	 * Drive the three query parameters metrics() reads.
+	 *
+	 * @param array<string,mixed> $overrides Values keyed by parameter name.
+	 *
+	 * @return void
+	 */
+	private function withQuery(array $overrides): void {
+		$this->request->method('getParam')->willReturnCallback(
+			static function (string $key, mixed $default = null) use ($overrides): mixed {
+				if (array_key_exists($key, $overrides) === true) {
+					return $overrides[$key];
+				}
+
+				return $default;
+			}
+		);
+	}//end withQuery()
+
+	/**
+	 * An unauthenticated caller is refused before any metric is computed.
+	 *
+	 * @return void
+	 */
+	public function testMetricsRefusesAnUnauthenticatedCallerBeforeComputingAnything(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->leadTimeService->expects($this->never())->method('getMetrics');
+
+		$response = $this->controller->metrics();
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame(['message' => 'unauthenticated'], $response->getData());
+	}//end testMetricsRefusesAnUnauthenticatedCallerBeforeComputingAnything()
+
+	/**
+	 * A non-string caseType is rejected with its own message.
+	 *
+	 * @return void
+	 */
+	public function testMetricsRejectsANonStringCaseTypeWithItsOwnMessage(): void {
+		$this->signIn();
+		$this->withQuery(['caseType' => ['array-injected-via-query-string']]);
+		$this->leadTimeService->expects($this->never())->method('getMetrics');
+
+		$response = $this->controller->metrics();
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['message' => 'caseType must be a string'], $response->getData());
+	}//end testMetricsRejectsANonStringCaseTypeWithItsOwnMessage()
+
+	/**
+	 * A period that does not match `\d+m` is rejected with its own message.
+	 *
+	 * @return void
+	 */
+	public function testMetricsRejectsAMalformedPeriodWithItsOwnMessage(): void {
+		$this->signIn();
+		$this->withQuery(['period' => 'twelve-months']);
+		$this->leadTimeService->expects($this->never())->method('getMetrics');
+
+		$response = $this->controller->metrics();
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['message' => 'period must look like 12m'], $response->getData());
+	}//end testMetricsRejectsAMalformedPeriodWithItsOwnMessage()
+
+	/**
+	 * A non-numeric atRiskDays is rejected with its own message.
+	 *
+	 * @return void
+	 */
+	public function testMetricsRejectsANonNumericAtRiskDaysWithItsOwnMessage(): void {
+		$this->signIn();
+		$this->withQuery(['atRiskDays' => 'soon']);
+		$this->leadTimeService->expects($this->never())->method('getMetrics');
+
+		$response = $this->controller->metrics();
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['message' => 'atRiskDays must be a number'], $response->getData());
+	}//end testMetricsRejectsANonNumericAtRiskDaysWithItsOwnMessage()
+
+	/**
+	 * With no query at all the service receives the documented defaults and
+	 * no caseType key whatsoever.
+	 *
+	 * @return void
+	 */
+	public function testMetricsAppliesTheDocumentedDefaultsAndOmitsCaseTypeEntirely(): void {
+		$this->signIn();
+		$this->withQuery([]);
+
+		$payload = ['average' => 21.5, 'atRisk' => 3];
+
+		$this->leadTimeService->expects($this->once())
+			->method('getMetrics')
+			->with(['period' => '12m', 'atRiskDays' => 5])
+			->willReturn($payload);
+
+		$response = $this->controller->metrics();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($payload, $response->getData());
+	}//end testMetricsAppliesTheDocumentedDefaultsAndOmitsCaseTypeEntirely()
+
+	/**
+	 * A supplied caseType is added to the params and atRiskDays is coerced to
+	 * an int — the service declares `array $params` but reads atRiskDays as a
+	 * threshold, and the query string always delivers it as a string.
+	 *
+	 * @return void
+	 */
+	public function testMetricsForwardsTheCaseTypeAndCoercesAtRiskDaysToAnInteger(): void {
+		$this->signIn();
+		$this->withQuery(['caseType' => 'bezwaar', 'period' => '6m', 'atRiskDays' => '10']);
+
+		$this->leadTimeService->expects($this->once())
+			->method('getMetrics')
+			->with(['period' => '6m', 'atRiskDays' => 10, 'caseType' => 'bezwaar'])
+			->willReturn([]);
+
+		$response = $this->controller->metrics();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+	}//end testMetricsForwardsTheCaseTypeAndCoercesAtRiskDaysToAnInteger()
+}//end class

--- a/tests/Unit/Controller/DrcControllerContractTest.php
+++ b/tests/Unit/Controller/DrcControllerContractTest.php
@@ -223,7 +223,7 @@ class DrcControllerContractTest extends TestCase {
 
 		$this->zgwService->expects($this->once())
 			->method('consumerHasScope')
-			->with($this->request, 'drc', 'documenten.verwijderen')
+			->with($this->request, 'drc', 'documenten.bijwerken')
 			->willReturn(false);
 		$this->zgwService->expects($this->never())->method('handleUpdate');
 

--- a/tests/Unit/Controller/DrcControllerContractTest.php
+++ b/tests/Unit/Controller/DrcControllerContractTest.php
@@ -1,0 +1,511 @@
+<?php
+
+/**
+ * DrcController Wire-Contract Tests
+ *
+ * Contract coverage (gate-25) for three DRC endpoints that had no automated
+ * proof of their wire behaviour: `patch()`, `unlock()` and `uploadChunk()`.
+ * All three are `@PublicPage` — reachable WITHOUT a Nextcloud session — so the
+ * ZGW JWT plus, where the operation demands one, an OAuth-style scope is the
+ * entire gate. Those two facts are what these tests pin:
+ *
+ *  - none of the three runs a line of its body before `validateJwtAuth()` has
+ *    answered, and the refusal is returned verbatim;
+ *  - `patch()` demands `documenten.bijwerken` on the `drc` component and
+ *    refuses with the ZGW-standard 403 `permission_denied` envelope naming that
+ *    scope — a copy-paste of `documenten.verwijderen` (the delete scope) or of
+ *    another component would be invisible from the response shape;
+ *  - `patch()` delegates as a PARTIAL update. It shares its delegate with
+ *    `update()` and the only thing separating them is that boolean, so a
+ *    PATCH that silently became a full replace would blank every field the
+ *    caller did not send;
+ *  - `unlock()` is a lock-protected operation: an unlocked document is a 400,
+ *    and a WRONG lock id is refused unless the consumer holds the forced
+ *    unlocking scope. Both the scope name and the ZGW `incorrect-lock-id`
+ *    invalidParams envelope are asserted, because a lock that any caller can
+ *    break is not a lock;
+ *  - `uploadChunk()` refuses everything it cannot place: no pending chunked
+ *    upload, a sequence number outside 1..totalParts, and — the one that
+ *    matters for storage — an EMPTY body, which must never be stored as a
+ *    zero-byte chunk that then merges into a corrupt file.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\DrcController;
+use OCA\Procest\Service\ZgwService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IL10N;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Minimal OpenRegister ObjectService stub for the DRC contract tests.
+ *
+ * The controller calls the store with NAMED arguments, so the stub's parameter
+ * names must match the real service's exactly; a \stdClass-based mock cannot be
+ * called with named arguments at all.
+ */
+interface DrcContractObjectServiceStub {
+	/**
+	 * Find a single object by identifier (real ObjectService::find()).
+	 *
+	 * @param int|string $id The object UUID.
+	 * @param mixed ...$args Remaining find() args (extend/files/register/schema).
+	 *
+	 * @return mixed The stored object row.
+	 */
+	public function find(int|string $id, ...$args): mixed;
+
+	/**
+	 * Save or update an object.
+	 *
+	 * @param string $register The register slug.
+	 * @param string $schema The schema slug.
+	 * @param array<string, mixed> $object The object data.
+	 * @param string|null $uuid The object UUID to overwrite.
+	 *
+	 * @return mixed The saved object row.
+	 */
+	public function saveObject(string $register, string $schema, array $object, ?string $uuid = null): mixed;
+
+	/**
+	 * Release OpenRegister's own lock on an object.
+	 *
+	 * @param string $identifier The object UUID.
+	 *
+	 * @return mixed The unlocked object row.
+	 */
+	public function unlockObject(string $identifier): mixed;
+}//end interface
+
+/**
+ * Wire-contract tests for DrcController::patch/unlock/uploadChunk.
+ *
+ * @covers \OCA\Procest\Controller\DrcController
+ */
+class DrcControllerContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock handed to the controller.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The ZgwService mock — JWT gate, scope oracle and store accessor.
+	 *
+	 * @var ZgwService|MockObject
+	 */
+	private ZgwService $zgwService;
+
+	/**
+	 * The IL10N mock; `t()` echoes its message so the branch can be identified.
+	 *
+	 * @var IL10N|MockObject
+	 */
+	private IL10N $l10n;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var DrcController
+	 */
+	private DrcController $controller;
+
+	/**
+	 * Build the controller with all collaborators mocked.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->zgwService = $this->createMock(ZgwService::class);
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->l10n->method('t')->willReturnArgument(0);
+
+		$this->controller = new DrcController(
+			appName: 'procest',
+			request: $this->request,
+			zgwService: $this->zgwService,
+			l10n: $this->l10n,
+		);
+	}//end setUp()
+
+	/**
+	 * Configure the JWT gate to REFUSE.
+	 *
+	 * @return JSONResponse The refusal the gate answers with.
+	 */
+	private function refuseJwt(): JSONResponse {
+		$refusal = new JSONResponse(
+			data: ['code' => 'not_authenticated'],
+			statusCode: Http::STATUS_UNAUTHORIZED
+		);
+		$this->zgwService->method('validateJwtAuth')->willReturn($refusal);
+
+		return $refusal;
+	}//end refuseJwt()
+
+	/**
+	 * Configure the JWT gate to ACCEPT.
+	 *
+	 * @return void
+	 */
+	private function acceptJwt(): void {
+		$this->zgwService->method('validateJwtAuth')->willReturn(null);
+	}//end acceptJwt()
+
+	/**
+	 * Make `getParam()` behave like the real request.
+	 *
+	 * @param array<string, mixed> $overrides Parameter values to serve.
+	 *
+	 * @return void
+	 */
+	private function withRequestParams(array $overrides): void {
+		$this->request->method('getParam')->willReturnCallback(
+			static function (string $key, mixed $default = null) use ($overrides): mixed {
+				return ($overrides[$key] ?? $default);
+			}
+		);
+	}//end withRequestParams()
+
+	/**
+	 * All three endpoints consult the JWT gate before anything else and return
+	 * its refusal verbatim — none of them reaches the store or the scope check.
+	 *
+	 * @return void
+	 */
+	public function testAllThreeEndpointsRefuseAnUnauthenticatedCaller(): void {
+		$refusal = $this->refuseJwt();
+		$this->zgwService->expects($this->never())->method('getObjectService');
+		$this->zgwService->expects($this->never())->method('consumerHasScope');
+		$this->zgwService->expects($this->never())->method('handleUpdate');
+
+		$responses = [
+			'patch' => $this->controller->patch(resource: 'gebruiksrechten', uuid: 'doc-1'),
+			'unlock' => $this->controller->unlock(uuid: 'doc-1'),
+			'uploadChunk' => $this->controller->uploadChunk(uuid: 'doc-1'),
+		];
+
+		foreach ($responses as $endpoint => $response) {
+			$this->assertSame($refusal, $response, $endpoint . ' must return the JWT refusal verbatim');
+			$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		}
+	}//end testAllThreeEndpointsRefuseAnUnauthenticatedCaller()
+
+	/**
+	 * A PATCH demands the DRC write scope `documenten.bijwerken`, and without
+	 * it answers the ZGW 403 envelope naming that scope — while writing
+	 * nothing.
+	 *
+	 * @return void
+	 */
+	public function testPatchDemandsTheDocumentenBijwerkenScopeAndRefusesWithout(): void {
+		$this->acceptJwt();
+
+		$this->zgwService->expects($this->once())
+			->method('consumerHasScope')
+			->with($this->request, 'drc', 'documenten.verwijderen')
+			->willReturn(false);
+		$this->zgwService->expects($this->never())->method('handleUpdate');
+
+		$response = $this->controller->patch(resource: 'gebruiksrechten', uuid: 'doc-1');
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame('permission_denied', $response->getData()['code']);
+		$this->assertSame(
+			'Scope documenten.bijwerken is required for this operation.',
+			$response->getData()['detail'],
+			'the refusal must name the scope the caller is missing'
+		);
+	}//end testPatchDemandsTheDocumentenBijwerkenScopeAndRefusesWithout()
+
+	/**
+	 * A scoped PATCH delegates to the documenten API as a PARTIAL update. The
+	 * `partial` flag is the only thing separating this route from `update()`,
+	 * and a PATCH that ran as a full replace would blank every unsent field.
+	 *
+	 * @return void
+	 */
+	public function testPatchDelegatesToTheDocumentenApiAsAPartialUpdate(): void {
+		$this->acceptJwt();
+		$this->zgwService->method('consumerHasScope')->willReturn(true);
+		$expected = new JSONResponse(data: ['url' => 'https://example.test/gebruiksrechten/doc-1']);
+
+		$seen = [];
+		$this->zgwService->expects($this->once())
+			->method('handleUpdate')
+			->willReturnCallback(
+				static function (
+					IRequest $request,
+					string $zgwApi,
+					string $resource,
+					string $uuid,
+					bool $partial = false,
+					mixed ...$rest,
+				) use (&$seen, $expected): JSONResponse {
+					$seen = [
+						'zgwApi' => $zgwApi,
+						'resource' => $resource,
+						'uuid' => $uuid,
+						'partial' => $partial,
+					];
+					return $expected;
+				}
+			);
+
+		$response = $this->controller->patch(resource: 'gebruiksrechten', uuid: 'doc-1');
+
+		$this->assertSame($expected, $response);
+		$this->assertSame(
+			['zgwApi' => 'documenten', 'resource' => 'gebruiksrechten', 'uuid' => 'doc-1', 'partial' => true],
+			$seen
+		);
+	}//end testPatchDelegatesToTheDocumentenApiAsAPartialUpdate()
+
+	/**
+	 * Unlocking a document that is not locked is a 400, not a silent success —
+	 * a client that gets 204 for an unlocked document cannot tell that its own
+	 * lock was never held.
+	 *
+	 * @return void
+	 */
+	public function testUnlockAnswers400WhenTheDocumentIsNotLocked(): void {
+		$this->acceptJwt();
+		$objectService = $this->createMock(DrcContractObjectServiceStub::class);
+		$objectService->method('find')->willReturn(['fileName' => 'brief.pdf']);
+		$objectService->expects($this->never())->method('unlockObject');
+
+		$this->zgwService->method('getObjectService')->willReturn($objectService);
+		$this->zgwService->method('loadMappingConfig')->willReturn(
+			['sourceRegister' => 'drc-register', 'sourceSchema' => 'eio']
+		);
+
+		$response = $this->controller->unlock(uuid: 'doc-1');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['detail' => 'Document is not locked.'], $response->getData());
+	}//end testUnlockAnswers400WhenTheDocumentIsNotLocked()
+
+	/**
+	 * A wrong lock id is refused unless the consumer holds the forced-unlocking
+	 * scope. The scope name and component are asserted, and the ZGW
+	 * `incorrect-lock-id` envelope with it — a lock any caller can break is not
+	 * a lock.
+	 *
+	 * @return void
+	 */
+	public function testUnlockRefusesAWrongLockIdWithoutTheForcedUnlockingScope(): void {
+		$this->acceptJwt();
+		$objectService = $this->createMock(DrcContractObjectServiceStub::class);
+		$objectService->method('find')->willReturn(['lockId' => 'the-real-lock']);
+		$objectService->expects($this->never())->method('unlockObject');
+
+		$this->zgwService->method('getObjectService')->willReturn($objectService);
+		$this->zgwService->method('loadMappingConfig')->willReturn(
+			['sourceRegister' => 'drc-register', 'sourceSchema' => 'eio']
+		);
+		$this->zgwService->method('getRequestBody')->willReturn(['lock' => 'a-guessed-lock']);
+
+		$this->zgwService->expects($this->once())
+			->method('consumerHasScope')
+			->with($this->request, 'documenten', 'geforceerd-bijwerken')
+			->willReturn(false);
+
+		$response = $this->controller->unlock(uuid: 'doc-1');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(
+			'Lock ID does not match and forced unlocking is not allowed.',
+			$response->getData()['detail']
+		);
+		$this->assertSame('incorrect-lock-id', $response->getData()['invalidParams'][0]['code']);
+	}//end testUnlockRefusesAWrongLockIdWithoutTheForcedUnlockingScope()
+
+	/**
+	 * The matching lock id unlocks: the store's own lock is released, the
+	 * lockId is cleared from the data blob (a stale lockId would keep the
+	 * document unwritable for every later caller), and the answer is 204.
+	 *
+	 * @return void
+	 */
+	public function testUnlockWithTheMatchingLockIdClearsTheLockAndAnswers204(): void {
+		$this->acceptJwt();
+
+		$saved = [];
+		$objectService = $this->createMock(DrcContractObjectServiceStub::class);
+		$objectService->method('find')->willReturn(['lockId' => 'the-real-lock', 'locked' => true]);
+		$objectService->expects($this->once())
+			->method('unlockObject')
+			->with('doc-1')
+			->willReturn(['id' => 'doc-1']);
+		$objectService->method('saveObject')->willReturnCallback(
+			static function (
+				string $register,
+				string $schema,
+				array $object,
+				?string $uuid = null,
+			) use (&$saved): array {
+				$saved = $object;
+				return $object;
+			}
+		);
+
+		$this->zgwService->method('getObjectService')->willReturn($objectService);
+		$this->zgwService->method('loadMappingConfig')->willReturn(
+			['sourceRegister' => 'drc-register', 'sourceSchema' => 'eio']
+		);
+		$this->zgwService->method('getRequestBody')->willReturn(['lock' => 'the-real-lock']);
+		$this->zgwService->expects($this->never())->method('consumerHasScope');
+
+		$response = $this->controller->unlock(uuid: 'doc-1');
+
+		$this->assertSame(Http::STATUS_NO_CONTENT, $response->getStatus());
+		$this->assertSame('', $saved['lockId'], 'the stored lockId must be cleared');
+		$this->assertFalse($saved['locked']);
+	}//end testUnlockWithTheMatchingLockIdClearsTheLockAndAnswers204()
+
+	/**
+	 * With OpenRegister unwired, unlock answers 503 rather than throwing.
+	 *
+	 * @return void
+	 */
+	public function testUnlockAnswers503WhenTheObjectStoreIsUnavailable(): void {
+		$this->acceptJwt();
+		$this->zgwService->method('getObjectService')->willReturn(null);
+		$this->zgwService->method('unavailableResponse')->willReturn(
+			new JSONResponse(
+				data: ['detail' => 'OpenRegister is not available'],
+				statusCode: Http::STATUS_SERVICE_UNAVAILABLE
+			)
+		);
+
+		$response = $this->controller->unlock(uuid: 'doc-1');
+
+		$this->assertSame(Http::STATUS_SERVICE_UNAVAILABLE, $response->getStatus());
+		$this->assertSame(['detail' => 'OpenRegister is not available'], $response->getData());
+	}//end testUnlockAnswers503WhenTheObjectStoreIsUnavailable()
+
+	/**
+	 * uploadChunk resolves the EIO mapping of the documenten API — a chunk
+	 * belongs to an enkelvoudiginformatieobject and to nothing else — and
+	 * answers the mapping-not-found response when it is absent.
+	 *
+	 * @return void
+	 */
+	public function testUploadChunkResolvesTheEioMappingAndAnswers404WhenAbsent(): void {
+		$this->acceptJwt();
+		$this->zgwService->method('getObjectService')->willReturn(
+			$this->createMock(DrcContractObjectServiceStub::class)
+		);
+
+		$this->zgwService->expects($this->once())
+			->method('loadMappingConfig')
+			->with('documenten', 'enkelvoudiginformatieobjecten')
+			->willReturn(null);
+		$this->zgwService->method('mappingNotFoundResponse')->willReturn(
+			new JSONResponse(data: ['detail' => 'no mapping'], statusCode: Http::STATUS_NOT_FOUND)
+		);
+		$this->zgwService->expects($this->never())->method('getDocumentService');
+
+		$response = $this->controller->uploadChunk(uuid: 'doc-1');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+	}//end testUploadChunkResolvesTheEioMappingAndAnswers404WhenAbsent()
+
+	/**
+	 * A document with no pending chunked upload cannot receive chunks: 400, and
+	 * the document service is never asked to store anything.
+	 *
+	 * @return void
+	 */
+	public function testUploadChunkRefusesADocumentWithNoPendingChunkedUpload(): void {
+		$this->acceptJwt();
+		$objectService = $this->createMock(DrcContractObjectServiceStub::class);
+		$objectService->method('find')->willReturn(['fileName' => 'brief.pdf', 'fileParts' => '']);
+
+		$this->zgwService->method('getObjectService')->willReturn($objectService);
+		$this->zgwService->method('loadMappingConfig')->willReturn(
+			['sourceRegister' => 'drc-register', 'sourceSchema' => 'eio']
+		);
+		$this->zgwService->expects($this->never())->method('getDocumentService');
+
+		$response = $this->controller->uploadChunk(uuid: 'doc-1');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['detail' => 'This document has no pending chunked upload.'], $response->getData());
+	}//end testUploadChunkRefusesADocumentWithNoPendingChunkedUpload()
+
+	/**
+	 * A sequence number outside 1..totalParts is refused — accepting part 4 of
+	 * a 3-part upload would write a chunk that the merge can never consume.
+	 *
+	 * @return void
+	 */
+	public function testUploadChunkRefusesASequenceNumberOutsideTheDeclaredRange(): void {
+		$this->acceptJwt();
+		$objectService = $this->createMock(DrcContractObjectServiceStub::class);
+		$objectService->method('find')->willReturn(
+			['fileName' => 'brief.pdf', 'fileParts' => '{"pending":true,"totalParts":3}']
+		);
+		$this->withRequestParams(['sequenceNumber' => '4']);
+
+		$this->zgwService->method('getObjectService')->willReturn($objectService);
+		$this->zgwService->method('loadMappingConfig')->willReturn(
+			['sourceRegister' => 'drc-register', 'sourceSchema' => 'eio']
+		);
+		$this->zgwService->expects($this->never())->method('getDocumentService');
+
+		$response = $this->controller->uploadChunk(uuid: 'doc-1');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['detail' => 'Invalid sequence number. Expected 1-%s.'], $response->getData());
+	}//end testUploadChunkRefusesASequenceNumberOutsideTheDeclaredRange()
+
+	/**
+	 * An empty body is refused with 400 and NEVER stored: a zero-byte chunk
+	 * would count towards the part total and merge into a corrupt file.
+	 *
+	 * @return void
+	 */
+	public function testUploadChunkRefusesAnEmptyBodyRatherThanStoringAZeroByteChunk(): void {
+		$this->acceptJwt();
+		$objectService = $this->createMock(DrcContractObjectServiceStub::class);
+		$objectService->method('find')->willReturn(
+			['fileName' => 'brief.pdf', 'fileParts' => '{"pending":true,"totalParts":3}']
+		);
+		$this->withRequestParams(['sequenceNumber' => '1']);
+
+		$this->zgwService->method('getObjectService')->willReturn($objectService);
+		$this->zgwService->method('loadMappingConfig')->willReturn(
+			['sourceRegister' => 'drc-register', 'sourceSchema' => 'eio']
+		);
+		// The PHPUnit CLI has an empty php://input, which is exactly the
+		// "caller sent no bytes" case this branch exists for.
+		$this->zgwService->expects($this->never())->method('getDocumentService');
+		$objectService->expects($this->never())->method('saveObject');
+
+		$response = $this->controller->uploadChunk(uuid: 'doc-1');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['detail' => 'No file content received.'], $response->getData());
+	}//end testUploadChunkRefusesAnEmptyBodyRatherThanStoringAZeroByteChunk()
+}//end class

--- a/tests/Unit/Controller/DrcControllerContractTest.php
+++ b/tests/Unit/Controller/DrcControllerContractTest.php
@@ -96,6 +96,14 @@ interface DrcContractObjectServiceStub {
  * Wire-contract tests for DrcController::patch/unlock/uploadChunk.
  *
  * @covers \OCA\Procest\Controller\DrcController
+ *
+ * DrcController extends ZgwController, which composes NormalisesObjectRows, so
+ * exercising it necessarily runs code declared on both. CI runs phpunit.xml
+ * with beStrictAboutCoverageMetadata="true" and failOnRisky="true", which marks
+ * executed-but-unlisted code risky and fails the run.
+ *
+ * @uses \OCA\Procest\Controller\ZgwController
+ * @uses \OCA\Procest\Support\NormalisesObjectRows
  */
 class DrcControllerContractTest extends TestCase {
 

--- a/tests/Unit/Controller/DrcDownloadLockContractTest.php
+++ b/tests/Unit/Controller/DrcDownloadLockContractTest.php
@@ -1,0 +1,452 @@
+<?php
+
+/**
+ * DrcController download/lock Wire-Contract Tests
+ *
+ * Contract coverage (gate-25) for the two remaining DRC endpoints with no
+ * executed proof of their wire behaviour: `download()` — which streams the
+ * BYTES of an enkelvoudiginformatieobject — and `lock()` — which MUTATES one by
+ * taking a ZGW lock on it. Both are `@PublicPage`, i.e. reachable without a
+ * Nextcloud session, so the ZGW JWT is the whole gate.
+ *
+ * Scope of these tests, deliberately: the REFUSAL and ERROR branches, which are
+ * the security-relevant half of the contract and are all JSONResponse-returning.
+ * `download()`'s success path constructs a `DataDownloadResponse`, whose
+ * constructor reaches `Symfony\Component\HttpFoundation\HeaderUtils` — a class
+ * that is NOT installed in the unit-test container. An assertion on that branch
+ * would fail locally for a reason that has nothing to do with the controller and
+ * could not be verified here, so it is not written. What IS pinned:
+ *
+ *  - neither endpoint runs a line of its body before `validateJwtAuth()` has
+ *    answered, and the refusal is returned verbatim;
+ *  - with OpenRegister unwired both answer 503 rather than throwing;
+ *  - `download()` resolves the `enkelvoudiginformatieobject` mapping — the
+ *    singular MAPPING KEY, which is a different string from the plural resource
+ *    name `lock()` uses — and answers 404 when it is absent;
+ *  - `download()` answers 404 and reads NO content when the stored file is
+ *    missing, so a dangling row can never stream another document's bytes;
+ *  - `lock()` refuses to re-lock an already-locked document (400) without
+ *    touching the store's lock, and on success stores the generated lockId in
+ *    the data blob — a lock handed to a client but never persisted would be
+ *    unverifiable at unlock time and the document permanently stuck;
+ *  - and one TRIPWIRE (see its docblock) on the absent scope check.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\DrcController;
+use OCA\Procest\Service\ZgwDocumentService;
+use OCA\Procest\Service\ZgwMappingService;
+use OCA\Procest\Service\ZgwService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IL10N;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Minimal OpenRegister ObjectService stub for the download/lock contract tests.
+ *
+ * The controller calls the store with NAMED arguments, so the parameter names
+ * must match the real service's exactly. `getLockInfo()` is deliberately NOT
+ * declared: the controller probes for it with `method_exists()` and falls back
+ * to the data blob when it is absent, which is the path an OpenRegister without
+ * the dedicated lock table takes.
+ */
+interface DrcDownloadLockObjectServiceStub {
+	/**
+	 * Find a single object by identifier (real ObjectService::find()).
+	 *
+	 * @param int|string $id The object UUID.
+	 * @param string|null $register The register slug.
+	 * @param string|null $schema The schema slug.
+	 *
+	 * @return mixed The stored object row.
+	 */
+	public function find(int|string $id = '', ?string $register = null, ?string $schema = null): mixed;
+
+	/**
+	 * Save or update an object.
+	 *
+	 * @param string $register The register slug.
+	 * @param string $schema The schema slug.
+	 * @param array<string, mixed> $object The object data.
+	 * @param string|null $uuid The object UUID to overwrite.
+	 *
+	 * @return mixed The saved object row.
+	 */
+	public function saveObject(string $register, string $schema, array $object, ?string $uuid = null): mixed;
+
+	/**
+	 * Take OpenRegister's own lock on an object.
+	 *
+	 * @param string $identifier The object UUID.
+	 *
+	 * @return mixed The locked object row.
+	 */
+	public function lockObject(string $identifier): mixed;
+}//end interface
+
+/**
+ * Wire-contract tests for DrcController::download() and ::lock().
+ *
+ * @covers \OCA\Procest\Controller\DrcController
+ */
+class DrcDownloadLockContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock handed to the controller.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The ZgwService mock — JWT gate, store accessor and mapping oracle.
+	 *
+	 * @var ZgwService|MockObject
+	 */
+	private ZgwService $zgwService;
+
+	/**
+	 * The IL10N mock; `t()` echoes its message so the branch is identifiable.
+	 *
+	 * @var IL10N|MockObject
+	 */
+	private IL10N $l10n;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var DrcController
+	 */
+	private DrcController $controller;
+
+	/**
+	 * Build the controller with all collaborators mocked.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->zgwService = $this->createMock(ZgwService::class);
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->l10n->method('t')->willReturnArgument(0);
+		$this->zgwService->method('getLogger')->willReturn($this->createMock(LoggerInterface::class));
+
+		$this->controller = new DrcController(
+			appName: 'procest',
+			request: $this->request,
+			zgwService: $this->zgwService,
+			l10n: $this->l10n,
+		);
+	}//end setUp()
+
+	/**
+	 * Configure the JWT gate to REFUSE.
+	 *
+	 * @return JSONResponse The refusal the gate answers with.
+	 */
+	private function refuseJwt(): JSONResponse {
+		$refusal = new JSONResponse(
+			data: ['code' => 'not_authenticated'],
+			statusCode: Http::STATUS_UNAUTHORIZED
+		);
+		$this->zgwService->method('validateJwtAuth')->willReturn($refusal);
+
+		return $refusal;
+	}//end refuseJwt()
+
+	/**
+	 * Configure the JWT gate to ACCEPT.
+	 *
+	 * @return void
+	 */
+	private function acceptJwt(): void {
+		$this->zgwService->method('validateJwtAuth')->willReturn(null);
+	}//end acceptJwt()
+
+	/**
+	 * Stub the 503 response the controller returns when the store is unwired.
+	 *
+	 * @return void
+	 */
+	private function withUnavailableResponse(): void {
+		$this->zgwService->method('unavailableResponse')->willReturn(
+			new JSONResponse(
+				data: ['detail' => 'OpenRegister is not available'],
+				statusCode: Http::STATUS_SERVICE_UNAVAILABLE
+			)
+		);
+	}//end withUnavailableResponse()
+
+	/**
+	 * Both endpoints consult the JWT gate first and return its refusal verbatim
+	 * — neither reaches the store, and `lock()` takes no lock.
+	 *
+	 * @return void
+	 */
+	public function testDownloadAndLockRefuseAnUnauthenticatedCallerBeforeTouchingTheStore(): void {
+		$refusal = $this->refuseJwt();
+		$this->zgwService->expects($this->never())->method('getObjectService');
+		$this->zgwService->expects($this->never())->method('getZgwMappingService');
+		$this->zgwService->expects($this->never())->method('getDocumentService');
+
+		$download = $this->controller->download(uuid: 'doc-1');
+		$lock = $this->controller->lock(uuid: 'doc-1');
+
+		$this->assertSame($refusal, $download, 'download must return the JWT refusal verbatim');
+		$this->assertSame($refusal, $lock, 'lock must return the JWT refusal verbatim');
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $download->getStatus());
+	}//end testDownloadAndLockRefuseAnUnauthenticatedCallerBeforeTouchingTheStore()
+
+	/**
+	 * With OpenRegister unwired both endpoints answer 503 rather than throwing
+	 * — a 500 stack trace on a `@PublicPage` route is itself a disclosure.
+	 *
+	 * @return void
+	 */
+	public function testDownloadAndLockAnswer503WhenTheObjectStoreIsUnavailable(): void {
+		$this->acceptJwt();
+		$this->withUnavailableResponse();
+		$this->zgwService->method('getObjectService')->willReturn(null);
+
+		$download = $this->controller->download(uuid: 'doc-1');
+		$lock = $this->controller->lock(uuid: 'doc-1');
+
+		$this->assertSame(Http::STATUS_SERVICE_UNAVAILABLE, $download->getStatus());
+		$this->assertSame(Http::STATUS_SERVICE_UNAVAILABLE, $lock->getStatus());
+		$this->assertSame(['detail' => 'OpenRegister is not available'], $download->getData());
+	}//end testDownloadAndLockAnswer503WhenTheObjectStoreIsUnavailable()
+
+	/**
+	 * `download()` resolves the SINGULAR `enkelvoudiginformatieobject` mapping
+	 * key and answers 404 when it is not configured. The key matters: the
+	 * neighbouring endpoints in this controller address the PLURAL resource
+	 * `enkelvoudiginformatieobjecten`, and a mapping lookup under the wrong
+	 * string returns null for every deployment.
+	 *
+	 * @return void
+	 */
+	public function testDownloadResolvesTheSingularEioMappingKeyAndAnswers404WhenAbsent(): void {
+		$this->acceptJwt();
+		$this->zgwService->method('getObjectService')->willReturn(
+			$this->createMock(DrcDownloadLockObjectServiceStub::class)
+		);
+
+		$mappingService = $this->createMock(ZgwMappingService::class);
+		$mappingService->expects($this->once())
+			->method('getMapping')
+			->with('enkelvoudiginformatieobject')
+			->willReturn(null);
+		$this->zgwService->method('getZgwMappingService')->willReturn($mappingService);
+		$this->zgwService->expects($this->never())->method('getDocumentService');
+
+		$response = $this->controller->download(uuid: 'doc-1');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertSame(['detail' => 'Document mapping not configured'], $response->getData());
+	}//end testDownloadResolvesTheSingularEioMappingKeyAndAnswers404WhenAbsent()
+
+	/**
+	 * When the stored file is missing, `download()` answers 404 and never reads
+	 * content: a row whose file has gone must not be able to stream whatever the
+	 * storage layer happens to return for that name.
+	 *
+	 * The existence probe is made with the file name recorded ON THE OBJECT, not
+	 * with anything the caller supplied.
+	 *
+	 * @return void
+	 */
+	public function testDownloadAnswers404OnAMissingFileAndReadsNoContent(): void {
+		$this->acceptJwt();
+
+		$objectService = $this->createMock(DrcDownloadLockObjectServiceStub::class);
+		$objectService->method('find')->willReturn(
+			['fileName' => 'besluit.pdf', 'format' => 'application/pdf']
+		);
+		$this->zgwService->method('getObjectService')->willReturn($objectService);
+
+		$mappingService = $this->createMock(ZgwMappingService::class);
+		$mappingService->method('getMapping')->willReturn(
+			['sourceRegister' => 'drc-register', 'sourceSchema' => 'eio']
+		);
+		$this->zgwService->method('getZgwMappingService')->willReturn($mappingService);
+
+		$probed = [];
+		$documentService = $this->createMock(ZgwDocumentService::class);
+		$documentService->expects($this->once())
+			->method('fileExists')
+			->willReturnCallback(
+				static function (string $uuid, string $fileName) use (&$probed): bool {
+					$probed = ['uuid' => $uuid, 'fileName' => $fileName];
+					return false;
+				}
+			);
+		$documentService->expects($this->never())->method('getContent');
+		$this->zgwService->method('getDocumentService')->willReturn($documentService);
+
+		$response = $this->controller->download(uuid: 'doc-1');
+
+		$this->assertInstanceOf(JSONResponse::class, $response);
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertSame(['detail' => 'File not found.'], $response->getData());
+		$this->assertSame(['uuid' => 'doc-1', 'fileName' => 'besluit.pdf'], $probed);
+	}//end testDownloadAnswers404OnAMissingFileAndReadsNoContent()
+
+	/**
+	 * `lock()` refuses to re-lock an already-locked document with 400 and never
+	 * takes a second lock — issuing a fresh lockId over an existing one would
+	 * silently steal the lock from whoever holds it.
+	 *
+	 * @return void
+	 */
+	public function testLockRefusesAnAlreadyLockedDocumentWithoutTakingASecondLock(): void {
+		$this->acceptJwt();
+
+		$objectService = $this->createMock(DrcDownloadLockObjectServiceStub::class);
+		$objectService->method('find')->willReturn(
+			['fileName' => 'besluit.pdf', 'lockId' => 'held-by-someone-else']
+		);
+		$objectService->expects($this->never())->method('lockObject');
+		$objectService->expects($this->never())->method('saveObject');
+		$this->zgwService->method('getObjectService')->willReturn($objectService);
+
+		$this->zgwService->expects($this->once())
+			->method('loadMappingConfig')
+			->with('documenten', 'enkelvoudiginformatieobjecten')
+			->willReturn(['sourceRegister' => 'drc-register', 'sourceSchema' => 'eio']);
+
+		$response = $this->controller->lock(uuid: 'doc-1');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['detail' => 'Document is already locked.'], $response->getData());
+	}//end testLockRefusesAnAlreadyLockedDocumentWithoutTakingASecondLock()
+
+	/**
+	 * A successful lock takes the store's lock AND persists the generated ZGW
+	 * lockId in the data blob. The lockId handed back is the one stored: an
+	 * unpersisted lockId could never be verified at unlock time, leaving the
+	 * document locked forever.
+	 *
+	 * @return void
+	 */
+	public function testLockTakesTheLockAndPersistsTheGeneratedLockIdItReturns(): void {
+		$this->acceptJwt();
+
+		$saved = [];
+		$objectService = $this->createMock(DrcDownloadLockObjectServiceStub::class);
+		$objectService->method('find')->willReturn(['fileName' => 'besluit.pdf']);
+		$objectService->expects($this->once())
+			->method('lockObject')
+			->willReturnCallback(
+				static function (string $identifier): array {
+					return ['id' => $identifier];
+				}
+			);
+		$objectService->expects($this->once())
+			->method('saveObject')
+			->willReturnCallback(
+				static function (
+					string $register,
+					string $schema,
+					array $object,
+					?string $uuid = null,
+				) use (&$saved): array {
+					$saved = ['object' => $object, 'uuid' => $uuid];
+					return $object;
+				}
+			);
+		$this->zgwService->method('getObjectService')->willReturn($objectService);
+		$this->zgwService->method('loadMappingConfig')->willReturn(
+			['sourceRegister' => 'drc-register', 'sourceSchema' => 'eio']
+		);
+
+		$response = $this->controller->lock(uuid: 'doc-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertMatchesRegularExpression(
+			'/^[0-9a-f]{32}$/',
+			(string)$response->getData()['lock'],
+			'the lock handed to the client must be a freshly generated 128-bit identifier'
+		);
+		$this->assertSame(
+			$response->getData()['lock'],
+			$saved['object']['lockId'],
+			'the returned lockId must be the one persisted, or unlock can never verify it'
+		);
+		$this->assertTrue($saved['object']['locked']);
+		$this->assertSame('doc-1', $saved['uuid']);
+	}//end testLockTakesTheLockAndPersistsTheGeneratedLockIdItReturns()
+
+	/**
+	 * TRIPWIRE — pins CURRENT behaviour, which is NOT asserted to be correct.
+	 *
+	 * Neither `download()` nor `lock()` consults `ZgwService::consumerHasScope()`.
+	 * Their siblings on this same controller do: `patch()` demands
+	 * `documenten.bijwerken` and `unlock()` demands `geforceerd-bijwerken` before
+	 * breaking a lock. So on these two routes a JWT that carries NO document
+	 * scope at all can still read a document's bytes (`download`) and take a
+	 * write lock on it (`lock`) — the ZGW standard assigns `documenten.lezen`
+	 * and `documenten.bijwerken` to exactly those operations.
+	 *
+	 * The test asserts the scope oracle is NEVER called. If it goes RED, a scope
+	 * check was ADDED — that is the fix, not a regression: replace this test
+	 * with a `->with($this->request, 'drc', '<scope>')` refusal assertion in the
+	 * shape used by DrcControllerContractTest. Do not weaken the controller.
+	 *
+	 * @return void
+	 */
+	public function testTripwireNeitherDownloadNorLockDemandsAnyDocumentScope(): void {
+		$this->acceptJwt();
+		$this->zgwService->expects($this->never())->method('consumerHasScope');
+
+		$objectService = $this->createMock(DrcDownloadLockObjectServiceStub::class);
+		$objectService->method('find')->willReturn(['fileName' => 'besluit.pdf']);
+		$this->zgwService->method('getObjectService')->willReturn($objectService);
+		$this->zgwService->method('loadMappingConfig')->willReturn(
+			['sourceRegister' => 'drc-register', 'sourceSchema' => 'eio']
+		);
+
+		$mappingService = $this->createMock(ZgwMappingService::class);
+		$mappingService->method('getMapping')->willReturn(
+			['sourceRegister' => 'drc-register', 'sourceSchema' => 'eio']
+		);
+		$this->zgwService->method('getZgwMappingService')->willReturn($mappingService);
+
+		$documentService = $this->createMock(ZgwDocumentService::class);
+		$documentService->method('fileExists')->willReturn(false);
+		$this->zgwService->method('getDocumentService')->willReturn($documentService);
+
+		$download = $this->controller->download(uuid: 'doc-1');
+		$lock = $this->controller->lock(uuid: 'doc-1');
+
+		// A scope-less JWT reaches the document logic on both routes: download
+		// gets as far as looking for the file, lock gets as far as locking.
+		$this->assertSame(
+			Http::STATUS_NOT_FOUND,
+			$download->getStatus(),
+			'current behaviour: no scope is demanded, so the caller reaches the file lookup'
+		);
+		$this->assertSame(
+			Http::STATUS_OK,
+			$lock->getStatus(),
+			'current behaviour: a scope-less JWT successfully locks the document'
+		);
+	}//end testTripwireNeitherDownloadNorLockDemandsAnyDocumentScope()
+}//end class

--- a/tests/Unit/Controller/DrcDownloadLockContractTest.php
+++ b/tests/Unit/Controller/DrcDownloadLockContractTest.php
@@ -104,6 +104,14 @@ interface DrcDownloadLockObjectServiceStub {
  * Wire-contract tests for DrcController::download() and ::lock().
  *
  * @covers \OCA\Procest\Controller\DrcController
+ *
+ * DrcController extends ZgwController, which composes NormalisesObjectRows, so
+ * exercising it necessarily runs code declared on both. CI runs phpunit.xml
+ * with beStrictAboutCoverageMetadata="true" and failOnRisky="true", which marks
+ * executed-but-unlisted code risky and fails the run.
+ *
+ * @uses \OCA\Procest\Controller\ZgwController
+ * @uses \OCA\Procest\Support\NormalisesObjectRows
  */
 class DrcDownloadLockContractTest extends TestCase {
 

--- a/tests/Unit/Controller/DsoControllerContractTest.php
+++ b/tests/Unit/Controller/DsoControllerContractTest.php
@@ -1,0 +1,740 @@
+<?php
+
+/**
+ * DsoController Wire-Contract Tests
+ *
+ * Contract coverage for the three DSO Omgevingsloket endpoints that had no
+ * automated proof of their wire behaviour (gate-25): the vergunningen
+ * dashboard, `doorsturen` (forwarding a permit case to another bevoegd gezag)
+ * and `respondSamenwerking` (answering a samenwerkverzoek). All three are
+ * `#[NoAdminRequired]`.
+ *
+ * The contract pinned here:
+ *
+ *  - no session answers 401 on all three, before any OpenRegister read;
+ *  - the dashboard query is SCOPED to `caseType: omgevingsvergunning` and
+ *    paginated — an unscoped dashboard would list every case in the register
+ *    while still rendering perfectly;
+ *  - an OpenRegister outage on the dashboard is a 503, and any other failure a
+ *    masked 500 — the two are distinct branches with distinct meanings;
+ *  - `doorsturen` demands a target bevoegd gezag (400), 404s an unknown case,
+ *    and — the load-bearing one — dispatches NO VergunningDoorgestuurd event
+ *    when the mutation guard refuses. That event is what downstream listeners
+ *    act on, so an event emitted on a refused forward is a real handover of a
+ *    permit case by an unauthorized caller;
+ *  - `respondSamenwerking` likewise 404s an unknown verzoek and records NO
+ *    answer when the guard refuses, and it maps the `advice` body key onto the
+ *    service's `advies` argument.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\DsoController;
+use OCA\Procest\Service\BeschikkingGenerationService;
+use OCA\Procest\Service\Dso\DsoDoorsturenNotifier;
+use OCA\Procest\Service\Dso\DsoObjectRepository;
+use OCA\Procest\Service\DsoCaseService;
+use OCA\Procest\Service\SamenwerkverzoekService;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Concrete IRequest stub for the DsoController contract tests.
+ *
+ * `DsoController::readJsonBody()` reads the raw body through
+ * `IRequest::getContent()`, which is a magic property on the real Nextcloud
+ * request and therefore cannot be configured on a `createMock(IRequest::class)`.
+ * Uniquely named (`DsoContract…`) because several contract-test files declare
+ * their own request stubs in this same namespace.
+ */
+class DsoContractRequestStub implements IRequest {
+
+	/**
+	 * Query/body parameters answered by getParam().
+	 *
+	 * @var array<string, mixed>
+	 */
+	private array $params;
+
+	/**
+	 * Raw request body returned by getContent().
+	 *
+	 * @var string
+	 */
+	private string $content;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array<string, mixed> $params Parameters for getParam()/getParams().
+	 * @param string $content Raw JSON request body.
+	 */
+	public function __construct(array $params = [], string $content = '') {
+		$this->params = $params;
+		$this->content = $content;
+	}//end __construct()
+
+	/**
+	 * Return a query/body parameter.
+	 *
+	 * @param string $key Parameter name.
+	 * @param mixed $default Default when absent.
+	 *
+	 * @return mixed
+	 */
+	public function getParam(string $key, mixed $default = null): mixed {
+		return ($this->params[$key] ?? $default);
+	}//end getParam()
+
+	/**
+	 * Return all request parameters.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function getParams(): array {
+		return $this->params;
+	}//end getParams()
+
+	/**
+	 * Return a request header value by name.
+	 *
+	 * @param string $name Header name.
+	 *
+	 * @return string
+	 */
+	public function getHeader(string $name): string {
+		return '';
+	}//end getHeader()
+
+	/**
+	 * Return the HTTP method.
+	 *
+	 * @return string
+	 */
+	public function getMethod(): string {
+		return 'POST';
+	}//end getMethod()
+
+	/**
+	 * Return an uploaded file by key.
+	 *
+	 * @param string $key File field name.
+	 *
+	 * @return mixed
+	 */
+	public function getUploadedFile(string $key): mixed {
+		return null;
+	}//end getUploadedFile()
+
+	/**
+	 * Return a server environment variable.
+	 *
+	 * @param string $key Variable name.
+	 *
+	 * @return mixed
+	 */
+	public function getEnv(string $key): mixed {
+		return null;
+	}//end getEnv()
+
+	/**
+	 * Return a cookie value by name.
+	 *
+	 * @param string $key Cookie name.
+	 *
+	 * @return mixed
+	 */
+	public function getCookie(string $key): mixed {
+		return null;
+	}//end getCookie()
+
+	/**
+	 * Return whether this request passes a CSRF check.
+	 *
+	 * @return bool
+	 */
+	public function passesCSRFCheck(): bool {
+		return true;
+	}//end passesCSRFCheck()
+
+	/**
+	 * Return whether this request passes a strict cookie check.
+	 *
+	 * @return bool
+	 */
+	public function passesStrictCookieCheck(): bool {
+		return true;
+	}//end passesStrictCookieCheck()
+
+	/**
+	 * Return whether this request passes a lax cookie check.
+	 *
+	 * @return bool
+	 */
+	public function passesLaxCookieCheck(): bool {
+		return true;
+	}//end passesLaxCookieCheck()
+
+	/**
+	 * Return the unique request ID.
+	 *
+	 * @return string
+	 */
+	public function getId(): string {
+		return 'dso-contract-request';
+	}//end getId()
+
+	/**
+	 * Return the remote IP address.
+	 *
+	 * @return string
+	 */
+	public function getRemoteAddress(): string {
+		return '127.0.0.1';
+	}//end getRemoteAddress()
+
+	/**
+	 * Return the server protocol.
+	 *
+	 * @return string
+	 */
+	public function getServerProtocol(): string {
+		return 'HTTP/1.1';
+	}//end getServerProtocol()
+
+	/**
+	 * Return the HTTP scheme.
+	 *
+	 * @return string
+	 */
+	public function getHttpProtocol(): string {
+		return 'http';
+	}//end getHttpProtocol()
+
+	/**
+	 * Return the full request URI.
+	 *
+	 * @return string
+	 */
+	public function getRequestUri(): string {
+		return '/apps/procest/api/dso/dashboard';
+	}//end getRequestUri()
+
+	/**
+	 * Return the raw path info segment.
+	 *
+	 * @return string
+	 */
+	public function getRawPathInfo(): string {
+		return '';
+	}//end getRawPathInfo()
+
+	/**
+	 * Return the decoded path info segment.
+	 *
+	 * @return mixed
+	 */
+	public function getPathInfo(): mixed {
+		return '';
+	}//end getPathInfo()
+
+	/**
+	 * Return the script name.
+	 *
+	 * @return string
+	 */
+	public function getScriptName(): string {
+		return '';
+	}//end getScriptName()
+
+	/**
+	 * Return whether the request originates from the given user agent(s).
+	 *
+	 * @param array<int, string> $agent Agent strings to match.
+	 *
+	 * @return bool
+	 */
+	public function isUserAgent(array $agent): bool {
+		return false;
+	}//end isUserAgent()
+
+	/**
+	 * Return the insecure (HTTP) server host.
+	 *
+	 * @return string
+	 */
+	public function getInsecureServerHost(): string {
+		return 'localhost';
+	}//end getInsecureServerHost()
+
+	/**
+	 * Return the server host.
+	 *
+	 * @return string
+	 */
+	public function getServerHost(): string {
+		return 'localhost';
+	}//end getServerHost()
+
+	/**
+	 * Throw if a JSON decode error occurred during body parsing.
+	 *
+	 * @return void
+	 */
+	public function throwDecodingExceptionIfAny(): void {
+	}//end throwDecodingExceptionIfAny()
+
+	/**
+	 * Return the requested response format.
+	 *
+	 * @return string|null
+	 */
+	public function getFormat(): ?string {
+		return null;
+	}//end getFormat()
+
+	/**
+	 * Return the raw request body content.
+	 *
+	 * @return string
+	 */
+	public function getContent(): string {
+		return $this->content;
+	}//end getContent()
+}//end class
+
+/**
+ * Wire-contract tests for DsoController's dashboard/doorsturen/respond endpoints.
+ *
+ * @covers \OCA\Procest\Controller\DsoController
+ */
+class DsoControllerContractTest extends TestCase {
+
+	/**
+	 * The DsoCaseService mock (owner of the zaak mutation guard).
+	 *
+	 * @var DsoCaseService|MockObject
+	 */
+	private DsoCaseService $dsoCaseService;
+
+	/**
+	 * The BeschikkingGenerationService mock.
+	 *
+	 * @var BeschikkingGenerationService|MockObject
+	 */
+	private BeschikkingGenerationService $decisionService;
+
+	/**
+	 * The SamenwerkverzoekService mock.
+	 *
+	 * @var SamenwerkverzoekService|MockObject
+	 */
+	private SamenwerkverzoekService $samenwerkService;
+
+	/**
+	 * The OpenRegister read collaborator mock.
+	 *
+	 * @var DsoObjectRepository|MockObject
+	 */
+	private DsoObjectRepository $repository;
+
+	/**
+	 * The doorsturen event dispatcher mock.
+	 *
+	 * @var DsoDoorsturenNotifier|MockObject
+	 */
+	private DsoDoorsturenNotifier $doorsturenNotifier;
+
+	/**
+	 * The IUserSession mock.
+	 *
+	 * @var IUserSession|MockObject
+	 */
+	private IUserSession $userSession;
+
+	/**
+	 * The LoggerInterface mock.
+	 *
+	 * @var LoggerInterface|MockObject
+	 */
+	private LoggerInterface $logger;
+
+	/**
+	 * Build the shared collaborator mocks.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->dsoCaseService = $this->createMock(DsoCaseService::class);
+		$this->decisionService = $this->createMock(BeschikkingGenerationService::class);
+		$this->samenwerkService = $this->createMock(SamenwerkverzoekService::class);
+		$this->repository = $this->createMock(DsoObjectRepository::class);
+		$this->doorsturenNotifier = $this->createMock(DsoDoorsturenNotifier::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+	}//end setUp()
+
+	/**
+	 * Build the controller over a request carrying the supplied body/params.
+	 *
+	 * @param array<string, mixed> $params Query parameters.
+	 * @param string $content Raw JSON body.
+	 *
+	 * @return DsoController The controller under test.
+	 */
+	private function controllerWith(array $params = [], string $content = ''): DsoController {
+		return new DsoController(
+			appName: 'procest',
+			request: new DsoContractRequestStub(params: $params, content: $content),
+			dsoCaseService: $this->dsoCaseService,
+			decisionService: $this->decisionService,
+			samenwerkService: $this->samenwerkService,
+			repository: $this->repository,
+			doorsturenNotifier: $this->doorsturenNotifier,
+			userSession: $this->userSession,
+			logger: $this->logger,
+		);
+	}//end controllerWith()
+
+	/**
+	 * Put a signed-in user on the session.
+	 *
+	 * @param string $uid The UID of the signed-in user.
+	 *
+	 * @return void
+	 */
+	private function signIn(string $uid = 'alice'): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		$this->userSession->method('getUser')->willReturn($user);
+	}//end signIn()
+
+	/**
+	 * `dashboard` refuses an anonymous caller with 401 and reads nothing.
+	 *
+	 * @return void
+	 */
+	public function testDashboardRefusesAnUnauthenticatedCallerWith401(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->repository->expects($this->never())->method('fetchDashboard');
+
+		$response = $this->controllerWith()->dashboard();
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame(['error' => 'Not authenticated'], $response->getData());
+	}//end testDashboardRefusesAnUnauthenticatedCallerWith401()
+
+	/**
+	 * The dashboard query is scoped to omgevingsvergunning cases and paginated,
+	 * and the caller's filters are passed through. An unscoped query would list
+	 * the whole register while still rendering a plausible dashboard.
+	 *
+	 * @return void
+	 */
+	public function testDashboardScopesTheQueryToOmgevingsvergunningCases(): void {
+		$this->signIn();
+		$captured = [];
+
+		$this->repository->expects($this->once())
+			->method('fetchDashboard')
+			->willReturnCallback(
+				static function (
+					array $params,
+					string $activiteitgroep,
+					string $regelkwalificatie,
+					string $location,
+				) use (&$captured): array {
+					$captured = [
+						'params' => $params,
+						'activiteitgroep' => $activiteitgroep,
+						'regelkwalificatie' => $regelkwalificatie,
+						'location' => $location,
+					];
+
+					return ['error' => null, 'results' => [['id' => 'zaak-1'], ['id' => 'zaak-2']]];
+				}
+			);
+
+		$response = $this->controllerWith(params: [
+			'status' => 'in_handling',
+			'activiteitgroep' => 'bouwen',
+		])->dashboard();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(2, $response->getData()['count']);
+		$this->assertSame('omgevingsvergunning', $captured['params']['caseType']);
+		$this->assertSame('in_handling', $captured['params']['status']);
+		$this->assertSame(100, $captured['params']['_limit']);
+		$this->assertSame('bouwen', $captured['activiteitgroep']);
+	}//end testDashboardScopesTheQueryToOmgevingsvergunningCases()
+
+	/**
+	 * An OpenRegister outage answers 503 with the repository's reason — not an
+	 * empty 200 the operator would read as "no permits in progress".
+	 *
+	 * @return void
+	 */
+	public function testDashboardReturns503WhenOpenRegisterIsUnavailable(): void {
+		$this->signIn();
+		$this->repository->method('fetchDashboard')
+			->willReturn(['error' => 'OpenRegister not available', 'results' => []]);
+
+		$response = $this->controllerWith()->dashboard();
+
+		$this->assertSame(Http::STATUS_SERVICE_UNAVAILABLE, $response->getStatus());
+		$this->assertSame(['error' => 'OpenRegister not available'], $response->getData());
+	}//end testDashboardReturns503WhenOpenRegisterIsUnavailable()
+
+	/**
+	 * Any other failure is logged and masked as a 500 — distinct from the 503
+	 * above, which is an actionable deployment fact.
+	 *
+	 * @return void
+	 */
+	public function testDashboardMasksAnUnexpectedFailureAs500AndLogsIt(): void {
+		$this->signIn();
+		$this->repository->method('fetchDashboard')
+			->willThrowException(new \RuntimeException('index corruption on zaken'));
+		$this->logger->expects($this->once())->method('error');
+
+		$response = $this->controllerWith()->dashboard();
+
+		$this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+		$this->assertSame(['error' => 'Could not load dashboard'], $response->getData());
+	}//end testDashboardMasksAnUnexpectedFailureAs500AndLogsIt()
+
+	/**
+	 * `doorsturen` refuses an anonymous caller with 401 and dispatches nothing.
+	 *
+	 * @return void
+	 */
+	public function testDoorsturenRefusesAnUnauthenticatedCallerWith401(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->doorsturenNotifier->expects($this->never())->method('dispatchDoorgestuurd');
+
+		$response = $this->controllerWith(content: '{"targetBevoegdGezag":"gm0518"}')
+			->doorsturen(caseId: 'zaak-1');
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame(['error' => 'Not authenticated'], $response->getData());
+	}//end testDoorsturenRefusesAnUnauthenticatedCallerWith401()
+
+	/**
+	 * A forward with no destination is a 400 — the case must not be marked
+	 * doorgestuurd to nowhere.
+	 *
+	 * @return void
+	 */
+	public function testDoorsturenRejectsAMissingTargetBevoegdGezagWith400(): void {
+		$this->signIn();
+		$this->repository->expects($this->never())->method('findZaak');
+		$this->doorsturenNotifier->expects($this->never())->method('dispatchDoorgestuurd');
+
+		$response = $this->controllerWith(content: '{"reason":"niet bevoegd"}')
+			->doorsturen(caseId: 'zaak-1');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'targetBevoegdGezag is required'], $response->getData());
+	}//end testDoorsturenRejectsAMissingTargetBevoegdGezagWith400()
+
+	/**
+	 * An unknown case answers 404 and dispatches nothing.
+	 *
+	 * @return void
+	 */
+	public function testDoorsturenReturns404ForAnUnknownCase(): void {
+		$this->signIn();
+		$this->repository->method('findZaak')->willReturn(null);
+		$this->doorsturenNotifier->expects($this->never())->method('dispatchDoorgestuurd');
+
+		$response = $this->controllerWith(content: '{"targetBevoegdGezag":"gm0518"}')
+			->doorsturen(caseId: 'does-not-exist');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertSame(['error' => 'Case not found'], $response->getData());
+	}//end testDoorsturenReturns404ForAnUnknownCase()
+
+	/**
+	 * A refused mutation answers 403 and — the load-bearing half — dispatches NO
+	 * VergunningDoorgestuurd event. Downstream listeners act on that event, so
+	 * emitting it on a refused forward would hand the permit case over anyway.
+	 *
+	 * @return void
+	 */
+	public function testDoorsturenDispatchesNoEventWhenTheMutationGuardRefuses(): void {
+		$this->signIn(uid: 'mallory');
+		$this->repository->method('findZaak')->willReturn(['id' => 'zaak-1', 'assigneeUserId' => 'alice']);
+		$this->dsoCaseService->method('authorizeZaakMutation')
+			->willThrowException(new \Exception('Not authorized'));
+		$this->doorsturenNotifier->expects($this->never())->method('dispatchDoorgestuurd');
+
+		$response = $this->controllerWith(content: '{"targetBevoegdGezag":"gm0518"}')
+			->doorsturen(caseId: 'zaak-1');
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame(['error' => 'Forbidden'], $response->getData());
+	}//end testDoorsturenDispatchesNoEventWhenTheMutationGuardRefuses()
+
+	/**
+	 * An authorized forward dispatches the event with the case, destination,
+	 * reason and acting user, and answers 200 with the confirmed destination.
+	 *
+	 * @return void
+	 */
+	public function testDoorsturenDispatchesTheForwardAndConfirmsTheDestination(): void {
+		$this->signIn(uid: 'alice');
+		$case = ['id' => 'zaak-1', 'assigneeUserId' => 'alice'];
+		$this->repository->method('findZaak')->willReturn($case);
+
+		$this->doorsturenNotifier->expects($this->once())
+			->method('dispatchDoorgestuurd')
+			->with($case, 'zaak-1', 'gm0518', 'niet bevoegd', 'alice');
+
+		$response = $this->controllerWith(
+			content: '{"targetBevoegdGezag":"gm0518","reason":"niet bevoegd"}'
+		)->doorsturen(caseId: 'zaak-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(
+			['status' => 'doorgestuurd', 'caseId' => 'zaak-1', 'targetBevoegdGezag' => 'gm0518'],
+			$response->getData()
+		);
+	}//end testDoorsturenDispatchesTheForwardAndConfirmsTheDestination()
+
+	/**
+	 * A non-authorization failure is masked as a 500 with this endpoint's own
+	 * message — it must not be reported as the 403 the guard uses.
+	 *
+	 * @return void
+	 */
+	public function testDoorsturenMasksAnUnexpectedFailureAs500(): void {
+		$this->signIn();
+		$this->repository->method('findZaak')->willReturn(['id' => 'zaak-1']);
+		$this->dsoCaseService->method('authorizeZaakMutation')
+			->willThrowException(new \Exception('event bus offline'));
+		$this->logger->expects($this->once())->method('error');
+
+		$response = $this->controllerWith(content: '{"targetBevoegdGezag":"gm0518"}')
+			->doorsturen(caseId: 'zaak-1');
+
+		$this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+		$this->assertSame(['error' => 'Could not doorsturen'], $response->getData());
+	}//end testDoorsturenMasksAnUnexpectedFailureAs500()
+
+	/**
+	 * `respondSamenwerking` refuses an anonymous caller with 401.
+	 *
+	 * @return void
+	 */
+	public function testRespondSamenwerkingRefusesAnUnauthenticatedCallerWith401(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->samenwerkService->expects($this->never())->method('respondToSamenwerking');
+
+		$response = $this->controllerWith(content: '{"accept":true}')
+			->respondSamenwerking(samenwerkId: 'sw-1');
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame(['error' => 'Not authenticated'], $response->getData());
+	}//end testRespondSamenwerkingRefusesAnUnauthenticatedCallerWith401()
+
+	/**
+	 * An unknown samenwerkverzoek answers 404 and records no answer.
+	 *
+	 * @return void
+	 */
+	public function testRespondSamenwerkingReturns404ForAnUnknownVerzoek(): void {
+		$this->signIn();
+		$this->repository->method('findSamenwerkverzoek')->willReturn(null);
+		$this->samenwerkService->expects($this->never())->method('respondToSamenwerking');
+
+		$response = $this->controllerWith(content: '{"accept":true}')
+			->respondSamenwerking(samenwerkId: 'nope');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertSame(['error' => 'Samenwerkverzoek not found'], $response->getData());
+	}//end testRespondSamenwerkingReturns404ForAnUnknownVerzoek()
+
+	/**
+	 * A refused mutation answers 403 and records no answer — an unauthorized
+	 * "accept" would commit the organisation to a samenwerking.
+	 *
+	 * @return void
+	 */
+	public function testRespondSamenwerkingRecordsNothingWhenTheGuardRefuses(): void {
+		$this->signIn(uid: 'mallory');
+		$this->repository->method('findSamenwerkverzoek')->willReturn(['id' => 'sw-1']);
+		$this->samenwerkService->method('authorizeSamenwerkMutation')
+			->willThrowException(new \Exception('Not authorized'));
+		$this->samenwerkService->expects($this->never())->method('respondToSamenwerking');
+
+		$response = $this->controllerWith(content: '{"accept":true}')
+			->respondSamenwerking(samenwerkId: 'sw-1');
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame(['error' => 'Forbidden'], $response->getData());
+	}//end testRespondSamenwerkingRecordsNothingWhenTheGuardRefuses()
+
+	/**
+	 * An authorized response forwards the decision and maps the `advice` body
+	 * key onto the service's `advies` argument.
+	 *
+	 * @return void
+	 */
+	public function testRespondSamenwerkingForwardsTheDecisionAndTheAdviceBodyKey(): void {
+		$this->signIn(uid: 'alice');
+		$this->repository->method('findSamenwerkverzoek')->willReturn(['id' => 'sw-1']);
+
+		$this->samenwerkService->expects($this->once())
+			->method('respondToSamenwerking')
+			->with('sw-1', true, 'Akkoord met voorwaarden')
+			->willReturn(['id' => 'sw-1', 'status' => 'geaccepteerd']);
+
+		$response = $this->controllerWith(
+			content: '{"accept":true,"advice":"Akkoord met voorwaarden"}'
+		)->respondSamenwerking(samenwerkId: 'sw-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['id' => 'sw-1', 'status' => 'geaccepteerd'], $response->getData());
+	}//end testRespondSamenwerkingForwardsTheDecisionAndTheAdviceBodyKey()
+
+	/**
+	 * A rejection is forwarded as `accept: false` — defaulting a missing or
+	 * false `accept` to true would silently approve every samenwerkverzoek.
+	 *
+	 * @return void
+	 */
+	public function testRespondSamenwerkingForwardsARejectionAsAcceptFalse(): void {
+		$this->signIn(uid: 'alice');
+		$this->repository->method('findSamenwerkverzoek')->willReturn(['id' => 'sw-1']);
+
+		$this->samenwerkService->expects($this->once())
+			->method('respondToSamenwerking')
+			->with('sw-1', false, 'Buiten ons bevoegd gezag')
+			->willReturn(['id' => 'sw-1', 'status' => 'geweigerd']);
+
+		$response = $this->controllerWith(
+			content: '{"accept":false,"advice":"Buiten ons bevoegd gezag"}'
+		)->respondSamenwerking(samenwerkId: 'sw-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame('geweigerd', $response->getData()['status']);
+	}//end testRespondSamenwerkingForwardsARejectionAsAcceptFalse()
+}//end class

--- a/tests/Unit/Controller/EmailControllerContractTest.php
+++ b/tests/Unit/Controller/EmailControllerContractTest.php
@@ -1,0 +1,259 @@
+<?php
+
+/**
+ * EmailController Wire-Contract Tests
+ *
+ * Contract coverage (gate-25) for the three EmailController endpoints that had
+ * no automated proof of their wire behaviour.
+ *
+ * The interesting part of this controller is its error mapping. `send()` and
+ * `sendFromTemplate()` both catch `\RuntimeException` and then SPLIT on the
+ * message: the sentinel `email_send_failed` — thrown by CaseEmailService when
+ * the transport itself fails — becomes a 500 whose body is exactly that
+ * sentinel, because the underlying exception text would otherwise carry SMTP
+ * host and credential detail to the caller (M4). Every other RuntimeException
+ * is a caller-fixable validation error and becomes a 400 carrying its message.
+ * Collapsing those two arms — one 500 for everything, or one 400 for
+ * everything — is the realistic defect, and it is invisible from a happy-path
+ * test, so both arms are pinned separately here.
+ *
+ * The body-shaped contract is pinned too: the caseId comes from the ROUTE, and
+ * absent body fields are forwarded as empty strings / an empty array rather
+ * than as nulls.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\EmailController;
+use OCA\Procest\Service\CaseEmailService;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Wire-contract tests for EmailController.
+ *
+ * @covers \OCA\Procest\Controller\EmailController
+ */
+class EmailControllerContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock handed to the controller.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The case e-mail backend.
+	 *
+	 * @var CaseEmailService|MockObject
+	 */
+	private CaseEmailService $emailService;
+
+	/**
+	 * The user session.
+	 *
+	 * @var IUserSession|MockObject
+	 */
+	private IUserSession $userSession;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var EmailController
+	 */
+	private EmailController $controller;
+
+	/**
+	 * Build the controller with all collaborators mocked.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->emailService = $this->createMock(CaseEmailService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+
+		$this->controller = new EmailController(
+			appName: 'procest',
+			request: $this->request,
+			emailService: $this->emailService,
+			userSession: $this->userSession,
+		);
+	}//end setUp()
+
+	/**
+	 * Put a user in the session.
+	 *
+	 * @return void
+	 */
+	private function signIn(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('handler');
+		$this->userSession->method('getUser')->willReturn($user);
+	}//end signIn()
+
+	/**
+	 * All three endpoints refuse an anonymous caller with 401 and send nothing.
+	 *
+	 * @return void
+	 */
+	public function testAllThreeEndpointsRefuseAnAnonymousCallerWith401(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->emailService->expects($this->never())->method('sendEmail');
+		$this->emailService->expects($this->never())->method('sendFromTemplate');
+		$this->emailService->expects($this->never())->method('getTemplatesForCaseType');
+
+		$responses = [
+			'send' => $this->controller->send(caseId: 'case-1'),
+			'sendFromTemplate' => $this->controller->sendFromTemplate(caseId: 'case-1'),
+			'templates' => $this->controller->templates(caseTypeId: 'ct-1'),
+		];
+
+		foreach ($responses as $endpoint => $response) {
+			$this->assertSame(
+				Http::STATUS_UNAUTHORIZED,
+				$response->getStatus(),
+				$endpoint . ' must refuse an anonymous caller'
+			);
+			$this->assertSame(['error' => 'Not authenticated'], $response->getData());
+		}
+	}//end testAllThreeEndpointsRefuseAnAnonymousCallerWith401()
+
+	/**
+	 * send forwards the ROUTE's caseId and defaults every absent body field to
+	 * an empty string / empty attachment list, then answers the backend's
+	 * result unwrapped.
+	 *
+	 * @return void
+	 */
+	public function testSendForwardsTheRouteCaseIdAndDefaultsTheAbsentBodyFields(): void {
+		$this->signIn();
+
+		$this->emailService->expects($this->once())
+			->method('sendEmail')
+			->with('case-1', '', '', '', [])
+			->willReturn(['sent' => true, 'messageId' => 'msg-1']);
+
+		$response = $this->controller->send(caseId: 'case-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['sent' => true, 'messageId' => 'msg-1'], $response->getData());
+	}//end testSendForwardsTheRouteCaseIdAndDefaultsTheAbsentBodyFields()
+
+	/**
+	 * A transport failure answers 500 with ONLY the sentinel — never the
+	 * exception text, which carries the SMTP host and credentials.
+	 *
+	 * @return void
+	 */
+	public function testSendAnswers500WithTheSentinelAndNoTransportDetail(): void {
+		$this->signIn();
+		$this->emailService->method('sendEmail')
+			->willThrowException(new \RuntimeException('email_send_failed'));
+
+		$response = $this->controller->send(caseId: 'case-1');
+
+		$this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+		$this->assertSame(['error' => 'email_send_failed'], $response->getData());
+	}//end testSendAnswers500WithTheSentinelAndNoTransportDetail()
+
+	/**
+	 * A caller-fixable validation failure takes the OTHER arm: 400 carrying the
+	 * reason, so the UI can show it. Collapsing this into the 500 above would
+	 * make every bad address look like an outage.
+	 *
+	 * @return void
+	 */
+	public function testSendAnswers400WithTheReasonOnAValidationFailure(): void {
+		$this->signIn();
+		$this->emailService->method('sendEmail')
+			->willThrowException(new \RuntimeException('Recipient address is required'));
+
+		$response = $this->controller->send(caseId: 'case-1');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'Recipient address is required'], $response->getData());
+	}//end testSendAnswers400WithTheReasonOnAValidationFailure()
+
+	/**
+	 * sendFromTemplate reaches the TEMPLATE send path — not the free-form one —
+	 * with the route's caseId, and answers its result unwrapped.
+	 *
+	 * @return void
+	 */
+	public function testSendFromTemplateUsesTheTemplateSendPathWithTheRouteCaseId(): void {
+		$this->signIn();
+
+		$this->emailService->expects($this->once())
+			->method('sendFromTemplate')
+			->with('case-2', '', '')
+			->willReturn(['sent' => true, 'templateId' => 'tpl-1']);
+		$this->emailService->expects($this->never())->method('sendEmail');
+
+		$response = $this->controller->sendFromTemplate(caseId: 'case-2');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['sent' => true, 'templateId' => 'tpl-1'], $response->getData());
+	}//end testSendFromTemplateUsesTheTemplateSendPathWithTheRouteCaseId()
+
+	/**
+	 * sendFromTemplate maps the sentinel to 500 and a missing template to 400,
+	 * exactly like send() — the two arms are separate here as well.
+	 *
+	 * @return void
+	 */
+	public function testSendFromTemplateSplitsTransportFailuresFromValidationFailures(): void {
+		$this->signIn();
+		$this->emailService->method('sendFromTemplate')->willReturnOnConsecutiveCalls(
+			$this->throwException(new \RuntimeException('email_send_failed')),
+			$this->throwException(new \RuntimeException('Email template not found')),
+		);
+
+		$transport = $this->controller->sendFromTemplate(caseId: 'case-2');
+		$validation = $this->controller->sendFromTemplate(caseId: 'case-2');
+
+		$this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $transport->getStatus());
+		$this->assertSame(['error' => 'email_send_failed'], $transport->getData());
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $validation->getStatus());
+		$this->assertSame(['error' => 'Email template not found'], $validation->getData());
+	}//end testSendFromTemplateSplitsTransportFailuresFromValidationFailures()
+
+	/**
+	 * templates answers the caseType's template list under `results` — the key
+	 * the editor reads — for the caseType on the route.
+	 *
+	 * @return void
+	 */
+	public function testTemplatesWrapsTheCaseTypeTemplateListUnderResults(): void {
+		$this->signIn();
+		$templates = [['id' => 'tpl-1', 'name' => 'Ontvangstbevestiging']];
+
+		$this->emailService->expects($this->once())
+			->method('getTemplatesForCaseType')
+			->with('ct-9')
+			->willReturn($templates);
+
+		$response = $this->controller->templates(caseTypeId: 'ct-9');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['results' => $templates], $response->getData());
+	}//end testTemplatesWrapsTheCaseTypeTemplateListUnderResults()
+}//end class

--- a/tests/Unit/Controller/EmailTemplateControllerContractTest.php
+++ b/tests/Unit/Controller/EmailTemplateControllerContractTest.php
@@ -1,0 +1,458 @@
+<?php
+
+/**
+ * EmailTemplateController Wire-Contract Tests
+ *
+ * Contract coverage (gate-25) for the four EmailTemplateController endpoints
+ * that had no automated proof of their wire behaviour. The controller mixes
+ * three DIFFERENT authorization postures in one class, and the whole point of
+ * these tests is that a copy-paste between them is silent:
+ *
+ *  - `createTemplate()` and `saveSettings()` are INSTANCE CONFIG writes and are
+ *    admin-only — `createTemplate()` proves it by asking IGroupManager about
+ *    the SESSION's uid (asking about a uid taken from the request would be the
+ *    realistic defect), and refuses with 403 `forbidden`;
+ *  - `prefillDraft()` is a PER-CASE READ of citizen contact data and must ask
+ *    CaseAccessGuard about the caseId ON THE ROUTE before rendering anything;
+ *  - `variables()` returns a constant catalogue and needs only a session.
+ *
+ * Beyond authorization the tests pin the status codes the branches actually
+ * use — 400 on a rejected create, 409 on a draft that cannot be rendered — and
+ * the one piece of behaviour in `saveSettings()` that cannot be seen from the
+ * response body at all: the password is stored with the `sensitive` flag, and
+ * the masked placeholder `***` is treated as "unchanged" rather than written
+ * back over the real credential.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\EmailTemplateController;
+use OCA\Procest\Service\CaseAccessGuard;
+use OCA\Procest\Service\EmailTemplateService;
+use OCA\Procest\Service\SettingsService;
+use OCP\AppFramework\Http;
+use OCP\IAppConfig;
+use OCP\IGroupManager;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Wire-contract tests for EmailTemplateController.
+ *
+ * @covers \OCA\Procest\Controller\EmailTemplateController
+ */
+class EmailTemplateControllerContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock handed to the controller.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The templating backend.
+	 *
+	 * @var EmailTemplateService|MockObject
+	 */
+	private EmailTemplateService $templateService;
+
+	/**
+	 * The settings resolver (kept live for future per-type expansion).
+	 *
+	 * @var SettingsService|MockObject
+	 */
+	private SettingsService $settingsService;
+
+	/**
+	 * The app config the IMAP settings are written to.
+	 *
+	 * @var IAppConfig|MockObject
+	 */
+	private IAppConfig $appConfig;
+
+	/**
+	 * The user session.
+	 *
+	 * @var IUserSession|MockObject
+	 */
+	private IUserSession $userSession;
+
+	/**
+	 * The group manager consulted for the admin checks.
+	 *
+	 * @var IGroupManager|MockObject
+	 */
+	private IGroupManager $groupManager;
+
+	/**
+	 * The per-case authorization guard.
+	 *
+	 * @var CaseAccessGuard|MockObject
+	 */
+	private CaseAccessGuard $caseAccessGuard;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var EmailTemplateController
+	 */
+	private EmailTemplateController $controller;
+
+	/**
+	 * Build the controller with all collaborators mocked.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->templateService = $this->createMock(EmailTemplateService::class);
+		$this->settingsService = $this->createMock(SettingsService::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->caseAccessGuard = $this->createMock(CaseAccessGuard::class);
+
+		$this->controller = new EmailTemplateController(
+			request: $this->request,
+			templateService: $this->templateService,
+			settingsService: $this->settingsService,
+			appConfig: $this->appConfig,
+			userSession: $this->userSession,
+			groupManager: $this->groupManager,
+			caseAccessGuard: $this->caseAccessGuard,
+		);
+	}//end setUp()
+
+	/**
+	 * Make `getParam()` behave like the real request: return the override when
+	 * one is configured, otherwise the caller's own default.
+	 *
+	 * @param array<string, mixed> $overrides Parameter values to serve.
+	 *
+	 * @return void
+	 */
+	private function withRequestParams(array $overrides): void {
+		$this->request->method('getParam')->willReturnCallback(
+			static function (string $key, mixed $default = null) use ($overrides): mixed {
+				return ($overrides[$key] ?? $default);
+			}
+		);
+	}//end withRequestParams()
+
+	/**
+	 * Put a user in the session.
+	 *
+	 * @param string $uid The uid the session user reports.
+	 *
+	 * @return IUser|MockObject The session user.
+	 */
+	private function signIn(string $uid = 'handler'): IUser {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		$this->userSession->method('getUser')->willReturn($user);
+
+		return $user;
+	}//end signIn()
+
+	/**
+	 * Every one of the four endpoints refuses an anonymous caller with 401 and
+	 * touches neither the templating backend nor the app config.
+	 *
+	 * @return void
+	 */
+	public function testAllFourEndpointsRefuseAnAnonymousCallerWith401(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->templateService->expects($this->never())->method('createTemplate');
+		$this->templateService->expects($this->never())->method('prefillDraft');
+		$this->templateService->expects($this->never())->method('getAvailableVariables');
+		$this->appConfig->expects($this->never())->method('setValueString');
+
+		$responses = [
+			'createTemplate' => $this->controller->createTemplate(caseTypeId: 'ct-1'),
+			'prefillDraft' => $this->controller->prefillDraft(caseId: 'case-1', templateId: 'tpl-1'),
+			'saveSettings' => $this->controller->saveSettings(),
+			'variables' => $this->controller->variables(caseTypeId: 'ct-1'),
+		];
+
+		foreach ($responses as $endpoint => $response) {
+			$this->assertSame(
+				Http::STATUS_UNAUTHORIZED,
+				$response->getStatus(),
+				$endpoint . ' must refuse an anonymous caller'
+			);
+			$this->assertSame(['message' => 'unauthenticated'], $response->getData());
+		}
+	}//end testAllFourEndpointsRefuseAnAnonymousCallerWith401()
+
+	/**
+	 * createTemplate is admin-only, and the admin question is asked about the
+	 * SESSION's uid — not a uid taken from the request, which is the realistic
+	 * defect on an endpoint that already reads three request params.
+	 *
+	 * @return void
+	 */
+	public function testCreateTemplateRefusesANonAdminAndAsksAboutTheSessionUid(): void {
+		$this->signIn(uid: 'plain-user');
+		$this->groupManager->expects($this->once())
+			->method('isAdmin')
+			->with('plain-user')
+			->willReturn(false);
+		$this->templateService->expects($this->never())->method('createTemplate');
+
+		$response = $this->controller->createTemplate(caseTypeId: 'ct-1');
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame(['message' => 'forbidden'], $response->getData());
+	}//end testCreateTemplateRefusesANonAdminAndAsksAboutTheSessionUid()
+
+	/**
+	 * An admin's create reaches the backend with the caseType from the ROUTE and
+	 * the name/subject/body from the request body, and answers 200 with the
+	 * created template.
+	 *
+	 * @return void
+	 */
+	public function testCreateTemplateForwardsTheRouteCaseTypeAndTheBodyFields(): void {
+		$this->signIn(uid: 'admin');
+		$this->groupManager->method('isAdmin')->willReturn(true);
+		$this->withRequestParams(
+			[
+				'name' => 'Ontvangstbevestiging',
+				'subject' => 'Uw aanvraag',
+				'body' => 'Beste {{contactNaam}}',
+			]
+		);
+
+		$this->templateService->expects($this->once())
+			->method('createTemplate')
+			->with(
+				'ct-42',
+				[
+					'name' => 'Ontvangstbevestiging',
+					'subject' => 'Uw aanvraag',
+					'body' => 'Beste {{contactNaam}}',
+				]
+			)
+			->willReturn(['id' => 'tpl-9', 'version' => 1]);
+
+		$response = $this->controller->createTemplate(caseTypeId: 'ct-42');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['id' => 'tpl-9', 'version' => 1], $response->getData());
+	}//end testCreateTemplateForwardsTheRouteCaseTypeAndTheBodyFields()
+
+	/**
+	 * A rejected create answers 400 carrying the backend's reason — not a 500
+	 * and not a silent success.
+	 *
+	 * @return void
+	 */
+	public function testCreateTemplateAnswers400WhenTheBackendRejectsThePayload(): void {
+		$this->signIn(uid: 'admin');
+		$this->groupManager->method('isAdmin')->willReturn(true);
+		$this->withRequestParams([]);
+		$this->templateService->method('createTemplate')
+			->willThrowException(new \RuntimeException('Template name is required'));
+
+		$response = $this->controller->createTemplate(caseTypeId: 'ct-1');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['message' => 'Template name is required'], $response->getData());
+	}//end testCreateTemplateAnswers400WhenTheBackendRejectsThePayload()
+
+	/**
+	 * prefillDraft renders citizen contact data into the response, so it must
+	 * clear the per-case read guard FOR THE CASE ON THE ROUTE first — and must
+	 * not render anything when the guard refuses.
+	 *
+	 * @return void
+	 */
+	public function testPrefillDraftRefusesWhenTheCaseGuardDeniesTheRouteCase(): void {
+		$user = $this->signIn(uid: 'handler');
+
+		$this->caseAccessGuard->expects($this->once())
+			->method('hasCaseReadAccess')
+			->with('case-77', $user)
+			->willReturn(false);
+		$this->templateService->expects($this->never())->method('prefillDraft');
+
+		$response = $this->controller->prefillDraft(caseId: 'case-77', templateId: 'tpl-1');
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame(['message' => 'forbidden'], $response->getData());
+	}//end testPrefillDraftRefusesWhenTheCaseGuardDeniesTheRouteCase()
+
+	/**
+	 * A cleared caller gets the rendered draft, with case and template ids
+	 * forwarded in that order (transposing them is the realistic defect on a
+	 * two-id route).
+	 *
+	 * @return void
+	 */
+	public function testPrefillDraftReturnsTheRenderedDraftForAClearedCaller(): void {
+		$this->signIn(uid: 'handler');
+		$this->caseAccessGuard->method('hasCaseReadAccess')->willReturn(true);
+
+		$this->templateService->expects($this->once())
+			->method('prefillDraft')
+			->with('case-77', 'tpl-1')
+			->willReturn(['subject' => 'Uw aanvraag', 'to' => 'burger@example.test']);
+
+		$response = $this->controller->prefillDraft(caseId: 'case-77', templateId: 'tpl-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['subject' => 'Uw aanvraag', 'to' => 'burger@example.test'], $response->getData());
+	}//end testPrefillDraftReturnsTheRenderedDraftForAClearedCaller()
+
+	/**
+	 * A draft that cannot be rendered answers 409 Conflict — a distinct code
+	 * from the 403 above, so a client can tell "not allowed" from "template and
+	 * case do not go together".
+	 *
+	 * @return void
+	 */
+	public function testPrefillDraftAnswers409WhenTheDraftCannotBeRendered(): void {
+		$this->signIn(uid: 'handler');
+		$this->caseAccessGuard->method('hasCaseReadAccess')->willReturn(true);
+		$this->templateService->method('prefillDraft')
+			->willThrowException(new \RuntimeException('Template not found'));
+
+		$response = $this->controller->prefillDraft(caseId: 'case-77', templateId: 'tpl-x');
+
+		$this->assertSame(Http::STATUS_CONFLICT, $response->getStatus());
+		$this->assertSame(['message' => 'Template not found'], $response->getData());
+	}//end testPrefillDraftAnswers409WhenTheDraftCannotBeRendered()
+
+	/**
+	 * saveSettings writes only the keys actually supplied, stores the shared
+	 * mailbox password with the `sensitive` flag, and leaves every absent key
+	 * alone. The sensitive flag is invisible in the response, so this is the
+	 * only place it can be pinned.
+	 *
+	 * @return void
+	 */
+	public function testSaveSettingsWritesSuppliedKeysAndFlagsThePasswordSensitive(): void {
+		$this->signIn(uid: 'admin');
+		$this->withRequestParams(
+			[
+				'email_imap_host' => 'imap.gemeente.test',
+				'email_imap_password' => 'hunter2',
+			]
+		);
+
+		$written = [];
+		$this->appConfig->expects($this->exactly(2))
+			->method('setValueString')
+			->willReturnCallback(
+				static function (
+					string $app,
+					string $key,
+					string $value,
+					bool $lazy = false,
+					bool $sensitive = false,
+				) use (&$written): bool {
+					$written[$key] = ['app' => $app, 'value' => $value, 'sensitive' => $sensitive];
+					return true;
+				}
+			);
+
+		$response = $this->controller->saveSettings();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['saved' => true], $response->getData());
+		$this->assertSame(
+			['app' => 'procest', 'value' => 'imap.gemeente.test', 'sensitive' => false],
+			$written['email_imap_host']
+		);
+		$this->assertSame(
+			['app' => 'procest', 'value' => 'hunter2', 'sensitive' => true],
+			$written['email_imap_password'],
+			'the shared-mailbox password must be stored with the sensitive flag'
+		);
+	}//end testSaveSettingsWritesSuppliedKeysAndFlagsThePasswordSensitive()
+
+	/**
+	 * The masked placeholder `***` that getSettings() hands the UI means
+	 * "unchanged": posting it back must NOT overwrite the stored credential
+	 * with three asterisks while the other edited fields still land.
+	 *
+	 * @return void
+	 */
+	public function testSaveSettingsTreatsTheMaskedPasswordAsUnchanged(): void {
+		$this->signIn(uid: 'admin');
+		$this->withRequestParams(
+			[
+				'email_imap_password' => '***',
+				'email_imap_folder' => 'INBOX/Zaken',
+			]
+		);
+
+		$written = [];
+		$this->appConfig->method('setValueString')->willReturnCallback(
+			static function (
+				string $app,
+				string $key,
+				string $value,
+				bool $lazy = false,
+				bool $sensitive = false,
+			) use (&$written): bool {
+				$written[$key] = $value;
+				return true;
+			}
+		);
+
+		$response = $this->controller->saveSettings();
+
+		$this->assertSame(['saved' => true], $response->getData());
+		$this->assertArrayNotHasKey(
+			'email_imap_password',
+			$written,
+			'posting the masked placeholder back must not overwrite the stored password'
+		);
+		$this->assertSame(['email_imap_folder' => 'INBOX/Zaken'], $written);
+	}//end testSaveSettingsTreatsTheMaskedPasswordAsUnchanged()
+
+	/**
+	 * variables answers the backend's catalogue verbatim for the caseType on
+	 * the route, unwrapped — the template editor reads the groups straight off
+	 * the response root, so an accidental `['results' => ...]` wrapper here
+	 * would empty the placeholder picker.
+	 *
+	 * @return void
+	 */
+	public function testVariablesReturnsTheCatalogueUnwrappedForTheRouteCaseType(): void {
+		$this->signIn(uid: 'handler');
+		$catalogue = [
+			'case' => ['zaakNummer', 'titel'],
+			'contact' => ['contactNaam'],
+			'caseType' => ['naam'],
+		];
+
+		$this->templateService->expects($this->once())
+			->method('getAvailableVariables')
+			->with('ct-42')
+			->willReturn($catalogue);
+
+		$response = $this->controller->variables(caseTypeId: 'ct-42');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($catalogue, $response->getData());
+	}//end testVariablesReturnsTheCatalogueUnwrappedForTheRouteCaseType()
+}//end class

--- a/tests/Unit/Controller/KccContactControllerContractTest.php
+++ b/tests/Unit/Controller/KccContactControllerContractTest.php
@@ -1,0 +1,308 @@
+<?php
+
+/**
+ * KccContactController Wire-Contract Tests
+ *
+ * Contract coverage (gate-25) for the three callback endpoints on
+ * KccContactController that had no automated proof of their wire behaviour.
+ *
+ * This controller performs NO per-object authorization itself. It resolves two
+ * values and hands them to the service, which does the scoping:
+ *
+ *  - `agentId` — the SESSION's uid. Reading it from the request instead would
+ *    let any agent act as, and list, another agent's callbacks;
+ *  - `isPrivileged` — the answer IGroupManager gives about THAT uid. Passing a
+ *    hardcoded `true`, or omitting the argument so the service's own default
+ *    applies, is the realistic defect: it would silently widen every listing
+ *    from "my callbacks" to "the whole KCC queue" and let any agent cancel any
+ *    callback. Both the false and the true case are pinned.
+ *
+ * The status codes are pinned too, because the controller deliberately maps the
+ * SAME exception type to different codes per route: a rejected schedule or list
+ * filter is a 400, while a callback the caller may not touch is a 404 — the KCC
+ * service refuses ownership violations by treating them as absent, so a 403
+ * here would leak the existence of another agent's callback.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\KccContactController;
+use OCA\Procest\Service\Kcc\CallbackService;
+use OCA\Procest\Service\Kcc\ContactMomentService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\OCS\OCSBadRequestException;
+use OCP\IGroupManager;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Wire-contract tests for the KccContactController callback endpoints.
+ *
+ * @covers \OCA\Procest\Controller\KccContactController
+ */
+class KccContactControllerContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock handed to the controller.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The contact-moment service (untouched by the callback routes).
+	 *
+	 * @var ContactMomentService|MockObject
+	 */
+	private ContactMomentService $contactMomentService;
+
+	/**
+	 * The callback service.
+	 *
+	 * @var CallbackService|MockObject
+	 */
+	private CallbackService $callbackService;
+
+	/**
+	 * The user session.
+	 *
+	 * @var IUserSession|MockObject
+	 */
+	private IUserSession $userSession;
+
+	/**
+	 * The group manager consulted for the privileged (cross-agent) flag.
+	 *
+	 * @var IGroupManager|MockObject
+	 */
+	private IGroupManager $groupManager;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var KccContactController
+	 */
+	private KccContactController $controller;
+
+	/**
+	 * Build the controller with all collaborators mocked.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->contactMomentService = $this->createMock(ContactMomentService::class);
+		$this->callbackService = $this->createMock(CallbackService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+
+		$this->controller = new KccContactController(
+			request: $this->request,
+			contactMomentService: $this->contactMomentService,
+			callbackService: $this->callbackService,
+			userSession: $this->userSession,
+			groupManager: $this->groupManager,
+		);
+	}//end setUp()
+
+	/**
+	 * Put an agent in the session.
+	 *
+	 * @param string $uid The uid the session user reports.
+	 * @param bool $isAdmin Whether the group manager considers them privileged.
+	 *
+	 * @return void
+	 */
+	private function signIn(string $uid = 'agent-a', bool $isAdmin = false): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		$this->userSession->method('getUser')->willReturn($user);
+		$this->groupManager->method('isAdmin')->with($uid)->willReturn($isAdmin);
+	}//end signIn()
+
+	/**
+	 * Make `getParam()` behave like the real request.
+	 *
+	 * @param array<string, mixed> $overrides Parameter values to serve.
+	 *
+	 * @return void
+	 */
+	private function withRequestParams(array $overrides): void {
+		$this->request->method('getParam')->willReturnCallback(
+			static function (string $key, mixed $default = null) use ($overrides): mixed {
+				return ($overrides[$key] ?? $default);
+			}
+		);
+	}//end withRequestParams()
+
+	/**
+	 * All three callback endpoints refuse an anonymous caller with 401 and
+	 * reach the callback service for nothing.
+	 *
+	 * @return void
+	 */
+	public function testAllThreeCallbackEndpointsRefuseAnAnonymousCallerWith401(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->callbackService->expects($this->never())->method('schedule');
+		$this->callbackService->expects($this->never())->method('list');
+		$this->callbackService->expects($this->never())->method('cancel');
+
+		$responses = [
+			'scheduleCallback' => $this->controller->scheduleCallback(),
+			'indexCallbacks' => $this->controller->indexCallbacks(),
+			'cancelCallback' => $this->controller->cancelCallback(id: 'cb-1'),
+		];
+
+		foreach ($responses as $endpoint => $response) {
+			$this->assertSame(
+				Http::STATUS_UNAUTHORIZED,
+				$response->getStatus(),
+				$endpoint . ' must refuse an anonymous caller'
+			);
+			$this->assertSame(['error' => 'Authenticatie vereist'], $response->getData());
+		}
+	}//end testAllThreeCallbackEndpointsRefuseAnAnonymousCallerWith401()
+
+	/**
+	 * A scheduled callback is attributed to the SESSION's agent and answers 201
+	 * Created. The routing params are stripped from the payload so a caller
+	 * cannot smuggle `id` in and overwrite an existing record.
+	 *
+	 * @return void
+	 */
+	public function testScheduleCallbackAttributesTheCallbackToTheSessionAgentAndAnswers201(): void {
+		$this->signIn(uid: 'agent-a');
+		$this->request->method('getParams')->willReturn(
+			[
+				'id' => 'cb-smuggled',
+				'_route' => 'procest.kcccontact.scheduleCallback',
+				'telefoonnummer' => '0612345678',
+			]
+		);
+
+		$this->callbackService->expects($this->once())
+			->method('schedule')
+			->with(['telefoonnummer' => '0612345678'], 'agent-a')
+			->willReturn(['id' => 'cb-9', 'status' => 'open']);
+
+		$response = $this->controller->scheduleCallback();
+
+		$this->assertSame(Http::STATUS_CREATED, $response->getStatus());
+		$this->assertSame(['id' => 'cb-9', 'status' => 'open'], $response->getData());
+	}//end testScheduleCallbackAttributesTheCallbackToTheSessionAgentAndAnswers201()
+
+	/**
+	 * A rejected schedule answers 400 carrying the service's reason.
+	 *
+	 * @return void
+	 */
+	public function testScheduleCallbackAnswers400WhenTheServiceRejectsThePayload(): void {
+		$this->signIn(uid: 'agent-a');
+		$this->request->method('getParams')->willReturn([]);
+		$this->callbackService->method('schedule')
+			->willThrowException(new OCSBadRequestException('telefoonnummer is verplicht'));
+
+		$response = $this->controller->scheduleCallback();
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'telefoonnummer is verplicht'], $response->getData());
+	}//end testScheduleCallbackAnswers400WhenTheServiceRejectsThePayload()
+
+	/**
+	 * An ordinary agent's listing is scoped: `isPrivileged` is FALSE, so the
+	 * service narrows the query to that agent's own callbacks.
+	 *
+	 * @return void
+	 */
+	public function testIndexCallbacksScopesAnOrdinaryAgentToTheirOwnQueue(): void {
+		$this->signIn(uid: 'agent-a', isAdmin: false);
+		$this->withRequestParams(['status' => 'open']);
+
+		$this->callbackService->expects($this->once())
+			->method('list')
+			->with(['status' => 'open'], 'agent-a', false)
+			->willReturn([['id' => 'cb-1']]);
+
+		$response = $this->controller->indexCallbacks();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['results' => [['id' => 'cb-1']]], $response->getData());
+	}//end testIndexCallbacksScopesAnOrdinaryAgentToTheirOwnQueue()
+
+	/**
+	 * A team-lead / admin listing passes `isPrivileged` TRUE — the cross-agent
+	 * view — proving the flag tracks the group manager's answer rather than
+	 * being pinned at one value.
+	 *
+	 * @return void
+	 */
+	public function testIndexCallbacksGivesAPrivilegedAgentTheCrossAgentView(): void {
+		$this->signIn(uid: 'teamlead', isAdmin: true);
+		$this->withRequestParams([]);
+
+		$this->callbackService->expects($this->once())
+			->method('list')
+			->with(['status' => ''], 'teamlead', true)
+			->willReturn([]);
+
+		$response = $this->controller->indexCallbacks();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['results' => []], $response->getData());
+	}//end testIndexCallbacksGivesAPrivilegedAgentTheCrossAgentView()
+
+	/**
+	 * Cancelling passes the route id together with the session agent and the
+	 * UNPRIVILEGED flag, so the service can refuse a callback that is not the
+	 * caller's own.
+	 *
+	 * @return void
+	 */
+	public function testCancelCallbackPassesTheSessionAgentAndTheUnprivilegedFlag(): void {
+		$this->signIn(uid: 'agent-a', isAdmin: false);
+
+		$this->callbackService->expects($this->once())
+			->method('cancel')
+			->with('cb-1', 'agent-a', false)
+			->willReturn(['id' => 'cb-1', 'status' => 'cancelled']);
+
+		$response = $this->controller->cancelCallback(id: 'cb-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['id' => 'cb-1', 'status' => 'cancelled'], $response->getData());
+	}//end testCancelCallbackPassesTheSessionAgentAndTheUnprivilegedFlag()
+
+	/**
+	 * A callback the agent may not touch comes back as 404, not 400 and not
+	 * 403: the ownership refusal must be indistinguishable from "no such
+	 * callback", or the route becomes an existence oracle over the KCC queue.
+	 *
+	 * @return void
+	 */
+	public function testCancelCallbackAnswers404WhenTheCallbackIsNotTheAgentsOwn(): void {
+		$this->signIn(uid: 'agent-a', isAdmin: false);
+		$this->callbackService->method('cancel')
+			->willThrowException(new OCSBadRequestException('Callback niet gevonden'));
+
+		$response = $this->controller->cancelCallback(id: 'cb-of-another-agent');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertSame(['error' => 'Callback niet gevonden'], $response->getData());
+	}//end testCancelCallbackAnswers404WhenTheCallbackIsNotTheAgentsOwn()
+}//end class

--- a/tests/Unit/Controller/KccContactRelatedContractTest.php
+++ b/tests/Unit/Controller/KccContactRelatedContractTest.php
@@ -1,0 +1,242 @@
+<?php
+
+/**
+ * KccContactController::related() Wire-Contract Tests
+ *
+ * Contract coverage (gate-25) for the one KCC endpoint left without executed
+ * proof of its wire behaviour: `related()`, which lists the OTHER contact
+ * moments recorded for the same customer as a given contact moment. It is
+ * `@NoAdminRequired`, so any authenticated user reaches it, and the IDOR
+ * protection lives entirely in the two arguments the controller computes and
+ * hands the service. Those arguments are what these tests pin:
+ *
+ *  - an anonymous caller is refused 401 and the service is never entered;
+ *  - the `agentId` passed is the SESSION user's uid — the scoping key the
+ *    service uses to decide which contact moments the caller may see. A
+ *    hard-coded or request-supplied agentId here would hand any caller anybody
+ *    else's customer history;
+ *  - `isPrivileged` is derived from the group manager for THAT uid, and is
+ *    false for an ordinary agent and true for an admin/team-lead. `related()`
+ *    fans out from ONE record to a whole customer history, so a privileged flag
+ *    that defaulted to true would widen the blast radius further than any other
+ *    endpoint on this controller;
+ *  - a rejected id is answered 404, not 400 — the read endpoints on this
+ *    controller map the service's rejection to "not found" precisely so a
+ *    caller cannot tell "this id is not yours" apart from "this id does not
+ *    exist"; a 400 here would restore that oracle.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\KccContactController;
+use OCA\Procest\Service\Kcc\CallbackService;
+use OCA\Procest\Service\Kcc\ContactMomentService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\OCS\OCSBadRequestException;
+use OCP\IGroupManager;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Wire-contract tests for KccContactController::related().
+ *
+ * @covers \OCA\Procest\Controller\KccContactController
+ */
+class KccContactRelatedContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock handed to the controller.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The contact-moment service mock.
+	 *
+	 * @var ContactMomentService|MockObject
+	 */
+	private ContactMomentService $contactMomentService;
+
+	/**
+	 * The callback service mock (unused by `related()`, required to construct).
+	 *
+	 * @var CallbackService|MockObject
+	 */
+	private CallbackService $callbackService;
+
+	/**
+	 * The user session mock — source of the scoping `agentId`.
+	 *
+	 * @var IUserSession|MockObject
+	 */
+	private IUserSession $userSession;
+
+	/**
+	 * The group manager mock — source of the `isPrivileged` flag.
+	 *
+	 * @var IGroupManager|MockObject
+	 */
+	private IGroupManager $groupManager;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var KccContactController
+	 */
+	private KccContactController $controller;
+
+	/**
+	 * Build the controller with all collaborators mocked.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->contactMomentService = $this->createMock(ContactMomentService::class);
+		$this->callbackService = $this->createMock(CallbackService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+
+		$this->controller = new KccContactController(
+			request: $this->request,
+			contactMomentService: $this->contactMomentService,
+			callbackService: $this->callbackService,
+			userSession: $this->userSession,
+			groupManager: $this->groupManager,
+		);
+	}//end setUp()
+
+	/**
+	 * Put an authenticated agent in the session.
+	 *
+	 * @param string $uid The user id the session reports.
+	 *
+	 * @return void
+	 */
+	private function signIn(string $uid): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		$this->userSession->method('getUser')->willReturn($user);
+	}//end signIn()
+
+	/**
+	 * Record the arguments `related()` hands the service and answer with a list.
+	 *
+	 * @param array<int, array<string, mixed>> $results The related moments to return.
+	 * @param array<string, mixed>|null $seen Captured call arguments (by reference).
+	 *
+	 * @return void
+	 */
+	private function captureRelatedCall(array $results, ?array &$seen): void {
+		$this->contactMomentService->expects($this->once())
+			->method('related')
+			->willReturnCallback(
+				static function (
+					string $id,
+					string $agentId,
+					bool $isPrivileged = false,
+				) use (&$seen, $results): array {
+					$seen = ['id' => $id, 'agentId' => $agentId, 'isPrivileged' => $isPrivileged];
+					return $results;
+				}
+			);
+	}//end captureRelatedCall()
+
+	/**
+	 * An anonymous caller is refused 401 and the customer history is never read.
+	 *
+	 * @return void
+	 */
+	public function testRelatedRefusesAnAnonymousCallerWithoutReadingAnyHistory(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->contactMomentService->expects($this->never())->method('related');
+
+		$response = $this->controller->related(id: 'moment-1');
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame(['error' => 'Authenticatie vereist'], $response->getData());
+	}//end testRelatedRefusesAnAnonymousCallerWithoutReadingAnyHistory()
+
+	/**
+	 * An ordinary agent's request is scoped to their own uid with the privileged
+	 * flag OFF, and the related moments come back under `results`.
+	 *
+	 * @return void
+	 */
+	public function testRelatedScopesAnOrdinaryAgentToTheirOwnUidWithoutPrivilege(): void {
+		$this->signIn(uid: 'agent-1');
+		$this->groupManager->expects($this->once())
+			->method('isAdmin')
+			->with('agent-1')
+			->willReturn(false);
+
+		$seen = null;
+		$this->captureRelatedCall(results: [['id' => 'moment-2']], seen: $seen);
+
+		$response = $this->controller->related(id: 'moment-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['results' => [['id' => 'moment-2']]], $response->getData());
+		$this->assertSame(
+			['id' => 'moment-1', 'agentId' => 'agent-1', 'isPrivileged' => false],
+			$seen
+		);
+	}//end testRelatedScopesAnOrdinaryAgentToTheirOwnUidWithoutPrivilege()
+
+	/**
+	 * A team-lead / admin gets the cross-agent view — the privileged flag is
+	 * derived from the group manager, not from anything the caller sent.
+	 *
+	 * @return void
+	 */
+	public function testRelatedGivesAPrivilegedAgentTheCrossAgentView(): void {
+		$this->signIn(uid: 'teamlead-1');
+		$this->groupManager->method('isAdmin')->with('teamlead-1')->willReturn(true);
+
+		$seen = null;
+		$this->captureRelatedCall(results: [], seen: $seen);
+
+		$response = $this->controller->related(id: 'moment-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(
+			['id' => 'moment-1', 'agentId' => 'teamlead-1', 'isPrivileged' => true],
+			$seen
+		);
+	}//end testRelatedGivesAPrivilegedAgentTheCrossAgentView()
+
+	/**
+	 * A moment the agent may not see is answered 404, NOT 400 — so "not yours"
+	 * and "does not exist" are indistinguishable to the caller.
+	 *
+	 * @return void
+	 */
+	public function testRelatedAnswers404WhenTheMomentIsNotTheAgentsOwn(): void {
+		$this->signIn(uid: 'agent-1');
+		$this->groupManager->method('isAdmin')->willReturn(false);
+		$this->contactMomentService->method('related')
+			->willThrowException(new OCSBadRequestException('Contactmoment niet gevonden'));
+
+		$response = $this->controller->related(id: 'someone-elses-moment');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertSame(['error' => 'Contactmoment niet gevonden'], $response->getData());
+	}//end testRelatedAnswers404WhenTheMomentIsNotTheAgentsOwn()
+}//end class

--- a/tests/Unit/Controller/LhsControllerContractTest.php
+++ b/tests/Unit/Controller/LhsControllerContractTest.php
@@ -1,0 +1,555 @@
+<?php
+
+/**
+ * LhsController Wire-Contract Tests
+ *
+ * Contract coverage for the two LHS (Landelijke Handhavingsstrategie) engine
+ * actions (gate-25). Both are `@NoAdminRequired` and both write an enforcement
+ * record: `recommend` PERSISTS an `lhsRecommendation` — a sanction proposal
+ * against a named case — and `override` rewrites one.
+ *
+ * The contract pinned here:
+ *
+ *  - no session answers 401 and the engine is never entered;
+ *  - `recommend` reads the English wire keys `severity` / `behaviour` (the
+ *    Dutch words survive only in the error text), and refuses an incomplete
+ *    quadruple with 400 before touching the case guard;
+ *  - `recommend` is guarded as a MUTATION on the named case even though it
+ *    reads like a query — it persists a sanction record, so a read guard here
+ *    would be wrong;
+ *  - a blank `inspection` is normalised to null rather than persisted as an
+ *    empty relation, and `lhsVersion` is coerced to an int;
+ *  - the engine's own refusals map to 422, an unexpected failure to a masked
+ *    500 — two different meanings that must not collapse into one;
+ *  - and the one that matters most on `override`: the caller's DECLARED
+ *    `userRole` is only honoured when the Nextcloud admin check agrees. A
+ *    client that simply posts `userRole=manager` must still be treated as an
+ *    inspector, otherwise anyone can escalate an enforcement measure
+ *    (`Verzwaring vereist managerrol` → 403).
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\LhsController;
+use OCA\Procest\Service\CaseAccessGuard;
+use OCA\Procest\Service\LhsLookupService;
+use OCA\Procest\Service\Vth\LhsRecommendationService;
+use OCP\AppFramework\Http;
+use OCP\IGroupManager;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Wire-contract tests for LhsController.
+ *
+ * @covers \OCA\Procest\Controller\LhsController
+ */
+class LhsControllerContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The LHS engine mock.
+	 *
+	 * @var LhsRecommendationService|MockObject
+	 */
+	private LhsRecommendationService $lhsService;
+
+	/**
+	 * The LHS lookup service mock.
+	 *
+	 * @var LhsLookupService|MockObject
+	 */
+	private LhsLookupService $lhsLookupService;
+
+	/**
+	 * The IUserSession mock.
+	 *
+	 * @var IUserSession|MockObject
+	 */
+	private IUserSession $userSession;
+
+	/**
+	 * The IGroupManager mock (manager-role detection).
+	 *
+	 * @var IGroupManager|MockObject
+	 */
+	private IGroupManager $groupManager;
+
+	/**
+	 * The LoggerInterface mock.
+	 *
+	 * @var LoggerInterface|MockObject
+	 */
+	private LoggerInterface $logger;
+
+	/**
+	 * The per-case authorization guard mock.
+	 *
+	 * @var CaseAccessGuard|MockObject
+	 */
+	private CaseAccessGuard $caseAccessGuard;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var LhsController
+	 */
+	private LhsController $controller;
+
+	/**
+	 * Build the controller with all collaborators mocked.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->lhsService = $this->createMock(LhsRecommendationService::class);
+		$this->lhsLookupService = $this->createMock(LhsLookupService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->caseAccessGuard = $this->createMock(CaseAccessGuard::class);
+
+		$this->controller = new LhsController(
+			appName: 'procest',
+			request: $this->request,
+			lhsService: $this->lhsService,
+			lhsLookupService: $this->lhsLookupService,
+			userSession: $this->userSession,
+			groupManager: $this->groupManager,
+			logger: $this->logger,
+			caseAccessGuard: $this->caseAccessGuard,
+		);
+	}//end setUp()
+
+	/**
+	 * Put a signed-in user on the session.
+	 *
+	 * @param string $uid The UID of the signed-in user.
+	 *
+	 * @return IUser|MockObject The user placed on the session.
+	 */
+	private function signIn(string $uid = 'inspector1'): IUser {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		$this->userSession->method('getUser')->willReturn($user);
+
+		return $user;
+	}//end signIn()
+
+	/**
+	 * Answer request parameters from the supplied map.
+	 *
+	 * @param array<string, mixed> $params The parameter map.
+	 *
+	 * @return void
+	 */
+	private function withParams(array $params): void {
+		$this->request->method('getParam')->willReturnCallback(
+			static function (string $key, mixed $default = null) use ($params): mixed {
+				return ($params[$key] ?? $default);
+			}
+		);
+	}//end withParams()
+
+	/**
+	 * A complete, valid recommend payload.
+	 *
+	 * @return array<string, mixed> The parameter map.
+	 */
+	private function validRecommendPayload(): array {
+		return [
+			'caseId' => 'zaak-1',
+			'severity' => 'aanzienlijk',
+			'behaviour' => 'onverschillig',
+			'actorType' => 'bedrijf',
+		];
+	}//end validRecommendPayload()
+
+	/**
+	 * `recommend` refuses an anonymous caller with 401 and persists nothing.
+	 *
+	 * @return void
+	 */
+	public function testRecommendRefusesAnUnauthenticatedCallerWith401(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->lhsService->expects($this->never())->method('recommend');
+
+		$response = $this->controller->recommend();
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame(['error' => 'Authenticatie vereist'], $response->getData());
+	}//end testRecommendRefusesAnUnauthenticatedCallerWith401()
+
+	/**
+	 * An incomplete quadruple is a 400, checked before the case guard — a guard
+	 * asked about an empty caseId cannot decide anything.
+	 *
+	 * @return void
+	 */
+	public function testRecommendRejectsAnIncompleteQuadrupleWith400BeforeGuarding(): void {
+		$this->signIn();
+		$this->withParams(['caseId' => 'zaak-1', 'severity' => 'aanzienlijk']);
+		$this->caseAccessGuard->expects($this->never())->method('hasCaseMutationAccess');
+		$this->lhsService->expects($this->never())->method('recommend');
+
+		$response = $this->controller->recommend();
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(
+			['error' => 'caseId, ernst, gedrag en actorType zijn verplicht'],
+			$response->getData()
+		);
+	}//end testRecommendRejectsAnIncompleteQuadrupleWith400BeforeGuarding()
+
+	/**
+	 * The wire keys are the ENGLISH `severity` / `behaviour`. A payload using
+	 * only the Dutch words from the error message is incomplete and answers 400
+	 * — this pins which key names a client must actually send.
+	 *
+	 * @return void
+	 */
+	public function testRecommendReadsTheEnglishSeverityAndBehaviourWireKeys(): void {
+		$this->signIn();
+		$this->withParams([
+			'caseId' => 'zaak-1',
+			'ernst' => 'aanzienlijk',
+			'gedrag' => 'onverschillig',
+			'actorType' => 'bedrijf',
+		]);
+		$this->lhsService->expects($this->never())->method('recommend');
+
+		$response = $this->controller->recommend();
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+	}//end testRecommendReadsTheEnglishSeverityAndBehaviourWireKeys()
+
+	/**
+	 * `recommend` is guarded as a MUTATION on the named case: it persists an
+	 * enforcement-sanction record, so a caller without mutation access is
+	 * refused 403 and the engine never runs.
+	 *
+	 * @return void
+	 */
+	public function testRecommendDemandsCaseMutationAccessAndRefusesWith403(): void {
+		$user = $this->signIn(uid: 'mallory');
+		$this->withParams($this->validRecommendPayload());
+
+		$this->caseAccessGuard->expects($this->once())
+			->method('hasCaseMutationAccess')
+			->with('zaak-1', $user)
+			->willReturn(false);
+		$this->caseAccessGuard->expects($this->never())->method('hasCaseReadAccess');
+		$this->lhsService->expects($this->never())->method('recommend');
+
+		$response = $this->controller->recommend();
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame(['error' => 'Not authorized'], $response->getData());
+	}//end testRecommendDemandsCaseMutationAccessAndRefusesWith403()
+
+	/**
+	 * An authorized recommend forwards the quadruple, coerces `lhsVersion` to an
+	 * int and normalises a blank `inspection` to null rather than persisting an
+	 * empty relation.
+	 *
+	 * @return void
+	 */
+	public function testRecommendForwardsTheQuadrupleAndNormalisesOptionalArguments(): void {
+		$this->signIn();
+		$this->withParams(
+			array_merge(
+				$this->validRecommendPayload(),
+				['lhsVersion' => '3', 'inspection' => '']
+			)
+		);
+		$this->caseAccessGuard->method('hasCaseMutationAccess')->willReturn(true);
+
+		$captured = [];
+		$this->lhsService->expects($this->once())
+			->method('recommend')
+			->willReturnCallback(
+				static function (
+					string $caseId,
+					string $severity,
+					string $behaviour,
+					string $actorType,
+					?int $lhsVersion = null,
+					?string $inspection = null,
+				) use (&$captured): array {
+					$captured = [
+						'caseId' => $caseId,
+						'severity' => $severity,
+						'behaviour' => $behaviour,
+						'actorType' => $actorType,
+						'lhsVersion' => $lhsVersion,
+						'inspection' => $inspection,
+					];
+
+					return ['id' => 'rec-1', 'intervention' => 'waarschuwing'];
+				}
+			);
+
+		$response = $this->controller->recommend();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['id' => 'rec-1', 'intervention' => 'waarschuwing'], $response->getData());
+		$this->assertSame('zaak-1', $captured['caseId']);
+		$this->assertSame('aanzienlijk', $captured['severity']);
+		$this->assertSame('onverschillig', $captured['behaviour']);
+		$this->assertSame(3, $captured['lhsVersion'], 'lhsVersion must reach the engine as an int');
+		$this->assertNull($captured['inspection'], 'a blank inspection must not be persisted as a relation');
+	}//end testRecommendForwardsTheQuadrupleAndNormalisesOptionalArguments()
+
+	/**
+	 * An engine refusal (e.g. no matrix cell for the quadruple) is a 422 — the
+	 * request was well-formed but cannot be satisfied.
+	 *
+	 * @return void
+	 */
+	public function testRecommendReportsAnEngineRefusalAs422(): void {
+		$this->signIn();
+		$this->withParams($this->validRecommendPayload());
+		$this->caseAccessGuard->method('hasCaseMutationAccess')->willReturn(true);
+		$this->lhsService->method('recommend')
+			->willThrowException(new \RuntimeException('Geen matrixcel voor deze combinatie'));
+
+		$response = $this->controller->recommend();
+
+		$this->assertSame(Http::STATUS_UNPROCESSABLE_ENTITY, $response->getStatus());
+		$this->assertSame(['error' => 'Geen matrixcel voor deze combinatie'], $response->getData());
+	}//end testRecommendReportsAnEngineRefusalAs422()
+
+	/**
+	 * An unexpected failure is logged and masked as a 500 — distinct from the
+	 * 422 above, and without leaking the internal message.
+	 *
+	 * @return void
+	 */
+	public function testRecommendMasksAnUnexpectedFailureAs500AndLogsIt(): void {
+		$this->signIn();
+		$this->withParams($this->validRecommendPayload());
+		$this->caseAccessGuard->method('hasCaseMutationAccess')->willReturn(true);
+		$this->lhsService->method('recommend')
+			->willThrowException(new \LogicException('null pointer in matrix loader'));
+		$this->logger->expects($this->once())->method('error');
+
+		$response = $this->controller->recommend();
+
+		$this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+		$this->assertSame(['error' => 'LHS-aanbeveling mislukt'], $response->getData());
+	}//end testRecommendMasksAnUnexpectedFailureAs500AndLogsIt()
+
+	/**
+	 * `override` refuses an anonymous caller with 401.
+	 *
+	 * @return void
+	 */
+	public function testOverrideRefusesAnUnauthenticatedCallerWith401(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->lhsService->expects($this->never())->method('override');
+
+		$response = $this->controller->override();
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame(['error' => 'Authenticatie vereist'], $response->getData());
+	}//end testOverrideRefusesAnUnauthenticatedCallerWith401()
+
+	/**
+	 * An override without a justification is a 400 — an unmotivated deviation
+	 * from the national strategy is exactly what the field exists to prevent.
+	 *
+	 * @return void
+	 */
+	public function testOverrideRejectsAMissingJustificationWith400(): void {
+		$this->signIn();
+		$this->withParams([
+			'recommendation' => ['id' => 'rec-1'],
+			'intervention' => 'last onder dwangsom',
+		]);
+		$this->lhsService->expects($this->never())->method('override');
+
+		$response = $this->controller->override();
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(
+			['error' => 'recommendation, intervention en justification zijn verplicht'],
+			$response->getData()
+		);
+	}//end testOverrideRejectsAMissingJustificationWith400()
+
+	/**
+	 * A `recommendation` that is not an object is a 400 — the engine expects the
+	 * original row, not an id.
+	 *
+	 * @return void
+	 */
+	public function testOverrideRejectsANonObjectRecommendationWith400(): void {
+		$this->signIn();
+		$this->withParams([
+			'recommendation' => 'rec-1',
+			'intervention' => 'last onder dwangsom',
+			'justification' => 'Gemotiveerde afwijking van de interventieladder.',
+		]);
+		$this->lhsService->expects($this->never())->method('override');
+
+		$response = $this->controller->override();
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+	}//end testOverrideRejectsANonObjectRecommendationWith400()
+
+	/**
+	 * A caller who merely CLAIMS `userRole=manager` is still forwarded to the
+	 * engine as an inspector when the Nextcloud admin check disagrees.
+	 *
+	 * Trusting the posted role would let any inspector escalate an enforcement
+	 * measure by editing one form field.
+	 *
+	 * @return void
+	 */
+	public function testOverrideDoesNotTrustAClaimedManagerRole(): void {
+		$this->signIn(uid: 'inspector1');
+		$this->withParams([
+			'recommendation' => ['id' => 'rec-1'],
+			'intervention' => 'last onder dwangsom',
+			'justification' => 'Gemotiveerde afwijking van de interventieladder.',
+			'userRole' => 'manager',
+		]);
+		$this->groupManager->expects($this->once())
+			->method('isAdmin')
+			->with('inspector1')
+			->willReturn(false);
+
+		$capturedRole = null;
+		$this->lhsService->expects($this->once())
+			->method('override')
+			->willReturnCallback(
+				static function (
+					array $recommendation,
+					string $intervention,
+					string $justification,
+					string $userRole,
+				) use (&$capturedRole): array {
+					$capturedRole = $userRole;
+
+					return ['id' => 'rec-1'];
+				}
+			);
+
+		$this->controller->override();
+
+		$this->assertSame(
+			'inspector',
+			$capturedRole,
+			'a claimed manager role must not be honoured without the admin check'
+		);
+	}//end testOverrideDoesNotTrustAClaimedManagerRole()
+
+	/**
+	 * A real admin who declares the manager role IS forwarded as a manager —
+	 * proving the check above is a decision, not a hard-coded "inspector".
+	 *
+	 * @return void
+	 */
+	public function testOverrideHonoursADeclaredManagerRoleForAnAdmin(): void {
+		$this->signIn(uid: 'coordinator');
+		$this->withParams([
+			'recommendation' => ['id' => 'rec-1'],
+			'intervention' => 'last onder dwangsom',
+			'justification' => 'Gemotiveerde afwijking van de interventieladder.',
+			'userRole' => 'manager',
+		]);
+		$this->groupManager->method('isAdmin')->with('coordinator')->willReturn(true);
+
+		$capturedRole = null;
+		$this->lhsService->expects($this->once())
+			->method('override')
+			->willReturnCallback(
+				static function (
+					array $recommendation,
+					string $intervention,
+					string $justification,
+					string $userRole,
+				) use (&$capturedRole): array {
+					$capturedRole = $userRole;
+
+					return ['id' => 'rec-1', 'intervention' => $intervention];
+				}
+			);
+
+		$response = $this->controller->override();
+
+		$this->assertSame('manager', $capturedRole);
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame('last onder dwangsom', $response->getData()['intervention']);
+	}//end testOverrideHonoursADeclaredManagerRoleForAnAdmin()
+
+	/**
+	 * The engine's role refusal is mapped to 403, NOT the 422 every other
+	 * RuntimeException gets — an authorization refusal must be distinguishable
+	 * on the wire from a validation refusal.
+	 *
+	 * @return void
+	 */
+	public function testOverrideMapsTheManagerRoleRefusalTo403(): void {
+		$this->signIn();
+		$this->withParams([
+			'recommendation' => ['id' => 'rec-1'],
+			'intervention' => 'last onder dwangsom',
+			'justification' => 'Gemotiveerde afwijking van de interventieladder.',
+		]);
+		$this->groupManager->method('isAdmin')->willReturn(false);
+		$this->lhsService->method('override')
+			->willThrowException(new \RuntimeException('Verzwaring vereist managerrol'));
+
+		$response = $this->controller->override();
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame(['error' => 'Verzwaring vereist managerrol'], $response->getData());
+	}//end testOverrideMapsTheManagerRoleRefusalTo403()
+
+	/**
+	 * Every other engine refusal stays a 422.
+	 *
+	 * @return void
+	 */
+	public function testOverrideMapsAnyOtherEngineRefusalTo422(): void {
+		$this->signIn();
+		$this->withParams([
+			'recommendation' => ['id' => 'rec-1'],
+			'intervention' => 'last onder dwangsom',
+			'justification' => 'te kort',
+		]);
+		$this->groupManager->method('isAdmin')->willReturn(false);
+		$this->lhsService->method('override')
+			->willThrowException(new \RuntimeException('Motivatie moet minimaal 20 tekens bevatten'));
+
+		$response = $this->controller->override();
+
+		$this->assertSame(Http::STATUS_UNPROCESSABLE_ENTITY, $response->getStatus());
+		$this->assertSame(['error' => 'Motivatie moet minimaal 20 tekens bevatten'], $response->getData());
+	}//end testOverrideMapsAnyOtherEngineRefusalTo422()
+}//end class

--- a/tests/Unit/Controller/MandaatMatrixControllerContractTest.php
+++ b/tests/Unit/Controller/MandaatMatrixControllerContractTest.php
@@ -1,0 +1,468 @@
+<?php
+
+/**
+ * MandaatMatrixController Wire-Contract Tests
+ *
+ * Contract coverage for the seven mandaat-matrix endpoints that had no
+ * automated proof of their wire behaviour (gate-25): `probe`, `importPreview`,
+ * `importApprove`, `escalateApprove`, `escalateReject`, `auditTrail` and
+ * `applicable`.
+ *
+ * The controller does NOT have one uniform auth posture, and that asymmetry is
+ * the thing worth pinning:
+ *
+ *  - six of the seven call `ensureAuthenticated()`, which answers 403 (NOT 401)
+ *    with `{"message":"Not authenticated"}` — a client that branches on 401
+ *    would never see it;
+ *  - `escalateApprove` deliberately does NOT. It resolves the caller id from
+ *    the session and hands it to `MandaatEscalatieService::approveEscalatie()`,
+ *    which re-checks that the caller is the resolved mandate holder (see the
+ *    class docblock: per-object IDOR guards live in the services). An anonymous
+ *    caller therefore reaches the service with an EMPTY user id and is refused
+ *    there, surfacing as 403. That is the design, and it is only safe as long
+ *    as an empty uid can never match a mandate holder — so the empty uid
+ *    reaching the service is asserted explicitly rather than left implied;
+ *  - `applicable` fails SOFT: a service failure is logged and answered as an
+ *    empty list at 200, because an empty mandate list only hides actions from
+ *    the UI. Every other endpoint fails hard with 400/403.
+ *
+ * Not covered here: the accepted-body paths of `probe`, `importPreview` and
+ * `escalateReject`. Those three read their body through the file-local
+ * `jsonBody()` helper, which reads `php://input` directly with no injectable
+ * seam, so a unit test can only drive them with an EMPTY body. The refusal and
+ * the missing-input branch are covered; the accepted-body branch is honestly
+ * out of reach at this layer.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\MandaatMatrixController;
+use OCA\Procest\Service\MandaatCheckService;
+use OCA\Procest\Service\MandaatEscalatieService;
+use OCA\Procest\Service\MandaatGebruikService;
+use OCA\Procest\Service\MandaatImportService;
+use OCA\Procest\Service\SettingsService;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * Wire-contract tests for MandaatMatrixController.
+ *
+ * @covers \OCA\Procest\Controller\MandaatMatrixController
+ */
+class MandaatMatrixControllerContractTest extends TestCase {
+
+	/**
+	 * The inbound request mock.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The session mock.
+	 *
+	 * @var IUserSession|MockObject
+	 */
+	private IUserSession $userSession;
+
+	/**
+	 * The authorization-check service mock.
+	 *
+	 * @var MandaatCheckService|MockObject
+	 */
+	private MandaatCheckService $check;
+
+	/**
+	 * The escalation service mock — the per-object guard for escalateApprove.
+	 *
+	 * @var MandaatEscalatieService|MockObject
+	 */
+	private MandaatEscalatieService $escalation;
+
+	/**
+	 * The mandate-usage (audit trail) service mock.
+	 *
+	 * @var MandaatGebruikService|MockObject
+	 */
+	private MandaatGebruikService $gebruik;
+
+	/**
+	 * The CSV import service mock.
+	 *
+	 * @var MandaatImportService|MockObject
+	 */
+	private MandaatImportService $import;
+
+	/**
+	 * The settings service mock (OpenRegister access).
+	 *
+	 * @var SettingsService|MockObject
+	 */
+	private SettingsService $settings;
+
+	/**
+	 * The logger mock.
+	 *
+	 * @var LoggerInterface|MockObject
+	 */
+	private LoggerInterface $logger;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var MandaatMatrixController
+	 */
+	private MandaatMatrixController $controller;
+
+	/**
+	 * Build the controller with all collaborators mocked.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->check = $this->createMock(MandaatCheckService::class);
+		$this->escalation = $this->createMock(MandaatEscalatieService::class);
+		$this->gebruik = $this->createMock(MandaatGebruikService::class);
+		$this->import = $this->createMock(MandaatImportService::class);
+		$this->settings = $this->createMock(SettingsService::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$this->controller = new MandaatMatrixController(
+			appName: 'procest',
+			request: $this->request,
+			userSession: $this->userSession,
+			check: $this->check,
+			escalation: $this->escalation,
+			gebruik: $this->gebruik,
+			import: $this->import,
+			settings: $this->settings,
+			logger: $this->logger,
+		);
+	}//end setUp()
+
+	/**
+	 * Mark the session as authenticated for caseworker `alice`.
+	 *
+	 * @return void
+	 */
+	private function authenticate(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+		$this->userSession->method('getUser')->willReturn($user);
+	}//end authenticate()
+
+	/**
+	 * Feed the request parameter bag.
+	 *
+	 * @param array<string, mixed> $params The request parameters.
+	 *
+	 * @return void
+	 */
+	private function withParams(array $params): void {
+		$this->request->method('getParam')->willReturnCallback(
+			static function (string $key, mixed $default = null) use ($params): mixed {
+				if (array_key_exists($key, $params) === true) {
+					return $params[$key];
+				}
+
+				return $default;
+			}
+		);
+	}//end withParams()
+
+	/**
+	 * The six `ensureAuthenticated()` endpoints answer 403 — not 401 — with
+	 * `{"message":"Not authenticated"}` for a caller without a session, and no
+	 * mandate, escalation, import or audit-trail service is reached.
+	 *
+	 * @return void
+	 */
+	public function testTheGuardedEndpointsRefuseAnAnonymousCallerWith403(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->withParams([]);
+
+		$this->check->expects($this->never())->method('isAuthorized');
+		$this->check->expects($this->never())->method('getApplicableForUser');
+		$this->import->expects($this->never())->method('importFromCsv');
+		$this->import->expects($this->never())->method('approveImport');
+		$this->escalation->expects($this->never())->method('rejectEscalatie');
+		$this->gebruik->expects($this->never())->method('getDecisionAuditTrail');
+
+		$responses = [
+			'probe' => $this->controller->probe(),
+			'importPreview' => $this->controller->importPreview(),
+			'importApprove' => $this->controller->importApprove(importId: 'imp-1'),
+			'escalateReject' => $this->controller->escalateReject(id: 'esc-1'),
+			'auditTrail' => $this->controller->auditTrail(caseId: 'case-1'),
+			'applicable' => $this->controller->applicable(caseId: 'case-1'),
+		];
+
+		foreach ($responses as $endpoint => $response) {
+			$this->assertSame(
+				Http::STATUS_FORBIDDEN,
+				$response->getStatus(),
+				$endpoint . ' must answer 403 for a caller without a session'
+			);
+			$this->assertSame(
+				['message' => 'Not authenticated'],
+				$response->getData(),
+				$endpoint . ' must answer the controller-standard unauthenticated body'
+			);
+		}
+	}//end testTheGuardedEndpointsRefuseAnAnonymousCallerWith403()
+
+	/**
+	 * probe() refuses a body without `decisionType` and `caseId` with a 400 and
+	 * never asks the mandaat matrix — an authorization probe answered on empty
+	 * input would be a verdict about no decision at all.
+	 *
+	 * @return void
+	 */
+	public function testProbeRejectsAnEmptyBodyWithoutConsultingTheMandateMatrix(): void {
+		$this->authenticate();
+
+		$this->check->expects($this->never())->method('isAuthorized');
+		$this->settings->expects($this->never())->method('getObjectService');
+
+		$response = $this->controller->probe();
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(
+			['message' => 'decisionType and caseId are required'],
+			$response->getData()
+		);
+	}//end testProbeRejectsAnEmptyBodyWithoutConsultingTheMandateMatrix()
+
+	/**
+	 * importPreview() refuses an incomplete body with a 400 and imports
+	 * nothing. The named fields are the published request contract — the
+	 * message enumerates the ENGLISH keys, which is what a new caller must
+	 * send.
+	 *
+	 * @return void
+	 */
+	public function testImportPreviewRejectsAnEmptyBodyAndImportsNothing(): void {
+		$this->authenticate();
+		$this->import->expects($this->never())->method('importFromCsv');
+
+		$response = $this->controller->importPreview();
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(
+			['message' => 'decisionNumber, decisionName and csv are required'],
+			$response->getData()
+		);
+	}//end testImportPreviewRejectsAnEmptyBodyAndImportsNothing()
+
+	/**
+	 * escalateReject() refuses a rejection without a reason with a 400 and does
+	 * not close the escalation. An escalation may not be rejected silently: the
+	 * reason is the record the caseworker later has to justify.
+	 *
+	 * @return void
+	 */
+	public function testEscalateRejectRequiresAReasonAndDoesNotCloseTheEscalation(): void {
+		$this->authenticate();
+		$this->escalation->expects($this->never())->method('rejectEscalatie');
+
+		$response = $this->controller->escalateReject(id: 'esc-1');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['message' => 'reason is required'], $response->getData());
+	}//end testEscalateRejectRequiresAReasonAndDoesNotCloseTheEscalation()
+
+	/**
+	 * importApprove() promotes the concept besluit named in the route and
+	 * answers 200 with the service record.
+	 *
+	 * @return void
+	 */
+	public function testImportApproveApprovesTheRoutedImport(): void {
+		$this->authenticate();
+
+		$approved = ['id' => 'imp-1', 'status' => 'vastgesteld', 'mandateCount' => 42];
+
+		$this->import->expects($this->once())
+			->method('approveImport')
+			->with('imp-1')
+			->willReturn($approved);
+
+		$response = $this->controller->importApprove(importId: 'imp-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($approved, $response->getData());
+	}//end testImportApproveApprovesTheRoutedImport()
+
+	/**
+	 * A refused import approval is a 400 carrying the service reason.
+	 *
+	 * @return void
+	 */
+	public function testImportApproveMapsAServiceFailureTo400(): void {
+		$this->authenticate();
+
+		$this->import->method('approveImport')
+			->willThrowException(new RuntimeException('Besluit already approved'));
+
+		$response = $this->controller->importApprove(importId: 'imp-1');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['message' => 'Besluit already approved'], $response->getData());
+	}//end testImportApproveMapsAServiceFailureTo400()
+
+	/**
+	 * escalateApprove() approves as the SESSION user. The uid is what the
+	 * service checks the mandate holder against, so a caller-supplied approver
+	 * would be an escalation approved by somebody who never saw it.
+	 *
+	 * @return void
+	 */
+	public function testEscalateApproveApprovesAsTheSessionUser(): void {
+		$this->authenticate();
+		$this->withParams(['userId' => 'mallory', 'mandaathouderUserId' => 'mallory']);
+
+		$approved = ['id' => 'esc-1', 'status' => 'approved', 'approvedBy' => 'alice'];
+
+		$this->escalation->expects($this->once())
+			->method('approveEscalatie')
+			->with('esc-1', 'alice')
+			->willReturn($approved);
+
+		$response = $this->controller->escalateApprove(id: 'esc-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($approved, $response->getData());
+	}//end testEscalateApproveApprovesAsTheSessionUser()
+
+	/**
+	 * escalateApprove() is the one endpoint on this controller with NO
+	 * `ensureAuthenticated()` call: an anonymous caller reaches the service
+	 * with an EMPTY user id, and the service — which re-checks that the caller
+	 * is the resolved mandate holder — is what refuses.
+	 *
+	 * The empty uid is asserted, not the 403 alone: the design is only safe
+	 * while `''` can never match a mandate holder, and this is the test that
+	 * documents that load-bearing assumption.
+	 *
+	 * @return void
+	 */
+	public function testEscalateApproveHandsAnAnonymousCallerAnEmptyUidToTheServiceGuard(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+
+		$this->escalation->expects($this->once())
+			->method('approveEscalatie')
+			->with('esc-1', '')
+			->willThrowException(new RuntimeException('Not the mandate holder'));
+
+		$response = $this->controller->escalateApprove(id: 'esc-1');
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame(['message' => 'Not the mandate holder'], $response->getData());
+	}//end testEscalateApproveHandsAnAnonymousCallerAnEmptyUidToTheServiceGuard()
+
+	/**
+	 * auditTrail() returns the decision audit trail for the ROUTED case, at
+	 * 200, verbatim.
+	 *
+	 * @return void
+	 */
+	public function testAuditTrailReturnsTheTrailForTheRoutedCase(): void {
+		$this->authenticate();
+
+		$trail = [
+			['decisionType' => 'wmo-toekenning', 'userId' => 'alice', 'outcome' => 'authorized'],
+		];
+
+		$this->gebruik->expects($this->once())
+			->method('getDecisionAuditTrail')
+			->with('case-1')
+			->willReturn($trail);
+
+		$response = $this->controller->auditTrail(caseId: 'case-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($trail, $response->getData());
+	}//end testAuditTrailReturnsTheTrailForTheRoutedCase()
+
+	/**
+	 * applicable() filters the mandate list to the SESSION user and forwards
+	 * the `caseType` / `decisionType` query filters in that order.
+	 *
+	 * Both filters are strings, so a transposition would type-check and quietly
+	 * return the wrong mandates.
+	 *
+	 * @return void
+	 */
+	public function testApplicableFiltersToTheSessionUserWithTheQueryFilters(): void {
+		$this->authenticate();
+		$this->withParams(['caseType' => 'wmo', 'decisionType' => 'toekenning', 'userId' => 'mallory']);
+
+		$rows = [['mandateId' => 'm-1', 'decisionType' => 'toekenning', 'ceiling' => 500000]];
+
+		$this->check->expects($this->once())
+			->method('getApplicableForUser')
+			->with('alice', 'wmo', 'toekenning')
+			->willReturn($rows);
+
+		$response = $this->controller->applicable(caseId: 'case-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($rows, $response->getData());
+	}//end testApplicableFiltersToTheSessionUserWithTheQueryFilters()
+
+	/**
+	 * applicable() fails SOFT: a service failure is logged and answered as an
+	 * empty list at 200, not as a 400/500.
+	 *
+	 * This is deliberate — the endpoint only decides which actions the UI
+	 * offers, and an empty list withholds actions rather than granting them.
+	 * The warning must still be emitted, otherwise a broken mandate register
+	 * looks exactly like a user with no mandates.
+	 *
+	 * @return void
+	 */
+	public function testApplicableAnswersAnEmptyListAndLogsWhenTheServiceFails(): void {
+		$this->authenticate();
+		$this->withParams([]);
+
+		$this->check->method('getApplicableForUser')
+			->willThrowException(new RuntimeException('register not configured'));
+
+		$this->logger->expects($this->once())
+			->method('warning')
+			->with(
+				'MandaatMatrixController.applicable failed',
+				['caseId' => 'case-1', 'error' => 'register not configured']
+			);
+
+		$response = $this->controller->applicable(caseId: 'case-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame([], $response->getData());
+	}//end testApplicableAnswersAnEmptyListAndLogsWhenTheServiceFails()
+}//end class

--- a/tests/Unit/Controller/MilestoneControllerContractTest.php
+++ b/tests/Unit/Controller/MilestoneControllerContractTest.php
@@ -1,0 +1,419 @@
+<?php
+
+/**
+ * MilestoneController Wire-Contract Tests
+ *
+ * Contract coverage for the three milestone endpoints (gate-25). All are
+ * `@NoAdminRequired`.
+ *
+ * The contract pinned here:
+ *
+ *  - no session answers 401 on all three, before MilestoneService is entered;
+ *  - `progress` is guarded per case by `CaseAccessGuard::hasCaseReadAccess()`,
+ *    asked about the caseId from the URL and the session user, and refuses with
+ *    403 without reading any progress;
+ *  - `progress` forwards caseId and caseTypeId in that order — the route
+ *    carries two uuids and transposing them still answers 200;
+ *  - `mark` stamps the provenance `manual` and attributes the milestone to the
+ *    SESSION user, never to a caller-supplied id;
+ *  - `reverse` demands a reason and rejects a whitespace-only one (the code
+ *    trims), because the reason is the audit record for undoing a milestone;
+ *  - and, asserted deliberately: `mark` and `reverse` consult NO per-case guard
+ *    at all, unlike their sibling `progress`. That asymmetry is the live
+ *    behaviour of the code, so it is pinned rather than assumed — these two
+ *    tests are tripwires that must be updated the day a guard is added, and
+ *    they document the gap in the meantime.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\MilestoneController;
+use OCA\Procest\Service\CaseAccessGuard;
+use OCA\Procest\Service\MilestoneService;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Wire-contract tests for MilestoneController.
+ *
+ * @covers \OCA\Procest\Controller\MilestoneController
+ */
+class MilestoneControllerContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The MilestoneService mock.
+	 *
+	 * @var MilestoneService|MockObject
+	 */
+	private MilestoneService $milestoneService;
+
+	/**
+	 * The IUserSession mock.
+	 *
+	 * @var IUserSession|MockObject
+	 */
+	private IUserSession $userSession;
+
+	/**
+	 * The per-case authorization guard mock.
+	 *
+	 * @var CaseAccessGuard|MockObject
+	 */
+	private CaseAccessGuard $caseAccessGuard;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var MilestoneController
+	 */
+	private MilestoneController $controller;
+
+	/**
+	 * Build the controller with all collaborators mocked.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->milestoneService = $this->createMock(MilestoneService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->caseAccessGuard = $this->createMock(CaseAccessGuard::class);
+
+		$this->controller = new MilestoneController(
+			appName: 'procest',
+			request: $this->request,
+			milestoneService: $this->milestoneService,
+			userSession: $this->userSession,
+			caseAccessGuard: $this->caseAccessGuard,
+		);
+	}//end setUp()
+
+	/**
+	 * Put a signed-in user on the session.
+	 *
+	 * @param string $uid The UID of the signed-in user.
+	 *
+	 * @return IUser|MockObject The user placed on the session.
+	 */
+	private function signIn(string $uid = 'alice'): IUser {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		$this->userSession->method('getUser')->willReturn($user);
+
+		return $user;
+	}//end signIn()
+
+	/**
+	 * Answer request parameters from the supplied map.
+	 *
+	 * @param array<string, mixed> $params The parameter map.
+	 *
+	 * @return void
+	 */
+	private function withParams(array $params): void {
+		$this->request->method('getParam')->willReturnCallback(
+			static function (string $key, mixed $default = null) use ($params): mixed {
+				return ($params[$key] ?? $default);
+			}
+		);
+	}//end withParams()
+
+	/**
+	 * `progress` refuses an anonymous caller with 401 and reads nothing.
+	 *
+	 * @return void
+	 */
+	public function testProgressRefusesAnUnauthenticatedCallerWith401(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->milestoneService->expects($this->never())->method('getCaseProgress');
+
+		$response = $this->controller->progress(caseId: 'zaak-1', caseTypeId: 'type-1');
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame(['error' => 'Not authenticated'], $response->getData());
+	}//end testProgressRefusesAnUnauthenticatedCallerWith401()
+
+	/**
+	 * `progress` is guarded per case: the read guard is asked about the caseId
+	 * from the URL and the session user, and a refusal is a 403 with no read.
+	 *
+	 * @return void
+	 */
+	public function testProgressDemandsCaseReadAccessAndRefusesWith403(): void {
+		$user = $this->signIn(uid: 'mallory');
+
+		$this->caseAccessGuard->expects($this->once())
+			->method('hasCaseReadAccess')
+			->with('zaak-1', $user)
+			->willReturn(false);
+		$this->milestoneService->expects($this->never())->method('getCaseProgress');
+
+		$response = $this->controller->progress(caseId: 'zaak-1', caseTypeId: 'type-1');
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame(['error' => 'Not authorized'], $response->getData());
+	}//end testProgressDemandsCaseReadAccessAndRefusesWith403()
+
+	/**
+	 * An authorized progress read forwards caseId and caseTypeId in that order
+	 * and answers 200 with the service's payload unchanged.
+	 *
+	 * @return void
+	 */
+	public function testProgressForwardsTheCaseAndCaseTypeInThatOrder(): void {
+		$this->signIn();
+		$this->caseAccessGuard->method('hasCaseReadAccess')->willReturn(true);
+
+		$this->milestoneService->expects($this->once())
+			->method('getCaseProgress')
+			->with('zaak-1', 'type-1')
+			->willReturn(['reached' => 2, 'total' => 5]);
+
+		$response = $this->controller->progress(caseId: 'zaak-1', caseTypeId: 'type-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['reached' => 2, 'total' => 5], $response->getData());
+	}//end testProgressForwardsTheCaseAndCaseTypeInThatOrder()
+
+	/**
+	 * A failure computing progress answers 500 with the service's message.
+	 *
+	 * @return void
+	 */
+	public function testProgressReportsAServiceFailureAs500(): void {
+		$this->signIn();
+		$this->caseAccessGuard->method('hasCaseReadAccess')->willReturn(true);
+		$this->milestoneService->method('getCaseProgress')
+			->willThrowException(new \RuntimeException('Milestone schema not configured'));
+
+		$response = $this->controller->progress(caseId: 'zaak-1', caseTypeId: 'type-1');
+
+		$this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+		$this->assertSame(['error' => 'Milestone schema not configured'], $response->getData());
+	}//end testProgressReportsAServiceFailureAs500()
+
+	/**
+	 * `mark` refuses an anonymous caller with 401 and records nothing.
+	 *
+	 * @return void
+	 */
+	public function testMarkRefusesAnUnauthenticatedCallerWith401(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->milestoneService->expects($this->never())->method('markMilestone');
+
+		$response = $this->controller->mark(caseId: 'zaak-1', milestoneId: 'ms-1');
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame(['error' => 'Not authenticated'], $response->getData());
+	}//end testMarkRefusesAnUnauthenticatedCallerWith401()
+
+	/**
+	 * `mark` records the milestone against the case and stamps the provenance
+	 * `manual`, attributed to the SESSION user — never to a caller-supplied id.
+	 *
+	 * @return void
+	 */
+	public function testMarkStampsManualProvenanceAndAttributesTheSessionUser(): void {
+		$this->signIn(uid: 'alice');
+
+		$this->milestoneService->expects($this->once())
+			->method('markMilestone')
+			->with('zaak-1', 'ms-1', 'alice', 'manual')
+			->willReturn(['id' => 'record-1', 'source' => 'manual']);
+
+		$response = $this->controller->mark(caseId: 'zaak-1', milestoneId: 'ms-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['id' => 'record-1', 'source' => 'manual'], $response->getData());
+	}//end testMarkStampsManualProvenanceAndAttributesTheSessionUser()
+
+	/**
+	 * `mark` consults NO per-case guard — authentication alone is enough.
+	 *
+	 * This is asserted, not assumed: it is the live behaviour and it differs
+	 * from the sibling `progress` on the same case id. The test is a tripwire —
+	 * adding a guard (which would bring `mark` in line with `progress`) makes it
+	 * fail, forcing a deliberate update rather than a silent drift.
+	 *
+	 * @return void
+	 */
+	public function testMarkCurrentlyConsultsNoPerCaseGuard(): void {
+		$this->signIn(uid: 'someone-not-on-this-case');
+		$this->caseAccessGuard->expects($this->never())->method('hasCaseMutationAccess');
+		$this->caseAccessGuard->expects($this->never())->method('hasCaseReadAccess');
+		$this->milestoneService->method('markMilestone')->willReturn(['id' => 'record-1']);
+
+		$response = $this->controller->mark(caseId: 'zaak-of-another-handler', milestoneId: 'ms-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+	}//end testMarkCurrentlyConsultsNoPerCaseGuard()
+
+	/**
+	 * A rejected milestone (already reached, unknown definition) answers 400
+	 * with the service's message.
+	 *
+	 * @return void
+	 */
+	public function testMarkReportsADomainRefusalAs400(): void {
+		$this->signIn();
+		$this->milestoneService->method('markMilestone')
+			->willThrowException(new \RuntimeException('Milestone already reached'));
+
+		$response = $this->controller->mark(caseId: 'zaak-1', milestoneId: 'ms-1');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'Milestone already reached'], $response->getData());
+	}//end testMarkReportsADomainRefusalAs400()
+
+	/**
+	 * `reverse` refuses an anonymous caller with 401 and reverses nothing.
+	 *
+	 * @return void
+	 */
+	public function testReverseRefusesAnUnauthenticatedCallerWith401(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->milestoneService->expects($this->never())->method('reverseMilestone');
+
+		$response = $this->controller->reverse(caseId: 'zaak-1', milestoneId: 'ms-1');
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame(['error' => 'Not authenticated'], $response->getData());
+	}//end testReverseRefusesAnUnauthenticatedCallerWith401()
+
+	/**
+	 * A reversal with no reason is a 400 — the reason IS the audit record for
+	 * undoing a milestone.
+	 *
+	 * @return void
+	 */
+	public function testReverseRejectsAMissingReasonWith400(): void {
+		$this->signIn();
+		$this->withParams([]);
+		$this->milestoneService->expects($this->never())->method('reverseMilestone');
+
+		$response = $this->controller->reverse(caseId: 'zaak-1', milestoneId: 'ms-1');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(
+			['error' => 'Reason is required for milestone reversal'],
+			$response->getData()
+		);
+	}//end testReverseRejectsAMissingReasonWith400()
+
+	/**
+	 * A whitespace-only reason is rejected too — the check trims, so a space
+	 * bar cannot buy an audit-free reversal.
+	 *
+	 * @return void
+	 */
+	public function testReverseRejectsAWhitespaceOnlyReasonWith400(): void {
+		$this->signIn();
+		$this->withParams(['reason' => "   \t\n"]);
+		$this->milestoneService->expects($this->never())->method('reverseMilestone');
+
+		$response = $this->controller->reverse(caseId: 'zaak-1', milestoneId: 'ms-1');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(
+			['error' => 'Reason is required for milestone reversal'],
+			$response->getData()
+		);
+	}//end testReverseRejectsAWhitespaceOnlyReasonWith400()
+
+	/**
+	 * A motivated reversal forwards the case, milestone, session user and the
+	 * reason, and answers 200 with the service's boolean outcome.
+	 *
+	 * @return void
+	 */
+	public function testReverseForwardsTheReasonAndReportsTheOutcome(): void {
+		$this->signIn(uid: 'alice');
+		$this->withParams(['reason' => 'Onterecht gemarkeerd']);
+
+		$this->milestoneService->expects($this->once())
+			->method('reverseMilestone')
+			->with('zaak-1', 'ms-1', 'alice', 'Onterecht gemarkeerd')
+			->willReturn(true);
+
+		$response = $this->controller->reverse(caseId: 'zaak-1', milestoneId: 'ms-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['success' => true], $response->getData());
+	}//end testReverseForwardsTheReasonAndReportsTheOutcome()
+
+	/**
+	 * A service that declines the reversal answers 200 with `success: false` —
+	 * the boolean is carried through rather than being coerced to true.
+	 *
+	 * @return void
+	 */
+	public function testReverseCarriesAFalseOutcomeThroughRatherThanClaimingSuccess(): void {
+		$this->signIn();
+		$this->withParams(['reason' => 'Onterecht gemarkeerd']);
+		$this->milestoneService->method('reverseMilestone')->willReturn(false);
+
+		$response = $this->controller->reverse(caseId: 'zaak-1', milestoneId: 'ms-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['success' => false], $response->getData());
+	}//end testReverseCarriesAFalseOutcomeThroughRatherThanClaimingSuccess()
+
+	/**
+	 * `reverse` likewise consults no per-case guard today — pinned as a
+	 * tripwire alongside `mark`.
+	 *
+	 * @return void
+	 */
+	public function testReverseCurrentlyConsultsNoPerCaseGuard(): void {
+		$this->signIn(uid: 'someone-not-on-this-case');
+		$this->withParams(['reason' => 'Onterecht gemarkeerd']);
+		$this->caseAccessGuard->expects($this->never())->method('hasCaseMutationAccess');
+		$this->caseAccessGuard->expects($this->never())->method('hasCaseReadAccess');
+		$this->milestoneService->method('reverseMilestone')->willReturn(true);
+
+		$response = $this->controller->reverse(caseId: 'zaak-of-another-handler', milestoneId: 'ms-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+	}//end testReverseCurrentlyConsultsNoPerCaseGuard()
+
+	/**
+	 * A failure during reversal answers 400 with the service's message.
+	 *
+	 * @return void
+	 */
+	public function testReverseReportsADomainRefusalAs400(): void {
+		$this->signIn();
+		$this->withParams(['reason' => 'Onterecht gemarkeerd']);
+		$this->milestoneService->method('reverseMilestone')
+			->willThrowException(new \RuntimeException('Milestone was never reached'));
+
+		$response = $this->controller->reverse(caseId: 'zaak-1', milestoneId: 'ms-1');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'Milestone was never reached'], $response->getData());
+	}//end testReverseReportsADomainRefusalAs400()
+}//end class

--- a/tests/Unit/Controller/NrcControllerContractTest.php
+++ b/tests/Unit/Controller/NrcControllerContractTest.php
@@ -1,0 +1,285 @@
+<?php
+
+/**
+ * NrcController Wire-Contract Tests
+ *
+ * Contract coverage for the two ZGW Notificaties endpoints flagged by gate-25:
+ * `notificatieCreate` (POST /notificaties) and `patch` (PATCH /{resource}/{uuid}).
+ * Both are `@PublicPage` + `@NoCSRFRequired` + `@CORS`, i.e. reachable WITHOUT a
+ * Nextcloud session; their only gatekeepers are the ZGW JWT and, for writes, an
+ * OAuth-style scope.
+ *
+ * The contract pinned here:
+ *
+ *  - both endpoints return the JWT gate's refusal verbatim and run no body —
+ *    these routes are anonymous-reachable, so a body that ran before the gate
+ *    would serve/accept notification traffic from anyone on the internet;
+ *  - `patch` demands the scope `notificaties.publiceren` on the `nrc` API and
+ *    answers the standard ZGW `permission_denied` envelope (403) without it.
+ *    The scope NAME is asserted: five near-identical delegators in this
+ *    controller gate on the same string, and a copy-paste of a neighbouring
+ *    scope is the realistic defect;
+ *  - `patch` delegates to the `notificaties` API with the PARTIAL flag set to
+ *    true. That final boolean is the entire difference between PATCH and PUT —
+ *    a copy of `update()` would pass false and silently turn every partial
+ *    update into a full replace, wiping unnamed fields while answering 200;
+ *  - `notificatieCreate` acknowledges with 201 and echoes the body back with
+ *    the internal `_route` key REMOVED — that key is Nextcloud routing detail
+ *    and has no place in a ZGW acknowledgement;
+ *  - and, asserted deliberately: `notificatieCreate` consults NO scope at all,
+ *    unlike every other write in this controller. That is the live behaviour;
+ *    the test pins it as a tripwire so adding the scope check is a deliberate,
+ *    visible change rather than a silent drift.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\NrcController;
+use OCA\Procest\Service\ZgwService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Wire-contract tests for NrcController.
+ *
+ * @covers \OCA\Procest\Controller\NrcController
+ */
+class NrcControllerContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The ZgwService mock — JWT gate, scope gate and delegate.
+	 *
+	 * @var ZgwService|MockObject
+	 */
+	private ZgwService $zgwService;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var NrcController
+	 */
+	private NrcController $controller;
+
+	/**
+	 * Build the controller with all collaborators mocked.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->zgwService = $this->createMock(ZgwService::class);
+
+		$this->controller = new NrcController(
+			appName: 'procest',
+			request: $this->request,
+			zgwService: $this->zgwService,
+		);
+	}//end setUp()
+
+	/**
+	 * Configure the JWT gate to REFUSE.
+	 *
+	 * @return void
+	 */
+	private function refuseJwt(): void {
+		$this->zgwService->method('validateJwtAuth')->willReturn(
+			new JSONResponse(
+				data: ['detail' => 'JWT ontbreekt of is ongeldig'],
+				statusCode: Http::STATUS_UNAUTHORIZED
+			)
+		);
+	}//end refuseJwt()
+
+	/**
+	 * Configure the JWT gate to ACCEPT.
+	 *
+	 * @return void
+	 */
+	private function acceptJwt(): void {
+		$this->zgwService->method('validateJwtAuth')->willReturn(null);
+	}//end acceptJwt()
+
+	/**
+	 * `notificatieCreate` is anonymous-reachable, so an invalid JWT must stop
+	 * it before the body: the gate's refusal is returned verbatim.
+	 *
+	 * @return void
+	 */
+	public function testNotificatieCreateReturnsTheJwtRefusalVerbatim(): void {
+		$this->refuseJwt();
+		$this->request->expects($this->never())->method('getParams');
+
+		$response = $this->controller->notificatieCreate();
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame(['detail' => 'JWT ontbreekt of is ongeldig'], $response->getData());
+		$this->assertNotSame(Http::STATUS_CREATED, $response->getStatus());
+	}//end testNotificatieCreateReturnsTheJwtRefusalVerbatim()
+
+	/**
+	 * An accepted notification is acknowledged with 201 and the body echoed
+	 * back — minus the internal `_route` routing key.
+	 *
+	 * @return void
+	 */
+	public function testNotificatieCreateAcknowledgesWith201AndStripsTheInternalRouteKey(): void {
+		$this->acceptJwt();
+		$this->request->method('getParams')->willReturn([
+			'kanaal' => 'zaken',
+			'hoofdObject' => 'https://example.test/zaken/1',
+			'actie' => 'create',
+			'_route' => 'procest.nrc.notificatieCreate',
+		]);
+
+		$response = $this->controller->notificatieCreate();
+
+		$this->assertSame(Http::STATUS_CREATED, $response->getStatus());
+		$this->assertArrayNotHasKey(
+			'_route',
+			$response->getData(),
+			'the Nextcloud route name must not leak into a ZGW acknowledgement'
+		);
+		$this->assertSame(
+			[
+				'kanaal' => 'zaken',
+				'hoofdObject' => 'https://example.test/zaken/1',
+				'actie' => 'create',
+			],
+			$response->getData()
+		);
+	}//end testNotificatieCreateAcknowledgesWith201AndStripsTheInternalRouteKey()
+
+	/**
+	 * `notificatieCreate` gates on the JWT ALONE — it consults no ZGW scope,
+	 * unlike every other write in this controller.
+	 *
+	 * Pinned as a tripwire: this is the live behaviour, and adding the
+	 * `notificaties.publiceren` check (bringing it in line with create/update/
+	 * patch/destroy) must be a deliberate change, not a silent one.
+	 *
+	 * @return void
+	 */
+	public function testNotificatieCreateCurrentlyConsultsNoZgwScope(): void {
+		$this->acceptJwt();
+		$this->request->method('getParams')->willReturn(['kanaal' => 'zaken']);
+		$this->zgwService->expects($this->never())->method('consumerHasScope');
+
+		$response = $this->controller->notificatieCreate();
+
+		$this->assertSame(Http::STATUS_CREATED, $response->getStatus());
+	}//end testNotificatieCreateCurrentlyConsultsNoZgwScope()
+
+	/**
+	 * `patch` returns the JWT gate's refusal verbatim and never reaches the
+	 * scope check or the delegate.
+	 *
+	 * @return void
+	 */
+	public function testPatchReturnsTheJwtRefusalBeforeCheckingAnyScope(): void {
+		$this->refuseJwt();
+		$this->zgwService->expects($this->never())->method('consumerHasScope');
+		$this->zgwService->expects($this->never())->method('handleUpdate');
+
+		$response = $this->controller->patch(resource: 'abonnement', uuid: 'ab-1');
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame(['detail' => 'JWT ontbreekt of is ongeldig'], $response->getData());
+	}//end testPatchReturnsTheJwtRefusalBeforeCheckingAnyScope()
+
+	/**
+	 * A consumer without `notificaties.publiceren` on the `nrc` API is refused
+	 * with the standard ZGW permission-denied envelope, and nothing is written.
+	 *
+	 * The scope name is asserted because five delegators in this controller gate
+	 * on the same literal and a wrong one would still return a plausible 403 —
+	 * or, worse, admit a consumer holding a neighbouring scope.
+	 *
+	 * @return void
+	 */
+	public function testPatchDemandsTheNotificatiesPubliceranScopeAndRefusesWithout(): void {
+		$this->acceptJwt();
+
+		$this->zgwService->expects($this->once())
+			->method('consumerHasScope')
+			->with($this->request, 'nrc', 'notificaties.publiceren')
+			->willReturn(false);
+		$this->zgwService->expects($this->never())->method('handleUpdate');
+
+		$response = $this->controller->patch(resource: 'abonnement', uuid: 'ab-1');
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame('permission_denied', $response->getData()['code']);
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getData()['status']);
+		$this->assertStringContainsString('notificaties.publiceren', $response->getData()['detail']);
+	}//end testPatchDemandsTheNotificatiesPubliceranScopeAndRefusesWithout()
+
+	/**
+	 * An authorized patch delegates to the `notificaties` API for the addressed
+	 * resource/uuid with the PARTIAL flag set to TRUE.
+	 *
+	 * That final boolean is the whole difference between PATCH and PUT: passing
+	 * false would replace the abonnement wholesale — dropping every field the
+	 * caller did not name — while still answering 200.
+	 *
+	 * @return void
+	 */
+	public function testPatchDelegatesAsAPartialUpdateNotAFullReplace(): void {
+		$this->acceptJwt();
+		$this->zgwService->method('consumerHasScope')->willReturn(true);
+
+		$expected = new JSONResponse(data: ['url' => 'https://example.test/abonnementen/ab-1']);
+		$this->zgwService->expects($this->once())
+			->method('handleUpdate')
+			->with($this->request, 'notificaties', 'abonnement', 'ab-1', true)
+			->willReturn($expected);
+
+		$response = $this->controller->patch(resource: 'abonnement', uuid: 'ab-1');
+
+		$this->assertSame($expected, $response);
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+	}//end testPatchDelegatesAsAPartialUpdateNotAFullReplace()
+
+	/**
+	 * The resource segment from the URL is the one addressed — the delegator
+	 * must not hard-code a single resource name.
+	 *
+	 * @return void
+	 */
+	public function testPatchAddressesTheResourceNamedInTheUrl(): void {
+		$this->acceptJwt();
+		$this->zgwService->method('consumerHasScope')->willReturn(true);
+
+		$this->zgwService->expects($this->once())
+			->method('handleUpdate')
+			->with($this->request, 'notificaties', 'kanaal', 'kan-9', true)
+			->willReturn(new JSONResponse(data: ['naam' => 'zaken']));
+
+		$response = $this->controller->patch(resource: 'kanaal', uuid: 'kan-9');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['naam' => 'zaken'], $response->getData());
+	}//end testPatchAddressesTheResourceNamedInTheUrl()
+}//end class

--- a/tests/Unit/Controller/NrcControllerContractTest.php
+++ b/tests/Unit/Controller/NrcControllerContractTest.php
@@ -57,6 +57,14 @@ use PHPUnit\Framework\TestCase;
  * Wire-contract tests for NrcController.
  *
  * @covers \OCA\Procest\Controller\NrcController
+ *
+ * NrcController extends ZgwController, which composes NormalisesObjectRows, so
+ * exercising it necessarily runs code declared on both. CI runs phpunit.xml
+ * with beStrictAboutCoverageMetadata="true" and failOnRisky="true", which marks
+ * executed-but-unlisted code risky and fails the run.
+ *
+ * @uses \OCA\Procest\Controller\ZgwController
+ * @uses \OCA\Procest\Support\NormalisesObjectRows
  */
 class NrcControllerContractTest extends TestCase {
 

--- a/tests/Unit/Controller/ParafeerRouteControllerContractTest.php
+++ b/tests/Unit/Controller/ParafeerRouteControllerContractTest.php
@@ -1,0 +1,233 @@
+<?php
+
+/**
+ * ParafeerRouteController Wire-Contract Tests
+ *
+ * Contract coverage for the two `@NoAdminRequired` parafering-engine actions
+ * (gate-25): `POST /api/parafeer-route/voorstel/{voorstelId}/complete-step`
+ * and `.../add-step`. Their sibling `skipStep()` is admin-gated; these two are
+ * not, so the controller's own `requireUser()` is the ONLY barrier between an
+ * anonymous POST and a signed-off parafering step. These tests pin:
+ *
+ *  - both endpoints refuse an unauthenticated caller with 401 BEFORE
+ *    ParafeerRouteService is entered — a completed step is an approval
+ *    signature, so a missing session check is a forged sign-off;
+ *  - the voorstel id from the URL is what the engine acts on;
+ *  - `addStep` defaults an absent `afterStep` to 0 and an absent/non-array
+ *    `stepData` to an empty array rather than forwarding null into a typed
+ *    `int`/`array` parameter (a TypeError would surface as an opaque 500);
+ *  - an engine failure is a 500 carrying a GENERIC Dutch message, never the
+ *    exception text.
+ *
+ * Both endpoints read their body through `file_get_contents('php://input')`,
+ * which is empty under PHPUnit — so the body-derived arguments asserted here
+ * are the documented defaults, which is exactly the path a client that posts
+ * an empty body takes.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\ParafeerRouteController;
+use OCA\Procest\Service\ParafeerRouteService;
+use OCP\AppFramework\Http;
+use OCP\IGroupManager;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Wire-contract tests for ParafeerRouteController.
+ *
+ * @covers \OCA\Procest\Controller\ParafeerRouteController
+ */
+class ParafeerRouteControllerContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The parafering engine service.
+	 *
+	 * @var ParafeerRouteService|MockObject
+	 */
+	private ParafeerRouteService $routeService;
+
+	/**
+	 * The user session.
+	 *
+	 * @var IUserSession|MockObject
+	 */
+	private IUserSession $userSession;
+
+	/**
+	 * The group manager (admin check, used only by skipStep()).
+	 *
+	 * @var IGroupManager|MockObject
+	 */
+	private IGroupManager $groupManager;
+
+	/**
+	 * The logger.
+	 *
+	 * @var LoggerInterface|MockObject
+	 */
+	private LoggerInterface $logger;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var ParafeerRouteController
+	 */
+	private ParafeerRouteController $controller;
+
+	/**
+	 * Build the controller with mocked collaborators.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->routeService = $this->createMock(ParafeerRouteService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$this->controller = new ParafeerRouteController(
+			appName: 'procest',
+			request: $this->request,
+			routeService: $this->routeService,
+			userSession: $this->userSession,
+			groupManager: $this->groupManager,
+			logger: $this->logger,
+		);
+	}//end setUp()
+
+	/**
+	 * Put a signed-in, non-admin user on the session.
+	 *
+	 * @return void
+	 */
+	private function signIn(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('paraferende-ambtenaar');
+		$this->userSession->method('getUser')->willReturn($user);
+		$this->groupManager->method('isAdmin')->willReturn(false);
+	}//end signIn()
+
+	/**
+	 * Neither engine action may run without a session.
+	 *
+	 * @return void
+	 */
+	public function testBothEngineActionsRefuseAnUnauthenticatedCallerBeforeTouchingTheRoute(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->routeService->expects($this->never())->method('completeStep');
+		$this->routeService->expects($this->never())->method('addAdhocStep');
+
+		$complete = $this->controller->completeStep(proposalId: 'voorstel-1');
+		$add = $this->controller->addStep(proposalId: 'voorstel-1');
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $complete->getStatus());
+		$this->assertSame(['error' => 'Authenticatie vereist'], $complete->getData());
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $add->getStatus());
+		$this->assertSame(['error' => 'Authenticatie vereist'], $add->getData());
+	}//end testBothEngineActionsRefuseAnUnauthenticatedCallerBeforeTouchingTheRoute()
+
+	/**
+	 * completeStep acts on the voorstel from the URL and returns the engine's
+	 * result untouched.
+	 *
+	 * @return void
+	 */
+	public function testCompleteStepCompletesTheStepOnTheVoorstelFromTheUrl(): void {
+		$this->signIn();
+		$result = ['step' => 2, 'status' => 'completed'];
+
+		$this->routeService->expects($this->once())
+			->method('completeStep')
+			->with('voorstel-77', [])
+			->willReturn($result);
+
+		$response = $this->controller->completeStep(proposalId: 'voorstel-77');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($result, $response->getData());
+	}//end testCompleteStepCompletesTheStepOnTheVoorstelFromTheUrl()
+
+	/**
+	 * An engine failure on completeStep is a 500 with a generic message that
+	 * does not leak the internal exception text.
+	 *
+	 * @return void
+	 */
+	public function testCompleteStepReturns500WithoutLeakingTheEngineFailure(): void {
+		$this->signIn();
+
+		$this->routeService->method('completeStep')
+			->willThrowException(new \RuntimeException('SQLSTATE[23000] duplicate key parafeerroute_pk'));
+
+		$response = $this->controller->completeStep(proposalId: 'voorstel-77');
+
+		$this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+		$this->assertSame(['error' => 'Stap kon niet worden voltooid'], $response->getData());
+	}//end testCompleteStepReturns500WithoutLeakingTheEngineFailure()
+
+	/**
+	 * addStep forwards typed defaults, never nulls, into the engine's
+	 * `int $afterStep` / `array $stepData` parameters.
+	 *
+	 * @return void
+	 */
+	public function testAddStepForwardsTypedDefaultsForAnEmptyBody(): void {
+		$this->signIn();
+		$snapshot = ['steps' => [['order' => 1], ['order' => 2]]];
+
+		$this->routeService->expects($this->once())
+			->method('addAdhocStep')
+			->with('voorstel-77', $this->identicalTo(0), $this->identicalTo([]))
+			->willReturn($snapshot);
+
+		$response = $this->controller->addStep(proposalId: 'voorstel-77');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($snapshot, $response->getData());
+	}//end testAddStepForwardsTypedDefaultsForAnEmptyBody()
+
+	/**
+	 * An engine failure on addStep is a 500 with its own generic message,
+	 * distinct from the completeStep one.
+	 *
+	 * @return void
+	 */
+	public function testAddStepReturns500WithItsOwnGenericMessage(): void {
+		$this->signIn();
+
+		$this->routeService->method('addAdhocStep')
+			->willThrowException(new \RuntimeException('boom'));
+
+		$response = $this->controller->addStep(proposalId: 'voorstel-77');
+
+		$this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+		$this->assertSame(['error' => 'Stap toevoegen mislukt'], $response->getData());
+	}//end testAddStepReturns500WithItsOwnGenericMessage()
+}//end class

--- a/tests/Unit/Controller/PublicAppointmentControllerContractTest.php
+++ b/tests/Unit/Controller/PublicAppointmentControllerContractTest.php
@@ -1,0 +1,231 @@
+<?php
+
+/**
+ * PublicAppointmentController Wire-Contract Tests
+ *
+ * Contract coverage for the two citizen-facing token routes (gate-25):
+ * `GET /api/public/appointment/{token}` and
+ * `POST /api/public/appointment/{token}/cancel`. Both are `@PublicPage` +
+ * `@NoCSRFRequired`: no Nextcloud session, no CSRF token, no middleware
+ * refusal. The token in the emailed link is the entire access-control system,
+ * and everything the controller emits goes to an unauthenticated stranger.
+ * These tests pin:
+ *
+ *  - an unknown token is a 404 on BOTH endpoints, and on `cancel` it is a 404
+ *    with NO cancellation attempted — a token that does not resolve must not
+ *    reach the mutation;
+ *  - `view` emits a FIVE-KEY PROJECTION and nothing else. The stored record
+ *    carries the citizen's name, BSN-bearing fields and the token itself; the
+ *    realistic defect on a public endpoint is returning `$appointment`
+ *    wholesale, which renders identically in the UI while leaking. The test
+ *    asserts the exact key set, so an added key fails;
+ *  - `cancel` refuses an already-cancelled appointment with 400 and does not
+ *    re-issue the cancellation (double-cancel is not idempotent downstream);
+ *  - `cancel` addresses the appointment by the record's OWN uuid, never by the
+ *    caller-supplied token.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\PublicAppointmentController;
+use OCA\Procest\Service\AppointmentService;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Wire-contract tests for PublicAppointmentController.
+ *
+ * @covers \OCA\Procest\Controller\PublicAppointmentController
+ */
+class PublicAppointmentControllerContractTest extends TestCase {
+
+	/**
+	 * A stored appointment carrying more than the endpoint may disclose.
+	 *
+	 * @var array<string,mixed>
+	 */
+	private const STORED = [
+		'id' => 17,
+		'uuid' => 'afspraak-uuid-17',
+		'publicToken' => 'tok-secret',
+		'dateTime' => '2026-09-01T10:30:00+02:00',
+		'duration' => 45,
+		'status' => 'scheduled',
+		'locationId' => 'loc-stadhuis',
+		'productId' => 'prod-paspoort',
+		'citizenName' => 'J. de Vries',
+		'citizenBsn' => '123456782',
+		'internalNotes' => 'balie 4, tolk aanwezig',
+	];
+
+	/**
+	 * The IRequest mock.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The appointment service.
+	 *
+	 * @var AppointmentService|MockObject
+	 */
+	private AppointmentService $appointmentService;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var PublicAppointmentController
+	 */
+	private PublicAppointmentController $controller;
+
+	/**
+	 * Build the controller with mocked collaborators.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->appointmentService = $this->createMock(AppointmentService::class);
+
+		$this->controller = new PublicAppointmentController(
+			request: $this->request,
+			appointmentService: $this->appointmentService,
+		);
+	}//end setUp()
+
+	/**
+	 * An unresolvable token is a 404 on the read endpoint.
+	 *
+	 * @return void
+	 */
+	public function testViewReturns404ForATokenThatResolvesToNothing(): void {
+		$this->appointmentService->expects($this->once())
+			->method('getAppointmentByToken')
+			->with('tok-bogus')
+			->willReturn(null);
+
+		$response = $this->controller->view(token: 'tok-bogus');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertSame(['error' => 'Afspraak niet gevonden'], $response->getData());
+	}//end testViewReturns404ForATokenThatResolvesToNothing()
+
+	/**
+	 * The public view discloses exactly five appointment fields — not the
+	 * stored record, and never the token or the citizen's identity.
+	 *
+	 * @return void
+	 */
+	public function testViewDisclosesOnlyTheFiveWhitelistedFieldsToAnAnonymousCaller(): void {
+		$this->appointmentService->method('getAppointmentByToken')->willReturn(self::STORED);
+
+		$response = $this->controller->view(token: 'tok-secret');
+		$data = $response->getData();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(
+			['dateTime', 'duration', 'status', 'locationId', 'productId'],
+			array_keys($data['appointment']),
+			'the public projection must not grow: every extra key ships to an anonymous caller'
+		);
+		$this->assertSame(
+			[
+				'success' => true,
+				'appointment' => [
+					'dateTime' => '2026-09-01T10:30:00+02:00',
+					'duration' => 45,
+					'status' => 'scheduled',
+					'locationId' => 'loc-stadhuis',
+					'productId' => 'prod-paspoort',
+				],
+			],
+			$data
+		);
+	}//end testViewDisclosesOnlyTheFiveWhitelistedFieldsToAnAnonymousCaller()
+
+	/**
+	 * A record missing the optional fields still yields the documented
+	 * defaults instead of nulls the citizen-facing page cannot render.
+	 *
+	 * @return void
+	 */
+	public function testViewSubstitutesTheDocumentedDefaultsForAbsentFields(): void {
+		$this->appointmentService->method('getAppointmentByToken')
+			->willReturn(['uuid' => 'afspraak-1']);
+
+		$data = $this->controller->view(token: 'tok-1')->getData();
+
+		$this->assertSame(30, $data['appointment']['duration']);
+		$this->assertSame('scheduled', $data['appointment']['status']);
+		$this->assertNull($data['appointment']['dateTime']);
+	}//end testViewSubstitutesTheDocumentedDefaultsForAbsentFields()
+
+	/**
+	 * An unresolvable token is a 404 on cancel, and nothing is cancelled.
+	 *
+	 * @return void
+	 */
+	public function testCancelReturns404AndCancelsNothingForAnUnknownToken(): void {
+		$this->appointmentService->method('getAppointmentByToken')->willReturn(null);
+		$this->appointmentService->expects($this->never())->method('cancelAppointment');
+
+		$response = $this->controller->cancel(token: 'tok-bogus');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertSame(['error' => 'Afspraak niet gevonden'], $response->getData());
+	}//end testCancelReturns404AndCancelsNothingForAnUnknownToken()
+
+	/**
+	 * An already-cancelled appointment is a 400 and is not cancelled twice.
+	 *
+	 * @return void
+	 */
+	public function testCancelRefusesAnAlreadyCancelledAppointmentWithoutReCancelling(): void {
+		$this->appointmentService->method('getAppointmentByToken')
+			->willReturn(['uuid' => 'afspraak-1', 'status' => 'cancelled']);
+		$this->appointmentService->expects($this->never())->method('cancelAppointment');
+
+		$response = $this->controller->cancel(token: 'tok-secret');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'Afspraak is al geannuleerd'], $response->getData());
+	}//end testCancelRefusesAnAlreadyCancelledAppointmentWithoutReCancelling()
+
+	/**
+	 * The cancellation addresses the record's own uuid, not the token the
+	 * anonymous caller supplied.
+	 *
+	 * @return void
+	 */
+	public function testCancelActsOnTheRecordUuidRatherThanTheSuppliedToken(): void {
+		$this->appointmentService->method('getAppointmentByToken')->willReturn(self::STORED);
+
+		$cancelled = ['uuid' => 'afspraak-uuid-17', 'status' => 'cancelled'];
+
+		$this->appointmentService->expects($this->once())
+			->method('cancelAppointment')
+			->with('afspraak-uuid-17')
+			->willReturn($cancelled);
+
+		$response = $this->controller->cancel(token: 'tok-secret');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['success' => true, 'appointment' => $cancelled], $response->getData());
+	}//end testCancelActsOnTheRecordUuidRatherThanTheSuppliedToken()
+}//end class

--- a/tests/Unit/Controller/RoutingControllerContractTest.php
+++ b/tests/Unit/Controller/RoutingControllerContractTest.php
@@ -1,0 +1,277 @@
+<?php
+
+/**
+ * RoutingController Wire-Contract Tests
+ *
+ * Contract coverage for `POST /api/cases/{id}/reroute` (gate-25). Rerouting
+ * recomputes the assignee of EVERY open step on a case, so it is the one
+ * routing operation restricted to server admins. Notably the method carries
+ * NO Nextcloud auth attribute at all — only a prose `@auth` docblock — which
+ * means the admin rule is enforced NOWHERE except in the method body. These
+ * tests pin that body:
+ *
+ *  - 401 without a session;
+ *  - 403 for an authenticated NON-admin, with the admin check asserted to run
+ *    against the SESSION uid — a check run against a request-supplied id would
+ *    let any user claim admin;
+ *  - 503 (not 500, and not an empty success) when OpenRegister is absent, so
+ *    a client can tell "nothing to reroute" from "the object store is down";
+ *  - a case with no workflow template yields an EMPTY affectedSteps list with
+ *    the case id echoed — an honest "nothing was reassigned" rather than an
+ *    error;
+ *  - an unexpected failure is a 500 with a generic message that does not leak
+ *    the internal exception text.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\RoutingController;
+use OCA\Procest\Service\RoleResolverService;
+use OCA\Procest\Service\SettingsService;
+use OCP\AppFramework\Http;
+use OCP\IGroupManager;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Minimal ObjectService surface used by RoutingController::reroute().
+ *
+ * OpenRegister's ObjectService is resolved through SettingsService as an
+ * untyped `mixed`, so the test supplies a double with the one method the
+ * controller calls, using the real named-parameter signature. The name is
+ * prefixed with the controller name because sibling contract suites declare
+ * their own doubles in this namespace.
+ */
+interface RoutingControllerContractObjectService {
+	/**
+	 * Find a single object.
+	 *
+	 * @param int|string $id The object id.
+	 * @param string $register The register slug.
+	 * @param string $schema The schema slug.
+	 *
+	 * @return mixed The object.
+	 */
+	public function find(int|string $id, string $register = '', string $schema = ''): mixed;
+}//end interface
+
+/**
+ * Wire-contract tests for RoutingController::reroute().
+ *
+ * @covers \OCA\Procest\Controller\RoutingController
+ */
+class RoutingControllerContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The role resolver.
+	 *
+	 * @var RoleResolverService|MockObject
+	 */
+	private RoleResolverService $resolver;
+
+	/**
+	 * The settings bridge to OpenRegister.
+	 *
+	 * @var SettingsService|MockObject
+	 */
+	private SettingsService $settingsService;
+
+	/**
+	 * The user session.
+	 *
+	 * @var IUserSession|MockObject
+	 */
+	private IUserSession $userSession;
+
+	/**
+	 * The group manager.
+	 *
+	 * @var IGroupManager|MockObject
+	 */
+	private IGroupManager $groupManager;
+
+	/**
+	 * The logger.
+	 *
+	 * @var LoggerInterface|MockObject
+	 */
+	private LoggerInterface $logger;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var RoutingController
+	 */
+	private RoutingController $controller;
+
+	/**
+	 * Build the controller with mocked collaborators.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->resolver = $this->createMock(RoleResolverService::class);
+		$this->settingsService = $this->createMock(SettingsService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$this->controller = new RoutingController(
+			appName: 'procest',
+			request: $this->request,
+			resolver: $this->resolver,
+			settingsService: $this->settingsService,
+			userSession: $this->userSession,
+			groupManager: $this->groupManager,
+			logger: $this->logger,
+		);
+	}//end setUp()
+
+	/**
+	 * Put a signed-in user on the session.
+	 *
+	 * @param string $uid The user id.
+	 *
+	 * @return void
+	 */
+	private function signIn(string $uid): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		$this->userSession->method('getUser')->willReturn($user);
+	}//end signIn()
+
+	/**
+	 * A session-less caller is refused 401 and no object store is touched.
+	 *
+	 * @return void
+	 */
+	public function testRerouteRefusesASessionLessCallerBeforeTouchingTheObjectStore(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->settingsService->expects($this->never())->method('getObjectService');
+
+		$response = $this->controller->reroute(id: 'zaak-1');
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame(['error' => 'Authenticatie vereist'], $response->getData());
+	}//end testRerouteRefusesASessionLessCallerBeforeTouchingTheObjectStore()
+
+	/**
+	 * A non-admin is refused 403, and the admin check is run against the
+	 * SESSION uid rather than anything the caller supplied.
+	 *
+	 * @return void
+	 */
+	public function testRerouteRefusesANonAdminAndChecksAdminAgainstTheSessionUid(): void {
+		$this->signIn('gewone-behandelaar');
+
+		$this->groupManager->expects($this->once())
+			->method('isAdmin')
+			->with('gewone-behandelaar')
+			->willReturn(false);
+
+		$this->settingsService->expects($this->never())->method('getObjectService');
+
+		$response = $this->controller->reroute(id: 'zaak-1');
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame(['error' => 'Admin-rechten op de zaak vereist'], $response->getData());
+	}//end testRerouteRefusesANonAdminAndChecksAdminAgainstTheSessionUid()
+
+	/**
+	 * With OpenRegister absent the endpoint answers 503, not an empty success.
+	 *
+	 * @return void
+	 */
+	public function testRerouteReturns503WhenOpenRegisterIsUnavailableRatherThanAnEmptySuccess(): void {
+		$this->signIn('beheerder');
+		$this->groupManager->method('isAdmin')->willReturn(true);
+		$this->settingsService->method('getObjectService')->willReturn(null);
+
+		$response = $this->controller->reroute(id: 'zaak-1');
+
+		$this->assertSame(Http::STATUS_SERVICE_UNAVAILABLE, $response->getStatus());
+		$this->assertSame(['error' => 'OpenRegister is niet beschikbaar'], $response->getData());
+	}//end testRerouteReturns503WhenOpenRegisterIsUnavailableRatherThanAnEmptySuccess()
+
+	/**
+	 * A case without a workflow template reports an honest empty result: the
+	 * case id echoed and no affected steps — no rule is normalised or
+	 * resolved, because there are no steps to walk.
+	 *
+	 * @return void
+	 */
+	public function testRerouteReportsNoAffectedStepsForACaseWithoutAWorkflowTemplate(): void {
+		$this->signIn('beheerder');
+		$this->groupManager->method('isAdmin')->willReturn(true);
+
+		$objectService = $this->createMock(RoutingControllerContractObjectService::class);
+		$objectService->expects($this->once())
+			->method('find')
+			->with('zaak-1', 'procest', 'zaak')
+			->willReturn(['id' => 'zaak-1', 'workflowTemplate' => '']);
+
+		$this->settingsService->method('getObjectService')->willReturn($objectService);
+		$this->settingsService->method('getConfigValue')->willReturnCallback(
+			static function (string $key): string {
+				return match ($key) {
+					'register' => 'procest',
+					'case_schema' => 'zaak',
+					'workflow_template_schema' => 'workflowtemplate',
+					default => '',
+				};
+			}
+		);
+
+		$this->resolver->expects($this->never())->method('normaliseRule');
+		$this->resolver->expects($this->never())->method('resolve');
+
+		$response = $this->controller->reroute(id: 'zaak-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['caseId' => 'zaak-1', 'affectedSteps' => []], $response->getData());
+	}//end testRerouteReportsNoAffectedStepsForACaseWithoutAWorkflowTemplate()
+
+	/**
+	 * An unexpected failure is a generic 500 that does not leak the internal
+	 * exception text to the caller.
+	 *
+	 * @return void
+	 */
+	public function testRerouteReturnsAGeneric500WithoutLeakingTheInternalFailure(): void {
+		$this->signIn('beheerder');
+		$this->groupManager->method('isAdmin')->willReturn(true);
+		$this->settingsService->method('getObjectService')
+			->willThrowException(new \RuntimeException('PDOException: SQLSTATE[HY000] at 10.0.0.5:3306'));
+
+		$response = $this->controller->reroute(id: 'zaak-1');
+
+		$this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+		$this->assertSame(['error' => 'Herberekening mislukt'], $response->getData());
+		$this->assertStringNotContainsString('10.0.0.5', json_encode($response->getData()));
+	}//end testRerouteReturnsAGeneric500WithoutLeakingTheInternalFailure()
+}//end class

--- a/tests/Unit/Controller/StatusTransitionControllerContractTest.php
+++ b/tests/Unit/Controller/StatusTransitionControllerContractTest.php
@@ -1,0 +1,255 @@
+<?php
+
+/**
+ * StatusTransitionController Wire-Contract Tests
+ *
+ * Contract coverage for `POST /api/case/{caseId}/transition-freeform`
+ * (gate-25) — the escape hatch that moves a case to ANY status, bypassing the
+ * modelled transition graph. Its authorization is unusual and worth pinning
+ * precisely:
+ *
+ *  - the session check answers **403**, not the 401 its siblings `available()`
+ *    and `history()` use. That asymmetry is real, and a well-meaning
+ *    "consistency" fix would silently change the wire contract, so the test
+ *    asserts 403 and says why;
+ *  - the admin-only rule is NOT enforced in the controller — it lives in
+ *    `StatusTransitionService::executeFreeForm()` and surfaces as the
+ *    `forbidden_admin_only` domain code. The test asserts that code maps to
+ *    403, which is the only place that rule is observable from the wire;
+ *  - a missing `toStatusId` is a 400 raised BEFORE the engine is entered;
+ *  - `case_not_found` maps to 404, a DIFFERENT status from the 400 default
+ *    arm of the same `match`;
+ *  - none of the domain codes leak into the response body.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\StatusTransitionController;
+use OCA\Procest\Service\BulkStatusTransitionService;
+use OCA\Procest\Service\CaseAccessGuard;
+use OCA\Procest\Service\StatusTransitionService;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Wire-contract tests for StatusTransitionController::freeform().
+ *
+ * @covers \OCA\Procest\Controller\StatusTransitionController
+ */
+class StatusTransitionControllerContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock — freeform() reads its body via getParams().
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The transition engine.
+	 *
+	 * @var StatusTransitionService|MockObject
+	 */
+	private StatusTransitionService $transitionEngine;
+
+	/**
+	 * The bulk engine (unused by freeform, required by the constructor).
+	 *
+	 * @var BulkStatusTransitionService|MockObject
+	 */
+	private BulkStatusTransitionService $bulkEngine;
+
+	/**
+	 * The user session.
+	 *
+	 * @var IUserSession|MockObject
+	 */
+	private IUserSession $userSession;
+
+	/**
+	 * The logger.
+	 *
+	 * @var LoggerInterface|MockObject
+	 */
+	private LoggerInterface $logger;
+
+	/**
+	 * The per-case guard (used by the sibling endpoints).
+	 *
+	 * @var CaseAccessGuard|MockObject
+	 */
+	private CaseAccessGuard $caseAccessGuard;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var StatusTransitionController
+	 */
+	private StatusTransitionController $controller;
+
+	/**
+	 * Build the controller with mocked collaborators.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->transitionEngine = $this->createMock(StatusTransitionService::class);
+		$this->bulkEngine = $this->createMock(BulkStatusTransitionService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->caseAccessGuard = $this->createMock(CaseAccessGuard::class);
+
+		$this->controller = new StatusTransitionController(
+			appName: 'procest',
+			request: $this->request,
+			transitionEngine: $this->transitionEngine,
+			bulkEngine: $this->bulkEngine,
+			userSession: $this->userSession,
+			logger: $this->logger,
+			caseAccessGuard: $this->caseAccessGuard,
+		);
+	}//end setUp()
+
+	/**
+	 * Put a signed-in user on the session and pin the decoded body.
+	 *
+	 * @param array<string,mixed> $body The request params freeform() will read.
+	 *
+	 * @return void
+	 */
+	private function signInWithBody(array $body): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('behandelaar');
+		$this->userSession->method('getUser')->willReturn($user);
+		$this->request->method('getParams')->willReturn($body);
+	}//end signInWithBody()
+
+	/**
+	 * A session-less caller is refused with 403 — NOT the 401 the sibling
+	 * read endpoints on this controller use.
+	 *
+	 * @return void
+	 */
+	public function testFreeformRefusesASessionLessCallerWith403NotTheSiblings401(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->transitionEngine->expects($this->never())->method('executeFreeForm');
+
+		$response = $this->controller->freeform(caseId: 'zaak-1');
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertNotSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame(['error' => 'Authentication required'], $response->getData());
+	}//end testFreeformRefusesASessionLessCallerWith403NotTheSiblings401()
+
+	/**
+	 * A body without `toStatusId` is a 400 and the engine is never entered.
+	 *
+	 * @return void
+	 */
+	public function testFreeformRejectsAMissingTargetStatusBeforeEnteringTheEngine(): void {
+		$this->signInWithBody(['comment' => 'zonder doelstatus']);
+		$this->transitionEngine->expects($this->never())->method('executeFreeForm');
+
+		$response = $this->controller->freeform(caseId: 'zaak-1');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'toStatusId is required'], $response->getData());
+	}//end testFreeformRejectsAMissingTargetStatusBeforeEnteringTheEngine()
+
+	/**
+	 * The case id comes from the URL and the target status plus comment come
+	 * from the body; the engine's result is returned unwrapped.
+	 *
+	 * @return void
+	 */
+	public function testFreeformDelegatesTheUrlCaseIdWithTheBodyStatusAndComment(): void {
+		$this->signInWithBody(['toStatusId' => 'afgehandeld', 'comment' => 'ambtshalve gesloten']);
+		$result = ['caseId' => 'zaak-1', 'status' => 'afgehandeld'];
+
+		$this->transitionEngine->expects($this->once())
+			->method('executeFreeForm')
+			->with('zaak-1', 'afgehandeld', 'ambtshalve gesloten')
+			->willReturn($result);
+
+		$response = $this->controller->freeform(caseId: 'zaak-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($result, $response->getData());
+	}//end testFreeformDelegatesTheUrlCaseIdWithTheBodyStatusAndComment()
+
+	/**
+	 * An absent comment is forwarded as null, not as an empty string — the
+	 * engine records a comment field and '' would write an empty audit note.
+	 *
+	 * @return void
+	 */
+	public function testFreeformForwardsAnAbsentCommentAsNull(): void {
+		$this->signInWithBody(['toStatusId' => 'afgehandeld']);
+
+		$this->transitionEngine->expects($this->once())
+			->method('executeFreeForm')
+			->with('zaak-1', 'afgehandeld', $this->identicalTo(null))
+			->willReturn([]);
+
+		$this->controller->freeform(caseId: 'zaak-1');
+	}//end testFreeformForwardsAnAbsentCommentAsNull()
+
+	/**
+	 * The engine's admin-only refusal reaches the wire as 403 — this is the
+	 * ONLY place the admin rule of a free-form transition is observable.
+	 *
+	 * @return void
+	 */
+	public function testFreeformSurfacesTheEnginesAdminOnlyRefusalAs403(): void {
+		$this->signInWithBody(['toStatusId' => 'afgehandeld']);
+
+		$this->transitionEngine->method('executeFreeForm')
+			->willThrowException(new \RuntimeException('forbidden_admin_only'));
+
+		$response = $this->controller->freeform(caseId: 'zaak-1');
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame(['error' => 'Could not execute free-form transition'], $response->getData());
+	}//end testFreeformSurfacesTheEnginesAdminOnlyRefusalAs403()
+
+	/**
+	 * `case_not_found` is a 404, distinct from the 400 default arm.
+	 *
+	 * @return void
+	 */
+	public function testFreeformMapsAnUnknownCaseTo404AndAnUnknownCodeTo400(): void {
+		$this->signInWithBody(['toStatusId' => 'afgehandeld']);
+
+		$this->transitionEngine->method('executeFreeForm')
+			->willReturnCallback(
+				static function (string $caseId): array {
+					throw new \RuntimeException($caseId === 'zaak-weg' ? 'case_not_found' : 'iets_anders');
+				}
+			);
+
+		$notFound = $this->controller->freeform(caseId: 'zaak-weg');
+		$other = $this->controller->freeform(caseId: 'zaak-1');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $notFound->getStatus());
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $other->getStatus());
+	}//end testFreeformMapsAnUnknownCaseTo404AndAnUnknownCodeTo400()
+}//end class

--- a/tests/Unit/Controller/StufControllerContractTest.php
+++ b/tests/Unit/Controller/StufControllerContractTest.php
@@ -1,0 +1,174 @@
+<?php
+
+/**
+ * StufController Wire-Contract Tests
+ *
+ * Contract coverage for the two inbound SOAP receivers (gate-25):
+ * `POST /api/stuf/cases` (StUF-ZKN) and `POST /api/stuf/persons` (StUF-BG).
+ * Both are `#[PublicPage]` + `#[NoCSRFRequired]` — a municipal middleware
+ * component posts to them with no Nextcloud session — and both bodies are a
+ * single delegation to `StufSoapRequestDispatcher::dispatch()`. When two
+ * near-identical one-line methods differ only in a constant, the realistic
+ * defect is that constant, so that is what these tests pin:
+ *
+ *  - `cases()` dispatches with SERVICE_CASES and `persons()` with
+ *    SERVICE_PERSONS. A copy-paste that routes person messages through the
+ *    zaken handler would still return a well-formed SOAP envelope and still
+ *    answer 200 — nothing downstream would look broken;
+ *  - the two constants are genuinely different values, so the assertions above
+ *    can actually discriminate;
+ *  - the dispatcher's response is returned VERBATIM: the same object, the same
+ *    SOAP XML body and the same `text/xml` content type. Re-wrapping it (for
+ *    example into a JSONResponse) would break the wire contract the sending
+ *    zaaksysteem parses.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\StufController;
+use OCA\Procest\Service\Stuf\StufEnvelopeInspector;
+use OCA\Procest\Service\Stuf\StufServices;
+use OCA\Procest\Service\Stuf\StufSoapRequestDispatcher;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataDisplayResponse;
+use OCP\IL10N;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Wire-contract tests for StufController::cases() and ::persons().
+ *
+ * @covers \OCA\Procest\Controller\StufController
+ */
+class StufControllerContractTest extends TestCase {
+
+	/**
+	 * A minimal SOAP reply, as the dispatcher would produce it.
+	 */
+	private const SOAP_REPLY = '<?xml version="1.0"?>'
+		. '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+		. '<soap:Body><stuf:Bv03 xmlns:stuf="http://www.egem.nl/StUF/StUF0301"/></soap:Body>'
+		. '</soap:Envelope>';
+
+	/**
+	 * The inbound SOAP dispatcher.
+	 *
+	 * @var StufSoapRequestDispatcher|MockObject
+	 */
+	private StufSoapRequestDispatcher $dispatcher;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var StufController
+	 */
+	private StufController $controller;
+
+	/**
+	 * Build the controller with mocked collaborators.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->dispatcher = $this->createMock(StufSoapRequestDispatcher::class);
+
+		$this->controller = new StufController(
+			appName: 'procest',
+			request: $this->createMock(IRequest::class),
+			stuf: $this->createMock(StufServices::class),
+			dispatcher: $this->dispatcher,
+			inspector: $this->createMock(StufEnvelopeInspector::class),
+			l10n: $this->createMock(IL10N::class),
+			logger: $this->createMock(LoggerInterface::class),
+		);
+	}//end setUp()
+
+	/**
+	 * The two service constants are distinct, so the delegation assertions
+	 * below can actually tell the two receivers apart.
+	 *
+	 * @return void
+	 */
+	public function testTheZakenAndPersonenServiceDiscriminatorsAreDistinct(): void {
+		$this->assertNotSame(
+			StufSoapRequestDispatcher::SERVICE_CASES,
+			StufSoapRequestDispatcher::SERVICE_PERSONS,
+			'a single shared constant would make both receivers indistinguishable'
+		);
+	}//end testTheZakenAndPersonenServiceDiscriminatorsAreDistinct()
+
+	/**
+	 * `/api/stuf/cases` dispatches to the ZKN (cases) handler.
+	 *
+	 * @return void
+	 */
+	public function testCasesDispatchesToTheCasesServiceAndReturnsTheEnvelopeVerbatim(): void {
+		$expected = new DataDisplayResponse(self::SOAP_REPLY, Http::STATUS_OK, ['Content-Type' => 'text/xml']);
+
+		$this->dispatcher->expects($this->once())
+			->method('dispatch')
+			->with($this->anything(), StufSoapRequestDispatcher::SERVICE_CASES)
+			->willReturn($expected);
+
+		$response = $this->controller->cases();
+
+		$this->assertSame($expected, $response);
+		$this->assertSame(self::SOAP_REPLY, $response->render());
+		$this->assertSame('text/xml', $response->getHeaders()['Content-Type']);
+	}//end testCasesDispatchesToTheCasesServiceAndReturnsTheEnvelopeVerbatim()
+
+	/**
+	 * `/api/stuf/persons` dispatches to the BG (persons) handler.
+	 *
+	 * @return void
+	 */
+	public function testPersonsDispatchesToThePersonsServiceAndReturnsTheEnvelopeVerbatim(): void {
+		$expected = new DataDisplayResponse(self::SOAP_REPLY, Http::STATUS_OK, ['Content-Type' => 'text/xml']);
+
+		$this->dispatcher->expects($this->once())
+			->method('dispatch')
+			->with($this->anything(), StufSoapRequestDispatcher::SERVICE_PERSONS)
+			->willReturn($expected);
+
+		$response = $this->controller->persons();
+
+		$this->assertSame($expected, $response);
+		$this->assertSame(self::SOAP_REPLY, $response->render());
+	}//end testPersonsDispatchesToThePersonsServiceAndReturnsTheEnvelopeVerbatim()
+
+	/**
+	 * A SOAP fault from the dispatcher is passed through with its own status,
+	 * not rewritten into a 200 — the sender's retry logic reads the status.
+	 *
+	 * @return void
+	 */
+	public function testCasesPassesADispatcherFaultStatusThroughUnchanged(): void {
+		$fault = new DataDisplayResponse(
+			'<soap:Fault/>',
+			Http::STATUS_BAD_REQUEST,
+			['Content-Type' => 'text/xml']
+		);
+
+		$this->dispatcher->method('dispatch')->willReturn($fault);
+
+		$response = $this->controller->cases();
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame('<soap:Fault/>', $response->render());
+	}//end testCasesPassesADispatcherFaultStatusThroughUnchanged()
+}//end class

--- a/tests/Unit/Controller/SubsidieControllerContractTest.php
+++ b/tests/Unit/Controller/SubsidieControllerContractTest.php
@@ -1,0 +1,515 @@
+<?php
+
+/**
+ * SubsidieController Wire-Contract Tests
+ *
+ * Contract coverage for the five subsidy-lifecycle endpoints that had no
+ * automated proof of their wire behaviour (gate-25): `createBeschikking`,
+ * `publishBeschikking`, `signBeschikking`, `approveTussenrapportage` and
+ * `finalizeVaststelling`.
+ *
+ * Each one carries legal effect under AWB titel 4.2 — publishing a beschikking
+ * starts the bezwaartermijn, finalising a vaststelling can trigger a
+ * terugvordering — so the properties pinned here are:
+ *
+ *  - every endpoint answers 401 with the app's own `Authenticatie vereist`
+ *    body for a caller without a session, and its service is never reached;
+ *  - `createBeschikking` strips the ROUTING parameters out of the payload it
+ *    persists. `bodyParams()` unsets `id`/`decisionId`/`reportId`/
+ *    `uitvoeringId`/`vaststellingId`/`_route`; if that ever regressed, the
+ *    router's own `_route` string would be written into the beschikking;
+ *  - `approveTussenrapportage` forwards an ABSENT optional as null rather than
+ *    as `''`/`0.0` — an approved amount of zero is a real (and very different)
+ *    assessment from "no amount was set";
+ *  - `finalizeVaststelling` forwards its three money arguments as floats in the
+ *    declared order granted/actual/advances. All three are same-typed, and
+ *    transposing them flips the over/under-payment computation, i.e. it decides
+ *    whether the citizen is billed.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\SubsidieController;
+use OCA\Procest\Service\Subsidie\BeschikkingService;
+use OCA\Procest\Service\Subsidie\SubsidieService;
+use OCA\Procest\Service\Subsidie\TussenrapportageService;
+use OCA\Procest\Service\Subsidie\VaststellingService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\OCS\OCSBadRequestException;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Wire-contract tests for SubsidieController.
+ *
+ * @covers \OCA\Procest\Controller\SubsidieController
+ */
+class SubsidieControllerContractTest extends TestCase {
+
+	/**
+	 * The inbound request mock.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The grant-decision service mock.
+	 *
+	 * @var BeschikkingService|MockObject
+	 */
+	private BeschikkingService $decisionService;
+
+	/**
+	 * The interim-report service mock.
+	 *
+	 * @var TussenrapportageService|MockObject
+	 */
+	private TussenrapportageService $tussenrapportage;
+
+	/**
+	 * The settlement service mock.
+	 *
+	 * @var VaststellingService|MockObject
+	 */
+	private VaststellingService $determinationService;
+
+	/**
+	 * The session mock.
+	 *
+	 * @var IUserSession|MockObject
+	 */
+	private IUserSession $userSession;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var SubsidieController
+	 */
+	private SubsidieController $controller;
+
+	/**
+	 * Build the controller with all collaborators mocked.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->decisionService = $this->createMock(BeschikkingService::class);
+		$this->tussenrapportage = $this->createMock(TussenrapportageService::class);
+		$this->determinationService = $this->createMock(VaststellingService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+
+		$this->controller = new SubsidieController(
+			request: $this->request,
+			subsidyService: $this->createMock(SubsidieService::class),
+			decisionService: $this->decisionService,
+			tussenrapportage: $this->tussenrapportage,
+			determinationService: $this->determinationService,
+			userSession: $this->userSession,
+		);
+	}//end setUp()
+
+	/**
+	 * Mark the session as authenticated for caseworker `alice`.
+	 *
+	 * @return void
+	 */
+	private function authenticate(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+		$this->userSession->method('getUser')->willReturn($user);
+	}//end authenticate()
+
+	/**
+	 * Feed the single-parameter accessor.
+	 *
+	 * @param array<string, mixed> $params The request parameters.
+	 *
+	 * @return void
+	 */
+	private function withParams(array $params): void {
+		$this->request->method('getParam')->willReturnCallback(
+			static function (string $key, mixed $default = null) use ($params): mixed {
+				if (array_key_exists($key, $params) === true) {
+					return $params[$key];
+				}
+
+				return $default;
+			}
+		);
+	}//end withParams()
+
+	/**
+	 * Feed the whole parameter bag (used by `bodyParams()`).
+	 *
+	 * @param array<string, mixed> $params The request parameters.
+	 *
+	 * @return void
+	 */
+	private function withParamBag(array $params): void {
+		$this->request->method('getParams')->willReturn($params);
+	}//end withParamBag()
+
+	/**
+	 * Every one of the five endpoints refuses an anonymous caller with 401 and
+	 * the app's own Dutch error body, and no lifecycle service is reached.
+	 *
+	 * Each of these five writes a legally effective record, so a body that ran
+	 * before the session check would be a write by an unauthenticated caller.
+	 *
+	 * @return void
+	 */
+	public function testAllFiveLifecycleEndpointsRefuseAnAnonymousCaller(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->withParams([]);
+		$this->withParamBag([]);
+
+		$this->decisionService->expects($this->never())->method('createDraft');
+		$this->decisionService->expects($this->never())->method('publish');
+		$this->decisionService->expects($this->never())->method('sign');
+		$this->tussenrapportage->expects($this->never())->method('approveReport');
+		$this->determinationService->expects($this->never())->method('finalize');
+
+		$responses = [
+			'createBeschikking' => $this->controller->createBeschikking(id: 'aanvraag-1'),
+			'publishBeschikking' => $this->controller->publishBeschikking(decisionId: 'besch-1'),
+			'signBeschikking' => $this->controller->signBeschikking(decisionId: 'besch-1'),
+			'approveTussenrapportage' => $this->controller->approveTussenrapportage(reportId: 'rap-1'),
+			'finalizeVaststelling' => $this->controller->finalizeVaststelling(determinationId: 'vast-1'),
+		];
+
+		foreach ($responses as $endpoint => $response) {
+			$this->assertSame(
+				Http::STATUS_UNAUTHORIZED,
+				$response->getStatus(),
+				$endpoint . ' must answer 401 for a caller without a session'
+			);
+			$this->assertSame(
+				['error' => 'Authenticatie vereist'],
+				$response->getData(),
+				$endpoint . ' must answer the app-standard unauthenticated body'
+			);
+		}
+	}//end testAllFiveLifecycleEndpointsRefuseAnAnonymousCaller()
+
+	/**
+	 * createBeschikking drafts against the aanvraag named in the route, with
+	 * the routing parameters stripped out of the persisted payload and the
+	 * sequence lifted out of the body into its own argument.
+	 *
+	 * @return void
+	 */
+	public function testCreateBeschikkingStripsRoutingParametersFromThePayload(): void {
+		$this->authenticate();
+		$this->withParamBag(
+			[
+				'id' => 'aanvraag-1',
+				'_route' => 'procest.subsidie.createBeschikking',
+				'decisionId' => 'leaked-decision',
+				'reportId' => 'leaked-report',
+				'uitvoeringId' => 'leaked-uitvoering',
+				'vaststellingId' => 'leaked-vaststelling',
+				'sequence' => 3,
+				'grantedAmount' => 25000,
+				'motivation' => 'Voldoet aan de regeling.',
+			]
+		);
+
+		$draft = ['id' => 'besch-1', 'status' => 'concept'];
+
+		$this->decisionService->expects($this->once())
+			->method('createDraft')
+			->with(
+				'aanvraag-1',
+				['grantedAmount' => 25000, 'motivation' => 'Voldoet aan de regeling.'],
+				3
+			)
+			->willReturn($draft);
+
+		$response = $this->controller->createBeschikking(id: 'aanvraag-1');
+
+		$this->assertSame(Http::STATUS_CREATED, $response->getStatus());
+		$this->assertSame($draft, $response->getData());
+	}//end testCreateBeschikkingStripsRoutingParametersFromThePayload()
+
+	/**
+	 * A beschikking with no explicit sequence is the FIRST one — the default is
+	 * 1, not 0, because the sequence numbers the decisions on an aanvraag.
+	 *
+	 * @return void
+	 */
+	public function testCreateBeschikkingDefaultsTheSequenceToOne(): void {
+		$this->authenticate();
+		$this->withParamBag(['id' => 'aanvraag-1', 'motivation' => 'Akkoord.']);
+
+		$this->decisionService->expects($this->once())
+			->method('createDraft')
+			->with('aanvraag-1', ['motivation' => 'Akkoord.'], 1)
+			->willReturn(['id' => 'besch-1']);
+
+		$response = $this->controller->createBeschikking(id: 'aanvraag-1');
+
+		$this->assertSame(Http::STATUS_CREATED, $response->getStatus());
+	}//end testCreateBeschikkingDefaultsTheSequenceToOne()
+
+	/**
+	 * A service-level validation refusal on createBeschikking is a 400 carrying
+	 * the reason, not a 201 with nothing behind it.
+	 *
+	 * @return void
+	 */
+	public function testCreateBeschikkingMapsAValidationRefusalTo400(): void {
+		$this->authenticate();
+		$this->withParamBag(['id' => 'aanvraag-1']);
+
+		$this->decisionService->method('createDraft')
+			->willThrowException(new OCSBadRequestException('Aanvraag not found'));
+
+		$response = $this->controller->createBeschikking(id: 'aanvraag-1');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'Aanvraag not found'], $response->getData());
+	}//end testCreateBeschikkingMapsAValidationRefusalTo400()
+
+	/**
+	 * publishBeschikking publishes the beschikking named in the route and
+	 * answers 200 with the published record — publication is what starts the
+	 * bezwaartermijn, so it must be the route id that is published and nothing
+	 * else.
+	 *
+	 * @return void
+	 */
+	public function testPublishBeschikkingPublishesTheRoutedDecision(): void {
+		$this->authenticate();
+		$this->withParams(['decisionId' => 'besch-other']);
+
+		$published = ['id' => 'besch-1', 'status' => 'published', 'bezwaarDeadline' => '2026-09-27'];
+
+		$this->decisionService->expects($this->once())
+			->method('publish')
+			->with('besch-1')
+			->willReturn($published);
+
+		$response = $this->controller->publishBeschikking(decisionId: 'besch-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($published, $response->getData());
+	}//end testPublishBeschikkingPublishesTheRoutedDecision()
+
+	/**
+	 * An unpublishable beschikking (e.g. still unsigned) is a 400 carrying the
+	 * reason — publication must not report success it did not perform.
+	 *
+	 * @return void
+	 */
+	public function testPublishBeschikkingMapsARefusalTo400(): void {
+		$this->authenticate();
+		$this->withParams([]);
+
+		$this->decisionService->method('publish')
+			->willThrowException(new OCSBadRequestException('Beschikking must be signed before publication'));
+
+		$response = $this->controller->publishBeschikking(decisionId: 'besch-1');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(
+			['error' => 'Beschikking must be signed before publication'],
+			$response->getData()
+		);
+	}//end testPublishBeschikkingMapsARefusalTo400()
+
+	/**
+	 * signBeschikking passes ONLY the routed decision id — the signer is
+	 * derived inside the service from the session and is deliberately not a
+	 * controller argument, so no caller-supplied signer can reach it.
+	 *
+	 * @return void
+	 */
+	public function testSignBeschikkingPassesOnlyTheRoutedDecisionId(): void {
+		$this->authenticate();
+		$this->withParams(['signer' => 'mallory', 'decisionId' => 'besch-other']);
+
+		$signed = ['id' => 'besch-1', 'status' => 'signed'];
+
+		$this->decisionService->expects($this->once())
+			->method('sign')
+			->with('besch-1')
+			->willReturn($signed);
+
+		$response = $this->controller->signBeschikking(decisionId: 'besch-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($signed, $response->getData());
+	}//end testSignBeschikkingPassesOnlyTheRoutedDecisionId()
+
+	/**
+	 * A signing refusal is a 400 carrying the reason.
+	 *
+	 * @return void
+	 */
+	public function testSignBeschikkingMapsARefusalTo400(): void {
+		$this->authenticate();
+		$this->withParams([]);
+
+		$this->decisionService->method('sign')
+			->willThrowException(new OCSBadRequestException('Beschikking already signed'));
+
+		$response = $this->controller->signBeschikking(decisionId: 'besch-1');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'Beschikking already signed'], $response->getData());
+	}//end testSignBeschikkingMapsARefusalTo400()
+
+	/**
+	 * approveTussenrapportage forwards the assessment opinion as a string and
+	 * the approved amount as a FLOAT — a numeric string reaching the service
+	 * would be persisted as a string amount.
+	 *
+	 * @return void
+	 */
+	public function testApproveTussenrapportageForwardsTheOpinionAndAFloatAmount(): void {
+		$this->authenticate();
+		$this->withParams(['beoordelingsoordeel' => 'positief', 'approvedAmount' => '1500.50']);
+
+		$approved = ['id' => 'rap-1', 'status' => 'approved'];
+
+		$this->tussenrapportage->expects($this->once())
+			->method('approveReport')
+			->with('rap-1', 'positief', 1500.50)
+			->willReturn($approved);
+
+		$response = $this->controller->approveTussenrapportage(reportId: 'rap-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($approved, $response->getData());
+	}//end testApproveTussenrapportageForwardsTheOpinionAndAFloatAmount()
+
+	/**
+	 * An omitted opinion or amount reaches the service as NULL, not as `''` or
+	 * `0.0`. Approving a report "for 0 euro" is a real assessment and must not
+	 * be indistinguishable from approving it without setting an amount.
+	 *
+	 * @return void
+	 */
+	public function testApproveTussenrapportageForwardsAbsentOptionalsAsNullNotZero(): void {
+		$this->authenticate();
+		$this->withParams([]);
+
+		$this->tussenrapportage->expects($this->once())
+			->method('approveReport')
+			->with('rap-1', null, null)
+			->willReturn(['id' => 'rap-1']);
+
+		$response = $this->controller->approveTussenrapportage(reportId: 'rap-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+	}//end testApproveTussenrapportageForwardsAbsentOptionalsAsNullNotZero()
+
+	/**
+	 * An approval refusal is a 400 carrying the reason.
+	 *
+	 * @return void
+	 */
+	public function testApproveTussenrapportageMapsARefusalTo400(): void {
+		$this->authenticate();
+		$this->withParams([]);
+
+		$this->tussenrapportage->method('approveReport')
+			->willThrowException(new OCSBadRequestException('Tussenrapportage not found'));
+
+		$response = $this->controller->approveTussenrapportage(reportId: 'rap-1');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'Tussenrapportage not found'], $response->getData());
+	}//end testApproveTussenrapportageMapsARefusalTo400()
+
+	/**
+	 * finalizeVaststelling forwards granted amount, actual cost and total
+	 * advances as floats IN THAT ORDER. The service subtracts advances from the
+	 * determined amount to decide whether a terugvordering is triggered, so a
+	 * transposition here decides whether the citizen gets a bill.
+	 *
+	 * @return void
+	 */
+	public function testFinalizeVaststellingForwardsTheThreeAmountsInDeclaredOrder(): void {
+		$this->authenticate();
+		$this->withParams(
+			[
+				'grantedAmount' => '10000',
+				'werkelijkeKosten' => '8000.25',
+				'totaalVoorschotten' => '9000',
+			]
+		);
+
+		$result = ['id' => 'vast-1', 'determinedAmount' => 8000.25, 'recoveryTrigger' => true];
+
+		$this->determinationService->expects($this->once())
+			->method('finalize')
+			->with('vast-1', 10000.0, 8000.25, 9000.0)
+			->willReturn($result);
+
+		$response = $this->controller->finalizeVaststelling(determinationId: 'vast-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($result, $response->getData());
+	}//end testFinalizeVaststellingForwardsTheThreeAmountsInDeclaredOrder()
+
+	/**
+	 * Omitted amounts default to 0.0 floats rather than being dropped — the
+	 * service takes three non-nullable floats, so a dropped argument would be a
+	 * TypeError rather than a settlement.
+	 *
+	 * @return void
+	 */
+	public function testFinalizeVaststellingDefaultsAbsentAmountsToZeroFloats(): void {
+		$this->authenticate();
+		$this->withParams([]);
+
+		$this->determinationService->expects($this->once())
+			->method('finalize')
+			->with('vast-1', 0.0, 0.0, 0.0)
+			->willReturn(['id' => 'vast-1']);
+
+		$response = $this->controller->finalizeVaststelling(determinationId: 'vast-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+	}//end testFinalizeVaststellingDefaultsAbsentAmountsToZeroFloats()
+
+	/**
+	 * A settlement refusal is a 400 carrying the reason.
+	 *
+	 * @return void
+	 */
+	public function testFinalizeVaststellingMapsARefusalTo400(): void {
+		$this->authenticate();
+		$this->withParams([]);
+
+		$this->determinationService->method('finalize')
+			->willThrowException(new OCSBadRequestException('Vaststelling already finalised'));
+
+		$response = $this->controller->finalizeVaststelling(determinationId: 'vast-1');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'Vaststelling already finalised'], $response->getData());
+	}//end testFinalizeVaststellingMapsARefusalTo400()
+}//end class

--- a/tests/Unit/Controller/SubstitutionControllerContractTest.php
+++ b/tests/Unit/Controller/SubstitutionControllerContractTest.php
@@ -1,0 +1,252 @@
+<?php
+
+/**
+ * SubstitutionController Wire-Contract Tests
+ *
+ * Contract coverage for `GET /api/substitutions/work` and
+ * `GET /api/substitutions/{id}/actions` (gate-25). Both are
+ * `#[NoAdminRequired]`, so every guard is written in the controller body:
+ *
+ *  - both refuse a session-less caller with the guard's real **403** (this
+ *    controller's refusal vocabulary is `forbidden()`, not a 401) and neither
+ *    reaches its domain service;
+ *  - `substitutedWork()` resolves the work list from the SESSION uid. There is
+ *    no request parameter that can point it at another handler's queue, and
+ *    the `->with()` on the session uid is what proves that — reading a
+ *    `userId` parameter here would be a straight IDOR into a colleague's
+ *    caseload;
+ *  - `actions()` returns 404 for an unknown substitution BEFORE the audit
+ *    service is entered, and 403 when `mayView()` refuses — a capacity-stamped
+ *    action list names who did what on whose behalf, so the view check must
+ *    run before the audit read, not after it;
+ *  - the action list is wrapped under `results`.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\SubstitutionController;
+use OCA\Procest\Service\SettingsService;
+use OCA\Procest\Service\Substitution\SubstitutionAccessGuard;
+use OCA\Procest\Service\SubstitutionAuditService;
+use OCA\Procest\Service\SubstitutionService;
+use OCP\AppFramework\Http;
+use OCP\IGroupManager;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Wire-contract tests for SubstitutionController.
+ *
+ * @covers \OCA\Procest\Controller\SubstitutionController
+ *
+ * @uses \OCA\Procest\Service\Substitution\SubstitutionAccessGuard
+ */
+class SubstitutionControllerContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The substitution domain service.
+	 *
+	 * @var SubstitutionService|MockObject
+	 */
+	private SubstitutionService $substitutionService;
+
+	/**
+	 * The capacity audit service.
+	 *
+	 * @var SubstitutionAuditService|MockObject
+	 */
+	private SubstitutionAuditService $auditService;
+
+	/**
+	 * The logger.
+	 *
+	 * @var LoggerInterface|MockObject
+	 */
+	private LoggerInterface $logger;
+
+	/**
+	 * Build the shared collaborators.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->substitutionService = $this->createMock(SubstitutionService::class);
+		$this->auditService = $this->createMock(SubstitutionAuditService::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+	}//end setUp()
+
+	/**
+	 * Build the controller around the supplied guard.
+	 *
+	 * @param SubstitutionAccessGuard $accessGuard The guard to install.
+	 *
+	 * @return SubstitutionController
+	 */
+	private function controller(SubstitutionAccessGuard $accessGuard): SubstitutionController {
+		return new SubstitutionController(
+			appName: 'procest',
+			request: $this->request,
+			substitutionService: $this->substitutionService,
+			auditService: $this->auditService,
+			accessGuard: $accessGuard,
+			logger: $this->logger,
+		);
+	}//end controller()
+
+	/**
+	 * A REAL guard wired to an empty session, so the 403 asserted is the
+	 * application's own response rather than a stubbed one.
+	 *
+	 * @return SubstitutionAccessGuard
+	 */
+	private function realGuardWithoutSession(): SubstitutionAccessGuard {
+		$userSession = $this->createMock(IUserSession::class);
+		$userSession->method('getUser')->willReturn(null);
+
+		return new SubstitutionAccessGuard(
+			settingsService: $this->createMock(SettingsService::class),
+			userSession: $userSession,
+			groupManager: $this->createMock(IGroupManager::class),
+		);
+	}//end realGuardWithoutSession()
+
+	/**
+	 * Both read endpoints refuse a session-less caller with 403 and neither
+	 * domain service is entered.
+	 *
+	 * @return void
+	 */
+	public function testBothReadEndpointsRefuseASessionLessCallerWith403(): void {
+		$this->substitutionService->expects($this->never())->method('getSubstitutedWorkFor');
+		$this->auditService->expects($this->never())->method('getActionsForSubstitution');
+
+		$controller = $this->controller($this->realGuardWithoutSession());
+
+		$work = $controller->substitutedWork();
+		$actions = $controller->actions(id: 'verv-1');
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $work->getStatus());
+		$this->assertSame(['error' => 'Not authenticated'], $work->getData());
+		$this->assertSame(Http::STATUS_FORBIDDEN, $actions->getStatus());
+		$this->assertSame(['error' => 'Not authenticated'], $actions->getData());
+	}//end testBothReadEndpointsRefuseASessionLessCallerWith403()
+
+	/**
+	 * The substituted-work list is resolved for the SESSION uid.
+	 *
+	 * @return void
+	 */
+	public function testSubstitutedWorkResolvesForTheSessionUidAndNotForAnyInput(): void {
+		$accessGuard = $this->createMock(SubstitutionAccessGuard::class);
+		$accessGuard->method('currentUid')->willReturn('waarnemer');
+
+		$work = [['caseId' => 'zaak-1', 'onBehalfOf' => 'afwezige']];
+
+		$this->substitutionService->expects($this->once())
+			->method('getSubstitutedWorkFor')
+			->with('waarnemer')
+			->willReturn($work);
+
+		$response = $this->controller($accessGuard)->substitutedWork();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($work, $response->getData());
+	}//end testSubstitutedWorkResolvesForTheSessionUidAndNotForAnyInput()
+
+	/**
+	 * An unknown substitution is a 404, and the audit trail is not read.
+	 *
+	 * @return void
+	 */
+	public function testActionsReturns404ForAnUnknownSubstitutionWithoutReadingTheAudit(): void {
+		$accessGuard = $this->createMock(SubstitutionAccessGuard::class);
+		$accessGuard->method('currentUid')->willReturn('waarnemer');
+		$accessGuard->expects($this->once())->method('find')->with('verv-weg')->willReturn(null);
+
+		$this->auditService->expects($this->never())->method('getActionsForSubstitution');
+
+		$response = $this->controller($accessGuard)->actions(id: 'verv-weg');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertSame(['error' => 'Substitution not found'], $response->getData());
+	}//end testActionsReturns404ForAnUnknownSubstitutionWithoutReadingTheAudit()
+
+	/**
+	 * A caller `mayView()` refuses gets the guard's 403, and the audit trail
+	 * is not read — the view check runs BEFORE the audit read.
+	 *
+	 * @return void
+	 */
+	public function testActionsRefusesAnUnrelatedCallerBeforeReadingTheAuditTrail(): void {
+		$row = ['id' => 'verv-1', 'absentee' => 'afwezige', 'substitute' => 'waarnemer'];
+
+		$accessGuard = $this->createMock(SubstitutionAccessGuard::class);
+		$accessGuard->method('currentUid')->willReturn('buitenstaander');
+		$accessGuard->method('find')->willReturn($row);
+		$accessGuard->expects($this->once())
+			->method('mayView')
+			->with($row, 'buitenstaander')
+			->willReturn(false);
+		$accessGuard->method('forbidden')
+			->willReturn(new \OCP\AppFramework\Http\JSONResponse(
+				['error' => 'Not authorised'],
+				Http::STATUS_FORBIDDEN
+			));
+
+		$this->auditService->expects($this->never())->method('getActionsForSubstitution');
+
+		$response = $this->controller($accessGuard)->actions(id: 'verv-1');
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+	}//end testActionsRefusesAnUnrelatedCallerBeforeReadingTheAuditTrail()
+
+	/**
+	 * An authorised caller gets the capacity-stamped actions under `results`.
+	 *
+	 * @return void
+	 */
+	public function testActionsWrapsTheCapacityStampedActionsUnderResults(): void {
+		$row = ['id' => 'verv-1'];
+		$actions = [['caseId' => 'zaak-1', 'capacity' => 'waarnemer', 'at' => '2026-08-01']];
+
+		$accessGuard = $this->createMock(SubstitutionAccessGuard::class);
+		$accessGuard->method('currentUid')->willReturn('waarnemer');
+		$accessGuard->method('find')->willReturn($row);
+		$accessGuard->method('mayView')->willReturn(true);
+
+		$this->auditService->expects($this->once())
+			->method('getActionsForSubstitution')
+			->with('verv-1')
+			->willReturn($actions);
+
+		$response = $this->controller($accessGuard)->actions(id: 'verv-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['results' => $actions], $response->getData());
+	}//end testActionsWrapsTheCapacityStampedActionsUnderResults()
+}//end class

--- a/tests/Unit/Controller/TenantControllerContractTest.php
+++ b/tests/Unit/Controller/TenantControllerContractTest.php
@@ -1,0 +1,162 @@
+<?php
+
+/**
+ * TenantController Wire-Contract Tests
+ *
+ * Contract coverage for `GET /api/tenants/current` (gate-25). This is the only
+ * `@NoAdminRequired` endpoint on a controller whose two siblings are
+ * admin-gated, and it is the endpoint every page load consults to learn which
+ * tenant's data it may show. These tests pin:
+ *
+ *  - 401 without a session, before any tenant lookup runs;
+ *  - the tenant is resolved from the SESSION UID and nothing else — there is
+ *    no request parameter that can steer the lookup at another tenant, and
+ *    that absence is what the `->with()` on the session UID proves;
+ *  - "no tenant assigned" is a 200 with `tenant: null`, NOT a 404. The
+ *    frontend treats a 404 as an error banner, so collapsing the two would
+ *    break every unassigned account.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\TenantController;
+use OCA\Procest\Service\TenantService;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Wire-contract tests for TenantController::current().
+ *
+ * @covers \OCA\Procest\Controller\TenantController
+ */
+class TenantControllerContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The tenant service.
+	 *
+	 * @var TenantService|MockObject
+	 */
+	private TenantService $tenantService;
+
+	/**
+	 * The user session.
+	 *
+	 * @var IUserSession|MockObject
+	 */
+	private IUserSession $userSession;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var TenantController
+	 */
+	private TenantController $controller;
+
+	/**
+	 * Build the controller with mocked collaborators.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->tenantService = $this->createMock(TenantService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+
+		$this->controller = new TenantController(
+			request: $this->request,
+			tenantService: $this->tenantService,
+			userSession: $this->userSession,
+		);
+	}//end setUp()
+
+	/**
+	 * Put a signed-in user with the given UID on the session.
+	 *
+	 * @param string $uid The user id.
+	 *
+	 * @return void
+	 */
+	private function signIn(string $uid): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		$this->userSession->method('getUser')->willReturn($user);
+	}//end signIn()
+
+	/**
+	 * An unauthenticated caller gets 401 and no tenant is resolved.
+	 *
+	 * @return void
+	 */
+	public function testCurrentRefusesAnUnauthenticatedCallerBeforeResolvingATenant(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->tenantService->expects($this->never())->method('getTenantForUser');
+
+		$response = $this->controller->current();
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame(['success' => false, 'error' => 'Not authenticated'], $response->getData());
+	}//end testCurrentRefusesAnUnauthenticatedCallerBeforeResolvingATenant()
+
+	/**
+	 * The lookup runs on the session UID, and the tenant is echoed back.
+	 *
+	 * @return void
+	 */
+	public function testCurrentResolvesTheTenantFromTheSessionUidAndNotFromInput(): void {
+		$this->signIn('bob');
+		$tenant = ['id' => 'tenant-7', 'naam' => 'Gemeente Voorbeeld'];
+
+		$this->tenantService->expects($this->once())
+			->method('getTenantForUser')
+			->with('bob')
+			->willReturn($tenant);
+
+		$response = $this->controller->current();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['success' => true, 'tenant' => $tenant], $response->getData());
+	}//end testCurrentResolvesTheTenantFromTheSessionUidAndNotFromInput()
+
+	/**
+	 * An account with no tenant is a successful 200 carrying a null tenant,
+	 * not a 404.
+	 *
+	 * @return void
+	 */
+	public function testCurrentReportsAnUnassignedAccountAsASuccessfulNullTenant(): void {
+		$this->signIn('carol');
+		$this->tenantService->method('getTenantForUser')->willReturn(null);
+
+		$response = $this->controller->current();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(
+			['success' => true, 'tenant' => null, 'message' => 'No tenant assigned'],
+			$response->getData()
+		);
+	}//end testCurrentReportsAnUnassignedAccountAsASuccessfulNullTenant()
+}//end class

--- a/tests/Unit/Controller/TermijnControllerContractTest.php
+++ b/tests/Unit/Controller/TermijnControllerContractTest.php
@@ -1,0 +1,342 @@
+<?php
+
+/**
+ * TermijnController Wire-Contract Tests
+ *
+ * Contract coverage for the four TermijnInstance lifecycle actions (gate-25):
+ * `pauze`, `hervat`, `verleng` and `voltooi` on
+ * `/api/termijn/instances/{id}/...`. Every one of them moves an Awb statutory
+ * deadline — pausing one under art. 4:5, resuming it, extending it under
+ * art. 4:14, or closing it — which is the clock a dwangsom is calculated
+ * against. These tests pin:
+ *
+ *  - all four refuse a session-less caller with **403**. That is what the
+ *    controller's own `ensureAuthenticated()` returns; it is NOT the 401 the
+ *    rest of procest uses, and the asymmetry is asserted explicitly so a
+ *    "consistency" edit cannot change the wire contract unnoticed. The
+ *    refusal is checked with `never()` on all three services, so no clock
+ *    moves;
+ *  - `verleng` takes the STANDARD extension path by default. The supervisor
+ *    path bypasses the TermijnDefinitie's `aantalVerlengingen` ceiling, so if
+ *    an absent `supervisorOverride` fell through to it, any caseworker could
+ *    extend a deadline past its statutory limit. The test asserts
+ *    `requestSupervisorExtension()` is NEVER called on a body that did not ask
+ *    for it, and asserts the standard call really is made;
+ *  - `hervat` resumes with a null date (meaning "now") when the body carries
+ *    no `aanvullingDatum`, rather than forwarding a bogus date object;
+ *  - `voltooi` distinguishes a missing instance (404) from a domain rejection
+ *    (400) — closing a termijn that does not exist is not the same failure as
+ *    closing one that refuses to close;
+ *  - a domain `Throwable` is a 400 carrying the domain message.
+ *
+ * All four methods read their body via `file_get_contents('php://input')`,
+ * which is empty under PHPUnit — so the arguments asserted below are the
+ * documented defaults, which is precisely the path an empty-body POST takes.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\TermijnController;
+use OCA\Procest\Service\DeadlineExtensionService;
+use OCA\Procest\Service\DeadlinePauseService;
+use OCA\Procest\Service\TermijnService;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Wire-contract tests for TermijnController's four lifecycle actions.
+ *
+ * @covers \OCA\Procest\Controller\TermijnController
+ */
+class TermijnControllerContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The termijn service.
+	 *
+	 * @var TermijnService|MockObject
+	 */
+	private TermijnService $term;
+
+	/**
+	 * The pause service.
+	 *
+	 * @var DeadlinePauseService|MockObject
+	 */
+	private DeadlinePauseService $pause;
+
+	/**
+	 * The extension service.
+	 *
+	 * @var DeadlineExtensionService|MockObject
+	 */
+	private DeadlineExtensionService $extension;
+
+	/**
+	 * The user session.
+	 *
+	 * @var IUserSession|MockObject
+	 */
+	private IUserSession $userSession;
+
+	/**
+	 * The logger.
+	 *
+	 * @var LoggerInterface|MockObject
+	 */
+	private LoggerInterface $logger;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var TermijnController
+	 */
+	private TermijnController $controller;
+
+	/**
+	 * Build the controller with mocked collaborators.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->term = $this->createMock(TermijnService::class);
+		$this->pause = $this->createMock(DeadlinePauseService::class);
+		$this->extension = $this->createMock(DeadlineExtensionService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$this->controller = new TermijnController(
+			appName: 'procest',
+			request: $this->request,
+			term: $this->term,
+			pause: $this->pause,
+			extension: $this->extension,
+			userSession: $this->userSession,
+			logger: $this->logger,
+		);
+	}//end setUp()
+
+	/**
+	 * Put a signed-in user on the session.
+	 *
+	 * @return void
+	 */
+	private function signIn(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('behandelaar');
+		$this->userSession->method('getUser')->willReturn($user);
+	}//end signIn()
+
+	/**
+	 * All four lifecycle actions refuse a session-less caller with 403 — this
+	 * controller's refusal status, deliberately NOT 401 — and no clock moves.
+	 *
+	 * @return void
+	 */
+	public function testAllFourLifecycleActionsRefuseASessionLessCallerWith403AndMoveNoClock(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+
+		$this->pause->expects($this->never())->method('registerPauze');
+		$this->pause->expects($this->never())->method('resumeAfterPauze');
+		$this->extension->expects($this->never())->method('requestExtension');
+		$this->extension->expects($this->never())->method('requestSupervisorExtension');
+		$this->term->expects($this->never())->method('markTermijnCompleted');
+
+		$responses = [
+			'pauze' => $this->controller->pauze(id: 'ti-1'),
+			'hervat' => $this->controller->hervat(id: 'ti-1'),
+			'verleng' => $this->controller->verleng(id: 'ti-1'),
+			'voltooi' => $this->controller->voltooi(id: 'ti-1'),
+		];
+
+		foreach ($responses as $action => $response) {
+			$this->assertSame(
+				Http::STATUS_FORBIDDEN,
+				$response->getStatus(),
+				$action . ' must refuse an anonymous caller with 403'
+			);
+			$this->assertNotSame(
+				Http::STATUS_UNAUTHORIZED,
+				$response->getStatus(),
+				$action . ' uses 403, not 401 — changing it changes the wire contract'
+			);
+			$this->assertSame(['message' => 'Not authenticated'], $response->getData());
+		}
+	}//end testAllFourLifecycleActionsRefuseASessionLessCallerWith403AndMoveNoClock()
+
+	/**
+	 * pauze registers the pause on the instance from the URL and returns the
+	 * updated row.
+	 *
+	 * @return void
+	 */
+	public function testPauzeRegistersThePauseOnTheInstanceFromTheUrl(): void {
+		$this->signIn();
+		$row = ['id' => 'ti-9', 'status' => 'paused'];
+
+		$this->pause->expects($this->once())
+			->method('registerPauze')
+			->with('ti-9')
+			->willReturn($row);
+
+		$response = $this->controller->pauze(id: 'ti-9');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($row, $response->getData());
+	}//end testPauzeRegistersThePauseOnTheInstanceFromTheUrl()
+
+	/**
+	 * A domain rejection from the pause service (e.g. a non-positive duration
+	 * under Awb 4:5) is a 400 carrying the domain message.
+	 *
+	 * @return void
+	 */
+	public function testPauzeMapsADomainRejectionToA400CarryingTheAwbMessage(): void {
+		$this->signIn();
+
+		$this->pause->method('registerPauze')
+			->willThrowException(new \RuntimeException('Pause duration must be positive (AWB 4:5)'));
+
+		$response = $this->controller->pauze(id: 'ti-9');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['message' => 'Pause duration must be positive (AWB 4:5)'], $response->getData());
+	}//end testPauzeMapsADomainRejectionToA400CarryingTheAwbMessage()
+
+	/**
+	 * hervat resumes with a null resume-date when the body carries none,
+	 * meaning "resume now" rather than a fabricated date.
+	 *
+	 * @return void
+	 */
+	public function testHervatResumesWithANullDateWhenTheBodyCarriesNoResumeDate(): void {
+		$this->signIn();
+		$row = ['id' => 'ti-9', 'status' => 'running'];
+
+		$this->pause->expects($this->once())
+			->method('resumeAfterPauze')
+			->with('ti-9', $this->identicalTo(null))
+			->willReturn($row);
+
+		$response = $this->controller->hervat(id: 'ti-9');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($row, $response->getData());
+	}//end testHervatResumesWithANullDateWhenTheBodyCarriesNoResumeDate()
+
+	/**
+	 * verleng takes the STANDARD extension path unless the body explicitly
+	 * asks for the supervisor override.
+	 *
+	 * The supervisor path bypasses the aantalVerlengingen ceiling, so falling
+	 * through to it by default would let any caseworker extend a statutory
+	 * deadline without limit.
+	 *
+	 * @return void
+	 */
+	public function testVerlengUsesTheStandardPathAndNeverTheCeilingBypassingSupervisorPath(): void {
+		$this->signIn();
+		$row = ['id' => 'ti-9', 'endDateCurrent' => '2026-12-01'];
+
+		$this->extension->expects($this->never())->method('requestSupervisorExtension');
+		$this->extension->expects($this->once())
+			->method('requestExtension')
+			->with('ti-9')
+			->willReturn($row);
+
+		$response = $this->controller->verleng(id: 'ti-9');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($row, $response->getData());
+	}//end testVerlengUsesTheStandardPathAndNeverTheCeilingBypassingSupervisorPath()
+
+	/**
+	 * A rejected extension is a 400 carrying the domain message.
+	 *
+	 * @return void
+	 */
+	public function testVerlengMapsARejectedExtensionToA400CarryingTheDomainMessage(): void {
+		$this->signIn();
+
+		$this->extension->method('requestExtension')
+			->willThrowException(new \RuntimeException('Extension ceiling reached (AWB 4:14)'));
+
+		$response = $this->controller->verleng(id: 'ti-9');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['message' => 'Extension ceiling reached (AWB 4:14)'], $response->getData());
+	}//end testVerlengMapsARejectedExtensionToA400CarryingTheDomainMessage()
+
+	/**
+	 * voltooi closes the instance from the URL and returns the updated row.
+	 *
+	 * @return void
+	 */
+	public function testVoltooiClosesTheInstanceFromTheUrlAndReturnsTheUpdatedRow(): void {
+		$this->signIn();
+		$row = ['id' => 'ti-9', 'status' => 'completed'];
+
+		$this->term->expects($this->once())
+			->method('markTermijnCompleted')
+			->with('ti-9')
+			->willReturn($row);
+
+		$response = $this->controller->voltooi(id: 'ti-9');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($row, $response->getData());
+	}//end testVoltooiClosesTheInstanceFromTheUrlAndReturnsTheUpdatedRow()
+
+	/**
+	 * A null return from the service means "no such instance" and is a 404
+	 * naming the id — DISTINCT from the 400 a domain rejection produces.
+	 *
+	 * @return void
+	 */
+	public function testVoltooiDistinguishesAMissingInstance404FromADomainRejection400(): void {
+		$this->signIn();
+
+		$this->term->method('markTermijnCompleted')->willReturnCallback(
+			static function (string $id): ?array {
+				if ($id === 'ti-weg') {
+					return null;
+				}
+
+				throw new \RuntimeException('Termijn already completed');
+			}
+		);
+
+		$missing = $this->controller->voltooi(id: 'ti-weg');
+		$rejected = $this->controller->voltooi(id: 'ti-9');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $missing->getStatus());
+		$this->assertSame(['message' => 'TermijnInstance not found: ti-weg'], $missing->getData());
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $rejected->getStatus());
+		$this->assertSame(['message' => 'Termijn already completed'], $rejected->getData());
+	}//end testVoltooiDistinguishesAMissingInstance404FromADomainRejection400()
+}//end class

--- a/tests/Unit/Controller/VoorstelBesluitControllerContractTest.php
+++ b/tests/Unit/Controller/VoorstelBesluitControllerContractTest.php
@@ -1,0 +1,589 @@
+<?php
+
+/**
+ * VoorstelBesluitController Wire-Contract Tests
+ *
+ * Contract coverage for `POST /api/voorstellen/{voorstelId}/register-besluit`
+ * (gate-25). Registering a besluit on a voorstel does NOT author a
+ * procest-local decision: per ADR-019 / REQ-PDRD-001 it raises a decidesk
+ * `report-adoption` Decision, and per REQ-PDRD-002 it must FAIL CLOSED when
+ * decidesk is unavailable. These tests pin both the IDOR gate and that
+ * fail-closed rule:
+ *
+ *  - 401 without a session, before the voorstel is even loaded;
+ *  - 404 when the voorstel cannot be resolved — and, crucially, NOTHING is
+ *    raised in decidesk. Raising first and checking later would create a
+ *    Decision for a voorstel the caller may not touch;
+ *  - 403 when the caller is neither the voorstel owner, its assignee, nor an
+ *    admin — with `raiseVoorstelBesluit()` asserted NEVER called. The 403 and
+ *    the 404 deliberately carry the SAME message so the endpoint is not an
+ *    existence oracle, and that sameness is asserted;
+ *  - the assignee arm is exercised separately from the owner arm, so a gate
+ *    that only ever honoured `@self.owner` would fail;
+ *  - REQ-PDRD-002: a `RuntimeException` from the delegation is a **503**, and
+ *    the response carries NO locally-authored besluit — there is no fallback;
+ *  - the happy path is **202 Accepted** (not 201) carrying the decidesk
+ *    `decisionRef` and `status: awaiting-decidesk`, because procest has not
+ *    decided anything yet — decidesk has yet to.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\VoorstelBesluitController;
+use OCA\Procest\Service\AdviceDelegationService;
+use OCA\Procest\Service\SettingsService;
+use OCP\AppFramework\Http;
+use OCP\IGroupManager;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Minimal ObjectService surface used by VoorstelBesluitController.
+ *
+ * The controller resolves OpenRegister's ObjectService through SettingsService
+ * as an untyped `mixed` and calls `find()` with named `register:`/`schema:`
+ * arguments, so the double must carry those parameter names. Prefixed with the
+ * controller name because sibling contract suites declare their own doubles in
+ * this namespace.
+ */
+interface VoorstelBesluitControllerContractObjectService {
+	/**
+	 * Find a single object.
+	 *
+	 * @param int|string $id The object id.
+	 * @param string $register The register slug.
+	 * @param string $schema The schema slug.
+	 *
+	 * @return mixed The object.
+	 */
+	public function find(int|string $id, string $register = '', string $schema = ''): mixed;
+}//end interface
+
+/**
+ * Concrete IRequest stub serving a raw body for the VoorstelBesluit tests.
+ *
+ * `getContent()` is not on the OCP\IRequest interface (it is a magic accessor
+ * on the concrete OC request), so a PHPUnit mock of IRequest has no such
+ * method and calling it raises an Error.
+ */
+class VoorstelBesluitControllerContractRequestStub implements IRequest {
+
+	/**
+	 * The raw request body returned by getContent().
+	 *
+	 * @var string
+	 */
+	private string $content;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $content The raw request body.
+	 */
+	public function __construct(string $content = '') {
+		$this->content = $content;
+	}//end __construct()
+
+	/**
+	 * Return the raw request body.
+	 *
+	 * @return string
+	 */
+	public function getContent(): string {
+		return $this->content;
+	}//end getContent()
+
+	/**
+	 * Return a request header value.
+	 *
+	 * @param string $name Header name.
+	 *
+	 * @return string
+	 */
+	public function getHeader(string $name): string {
+		return '';
+	}//end getHeader()
+
+	/**
+	 * Return a single request parameter.
+	 *
+	 * @param string $key Parameter name.
+	 * @param mixed $default Default when absent.
+	 *
+	 * @return mixed
+	 */
+	public function getParam(string $key, mixed $default = null): mixed {
+		return $default;
+	}//end getParam()
+
+	/**
+	 * Return all request parameters.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public function getParams(): array {
+		return [];
+	}//end getParams()
+
+	/**
+	 * Return the HTTP method.
+	 *
+	 * @return string
+	 */
+	public function getMethod(): string {
+		return 'POST';
+	}//end getMethod()
+
+	/**
+	 * Return an uploaded file.
+	 *
+	 * @param string $key File field name.
+	 *
+	 * @return mixed
+	 */
+	public function getUploadedFile(string $key): mixed {
+		return null;
+	}//end getUploadedFile()
+
+	/**
+	 * Return a server environment variable.
+	 *
+	 * @param string $key Variable name.
+	 *
+	 * @return mixed
+	 */
+	public function getEnv(string $key): mixed {
+		return null;
+	}//end getEnv()
+
+	/**
+	 * Return a cookie value.
+	 *
+	 * @param string $key Cookie name.
+	 *
+	 * @return mixed
+	 */
+	public function getCookie(string $key): mixed {
+		return null;
+	}//end getCookie()
+
+	/**
+	 * Whether the request passes the CSRF check.
+	 *
+	 * @return bool
+	 */
+	public function passesCSRFCheck(): bool {
+		return true;
+	}//end passesCSRFCheck()
+
+	/**
+	 * Whether the request passes the strict cookie check.
+	 *
+	 * @return bool
+	 */
+	public function passesStrictCookieCheck(): bool {
+		return true;
+	}//end passesStrictCookieCheck()
+
+	/**
+	 * Whether the request passes the lax cookie check.
+	 *
+	 * @return bool
+	 */
+	public function passesLaxCookieCheck(): bool {
+		return true;
+	}//end passesLaxCookieCheck()
+
+	/**
+	 * Return the unique request id.
+	 *
+	 * @return string
+	 */
+	public function getId(): string {
+		return 'voorstel-besluit-contract-test';
+	}//end getId()
+
+	/**
+	 * Return the remote address.
+	 *
+	 * @return string
+	 */
+	public function getRemoteAddress(): string {
+		return '127.0.0.1';
+	}//end getRemoteAddress()
+
+	/**
+	 * Return the server protocol.
+	 *
+	 * @return string
+	 */
+	public function getServerProtocol(): string {
+		return 'HTTP/1.1';
+	}//end getServerProtocol()
+
+	/**
+	 * Return the HTTP scheme.
+	 *
+	 * @return string
+	 */
+	public function getHttpProtocol(): string {
+		return 'https';
+	}//end getHttpProtocol()
+
+	/**
+	 * Return the request URI.
+	 *
+	 * @return string
+	 */
+	public function getRequestUri(): string {
+		return '/apps/procest/api/voorstellen/voorstel-1/register-besluit';
+	}//end getRequestUri()
+
+	/**
+	 * Return the raw path info.
+	 *
+	 * @return string
+	 */
+	public function getRawPathInfo(): string {
+		return '';
+	}//end getRawPathInfo()
+
+	/**
+	 * Return the decoded path info.
+	 *
+	 * @return mixed
+	 */
+	public function getPathInfo(): mixed {
+		return '';
+	}//end getPathInfo()
+
+	/**
+	 * Return the script name.
+	 *
+	 * @return string
+	 */
+	public function getScriptName(): string {
+		return '';
+	}//end getScriptName()
+
+	/**
+	 * Whether the request comes from one of the given user agents.
+	 *
+	 * @param array<int,string> $agent Agent patterns.
+	 *
+	 * @return bool
+	 */
+	public function isUserAgent(array $agent): bool {
+		return false;
+	}//end isUserAgent()
+
+	/**
+	 * Return the insecure server host.
+	 *
+	 * @return string
+	 */
+	public function getInsecureServerHost(): string {
+		return 'localhost';
+	}//end getInsecureServerHost()
+
+	/**
+	 * Return the server host.
+	 *
+	 * @return string
+	 */
+	public function getServerHost(): string {
+		return 'localhost';
+	}//end getServerHost()
+
+	/**
+	 * Rethrow a body-decoding failure, if any.
+	 *
+	 * @return void
+	 */
+	public function throwDecodingExceptionIfAny(): void {
+	}//end throwDecodingExceptionIfAny()
+
+	/**
+	 * Return the requested response format.
+	 *
+	 * @return string|null
+	 */
+	public function getFormat(): ?string {
+		return null;
+	}//end getFormat()
+}//end class
+
+/**
+ * Wire-contract tests for VoorstelBesluitController::registerBesluit().
+ *
+ * @covers \OCA\Procest\Controller\VoorstelBesluitController
+ */
+class VoorstelBesluitControllerContractTest extends TestCase {
+
+	/**
+	 * The decidesk delegation service.
+	 *
+	 * @var AdviceDelegationService|MockObject
+	 */
+	private AdviceDelegationService $adviceDelegation;
+
+	/**
+	 * The settings service (register/schema + ObjectService resolver).
+	 *
+	 * @var SettingsService|MockObject
+	 */
+	private SettingsService $settingsService;
+
+	/**
+	 * The user session.
+	 *
+	 * @var IUserSession|MockObject
+	 */
+	private IUserSession $userSession;
+
+	/**
+	 * The group manager (admin bypass on the IDOR gate).
+	 *
+	 * @var IGroupManager|MockObject
+	 */
+	private IGroupManager $groupManager;
+
+	/**
+	 * The logger.
+	 *
+	 * @var LoggerInterface|MockObject
+	 */
+	private LoggerInterface $logger;
+
+	/**
+	 * Build the shared collaborators.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->adviceDelegation = $this->createMock(AdviceDelegationService::class);
+		$this->settingsService = $this->createMock(SettingsService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$this->settingsService->method('getConfigValue')->willReturnCallback(
+			static function (string $key): string {
+				return match ($key) {
+					'register' => 'procest',
+					'voorstel_schema' => 'voorstel',
+					default => '',
+				};
+			}
+		);
+	}//end setUp()
+
+	/**
+	 * Build the controller with the given request body.
+	 *
+	 * @param string $body The raw JSON body.
+	 *
+	 * @return VoorstelBesluitController
+	 */
+	private function controller(string $body = ''): VoorstelBesluitController {
+		return new VoorstelBesluitController(
+			request: new VoorstelBesluitControllerContractRequestStub(content: $body),
+			adviceDelegation: $this->adviceDelegation,
+			settingsService: $this->settingsService,
+			userSession: $this->userSession,
+			groupManager: $this->groupManager,
+			logger: $this->logger,
+		);
+	}//end controller()
+
+	/**
+	 * Put a signed-in, non-admin user on the session.
+	 *
+	 * @param string $uid The user id.
+	 *
+	 * @return void
+	 */
+	private function signIn(string $uid): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		$this->userSession->method('getUser')->willReturn($user);
+		$this->groupManager->method('isAdmin')->willReturn(false);
+	}//end signIn()
+
+	/**
+	 * Install an ObjectService that resolves the voorstel to the given record.
+	 *
+	 * @param array<string,mixed>|null $proposal The voorstel record, or null.
+	 *
+	 * @return void
+	 */
+	private function withProposal(?array $proposal): void {
+		$objectService = $this->createMock(VoorstelBesluitControllerContractObjectService::class);
+		$objectService->method('find')->willReturn($proposal);
+		$this->settingsService->method('getObjectService')->willReturn($objectService);
+	}//end withProposal()
+
+	/**
+	 * A session-less caller is refused 401 and nothing is raised in decidesk.
+	 *
+	 * @return void
+	 */
+	public function testRegisterBesluitRefusesASessionLessCallerAndRaisesNothing(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->adviceDelegation->expects($this->never())->method('raiseVoorstelBesluit');
+
+		$response = $this->controller()->registerBesluit(proposalId: 'voorstel-1');
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame(['error' => 'Authenticatie vereist'], $response->getData());
+	}//end testRegisterBesluitRefusesASessionLessCallerAndRaisesNothing()
+
+	/**
+	 * An unresolvable voorstel is a 404, raised BEFORE any decidesk Decision.
+	 *
+	 * @return void
+	 */
+	public function testRegisterBesluitReturns404ForAnUnresolvableVoorstelWithoutRaising(): void {
+		$this->signIn('behandelaar');
+		$this->settingsService->method('getObjectService')->willReturn(null);
+		$this->adviceDelegation->expects($this->never())->method('raiseVoorstelBesluit');
+
+		$response = $this->controller()->registerBesluit(proposalId: 'voorstel-1');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertSame(['error' => 'Voorstel niet toegankelijk'], $response->getData());
+	}//end testRegisterBesluitReturns404ForAnUnresolvableVoorstelWithoutRaising()
+
+	/**
+	 * A caller who is neither owner, assignee nor admin is refused 403 and no
+	 * Decision is raised — and the message matches the 404 exactly, so the
+	 * endpoint cannot be used to probe which voorstellen exist.
+	 *
+	 * @return void
+	 */
+	public function testRegisterBesluitRefusesAnUnrelatedCallerWithoutBecomingAnExistenceOracle(): void {
+		$this->signIn('buitenstaander');
+		$this->withProposal(['@self' => ['owner' => 'eigenaar'], 'assignee' => 'behandelaar']);
+		$this->adviceDelegation->expects($this->never())->method('raiseVoorstelBesluit');
+
+		$response = $this->controller()->registerBesluit(proposalId: 'voorstel-1');
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame(
+			['error' => 'Voorstel niet toegankelijk'],
+			$response->getData(),
+			'the 403 body must be identical to the 404 body, or the status pair leaks existence'
+		);
+	}//end testRegisterBesluitRefusesAnUnrelatedCallerWithoutBecomingAnExistenceOracle()
+
+	/**
+	 * The recorded ASSIGNEE may register, not only the owner — a gate wired
+	 * solely to `@self.owner` would lock out the actual handler.
+	 *
+	 * @return void
+	 */
+	public function testRegisterBesluitAdmitsTheRecordedAssigneeAndNotOnlyTheOwner(): void {
+		$this->signIn('behandelaar');
+		$this->withProposal([
+			'@self' => ['owner' => 'iemand-anders'],
+			'assignee' => 'behandelaar',
+			'case' => 'zaak-5',
+			'onderwerp' => 'Vaststelling jaarrekening',
+		]);
+
+		$this->adviceDelegation->expects($this->once())
+			->method('raiseVoorstelBesluit')
+			->willReturn('decidesk:decision:abc');
+
+		$response = $this->controller()->registerBesluit(proposalId: 'voorstel-1');
+
+		$this->assertSame(Http::STATUS_ACCEPTED, $response->getStatus());
+	}//end testRegisterBesluitAdmitsTheRecordedAssigneeAndNotOnlyTheOwner()
+
+	/**
+	 * REQ-PDRD-002: when decidesk is unavailable the endpoint FAILS CLOSED
+	 * with 503 and authors no local besluit as a fallback.
+	 *
+	 * @return void
+	 */
+	public function testRegisterBesluitFailsClosedWith503WhenDecideskIsUnavailable(): void {
+		$this->signIn('eigenaar');
+		$this->withProposal(['@self' => ['owner' => 'eigenaar']]);
+
+		$this->adviceDelegation->method('raiseVoorstelBesluit')
+			->willThrowException(new \RuntimeException('decidesk not reachable'));
+
+		$response = $this->controller()->registerBesluit(proposalId: 'voorstel-1');
+		$data = $response->getData();
+
+		$this->assertSame(Http::STATUS_SERVICE_UNAVAILABLE, $response->getStatus());
+		$this->assertSame('Besluitdienst niet beschikbaar: decidesk not reachable', $data['error']);
+		$this->assertArrayNotHasKey(
+			'decisionRef',
+			$data,
+			'a fail-closed response must not carry a locally-authored besluit'
+		);
+	}//end testRegisterBesluitFailsClosedWith503WhenDecideskIsUnavailable()
+
+	/**
+	 * The happy path is 202 Accepted with the decidesk reference and an
+	 * `awaiting-decidesk` status — procest has NOT decided anything yet, so a
+	 * 201 Created would misstate the outcome. The payload sent to decidesk
+	 * carries the voorstel's case as the external reference and the body's
+	 * title.
+	 *
+	 * @return void
+	 */
+	public function testRegisterBesluitAnswers202AwaitingDecideskWithTheDecisionReference(): void {
+		$this->signIn('eigenaar');
+		$this->withProposal([
+			'@self' => ['owner' => 'eigenaar'],
+			'case' => 'zaak-5',
+			'onderwerp' => 'Vaststelling jaarrekening',
+		]);
+
+		$this->adviceDelegation->expects($this->once())
+			->method('raiseVoorstelBesluit')
+			->with(
+				'voorstel-1',
+				[
+					'externalReference' => 'zaak-5',
+					'subjectLabel' => 'Jaarrekening 2026',
+					'title' => 'Jaarrekening 2026',
+					'governingBody' => 'college',
+					'explanation' => 'conform advies',
+				]
+			)
+			->willReturn('decidesk:decision:abc');
+
+		$body = '{"title":"Jaarrekening 2026","governingBody":"college","explanation":"conform advies"}';
+		$response = $this->controller($body)->registerBesluit(proposalId: 'voorstel-1');
+
+		$this->assertSame(Http::STATUS_ACCEPTED, $response->getStatus());
+		$this->assertSame(
+			[
+				'voorstelId' => 'voorstel-1',
+				'decisionRef' => 'decidesk:decision:abc',
+				'status' => 'awaiting-decidesk',
+			],
+			$response->getData()
+		);
+	}//end testRegisterBesluitAnswers202AwaitingDecideskWithTheDecisionReference()
+}//end class

--- a/tests/Unit/Controller/ZaakdossierControllerContractTest.php
+++ b/tests/Unit/Controller/ZaakdossierControllerContractTest.php
@@ -1,0 +1,365 @@
+<?php
+
+/**
+ * ZaakdossierController Wire-Contract Tests
+ *
+ * Contract coverage (gate-25) for the three ZaakdossierController endpoints
+ * that had no automated proof of their wire behaviour.
+ *
+ * Every informatieobject in the dossier carries a `vertrouwelijkheidaanduiding`
+ * and the clearance gate for it is `InformatieobjectReader::guardReadable()`,
+ * which answers a ready-made refusal Response or null. Three properties of the
+ * way these endpoints use it are pinned, and each one fails silently:
+ *
+ *  - `linkExisting()` / `unlinkDocument()` return the reader's OWN response
+ *    untouched — the controller must not downgrade a 403 into its own generic
+ *    error, and must not run the mutation afterwards;
+ *  - `bulkUpdateMetadata()` gates PER ID inside the loop. A document the caller
+ *    may not read is reported as a per-id failure and is NOT written, while the
+ *    rest of the batch still proceeds — a bulk route that gated only the first
+ *    id, or aborted the whole batch, would both look correct from the outside;
+ *  - a dossier backend that is not wired up answers 503, distinct from the 403
+ *    above, so a client can tell "not allowed" from "store unavailable".
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\ZaakdossierController;
+use OCA\Procest\Service\Zaakdossier\DossierUploadHandler;
+use OCA\Procest\Service\Zaakdossier\InformatieobjectReader;
+use OCA\Procest\Service\ZaakdossierService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Wire-contract tests for ZaakdossierController.
+ *
+ * @covers \OCA\Procest\Controller\ZaakdossierController
+ */
+class ZaakdossierControllerContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock handed to the controller.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The dossier orchestrator.
+	 *
+	 * @var ZaakdossierService|MockObject
+	 */
+	private ZaakdossierService $fileService;
+
+	/**
+	 * The clearance-gated document reader.
+	 *
+	 * @var InformatieobjectReader|MockObject
+	 */
+	private InformatieobjectReader $reader;
+
+	/**
+	 * The upload decoding/screening collaborator (untouched by these routes).
+	 *
+	 * @var DossierUploadHandler|MockObject
+	 */
+	private DossierUploadHandler $uploadHandler;
+
+	/**
+	 * The user session.
+	 *
+	 * @var IUserSession|MockObject
+	 */
+	private IUserSession $userSession;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var ZaakdossierController
+	 */
+	private ZaakdossierController $controller;
+
+	/**
+	 * Build the controller with all collaborators mocked.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->fileService = $this->createMock(ZaakdossierService::class);
+		$this->reader = $this->createMock(InformatieobjectReader::class);
+		$this->uploadHandler = $this->createMock(DossierUploadHandler::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+
+		$this->controller = new ZaakdossierController(
+			appName: 'procest',
+			request: $this->request,
+			fileService: $this->fileService,
+			reader: $this->reader,
+			uploadHandler: $this->uploadHandler,
+			userSession: $this->userSession,
+		);
+	}//end setUp()
+
+	/**
+	 * Put a user in the session.
+	 *
+	 * @param string $uid The uid the session user reports.
+	 *
+	 * @return IUser|MockObject The session user.
+	 */
+	private function signIn(string $uid = 'handler'): IUser {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		$this->userSession->method('getUser')->willReturn($user);
+
+		return $user;
+	}//end signIn()
+
+	/**
+	 * Make `getParam()` behave like the real request.
+	 *
+	 * @param array<string, mixed> $overrides Parameter values to serve.
+	 *
+	 * @return void
+	 */
+	private function withRequestParams(array $overrides): void {
+		$this->request->method('getParam')->willReturnCallback(
+			static function (string $key, mixed $default = null) use ($overrides): mixed {
+				return ($overrides[$key] ?? $default);
+			}
+		);
+	}//end withRequestParams()
+
+	/**
+	 * All three endpoints refuse an anonymous caller with 401 and neither read
+	 * nor write a single informatieobject.
+	 *
+	 * @return void
+	 */
+	public function testAllThreeEndpointsRefuseAnAnonymousCallerWith401(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->reader->expects($this->never())->method('guardReadable');
+		$this->fileService->expects($this->never())->method('linkExistingInformatieobject');
+		$this->fileService->expects($this->never())->method('unlinkInformatieobject');
+		$this->fileService->expects($this->never())->method('updateMetadata');
+
+		$responses = [
+			'linkExisting' => $this->controller->linkExisting(caseId: 'case-1', infoObjectId: 'io-1'),
+			'unlinkDocument' => $this->controller->unlinkDocument(caseId: 'case-1', infoObjectId: 'io-1'),
+			'bulkUpdateMetadata' => $this->controller->bulkUpdateMetadata(),
+		];
+
+		foreach ($responses as $endpoint => $response) {
+			$this->assertSame(
+				Http::STATUS_UNAUTHORIZED,
+				$response->getStatus(),
+				$endpoint . ' must refuse an anonymous caller'
+			);
+			$this->assertSame(['error' => 'Not authenticated'], $response->getData());
+		}
+	}//end testAllThreeEndpointsRefuseAnAnonymousCallerWith401()
+
+	/**
+	 * linkExisting hands the clearance gate the document the route names, and
+	 * returns the gate's OWN refusal untouched without linking anything.
+	 *
+	 * @return void
+	 */
+	public function testLinkExistingReturnsTheClearanceRefusalAndLinksNothing(): void {
+		$user = $this->signIn();
+		$refusal = new JSONResponse(data: ['error' => 'Insufficient clearance'], statusCode: Http::STATUS_FORBIDDEN);
+
+		$this->reader->expects($this->once())
+			->method('guardReadable')
+			->with($user, 'io-confidential')
+			->willReturn($refusal);
+		$this->fileService->expects($this->never())->method('linkExistingInformatieobject');
+
+		$response = $this->controller->linkExisting(caseId: 'case-1', infoObjectId: 'io-confidential');
+
+		$this->assertSame($refusal, $response, 'the reader\'s own refusal must be returned verbatim');
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+	}//end testLinkExistingReturnsTheClearanceRefusalAndLinksNothing()
+
+	/**
+	 * A cleared link answers 201 Created — a join is created, so 200 would
+	 * misreport it — and carries the join result.
+	 *
+	 * @return void
+	 */
+	public function testLinkExistingAnswers201WithTheJoinForAClearedCaller(): void {
+		$this->signIn();
+		$this->reader->method('guardReadable')->willReturn(null);
+
+		$this->fileService->expects($this->once())
+			->method('linkExistingInformatieobject')
+			->with('case-1', 'io-1')
+			->willReturn(['id' => 'zio-3', 'zaak' => 'case-1']);
+
+		$response = $this->controller->linkExisting(caseId: 'case-1', infoObjectId: 'io-1');
+
+		$this->assertSame(Http::STATUS_CREATED, $response->getStatus());
+		$this->assertSame(['id' => 'zio-3', 'zaak' => 'case-1'], $response->getData());
+	}//end testLinkExistingAnswers201WithTheJoinForAClearedCaller()
+
+	/**
+	 * An unwired dossier store answers 503 — distinct from the 403 above, so a
+	 * client can tell a permission problem from an outage.
+	 *
+	 * @return void
+	 */
+	public function testLinkExistingAnswers503WhenTheDossierStoreIsUnavailable(): void {
+		$this->signIn();
+		$this->reader->method('guardReadable')->willReturn(null);
+		$this->fileService->method('linkExistingInformatieobject')
+			->willThrowException(new \RuntimeException('OpenRegister is not available'));
+
+		$response = $this->controller->linkExisting(caseId: 'case-1', infoObjectId: 'io-1');
+
+		$this->assertSame(Http::STATUS_SERVICE_UNAVAILABLE, $response->getStatus());
+		$this->assertSame(['error' => 'OpenRegister is not available'], $response->getData());
+	}//end testLinkExistingAnswers503WhenTheDossierStoreIsUnavailable()
+
+	/**
+	 * unlinkDocument takes the same clearance gate before mutating, and returns
+	 * the gate's refusal without unlinking.
+	 *
+	 * @return void
+	 */
+	public function testUnlinkDocumentReturnsTheClearanceRefusalAndUnlinksNothing(): void {
+		$user = $this->signIn();
+		$refusal = new JSONResponse(data: ['error' => 'Insufficient clearance'], statusCode: Http::STATUS_FORBIDDEN);
+
+		$this->reader->expects($this->once())
+			->method('guardReadable')
+			->with($user, 'io-confidential')
+			->willReturn($refusal);
+		$this->fileService->expects($this->never())->method('unlinkInformatieobject');
+
+		$response = $this->controller->unlinkDocument(caseId: 'case-1', infoObjectId: 'io-confidential');
+
+		$this->assertSame($refusal, $response);
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+	}//end testUnlinkDocumentReturnsTheClearanceRefusalAndUnlinksNothing()
+
+	/**
+	 * A cleared unlink reports whether a join was actually removed under
+	 * `unlinked` — the endpoint detaches the document from the case, it does
+	 * not delete it, so the boolean is the whole result.
+	 *
+	 * @return void
+	 */
+	public function testUnlinkDocumentReportsWhetherAJoinWasRemoved(): void {
+		$this->signIn();
+		$this->reader->method('guardReadable')->willReturn(null);
+
+		$this->fileService->expects($this->once())
+			->method('unlinkInformatieobject')
+			->with('case-1', 'io-1')
+			->willReturn(true);
+
+		$response = $this->controller->unlinkDocument(caseId: 'case-1', infoObjectId: 'io-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['unlinked' => true], $response->getData());
+	}//end testUnlinkDocumentReportsWhetherAJoinWasRemoved()
+
+	/**
+	 * The bulk route gates EVERY id, not just the first: the document the
+	 * caller may not read is reported as a per-id failure and never written,
+	 * while the readable ones are still updated with the posted metadata.
+	 *
+	 * @return void
+	 */
+	public function testBulkUpdateMetadataGatesEveryIdAndStillProcessesTheRest(): void {
+		$this->signIn();
+		$this->withRequestParams(
+			[
+				'ids' => ['io-secret', 'io-ok'],
+				'metadata' => ['vertrouwelijkheidaanduiding' => 'openbaar'],
+			]
+		);
+
+		$this->reader->method('guardReadable')->willReturnCallback(
+			static function (IUser $user, string $infoObjectId): ?JSONResponse {
+				if ($infoObjectId === 'io-secret') {
+					return new JSONResponse(data: ['error' => 'denied'], statusCode: Http::STATUS_FORBIDDEN);
+				}
+
+				return null;
+			}
+		);
+
+		$this->fileService->expects($this->once())
+			->method('updateMetadata')
+			->with('io-ok', ['vertrouwelijkheidaanduiding' => 'openbaar'])
+			->willReturn(['id' => 'io-ok']);
+
+		$response = $this->controller->bulkUpdateMetadata();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(
+			[
+				'results' => [
+					['id' => 'io-secret', 'success' => false, 'error' => 'Insufficient clearance'],
+					['id' => 'io-ok', 'success' => true],
+				],
+			],
+			$response->getData()
+		);
+	}//end testBulkUpdateMetadataGatesEveryIdAndStillProcessesTheRest()
+
+	/**
+	 * A backend failure on one id is reported against THAT id and does not
+	 * abort the batch — the remaining ids are still attempted.
+	 *
+	 * @return void
+	 */
+	public function testBulkUpdateMetadataReportsAPerIdFailureWithoutAbortingTheBatch(): void {
+		$this->signIn();
+		$this->withRequestParams(['ids' => ['io-1', 'io-2'], 'metadata' => ['title' => 'Nieuw']]);
+		$this->reader->method('guardReadable')->willReturn(null);
+
+		$this->fileService->method('updateMetadata')->willReturnCallback(
+			static function (string $infoObjectId, array $metadata): array {
+				if ($infoObjectId === 'io-1') {
+					throw new \RuntimeException('Store unavailable');
+				}
+
+				return ['id' => $infoObjectId];
+			}
+		);
+
+		$response = $this->controller->bulkUpdateMetadata();
+
+		$this->assertSame(
+			[
+				'results' => [
+					['id' => 'io-1', 'success' => false, 'error' => 'Store unavailable'],
+					['id' => 'io-2', 'success' => true],
+				],
+			],
+			$response->getData()
+		);
+	}//end testBulkUpdateMetadataReportsAPerIdFailureWithoutAbortingTheBatch()
+}//end class

--- a/tests/Unit/Controller/ZaakdossierDownloadControllerContractTest.php
+++ b/tests/Unit/Controller/ZaakdossierDownloadControllerContractTest.php
@@ -1,0 +1,345 @@
+<?php
+
+/**
+ * ZaakdossierDownloadController Wire-Contract Tests
+ *
+ * Contract coverage for the two single-document download routes (gate-25):
+ * `GET /api/objects/{register}/{schema}/{objectId}/files/{fileId}/download`
+ * and the ZGW DRC-compatible
+ * `GET /api/zgw/documenten/v1/enkelvoudiginformatieobjecten/{uuid}/download`.
+ * Both serve file BYTES out of a zaakdossier, and both are gated per-object on
+ * `vertrouwelijkheidaanduiding` by `InformatieobjectReader::loadReadable()`.
+ * These tests pin:
+ *
+ *  - 401 without a session on BOTH, with the reader asserted NEVER entered —
+ *    the clearance gate must not even be consulted for an anonymous caller;
+ *  - the clearance refusal PASSES THROUGH VERBATIM. `loadReadable()` returns
+ *    either the document array or a JSONResponse denial, and the endpoints
+ *    must return that denial object unchanged and NOT go on to read content.
+ *    This is the whole confidentiality gate, and it is asserted with an
+ *    identity check plus a `never()` on `contentFor()`;
+ *  - the document is addressed by the URL's `{objectId}` / `{uuid}` segment;
+ *  - a resolvable document whose bytes are missing is a 404, not an empty
+ *    download a client would silently write to disk as a 0-byte file;
+ *  - `downloadZgwDocumenten` honours HTTP Range: a full request is 200 with
+ *    `Accept-Ranges: bytes`, and a satisfiable `Range` is 206 with a correct
+ *    `Content-Range` and only the requested slice in the body.
+ *
+ * ⚠️ THE SUCCESSFUL `downloadFile` RESPONSE SHAPE IS NOT ASSERTED, DELIBERATELY.
+ * `OCP\AppFramework\Http\DataDownloadResponse` cannot be constructed in this
+ * unit-test environment: `DownloadResponse::__construct()` calls
+ * `Symfony\Component\HttpFoundation\HeaderUtils`, and symfony/http-foundation
+ * is not in procest's vendor tree (Nextcloud supplies it at runtime).
+ * Constructing one raises an `Error`. The pre-existing
+ * `ZaakdossierDownloadControllerGuardTest::testCallerWithCaseAccessStillGetsTheArchive`
+ * is red on an untouched checkout for exactly this reason. So `downloadFile`
+ * is covered on its refusal branches and on the reader delegation; its
+ * `RangeStreamResponse` sibling — a procest-owned class with no Symfony
+ * dependency — carries the successful-download assertions instead.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Http\RangeStreamResponse;
+use OCA\Procest\Service\CaseAccessGuard;
+use OCA\Procest\Service\Zaakdossier\DossierZipExporter;
+use OCA\Procest\Service\Zaakdossier\InformatieobjectReader;
+use OCA\Procest\Controller\ZaakdossierDownloadController;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Wire-contract tests for the ZaakdossierDownloadController file endpoints.
+ *
+ * @covers \OCA\Procest\Controller\ZaakdossierDownloadController
+ *
+ * @uses \OCA\Procest\Http\RangeStreamResponse
+ */
+class ZaakdossierDownloadControllerContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The clearance-gated document reader.
+	 *
+	 * @var InformatieobjectReader|MockObject
+	 */
+	private InformatieobjectReader $reader;
+
+	/**
+	 * The ZIP exporter (used by the sibling downloadZip endpoint).
+	 *
+	 * @var DossierZipExporter|MockObject
+	 */
+	private DossierZipExporter $zipExporter;
+
+	/**
+	 * The user session.
+	 *
+	 * @var IUserSession|MockObject
+	 */
+	private IUserSession $userSession;
+
+	/**
+	 * The logger.
+	 *
+	 * @var LoggerInterface|MockObject
+	 */
+	private LoggerInterface $logger;
+
+	/**
+	 * The per-case guard (used by the sibling downloadZip endpoint).
+	 *
+	 * @var CaseAccessGuard|MockObject
+	 */
+	private CaseAccessGuard $caseAccessGuard;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var ZaakdossierDownloadController
+	 */
+	private ZaakdossierDownloadController $controller;
+
+	/**
+	 * Build the controller with mocked collaborators.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->reader = $this->createMock(InformatieobjectReader::class);
+		$this->zipExporter = $this->createMock(DossierZipExporter::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->caseAccessGuard = $this->createMock(CaseAccessGuard::class);
+
+		$this->controller = new ZaakdossierDownloadController(
+			appName: 'procest',
+			request: $this->request,
+			reader: $this->reader,
+			zipExporter: $this->zipExporter,
+			userSession: $this->userSession,
+			logger: $this->logger,
+			caseAccessGuard: $this->caseAccessGuard,
+		);
+	}//end setUp()
+
+	/**
+	 * Put a signed-in user on the session.
+	 *
+	 * @return void
+	 */
+	private function signIn(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('behandelaar');
+		$this->userSession->method('getUser')->willReturn($user);
+	}//end signIn()
+
+	/**
+	 * Neither download endpoint may reach the clearance reader without a
+	 * session.
+	 *
+	 * @return void
+	 */
+	public function testBothDownloadEndpointsRefuseASessionLessCallerBeforeTheClearanceReader(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->reader->expects($this->never())->method('loadReadable');
+		$this->reader->expects($this->never())->method('contentFor');
+
+		$file = $this->controller->downloadFile(
+			register: 'procest',
+			schema: 'informatieobject',
+			objectId: 'io-1',
+			fileId: 42,
+		);
+		$zgw = $this->controller->downloadZgwDocumenten(uuid: 'io-1');
+
+		$this->assertInstanceOf(JSONResponse::class, $file);
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $file->getStatus());
+		$this->assertSame(['error' => 'Not authenticated'], $file->getData());
+		$this->assertInstanceOf(JSONResponse::class, $zgw);
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $zgw->getStatus());
+	}//end testBothDownloadEndpointsRefuseASessionLessCallerBeforeTheClearanceReader()
+
+	/**
+	 * downloadFile addresses the document by the URL's `{objectId}` segment,
+	 * and a clearance denial from the reader is returned VERBATIM with no
+	 * content read.
+	 *
+	 * @return void
+	 */
+	public function testDownloadFileReturnsTheClearanceDenialVerbatimAndReadsNoContent(): void {
+		$this->signIn();
+
+		$denial = new JSONResponse(
+			['error' => 'Insufficient clearance for this document'],
+			Http::STATUS_FORBIDDEN
+		);
+
+		$this->reader->expects($this->once())
+			->method('loadReadable')
+			->with($this->anything(), 'io-vertrouwelijk')
+			->willReturn($denial);
+
+		$this->reader->expects($this->never())->method('contentFor');
+
+		$response = $this->controller->downloadFile(
+			register: 'procest',
+			schema: 'informatieobject',
+			objectId: 'io-vertrouwelijk',
+			fileId: 42,
+		);
+
+		$this->assertSame($denial, $response);
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+	}//end testDownloadFileReturnsTheClearanceDenialVerbatimAndReadsNoContent()
+
+	/**
+	 * A cleared document whose bytes are missing is a 404, not a 0-byte
+	 * download.
+	 *
+	 * @return void
+	 */
+	public function testDownloadFileReturns404WhenTheClearedDocumentHasNoBytes(): void {
+		$this->signIn();
+
+		$this->reader->method('loadReadable')
+			->willReturn(['fileName' => 'besluit.pdf', 'format' => 'application/pdf']);
+
+		$this->reader->expects($this->once())
+			->method('contentFor')
+			->with('io-1', 'besluit.pdf')
+			->willReturn(null);
+
+		$response = $this->controller->downloadFile(
+			register: 'procest',
+			schema: 'informatieobject',
+			objectId: 'io-1',
+			fileId: 42,
+		);
+
+		$this->assertInstanceOf(JSONResponse::class, $response);
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertSame(['error' => 'File not found'], $response->getData());
+	}//end testDownloadFileReturns404WhenTheClearedDocumentHasNoBytes()
+
+	/**
+	 * The ZGW route applies the SAME clearance gate on the `{uuid}` segment
+	 * and passes its denial through without reading content.
+	 *
+	 * @return void
+	 */
+	public function testDownloadZgwDocumentenAppliesTheSameClearanceGateOnTheUuid(): void {
+		$this->signIn();
+
+		$denial = new JSONResponse(['error' => 'Not authorized'], Http::STATUS_FORBIDDEN);
+
+		$this->reader->expects($this->once())
+			->method('loadReadable')
+			->with($this->anything(), 'eio-9')
+			->willReturn($denial);
+
+		$this->reader->expects($this->never())->method('contentFor');
+
+		$response = $this->controller->downloadZgwDocumenten(uuid: 'eio-9');
+
+		$this->assertSame($denial, $response);
+	}//end testDownloadZgwDocumentenAppliesTheSameClearanceGateOnTheUuid()
+
+	/**
+	 * The ZGW route also answers 404 when the cleared document has no bytes.
+	 *
+	 * @return void
+	 */
+	public function testDownloadZgwDocumentenReturns404WhenTheDocumentHasNoBytes(): void {
+		$this->signIn();
+
+		$this->reader->method('loadReadable')->willReturn(['fileName' => 'rapport.pdf']);
+		$this->reader->method('contentFor')->willReturn(null);
+
+		$response = $this->controller->downloadZgwDocumenten(uuid: 'eio-9');
+
+		$this->assertInstanceOf(JSONResponse::class, $response);
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+	}//end testDownloadZgwDocumentenReturns404WhenTheDocumentHasNoBytes()
+
+	/**
+	 * Without a Range header the ZGW download is a full 200 carrying the whole
+	 * document, its declared MIME type, and `Accept-Ranges: bytes`.
+	 *
+	 * @return void
+	 */
+	public function testDownloadZgwDocumentenServesTheWholeDocumentWith200AndAcceptRanges(): void {
+		$this->signIn();
+		$this->request->method('getHeader')->willReturn('');
+
+		$this->reader->method('loadReadable')
+			->willReturn(['fileName' => 'rapport.pdf', 'format' => 'application/pdf']);
+		$this->reader->method('contentFor')->willReturn('0123456789');
+
+		$response = $this->controller->downloadZgwDocumenten(uuid: 'eio-9');
+
+		$this->assertInstanceOf(RangeStreamResponse::class, $response);
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+
+		$headers = $response->getHeaders();
+		$this->assertSame('bytes', $headers['Accept-Ranges']);
+		$this->assertSame('application/pdf', $headers['Content-Type']);
+		$this->assertSame('10', $headers['Content-Length']);
+		$this->assertArrayNotHasKey('Content-Range', $headers);
+	}//end testDownloadZgwDocumentenServesTheWholeDocumentWith200AndAcceptRanges()
+
+	/**
+	 * A satisfiable Range header yields 206 with only the requested slice and
+	 * a matching Content-Range — the resumable-transfer contract ZGW DRC
+	 * clients rely on.
+	 *
+	 * @return void
+	 */
+	public function testDownloadZgwDocumentenServesASatisfiableRangeAs206PartialContent(): void {
+		$this->signIn();
+
+		$this->request->expects($this->once())
+			->method('getHeader')
+			->with('Range')
+			->willReturn('bytes=2-5');
+
+		$this->reader->method('loadReadable')
+			->willReturn(['fileName' => 'rapport.pdf', 'format' => 'application/pdf']);
+		$this->reader->method('contentFor')->willReturn('0123456789');
+
+		$response = $this->controller->downloadZgwDocumenten(uuid: 'eio-9');
+		$headers = $response->getHeaders();
+
+		$this->assertInstanceOf(RangeStreamResponse::class, $response);
+		$this->assertSame(Http::STATUS_PARTIAL_CONTENT, $response->getStatus());
+		$this->assertSame('bytes 2-5/10', $headers['Content-Range']);
+		$this->assertSame('4', $headers['Content-Length']);
+		$this->assertSame('2345', $response->render());
+	}//end testDownloadZgwDocumentenServesASatisfiableRangeAs206PartialContent()
+}//end class

--- a/tests/Unit/Controller/ZaakdossierListContractTest.php
+++ b/tests/Unit/Controller/ZaakdossierListContractTest.php
@@ -1,0 +1,254 @@
+<?php
+
+/**
+ * ZaakdossierController::listDossier() Wire-Contract Tests
+ *
+ * Contract coverage (gate-25) for the one dossier endpoint left without
+ * executed proof of its wire behaviour: `listDossier()`, the case dossier
+ * listing. It is `@NoAdminRequired` and returns document metadata whose
+ * visibility depends on the caller's clearance
+ * (`vertrouwelijkheidaanduiding`), enforced server-side by
+ * `InformatieobjectReader::filterForUser()` (ADR-005 Rule 3). These tests pin:
+ *
+ *  - an anonymous caller is refused 401 and the dossier is never fetched;
+ *  - an unavailable dossier store is a 503 carrying the store's own message,
+ *    not an empty 200 a client would render as "this case has no documents";
+ *  - the clearance filter is applied for the SESSION user, and — the assertion
+ *    that matters — the list that gets GROUPED and returned is the FILTERED
+ *    one. Grouping the raw list instead would put every confidential document
+ *    back on the wire while the filter still ran and still reported success:
+ *    the filter would be executed, correct, and bypassed. Only comparing what
+ *    goes INTO `groupByType()` against what came OUT of the filter can see that;
+ *  - a dossier with no `informatieobjecten` key still reaches the filter with an
+ *    empty list rather than throwing on the missing key.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\ZaakdossierController;
+use OCA\Procest\Service\Zaakdossier\DossierUploadHandler;
+use OCA\Procest\Service\Zaakdossier\InformatieobjectReader;
+use OCA\Procest\Service\ZaakdossierService;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Wire-contract tests for ZaakdossierController::listDossier().
+ *
+ * @covers \OCA\Procest\Controller\ZaakdossierController
+ */
+class ZaakdossierListContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock handed to the controller.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The dossier orchestrator mock.
+	 *
+	 * @var ZaakdossierService|MockObject
+	 */
+	private ZaakdossierService $fileService;
+
+	/**
+	 * The clearance-gated document reader mock.
+	 *
+	 * @var InformatieobjectReader|MockObject
+	 */
+	private InformatieobjectReader $reader;
+
+	/**
+	 * The upload handler mock (unused by `listDossier()`, required to construct).
+	 *
+	 * @var DossierUploadHandler|MockObject
+	 */
+	private DossierUploadHandler $uploadHandler;
+
+	/**
+	 * The user session mock.
+	 *
+	 * @var IUserSession|MockObject
+	 */
+	private IUserSession $userSession;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var ZaakdossierController
+	 */
+	private ZaakdossierController $controller;
+
+	/**
+	 * Build the controller with all collaborators mocked.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->fileService = $this->createMock(ZaakdossierService::class);
+		$this->reader = $this->createMock(InformatieobjectReader::class);
+		$this->uploadHandler = $this->createMock(DossierUploadHandler::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+
+		$this->controller = new ZaakdossierController(
+			appName: 'procest',
+			request: $this->request,
+			fileService: $this->fileService,
+			reader: $this->reader,
+			uploadHandler: $this->uploadHandler,
+			userSession: $this->userSession,
+		);
+	}//end setUp()
+
+	/**
+	 * Put an authenticated user in the session.
+	 *
+	 * @param string $uid The user id the session reports.
+	 *
+	 * @return IUser|MockObject The signed-in user.
+	 */
+	private function signIn(string $uid = 'handler-1'): IUser {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		$this->userSession->method('getUser')->willReturn($user);
+
+		return $user;
+	}//end signIn()
+
+	/**
+	 * An anonymous caller is refused 401 and the dossier is never fetched.
+	 *
+	 * @return void
+	 */
+	public function testListDossierRefusesAnAnonymousCallerWithoutFetchingTheDossier(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->fileService->expects($this->never())->method('getDossierForCase');
+		$this->reader->expects($this->never())->method('filterForUser');
+
+		$response = $this->controller->listDossier(caseId: 'case-1');
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame(['error' => 'Not authenticated'], $response->getData());
+	}//end testListDossierRefusesAnAnonymousCallerWithoutFetchingTheDossier()
+
+	/**
+	 * An unavailable dossier store is a 503 carrying the store's own message —
+	 * never an empty 200 that a client renders as "no documents on this case".
+	 *
+	 * @return void
+	 */
+	public function testListDossierAnswers503WhenTheDossierStoreIsUnavailable(): void {
+		$this->signIn();
+		$this->fileService->method('getDossierForCase')
+			->willThrowException(new \RuntimeException('OpenRegister register not configured'));
+		$this->reader->expects($this->never())->method('filterForUser');
+		$this->fileService->expects($this->never())->method('groupByType');
+
+		$response = $this->controller->listDossier(caseId: 'case-1');
+
+		$this->assertSame(Http::STATUS_SERVICE_UNAVAILABLE, $response->getStatus());
+		$this->assertSame(['error' => 'OpenRegister register not configured'], $response->getData());
+	}//end testListDossierAnswers503WhenTheDossierStoreIsUnavailable()
+
+	/**
+	 * The clearance filter runs for the session user, and the list that is
+	 * grouped and returned is the FILTERED one — a confidential document the
+	 * reader removed must not reappear in the response because the grouping was
+	 * fed the raw dossier.
+	 *
+	 * @return void
+	 */
+	public function testListDossierGroupsTheClearanceFilteredListAndNotTheRawDossier(): void {
+		$this->signIn(uid: 'handler-1');
+
+		$public = ['id' => 'doc-1', 'vertrouwelijkheidaanduiding' => 'openbaar'];
+		$secret = ['id' => 'doc-2', 'vertrouwelijkheidaanduiding' => 'zeer_geheim'];
+		$this->fileService->method('getDossierForCase')->willReturn(
+			['informatieobjecten' => [$public, $secret]]
+		);
+
+		$filterSeen = [];
+		$this->reader->expects($this->once())
+			->method('filterForUser')
+			->willReturnCallback(
+				static function (IUser $user, array $informatieobjecten) use (&$filterSeen, $public): array {
+					$filterSeen = ['uid' => $user->getUID(), 'offered' => $informatieobjecten];
+					return [$public];
+				}
+			);
+
+		$grouped = [];
+		$this->fileService->expects($this->once())
+			->method('groupByType')
+			->willReturnCallback(
+				static function (array $documents) use (&$grouped): array {
+					$grouped = $documents;
+					return ['overig' => $documents];
+				}
+			);
+
+		$response = $this->controller->listDossier(caseId: 'case-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(
+			['uid' => 'handler-1', 'offered' => [$public, $secret]],
+			$filterSeen,
+			'the whole dossier must be offered to the clearance filter for the session user'
+		);
+		$this->assertSame(
+			[$public],
+			$grouped,
+			'grouping must consume the FILTERED list — the removed document must not be regrouped'
+		);
+		$this->assertSame(['overig' => [$public]], $response->getData());
+	}//end testListDossierGroupsTheClearanceFilteredListAndNotTheRawDossier()
+
+	/**
+	 * A dossier without an `informatieobjecten` key still reaches the filter,
+	 * with an empty list — the endpoint must not throw on a case that has no
+	 * documents yet.
+	 *
+	 * @return void
+	 */
+	public function testListDossierOffersAnEmptyListWhenTheDossierHasNoDocuments(): void {
+		$this->signIn();
+		$this->fileService->method('getDossierForCase')->willReturn(['zaak' => 'case-1']);
+
+		$offered = null;
+		$this->reader->expects($this->once())
+			->method('filterForUser')
+			->willReturnCallback(
+				static function (IUser $user, array $informatieobjecten) use (&$offered): array {
+					$offered = $informatieobjecten;
+					return [];
+				}
+			);
+		$this->fileService->method('groupByType')->willReturn([]);
+
+		$response = $this->controller->listDossier(caseId: 'case-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame([], $offered);
+		$this->assertSame([], $response->getData());
+	}//end testListDossierOffersAnEmptyListWhenTheDossierHasNoDocuments()
+}//end class

--- a/tests/Unit/Controller/ZrcControllerContractTest.php
+++ b/tests/Unit/Controller/ZrcControllerContractTest.php
@@ -1,0 +1,363 @@
+<?php
+
+/**
+ * ZrcController Wire-Contract Tests
+ *
+ * Contract coverage for the eight publicly-reachable ZRC endpoints that had no
+ * automated proof of their wire behaviour (gate-25). Every endpoint in this
+ * controller is annotated `@PublicPage`, i.e. it is reachable WITHOUT a
+ * Nextcloud session, and its only gatekeeper is the ZGW JWT that
+ * `ZgwService::validateJwtAuth()` inspects plus a per-operation OAuth-style
+ * scope. Those two facts are the contract these tests pin:
+ *
+ *  - an unauthenticated caller gets the JWT error verbatim, never the payload;
+ *  - a caller WITHOUT the operation's scope gets 403, and the scope demanded is
+ *    the specific one the ZGW standard assigns to that operation
+ *    (`zaken.bijwerken` for writes to a sub-resource, `zaken.verwijderen` for a
+ *    delete) — a copy-paste of the wrong scope name is the realistic defect in
+ *    six near-identical delegators;
+ *  - the delegating endpoints address the `zaakeigenschappen` resource of the
+ *    `zaken` API, not some neighbouring resource;
+ *  - `zoek` answers 201 rather than the 200 its own delegate returns, as the
+ *    ZGW specification requires for the search operation.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\ZrcController;
+use OCA\Procest\Service\CaseRelationService;
+use OCA\Procest\Service\ZgwService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IL10N;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Wire-contract tests for ZrcController.
+ *
+ * @covers \OCA\Procest\Controller\ZrcController
+ */
+class ZrcControllerContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock handed to the controller.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The ZgwService mock — the controller's only gatekeeper and delegate.
+	 *
+	 * @var ZgwService|MockObject
+	 */
+	private ZgwService $zgwService;
+
+	/**
+	 * The IL10N mock used by the permission-denied response.
+	 *
+	 * @var IL10N|MockObject
+	 */
+	private IL10N $l10n;
+
+	/**
+	 * The CaseRelationService mock.
+	 *
+	 * @var CaseRelationService|MockObject
+	 */
+	private CaseRelationService $caseRelationService;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var ZrcController
+	 */
+	private ZrcController $controller;
+
+	/**
+	 * Build the controller with all collaborators mocked.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->zgwService = $this->createMock(ZgwService::class);
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->caseRelationService = $this->createMock(CaseRelationService::class);
+
+		$this->l10n->method('t')->willReturnArgument(0);
+
+		$this->controller = new ZrcController(
+			appName: 'procest',
+			request: $this->request,
+			zgwService: $this->zgwService,
+			l10n: $this->l10n,
+			caseRelationService: $this->caseRelationService,
+		);
+	}//end setUp()
+
+	/**
+	 * Configure the JWT gate to REFUSE with the supplied status.
+	 *
+	 * @param int $status The HTTP status the JWT gate answers with.
+	 *
+	 * @return void
+	 */
+	private function refuseJwt(int $status = Http::STATUS_UNAUTHORIZED): void {
+		$this->zgwService->method('validateJwtAuth')->willReturn(
+			new JSONResponse(data: ['detail' => 'JWT missing'], statusCode: $status)
+		);
+	}//end refuseJwt()
+
+	/**
+	 * Configure the JWT gate to ACCEPT (validateJwtAuth returns null).
+	 *
+	 * @return void
+	 */
+	private function acceptJwt(): void {
+		$this->zgwService->method('validateJwtAuth')->willReturn(null);
+	}//end acceptJwt()
+
+	/**
+	 * Every anonymous-reachable endpoint must return the JWT gate's refusal.
+	 *
+	 * This is the single most important property of the controller: all eight
+	 * routes are `@PublicPage`, so if any of them ran its body before consulting
+	 * `validateJwtAuth()` it would serve zaak data to an unauthenticated caller.
+	 *
+	 * @return void
+	 */
+	public function testAllZaakSubResourceEndpointsRefuseAnUnauthenticatedCaller(): void {
+		$this->refuseJwt();
+		$this->zgwService->method('resolvePathUuid')->willReturnArgument(1);
+
+		$responses = [
+			'zaakeigenschappenIndex' => $this->controller->zaakeigenschappenIndex(zaakUuid: 'zaak-1'),
+			'zaakeigenschappenCreate' => $this->controller->zaakeigenschappenCreate(zaakUuid: 'zaak-1'),
+			'zaakeigenschappenShow' => $this->controller->zaakeigenschappenShow(zaakUuid: 'zaak-1', uuid: 'e-1'),
+			'zaakeigenschappenUpdate' => $this->controller->zaakeigenschappenUpdate(zaakUuid: 'zaak-1', uuid: 'e-1'),
+			'zaakeigenschappenPatch' => $this->controller->zaakeigenschappenPatch(zaakUuid: 'zaak-1', uuid: 'e-1'),
+			'zaakeigenschappenDestroy' => $this->controller->zaakeigenschappenDestroy(zaakUuid: 'zaak-1', uuid: 'e-1'),
+			'zaakbesluitenIndex' => $this->controller->zaakbesluitenIndex(zaakUuid: 'zaak-1'),
+			'zoek' => $this->controller->zoek(),
+		];
+
+		foreach ($responses as $endpoint => $response) {
+			// `zoek` re-wraps its delegate's payload and is documented to answer
+			// 201 — but it must not turn a REFUSAL into a success payload, so
+			// its refusal carries the delegate's error body through.
+			if ($endpoint === 'zoek') {
+				$this->assertSame(
+					['detail' => 'JWT missing'],
+					$response->getData(),
+					'zoek must carry the JWT refusal body through, not an empty result set'
+				);
+				continue;
+			}
+
+			$this->assertSame(
+				Http::STATUS_UNAUTHORIZED,
+				$response->getStatus(),
+				$endpoint . ' must return the JWT gate refusal, not its payload'
+			);
+		}
+	}//end testAllZaakSubResourceEndpointsRefuseAnUnauthenticatedCaller()
+
+	/**
+	 * zaakeigenschappenIndex delegates to the zaken API's zaakeigenschappen
+	 * resource and returns the handler's response untouched.
+	 *
+	 * @return void
+	 */
+	public function testZaakeigenschappenIndexDelegatesToTheZaakeigenschappenResource(): void {
+		$this->acceptJwt();
+		$expected = new JSONResponse(data: [['url' => 'https://example.test/e-1']]);
+
+		$this->zgwService->expects($this->once())
+			->method('handleIndex')
+			->with($this->request, 'zaken', 'zaakeigenschappen')
+			->willReturn($expected);
+
+		$response = $this->controller->zaakeigenschappenIndex(zaakUuid: 'zaak-1');
+
+		$this->assertSame($expected, $response);
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+	}//end testZaakeigenschappenIndexDelegatesToTheZaakeigenschappenResource()
+
+	/**
+	 * zaakeigenschappenShow delegates with the sub-resource uuid, NOT the zaak
+	 * uuid — transposing the two is the realistic defect on a two-uuid route.
+	 *
+	 * @return void
+	 */
+	public function testZaakeigenschappenShowDelegatesWithTheSubResourceUuid(): void {
+		$this->acceptJwt();
+		$expected = new JSONResponse(data: ['url' => 'https://example.test/e-1']);
+
+		$this->zgwService->expects($this->once())
+			->method('handleShow')
+			->with($this->request, 'zaken', 'zaakeigenschappen', 'eigenschap-9')
+			->willReturn($expected);
+
+		$response = $this->controller->zaakeigenschappenShow(zaakUuid: 'zaak-1', uuid: 'eigenschap-9');
+
+		$this->assertSame($expected, $response);
+	}//end testZaakeigenschappenShowDelegatesWithTheSubResourceUuid()
+
+	/**
+	 * Creating a zaakeigenschap demands `zaken.bijwerken`, not
+	 * `zaken.aanmaken` — the latter is reserved for creating a zaak itself.
+	 *
+	 * @return void
+	 */
+	public function testZaakeigenschappenCreateDemandsTheBijwerkenScopeAndRefusesWithout(): void {
+		$this->acceptJwt();
+
+		$this->zgwService->expects($this->once())
+			->method('consumerHasScope')
+			->with($this->request, 'zrc', 'zaken.bijwerken')
+			->willReturn(false);
+
+		$response = $this->controller->zaakeigenschappenCreate(zaakUuid: 'zaak-1');
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame('permission_denied', $response->getData()['code']);
+	}//end testZaakeigenschappenCreateDemandsTheBijwerkenScopeAndRefusesWithout()
+
+	/**
+	 * Updating a zaakeigenschap demands `zaken.bijwerken`.
+	 *
+	 * @return void
+	 */
+	public function testZaakeigenschappenUpdateDemandsTheBijwerkenScopeAndRefusesWithout(): void {
+		$this->acceptJwt();
+		$this->zgwService->method('resolvePathUuid')->willReturnArgument(1);
+
+		$this->zgwService->expects($this->once())
+			->method('consumerHasScope')
+			->with($this->request, 'zrc', 'zaken.bijwerken')
+			->willReturn(false);
+
+		$response = $this->controller->zaakeigenschappenUpdate(zaakUuid: 'zaak-1', uuid: 'e-1');
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame('permission_denied', $response->getData()['code']);
+	}//end testZaakeigenschappenUpdateDemandsTheBijwerkenScopeAndRefusesWithout()
+
+	/**
+	 * Patching a zaakeigenschap demands `zaken.bijwerken`.
+	 *
+	 * @return void
+	 */
+	public function testZaakeigenschappenPatchDemandsTheBijwerkenScopeAndRefusesWithout(): void {
+		$this->acceptJwt();
+		$this->zgwService->method('resolvePathUuid')->willReturnArgument(1);
+
+		$this->zgwService->expects($this->once())
+			->method('consumerHasScope')
+			->with($this->request, 'zrc', 'zaken.bijwerken')
+			->willReturn(false);
+
+		$response = $this->controller->zaakeigenschappenPatch(zaakUuid: 'zaak-1', uuid: 'e-1');
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame('permission_denied', $response->getData()['code']);
+	}//end testZaakeigenschappenPatchDemandsTheBijwerkenScopeAndRefusesWithout()
+
+	/**
+	 * Deleting a zaakeigenschap demands `zaken.verwijderen` — a DIFFERENT scope
+	 * from the write operations above. A delete accepted on a write scope is a
+	 * privilege escalation, so the scope name is asserted, not just the 403.
+	 *
+	 * @return void
+	 */
+	public function testZaakeigenschappenDestroyDemandsTheVerwijderenScopeAndRefusesWithout(): void {
+		$this->acceptJwt();
+
+		$this->zgwService->expects($this->once())
+			->method('consumerHasScope')
+			->with($this->request, 'zrc', 'zaken.verwijderen')
+			->willReturn(false);
+
+		$response = $this->controller->zaakeigenschappenDestroy(zaakUuid: 'zaak-1', uuid: 'e-1');
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame('permission_denied', $response->getData()['code']);
+	}//end testZaakeigenschappenDestroyDemandsTheVerwijderenScopeAndRefusesWithout()
+
+	/**
+	 * zaakbesluitenIndex answers 503 when OpenRegister is not wired up, rather
+	 * than throwing or serving an empty list that a client cannot distinguish
+	 * from "this zaak has no besluiten".
+	 *
+	 * @return void
+	 */
+	public function testZaakbesluitenIndexReturns503WhenTheObjectStoreIsUnavailable(): void {
+		$this->acceptJwt();
+		$this->zgwService->method('getObjectService')->willReturn(null);
+		$this->zgwService->method('unavailableResponse')->willReturn(
+			new JSONResponse(
+				data: ['detail' => 'OpenRegister is not available'],
+				statusCode: Http::STATUS_SERVICE_UNAVAILABLE
+			)
+		);
+
+		$response = $this->controller->zaakbesluitenIndex(zaakUuid: 'zaak-1');
+
+		$this->assertSame(Http::STATUS_SERVICE_UNAVAILABLE, $response->getStatus());
+	}//end testZaakbesluitenIndexReturns503WhenTheObjectStoreIsUnavailable()
+
+	/**
+	 * zaakbesluitenIndex answers 404 when the besluiten mapping is absent —
+	 * distinct from the 503 above, because an unconfigured mapping is a
+	 * deployment fact a client can act on.
+	 *
+	 * @return void
+	 */
+	public function testZaakbesluitenIndexReturns404WhenTheBesluitMappingIsMissing(): void {
+		$this->acceptJwt();
+		$this->zgwService->method('getObjectService')->willReturn(new \stdClass());
+		$this->zgwService->method('loadMappingConfig')->willReturn(null);
+
+		$response = $this->controller->zaakbesluitenIndex(zaakUuid: 'zaak-1');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertSame(['detail' => 'Besluit mapping not configured'], $response->getData());
+	}//end testZaakbesluitenIndexReturns404WhenTheBesluitMappingIsMissing()
+
+	/**
+	 * `POST /zaken/_zoek` returns 201 Created, not the 200 its own delegate
+	 * answers with, and carries the delegate's result set unchanged.
+	 *
+	 * @return void
+	 */
+	public function testZoekReturns201WithTheSearchResultsOfTheZakenResource(): void {
+		$this->acceptJwt();
+		$results = [['identificatie' => 'ZAAK-2026-0001']];
+
+		$this->zgwService->expects($this->once())
+			->method('handleIndex')
+			->with($this->request, 'zaken', 'zaken')
+			->willReturn(new JSONResponse(data: $results));
+
+		$response = $this->controller->zoek();
+
+		$this->assertSame(Http::STATUS_CREATED, $response->getStatus());
+		$this->assertSame($results, $response->getData());
+	}//end testZoekReturns201WithTheSearchResultsOfTheZakenResource()
+}//end class

--- a/tests/Unit/Controller/ZrcControllerContractTest.php
+++ b/tests/Unit/Controller/ZrcControllerContractTest.php
@@ -49,6 +49,16 @@ use PHPUnit\Framework\TestCase;
  * Wire-contract tests for ZrcController.
  *
  * @covers \OCA\Procest\Controller\ZrcController
+ *
+ * The ZGW controllers inherit from ZgwController, which in turn composes the
+ * NormalisesObjectRows trait, so exercising this controller necessarily runs
+ * code declared on both. CI runs phpunit.xml with
+ * beStrictAboutCoverageMetadata="true" and failOnRisky="true", which marks
+ * executed-but-unlisted code risky and fails the run — so both are declared as
+ * used rather than covered.
+ *
+ * @uses \OCA\Procest\Controller\ZgwController
+ * @uses \OCA\Procest\Support\NormalisesObjectRows
  */
 class ZrcControllerContractTest extends TestCase {
 

--- a/tests/Unit/Controller/ZtcControllerContractTest.php
+++ b/tests/Unit/Controller/ZtcControllerContractTest.php
@@ -85,6 +85,14 @@ interface ZtcContractObjectServiceStub {
  * Wire-contract tests for the ZtcController publish endpoints.
  *
  * @covers \OCA\Procest\Controller\ZtcController
+ *
+ * ZtcController extends ZgwController, which composes NormalisesObjectRows, so
+ * exercising it necessarily runs code declared on both. CI runs phpunit.xml
+ * with beStrictAboutCoverageMetadata="true" and failOnRisky="true", which marks
+ * executed-but-unlisted code risky and fails the run.
+ *
+ * @uses \OCA\Procest\Controller\ZgwController
+ * @uses \OCA\Procest\Support\NormalisesObjectRows
  */
 class ZtcControllerContractTest extends TestCase {
 

--- a/tests/Unit/Controller/ZtcControllerContractTest.php
+++ b/tests/Unit/Controller/ZtcControllerContractTest.php
@@ -1,0 +1,364 @@
+<?php
+
+/**
+ * ZtcController Wire-Contract Tests
+ *
+ * Contract coverage (gate-25) for the three ZTC publish endpoints that had no
+ * automated proof of their wire behaviour. All three are `@PublicPage`, i.e.
+ * reachable WITHOUT a Nextcloud session, and all three are three-line
+ * delegators onto one shared `handlePublish()` body — which is exactly why the
+ * realistic defect here is a copy-paste: publishing a zaaktype through the
+ * besluittype route would flip `isDraft` on the wrong catalogue object, and
+ * nothing in the response shape would show it.
+ *
+ * What is pinned:
+ *
+ *  - the JWT gate is consulted BEFORE anything is published, and its refusal is
+ *    returned verbatim — an unauthenticated caller must not be able to publish
+ *    a draft catalogue object;
+ *  - each route addresses its OWN resource of the `catalogi` API — `zaaktypen`,
+ *    `besluittypen`, `informatieobjecttypen` — asserted by name;
+ *  - publishing means writing `isDraft: false` back onto the stored object and
+ *    answering 201, not merely reading it;
+ *  - an unavailable OpenRegister answers 503 and a missing mapping 404, two
+ *    distinct deployment facts a client can act on.
+ *
+ * NOTE: unlike DRC's write routes, these publish endpoints check NO ZGW scope —
+ * a valid JWT is the whole gate. That is asserted as observed behaviour (the
+ * happy-path test publishes without any scope being granted), so that adding or
+ * removing a scope check here becomes a visible, deliberate change.
+ *
+ * @category Tests
+ * @package  OCA\Procest\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://procest.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Procest\Tests\Unit\Controller;
+
+use OCA\Procest\Controller\ZtcController;
+use OCA\Procest\Service\ZgwService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Minimal OpenRegister ObjectService stub for the ZTC publish tests.
+ *
+ * The real ObjectService is called with NAMED arguments by the controller, so
+ * the stub's parameter names must match the real ones exactly — a mock built on
+ * \stdClass cannot be called with named arguments at all.
+ */
+interface ZtcContractObjectServiceStub {
+	/**
+	 * Find a single object by identifier (real ObjectService::find()).
+	 *
+	 * @param int|string $id The object UUID.
+	 * @param mixed ...$args Remaining find() args (extend/files/register/schema).
+	 *
+	 * @return mixed The stored object row.
+	 */
+	public function find(int|string $id, ...$args): mixed;
+
+	/**
+	 * Save or update an object.
+	 *
+	 * @param string $register The register slug.
+	 * @param string $schema The schema slug.
+	 * @param array<string, mixed> $object The object data.
+	 * @param string|null $uuid The object UUID to overwrite.
+	 *
+	 * @return mixed The saved object row.
+	 */
+	public function saveObject(string $register, string $schema, array $object, ?string $uuid = null): mixed;
+}//end interface
+
+/**
+ * Wire-contract tests for the ZtcController publish endpoints.
+ *
+ * @covers \OCA\Procest\Controller\ZtcController
+ */
+class ZtcControllerContractTest extends TestCase {
+
+	/**
+	 * The IRequest mock handed to the controller.
+	 *
+	 * @var IRequest|MockObject
+	 */
+	private IRequest $request;
+
+	/**
+	 * The ZgwService mock — the controller's JWT gate and store accessor.
+	 *
+	 * @var ZgwService|MockObject
+	 */
+	private ZgwService $zgwService;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var ZtcController
+	 */
+	private ZtcController $controller;
+
+	/**
+	 * Build the controller with all collaborators mocked.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->zgwService = $this->createMock(ZgwService::class);
+
+		$this->controller = new ZtcController(
+			appName: 'procest',
+			request: $this->request,
+			zgwService: $this->zgwService,
+		);
+	}//end setUp()
+
+	/**
+	 * Configure the JWT gate to REFUSE.
+	 *
+	 * @return JSONResponse The refusal the gate answers with.
+	 */
+	private function refuseJwt(): JSONResponse {
+		$refusal = new JSONResponse(
+			data: ['code' => 'not_authenticated'],
+			statusCode: Http::STATUS_UNAUTHORIZED
+		);
+		$this->zgwService->method('validateJwtAuth')->willReturn($refusal);
+
+		return $refusal;
+	}//end refuseJwt()
+
+	/**
+	 * Configure the JWT gate to ACCEPT.
+	 *
+	 * @return void
+	 */
+	private function acceptJwt(): void {
+		$this->zgwService->method('validateJwtAuth')->willReturn(null);
+	}//end acceptJwt()
+
+	/**
+	 * All three publish routes consult the JWT gate first and return its
+	 * refusal verbatim, publishing nothing.
+	 *
+	 * @return void
+	 */
+	public function testAllThreePublishRoutesRefuseAnUnauthenticatedCaller(): void {
+		$refusal = $this->refuseJwt();
+		$this->zgwService->expects($this->never())->method('getObjectService');
+
+		$responses = [
+			'publishZaaktype' => $this->controller->publishZaaktype(uuid: 'zt-1'),
+			'publishBesluittype' => $this->controller->publishBesluittype(uuid: 'bt-1'),
+			'publishInformatieobjecttype' => $this->controller->publishInformatieobjecttype(uuid: 'iot-1'),
+		];
+
+		foreach ($responses as $endpoint => $response) {
+			$this->assertSame($refusal, $response, $endpoint . ' must return the JWT refusal verbatim');
+			$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		}
+	}//end testAllThreePublishRoutesRefuseAnUnauthenticatedCaller()
+
+	/**
+	 * Each route resolves the mapping for its OWN catalogi resource. This is
+	 * the assertion that separates three otherwise identical delegators: a
+	 * copy-paste would publish the wrong kind of catalogue object.
+	 *
+	 * @return void
+	 */
+	public function testEachPublishRouteAddressesItsOwnCatalogiResource(): void {
+		$this->acceptJwt();
+		$this->zgwService->method('getObjectService')->willReturn(
+			$this->createMock(ZtcContractObjectServiceStub::class)
+		);
+
+		$seen = [];
+		$this->zgwService->method('loadMappingConfig')->willReturnCallback(
+			static function (string $zgwApi, string $resource) use (&$seen): ?array {
+				$seen[] = $zgwApi . '/' . $resource;
+				return null;
+			}
+		);
+		$this->zgwService->method('mappingNotFoundResponse')->willReturn(
+			new JSONResponse(data: ['detail' => 'no mapping'], statusCode: Http::STATUS_NOT_FOUND)
+		);
+
+		$statuses = [
+			$this->controller->publishZaaktype(uuid: 'zt-1')->getStatus(),
+			$this->controller->publishBesluittype(uuid: 'bt-1')->getStatus(),
+			$this->controller->publishInformatieobjecttype(uuid: 'iot-1')->getStatus(),
+		];
+
+		$this->assertSame(
+			['catalogi/zaaktypen', 'catalogi/besluittypen', 'catalogi/informatieobjecttypen'],
+			$seen
+		);
+		$this->assertSame(
+			[Http::STATUS_NOT_FOUND, Http::STATUS_NOT_FOUND, Http::STATUS_NOT_FOUND],
+			$statuses,
+			'an unmapped resource must answer 404, not publish and not 500'
+		);
+	}//end testEachPublishRouteAddressesItsOwnCatalogiResource()
+
+	/**
+	 * With OpenRegister unwired the route answers 503 and never looks up a
+	 * mapping — distinct from the 404 above.
+	 *
+	 * @return void
+	 */
+	public function testPublishZaaktypeAnswers503WhenTheObjectStoreIsUnavailable(): void {
+		$this->acceptJwt();
+		$this->zgwService->method('getObjectService')->willReturn(null);
+		$this->zgwService->expects($this->never())->method('loadMappingConfig');
+		$this->zgwService->method('unavailableResponse')->willReturn(
+			new JSONResponse(
+				data: ['detail' => 'OpenRegister is not available'],
+				statusCode: Http::STATUS_SERVICE_UNAVAILABLE
+			)
+		);
+
+		$response = $this->controller->publishZaaktype(uuid: 'zt-1');
+
+		$this->assertSame(Http::STATUS_SERVICE_UNAVAILABLE, $response->getStatus());
+		$this->assertSame(['detail' => 'OpenRegister is not available'], $response->getData());
+	}//end testPublishZaaktypeAnswers503WhenTheObjectStoreIsUnavailable()
+
+	/**
+	 * Publishing WRITES: the stored object is saved back with `isDraft` false,
+	 * onto the same uuid and the resource's own register/schema, and the route
+	 * answers 201 with the outbound-mapped body.
+	 *
+	 * @return void
+	 */
+	public function testPublishBesluittypeClearsTheDraftFlagAndAnswers201(): void {
+		$this->acceptJwt();
+
+		$saved = [];
+		$objectService = $this->createMock(ZtcContractObjectServiceStub::class);
+		$objectService->method('find')->willReturn(
+			['id' => 'row-1', 'isDraft' => true, 'omschrijving' => 'Vergunning verleend']
+		);
+		$objectService->expects($this->once())
+			->method('saveObject')
+			->willReturnCallback(
+				static function (
+					string $register,
+					string $schema,
+					array $object,
+					?string $uuid = null,
+				) use (&$saved): array {
+					$saved = [
+						'register' => $register,
+						'schema' => $schema,
+						'object' => $object,
+						'uuid' => $uuid,
+					];
+					return $object;
+				}
+			);
+
+		$this->zgwService->method('getObjectService')->willReturn($objectService);
+		$this->zgwService->method('loadMappingConfig')->willReturn(
+			['sourceRegister' => 'ztc-register', 'sourceSchema' => 'besluittype']
+		);
+		$this->zgwService->method('createOutboundMapping')->willReturn(new \stdClass());
+		$this->zgwService->method('applyOutboundMapping')->willReturn(
+			['url' => 'https://example.test/besluittypen/bt-1', 'concept' => false]
+		);
+
+		$response = $this->controller->publishBesluittype(uuid: 'bt-1');
+
+		$this->assertSame(Http::STATUS_CREATED, $response->getStatus());
+		$this->assertSame(['url' => 'https://example.test/besluittypen/bt-1', 'concept' => false], $response->getData());
+		$this->assertFalse($saved['object']['isDraft'], 'publishing must clear the draft flag on the stored object');
+		$this->assertSame('bt-1', $saved['uuid'], 'the publish must overwrite the object the route names');
+		$this->assertSame('ztc-register', $saved['register']);
+		$this->assertSame('besluittype', $saved['schema']);
+	}//end testPublishBesluittypeClearsTheDraftFlagAndAnswers201()
+
+	/**
+	 * The publish loses the store's bookkeeping keys before writing back —
+	 * saving `@self` / `id` / `organisation` into the object body is how a
+	 * republish corrupts a catalogue row.
+	 *
+	 * @return void
+	 */
+	public function testPublishInformatieobjecttypeStripsTheStoreBookkeepingKeys(): void {
+		$this->acceptJwt();
+
+		$saved = [];
+		$objectService = $this->createMock(ZtcContractObjectServiceStub::class);
+		$objectService->method('find')->willReturn(
+			[
+				'@self' => ['id' => 'row-2', 'created' => '2026-01-01'],
+				'id' => 'row-2',
+				'organisation' => 'gemeente',
+				'isDraft' => true,
+				'omschrijving' => 'Bijlage',
+			]
+		);
+		$objectService->method('saveObject')->willReturnCallback(
+			static function (
+				string $register,
+				string $schema,
+				array $object,
+				?string $uuid = null,
+			) use (&$saved): array {
+				$saved = $object;
+				return $object;
+			}
+		);
+
+		$this->zgwService->method('getObjectService')->willReturn($objectService);
+		$this->zgwService->method('loadMappingConfig')->willReturn(
+			['sourceRegister' => 'ztc-register', 'sourceSchema' => 'informatieobjecttype']
+		);
+		$this->zgwService->method('createOutboundMapping')->willReturn(new \stdClass());
+		$this->zgwService->method('applyOutboundMapping')->willReturn(['concept' => false]);
+
+		$response = $this->controller->publishInformatieobjecttype(uuid: 'iot-1');
+
+		$this->assertSame(Http::STATUS_CREATED, $response->getStatus());
+		$this->assertArrayNotHasKey('@self', $saved);
+		$this->assertArrayNotHasKey('id', $saved);
+		$this->assertArrayNotHasKey('organisation', $saved);
+		$this->assertSame('Bijlage', $saved['omschrijving'], 'the payload itself must survive the publish');
+	}//end testPublishInformatieobjecttypeStripsTheStoreBookkeepingKeys()
+
+	/**
+	 * A store failure during publish answers 400 with the reason rather than
+	 * escaping as an unhandled 500.
+	 *
+	 * @return void
+	 */
+	public function testPublishZaaktypeAnswers400WhenTheStoreRefusesTheWrite(): void {
+		$this->acceptJwt();
+
+		$objectService = $this->createMock(ZtcContractObjectServiceStub::class);
+		$objectService->method('find')->willThrowException(new \RuntimeException('Object not found'));
+
+		$this->zgwService->method('getObjectService')->willReturn($objectService);
+		$this->zgwService->method('loadMappingConfig')->willReturn(
+			['sourceRegister' => 'ztc-register', 'sourceSchema' => 'zaaktype']
+		);
+
+		$response = $this->controller->publishZaaktype(uuid: 'zt-missing');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['detail' => 'Object not found'], $response->getData());
+	}//end testPublishZaaktypeAnswers400WhenTheStoreRefusesTheWrite()
+}//end class


### PR DESCRIPTION
## What this does

Closes procest's `gate-25 contract-coverage` by **writing the missing contract tests** — no `@contract exclude`, no exclusions, nothing retargeted or weakened. Test files only: **zero lines of `lib/` or `src/`** (41 files, **+14505/−0**).

## Result — CI confirmed

`pull_request` run `32000778599` @ `30289970`: **30 success / 5 skipped / 2 failure**. The 2 are `Hydra Gates` + `Quality Report`, i.e. **exactly `development`'s own failing set** ⇒ at parity, and strictly better by one gate. All **6/6 PHPUnit** cells, **E2E** and every static job pass.

```
[gate-25] contract-coverage: PASS
[hydra-gates] RESULT: 3 GATE(S) FAILED     (base: 4)
```

⚠️ **The gate package moved mid-task** (`f935e2c` → `742f370e`), so the closure is measured on **both**:

| package | base `e6d071ea` | head |
|---|---|---|
| `f935e2c` | **FAIL — 116** (reproduces CI run `31993726970` exactly) | **PASS** |
| `742f370e` | **FAIL — 116** | **PASS** (CI-confirmed) |

**373 contract tests / 1288 assertions.** Full suite in CI: `Tests: 2288, Assertions: 10532`, **0 failures**.

## The split, re-derived on this base

The dispatch said 97 genuine / 19 newman-blind. On `e6d071ea` it is **96 / 20** — same defect, drifted by one more endpoint. A count that does not name its tree is not a count.

All **96 genuine** are closed. The **20** were closed too: they are declared only by collections under `tests/newman/` and `data/`, which `_newman_paths()` never opens **and which procest never executes** (`enable-newman: false`). That coverage was a declaration no runner has ever asserted.

## What the tests actually assert

Not "the route exists". `is_covered()` would accept `$this->controller->foo();` with no assertion at all — everything below is above that bar and none of it is enforced by the gate.

- **The status code on each branch, and the differences rather than a smoothed-over 401**: `ensureAuthenticated()` returning **403** where that is what the code does; a refusal mapped to **404 not 403** where the endpoint deliberately offers no existence oracle; **502** where an upstream store failure is distinguished from a bad request; **503** where a dependency is unwired.
- **The specific scope / permission / role NAME**, via `->with(...)` — a delete accepting a write scope is a privilege escalation, and six near-identical delegators are exactly where a copy-pasted scope name survives review.
- **`expects($this->never())` on the collaborator** in refusal tests, so a handler that answers 401 only *after* reaching its service still fails.
- **The wire keys** — the literal `justificatie` on a statutory deadline extension, `severity`/`behaviour` in English on the LHS surface.
- **Argument order** where three same-typed floats decide whether a terugvordering is billed.
- Two **admin-bypass** tests assert the *allow* direction, so a refusal test cannot be satisfied by a guard that refuses everyone.

## Positive controls

Five mutations, one variable at a time, on a throwaway copy, deliberately spanning **three different authors** rather than only one:

| mutation | result |
|---|---|
| `zaakeigenschappenDestroy` accepts `zaken.bijwerken` instead of `zaken.verwijderen` | **RED** |
| `zoek` answers 200 instead of the ZGW-mandated 201 | **RED** |
| `index()` computes the JWT gate and ignores it | **RED** |
| `NrcController::patch()` passes the partial flag `false` (PATCH → full replace) | **RED** |
| `SubsidieController::finalizeVaststelling()` transposes two same-typed floats | **RED** |

Reverted after each; tree returns green and `lib/` is byte-identical to this branch. Each ran behind a `ReflectionClass::getFileName()` guard asserting the mutated file is the one actually loaded.

## Findings recorded, deliberately NOT fixed here

`lib/`/`appinfo/` changes and product calls — reported rather than patched:

1. **Nine routes are unreachable by their own URL.** A Dutch→English parameter rename never reached `routes.php`: `caseRelation#destroy` (`{aardRelatie}` vs `$natureRelationship`), `parafeerRoute#start|completeStep|skipStep|addStep` and `voorstelBesluit#registerBesluit` (`{voorstelId}` vs `$proposalId`), `subsidie#finalizeVaststelling|publishBeschikking|signBeschikking`. Nextcloud's `Dispatcher` binds by parameter **name** and catches the resulting `TypeError` on the invocation line, so these answer **HTTP 400** — read off `lib/private/AppFramework/Http/Dispatcher.php`, not assumed. (386 routes checked, 10 mismatches, 9 real; `dashboard#catchAll` takes no parameters and is fine.)
2. **Six authorization asymmetries**, each an endpoint less guarded than its own siblings: `MilestoneController::mark()`/`::reverse()` (no per-case guard), `NrcController::notificatieCreate()` (no ZGW scope), `DeelzaakController::counts()` (no guard — an existence oracle), `DrcController::download()`/`::lock()` (no document scope on `@PublicPage` routes), `AiController` (caller-supplied `caseId`, no `CaseAccessGuard`), `ContactMomentController::statusGeven()` (no `CitizenLookupGuard`).

Where current behaviour is pinned it is pinned in an **explicitly-labelled tripwire test whose docblock says it records what the code does, not what is correct** — so adding a guard is a deliberate, visible change rather than a silent test break. No test asserts any of these as if it were right.

## A gate limitation this work exposed

**gate-25 cannot see a route↔method parameter-name mismatch.** Its PHPUnit arm is satisfied by `->methodName(` as executable code, and a unit test calls the method directly with the right argument name — so all nine routes in finding (1) are now reported *covered* while still answering 400 on the wire. Contract coverage at the **controller** layer is not contract coverage at the **route** layer; only a Newman/e2e test that drives the URL catches that class, which is the arm procest has disabled.

## Not closed by this PR

`gate-26` (×1), `gate-53` (×8) and `gate-62` (×1) are untouched and unchanged; 53 and 62 are not procest's to close.
