### PR TITLE
fix(gates): close gate-26 and gate-62 — register the public consultation page, publish through OpenRegister in process

### DIFF
--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -469,6 +469,46 @@ class SettingsService {
 	}//end getObjectService()
 
 	/**
+	 * Lazily resolve OpenRegister's FileService for in-process file attachment.
+	 *
+	 * ADR-084 publishes `ObjectServiceInterface` — 25 methods — and **none of
+	 * them attaches a file**. OpenRegister's own `files#create` route runs
+	 * `FileService::addFile()`, and `FileService` is not a published contract,
+	 * so an app that must attach bytes to an OpenRegister object in process has
+	 * exactly this one route. Recorded as a contract gap in
+	 * `openspec/changes/woo-publication-in-process-object-writes/proposal.md`
+	 * rather than worked around with a self-addressed HTTP call, which is what
+	 * ADR-080 D2/D3 forbids.
+	 *
+	 * Same lazy-resolve contract as {@see self::getObjectService()} and
+	 * {@see self::getApprovalService()}: OpenRegister is an optional runtime
+	 * dependency, so the class is resolved through the container at call time
+	 * rather than type-hinted in the constructor, and callers MUST handle null.
+	 *
+	 * @return object|null The OpenRegister FileService or null when unavailable
+	 *
+	 * @psalm-suppress MixedReturnStatement
+	 * @psalm-suppress MixedInferredReturnType
+	 *
+	 * @spec openspec/changes/woo-publication-in-process-object-writes/specs/woo-publication-via-opencatalogi/spec.md
+	 */
+	public function getFileService(): ?object {
+		if ($this->isOpenRegisterAvailable() === false) {
+			return null;
+		}
+
+		try {
+			return $this->container->get('OCA\OpenRegister\Service\FileService');
+		} catch (\Throwable $e) {
+			$this->logger->error(
+				'Procest: Could not access OpenRegister FileService',
+				['exception' => $e->getMessage()]
+			);
+			return null;
+		}
+	}//end getFileService()
+
+	/**
 	 * Lazily resolve OpenRegister's ApprovalService for parafering chain delegation.
 	 *
 	 * Per ADR-022 (apps consume OpenRegister abstractions) the parafering

--- a/lib/Service/WooPublication/OpenCatalogiApiClient.php
+++ b/lib/Service/WooPublication/OpenCatalogiApiClient.php
@@ -3,29 +3,42 @@
 /**
  * Procest OpenCatalogi API Client.
  *
- * The single thin HTTP boundary for every outbound call this app makes to
- * OpenCatalogi's publication model. OpenCatalogi is called as a local peer
- * app on the same Nextcloud instance, the same way `LibresignApiClient`
- * calls LibreSign (`OCP\Http\Client\IClientService`).
- *
- * Unlike the LibreSign integration, the routes used here are NOT an
- * assumption: OpenCatalogi's own `PublicationsController` exposes no write
- * endpoint (index/show/uses/used/attachments/download only — confirmed
- * against `origin/development` in the opencatalogi repo). Both OpenCatalogi's
- * own backend (`PublicationService::getObjectService()`) and frontend
+ * The boundary for every outbound call this app makes to OpenCatalogi's
+ * publication model. OpenCatalogi is a peer app on the SAME Nextcloud
+ * instance, and its own `PublicationsController` exposes no write endpoint
+ * (index/show/uses/used/attachments/download only — confirmed against
+ * `origin/development` in the opencatalogi repo). Both OpenCatalogi's own
+ * backend (`PublicationService::getObjectService()`) and frontend
  * (`src/store/modules/object.js`) create/update/withdraw publications through
- * OpenRegister's generic Objects API instead
- * (`/index.php/apps/openregister/api/objects/{register}/{schema}[/{id}]`,
- * confirmed against `openregister/appinfo/routes.php`:
- * `objects#create`/`objects#patch`/`files#create`). This client follows the
- * exact same path, addressing the register/schema OpenCatalogi ships by
+ * OpenRegister instead, addressing the register/schema OpenCatalogi ships by
  * default (`lib/Settings/publication_register.json`: register slug
  * `publication`, schemas `publication`/`document`).
  *
- * "Publish" and "withdraw" are not separate endpoints either — a publication
+ * This client reaches OpenRegister **in process**, through the contract
+ * OpenRegister publishes (ADR-084 `ObjectServiceInterface`) — not through an
+ * authenticated HTTP request from this instance to itself. That HTTP hop is
+ * what ADR-080 D2/D3 forbids and hydra gate-62 names; it also cost a full
+ * request cycle per object and needed a stored service account with a real app
+ * password. See
+ * `openspec/changes/woo-publication-in-process-object-writes/proposal.md`,
+ * including the two things measured while writing it:
+ *
+ *   - `ObjectServiceInterface::updateObject()` is documented as a partial
+ *     update and implemented as a full replace, and the merging write
+ *     (`patchObject()`) is not on the contract. `updatePublication()`
+ *     therefore does its own read-merge-write, exactly as OpenRegister's
+ *     `objects#patch` route does.
+ *   - The contract publishes no file operation at all, so `attachFile()` uses
+ *     OpenRegister's `FileService` directly. Recorded as a gap.
+ *
+ * "Publish" and "withdraw" are not separate operations either — a publication
  * is live when `publicatiedatum` is a past date, and withdrawn when
  * `depublicatiedatum` is a past date (per the schema's own field
- * descriptions); both are set via `objects#patch`.
+ * descriptions); both are set through {@see self::updatePublication()}.
+ *
+ * `resolveCatalog()` is the one call that stays on HTTP: it reads
+ * OpenCatalogi's OWN catalog listing, which is not OpenRegister's Objects API
+ * and is therefore outside ADR-080 D2/D3.
  *
  * @category Service
  * @package  OCA\Procest\Service\WooPublication
@@ -36,6 +49,7 @@
  *
  * @link https://conduction.nl
  *
+ * @spec openspec/changes/woo-publication-in-process-object-writes/specs/woo-publication-via-opencatalogi/spec.md
  * @spec openspec/changes/woo-publication-via-opencatalogi/design.md#d1
  * @spec openspec/changes/woo-publication-via-opencatalogi/design.md#d2
  *
@@ -48,6 +62,7 @@ declare(strict_types=1);
 namespace OCA\Procest\Service\WooPublication;
 
 use OCA\Procest\AppInfo\Application;
+use OCA\Procest\Service\SettingsService;
 use OCP\Http\Client\IClientService;
 use OCP\IAppConfig;
 use OCP\IURLGenerator;
@@ -56,60 +71,55 @@ use RuntimeException;
 use Throwable;
 
 /**
- * Thin HTTP client for OpenRegister's Objects API, scoped to the
- * register/schema OpenCatalogi's publication model owns.
+ * Writes OpenCatalogi's publication model through OpenRegister in process.
  *
- * @spec openspec/changes/woo-publication-via-opencatalogi/design.md#d1
+ * @spec openspec/changes/woo-publication-in-process-object-writes/specs/woo-publication-via-opencatalogi/spec.md
  */
 class OpenCatalogiApiClient {
 
 	/**
-	 * OpenRegister objects endpoint template (register/schema, no id).
-	 *
-	 * @var string
-	 */
-	private const OBJECTS_PATH = '/index.php/apps/openregister/api/objects/%s/%s';
-
-	/**
-	 * OpenRegister single-object endpoint template.
-	 *
-	 * @var string
-	 */
-	private const OBJECT_PATH = '/index.php/apps/openregister/api/objects/%s/%s/%s';
-
-	/**
-	 * OpenRegister object-file-attach endpoint template.
-	 *
-	 * @var string
-	 */
-	private const OBJECT_FILES_PATH = '/index.php/apps/openregister/api/objects/%s/%s/%s/files';
-
-	/**
 	 * OpenCatalogi's public catalog-listing endpoint (discovery only, D-Fallback).
+	 *
+	 * This is OpenCatalogi's own app API. It is deliberately the only route
+	 * this class still fetches over HTTP.
 	 *
 	 * @var string
 	 */
 	private const CATALOGI_PATH = '/index.php/apps/opencatalogi/api/catalogi';
 
 	/**
-	 * Request timeout in seconds.
+	 * Request timeout in seconds, for the one remaining HTTP call.
 	 *
 	 * @var int
 	 */
 	private const TIMEOUT_SECONDS = 15;
 
 	/**
+	 * The single domain error every failure of this client surfaces as.
+	 *
+	 * `WooPublicationService` catches `Throwable` around each call and maps it
+	 * to `['available' => false, 'reason' => 'opencatalogi_api_error']`, so
+	 * keeping this exact message keeps that behaviour identical across the
+	 * transport change.
+	 *
+	 * @var string
+	 */
+	private const DOMAIN_ERROR = 'opencatalogi_api_error';
+
+	/**
 	 * Constructor.
 	 *
-	 * @param IClientService $clientService HTTP client factory.
+	 * @param IClientService $clientService HTTP client factory (catalog discovery only).
 	 * @param IURLGenerator $urlGenerator Resolves this Nextcloud instance's own base URL.
-	 * @param IAppConfig $appConfig App config (service-account credentials).
+	 * @param IAppConfig $appConfig App config (service-account credentials for discovery).
+	 * @param SettingsService $settingsService Resolves OpenRegister's ObjectService/FileService.
 	 * @param LoggerInterface $logger Structured logger.
 	 */
 	public function __construct(
 		private readonly IClientService $clientService,
 		private readonly IURLGenerator $urlGenerator,
 		private readonly IAppConfig $appConfig,
+		private readonly SettingsService $settingsService,
 		private readonly LoggerInterface $logger,
 	) {
 	}//end __construct()
@@ -123,17 +133,28 @@ class OpenCatalogiApiClient {
 	 *
 	 * @return array<string, mixed> The created object.
 	 *
-	 * @throws RuntimeException 'opencatalogi_api_error' on any transport/decode failure.
+	 * @throws RuntimeException 'opencatalogi_api_error' on any write failure.
 	 *
-	 * @spec openspec/changes/woo-publication-via-opencatalogi/design.md#d1
+	 * @spec openspec/changes/woo-publication-in-process-object-writes/specs/woo-publication-via-opencatalogi/spec.md
 	 */
 	public function createPublication(string $register, string $schema, array $payload): array {
-		return $this->call(method: 'POST', path: sprintf(self::OBJECTS_PATH, $register, $schema), payload: $payload);
+		return $this->storeObject(register: $register, schema: $schema, object: $payload, uuid: null);
 	}//end createPublication()
 
 	/**
-	 * Update (patch) an existing publication object — used for republish and
-	 * for setting `depublicatiedatum` on withdraw.
+	 * Update an existing publication object — used for republish and for
+	 * setting `depublicatiedatum` on withdraw.
+	 *
+	 * PATCH semantics, done as a read-merge-write. This is not a stylistic
+	 * choice: `ObjectServiceInterface::saveObject()` is PUT-semantic (a
+	 * property absent from the payload is written as null), and
+	 * `ObjectServiceInterface::updateObject()` does NOT merge despite its
+	 * docblock — its body assigns `$data['id']` and calls `saveObject()`. The
+	 * merging write, `patchObject()`, is not on the published contract. With a
+	 * single-key payload such as withdraw's `['depublicatiedatum' => now]`, a
+	 * bare save would erase the publication's title, summary, dates and
+	 * category while reporting success. OpenRegister's own `objects#patch`
+	 * route merges for exactly this reason; this reproduces it.
 	 *
 	 * @param string $register The publication register slug.
 	 * @param string $schema The publication schema slug.
@@ -142,15 +163,18 @@ class OpenCatalogiApiClient {
 	 *
 	 * @return array<string, mixed> The updated object.
 	 *
-	 * @throws RuntimeException 'opencatalogi_api_error' on any transport/decode failure.
+	 * @throws RuntimeException 'opencatalogi_api_error' on any read/write failure.
 	 *
-	 * @spec openspec/changes/woo-publication-via-opencatalogi/design.md#d1
+	 * @spec openspec/changes/woo-publication-in-process-object-writes/specs/woo-publication-via-opencatalogi/spec.md
 	 */
 	public function updatePublication(string $register, string $schema, string $id, array $payload): array {
-		return $this->call(
-			method: 'PATCH',
-			path: sprintf(self::OBJECT_PATH, $register, $schema, $id),
-			payload: $payload,
+		$stored = $this->readObjectData(register: $register, schema: $schema, id: $id);
+
+		return $this->storeObject(
+			register: $register,
+			schema: $schema,
+			object: array_merge($stored, $payload),
+			uuid: $id,
 		);
 	}//end updatePublication()
 
@@ -163,30 +187,46 @@ class OpenCatalogiApiClient {
 	 *
 	 * @return array<string, mixed> The created document object.
 	 *
-	 * @throws RuntimeException 'opencatalogi_api_error' on any transport/decode failure.
+	 * @throws RuntimeException 'opencatalogi_api_error' on any write failure.
 	 *
-	 * @spec openspec/changes/woo-publication-via-opencatalogi/design.md#d1
+	 * @spec openspec/changes/woo-publication-in-process-object-writes/specs/woo-publication-via-opencatalogi/spec.md
 	 */
 	public function attachDocument(string $register, string $schema, array $payload): array {
-		return $this->call(method: 'POST', path: sprintf(self::OBJECTS_PATH, $register, $schema), payload: $payload);
+		return $this->storeObject(register: $register, schema: $schema, object: $payload, uuid: null);
 	}//end attachDocument()
 
 	/**
-	 * Attach file bytes to an object (publication or document) via
-	 * OpenRegister's generic per-object file API.
+	 * Attach file bytes to an object (publication or document).
 	 *
-	 * @param string $register The register slug.
-	 * @param string $schema The schema slug.
+	 * `ObjectServiceInterface` publishes no file operation, so this goes
+	 * through OpenRegister's `FileService::addFile()`, which is precisely what
+	 * OpenRegister's own `files#create` route calls. `addFile()` accepts the
+	 * object UUID as a string and resolves it itself, and it base64-decodes
+	 * string content (and strips a `data:` prefix) before writing — so the
+	 * base64 body this method receives is passed through unchanged, exactly as
+	 * the HTTP route passed it.
+	 *
+	 * `$mimeType` is accepted for call-shape compatibility and is NOT used:
+	 * `FileService::addFile()` has no MIME parameter and
+	 * `FilesController::create()` reads only `name`/`filename`, `content`,
+	 * `share` and `tags` out of the request body — so the HTTP route this
+	 * replaces discarded it too. It stays on the signature because dropping a
+	 * parameter would change the call shape at its one caller.
+	 *
+	 * @param string $register The register slug (unused by the in-process file API — the object id is the anchor).
+	 * @param string $schema The schema slug (unused by the in-process file API — the object id is the anchor).
 	 * @param string $objectId The object id to attach the file to.
 	 * @param string $fileName The file name.
 	 * @param string $base64Content The base64-encoded file content.
-	 * @param string $mimeType The file MIME type.
+	 * @param string $mimeType The file MIME type (accepted, not used — see above).
 	 *
-	 * @return array<string, mixed> The file-attach response.
+	 * @return array<string, mixed> The stored file's metadata.
 	 *
-	 * @throws RuntimeException 'opencatalogi_api_error' on any transport/decode failure.
+	 * @throws RuntimeException 'opencatalogi_api_error' on any attach failure.
 	 *
-	 * @spec openspec/changes/woo-publication-via-opencatalogi/design.md#d1
+	 * @SuppressWarnings(PHPMD.UnusedFormalParameter) register/schema/mimeType are call-shape compatibility — see the docblock.
+	 *
+	 * @spec openspec/changes/woo-publication-in-process-object-writes/specs/woo-publication-via-opencatalogi/spec.md
 	 */
 	public function attachFile(
 		string $register,
@@ -196,17 +236,42 @@ class OpenCatalogiApiClient {
 		string $base64Content,
 		string $mimeType,
 	): array {
-		$payload = [
-			'name' => $fileName,
-			'content' => $base64Content,
-			'mimeType' => $mimeType,
-		];
+		$fileService = $this->settingsService->getFileService();
+		if ($fileService === null) {
+			$this->logger->warning(
+				'OpenCatalogiApiClient: OpenRegister FileService unavailable',
+				['app' => Application::APP_ID, 'objectId' => $objectId],
+			);
+			throw new RuntimeException(self::DOMAIN_ERROR);
+		}
 
-		return $this->call(
-			method: 'POST',
-			path: sprintf(self::OBJECT_FILES_PATH, $register, $schema, $objectId),
-			payload: $payload,
-		);
+		try {
+			$file = $fileService->addFile(
+				objectEntity: $objectId,
+				fileName: $fileName,
+				content: $base64Content,
+				share: false,
+				tags: [],
+			);
+
+			$formatted = $fileService->formatFile($file);
+			if (is_array($formatted) === true) {
+				return $formatted;
+			}
+
+			return [];
+		} catch (Throwable $e) {
+			$this->logger->warning(
+				'OpenCatalogiApiClient: file attach failed',
+				[
+					'app' => Application::APP_ID,
+					'objectId' => $objectId,
+					'fileName' => $fileName,
+					'error' => $e->getMessage(),
+				],
+			);
+			throw new RuntimeException(self::DOMAIN_ERROR, 0, $e);
+		}//end try
 	}//end attachFile()
 
 	/**
@@ -216,13 +281,16 @@ class OpenCatalogiApiClient {
 	 * logged and swallowed; the caller keeps using the configured
 	 * register/schema defaults regardless.
 	 *
+	 * This reads OpenCatalogi's own app API, not OpenRegister's Objects API,
+	 * so it stays an HTTP call.
+	 *
 	 * @return array<string, mixed>|null The first `hasWooSitemap: true` catalog, or null.
 	 *
 	 * @spec openspec/changes/woo-publication-via-opencatalogi/design.md#fallback
 	 */
 	public function resolveCatalog(): ?array {
 		try {
-			$result = $this->call(method: 'GET', path: self::CATALOGI_PATH, payload: null);
+			$result = $this->fetchCatalogi();
 		} catch (Throwable $e) {
 			$this->logger->info(
 				'OpenCatalogiApiClient::resolveCatalog: discovery call failed, continuing with defaults',
@@ -250,23 +318,188 @@ class OpenCatalogiApiClient {
 	}//end resolveCatalog()
 
 	/**
-	 * Perform the HTTP call and decode the response.
+	 * Resolve OpenRegister's ObjectService, or fail with the domain error.
 	 *
-	 * Every route this client addresses (OpenRegister's Objects API,
-	 * OpenCatalogi's public catalog listing) returns plain JSON, not an OCS
-	 * envelope — unlike LibreSign's `/ocs/v2.php` routes — so no envelope
-	 * unwrapping is needed here.
+	 * `WooPublicationService::checkAvailability()` already refuses to call this
+	 * client when OpenRegister is unavailable, so a null here is exceptional
+	 * rather than routine — but it must not be dereferenced, and it must
+	 * surface the same error the transport failures do.
 	 *
-	 * @param string $method 'GET', 'POST', or 'PATCH'.
-	 * @param string $path The route path (leading slash).
-	 * @param array<string, mixed>|null $payload The JSON body for POST/PATCH requests.
+	 * @return object The OpenRegister ObjectService.
 	 *
-	 * @return array<string, mixed>
+	 * @throws RuntimeException 'opencatalogi_api_error' when OpenRegister is unavailable.
+	 *
+	 * @spec openspec/changes/woo-publication-in-process-object-writes/specs/woo-publication-via-opencatalogi/spec.md
+	 */
+	private function requireObjectService(): object {
+		$objectService = $this->settingsService->getObjectService();
+		if ($objectService === null) {
+			$this->logger->warning(
+				'OpenCatalogiApiClient: OpenRegister ObjectService unavailable',
+				['app' => Application::APP_ID],
+			);
+			throw new RuntimeException(self::DOMAIN_ERROR);
+		}
+
+		return $objectService;
+	}//end requireObjectService()
+
+	/**
+	 * Read an object's stored property data, for the merge half of a PATCH.
+	 *
+	 * Uses `findSilent()` rather than `find()` so a publication update does not
+	 * write a read entry into the audit trail — the same choice OpenRegister's
+	 * `objects#patch` route makes. `_rbac` and `_multitenancy` stay at their
+	 * contract defaults (both `true`), which is STRICTER than that route's
+	 * internal read: the merge cannot pull in an object the caller may not see.
+	 *
+	 * @param string $register The register slug.
+	 * @param string $schema The schema slug.
+	 * @param string $id The object id.
+	 *
+	 * @return array<string, mixed> The stored property data.
+	 *
+	 * @throws RuntimeException 'opencatalogi_api_error' when the object cannot be read.
+	 *
+	 * @spec openspec/changes/woo-publication-in-process-object-writes/specs/woo-publication-via-opencatalogi/spec.md
+	 */
+	private function readObjectData(string $register, string $schema, string $id): array {
+		$objectService = $this->requireObjectService();
+
+		try {
+			$stored = $objectService->findSilent(
+				id: $id,
+				register: $register,
+				schema: $schema,
+			);
+		} catch (Throwable $e) {
+			$this->logger->warning(
+				'OpenCatalogiApiClient: could not read the object to patch',
+				['app' => Application::APP_ID, 'id' => $id, 'error' => $e->getMessage()],
+			);
+			throw new RuntimeException(self::DOMAIN_ERROR, 0, $e);
+		}
+
+		return $this->objectData(entity: $stored);
+	}//end readObjectData()
+
+	/**
+	 * Persist an object through the published contract and return it as an array.
+	 *
+	 * @param string $register The register slug.
+	 * @param string $schema The schema slug.
+	 * @param array<string, mixed> $object The object data to store.
+	 * @param string|null $uuid The uuid to update, or null to create.
+	 *
+	 * @return array<string, mixed> The stored object, with its id.
+	 *
+	 * @throws RuntimeException 'opencatalogi_api_error' on any write failure.
+	 *
+	 * @spec openspec/changes/woo-publication-in-process-object-writes/specs/woo-publication-via-opencatalogi/spec.md
+	 */
+	private function storeObject(string $register, string $schema, array $object, ?string $uuid): array {
+		$objectService = $this->requireObjectService();
+
+		try {
+			$saved = $objectService->saveObject(
+				object: $object,
+				register: $register,
+				schema: $schema,
+				uuid: $uuid,
+			);
+		} catch (Throwable $e) {
+			$this->logger->warning(
+				'OpenCatalogiApiClient: object write failed',
+				[
+					'app' => Application::APP_ID,
+					'register' => $register,
+					'schema' => $schema,
+					'uuid' => ($uuid ?? ''),
+					'error' => $e->getMessage(),
+				],
+			);
+			throw new RuntimeException(self::DOMAIN_ERROR, 0, $e);
+		}//end try
+
+		$data = $this->objectData(entity: $saved);
+		$identifier = $this->objectIdentifier(entity: $saved);
+		if ($identifier !== null) {
+			$data['id'] = $identifier;
+		}
+
+		return $data;
+	}//end storeObject()
+
+	/**
+	 * The property data of whatever OpenRegister returned.
+	 *
+	 * `ObjectServiceInterface` returns `ObjectEntityInterface`, whose
+	 * `getObject(): array` is the property data. The service is resolved from
+	 * the container as an untyped `object`, so the shape is checked rather than
+	 * assumed — and an already-array return is accepted for the same reason.
+	 *
+	 * @param mixed $entity Whatever the object service returned.
+	 *
+	 * @return array<string, mixed> The property data.
+	 *
+	 * @throws RuntimeException 'opencatalogi_api_error' when the return cannot be read.
+	 */
+	private function objectData(mixed $entity): array {
+		if (is_array($entity) === true) {
+			return $entity;
+		}
+
+		if (is_object($entity) === true && method_exists($entity, 'getObject') === true) {
+			$data = $entity->getObject();
+			if (is_array($data) === true) {
+				return $data;
+			}
+		}
+
+		$this->logger->warning(
+			'OpenCatalogiApiClient: OpenRegister returned an unreadable object shape',
+			['app' => Application::APP_ID, 'type' => get_debug_type($entity)],
+		);
+		throw new RuntimeException(self::DOMAIN_ERROR);
+	}//end objectData()
+
+	/**
+	 * The stored object's identifier, which the caller reads back as `id`.
+	 *
+	 * @param mixed $entity Whatever the object service returned.
+	 *
+	 * @return string|null The uuid, or null when the shape carries none.
+	 */
+	private function objectIdentifier(mixed $entity): ?string {
+		if (is_object($entity) === true && method_exists($entity, 'getUuid') === true) {
+			$uuid = $entity->getUuid();
+			if (is_string($uuid) === true && $uuid !== '') {
+				return $uuid;
+			}
+		}
+
+		if (is_array($entity) === true) {
+			$identifier = ($entity['id'] ?? $entity['uuid'] ?? null);
+			if (is_string($identifier) === true && $identifier !== '') {
+				return $identifier;
+			}
+		}
+
+		return null;
+	}//end objectIdentifier()
+
+	/**
+	 * GET OpenCatalogi's catalog listing and decode it.
+	 *
+	 * The only HTTP call left in this class. OpenCatalogi's routes return plain
+	 * JSON, not an OCS envelope, so no envelope unwrapping is needed.
+	 *
+	 * @return array<string, mixed> The decoded listing.
 	 *
 	 * @throws RuntimeException 'opencatalogi_api_error' on any transport/decode failure.
 	 */
-	private function call(string $method, string $path, ?array $payload): array {
-		$url = rtrim($this->urlGenerator->getBaseUrl(), '/') . $path;
+	private function fetchCatalogi(): array {
+		$url = rtrim($this->urlGenerator->getBaseUrl(), '/') . self::CATALOGI_PATH;
 
 		$options = [
 			'timeout' => self::TIMEOUT_SECONDS,
@@ -282,21 +515,13 @@ class OpenCatalogiApiClient {
 			$options['auth'] = [$serviceUid, $serviceAppPass];
 		}
 
-		if ($payload !== null) {
-			$options['json'] = $payload;
-		}
-
 		try {
 			$client = $this->clientService->newClient();
-			$response = match ($method) {
-				'POST' => $client->post($url, $options),
-				'PATCH' => $client->patch($url, $options),
-				default => $client->get($url, $options),
-			};
+			$response = $client->get($url, $options);
 
 			$decoded = json_decode((string)$response->getBody(), true);
 			if (is_array($decoded) === false) {
-				throw new RuntimeException('opencatalogi_api_error');
+				throw new RuntimeException(self::DOMAIN_ERROR);
 			}
 
 			return $decoded;
@@ -304,10 +529,10 @@ class OpenCatalogiApiClient {
 			throw $e;
 		} catch (Throwable $e) {
 			$this->logger->warning(
-				'OpenCatalogiApiClient: request failed',
-				['app' => Application::APP_ID, 'url' => $url, 'method' => $method, 'error' => $e->getMessage()],
+				'OpenCatalogiApiClient: catalog discovery request failed',
+				['app' => Application::APP_ID, 'url' => $url, 'error' => $e->getMessage()],
 			);
-			throw new RuntimeException('opencatalogi_api_error', 0, $e);
+			throw new RuntimeException(self::DOMAIN_ERROR, 0, $e);
 		}//end try
-	}//end call()
+	}//end fetchCatalogi()
 }//end class

--- a/openspec/changes/woo-publication-in-process-object-writes/proposal.md
+++ b/openspec/changes/woo-publication-in-process-object-writes/proposal.md
@@ -1,0 +1,138 @@
+# Proposal: woo-publication-in-process-object-writes
+
+## Summary
+
+Move procest's WOO publication writes off a **self-addressed HTTP call to
+OpenRegister's Objects API** and onto OpenRegister's **published in-process
+contract** (`ObjectServiceInterface`, ADR-084). `OpenCatalogiApiClient` keeps
+its public method surface and its error contract; only the transport under it
+changes. The service-account credentials the HTTP hop needed
+(`opencatalogi_service_uid` / `opencatalogi_service_app_password`) stop being
+consulted for publication writes.
+
+This is the change ADR-080 D2/D3 asks for and hydra gate-62 (`store-plane`)
+names: `lib/Service/WooPublication/OpenCatalogiApiClient.php` builds and
+fetches an OpenRegister objects-API URL with `IClientService`.
+
+## Motivation
+
+`WooPublicationService` publishes a WOO besluit to OpenCatalogi's publication
+register. OpenCatalogi exposes no write endpoint of its own, so both
+OpenCatalogi and procest write through OpenRegister's generic Objects API.
+procest did that over HTTP, to its own instance:
+
+```
+IURLGenerator::getBaseUrl() + /index.php/apps/openregister/api/objects/…
+```
+
+That is an app on a Nextcloud instance making an authenticated HTTP request to
+the same Nextcloud instance. It costs a full request cycle per object, needs a
+stored service account with a real app password, and re-implements — in
+procest — routing, envelope handling and error mapping that OpenRegister
+already publishes as a PHP contract.
+
+**Why not `GenericStoreService`** (the class gate-62's message points at):
+measured against `openregister@development`, its public surface is exactly
+`isConfigured()`, `search()`, `resolve()` — no create, no patch, no file
+attach, which is all three of the operations this client performs — and
+`SecurityService::assertSafeFetchUrl()` ends in
+`filter_var(..., FILTER_FLAG_NO_PRIV_RANGE|FILTER_FLAG_NO_RES_RANGE)` and
+**throws** when that fails. The store plane is built for REMOTE stores; a
+same-instance URL fails closed on the first call. The correct target is the
+ADR-084 contract, which is what this change adopts.
+
+## Affected Projects
+
+- [x] Project: procest
+
+## What changes
+
+1. **Publication create / update / document-create go through
+   `ObjectServiceInterface`.** `createPublication()` and `attachDocument()`
+   call `saveObject(object:, register:, schema:)`. `updatePublication()` does
+   a **read-merge-write**: `findSilent()` the stored object, shallow-merge the
+   partial payload over `getObject()`, then `saveObject(..., uuid: $id)`.
+
+2. **`attachFile()` goes through OpenRegister's `FileService::addFile()`,
+   resolved from the DI container** the same way `SettingsService` already
+   resolves `ObjectService` and `ApprovalService`. See the contract gap below —
+   this one operation has no published-contract equivalent.
+
+3. **`resolveCatalog()` stays on `IClientService`.** It reads
+   `/index.php/apps/opencatalogi/api/catalogi`, which is OpenCatalogi's own
+   app API, not OpenRegister's Objects API. ADR-080 D2/D3 and gate-62 are about
+   the latter. Nothing about that call changes.
+
+4. **The OpenRegister objects-API path constants are deleted** from the client,
+   along with the POST/PATCH transport branches that only served them.
+
+## The defect writing this spec exposed
+
+⚠️ **`ObjectServiceInterface::updateObject()`'s docblock says "Apply a partial
+update to an existing object." The implementation is a full replace.** Read at
+`openregister@origin/development`:
+
+```php
+public function updateObject(string $objectId, array $data, …): ObjectEntity {
+    $data['id'] = $objectId;
+    return $this->saveObject(object: $data);
+}
+```
+
+There is no merge. `saveObject()` is PUT-semantic — OpenRegister's own
+`patchObject()` docblock states it outright: *"a property absent from the
+payload is written as null — so every partial-write caller either merges first
+or silently nulls live data."* The one method that really does merge,
+`patchObject()`, is **not on `ObjectServiceInterface`** (the contract publishes
+25 methods and that is not one of them).
+
+This matters here and not in the abstract: `withdraw()` sends the single-key
+payload `['depublicatiedatum' => now]`. Routed through `updateObject()`,
+withdrawing a publication would have **erased its title, summary, description,
+publication date, category, status and case reference** — while reporting
+success. The HTTP `objects#patch` route this client used does
+`findSilent()` → `array_merge($existing, $patch)` → `saveObject(uuid:)`, so the
+migration has to reproduce that merge in procest, and it does.
+
+**Reported, not fixed here:** the interface docblock and the implementation
+disagree, and the fleet's only merging write is unpublished. That belongs in
+`ConductionNL/openregister`.
+
+## Contract gap: no file operation is published
+
+`ObjectServiceInterface` publishes no file API. OpenRegister's HTTP
+`files#create` route runs `FileService::addFile()`, and `FileService` is not a
+published contract. The three options were: drop the file attach (a behaviour
+loss — the redacted PDFs are the point of a WOO publication), keep the HTTP
+call (gate-62 stays red, and the ADR is not obeyed), or call `FileService`
+in-process. This change takes the third and records the gap.
+
+Also measured while doing so: **`files#create` never used the `mimeType` the
+client sent.** `FileService::addFile(objectEntity, fileName, content, share,
+tags)` has no MIME parameter, and `FilesController::create()` reads only
+`name`/`filename`, `content`, `share` and `tags` out of the request body. The
+parameter is kept on `attachFile()` — removing it would change the call shape
+at the one caller — and is documented as accepted-but-unused rather than
+quietly dropped.
+
+## Behaviour that changes on purpose
+
+- **Acting identity.** The HTTP hop authenticated as a configured service
+  account. In-process calls act as the session user, with `_rbac` and
+  `_multitenancy` at their contract defaults (`true`). A publish therefore now
+  requires the acting user to be permitted to write in the publication
+  register, instead of borrowing the service account's rights. This is a
+  tightening, and it is the point of ADR-084's default-on flags.
+- **The internal read is stricter.** OpenRegister's own `objects#patch` reads
+  the object with `_rbac: false, _multitenancy: false` before merging. This
+  change reads it with both at their defaults, so the merge cannot pull in an
+  object the caller may not see.
+- **The service-account app config keys stop being read for publication
+  writes.** They still gate `resolveCatalog()`. They are not removed — an
+  installed deployment may still carry them and removal is a config migration.
+
+## Out of scope
+
+- Fixing `updateObject()` / publishing `patchObject()` in OpenRegister.
+- Publishing a file contract in OpenRegister.
+- Removing the service-account config keys.

--- a/openspec/changes/woo-publication-in-process-object-writes/specs/woo-publication-via-opencatalogi/spec.md
+++ b/openspec/changes/woo-publication-in-process-object-writes/specs/woo-publication-via-opencatalogi/spec.md
@@ -1,0 +1,213 @@
+# WOO publication — in-process OpenRegister object writes
+
+## ADDED Requirements
+
+### Requirement: REQ-WPI-001 — Publication objects MUST be written through OpenRegister's published in-process contract, not over HTTP
+
+`OpenCatalogiApiClient` MUST create and update publication and document
+objects by calling OpenRegister's `ObjectServiceInterface` (ADR-084) in
+process. It MUST NOT build or fetch an OpenRegister objects-API URL with
+`IClientService` (ADR-080 D2/D3). The service MUST be resolved through
+`SettingsService::getObjectService()`, which returns `null` when OpenRegister
+is absent.
+
+Only methods published on `ObjectServiceInterface` may be used. Every call
+MUST pass its arguments by name.
+
+#### Scenario: Creating a publication saves an object instead of posting a URL
+
+- **GIVEN** OpenCatalogi's publication register/schema are configured
+- **WHEN** `OpenCatalogiApiClient::createPublication()` is called with a payload
+- **THEN** it MUST call `saveObject(object: <payload>, register: <register>, schema: <schema>, uuid: null)` on the OpenRegister object service
+- **AND** it MUST NOT perform any HTTP request
+- **AND** it MUST return the stored object as an associative array carrying the object's `id`
+
+#### Scenario: Creating a linked document saves an object instead of posting a URL
+
+- **GIVEN** a publication id
+- **WHEN** `OpenCatalogiApiClient::attachDocument()` is called with a document payload
+- **THEN** it MUST call `saveObject(object: <payload>, register: <register>, schema: <document schema>, uuid: null)`
+- **AND** it MUST NOT perform any HTTP request
+
+#### Scenario: The OpenRegister objects-API URL is gone from the client
+
+- **GIVEN** the shipped `lib/Service/WooPublication/OpenCatalogiApiClient.php`
+- **WHEN** its source is read
+- **THEN** it MUST contain no `/apps/openregister/api/objects/` path in executable code
+
+### Requirement: REQ-WPI-002 — A partial publication update MUST be a read-merge-write, never a bare save
+
+`updatePublication()` receives a PARTIAL payload — `withdraw()` sends only
+`depublicatiedatum`. `ObjectServiceInterface::saveObject()` is PUT-semantic: a
+property absent from the payload is written as null.
+`ObjectServiceInterface::updateObject()` does not help — despite a docblock
+reading "Apply a partial update to an existing object", its implementation
+assigns `$data['id']` and calls `saveObject()` with no merge, and the one
+method that really merges (`patchObject()`) is not published on the contract.
+
+`updatePublication()` MUST therefore read the stored object, shallow-merge the
+partial payload over it, and save the merged result under the same uuid —
+reproducing what OpenRegister's own `objects#patch` route does. It MUST NOT
+call `updateObject()`.
+
+The read MUST use `findSilent()` so a publication update does not write a
+spurious read entry into the audit trail, and MUST leave `_rbac` and
+`_multitenancy` at their contract defaults.
+
+#### Scenario: Withdrawing a publication preserves every field it did not name
+
+- **GIVEN** a stored publication carrying `title`, `summary`, `publicationDate`, `tooiCategorieUri` and `status`
+- **WHEN** `updatePublication()` is called with the single-key payload `{ depublicatiedatum: <now> }`
+- **THEN** the object saved back MUST carry `depublicatiedatum` set to that value
+- **AND** it MUST still carry the original `title`, `summary`, `publicationDate`, `tooiCategorieUri` and `status`
+
+#### Scenario: A key present in both the stored object and the payload takes the payload's value
+
+- **GIVEN** a stored publication with `status: "published"`
+- **WHEN** `updatePublication()` is called with `{ status: "withdrawn" }`
+- **THEN** the object saved back MUST carry `status: "withdrawn"`
+
+#### Scenario: The merged object is saved under the same uuid
+
+- **GIVEN** an existing publication with uuid `pub-001`
+- **WHEN** `updatePublication()` is called for `pub-001`
+- **THEN** `saveObject()` MUST be called with `uuid: "pub-001"`, so the write updates that object rather than creating a second one
+
+### Requirement: REQ-WPI-003 — File bytes MUST be attached in process, and the transport failure contract MUST be unchanged
+
+`attachFile()` MUST attach file content through OpenRegister's
+`FileService::addFile()` resolved from the DI container, rather than posting to
+OpenRegister's per-object files route. `ObjectServiceInterface` publishes no
+file operation, so this is the only in-process route available; the gap is
+recorded in the proposal.
+
+`attachFile()`'s `$mimeType` parameter MUST be kept for call-shape
+compatibility and MUST be documented as unused by OpenRegister — the HTTP
+route it replaces also ignored it, because `FileService::addFile()` takes no
+MIME argument.
+
+Every failure of any operation on this client MUST continue to surface as
+`RuntimeException` with message `opencatalogi_api_error`, so
+`WooPublicationService`'s existing `catch (Throwable)` arms — which map it to
+`['available' => false, 'reason' => 'opencatalogi_api_error']` — keep working
+unchanged.
+
+#### Scenario: Attaching file bytes calls the in-process file service
+
+- **GIVEN** a created document object with id `doc-001` and base64 file content
+- **WHEN** `attachFile()` is called
+- **THEN** it MUST call `addFile(objectEntity: "doc-001", fileName: <name>, content: <base64>, share: false, tags: [])`
+- **AND** it MUST NOT perform any HTTP request
+
+#### Scenario: An OpenRegister failure is reported as the existing domain error
+
+- **GIVEN** the OpenRegister object service throws on `saveObject()`
+- **WHEN** `createPublication()` is called
+- **THEN** it MUST throw `RuntimeException` with message `opencatalogi_api_error`
+
+#### Scenario: OpenRegister being unavailable is reported as the existing domain error
+
+- **GIVEN** `SettingsService::getObjectService()` returns null
+- **WHEN** `createPublication()` is called
+- **THEN** it MUST throw `RuntimeException` with message `opencatalogi_api_error`
+- **AND** it MUST NOT dereference the null service
+
+### Requirement: REQ-WPI-004 — Catalog discovery stays an OpenCatalogi HTTP read and MUST keep its swallow-and-continue contract
+
+`resolveCatalog()` reads OpenCatalogi's own catalog listing
+(`/index.php/apps/opencatalogi/api/catalogi`), which is not OpenRegister's
+Objects API and is therefore outside ADR-080 D2/D3. It MUST keep using
+`IClientService`, MUST keep sending the configured service-account credentials
+when both are set, and MUST keep swallowing every failure and returning `null`
+so discovery never gates publication.
+
+#### Scenario: Discovery still returns the first WOO-flagged catalog
+
+- **GIVEN** OpenCatalogi answers with a list containing a catalog whose `hasWooSitemap` is true
+- **WHEN** `resolveCatalog()` is called
+- **THEN** it MUST return that catalog
+
+#### Scenario: A discovery transport failure returns null rather than throwing
+
+- **GIVEN** the HTTP client throws
+- **WHEN** `resolveCatalog()` is called
+- **THEN** it MUST return `null` and MUST NOT throw
+
+## MODIFIED Requirements
+
+### Requirement: Publish a WOO decision to OpenCatalogi
+
+The system MUST create a publication (and its disclosable documents) in
+OpenCatalogi's publication register when a case worker triggers publication
+of an assembled WOO decision, and record the result on the procest decision
+object through a single write.
+
+The publication, its documents and their file bytes MUST be written through
+OpenRegister **in process** (`ObjectServiceInterface` for objects,
+`FileService` for file bytes), not through a self-addressed HTTP call. The
+acting identity is therefore the session user under OpenRegister's default
+`_rbac` / `_multitenancy` scoping, not a stored service account.
+
+#### Scenario: Successful publish creates the publication and records the result
+
+- **GIVEN** an assembled WOO decision with at least one disclosable document,
+  and OpenCatalogi installed and enabled
+- **WHEN** the case worker calls `POST /api/cases/{id}/woo/publish`
+- **THEN** the system MUST create a publication object in OpenCatalogi's
+  configured register/schema with the built payload
+- **AND** create a `document` object for each disclosable document, linked to
+  the publication
+- **AND** write `wooPublication.publicationId`, `.publicationUrl`, `.status`
+  ("published"), `.category`, and `.publishedAt` onto the procest decision
+  object via exactly one `ObjectService::saveObject()` call
+- **AND** return the publication id and url in the response
+
+#### Scenario: Publish is idempotent per decision
+
+- **GIVEN** a WOO decision that was already published (has
+  `wooPublication.publicationId` set)
+- **WHEN** the case worker calls `POST /api/cases/{id}/woo/publish` again
+- **THEN** the system MUST update the existing publication rather than create
+  a duplicate
+- **AND** the update MUST preserve every stored publication field the new
+  payload does not name
+
+#### Scenario: No disclosable documents blocks publish with a clear reason
+
+- **GIVEN** a WOO decision where every document is `niet_openbaar` or
+  `deels_openbaar`-pending-redaction
+- **WHEN** the case worker calls `POST /api/cases/{id}/woo/publish`
+- **THEN** the system MUST NOT create a publication
+- **AND** the response MUST report `available: false` with reason
+  `no_publishable_documents`
+
+### Requirement: Withdraw a published WOO decision
+
+The system MUST support withdrawing (depublishing) a previously published WOO
+decision, marking it withdrawn both in OpenCatalogi and on the procest
+decision object.
+
+Withdrawal sends a single-key partial payload to OpenCatalogi's publication
+object. Because OpenRegister's published write is PUT-semantic, that write
+MUST be performed as a read-merge-write; a bare save of the partial payload
+would null every other property of the publication while reporting success.
+
+#### Scenario: Withdraw a published decision
+
+- **GIVEN** a WOO decision with `wooPublication.status` "published" and a
+  known `publicationId`
+- **WHEN** the case worker calls `POST /api/cases/{id}/woo/withdraw`
+- **THEN** the system MUST set the OpenCatalogi publication's depublication
+  date to now
+- **AND** the publication MUST retain its title, summary, publication date and
+  category
+- **AND** update `wooPublication.status` to "withdrawn" and set
+  `wooPublication.withdrawnAt` on the procest decision object via one
+  `ObjectService::saveObject()` call
+
+#### Scenario: Withdraw without a prior publish is rejected
+
+- **GIVEN** a WOO decision with no `wooPublication.publicationId`
+- **WHEN** the case worker calls `POST /api/cases/{id}/woo/withdraw`
+- **THEN** the system MUST return an error indicating there is nothing to
+  withdraw, and MUST NOT call OpenCatalogi

--- a/openspec/changes/woo-publication-in-process-object-writes/tasks.md
+++ b/openspec/changes/woo-publication-in-process-object-writes/tasks.md
@@ -1,0 +1,52 @@
+# Tasks: woo-publication-in-process-object-writes
+
+## 1. OpenRegister service resolution
+
+- [x] T01 — Add `SettingsService::getFileService()`, resolving
+  `OCA\OpenRegister\Service\FileService` from the DI container with the same
+  availability guard and null-on-failure contract as the existing
+  `getObjectService()` / `getApprovalService()`.
+  → `lib/Service/SettingsService.php`
+
+## 2. OpenCatalogiApiClient — transport migration
+
+- [x] T02 — Inject `SettingsService` into `OpenCatalogiApiClient` and add a
+  private resolver that throws `RuntimeException('opencatalogi_api_error')`
+  when OpenRegister is unavailable, so the client's existing error contract is
+  unchanged. (REQ-WPI-003)
+- [x] T03 — `createPublication()` and `attachDocument()` call
+  `saveObject(object:, register:, schema:, uuid: null)`. (REQ-WPI-001)
+- [x] T04 — `updatePublication()` performs a read-merge-write:
+  `findSilent(id:, register:, schema:)` → `array_merge($stored, $payload)` →
+  `saveObject(..., uuid: $id)`. Do NOT use `updateObject()` — its
+  implementation is a full replace despite its docblock. (REQ-WPI-002)
+- [x] T05 — `attachFile()` calls `FileService::addFile(objectEntity:,
+  fileName:, content:, share:, tags:)`; keep `$mimeType` on the signature and
+  document that OpenRegister's file API has never accepted one. (REQ-WPI-003)
+- [x] T06 — Delete the OpenRegister objects-API path constants and the
+  POST/PATCH transport branches; keep `resolveCatalog()`'s GET on
+  `IClientService` with its service-account auth and swallow-and-continue
+  contract. (REQ-WPI-001, REQ-WPI-004)
+
+## 3. Tests
+
+- [x] T07 — Rewrite `tests/Unit/Service/WooPublication/OpenCatalogiApiClientTest.php`
+  against the new transport: assert the named arguments each operation passes,
+  that no HTTP client is ever constructed for an object write, and that the
+  `opencatalogi_api_error` contract still holds for a thrown service, a null
+  service and a null file service.
+- [x] T08 — Cover the read-merge-write directly: a stored object with five
+  properties, a single-key partial payload, and an assertion that all five
+  survive the save. This is the test that fails against a bare `saveObject()`.
+- [x] T09 — Positive-control every new assertion: show the suite RED against a
+  deliberately wrong route (a bare save instead of the merge, and
+  `updateObject()` instead of `saveObject(uuid:)`), then revert and show it
+  GREEN, with `git status` clean before either result is quoted.
+
+## 4. Verification
+
+- [x] T10 — hydra gate-62 (`check_store_and_settings_surface.py --gate store`)
+  goes FAIL 1 → PASS on the app tree, measured on the same gate package sha on
+  both sides.
+- [x] T11 — `composer check:strict` scope (phpcs/phpmd/psalm/phpstan) stays at
+  or below its pre-change finding count for the touched files.

--- a/src/customComponents.js
+++ b/src/customComponents.js
@@ -50,6 +50,12 @@ import TermijnDashboard from './views/dashboard/TermijnDashboard.vue'
 import DoorlooptijdView from './views/DoorlooptijdDashboard.vue'
 // --- Surviving custom pages — see design.md "Custom-fallback inventory". ---
 import MyWorkView from './views/MyWorkCards.vue'
+// Token-addressed advice-response surface for external advisory bodies
+// (consultation-management TASK-CN-06). Declared as page
+// `ExternalConsultationResponse` in src/manifest.d/consultation-public.json;
+// its absence here rendered the manifest renderer's "This page is empty"
+// placeholder on /public/consultations/:token instead of this component.
+import ExternalConsultationResponsePage from './views/public/ExternalConsultationResponsePage.vue'
 import PublicAppointmentPage from './views/public/PublicAppointmentPage.vue'
 // Remote-org accept/reject for a federated zaakoverdracht (federated-case-collaboration).
 import PublicFederatedTransferPage from './views/public/PublicFederatedTransferPage.vue'
@@ -138,6 +144,7 @@ export default {
 	PublicAppointmentPage,
 	PublicStatusPage,
 	PublicFederatedTransferPage,
+	ExternalConsultationResponsePage,
 
 	// --- Leverancier-zaakportaal external supplier portal MOVED to Portaliq
 	//     (ADR-046, procest#162) — see import-section comment. ---

--- a/tests/Unit/Service/SettingsServiceTest.php
+++ b/tests/Unit/Service/SettingsServiceTest.php
@@ -127,6 +127,68 @@ class SettingsServiceTest extends TestCase {
 	}//end testIsOpenRegisterAvailableReturnsFalse()
 
 	/**
+	 * getFileService() resolves OpenRegister's FileService by class name.
+	 *
+	 * ADR-084 publishes no file operation, so this container lookup is the
+	 * only in-process route an app has for attaching bytes to an OpenRegister
+	 * object — see
+	 * openspec/changes/woo-publication-in-process-object-writes/proposal.md.
+	 * The class name is asserted because it IS the contract here: there is no
+	 * interface to type-hint against, so a typo would surface only at runtime.
+	 *
+	 * @return void
+	 */
+	public function testGetFileServiceResolvesOpenRegistersFileService(): void {
+		$this->appManager->method('isEnabledForUser')->willReturn(true);
+
+		$fileService = new \stdClass();
+		$this->container
+			->expects($this->once())
+			->method('get')
+			->with('OCA\OpenRegister\Service\FileService')
+			->willReturn($fileService);
+
+		$this->assertSame($fileService, $this->service->getFileService());
+
+	}//end testGetFileServiceResolvesOpenRegistersFileService()
+
+	/**
+	 * getFileService() returns null — never throws — when OpenRegister is
+	 * absent, so callers can degrade rather than break the case flow.
+	 *
+	 * @return void
+	 */
+	public function testGetFileServiceReturnsNullWithoutOpenRegister(): void {
+		$this->appManager->method('isEnabledForUser')->willReturn(false);
+		$this->appManager->method('isInstalled')->willReturn(false);
+
+		$this->container->expects($this->never())->method('get');
+
+		$this->assertNull($this->service->getFileService());
+
+	}//end testGetFileServiceReturnsNullWithoutOpenRegister()
+
+	/**
+	 * A container that cannot resolve the class is logged and reported as
+	 * null, not propagated. `\Throwable` is caught deliberately: a container
+	 * miss on a class the app does not own can surface as an `Error`, which a
+	 * `\Exception` catch would let through.
+	 *
+	 * @return void
+	 */
+	public function testGetFileServiceReturnsNullWhenTheContainerCannotResolveIt(): void {
+		$this->appManager->method('isEnabledForUser')->willReturn(true);
+		$this->container
+			->method('get')
+			->willThrowException(new \RuntimeException('not registered'));
+
+		$this->logger->expects($this->once())->method('error');
+
+		$this->assertNull($this->service->getFileService());
+
+	}//end testGetFileServiceReturnsNullWhenTheContainerCannotResolveIt()
+
+	/**
 	 * Test that getSettings returns all config keys with their values.
 	 *
 	 * @return void

--- a/tests/Unit/Service/WooPublication/OpenCatalogiApiClientTest.php
+++ b/tests/Unit/Service/WooPublication/OpenCatalogiApiClientTest.php
@@ -3,9 +3,30 @@
 /**
  * OpenCatalogiApiClient Unit Tests.
  *
- * Mocks OCP\Http\Client\IClientService/IClient/IResponse — the thin HTTP
- * boundary this class owns — so no real HTTP happens in tests. Asserts the
- * request shapes against OpenRegister's confirmed Objects API routes.
+ * The client no longer speaks HTTP to OpenRegister — it calls OpenRegister's
+ * published in-process contract (ADR-084 `ObjectServiceInterface`) and, for
+ * file bytes, `FileService`. These tests assert that migration behaviourally:
+ * WHAT each operation asks OpenRegister to store, not which URL it built.
+ *
+ * WHY THE DOUBLES ARE HAND-WRITTEN AND NOT `createMock()`
+ * ------------------------------------------------------
+ * Every call this client makes into OpenRegister passes its arguments BY NAME
+ * (`saveObject(object:, register:, schema:, uuid:)`), and **a PHPUnit mock
+ * cannot observe named arguments** — it sees its own parameter defaults, so an
+ * `expects()->with(...)` assertion passes just as well against code that never
+ * passed the argument at all. A recording double that declares the real
+ * parameter NAMES is the only shape that can tell those apart, so the doubles
+ * below mirror `ObjectServiceInterface::saveObject()` /
+ * `::findSilent()` and `FileService::addFile()` signature for signature,
+ * defaults included.
+ *
+ * The load-bearing test here is
+ * {@see OpenCatalogiApiClientTest::testUpdatePublicationMergesOverTheStoredObject()}.
+ * `saveObject()` is PUT-semantic and `updateObject()` does not merge despite
+ * its docblock, so a partial payload written with a bare save silently nulls
+ * every property it does not name. That test seeds five stored properties,
+ * sends a one-key payload, and asserts all five survive — it fails against a
+ * bare save, which is exactly the defect it exists to catch.
  *
  * @category Tests
  * @package  OCA\Procest\Tests\Unit\Service\WooPublication
@@ -17,13 +38,14 @@
  * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
  * SPDX-License-Identifier: EUPL-1.2
  *
- * @spec openspec/changes/woo-publication-via-opencatalogi/specs/woo-publication-via-opencatalogi/spec.md
+ * @spec openspec/changes/woo-publication-in-process-object-writes/specs/woo-publication-via-opencatalogi/spec.md
  */
 
 declare(strict_types=1);
 
 namespace OCA\Procest\Tests\Unit\Service\WooPublication;
 
+use OCA\Procest\Service\SettingsService;
 use OCA\Procest\Service\WooPublication\OpenCatalogiApiClient;
 use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
@@ -35,189 +57,588 @@ use Psr\Log\LoggerInterface;
 use RuntimeException;
 
 /**
+ * Stand-in for OpenRegister's `ObjectEntityInterface`.
+ *
+ * The client reads a stored object through `getObject(): array` and its
+ * identifier through `getUuid(): ?string` — the two contract methods it needs.
+ */
+class OpenCatalogiApiClientObjectEntityDouble {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array<string, mixed> $data The stored property data.
+	 * @param string|null $uuid The object uuid.
+	 */
+	public function __construct(
+		private readonly array $data,
+		private readonly ?string $uuid,
+	) {
+	}//end __construct()
+
+	/**
+	 * The stored property data.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function getObject(): array {
+		return $this->data;
+	}//end getObject()
+
+	/**
+	 * The object uuid.
+	 *
+	 * @return string|null
+	 */
+	public function getUuid(): ?string {
+		return $this->uuid;
+	}//end getUuid()
+}//end class
+
+/**
+ * Recording double for OpenRegister's ObjectService.
+ *
+ * Signatures mirror `ObjectServiceInterface` verbatim, defaults included, so
+ * the client's named arguments bind to the parameters they name and the
+ * recorded values are what the client really passed.
+ */
+class OpenCatalogiApiClientObjectServiceDouble {
+
+	/**
+	 * Every `saveObject()` call, in order.
+	 *
+	 * @var array<int, array<string, mixed>>
+	 */
+	public array $saveCalls = [];
+
+	/**
+	 * Every `findSilent()` call, in order.
+	 *
+	 * @var array<int, array<string, mixed>>
+	 */
+	public array $findCalls = [];
+
+	/**
+	 * Property data `findSilent()` hands back.
+	 *
+	 * @var array<string, mixed>
+	 */
+	public array $storedData = [];
+
+	/**
+	 * Thrown from `saveObject()` when set.
+	 *
+	 * @var \Throwable|null
+	 */
+	public ?\Throwable $saveThrows = null;
+
+	/**
+	 * Thrown from `findSilent()` when set.
+	 *
+	 * @var \Throwable|null
+	 */
+	public ?\Throwable $findThrows = null;
+
+	/**
+	 * Persist an object — mirrors ObjectServiceInterface::saveObject().
+	 *
+	 * @param array<string, mixed> $object The object to store.
+	 * @param array<string, mixed>|null $extend Relations to expand.
+	 * @param string|int|null $register Register id, UUID or slug.
+	 * @param string|int|null $schema Schema id, UUID or slug.
+	 * @param string|null $uuid The object UUID.
+	 * @param bool $_rbac Apply register RBAC.
+	 * @param bool $_multitenancy Apply organisation scoping.
+	 * @param bool $silent Suppress events for this save.
+	 * @param bool $_validation Validate against the schema.
+	 * @param array<string, mixed>|null $uploadedFiles Files uploaded alongside the object.
+	 * @param object|null $currentUser Explicit acting user.
+	 * @param bool $failIfExists Fail instead of updating.
+	 *
+	 * @return OpenCatalogiApiClientObjectEntityDouble The stored object.
+	 *
+	 * @SuppressWarnings(PHPMD.ExcessiveParameterList) Mirrors the published contract.
+	 * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Mirrors the published contract.
+	 * @SuppressWarnings(PHPMD.UnusedFormalParameter) Mirrors the published contract.
+	 */
+	public function saveObject(
+		array $object,
+		?array $extend = [],
+		string|int|null $register = null,
+		string|int|null $schema = null,
+		?string $uuid = null,
+		bool $_rbac = true,
+		bool $_multitenancy = true,
+		bool $silent = false,
+		bool $_validation = true,
+		?array $uploadedFiles = null,
+		?object $currentUser = null,
+		bool $failIfExists = false,
+	): OpenCatalogiApiClientObjectEntityDouble {
+		$this->saveCalls[] = [
+			'object' => $object,
+			'register' => $register,
+			'schema' => $schema,
+			'uuid' => $uuid,
+			'_rbac' => $_rbac,
+			'_multitenancy' => $_multitenancy,
+		];
+
+		if ($this->saveThrows !== null) {
+			throw $this->saveThrows;
+		}
+
+		return new OpenCatalogiApiClientObjectEntityDouble(
+			data: $object,
+			uuid: ($uuid ?? 'generated-uuid'),
+		);
+	}//end saveObject()
+
+	/**
+	 * Read an object without audit — mirrors ObjectServiceInterface::findSilent().
+	 *
+	 * @param string $id Object id, UUID or slug.
+	 * @param array<string, mixed>|null $_extend Relations to expand.
+	 * @param bool $files Include file metadata.
+	 * @param string|int|null $register Register id, UUID or slug.
+	 * @param string|int|null $schema Schema id, UUID or slug.
+	 * @param bool $_rbac Apply register RBAC.
+	 * @param bool $_multitenancy Apply organisation scoping.
+	 *
+	 * @return OpenCatalogiApiClientObjectEntityDouble The object.
+	 *
+	 * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Mirrors the published contract.
+	 * @SuppressWarnings(PHPMD.UnusedFormalParameter) Mirrors the published contract.
+	 */
+	public function findSilent(
+		string $id,
+		?array $_extend = [],
+		bool $files = false,
+		string|int|null $register = null,
+		string|int|null $schema = null,
+		bool $_rbac = true,
+		bool $_multitenancy = true,
+	): OpenCatalogiApiClientObjectEntityDouble {
+		$this->findCalls[] = [
+			'id' => $id,
+			'register' => $register,
+			'schema' => $schema,
+			'_rbac' => $_rbac,
+			'_multitenancy' => $_multitenancy,
+		];
+
+		if ($this->findThrows !== null) {
+			throw $this->findThrows;
+		}
+
+		return new OpenCatalogiApiClientObjectEntityDouble(data: $this->storedData, uuid: $id);
+	}//end findSilent()
+}//end class
+
+/**
+ * Recording double for OpenRegister's FileService.
+ *
+ * Mirrors the subset of `addFile()` the client uses, with the same parameter
+ * names, plus `formatFile()`.
+ */
+class OpenCatalogiApiClientFileServiceDouble {
+
+	/**
+	 * Every `addFile()` call, in order.
+	 *
+	 * @var array<int, array<string, mixed>>
+	 */
+	public array $addCalls = [];
+
+	/**
+	 * Thrown from `addFile()` when set.
+	 *
+	 * @var \Throwable|null
+	 */
+	public ?\Throwable $throws = null;
+
+	/**
+	 * Attach file bytes — mirrors FileService::addFile().
+	 *
+	 * @param object|string $objectEntity The object entity or its uuid.
+	 * @param string $fileName The file name.
+	 * @param mixed $content The file content.
+	 * @param bool $share Whether to create a share link.
+	 * @param array<int, string> $tags Tags to attach.
+	 *
+	 * @return object The stored file node.
+	 *
+	 * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Mirrors the real signature.
+	 */
+	public function addFile(
+		object|string $objectEntity,
+		string $fileName,
+		mixed $content,
+		bool $share = false,
+		array $tags = [],
+	): object {
+		$this->addCalls[] = [
+			'objectEntity' => $objectEntity,
+			'fileName' => $fileName,
+			'content' => $content,
+			'share' => $share,
+			'tags' => $tags,
+		];
+
+		if ($this->throws !== null) {
+			throw $this->throws;
+		}
+
+		return new \stdClass();
+	}//end addFile()
+
+	/**
+	 * Format a stored file node — mirrors FileService::formatFile().
+	 *
+	 * @param object $file The stored file node.
+	 *
+	 * @return array<string, mixed> The file metadata.
+	 *
+	 * @SuppressWarnings(PHPMD.UnusedFormalParameter) Mirrors the real signature.
+	 */
+	public function formatFile(object $file): array {
+		return ['id' => 1, 'name' => 'stored-file'];
+	}//end formatFile()
+}//end class
+
+/**
  * @covers \OCA\Procest\Service\WooPublication\OpenCatalogiApiClient
+ *
+ * @uses   \OCA\Procest\AppInfo\Application
+ * @uses   \OCA\Procest\Service\SettingsService
  */
 class OpenCatalogiApiClientTest extends TestCase {
 
 	/**
-	 * Build an IAppConfig stub with no service-account credentials configured.
+	 * The recording object-service double the client under test resolves.
 	 *
-	 * @return IAppConfig
+	 * @var OpenCatalogiApiClientObjectServiceDouble
 	 */
-	private function emptyAppConfig(): IAppConfig {
-		$appConfig = $this->createMock(IAppConfig::class);
-		$appConfig->method('getValueString')->willReturn('');
-
-		return $appConfig;
-	}//end emptyAppConfig()
+	private OpenCatalogiApiClientObjectServiceDouble $objectService;
 
 	/**
-	 * Build an IURLGenerator stub returning a fixed base URL.
+	 * The recording file-service double the client under test resolves.
 	 *
-	 * @return IURLGenerator
+	 * @var OpenCatalogiApiClientFileServiceDouble
 	 */
-	private function urlGenerator(): IURLGenerator {
+	private OpenCatalogiApiClientFileServiceDouble $fileService;
+
+	/**
+	 * Whether any HTTP client was constructed during a test.
+	 *
+	 * @var bool
+	 */
+	private bool $httpClientWasBuilt = false;
+
+	/**
+	 * Fresh doubles for every test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->objectService = new OpenCatalogiApiClientObjectServiceDouble();
+		$this->fileService = new OpenCatalogiApiClientFileServiceDouble();
+		$this->httpClientWasBuilt = false;
+	}//end setUp()
+
+	/**
+	 * Build the client with the recording doubles wired in.
+	 *
+	 * `newClient()` flips a flag rather than returning a working client, so a
+	 * test can assert an object write performed NO HTTP at all — which is the
+	 * whole point of the migration and cannot be shown by asserting on a URL
+	 * that no longer exists.
+	 *
+	 * @param object|null $objectServiceOverride Replaces the object service (null = unavailable).
+	 * @param object|null $fileServiceOverride Replaces the file service (null = unavailable).
+	 * @param IClient|null $httpClient A working HTTP client, for the discovery tests.
+	 *
+	 * @return OpenCatalogiApiClient
+	 */
+	private function client(
+		?object $objectServiceOverride = null,
+		?object $fileServiceOverride = null,
+		?IClient $httpClient = null,
+	): OpenCatalogiApiClient {
+		$settingsService = $this->createMock(SettingsService::class);
+		$settingsService->method('getObjectService')->willReturn($objectServiceOverride);
+		$settingsService->method('getFileService')->willReturn($fileServiceOverride);
+
+		$clientService = $this->createMock(IClientService::class);
+		$clientService->method('newClient')->willReturnCallback(
+			function () use ($httpClient): IClient {
+				$this->httpClientWasBuilt = true;
+				if ($httpClient !== null) {
+					return $httpClient;
+				}
+
+				return $this->createMock(IClient::class);
+			}
+		);
+
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 		$urlGenerator->method('getBaseUrl')->willReturn('https://cloud.example.nl');
 
-		return $urlGenerator;
-	}//end urlGenerator()
+		$appConfig = $this->createMock(IAppConfig::class);
+		$appConfig->method('getValueString')->willReturn('');
+
+		return new OpenCatalogiApiClient(
+			clientService: $clientService,
+			urlGenerator: $urlGenerator,
+			appConfig: $appConfig,
+			settingsService: $settingsService,
+			logger: $this->createMock(LoggerInterface::class),
+		);
+	}//end client()
 
 	/**
-	 * createPublication() posts to OpenRegister's confirmed objects#create route.
+	 * createPublication() stores the payload through the published contract,
+	 * with no uuid (a create) and with no HTTP request at all.
 	 *
 	 * @return void
 	 */
-	public function testCreatePublicationPostsToObjectsCreateRoute(): void {
-		$capturedUrl = null;
-		$capturedOptions = null;
+	public function testCreatePublicationSavesThroughTheObjectContract(): void {
+		$client = $this->client(objectServiceOverride: $this->objectService);
 
-		$response = $this->createMock(IResponse::class);
-		$response->method('getBody')->willReturn(json_encode(['id' => 'pub-001', 'title' => 'Test']));
+		$result = $client->createPublication('publication', 'publication', ['title' => 'Test']);
 
-		$client = $this->createMock(IClient::class);
-		$client->expects($this->once())
-			->method('post')
-			->with(
-				$this->callback(function (string $url) use (&$capturedUrl) {
-					$capturedUrl = $url;
-					return true;
-				}),
-				$this->callback(function (array $options) use (&$capturedOptions) {
-					$capturedOptions = $options;
-					return true;
-				})
-			)
-			->willReturn($response);
+		$this->assertCount(1, $this->objectService->saveCalls);
+		$call = $this->objectService->saveCalls[0];
+		$this->assertSame(['title' => 'Test'], $call['object']);
+		$this->assertSame('publication', $call['register']);
+		$this->assertSame('publication', $call['schema']);
+		$this->assertNull($call['uuid'], 'a create must not name a uuid');
 
-		$clientService = $this->createMock(IClientService::class);
-		$clientService->method('newClient')->willReturn($client);
+		// The contract's authorisation flags must stay at their defaults —
+		// ADR-022 makes them the authorisation boundary, and a double that
+		// records what it received is the only way to see them.
+		$this->assertTrue($call['_rbac']);
+		$this->assertTrue($call['_multitenancy']);
 
-		$apiClient = new OpenCatalogiApiClient(
-			clientService: $clientService,
-			urlGenerator: $this->urlGenerator(),
-			appConfig: $this->emptyAppConfig(),
-			logger: $this->createMock(LoggerInterface::class),
+		$this->assertFalse(
+			$this->httpClientWasBuilt,
+			'an object write must perform no HTTP request'
+		);
+		$this->assertSame('generated-uuid', $result['id']);
+		$this->assertSame('Test', $result['title']);
+	}//end testCreatePublicationSavesThroughTheObjectContract()
+
+	/**
+	 * attachDocument() stores the document payload against the document schema.
+	 *
+	 * @return void
+	 */
+	public function testAttachDocumentSavesAgainstTheDocumentSchema(): void {
+		$client = $this->client(objectServiceOverride: $this->objectService);
+
+		$client->attachDocument(
+			'publication',
+			'document',
+			['title' => 'besluit.pdf', 'publication' => ['id' => 'pub-001']],
 		);
 
-		$result = $apiClient->createPublication('publication', 'publication', ['title' => 'Test']);
+		$this->assertCount(1, $this->objectService->saveCalls);
+		$call = $this->objectService->saveCalls[0];
+		$this->assertSame('document', $call['schema']);
+		$this->assertSame(['id' => 'pub-001'], $call['object']['publication']);
+		$this->assertNull($call['uuid']);
+		$this->assertFalse($this->httpClientWasBuilt);
+	}//end testAttachDocumentSavesAgainstTheDocumentSchema()
 
-		$this->assertSame('pub-001', $result['id']);
+	/**
+	 * THE LOAD-BEARING TEST: a partial update must be merged over the stored
+	 * object, never written as-is.
+	 *
+	 * `saveObject()` is PUT-semantic, so a bare save of the one-key withdraw
+	 * payload would null the title, summary, publication date, category and
+	 * status of a live publication and report success. Five stored properties
+	 * go in; all five must come back out.
+	 *
+	 * @return void
+	 */
+	public function testUpdatePublicationMergesOverTheStoredObject(): void {
+		$this->objectService->storedData = [
+			'title' => 'WOO-besluit 2026-014',
+			'summary' => 'Samenvatting',
+			'publicationDate' => '2026-03-01',
+			'tooiCategorieUri' => 'https://identifier.overheid.nl/tooi/def/thes/kern/c_3baef532',
+			'status' => 'published',
+		];
+
+		$client = $this->client(objectServiceOverride: $this->objectService);
+
+		$client->updatePublication(
+			'publication',
+			'publication',
+			'pub-001',
+			['depublicatiedatum' => '2026-07-13T00:00:00+02:00'],
+		);
+
+		$this->assertCount(1, $this->objectService->findCalls, 'a patch must read before it writes');
+		$this->assertSame('pub-001', $this->objectService->findCalls[0]['id']);
+		$this->assertSame('publication', $this->objectService->findCalls[0]['register']);
+		$this->assertSame('publication', $this->objectService->findCalls[0]['schema']);
+
+		$this->assertCount(1, $this->objectService->saveCalls);
+		$written = $this->objectService->saveCalls[0]['object'];
+
+		$this->assertSame('2026-07-13T00:00:00+02:00', $written['depublicatiedatum']);
+		$this->assertSame('WOO-besluit 2026-014', $written['title']);
+		$this->assertSame('Samenvatting', $written['summary']);
+		$this->assertSame('2026-03-01', $written['publicationDate']);
 		$this->assertSame(
-			'https://cloud.example.nl/index.php/apps/openregister/api/objects/publication/publication',
-			$capturedUrl
+			'https://identifier.overheid.nl/tooi/def/thes/kern/c_3baef532',
+			$written['tooiCategorieUri']
 		);
-		$this->assertSame('Test', $capturedOptions['json']['title']);
-	}//end testCreatePublicationPostsToObjectsCreateRoute()
+		$this->assertSame('published', $written['status']);
+
+		// The merged object must go back to the SAME object, not create a second.
+		$this->assertSame('pub-001', $this->objectService->saveCalls[0]['uuid']);
+	}//end testUpdatePublicationMergesOverTheStoredObject()
 
 	/**
-	 * updatePublication() PATCHes the single-object route.
+	 * A key present in both the stored object and the payload takes the
+	 * payload's value — the other half of the merge rule.
 	 *
 	 * @return void
 	 */
-	public function testUpdatePublicationPatchesSingleObjectRoute(): void {
-		$capturedUrl = null;
+	public function testUpdatePublicationLetsThePayloadWinOnAConflictingKey(): void {
+		$this->objectService->storedData = ['status' => 'published', 'title' => 'Keep me'];
 
-		$response = $this->createMock(IResponse::class);
-		$response->method('getBody')->willReturn(json_encode(['id' => 'pub-001']));
+		$client = $this->client(objectServiceOverride: $this->objectService);
+		$client->updatePublication('publication', 'publication', 'pub-001', ['status' => 'withdrawn']);
 
-		$client = $this->createMock(IClient::class);
-		$client->expects($this->once())
-			->method('patch')
-			->with($this->callback(function (string $url) use (&$capturedUrl) {
-				$capturedUrl = $url;
-				return true;
-			}), $this->anything())
-			->willReturn($response);
-
-		$clientService = $this->createMock(IClientService::class);
-		$clientService->method('newClient')->willReturn($client);
-
-		$apiClient = new OpenCatalogiApiClient(
-			clientService: $clientService,
-			urlGenerator: $this->urlGenerator(),
-			appConfig: $this->emptyAppConfig(),
-			logger: $this->createMock(LoggerInterface::class),
-		);
-
-		$apiClient->updatePublication('publication', 'publication', 'pub-001', ['depublicatiedatum' => '2026-07-13']);
-
-		$this->assertSame(
-			'https://cloud.example.nl/index.php/apps/openregister/api/objects/publication/publication/pub-001',
-			$capturedUrl
-		);
-	}//end testUpdatePublicationPatchesSingleObjectRoute()
+		$written = $this->objectService->saveCalls[0]['object'];
+		$this->assertSame('withdrawn', $written['status']);
+		$this->assertSame('Keep me', $written['title']);
+	}//end testUpdatePublicationLetsThePayloadWinOnAConflictingKey()
 
 	/**
-	 * attachFile() posts name+content to the per-object files route.
+	 * attachFile() attaches bytes through the in-process file service, keyed on
+	 * the object id, with the base64 body passed through unchanged.
 	 *
 	 * @return void
 	 */
-	public function testAttachFilePostsToFilesRoute(): void {
-		$capturedUrl = null;
-		$capturedOptions = null;
-
-		$response = $this->createMock(IResponse::class);
-		$response->method('getBody')->willReturn(json_encode(['id' => 1]));
-
-		$client = $this->createMock(IClient::class);
-		$client->method('post')
-			->with(
-				$this->callback(function (string $url) use (&$capturedUrl) {
-					$capturedUrl = $url;
-					return true;
-				}),
-				$this->callback(function (array $options) use (&$capturedOptions) {
-					$capturedOptions = $options;
-					return true;
-				})
-			)
-			->willReturn($response);
-
-		$clientService = $this->createMock(IClientService::class);
-		$clientService->method('newClient')->willReturn($client);
-
-		$apiClient = new OpenCatalogiApiClient(
-			clientService: $clientService,
-			urlGenerator: $this->urlGenerator(),
-			appConfig: $this->emptyAppConfig(),
-			logger: $this->createMock(LoggerInterface::class),
+	public function testAttachFileUsesTheInProcessFileService(): void {
+		$client = $this->client(
+			objectServiceOverride: $this->objectService,
+			fileServiceOverride: $this->fileService,
 		);
 
-		$apiClient->attachFile('publication', 'document', 'doc-001', 'besluit.pdf', base64_encode('content'), 'application/pdf');
-
-		$this->assertSame(
-			'https://cloud.example.nl/index.php/apps/openregister/api/objects/publication/document/doc-001/files',
-			$capturedUrl
+		$result = $client->attachFile(
+			'publication',
+			'document',
+			'doc-001',
+			'besluit.pdf',
+			base64_encode('content'),
+			'application/pdf',
 		);
-		$this->assertSame('besluit.pdf', $capturedOptions['json']['name']);
-		$this->assertSame(base64_encode('content'), $capturedOptions['json']['content']);
-	}//end testAttachFilePostsToFilesRoute()
+
+		$this->assertCount(1, $this->fileService->addCalls);
+		$call = $this->fileService->addCalls[0];
+		$this->assertSame('doc-001', $call['objectEntity']);
+		$this->assertSame('besluit.pdf', $call['fileName']);
+		$this->assertSame(base64_encode('content'), $call['content']);
+		$this->assertFalse($call['share'], 'a WOO attachment must not create a public share link');
+		$this->assertSame([], $call['tags']);
+
+		$this->assertFalse($this->httpClientWasBuilt);
+		$this->assertSame('stored-file', $result['name']);
+	}//end testAttachFileUsesTheInProcessFileService()
 
 	/**
-	 * resolveCatalog() swallows a transport failure and returns null (never gates publication).
+	 * A thrown object service surfaces as the unchanged domain error.
 	 *
 	 * @return void
 	 */
-	public function testResolveCatalogSwallowsTransportFailure(): void {
-		$client = $this->createMock(IClient::class);
-		$client->method('get')->willThrowException(new \Exception('connection refused'));
+	public function testAnObjectWriteFailureSurfacesAsTheDomainError(): void {
+		$this->objectService->saveThrows = new \Exception('database is gone');
+		$client = $this->client(objectServiceOverride: $this->objectService);
 
-		$clientService = $this->createMock(IClientService::class);
-		$clientService->method('newClient')->willReturn($client);
-
-		$apiClient = new OpenCatalogiApiClient(
-			clientService: $clientService,
-			urlGenerator: $this->urlGenerator(),
-			appConfig: $this->emptyAppConfig(),
-			logger: $this->createMock(LoggerInterface::class),
-		);
-
-		$this->assertNull($apiClient->resolveCatalog());
-	}//end testResolveCatalogSwallowsTransportFailure()
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('opencatalogi_api_error');
+		$client->createPublication('publication', 'publication', []);
+	}//end testAnObjectWriteFailureSurfacesAsTheDomainError()
 
 	/**
-	 * resolveCatalog() returns the first hasWooSitemap catalog.
+	 * A failed read on the patch path surfaces as the same domain error, and
+	 * nothing is written.
+	 *
+	 * @return void
+	 */
+	public function testAFailedPatchReadSurfacesAsTheDomainErrorAndWritesNothing(): void {
+		$this->objectService->findThrows = new \Exception('not found');
+		$client = $this->client(objectServiceOverride: $this->objectService);
+
+		try {
+			$client->updatePublication('publication', 'publication', 'pub-001', ['status' => 'withdrawn']);
+			$this->fail('a failed read must not fall through to a write');
+		} catch (RuntimeException $e) {
+			$this->assertSame('opencatalogi_api_error', $e->getMessage());
+		}
+
+		$this->assertCount(
+			0,
+			$this->objectService->saveCalls,
+			'a patch whose read failed must never save — that would be a full replace with the partial payload'
+		);
+	}//end testAFailedPatchReadSurfacesAsTheDomainErrorAndWritesNothing()
+
+	/**
+	 * An unavailable OpenRegister is the domain error, not a null dereference.
+	 *
+	 * @return void
+	 */
+	public function testAnUnavailableObjectServiceSurfacesAsTheDomainError(): void {
+		$client = $this->client(objectServiceOverride: null);
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('opencatalogi_api_error');
+		$client->createPublication('publication', 'publication', ['title' => 'Test']);
+	}//end testAnUnavailableObjectServiceSurfacesAsTheDomainError()
+
+	/**
+	 * An unavailable file service is the domain error too.
+	 *
+	 * @return void
+	 */
+	public function testAnUnavailableFileServiceSurfacesAsTheDomainError(): void {
+		$client = $this->client(
+			objectServiceOverride: $this->objectService,
+			fileServiceOverride: null,
+		);
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('opencatalogi_api_error');
+		$client->attachFile('publication', 'document', 'doc-001', 'a.pdf', base64_encode('x'), 'application/pdf');
+	}//end testAnUnavailableFileServiceSurfacesAsTheDomainError()
+
+	/**
+	 * A failed file attach surfaces as the domain error.
+	 *
+	 * @return void
+	 */
+	public function testAFailedFileAttachSurfacesAsTheDomainError(): void {
+		$this->fileService->throws = new \Exception('disk full');
+		$client = $this->client(
+			objectServiceOverride: $this->objectService,
+			fileServiceOverride: $this->fileService,
+		);
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('opencatalogi_api_error');
+		$client->attachFile('publication', 'document', 'doc-001', 'a.pdf', base64_encode('x'), 'application/pdf');
+	}//end testAFailedFileAttachSurfacesAsTheDomainError()
+
+	/**
+	 * resolveCatalog() still reads OpenCatalogi's own catalog listing over HTTP
+	 * and returns the first WOO-flagged catalog.
 	 *
 	 * @return void
 	 */
@@ -230,45 +651,45 @@ class OpenCatalogiApiClientTest extends TestCase {
 			],
 		]));
 
-		$client = $this->createMock(IClient::class);
-		$client->method('get')->willReturn($response);
+		$capturedUrl = null;
+		$httpClient = $this->createMock(IClient::class);
+		$httpClient->method('get')
+			->with($this->callback(function (string $url) use (&$capturedUrl): bool {
+				$capturedUrl = $url;
+				return true;
+			}), $this->anything())
+			->willReturn($response);
 
-		$clientService = $this->createMock(IClientService::class);
-		$clientService->method('newClient')->willReturn($client);
-
-		$apiClient = new OpenCatalogiApiClient(
-			clientService: $clientService,
-			urlGenerator: $this->urlGenerator(),
-			appConfig: $this->emptyAppConfig(),
-			logger: $this->createMock(LoggerInterface::class),
+		$client = $this->client(
+			objectServiceOverride: $this->objectService,
+			httpClient: $httpClient,
 		);
 
-		$catalog = $apiClient->resolveCatalog();
+		$catalog = $client->resolveCatalog();
 
 		$this->assertSame('woo-verzoeken', $catalog['slug']);
+		$this->assertSame(
+			'https://cloud.example.nl/index.php/apps/opencatalogi/api/catalogi',
+			$capturedUrl,
+			'discovery reads OpenCatalogi\'s own API, not OpenRegister\'s objects API'
+		);
 	}//end testResolveCatalogReturnsFirstWooFlaggedCatalog()
 
 	/**
-	 * A transport failure on createPublication() surfaces as a domain RuntimeException.
+	 * resolveCatalog() swallows a transport failure and returns null, so
+	 * discovery never gates publication.
 	 *
 	 * @return void
 	 */
-	public function testTransportFailureThrowsDomainException(): void {
-		$client = $this->createMock(IClient::class);
-		$client->method('post')->willThrowException(new \Exception('connection refused'));
+	public function testResolveCatalogSwallowsTransportFailure(): void {
+		$httpClient = $this->createMock(IClient::class);
+		$httpClient->method('get')->willThrowException(new \Exception('connection refused'));
 
-		$clientService = $this->createMock(IClientService::class);
-		$clientService->method('newClient')->willReturn($client);
-
-		$apiClient = new OpenCatalogiApiClient(
-			clientService: $clientService,
-			urlGenerator: $this->urlGenerator(),
-			appConfig: $this->emptyAppConfig(),
-			logger: $this->createMock(LoggerInterface::class),
+		$client = $this->client(
+			objectServiceOverride: $this->objectService,
+			httpClient: $httpClient,
 		);
 
-		$this->expectException(RuntimeException::class);
-		$this->expectExceptionMessage('opencatalogi_api_error');
-		$apiClient->createPublication('publication', 'publication', []);
-	}//end testTransportFailureThrowsDomainException()
+		$this->assertNull($client->resolveCatalog());
+	}//end testResolveCatalogSwallowsTransportFailure()
 }//end class

--- a/tests/e2e/helpers/page-components.ts
+++ b/tests/e2e/helpers/page-components.ts
@@ -94,3 +94,24 @@ export const PublicAppointmentPage = '/public/appointments/e2e-unresolvable-toke
  */
 export const PublicFederatedTransferPage =
 	'/public/federation/transfer/e2e-unresolvable-token/e2e-transfer'
+
+/**
+ * `src/views/public/ExternalConsultationResponsePage.vue` — the token-addressed
+ * advice-response surface for an external advisory body (manifest page
+ * `ExternalConsultationResponse`, declared in
+ * `src/manifest.d/consultation-public.json`).
+ *
+ * The token below is 44 characters, so it passes the controller's minimum-length
+ * check and reaches the real `secureToken` lookup rather than short-circuiting
+ * on length — and no consultation carries it, so
+ * `consultationPublic#publicResponseGet` answers a uniform 404 and the page
+ * lands in its `loadError` branch deterministically, with no fixture to seed.
+ * Measured against a running instance (procest 0.3.9, 2026-08-17): a 44-char
+ * unknown token and a 5-char token both answer
+ * `404 {"error":"Invalid or expired token"}`, while a token that a seeded
+ * consultation really carries answers 200 with that consultation — see
+ * `workflows/external-consultation-response.spec.ts`, which asserts both
+ * directions.
+ */
+export const ExternalConsultationResponsePage =
+	'/public/consultations/e2eunresolvableconsultationtoken000000000000'

--- a/tests/e2e/workflows/external-consultation-response.spec.ts
+++ b/tests/e2e/workflows/external-consultation-response.spec.ts
@@ -1,0 +1,235 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Procest Contributors
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * The token-addressed external consultation-response surface:
+ * `/public/consultations/:token` (manifest page `ExternalConsultationResponse`,
+ * component `src/views/public/ExternalConsultationResponsePage.vue`) and the
+ * `consultationPublic#publicResponseGet` endpoint that feeds it.
+ *
+ * WHY THIS SPEC ASSERTS THE GUARD AND NOT ONLY THE RENDER
+ * ------------------------------------------------------
+ * This page is anonymous and addressed by a bearer secret in the URL — the
+ * token IS the authorization. A spec that only proved the page renders would
+ * pass just as well against a lookup that ignored its filter and handed back
+ * `results[0]` of the whole consultation collection, which is a cross-tenant
+ * disclosure with no error to notice. So the guard is asserted in BOTH
+ * directions, and the "yes" direction is what makes the "no" direction mean
+ * anything:
+ *
+ *   token of consultation A  -> 200, and the body is A
+ *   token of consultation B  -> 200, and the body is B      <- discriminating
+ *   an unknown 44-char token -> not 200, and no consultation body
+ *   a 5-char token           -> not 200, and no consultation body
+ *
+ * The A/B pair is the load-bearing one. A guard that returned the first row of
+ * an unfiltered query would answer both A and B with the SAME object and still
+ * satisfy every single-token assertion; only asking for two different tokens
+ * and getting two different consultations shows the filter is real. Both were
+ * measured against a running instance (procest 0.3.9 + OpenRegister
+ * 0.2.17-unstable.38, 2026-08-17) before this spec was written.
+ *
+ * The response body is also checked to carry no `secureToken`: the controller
+ * unsets it before responding, and a regression there would hand every reader
+ * of one consultation the credential for it.
+ *
+ * WHAT THE RENDER TEST PROVES, AND WHY IT IS NOT A TAUTOLOGY
+ * ---------------------------------------------------------
+ * Three outcomes are distinguishable on this route (measured; see
+ * `../page-shells.spec.ts` for the same three):
+ *
+ *   route resolves + component registered    -> the component's own root
+ *                                               `.external-consultation-response`
+ *   route resolves + component NOT registered -> the manifest renderer's
+ *                                               "This page is empty" placeholder
+ *   route does not resolve                    -> falls back to the Dashboard
+ *
+ * The middle case is what this page was in until the component was added to
+ * `src/customComponents.js`. The root element is OUTSIDE every `v-if` in the
+ * component's template, so it holds whether or not the token resolves, and it
+ * is a thing neither the placeholder nor the Dashboard can produce. The
+ * heading assertion below uses the UNRESOLVABLE token deliberately: a token
+ * nothing carries answers 404 for an anonymous and for an authenticated caller
+ * alike, so the `loadError` branch stays deterministic and the assertion does
+ * not rot when the anonymous read path changes.
+ *
+ * KNOWN GAP, DELIBERATELY NOT PINNED AS AN ASSERTION
+ * --------------------------------------------------
+ * Measured on a live instance: an ANONYMOUS caller presenting a token that a
+ * consultation really carries is also answered 404, because OpenRegister
+ * returns zero rows for a caller with no organisation scope, so the whole
+ * public surface currently cannot be entered. Nothing mints a `secureToken`
+ * either (see `AdvisoryBodyService`'s own note). Asserting "valid token +
+ * anonymous -> 404" here would pin that gap as the contract, so this spec
+ * asserts only the security invariant that survives the fix: an anonymous
+ * caller MUST NOT receive a consultation body for a token no consultation
+ * carries.
+ */
+
+import { test, expect, request, type APIRequestContext } from '@playwright/test'
+
+import { STORAGE_STATE } from '../helpers/auth'
+import {
+	RUN_PREFIX,
+	createObject,
+	deleteObject,
+	getRequestToken,
+	objectId,
+} from '../helpers/fixtures'
+import { navToRoute } from '../helpers/nav'
+import { ExternalConsultationResponsePage } from '../helpers/page-components'
+
+/** The app-relative public endpoint the page reads on mount. */
+const PUBLIC_CONSULTATION_API = '/index.php/apps/procest/api/public/consultations'
+
+/**
+ * Tokens for the two seeded consultations. 48 hex characters each, matching
+ * the shape `ConsultationRepository::findBySecureToken()` expects (it refuses
+ * anything shorter than 32 outright) and unique per run so two concurrent runs
+ * cannot resolve each other's fixtures.
+ */
+const RUN_SUFFIX = RUN_PREFIX.replace(/[^a-z0-9]/gi, '').toLowerCase()
+const TOKEN_A = `a1a1a1a1a1a1a1a1${RUN_SUFFIX}`.padEnd(48, '0').slice(0, 48)
+const TOKEN_B = `b2b2b2b2b2b2b2b2${RUN_SUFFIX}`.padEnd(48, '0').slice(0, 48)
+
+/** A token no consultation carries, long enough to reach the real lookup. */
+const TOKEN_UNKNOWN = 'c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3'
+
+/** Shorter than the repository's 32-character floor. */
+const TOKEN_TOO_SHORT = 'short'
+
+let api: APIRequestContext
+let anon: APIRequestContext
+let token: string
+let consultationAId = ''
+let consultationBId = ''
+
+/**
+ * Seed one consultation carrying a known secure token.
+ *
+ * `parentCase`, `adviceAuthority` and `questionFormulation` are the schema's
+ * required properties, and `parentCase` carries `format: uuid` — measured
+ * against the live schema, which answers 400 naming each of them in turn.
+ *
+ * @param label       Human-visible marker, embedded in `subject`.
+ * @param secureToken The token the public endpoint must resolve to this row.
+ * @param parentCase  A syntactically valid case uuid.
+ */
+async function seedConsultation(
+	label: string,
+	secureToken: string,
+	parentCase: string,
+): Promise<string> {
+	const created = await createObject(api, token, 'consultation', {
+		subject: `${RUN_PREFIX} ${label}`,
+		status: 'open',
+		parentCase,
+		adviceAuthority: `${RUN_PREFIX}-body`,
+		questionFormulation: `${RUN_PREFIX} question ${label}`,
+		latestResponseDate: '2026-12-31',
+		secureToken,
+	})
+	return objectId(created)
+}
+
+test.describe('External consultation response — public token surface', () => {
+	test.describe.configure({ mode: 'serial' })
+
+	test.beforeAll(async ({ baseURL }) => {
+		api = await request.newContext({ baseURL, storageState: STORAGE_STATE })
+		anon = await request.newContext({ baseURL })
+		token = await getRequestToken(api)
+		consultationAId = await seedConsultation(
+			'CONSULTATION-A',
+			TOKEN_A,
+			'11111111-1111-4111-8111-111111111111',
+		)
+		consultationBId = await seedConsultation(
+			'CONSULTATION-B',
+			TOKEN_B,
+			'22222222-2222-4222-8222-222222222222',
+		)
+	})
+
+	test.afterAll(async () => {
+		await deleteObject(api, token, 'consultation', consultationAId)
+		await deleteObject(api, token, 'consultation', consultationBId)
+		await api.dispose()
+		await anon.dispose()
+	})
+
+	test('the route renders the ExternalConsultationResponsePage component, not the empty-page placeholder', async ({
+		page,
+	}) => {
+		await navToRoute(page, ExternalConsultationResponsePage)
+
+		// The component's template root — outside every v-if, so it is present
+		// in the loading, error, form and submitted states alike. Neither the
+		// manifest renderer's placeholder nor the Dashboard fallback can
+		// produce it.
+		await expect(page.locator('.external-consultation-response')).toBeVisible({
+			timeout: 15000,
+		})
+
+		// The exact string the manifest renderer shows when it cannot resolve a
+		// declared page's component. Asserting its ABSENCE is what makes the
+		// test able to fail for the defect it was written for.
+		await expect(page.locator('body')).not.toContainText('This page is empty')
+
+		// An unresolvable token deterministically lands in the loadError branch.
+		await expect(
+			page.getByRole('heading', { name: 'Not found', level: 2 }).first(),
+		).toBeVisible({ timeout: 15000 })
+
+		await expect(page.locator('body')).not.toContainText('Internal Server Error')
+	})
+
+	test('the token guard resolves each token to its OWN consultation', async () => {
+		const resA = await api.get(`${PUBLIC_CONSULTATION_API}/${TOKEN_A}`)
+		expect(
+			resA.status(),
+			'a token a consultation really carries must resolve — without this the refusal tests below prove nothing',
+		).toBe(200)
+		const bodyA = await resA.json()
+		expect(bodyA.subject).toBe(`${RUN_PREFIX} CONSULTATION-A`)
+
+		const resB = await api.get(`${PUBLIC_CONSULTATION_API}/${TOKEN_B}`)
+		expect(resB.status()).toBe(200)
+		const bodyB = await resB.json()
+
+		// The discriminating assertion: a lookup that ignored its filter and
+		// returned the first row of the collection would answer both calls with
+		// the same consultation and pass every other check in this file.
+		expect(bodyB.subject).toBe(`${RUN_PREFIX} CONSULTATION-B`)
+		expect(bodyB.subject).not.toBe(bodyA.subject)
+	})
+
+	test('the response never echoes the secure token back', async () => {
+		const res = await api.get(`${PUBLIC_CONSULTATION_API}/${TOKEN_A}`)
+		expect(res.status()).toBe(200)
+		const raw = await res.text()
+		expect(raw).not.toContain('secureToken')
+		expect(raw).not.toContain(TOKEN_A)
+	})
+
+	test('an unknown token is refused and discloses no consultation', async () => {
+		const res = await api.get(`${PUBLIC_CONSULTATION_API}/${TOKEN_UNKNOWN}`)
+		expect(res.status()).not.toBe(200)
+		const raw = await res.text()
+		expect(raw).not.toContain(RUN_PREFIX)
+	})
+
+	test('a token below the minimum length is refused and discloses no consultation', async () => {
+		const res = await api.get(`${PUBLIC_CONSULTATION_API}/${TOKEN_TOO_SHORT}`)
+		expect(res.status()).not.toBe(200)
+		const raw = await res.text()
+		expect(raw).not.toContain(RUN_PREFIX)
+	})
+
+	test('an anonymous caller with an unknown token receives no consultation', async () => {
+		const res = await anon.get(`${PUBLIC_CONSULTATION_API}/${TOKEN_UNKNOWN}`)
+		expect(res.status()).not.toBe(200)
+		const raw = await res.text()
+		expect(raw).not.toContain(RUN_PREFIX)
+	})
+})


### PR DESCRIPTION
Closes procest's last two app-owned gates. Both were previously deferred as product/spec decisions; both are now authorised.

## Measured, same gate package on both sides

Gate package **`742f370e`**, `SCOPE-MODE: full`, runner run locally against base `78c96081` and against this head.

| gate | base `78c96081` | this PR |
|---|---|---|
| gate-25 contract-coverage | PASS | PASS |
| **gate-26 visual-coverage** | **FAIL — 1** | **PASS** |
| gate-53 effective-manifest-crossref | FAIL — 8 | FAIL — 8 (unchanged, **not procest's** — fixed in `ConductionNL/.github`) |
| **gate-62 store-plane** | **FAIL — 1** | **PASS** |
| runner | `3 gate(s) failed` | `1 gate(s) failed` |

The base run reproduces CI's `development` verdict at `78c96081` exactly (3 failed; 25 PASS / 26=1 / 53=8 / 62=1), so the instrument is validated against CI, not only against itself.

⚠️ A first base run reported gate-53 and gate-22 as FAIL for a different reason — *"ajv not resolvable"* — because the base worktree had no `node_modules`. That is an environment refusal, not a finding. Re-run with ajv resolvable to get the numbers above.

## 1 — gate-26: `ExternalConsultationResponsePage`

`/public/consultations/:token` is declared as manifest page `ExternalConsultationResponse` and its backend is routed, but the component was never in `src/customComponents.js`, so the route rendered OpenBuild's *"This page is empty"* placeholder. Registering it restores the page.

**Token-guard verdict: SOUND — measured, not read.** Against a running instance (procest 0.3.9 + OpenRegister 0.2.17-unstable.38) with two seeded consultations:

| probe | result |
|---|---|
| token of consultation A | 200, body is **A** |
| token of consultation B | 200, body is **B** |
| unknown 48-char token | 404 `Invalid or expired token` |
| 5-char token | 404 |
| `secureToken` in any 200 body | **0 occurrences** |

The A/B pair is the load-bearing one: a lookup that ignored its filter and returned `results[0]` would answer both with the same object and still pass every single-token check. `filters: ['secureToken' => $token]` is a JSON-property filter on a **declared** property, so it really does select. Nothing here is an IDOR.

The new e2e spec asserts all of the above plus the render, driving the route with an unresolvable token and asserting the component's own template root (`.external-consultation-response`, outside every `v-if`) **and** the absence of the placeholder — so it tells apart all three outcomes the route can produce. No `@visual exclude` anywhere.

**Reported, deliberately NOT changed here — two pre-existing gaps that keep this surface unusable in practice:**
1. **No `secureToken` is ever minted.** `AdvisoryBodyService` says so in its own comment: `issueSecureToken()` was removed and had no caller.
2. **An anonymous caller is answered 404 even with a valid token.** Measured: an authenticated admin gets 200 for the same token; anonymous OpenRegister object search on that register/schema returns `total: 0` with no error, so the whole public surface is currently unenterable. The honest fix is not a `_rbac: false` elevation on user-supplied input — `SearchesObjects::runAsSystemIfAvailable()`'s own docblock forbids exactly that. The spec deliberately does **not** pin "valid token + anonymous → 404" as an assertion, because that would enshrine the gap.

## 2 — gate-62: store-plane

`OpenCatalogiApiClient` fetched an OpenRegister objects-API URL with `IClientService`. Publication create/update and document create now go through ADR-084's published `ObjectServiceInterface`; the file attach goes through OpenRegister's `FileService` in process; `resolveCatalog()` stays on HTTP because it reads OpenCatalogi's **own** `/api/catalogi`, not OpenRegister's Objects API.

`GenericStoreService` — which the gate's message names — cannot carry this: measured against `openregister@development` its public surface is exactly `isConfigured/search/resolve`, and `assertSafeFetchUrl()` throws on any private/reserved address, so a same-instance call fails closed.

### 🔴 Writing the requirement exposed a defect the docblock denies

`ObjectServiceInterface::updateObject()` is documented as *"Apply a partial update to an existing object"*. Its body is:

```php
$data['id'] = $objectId;
return $this->saveObject(object: $data);
```

No merge. `saveObject()` is PUT-semantic — OpenRegister's own `patchObject()` docblock says *"a property absent from the payload is written as null"* — and `patchObject()` is **not on the published contract**. `withdraw()` sends the single-key payload `['depublicatiedatum' => now]`, so routing it through `updateObject()` would have **erased the publication's title, summary, dates, category, status and case reference while reporting success**. `updatePublication()` therefore does its own read-merge-write, reproducing OpenRegister's `objects#patch`. **Reported for `ConductionNL/openregister`, not fixed here.**

### Contract gap, recorded rather than worked around

`ObjectServiceInterface` publishes **no file operation** (25 methods, none of them). So `attachFile()` uses `FileService::addFile()`. Also found while reading it: `files#create` **never used the `mimeType` this client sent** — `addFile()` has no MIME parameter. The parameter is kept (dropping it would change the call shape at its one caller) and documented as accepted-but-unused.

### Positive controls

Doubles are hand-written, not `createMock()`: every call into OpenRegister passes its arguments **by name**, and a PHPUnit mock cannot observe named arguments. Each mutation ran one at a time on a throwaway copy, with `ReflectionClass::getFileName()` + md5 asserting the mutated file was the one loaded:

| mutation | result |
|---|---|
| bare save instead of the merge | **RED** (2 tests) |
| update routed as a create (`uuid: null`) | **RED** |
| file attached with `share: true` | **RED** |
| failed patch-read falls through to a write | **RED** |

Reverted after each; the branch file's md5 is unchanged and `git status` was empty before any result was quoted.

## Local verification

- Full unit suite, CI's own `phpunit.xml` under **xdebug** (not pcov): `Tests: 2294, Assertions: 10555, Errors: 4, Failures: 2, **Risky: 0**` — the 6 red are the documented local-only `symfony/http-foundation` absence (`DashboardControllerServiceWorker` ×3, `AiAuditExportController` ×2, `ZaakdossierDownloadControllerGuard` ×1); Nextcloud supplies the package at runtime, CI is the authority. Base was 2288 tests.
- phpcs / phpmd (both rulesets) / psalm / phpstan: **clean** on the changed files; phpstan analysed **616 files**, so not a zero-file run.
- eslint `src`: **0 errors**; prettier clean.
- Playwright collects **140 tests** (base 134); `tsc --noEmit` clean on the new spec, and the same command reports `TS2724` on a deliberately broken import, so the check can say no.

Not merged — orchestrator verifies.
