### PR TITLE
docs(openspec): change proposals for the AI-tooling and leaf-integration sweep

### DIFF
--- a/openspec/changes/email-case-matching/.openspec.yaml
+++ b/openspec/changes/email-case-matching/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-18

--- a/openspec/changes/email-case-matching/design.md
+++ b/openspec/changes/email-case-matching/design.md
@@ -1,0 +1,146 @@
+# Design — email-case-matching
+
+## Context
+
+Three facts ground this change:
+
+1. **The case number is `identifier`, format `YYYY-NNNN`.** The `case` schema
+   (`lib/Settings/procest_register.json`) has no `zaaknummer`/`caseNumber` property and no `pattern`;
+   `identifier` is read-only and materialised by OpenRegister from
+   `x-openregister-calculations.identifier = concat(year(startDate), "-", sequence(scope: yearly, pad: 4))`
+   — e.g. `2026-0042`. There is **no `ZAAK-` prefix in the data.**
+2. **Procest's existing inbound path doesn't cover this.** `InboundEmailJob` polls one shared
+   functional IMAP mailbox with its own IMAP client and recognises only the bracketed subject tag
+   `/\[([A-Z]+-\d{4}-\d{4,6})\]/` — which the schema-generated identifier can never produce
+   (prefixed, bracket-required, while `CaseEmailRepository` then looks the raw prefixed string up
+   against `identifier`). Personal NC Mail mailboxes, body text, and untagged mail are all invisible.
+3. **The mechanism to copy exists and is proven.** Pipelinq's `EmailMatchService` +
+   `EmailMatchJob` (300 s) read `mail_messages`/`mail_mailboxes`/`mail_recipients`, link through the
+   generic `OCA\OpenRegister\Service\EmailLinkService` (`linkEmail`/`getLinkedEmails`), keep a
+   per-user id cursor, store per-user settings/status blobs in `IAppConfig`, and fail closed on an
+   empty `register` app-config. Its matching basis is correspondent **addresses only** — it never
+   scans subject or body text, so text recognition is genuinely new capability, not a copy.
+
+## Goals / Non-Goals
+
+**Goals:** automatic, idempotent, opt-in case attachment of NC Mail messages by case-number
+recognition; recognizer configurable and correct against the real identifier format; strict
+no-auto-create; fail-closed guards mirroring pipelinq.
+
+**Non-Goals:** replacing `InboundEmailJob` or its archival flow; `mailObjectTemplate`/auto-create;
+moving the shared matcher core into the leaf (recommended direction, D6, separate change);
+scanning attachments; retroactive full-mailbox scans by default (cursor starts at the current
+high-water mark; an admin occ command may backfill explicitly).
+
+## Decisions
+
+### D1 — Copy pipelinq's transport skeleton verbatim, replace only the recognizer
+
+Message iteration (`mail_messages ⋈ mail_mailboxes` on account, `id > cursor`, ASC, batch cap),
+per-user settings/status blobs, DI-container resolution of the leaf with `method_exists` guards
+(openregister and mail stay optional runtime deps), leaf-side idempotency plus a caller-side
+`getLinkedEmails` pre-check, and the empty-register refusal are all lifted from
+`pipelinq/lib/Service/EmailMatchService.php` unchanged in shape. Divergence is confined to one seam:
+`extractAddresses → matchEmailToEntities` becomes `extractCaseNumberCandidates → resolveCasesByIdentifier`.
+Keeping the seam identical is what makes D6 (later extraction into the leaf) cheap.
+
+### D2 — The recognizer must match the data, not the legacy tag
+
+Default pattern (app-config `email_case_matching_pattern`):
+
+```
+/(?<![\w-])(?:\[)?(?:[A-Z]{2,10}-)?((?:19|20)\d{2}-\d{4,6})(?:\])?(?![\w-])/u
+```
+
+- Capture group 1 is the bare identifier (`2026-0042`) — exactly what the `identifier` property
+  holds, so resolution is a plain equality filter.
+- Optional uppercase prefix and optional brackets accept the legacy `[ZAAK-2026-000142]` tag style
+  as *decoration*, fixing at the recognition layer the mismatch `InboundEmailJob` has at line 53
+  (its pattern requires the prefix+brackets and then resolves the **prefixed** string against
+  `identifier`, which can never match — flagged as a separate defect, not fixed here).
+- Boundary guards `(?<![\w-]) … (?![\w-])` stop `12026-00421` and phone-number fragments from
+  matching.
+- Validation on read: pattern must compile and contain ≥1 capture group, else the run is refused
+  (REQ-ECM-001). A recognizer that silently matches nothing is the classic silent failure; refusing
+  loudly is the only honest behaviour.
+
+False-positive risk is real (`YYYY-NNNN` is a common shape — invoice numbers, other systems' ids).
+Two mitigations keep precision acceptable: candidates only ever *link* (no create, no mutation of the
+case), and a candidate must resolve to an existing case identifier before anything happens. The
+year prefix restriction (`19|20`) removes most numeric noise. Instances wanting stricter matching
+set a stricter pattern.
+
+### D3 — Subject first, body as fallback, and honesty about "body"
+
+Subject comes free from `mail_messages.subject`. The body is **not** in the tables pipelinq reads:
+NC Mail caches a bounded plaintext preview (`preview_text`) and otherwise fetches bodies from IMAP.
+Scan order is therefore: subject → (only when the subject resolved nothing) the body text available
+from the Mail store — the cached preview when present, the full body via Mail's message retrieval
+where that is cheaply available. The spec's wording ("body text available from the Nextcloud Mail
+store") is deliberate: a case number deep in a long body may fall outside the cached preview, and
+this change does not promise IMAP round-trips per message. This limitation is accepted for V1 and
+documented in the settings UI help text; the shared-core extraction (D6) is the right place to give
+body retrieval a proper leaf-side home.
+
+### D4 — Strict no-auto-create
+
+`linkedTypes: ["mail"]` without `mailObjectTemplate` is the current, deliberate posture: mail can be
+attached to cases, mail cannot spawn cases. This change preserves it exactly (REQ-ECM-005). Anything
+else would let an inbound email create ZGW case records with no intake validation.
+
+### D5 — Coexistence with InboundEmailJob
+
+Two paths, two jobs, no shared state, no conflict:
+
+| | `InboundEmailJob` (existing) | `CaseEmailMatchJob` (this change) |
+|---|---|---|
+| Source | one shared functional mailbox, direct IMAP | per-user NC Mail accounts, Mail DB tables |
+| Recognition | bracketed subject tag only | configurable pattern, subject then body |
+| Effect | link + archival (`EmailArchivalService`) | leaf link only |
+| Toggle | IMAP config presence | instance + per-user toggles |
+
+Both end at the same place (email attached to the case), and leaf-side idempotency keys on the
+message make double-processing harmless. Convergence criterion for a later change: when the shared
+mailbox is migrated to an NC Mail account, `InboundEmailJob`'s recognition collapses into this
+matcher and only its archival trigger remains.
+
+### D6 — The generic matcher belongs in the email leaf (recommendation)
+
+After this change, two apps will carry near-identical 1000-line matcher transports differing only in
+one method. The honest architectural direction (ADR-012, ADR-022): lift the core — message iteration,
+cursor, per-user settings/status, idempotent `linkEmail` — into the OpenRegister email leaf as a
+generic matching engine that accepts app-registered **recognizers**; pipelinq contributes the
+correspondent-address recognizer (+ public-domain guard), procest contributes the case-number
+recognizer (pattern + identifier resolution — the only genuinely procest-specific ~100 lines of this
+change). That is a separate openregister change; this change keeps the seam clean (D1) so the
+extraction is mechanical. Until it lands, duplication is accepted and recorded here rather than
+hidden.
+
+## Fail-closed invariants
+
+- Empty `register` app-config, or `case` schema unresolvable → refuse, log once, zero OR calls
+  (never cast `''` to int; pipelinq's `registerSlug()` guard verbatim).
+- Invalid recognizer pattern → refuse the run, log error.
+- Leaf or Mail app absent → no-op (container resolution returns null; `method_exists` guards).
+- Instance toggle `no` → nothing runs regardless of user settings.
+
+## Risks / Trade-offs
+
+- **False positives** (D2): mitigated by year-anchored pattern, existing-identifier resolution, and
+  link-only effect; residual risk is an irrelevant-but-harmless link a handler can remove in the
+  Mail sidebar.
+- **Preview-bounded body scan** (D3): a case number beyond the cached preview is missed in V1;
+  documented, revisited with D6.
+- **Privacy**: scanning personal mailboxes is exactly why both toggles default to off and the user
+  toggle is per-user; the matcher stores no message content, only link rows in the leaf and numeric
+  counters in status.
+- **Duplication with pipelinq** (D6): accepted, bounded, and pointed at its resolution.
+
+## Migration / Rollout
+
+- Purely additive: new service, new job (registered in `info.xml`), new app-config keys, new
+  per-user settings section. No schema change, no data migration.
+- Cursor initialises at the account's current max message id — no historic scan on enable; an
+  explicit occ command may be added later for backfill.
+- Rollback: disable the toggles or remove the job registration; existing leaf links remain (they are
+  ordinary email-leaf links, indistinguishable from manual ones — by design).

--- a/openspec/changes/email-case-matching/proposal.md
+++ b/openspec/changes/email-case-matching/proposal.md
@@ -1,0 +1,89 @@
+# Proposal: email-case-matching
+
+kind: feature — cites **ADR-022** (apps-consume-or-abstractions / leaf-first), **ADR-012** (deduplication),
+**ADR-019** (cross-app integration). Prior art: pipelinq `EmailMatchService` + `EmailMatchJob`
+(`pipelinq/lib/Service/EmailMatchService.php`, 5-minute `TimedJob`, links Nextcloud Mail messages to CRM
+records through OpenRegister's email leaf).
+
+## Summary
+
+When a procest case number appears in the subject or body of an email in a user's Nextcloud Mail
+account, that email is automatically attached to the case through OpenRegister's email leaf
+(`OCA\OpenRegister\Service\EmailLinkService`), idempotently, on a 5-minute `TimedJob`. The `case`
+schema's `configuration.linkedTypes` already contains `"mail"`, so the Mail sidebar can link messages
+to cases **manually** today — but there is no `mailObjectTemplate` and no matching job, so nothing
+links automatically. This change adds the automatic path: a configurable case-number recognizer
+(grounded in the schema's generated `identifier` format `YYYY-NNNN`, e.g. `2026-0042`), subject
+scanned first then body, links to every matched case, never auto-creates a case, per-instance and
+per-user enable toggles (both default off), and a fail-closed guard when the register is
+unconfigured — mirroring pipelinq's guard exactly.
+
+## Why
+
+A case handler's correspondence about `2026-0042` lands in their NC Mail inbox and never reaches the
+case file unless they remember to link it by hand in the Mail sidebar. Procest's only automatic
+inbound-mail path today is `InboundEmailJob`, which polls one **shared functional IMAP mailbox** and
+only recognises bracketed subject tags — personal mailboxes and untagged replies are invisible to the
+case. Pipelinq has already proven the NC-Mail-tables + email-leaf pattern in production; procest needs
+the same mechanism with a different recognizer: case-number tokens in text instead of correspondent
+addresses.
+
+## What
+
+1. `CaseEmailMatchService` — reads `mail_messages` / `mail_mailboxes` (and nothing procest-local) for
+   new messages per configured account, extracts case-number candidates from the subject (then the
+   body text available from the Mail store when the subject has none), resolves each candidate against
+   the `case` schema's `identifier` property via OpenRegister, and calls
+   `EmailLinkService::linkEmail(...)` for every resolved case. Idempotent via the leaf's existing-link
+   check plus a per-user message-id cursor.
+2. `CaseEmailMatchJob` — `TimedJob`, 300 s, iterating users with matching enabled; per-message
+   failures never abort a run.
+3. Configuration — instance toggle `email_case_matching_enabled` (default `no`) via
+   `SettingsService`; per-user settings blob (enabled + mail account) in `IAppConfig`, mirroring
+   pipelinq's per-user `email_match_settings.<uid>` shape; configurable recognizer pattern
+   `email_case_matching_pattern` with a validated default that matches the schema's real identifier
+   format **and** the legacy bracketed tag (see design D2 — the existing `InboundEmailJob` pattern
+   `/\[([A-Z]+-\d{4}-\d{4,6})\]/` does not match what the schema actually generates; this change must
+   not repeat that mismatch).
+4. Fail closed — when `SettingsService::getConfigValue('register')` is empty or the case schema is
+   unresolvable, the matcher refuses to run (no writes, one log line); an empty register value is
+   never cast to an id (pipelinq's `registerSlug()` guard convention).
+
+## Capabilities
+
+### Added Capabilities
+
+- `email-case-matching` — automatic, idempotent attachment of NC Mail messages to cases by case-number
+  recognition, through the OpenRegister email leaf.
+
+## Affected Projects
+
+- **procest** — new service, job, settings keys, per-user settings surface.
+- **openregister** — no change required (the email leaf is generic and already consumed by pipelinq).
+  Recommended follow-up, not part of this change: lift the generic matcher core (message iteration,
+  cursor, idempotent leaf linking, per-user settings) from pipelinq's `EmailMatchService` into the
+  email leaf, leaving each app only its recognizer — pipelinq contributes the correspondent-address
+  recognizer, procest the case-number recognizer. Recorded as the design direction in design.md D6.
+- **pipelinq** — untouched; its `EmailMatchService` is prior art and the donor for the future shared
+  core.
+
+## Out of Scope
+
+- Auto-creating a case from an unmatched email (`mailObjectTemplate`) — explicitly excluded: no match
+  means nothing happens.
+- Changing or replacing `InboundEmailJob` (shared functional mailbox, direct IMAP, archival path). The
+  two paths coexist; convergence criteria in design D5. Fixing that job's pattern/identifier mismatch
+  is flagged there as its own defect fix.
+- Attachment archival to the case dossier (that is `EmailArchivalService`'s existing surface, driven
+  by the shared-mailbox path).
+- Lifting the shared matcher core into the email leaf (recommended direction, separate openregister
+  change).
+
+## Success Criteria
+
+- An email whose subject or body contains `2026-0042` is linked to that case within 5 minutes for an
+  enabled user, visible in the case's Mail leaf surface, and re-runs create no duplicate links.
+- An email with several case numbers is linked to each; an email with none causes no write and no
+  case creation.
+- With the instance toggle off, the user toggle off, or the register unconfigured, the job performs
+  zero OpenRegister writes.

--- a/openspec/changes/email-case-matching/specs/email-case-matching/spec.md
+++ b/openspec/changes/email-case-matching/specs/email-case-matching/spec.md
@@ -1,0 +1,178 @@
+# email-case-matching Specification
+
+**Status:** proposed
+**Scope:** procest
+**Tier:** V1
+**Depends on:** OpenRegister email leaf (`OCA\OpenRegister\Service\EmailLinkService`, generic —
+already consumed by pipelinq), Nextcloud Mail app tables (`mail_messages`, `mail_mailboxes`),
+procest `SettingsService` app-config (`register`, case schema resolution).
+
+## Purpose
+
+Automatically attach an inbound Nextcloud Mail message to every case whose case number appears in the
+message's subject or body, through the OpenRegister email leaf — idempotently, opt-in, and fail-closed.
+The manual Mail-sidebar link (via `case` `configuration.linkedTypes: ["mail"]`) stays untouched; this
+capability adds the automatic path only. No case is ever created by this capability.
+
+## ADDED Requirements
+
+### Requirement: REQ-ECM-001 — Configurable case-number recognition grounded in the identifier format
+
+The system SHALL extract case-number candidates from email text using a configurable regular
+expression stored in app-config `email_case_matching_pattern`. The default pattern SHALL match the
+`case` schema's generated `identifier` format — `YYYY-NNNN` with a yearly sequence padded to at least
+4 digits (e.g. `2026-0042`, materialised by `x-openregister-calculations.identifier`) — both bare and
+with an optional uppercase prefix and/or surrounding brackets as decoration (so `2026-0042`,
+`ZAAK-2026-0042`, and `[ZAAK-2026-000142]` all yield an identifier candidate). Capture group 1 SHALL
+be the identifier as resolvable against the `identifier` property. A configured pattern SHALL be
+validated before use (compiles, contains at least one capture group); an invalid pattern SHALL cause
+the matcher to refuse the run with a logged error — it SHALL NOT fall back to matching everything or
+nothing silently. Each candidate SHALL be resolved to a case by exact match on the `identifier`
+property of the configured register's `case` schema; a candidate that resolves to no case SHALL be
+skipped.
+
+#### Scenario: Default pattern matches what the schema generates
+
+- **GIVEN** the default `email_case_matching_pattern`
+- **WHEN** it is applied to the texts `Betreft zaak 2026-0042`, `Re: [ZAAK-2026-000142] aanvulling`, and `ZAAK-2026-0042 stukken`
+- **THEN** it SHALL yield the candidates `2026-0042`, `2026-000142`, and `2026-0042` respectively
+
+#### Scenario: Invalid configured pattern fails closed
+
+- **GIVEN** an administrator sets `email_case_matching_pattern` to a non-compiling expression
+- **WHEN** the matching job runs
+- **THEN** the run SHALL be refused with a logged error and zero messages SHALL be scanned or linked
+
+---
+
+### Requirement: REQ-ECM-002 — Subject is scanned first, body only when the subject yields nothing
+
+For each new message the system SHALL scan the subject (`mail_messages.subject`) first; only when the
+subject yields no resolvable case SHALL it scan the message body text available from the Nextcloud
+Mail store for that message. All distinct candidates found in the scanned text SHALL be processed.
+
+#### Scenario: Case number in the subject links without a body read
+
+- **GIVEN** an enabled user and an email with subject `Aanvulling zaak 2026-0042`
+- **WHEN** the matching job processes the message
+- **THEN** the email SHALL be linked to case `2026-0042` via the email leaf
+- **AND** the body SHALL NOT need to be read for this message
+
+#### Scenario: Case number only in the body still links
+
+- **GIVEN** an email with subject `Re: onze afspraak` and a body containing `dit betreft zaak 2026-0042`
+- **WHEN** the matching job processes the message
+- **THEN** the subject scan SHALL yield nothing, the body SHALL be scanned, and the email SHALL be linked to case `2026-0042`
+
+---
+
+### Requirement: REQ-ECM-003 — Linking is idempotent through the email leaf
+
+The system SHALL attach a matched email to a case exclusively via
+`EmailLinkService::linkEmail(objectUuid, registerId, schemaId, mailAccountId, messageId, messageUid)`
+and SHALL NOT write any procest-local link table. Before linking, the system SHALL check the leaf's
+existing links for the case (`getLinkedEmails`) and SHALL NOT create a duplicate link for the same
+`(case, mailAccountId, messageId)`; reprocessing a message (cursor reset, job re-run) SHALL yield no
+new links.
+
+#### Scenario: Already-linked email is not linked twice
+
+- **GIVEN** case `2026-0042` already holds a leaf link for message M
+- **WHEN** the matching job processes message M again
+- **THEN** no new link SHALL be created and the run's linked-count SHALL not increase for M
+
+---
+
+### Requirement: REQ-ECM-004 — Multiple case numbers link to every matched case
+
+When the scanned text yields multiple distinct resolvable case numbers, the system SHALL link the
+email to each of those cases. A failure to link one case SHALL be logged and SHALL NOT prevent
+linking the others.
+
+#### Scenario: Email naming two cases is attached to both
+
+- **GIVEN** an email whose subject reads `Samenhang 2026-0042 en 2026-0043` and both cases exist
+- **WHEN** the matching job processes the message
+- **THEN** the email SHALL be linked to case `2026-0042` and to case `2026-0043`
+
+---
+
+### Requirement: REQ-ECM-005 — No match means nothing happens
+
+An email in which no candidate resolves to an existing case SHALL cause no OpenRegister write of any
+kind. The system SHALL NOT auto-create a case from an email (there is deliberately no
+`mailObjectTemplate` on the `case` schema), SHALL NOT link to a "fallback" case, and SHALL NOT store
+the miss anywhere except the run's scanned counter.
+
+#### Scenario: Email without a case number is left alone
+
+- **GIVEN** an email whose subject and body contain no resolvable case number
+- **WHEN** the matching job processes the message
+- **THEN** no link SHALL be created and no case SHALL be created
+
+#### Scenario: A candidate that resolves to no case is skipped
+
+- **GIVEN** an email containing `2099-9999` and no such case exists
+- **WHEN** the matching job processes the message
+- **THEN** the candidate SHALL be skipped with no write
+
+---
+
+### Requirement: REQ-ECM-006 — Matching is opt-in per instance and per user
+
+The system SHALL run matching only when BOTH the instance toggle (app-config
+`email_case_matching_enabled`, default `no`, managed through `SettingsService`) AND the user's own
+setting (per-user settings blob in `IAppConfig`: `enabled` default `false`, plus the mail account id
+to index) allow it. Each user's settings SHALL be independent. Disabling either level SHALL stop all
+scanning for the affected scope from the next run.
+
+#### Scenario: Instance toggle off stops everything
+
+- **GIVEN** `email_case_matching_enabled` is `no`
+- **WHEN** the matching job runs
+- **THEN** no user's mail SHALL be scanned and no links SHALL be created
+
+#### Scenario: User opt-in is individual
+
+- **GIVEN** the instance toggle is on, user A has matching enabled and user B has not
+- **WHEN** the matching job runs
+- **THEN** only user A's configured account SHALL be scanned
+
+---
+
+### Requirement: REQ-ECM-007 — Fail closed when the register is unconfigured
+
+When app-config `register` is empty, or the `case` schema cannot be resolved on the configured
+register, the matcher SHALL refuse to run: zero OpenRegister calls, one logged warning. An empty
+register value SHALL NEVER be cast to an integer or passed onward (which would scope writes to
+register id 0 — the exact failure pipelinq's `EmailMatchService::registerSlug()` guard exists to
+prevent; this guard SHALL mirror it).
+
+#### Scenario: Unconfigured register refuses, not misroutes
+
+- **GIVEN** app-config `register` is `''`
+- **WHEN** the matching job runs for an enabled user
+- **THEN** the run SHALL be refused before any OpenRegister call and a warning SHALL be logged
+
+---
+
+### Requirement: REQ-ECM-008 — A 5-minute TimedJob with a per-user cursor
+
+Matching SHALL run as a `TimedJob` (`CaseEmailMatchJob`) with a 300-second interval, iterating only
+opted-in users. Message discovery SHALL read the Nextcloud Mail tables (`mail_messages` joined to
+`mail_mailboxes` on the configured account) above a per-user last-processed message-id cursor, in
+ascending id order with a bounded batch size. Per-message failures SHALL be logged and SHALL NOT
+abort the run; the cursor SHALL advance only over processed messages. Last-run status (timestamp,
+scanned, linked, last error) SHALL be recorded per user for the settings surface.
+
+#### Scenario: New mail is linked within the job interval
+
+- **GIVEN** an enabled user whose account receives an email containing `2026-0042` in the subject
+- **WHEN** the next `CaseEmailMatchJob` run completes
+- **THEN** the email SHALL be linked to case `2026-0042` and the user's cursor SHALL have advanced past the message
+
+#### Scenario: One poisoned message does not stop the batch
+
+- **GIVEN** a batch where one message's processing throws
+- **WHEN** the run completes
+- **THEN** the remaining messages SHALL still be processed and the failure SHALL be logged

--- a/openspec/changes/email-case-matching/tasks.md
+++ b/openspec/changes/email-case-matching/tasks.md
@@ -1,0 +1,49 @@
+# Tasks — Email-to-case matching via the OpenRegister email leaf
+
+## Phase 1: Recognizer and resolution
+
+- [ ] Add `lib/Service/CaseEmailMatchService.php`: pattern loading + validation (compile check,
+      ≥1 capture group; refuse the run on invalid — REQ-ECM-001), `extractCaseNumberCandidates()`
+      over a text, and `resolveCasesByIdentifier()` doing an exact `identifier` equality lookup on
+      the configured register's `case` schema through the OpenRegister object surface.
+- [ ] Default pattern per design D2 (`(?<![\w-])(?:\[)?(?:[A-Z]{2,10}-)?((?:19|20)\d{2}-\d{4,6})(?:\])?(?![\w-])`),
+      app-config key `email_case_matching_pattern`; add the key to `SettingsService::CONFIG_KEYS`.
+- [ ] Fail-closed guards mirroring pipelinq `EmailMatchService::registerSlug()`: empty `register`
+      app-config or unresolvable `case` schema → zero OR calls, one logged warning (REQ-ECM-007).
+
+## Phase 2: Message discovery and linking
+
+- [ ] Message iteration lifted from pipelinq's shape: `mail_messages` ⋈ `mail_mailboxes` on the
+      configured account, `id > cursor`, ASC, batch cap 200; subject from `mail_messages.subject`;
+      body text from the Mail store (cached preview, full body where cheaply retrievable) only when
+      the subject resolves nothing (REQ-ECM-002, design D3).
+- [ ] Link via the leaf only: resolve `OCA\OpenRegister\Service\EmailLinkService` through the DI
+      container with `method_exists` guards (openregister + mail optional runtime deps); pre-check
+      `getLinkedEmails` per case, then `linkEmail(objectUuid, registerId, schemaId, mailAccountId,
+      messageId, messageUid)`; link every distinct resolved case, per-case failures logged and
+      non-fatal (REQ-ECM-003, REQ-ECM-004). No procest-local link table.
+- [ ] No-match and no-resolution paths write nothing and create nothing (REQ-ECM-005).
+
+## Phase 3: Job, toggles, settings surface
+
+- [ ] Add `lib/BackgroundJob/CaseEmailMatchJob.php` (`TimedJob`, 300 s), registered in
+      `appinfo/info.xml`; iterate opted-in users; per-user cursor + last-run status blob (timestamp,
+      scanned, linked, last error) in `IAppConfig` (REQ-ECM-008).
+- [ ] Instance toggle `email_case_matching_enabled` (default `no`) via `SettingsService`
+      (+ `CONFIG_KEYS`); per-user settings blob (enabled default `false`, mail account id) with
+      read/write endpoints and a section in the email settings UI showing account selector, enable
+      toggle, last-run status (REQ-ECM-006).
+- [ ] Cursor initialises at the account's current max `mail_messages.id` on first enable (no
+      historic scan).
+
+## Phase 4: Tests and verification
+
+- [ ] Unit tests: recognizer (bare / prefixed / bracketed / boundary-guarded negatives / invalid
+      pattern refusal), subject-first ordering, multi-case linking, idempotent re-run, no-match
+      no-op, unresolvable-candidate skip, empty-register refusal, instance/user toggle gating,
+      poisoned-message continuation.
+- [ ] Dev-environment smoke: enable both toggles, send a mail with `2026-0042` in the subject to the
+      configured account, run the job, verify the link appears on the case's Mail surface; repeat
+      run and verify no duplicate.
+- [ ] `grep` the diff for forbidden debug helpers, `php -l` all touched files, run the hydra gates,
+      and `openspec validate --strict` on this change.

--- a/openspec/changes/hermiq-ai-tooling/.openspec.yaml
+++ b/openspec/changes/hermiq-ai-tooling/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-18

--- a/openspec/changes/hermiq-ai-tooling/README.md
+++ b/openspec/changes/hermiq-ai-tooling/README.md
@@ -1,0 +1,3 @@
+# hermiq-ai-tooling
+
+Extend procest-mcp-adoption with curated #[McpTool] tools: guard-enforcing writes (scope×reach annotated, default-deny, approval-gated) and aggregation reads, so every automatable Procest action is commandable from Hermiq chat under granular per-agent grants

--- a/openspec/changes/hermiq-ai-tooling/design.md
+++ b/openspec/changes/hermiq-ai-tooling/design.md
@@ -1,0 +1,95 @@
+## Context
+
+`procest-mcp-adoption` ships the derived read surface (22 tools, 13 schemas, zero write verbs) and deletes `lib/Mcp/ProcestToolProvider.php`. Its design leaves the curated seam explicitly open: Q2 (guard-enforcing status transition), Q3 (aggregation reads + the first `IMcpScannableServices`), Q4 (overdue complaints under the get-only AVG posture). This change is that follow-up.
+
+Mechanics this change builds on, verified in the checkouts:
+
+- **`#[McpTool]`** (`openregister/lib/Mcp/Attribute/McpTool.php`): attribute on a public service method; `AttributeToolScanner` discovers it on the classes an app's `IMcpScannableServices` implementation enumerates (`getScannableServiceClasses(): array` — `openregister/lib/Mcp/IMcpScannableServices.php`), registers id `{appId}.{toolName}`, infers input/output schema from the signature + docblock, forwards only author-declared `scope`/hints. The method runs in-process in the caller's ambient session and owns its own authorization (ADR-041/ADR-063).
+- **Reach** (`hermiq/lib/Service/Engine/ToolReachResolver.php`): descriptor key `reach`, closed vocabulary `self` < `user` < `instance` < `external`, measuring blast radius of effect and disclosure — orthogonal to CRUD scope (`sendMail` is `create` yet `external`). A three-segment derived id infers reach from its verb; **a two-segment curated id cannot, so an undeclared reach resolves to `external` — fail closed.** Every curated Procest tool therefore declares `reach` explicitly.
+- **Grants and approvals** (Hermiq): write scopes are default-deny per agent until an operator grants them (granular per tool per agent); gated invocations pend as `approval` objects via `ApprovalService` (EU AI Act Art. 14 write-path) and resolve asynchronously; run history + the OpenRegister audit trail record every call. These are Hermiq's own specs (`agent-capability-reach`, `human-approval-gate-enforcement`) — referenced as the enforcement point, not restated.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Every Procest action a caseworker performs that is *safe to automate under a guard-enforcing service* gets exactly one curated tool, reads strictly separated from writes.
+- Every write annotated `scope`×`reach`, default-deny, approval-gated where high-impact; the acting agent can never do more than the acting user could.
+- The domain's top chat questions become answerable: deadlines about to breach, doorlooptijden, workload, overdue complaints.
+
+**Non-Goals:**
+- No derived write verbs — the `x-openregister-mcp` posture from `procest-mcp-adoption` (read-only) is untouched.
+- No tool for actions whose refusal D6 grounded in law or mandate (see §D3).
+- No hermiq-side changes; no bespoke Procest approval/consent UI (Hermiq owns oversight).
+
+## Decisions
+
+### D1 — Curated reads (aggregation + one redacted projection)
+
+All `scope: read`, `reach: user` (reads disclose nothing beyond what the caller's own RBAC already reaches — the `ToolReachResolver` doctrine), `readOnlyHint: true`.
+
+| Tool id | Owning service / method | Answers |
+|---|---|---|
+| `procest.getDeadlineDashboard` | `DeadlineReportingService::dashboard` (cf. `DeadlineReportingController::dashboard`) | "Which cases breach their deadline this week?" — buckets by urgency, statutory vs. internal termijnen. |
+| `procest.getDoorlooptijdMetrics` | `DoorlooptijdService` (cf. `DoorlooptijdController::metrics`) | "How are our doorlooptijden trending per caseType?" |
+| `procest.getKpiOverview` | `KpiAggregationService` (cf. `KpiController::index`) | "How is the team doing this quarter?" |
+| `procest.getWorkload` | `WorkQueueService::workload` (cf. `WorkQueueController::workload`) | "Who has capacity for a new bezwaar?" |
+| `procest.listAvailableTransitions` | `StatusTransitionService` (cf. `StatusTransitionController::available`) | "What can happen next on case X?" — also the read half the write tool below needs. |
+| `procest.listOverdueComplaints` | `ComplaintService` (new projection method) | Q4. Returns complaint number, subject, category, deadlines, status, handler — **never `complainant`**. Resolves "which complaints are overdue" without reopening `complaint.search` (the AVG reason `complaint` is get-only in REQ-MCP-104). |
+
+Aggregations return aggregates, not rows; `listOverdueComplaints` is the one row-returning read and is projected in the method body (the scanner exposes what the method returns — the redaction lives server-side, not in a hint).
+
+### D2 — Curated writes: one tool per action, on the owning service
+
+The D6 rule, operationalised: the tool *is* the service call, so every guard, clock, mandate check and notification the human path runs, the agent path runs. Scope/reach reasoning: everything that changes an OpenRegister object other instance users see is `reach: instance`; everything that notifies a citizen or an external party is `reach: external`.
+
+| Tool id | Owning service | scope | reach | Approval | Notes |
+|---|---|---|---|---|---|
+| `procest.transitionCase` | `StatusTransitionService` (guard evaluation, `statusRecord` emission, automatic actions, termijn recalculation — the exact machinery a derived `case.update` bypasses, D6) | update | instance | **Gated when the target `statusType.isFinal` is true**; ungated otherwise | Q2 resolved. Freeform transitions (`StatusTransitionController::freeform`) are NOT exposed — guard-bypassing by construction. |
+| `procest.reassignCase` | `CaseReassignmentService` (cf. `reassignExecute`) | update | instance | **Always gated** | Changes another user's worklist — the canonical instance-reach write. |
+| `procest.completeTask` | Workflow engine task completion (`WorkflowEngineService` step advancement — never a raw `task` write, D6) | update | instance | Ungated | Task *creation* is not exposed: a free-floating agent task desynchronises the engine. |
+| `procest.extendDeadline` | `DeadlineExtensionService` (cf. `TermijnController::verleng`) | update | instance | **Always gated** | Verdaging moves a statutory clock; `extensionCount` and notifications ride along. |
+| `procest.pauseDeadline` / `procest.resumeDeadline` | `DeadlinePauseService` (cf. `TermijnController::pauze`/`hervat`) | update | instance | **Always gated** | Opschorting — same statutory-clock argument. |
+| `procest.scheduleAppointment` | `AppointmentService::create` | create | **external** | **Always gated** | Books a slot and notifies the citizen — leaves the building. |
+| `procest.cancelAppointment` | `AppointmentService` (cf. `AppointmentController::cancel`) | update | **external** | **Always gated** | Citizen-visible cancellation. |
+| `procest.draftBeschikking` | `BeschikkingGenerationService` | create | user | **Always gated** | Produces a **draft only**, visible to the caseworker; the beschikking lifecycle beyond draft is refused (§D3). |
+
+The approval column is Procest's declared posture; Hermiq enforces it (an operator can only tighten, never loosen, from the tool's declaration). "Gated" means the invocation returns Hermiq's pending-approval envelope and the side effect happens only after a human approves — asynchronously, attributable, audited.
+
+### D3 — Standing refusals (D6 extended)
+
+| Never a tool | Why |
+|---|---|
+| `beschikking` akkoord / onderteken / verzend (`BeschikkingController::akkoord/onderteken/verzend`) | Approval requires mandate (`MandaatCheckService`), signing runs the parafering route (`ParafeerRouteService` / `ParaferingApprovalBridge`), dispatch reaches the citizen. An agent issuing a beschikking is a mandate breach — D6 said it for `decision.create`; the same holds one layer down. Drafting (D2) is the automation boundary. |
+| Case create / delete | Unchanged from D6: intake paths own creation (leaf-integrations' `FormsIntakeService`, DSO, KCC); vernietiging is an Archiefwet act. |
+| Freeform/bulk transitions (`freeform`, `bulkExecute`) | The guard-bypassing and mass-effect variants of `transitionCase`. Bulk = one approval per case or nothing. |
+| Raw `task` / `case` / `bezwaar` / `complaint` object writes | The derived surface stays read-only; REQ-MCP-102 is not weakened. |
+| Tenant / mandate / parafering / audit administration | Control-plane, excluded wholesale in `procest-mcp-adoption` D2; tooling them would be reconnaissance-plus-write. |
+
+### D4 — Chat is a command surface (scenarios the tool set must serve)
+
+1. *"Which cases breach their deadline this week?"* → `procest.getDeadlineDashboard` (optionally `procest.termijnInstance.search` from the derived surface for the per-case list). Read-only, no grant beyond read needed.
+2. *"Henk is out sick — move his open bezwaar cases to Fatima."* → `procest.case.search(filters: {assignee: henk, isFinalStatus: false})` (derived) + one `procest.reassignCase` per case, each pending approval; the user approves the batch in Hermiq's oversight surface. Nothing moved until approved.
+3. *"Draft the toewijzingsbeschikking for case 2026-0412 and put it on my desk."* → `procest.case.get` + `procest.draftBeschikking` (gated); signing and sending remain human acts on the beschikking detail page.
+
+### D5 — Scanner hygiene
+
+`ProcestScannableServices::getScannableServiceClasses()` lists **exactly** the classes carrying `#[McpTool]` — an over-broad list makes every future public method a reflection candidate. Where an existing method signature is not scanner-friendly (array blobs, controller-shaped params), a thin typed wrapper method on the same service carries the attribute and delegates; no logic moves. Tool names are the wrapper/method names — English, verb-first, matching the ids above.
+
+## Risks / Trade-offs
+
+- **[A curated write with a weaker in-method guard than its controller]** → The attribute goes on service methods whose controllers already delegate authorization to the service, and the verification phase invokes each write as a non-privileged user expecting denial (the guard must be shown able to say NO).
+- **[Reach misdeclaration]** → Fail-closed helps (undeclared → `external` → maximally gated); the residual risk is *over*-declaring reach and silently over-gating — verification asserts each tool's resolved reach equals the D2 table.
+- **[Tool-count context burn]** → +15 curated tools on top of 22 derived ≈ 37. Still ~5% of the naive surface; the aggregation reads *replace* row-sweeps, reducing tokens per answer. If selection accuracy degrades, `getKpiOverview` and `getWorkload` are the first to drop.
+- **[Approval fatigue]** → Everything gated is genuinely consequential (statutory clocks, citizen contact, worklists). `transitionCase` on non-final statuses and `completeTask` are deliberately ungated so routine flow doesn't train users to rubber-stamp.
+- **[Audit attributes to the session user, not the agent principal]** → Known fleet gap (openregister #369), inherited from `procest-mcp-adoption`, not widened here; Hermiq's run history carries the agent identity in the meantime.
+
+## Migration Plan
+
+1. Land `ProcestScannableServices` + read-tool attributes; verify via `tools/list` (22 derived + 6 reads).
+2. Land write-tool attributes with their reach/scope/approval declarations; verify default-deny (fresh agent: writes invisible/denied), then grant-and-approve one `reassignCase` end to end on a dev instance.
+3. **Rollback:** remove the attribute(s) or the registration line — the catalogue shrinks accordingly; no data shape changed.
+
+## Open Questions
+
+- **Q1** — Should `procest.transitionCase` gating key off more than `statusType.isFinal` (e.g. transitions that trigger automatic external actions)? Needs a survey of `automaticAction` configs in the wild.
+- **Q2** — Batch reassignment as a first-class tool (one approval for N cases) vs. N gated calls: N calls is safer but noisy for the 40-case sick-leave scenario. Product call.
+- **Q3** — Should `procest.listOverdueComplaints`'s projection become an OpenRegister-level capability (field denylist on the dialect, `procest-mcp-adoption` Q1) so `complaint.search` could return redacted rows instead? If that lands, this tool dissolves into the derived surface.

--- a/openspec/changes/hermiq-ai-tooling/proposal.md
+++ b/openspec/changes/hermiq-ai-tooling/proposal.md
@@ -1,0 +1,35 @@
+# Hermiq AI tooling for Procest — curated tools over every automatable action
+
+## Why
+
+The product line: **every app provides MCP tooling for all of its actions, so any action can in principle be automated by an AI agent — and users grant rights per agent, very granularly.** Even without automation, chat is a command surface: a caseworker who can say "extend the deadline on case 2026-0412 by two weeks, verdaging under Awb" and approve the resulting action is commanding Procest through Hermiq.
+
+`procest-mcp-adoption` (read it first; this change extends it) delivers half of that: 22 derived read-only tools over 13 curated schemas, the hand-written `ProcestToolProvider` (`procest.listProcesses`, `procest.getProcessDetails`, `ProcestCaseAuthorizer`) deleted. Its design deliberately stopped short and left three seams open as questions: **Q2** (expose `StatusTransitionService::transition` as a guard-enforcing curated write), **Q3** (aggregation reads over `KpiAggregationService` / `DoorlooptijdService` / deadline reporting, introducing the first `IMcpScannableServices` opt-in), **Q4** ("which complaints are overdue" is unanswerable because `complaint` is get-only). Its D6 established the rule this change builds on: *every lawful Procest write goes through a service that enforces a guard, a mandate, a clock or a retention rule* — so the only sound write tool is a curated `#[McpTool]` on the **owning service**, never a derived `ObjectService` write.
+
+The safety model is Hermiq's, not invented here: every tool descriptor carries a CRUD `scope` (`read`/`create`/`update`/`delete`) and an orthogonal `reach` (`self`/`user`/`instance`/`external`, `ToolReachResolver`) measuring blast radius of effect and disclosure; a two-segment curated id (`procest.transitionCase`) carries no verb to infer from, so an undeclared reach **fails closed to `external`**; write scopes are default-deny per agent until granted; high-impact invocations pend on `ApprovalService` (EU AI Act Art. 14 human oversight) and everything lands in the audit trail.
+
+## What Changes
+
+- **First `IMcpScannableServices` opt-in.** `lib/Mcp/ProcestScannableServices.php` (the class `procest-mcp-adoption` D3 explicitly deferred to "the first change that introduces a curated tool") enumerating exactly the services that carry `#[McpTool]` methods; registered in `lib/AppInfo/Application.php`.
+- **Curated aggregation reads (resolves Q3, Q4):** `procest.getDeadlineDashboard` (`DeadlineReportingService::dashboard` — "which cases breach their deadline this week"), `procest.getDoorlooptijdMetrics` (`DoorlooptijdService`), `procest.getKpiOverview` (`KpiAggregationService`), `procest.getWorkload` (`WorkQueueService::workload`), `procest.listAvailableTransitions` (`StatusTransitionService`), and `procest.listOverdueComplaints` — a **redacted projection** (no `complainant`) that answers Q4 without reopening `complaint.search`.
+- **Curated guard-enforcing writes (resolves Q2), one tool per real user action**, each on its owning service, each annotated `scope`×`reach`, all default-deny: `procest.transitionCase`, `procest.reassignCase`, `procest.completeTask`, `procest.extendDeadline`, `procest.pauseDeadline`, `procest.resumeDeadline`, `procest.scheduleAppointment`, `procest.cancelAppointment`, `procest.draftBeschikking`. Full table with per-tool scope, reach and approval posture in `design.md` §D2.
+- **Human approval gates** on every high-impact write — reassignment, every statutory-clock change, beschikking drafting, everything with `reach: external` — via Hermiq's `ApprovalService`; the tool result returns the pending-approval envelope, never a completed side effect.
+- **Refusals extended, not relaxed:** `beschikking` akkoord/onderteken/verzend (mandate + parafering + external dispatch), case create/delete, raw status or task writes, and every derived write verb remain non-tools. The read-only posture of the *derived* surface from `procest-mcp-adoption` is unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+_None._ The MCP surface is the existing `mcp-integration` capability; this change widens it with curated tools.
+
+### Modified Capabilities
+
+- `mcp-integration`: extended with REQ-MCP-201 … REQ-MCP-208 (scannable-services opt-in, aggregation reads, redacted complaint projection, guard-enforcing writes with scope×reach, default-deny + fail-closed reach, approval gates, standing refusals, audit posture). REQ-MCP-101 … REQ-MCP-105 from `procest-mcp-adoption` stand unmodified.
+
+## Impact
+
+- **Depends on:** `procest-mcp-adoption` fully applied (provider deleted, dialect live) — this change assumes the derived read surface exists and adds no derived verbs.
+- **PHP:** new `lib/Mcp/ProcestScannableServices.php`; `#[McpTool]` attributes (+ explicit `reach`, `scope`, hints) on methods of `lib/Service/DeadlineReportingService.php`, `DoorlooptijdService.php`, `KpiAggregationService.php`, `WorkQueueService.php`, `StatusTransitionService.php`, `CaseReassignmentService.php`, `DeadlineExtensionService.php`, `DeadlinePauseService.php`, `AppointmentService.php`, `BeschikkingGenerationService.php`, `ComplaintService.php` (redacted projection), Workflow engine task completion; registration line in `lib/AppInfo/Application.php`. New thin wrapper methods only where an existing method's signature is not scanner-friendly — no business logic moves.
+- **Consumers:** Hermiq resolves the new tools from the registry at turn time; grants ship default-deny, so nothing is invocable until an operator grants it per agent. No Hermiq code change required; hermiq-side grant/approval behaviour is hermiq's own spec, referenced not restated.
+- **AVG:** aggregation tools return counts and aggregates, not citizen rows; `procest.listOverdueComplaints` is the only new row-returning read and is field-projected to exclude `complainant`. Writes disclose nothing new; every invocation is audited.
+- **Out of scope:** any derived (`x-openregister-mcp`) write verb; beschikking approval/signing/dispatch tools; case creation/destruction tools; hermiq-side grant UI or approval flow changes; the email→case matching job (`email-case-matching`, concurrent) and the leaf surfaces (`leaf-integrations`).

--- a/openspec/changes/hermiq-ai-tooling/specs/mcp-integration/spec.md
+++ b/openspec/changes/hermiq-ai-tooling/specs/mcp-integration/spec.md
@@ -1,0 +1,128 @@
+# MCP Integration — curated Hermiq AI tooling (delta)
+
+## Purpose
+
+@e2e exclude Backend MCP tool surface; invoked by the AI orchestrator (Hermiq) over JSON-RPC and the chat facade, not via the browser UI.
+
+Extend the declarative surface `procest-mcp-adoption` established (22 derived read-only tools, REQ-MCP-101 … REQ-MCP-105 — unmodified here) with curated `#[McpTool]` tools on Procest's owning services: aggregation reads, one redacted projection, and guard-enforcing writes annotated `scope`×`reach`, default-deny per agent, approval-gated where high-impact — so every automatable Procest action is commandable from Hermiq chat under granular per-agent grants.
+
+## ADDED Requirements
+
+### Requirement: REQ-MCP-201 — First IMcpScannableServices opt-in, exact enumeration
+
+Procest MUST add `lib/Mcp/ProcestScannableServices.php` implementing `OCA\OpenRegister\Mcp\IMcpScannableServices`, registered in `lib/AppInfo/Application.php`, whose `getScannableServiceClasses()` returns exactly the service classes that carry at least one `#[McpTool]` method — no more (an over-broad list makes unrelated public methods reflection candidates) and no fewer. Procest MUST NOT reintroduce any `IMcpToolProvider` implementation (that is the seam `procest-mcp-adoption` closed: a hand-written provider shadows derived twins).
+
+#### Scenario: Scanner discovers exactly the curated tools
+
+- **WHEN** `tools/list` is enumerated for `appId = procest` after this change
+- **THEN** it SHALL contain the 22 derived tools from `procest-mcp-adoption` plus exactly the curated ids of REQ-MCP-202 and REQ-MCP-204
+- **AND** no `IMcpToolProvider` implementation SHALL exist under `lib/`
+
+### Requirement: REQ-MCP-202 — Curated aggregation reads
+
+Procest MUST expose, via `#[McpTool]` on the named owning service, the read tools `procest.getDeadlineDashboard` (`DeadlineReportingService`), `procest.getDoorlooptijdMetrics` (`DoorlooptijdService`), `procest.getKpiOverview` (`KpiAggregationService`), `procest.getWorkload` (`WorkQueueService`), and `procest.listAvailableTransitions` (`StatusTransitionService`). Each MUST declare `scope: "read"`, `reach: "user"`, `readOnlyHint: true`, and MUST return aggregates or transition metadata — never citizen rows. Reads and writes MUST be separate tools: no curated tool both reports and mutates.
+
+#### Scenario: Deadline-breach question is answerable
+
+- **WHEN** an agent is asked which cases breach their deadline this week
+- **THEN** it SHALL be able to answer from `procest.getDeadlineDashboard` (optionally joined with the derived `procest.termijnInstance.search`) without any write grant and without sweeping case rows
+
+#### Scenario: Reads run under the caller's own RBAC
+
+- **WHEN** a non-privileged user's agent invokes any REQ-MCP-202 tool
+- **THEN** the result SHALL reflect only data that user can already read through the Procest UI (ambient session, no impersonation)
+
+### Requirement: REQ-MCP-203 — Overdue complaints via redacted projection
+
+Procest MUST expose `procest.listOverdueComplaints` via `#[McpTool]` on `ComplaintService` (`scope: "read"`, `reach: "user"`, `readOnlyHint: true`), returning per complaint at most: complaint number, subject, category, status, handler, `acknowledgementOfReceiptDeadline`, `afhandelDeadline`, and overdue flags. The projection MUST be applied in the method body and MUST NOT include `complainant` (an embedded citizen record) or any of its fields. The `complaint` schema's dialect posture from REQ-MCP-104 (get-only, no `search`) MUST remain unchanged.
+
+#### Scenario: Overdue complaints without complainant exposure
+
+- **WHEN** an agent asks which complaints are past their afhandeltermijn
+- **THEN** `procest.listOverdueComplaints` SHALL return the overdue complaints' handling fields
+- **AND** no result item SHALL contain `complainant` or any complainant contact detail
+- **AND** `procest.complaint.search` SHALL still not exist
+
+### Requirement: REQ-MCP-204 — Guard-enforcing write tools, one per action, on the owning service
+
+Procest MUST expose exactly these write tools via `#[McpTool]`, each on the named owning service so that every guard, clock, mandate check and notification of the human path also runs on the agent path, and each declaring the listed `scope` and `reach` (Hermiq treats these declarations as the enforcement floor):
+
+- `procest.transitionCase` — `StatusTransitionService` (guard evaluation, `statusRecord` emission, automatic actions, termijn recalculation); `scope: "update"`, `reach: "instance"`.
+- `procest.reassignCase` — `CaseReassignmentService`; `scope: "update"`, `reach: "instance"`.
+- `procest.completeTask` — workflow engine step completion (`WorkflowEngineService`), never a raw `task` object write; `scope: "update"`, `reach: "instance"`.
+- `procest.extendDeadline` — `DeadlineExtensionService`; `scope: "update"`, `reach: "instance"`.
+- `procest.pauseDeadline` / `procest.resumeDeadline` — `DeadlinePauseService`; `scope: "update"`, `reach: "instance"`.
+- `procest.scheduleAppointment` — `AppointmentService`; `scope: "create"`, `reach: "external"` (notifies the citizen).
+- `procest.cancelAppointment` — `AppointmentService`; `scope: "update"`, `reach: "external"`.
+- `procest.draftBeschikking` — `BeschikkingGenerationService`, draft only; `scope: "create"`, `reach: "user"`.
+
+No curated write MUST bypass its owning service to write through `ObjectService`, and no derived (`x-openregister-mcp`) write verb MUST be declared on any Procest schema (REQ-MCP-102 stands).
+
+#### Scenario: Agent transition runs the full state machine
+
+- **WHEN** an agent invokes `procest.transitionCase` for a permitted transition
+- **THEN** guard evaluation, `statusRecord` emission, automatic actions and termijn recalculation SHALL all occur exactly as for the same transition performed in the UI
+
+#### Scenario: Guards can say no
+
+- **WHEN** a non-privileged user's agent invokes any REQ-MCP-204 tool on a case that user may not modify
+- **THEN** the owning service SHALL deny the action and the tool SHALL return an error, not a partial effect
+
+#### Scenario: Task completion goes through the engine
+
+- **WHEN** an agent completes a task via `procest.completeTask`
+- **THEN** the workflow engine SHALL advance the step and materialise `isTerminalStatus`
+- **AND** no tool SHALL exist that creates or edits a `task` object directly
+
+### Requirement: REQ-MCP-205 — Explicit reach on every curated tool; writes default-deny
+
+Every curated (two-segment) Procest tool MUST explicitly declare a `reach` from the closed vocabulary `self`/`user`/`instance`/`external` — a two-segment id carries no verb for Hermiq's `ToolReachResolver` to infer from, and an undeclared reach resolves to `external` (fail-closed), silently over-gating the tool. Every write tool MUST be default-deny: invocable by an agent only after an operator grants that agent that tool (or its scope×reach class) in Hermiq — Procest MUST NOT mark any write tool as default-granted.
+
+#### Scenario: Ungranted write is not invocable
+
+- **WHEN** a freshly created agent with no write grants attempts `procest.reassignCase`
+- **THEN** the invocation SHALL be denied by grant resolution before the Procest service is reached
+
+#### Scenario: Declared reach matches the contract
+
+- **WHEN** the tool catalogue is enumerated
+- **THEN** every curated Procest tool SHALL carry an explicit valid `reach`, and `procest.scheduleAppointment` / `procest.cancelAppointment` SHALL resolve to `external`
+
+### Requirement: REQ-MCP-206 — Human approval gates on high-impact writes
+
+The following tools MUST be declared approval-gated, such that an invocation produces a pending approval (Hermiq `ApprovalService`, EU AI Act Art. 14 human oversight) and the side effect occurs only after a human approves: `procest.reassignCase`, `procest.extendDeadline`, `procest.pauseDeadline`, `procest.resumeDeadline`, `procest.scheduleAppointment`, `procest.cancelAppointment`, `procest.draftBeschikking`, and `procest.transitionCase` when the target `statusType.isFinal` is true. `procest.transitionCase` to a non-final status and `procest.completeTask` MAY execute ungated. Operators MAY tighten (gate more), never loosen below this declaration.
+
+#### Scenario: Reassignment waits for a human
+
+- **WHEN** an agent is told "Henk is out sick — move his open bezwaar cases to Fatima" and invokes `procest.case.search(filters: { assignee: "henk", isFinalStatus: false })` followed by `procest.reassignCase` per case
+- **THEN** each reassignment SHALL pend as an approval and no case SHALL move until the user approves it
+- **AND** approved reassignments SHALL execute through `CaseReassignmentService` with its normal notifications
+
+#### Scenario: Closing a case is gated, routine flow is not
+
+- **WHEN** an agent invokes `procest.transitionCase` toward a status whose `statusType.isFinal` is true
+- **THEN** the invocation SHALL pend for approval
+- **AND** the same tool toward a non-final status SHALL execute directly (subject to grants and guards)
+
+### Requirement: REQ-MCP-207 — Standing refusals
+
+Procest MUST NOT expose, curated or derived: beschikking approval, signing, or dispatch (`akkoord`/`onderteken`/`verzend` — mandate via `MandaatCheckService`, parafering route, citizen dispatch; drafting per REQ-MCP-204 is the automation boundary); case creation or deletion (intake paths and the Archiefwet own them — REQ-MCP-102's reasoning stands); freeform or bulk status transitions (`StatusTransitionController::freeform`/`bulkExecute` — guard-bypassing and mass-effect variants); and any tool over tenant, mandate, parafering, or audit administration schemas/services.
+
+#### Scenario: An agent cannot issue a beschikking
+
+- **WHEN** an agent is asked to sign and send the beschikking for a case
+- **THEN** no tool SHALL exist for approval, signing, or dispatch — only `procest.draftBeschikking` (gated, draft only) — and the agent SHALL answer that signing and sending are human acts on the beschikking detail page
+
+#### Scenario: No mass-effect surface
+
+- **WHEN** the tool catalogue is enumerated
+- **THEN** no curated tool SHALL accept a list of case ids for a single transition or reassignment invocation
+
+### Requirement: REQ-MCP-208 — Every curated invocation is audited
+
+Every curated tool invocation — including denied grants, pending approvals, approvals, rejections, and executed effects — MUST be traceable in the audit surfaces: the OpenRegister audit trail for object effects and Hermiq's run history / approval records for the invocation chain. Procest MUST NOT suppress or bypass audit emission on any curated path. (Known fleet limitation, inherited not widened: object-level audit attributes to the session user, not the agent principal — openregister #369.)
+
+#### Scenario: A gated write leaves a full trail
+
+- **WHEN** a `procest.extendDeadline` invocation is approved and executed
+- **THEN** the approval record, the invocation, and the resulting termijn change SHALL each be retrievable from their respective audit surfaces after the fact

--- a/openspec/changes/hermiq-ai-tooling/tasks.md
+++ b/openspec/changes/hermiq-ai-tooling/tasks.md
@@ -1,0 +1,32 @@
+# Tasks — hermiq-ai-tooling
+
+**Gate T0 blocks everything below:** `procest-mcp-adoption` must be fully applied first (`lib/Mcp/ProcestToolProvider.php` deleted, dialect imported, 22 derived tools live) — this change adds curated tools on top of that surface and must not race the provider surgery.
+
+## 1. Scannable-services opt-in (REQ-MCP-201)
+
+- [ ] 1.1 New `lib/Mcp/ProcestScannableServices.php` implementing `OCA\OpenRegister\Mcp\IMcpScannableServices`; `getScannableServiceClasses()` returns exactly the classes attributed in phases 2–3. Register in `lib/AppInfo/Application.php`. SPDX + full PHPDoc.
+- [ ] 1.2 Assert no `IMcpToolProvider` implementation exists anywhere under `lib/` (grep, non-zero file count).
+
+## 2. Curated reads (REQ-MCP-202, REQ-MCP-203)
+
+- [ ] 2.1 `#[McpTool]` (with explicit `scope: read`, `reach: user`, `readOnlyHint: true`, agent-facing descriptions) on `DeadlineReportingService` (`getDeadlineDashboard`), `DoorlooptijdService` (`getDoorlooptijdMetrics`), `KpiAggregationService` (`getKpiOverview`), `WorkQueueService` (`getWorkload`), `StatusTransitionService` (`listAvailableTransitions`). Add thin typed wrapper methods only where an existing signature is not scanner-friendly; move no logic.
+- [ ] 2.2 `ComplaintService`: new projected method for `procest.listOverdueComplaints` — redaction in the method body, `complainant` never in the return shape. PHPUnit: a complaint with a populated `complainant` yields a result item without it (the projection must be shown able to strip).
+
+## 3. Curated writes (REQ-MCP-204, REQ-MCP-205, REQ-MCP-206)
+
+- [ ] 3.1 `#[McpTool]` write tools per the design D2 table: `transitionCase` (`StatusTransitionService`), `reassignCase` (`CaseReassignmentService`), `completeTask` (engine step completion via `WorkflowEngineService` — never a raw `task` write), `extendDeadline` (`DeadlineExtensionService`), `pauseDeadline`/`resumeDeadline` (`DeadlinePauseService`), `scheduleAppointment`/`cancelAppointment` (`AppointmentService`), `draftBeschikking` (`BeschikkingGenerationService`, draft only). Every attribute declares `scope`, explicit `reach`, `readOnlyHint: false`, and the approval posture per REQ-MCP-206.
+- [ ] 3.2 Assert every write delegates to its owning service (no `ObjectService` writes on any curated path) and that no derived write verb was added to any schema (`grep -n '"create"\|"update"\|"delete"' inside every x-openregister-mcp block` → zero).
+- [ ] 3.3 PHPUnit per write tool: (a) the guard says NO for a non-privileged caller; (b) `transitionCase` emits a `statusRecord` and recalculates termijnen; (c) `completeTask` advances the engine step; (d) `draftBeschikking` produces a draft and never touches akkoord/onderteken/verzend paths.
+
+## 4. Specs, quality, changelog
+
+- [ ] 4.1 Sync the delta into `openspec/specs/mcp-integration/spec.md` at archive time (REQ-MCP-101…105 unmodified, 201…208 appended); ensure no `@spec` tag points at a change path (gate-46). `openspec validate` clean.
+- [ ] 4.2 `php -l` on every touched file; `composer check:strict` (PHPCS/PHPMD/Psalm/PHPStan) clean; PHPUnit zero new failures against a self-measured baseline; run the hydra-gates suite and resolve any finding.
+- [ ] 4.3 CHANGELOG entry: curated Hermiq AI tooling — 6 reads + 9 writes, scope×reach annotated, default-deny, approval-gated; derived surface unchanged.
+
+## 5. Verify on a live instance
+
+- [ ] 5.1 `tools/list` for `procest`: 22 derived + 15 curated tools, every curated id two-segment and carrying an explicit valid `reach`; `scheduleAppointment`/`cancelAppointment` resolve `external`; no tool id ends in `.create`/`.update`/`.delete` beyond the (still absent) derived writes.
+- [ ] 5.2 Default-deny proven: a fresh agent with no write grants is denied `procest.reassignCase` before the service runs; the same agent can still call `procest.getDeadlineDashboard`.
+- [ ] 5.3 End-to-end gated write: grant `reassignCase` to a test agent, run the "reassign Henk's open cases to Fatima" scenario — each call pends in Hermiq approvals, nothing moves pre-approval, approval executes through `CaseReassignmentService` with notifications, and the approval + invocation + object change are each retrievable from their audit surfaces (REQ-MCP-208).
+- [ ] 5.4 Chat scenarios from design D4 answered live via the Hermiq chat facade: deadline-breach question (read-only), reassignment (gated), beschikking draft (gated, draft-only) — confirming signing/sending remain unavailable to the agent (REQ-MCP-207).

--- a/openspec/changes/leaf-integrations/.openspec.yaml
+++ b/openspec/changes/leaf-integrations/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-18

--- a/openspec/changes/leaf-integrations/README.md
+++ b/openspec/changes/leaf-integrations/README.md
@@ -1,0 +1,3 @@
+# leaf-integrations
+
+Close Procest's remaining OpenRegister leaf-integration gaps: create-case-from-email (mailObjectTemplate), Talk deliberation rooms, Forms citizen intake, Maps on the VTH inspection surfaces, and Deck coordination boards

--- a/openspec/changes/leaf-integrations/design.md
+++ b/openspec/changes/leaf-integrations/design.md
@@ -1,0 +1,83 @@
+## Context
+
+Three declaration surfaces drive OpenRegister's leaf integrations, and Procest already uses all three:
+
+1. **`configuration.linkedTypes`** on a schema (read by `Schema::getLinkedTypes()`; consumed by `LinkedEntityService::scanMagicTables()` and the Mail sidebar's link tab) declares which leaves may link objects of that schema. `case` declares `["mail", "calendar", "forms", "photos", "maps", "shares", "decidesk-decisions"]`; `inspectionChecklistRun` declares `["forms", "photos"]`. OpenRegister's `LogDanglingLinkedTypes` repair step logs any value not registered in the integration registry, so additions must be real registry ids.
+2. **`configuration.mailObjectTemplate`** (validated by `Schema.php::validateMailObjectTemplate` — object of non-empty property names → scalar values) makes the Mail sidebar's ActionsTab show a create button per schema (`hasCreateTemplate()`), prefilling fields via `{{placeholder}}` substitution from `buildPlaceholders()`: `subject`, `sender`, `senderName`, `date`, `date30`, `datetime`, `preview` (600-char plain-text body), `messageId`, `mailRef`.
+3. **Manifest widgets `{"type": "integration", "integrationId": "…"}`** and `component:` sidebar tabs resolved through `leafTab(id)` (`src/integrations/leafTabs.js` → `builtinIntegrations` from `@conduction/nextcloud-vue`). The lib registers 18 leaves in `leaves.js`; each fetches `/apps/openregister/api/objects/{register}/{schema}/{id}/integrations/{integrationId}` with zero per-app glue.
+
+Precedents in this repo: `case-email-integration` (email leaf + `CaseEmailTab`), `migrate-appointments-to-calendar-leaf`, `migrate-inspection-forms-to-forms-leaf`, `migrate-maps-to-maps-leaf`, `consume-decidesk-besluitvorming-leaf`. This change is the same ADR-022 consumption pattern applied to the leaves Procest does not yet touch.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A caseworker starts a case or complaint from an email in one click, prefilled.
+- Case deliberation gets a Talk room surface; case coordination gets a Deck board surface.
+- A Nextcloud Forms submission can become a case with its statutory clock started correctly.
+- Field inspections get the maps leaf where their coordinates already live.
+
+**Non-Goals:**
+- Automatic email→case matching (the concurrent `email-case-matching` change owns the matching job; this change owns only the manual button).
+- Any leaf-*side* work: clustering, WMS/layers, cases-on-map overview (OpenRegister `integration-maps`, issue #1316 — stub directory in this repo, authoritative spec in ConductionNL/openregister).
+- Deck⇄task sync. `task` records are dispatched and completed by `WorkflowEngineService` against `workflowStepId`; a mirrored Deck card would desynchronise the engine (same argument that refused derived `task` writes in `procest-mcp-adoption` design D6).
+- Data migration of `hearing.talkRoomUrl` / `hearingSession.videoCallUrl`.
+
+## Decisions
+
+### D1 — mailObjectTemplate: `case` and `complaint`, nothing else
+
+| Schema | Template (property → value) | Why |
+|---|---|---|
+| `case` | `title` → `{{subject}}`, `description` → `{{preview}}`, `intakeChannel` → `email`, `communicationChannel` → `email`, `startDate` → `{{date}}`, `initiatorDisplayName` → `{{senderName}}` | The citizen-email-starts-a-case flow. All six are real `case` properties. `initiatorSourceId` is **deliberately absent** — it is documented as BSN/KvK/contact-URI and an email address is none of those; prefill nothing rather than pollute an identifying field. `caseType`/`status` are also absent: the create dialog makes the user choose a type, and the intake conventions (initial status per `caseType`) apply on save. |
+| `complaint` | `subject` → `{{subject}}`, `description` → `{{preview}}`, `receiptChannel` → `email`, `receiptDate` → `{{date}}` | The Awb ch. 9 klacht arrives by email constantly. `complainant` is **deliberately absent** — it is an embedded citizen record (see `procest-mcp-adoption` design D5); the caseworker fills it consciously, the sender's display name is not authoritative identity. |
+
+No other schema gets a template. `task` creation is engine-driven (D6 of the MCP design), `bezwaar` requires a parent case, and everything else is not started from an email in practice. Values are all scalars, so `Schema.php::validateMailObjectTemplate` accepts them at import.
+
+### D2 — Talk: leaf on the case, legacy URL fields stay put
+
+`talk` is added to `case.linkedTypes` and surfaced twice, matching the calendar precedent: a `TalkLeafTab` sidebar tab (`leafTab('talk')` → `CnTalkTab`, `requiredApp: 'spreed'`, empty-state "Talk not available") and a `case-talk` integration widget on the case detail grid. The leaf owns room create/link/unlink.
+
+`hearing.talkRoomUrl` and `hearingSession.videoCallUrl` remain raw strings. Rewiring hearings onto linked Talk rooms renames a wire-visible property, and **a property rename is a data migration** — out of scope here, noted as a follow-up so the debt is recorded rather than smuggled in.
+
+### D3 — Forms intake creates cases through the intake conventions, never a raw insert
+
+The forms leaf today *renders* forms on a case (`FormsLeafTab`, inspection checklists/advice). Intake is the inverse direction: a submission exists before the case does. Two pieces:
+
+1. **Binding:** optional `caseType.intakeFormRef` (string — Nextcloud Forms form hash) declares "submissions of this form open a case of this type". Declared per caseType by an admin; absent means no forms intake for that type.
+2. **Creation:** a Forms submission event listener resolves the bound `caseType` and calls `FormsIntakeService`, which creates the case the way the existing intake paths do (`DsoIntakeService` is the precedent): initial status from the caseType, `intakeChannel: "forms"`, `startDate` = submission date, so the materialised `deadline` calculation (`x-openregister-calculations` on `case`: `dateAdd(startDate, @ref.caseType.processingDeadline)`) starts the statutory clock. Submission answers land in the case `description` and the submission is linked via the forms leaf so the full answer set stays reachable.
+
+A raw `ObjectService` insert is exactly the malformed, clock-less case the MCP design refused (`case.create`, D6); the same reasoning binds this change: **the service, not the leaf, creates the case.** When the `forms` app is absent the listener never fires and the binding field is inert.
+
+### D4 — Maps: consumption on the VTH surfaces; everything else is `integration-maps`
+
+Procest's per-case maps leaf already shipped (`migrate-maps-to-maps-leaf`, `MapsLeafTab`). The positioning against OpenRegister's `integration-maps` change (cross-repo stub here; authoritative in ConductionNL/openregister #1316):
+
+- **`integration-maps` owns the leaf**: provider behaviour, layers, clustering, and the eventual multi-object overview that would retire `CasesOnMapView`.
+- **This change owns Procest's declarations only**: `maps` added to `linkedTypes` of `fieldInspection` (carries `gpsLocation`; `register.d/40-mobiel-inspectie-offline.json` — the fragment currently has no `configuration` object at all, so one is created) and `inspectionChecklistRun`, plus the maps leaf tab on their detail pages. VTH field inspections are location-bound records (`location` schema: `latitude`/`longitude`/`addressDesignationId`/`parcelId`; `fieldInspection.gpsLocation`) that today render no map at all.
+
+Nothing here changes leaf behaviour, so there is no overlap to reconcile beyond ordering: this change has no dependency on `integration-maps` landing (it consumes the leaf as it exists today).
+
+### D5 — Deck: coordination, explicitly not workflow
+
+`deck` joins `case.linkedTypes`; `DeckLeafTab` + `case-deck` widget mirror the Talk wiring (`requiredApp: 'deck'`). One hard rule, spec-carried: **no Procest code creates, mirrors, or completes Deck cards from `task` records or vice versa.** Tasks belong to `WorkflowEngineService` (`workflowStepId`, materialised `isTerminalStatus`); Deck is for the ad-hoc "who calls the objector, who books the room" coordination around a case. The kanban `WorkflowBoardView` stays the workflow surface. If a sync is ever wanted it is its own change with its own conflict story.
+
+## Risks / Trade-offs
+
+- **[Dangling linkedTypes]** → `talk`, `deck`, `maps` are all registry ids in `leaves.js`; `LogDanglingLinkedTypes` logs (not fails) dangling values, so a typo would be silent in CI — the verification phase greps the declared ids against `leaves.js` and checks the repair-step output on a live instance.
+- **[mailObjectTemplate prefill treated as identity]** → Templates deliberately never touch `initiatorSourceId`/`complainant`; the create dialog shows every prefilled field for correction before save.
+- **[Forms intake spam]** → Only forms explicitly bound via `intakeFormRef` create cases; the listener validates the binding server-side. An unbound submission does nothing.
+- **[Union merge drops new configuration]** → `case` is redefined in `register.d/dso-omgevingsloket.json` (properties only, no `configuration`) — same exposure `procest-mcp-adoption` documented; verification reads the imported schema back from OpenRegister, not from the file.
+- **[Leaf availability]** → Every leaf tab degrades to the lib's empty state when its `requiredApp` (spreed, deck, forms, maps) is absent; no Procest-side guard code needed.
+
+## Migration Plan
+
+1. Schema/JSON declarations (register version bump), `python3 -m json.tool` after every edit.
+2. Frontend wiring (registry + manifest), then `FormsIntakeService` + listener.
+3. Deploy → re-run register import → verify declarations from OpenRegister → verify each surface in the UI.
+4. **Rollback:** revert; all declarations are additive JSON + additive code, nothing depends on them.
+
+## Open Questions
+
+- **Q1** — Should hearings (`hearing`, `hearingSession`) migrate their raw `talkRoomUrl`/`videoCallUrl` strings to linked Talk rooms? Property rename ⇒ data migration; needs its own change.
+- **Q2** — Should `intakeFormRef` support field mapping (form question → case property) beyond the description dump? Deferred until a real form demands it.
+- **Q3** — When OpenRegister's `integration-maps` ships the multi-object overview, `CasesOnMapView` should be retired in favour of it — tracked there, not here.

--- a/openspec/changes/leaf-integrations/proposal.md
+++ b/openspec/changes/leaf-integrations/proposal.md
@@ -1,0 +1,41 @@
+# Close Procest's remaining OpenRegister leaf-integration gaps
+
+## Why
+
+OpenRegister ships ~18 app-agnostic integration leaves (calendar, contacts, email, talk, bookmarks, collectives, maps, photos, activity, analytics, cospend, deck, flow, forms, polls, time-tracker, shares, openproject — `nextcloud-vue/src/integrations/builtin/leaves.js`), consumed through three declaration surfaces: schema `configuration.linkedTypes` (which schemas the Mail sidebar and `LinkedEntityService` may link), schema `configuration.mailObjectTemplate` (the create-from-email button in the Mail sidebar's ActionsTab), and manifest widgets `{"type": "integration", "integrationId": "…"}` plus `component:` sidebar tabs resolved via `leafTab()` (`src/integrations/leafTabs.js`, ADR-022).
+
+Procest already consumes a lot of this. The `case` schema declares `linkedTypes: ["mail", "calendar", "forms", "photos", "maps", "shares", "decidesk-decisions"]`; the case detail renders `files`, `notes`, `contacts`, `calendar` and `decidesk-decisions` integration widgets (`src/manifest.json`) and `CaseEmailTab`, `CalendarLeafTab`, `FormsLeafTab`, `PhotosLeafTab`, `MapsLeafTab`, `CaseNotesTab`, `VersionHistoryLeafTab` sidebar tabs (`src/registry.js`); `inspectionChecklistRun` declares `linkedTypes: ["forms", "photos"]`.
+
+What is missing, verified against the checkout:
+
+- **No `mailObjectTemplate` anywhere in Procest** (`grep -rn mailObjectTemplate lib/` → zero hits). A caseworker reading a citizen email in Mail can *link* it to an existing case, but cannot *start* a case (or a complaint) from it — pipelinq (lead) and shillinq (invoice) already ship this button.
+- **No Talk leaf.** `hearing.talkRoomUrl` and `hearingSession.videoCallUrl` are raw pasted strings; case deliberation has no room surface at all.
+- **Forms leaf is render-only.** `FormsLeafTab` shows checklist/advice forms on a case; there is no citizen-intake path where a Nextcloud Forms submission becomes a case with its statutory clock started.
+- **Maps stops at the `case` schema.** The VTH inspection surfaces — `fieldInspection` (which carries `gpsLocation`) and `inspectionChecklistRun` — have no maps leaf, even though field inspections are the most location-bound records Procest owns.
+- **No Deck leaf.** Case workers have no ad-hoc coordination board attached to a case.
+
+## What Changes
+
+- **Create-case-from-email.** Declare `configuration.mailObjectTemplate` on `case` (title/description/intakeChannel/startDate/initiatorDisplayName/communicationChannel prefilled from the email placeholders) and on `complaint` (subject/description/receiptChannel/receiptDate) in `lib/Settings/procest_register.json`. This is the **button surface only**: the automatic email→case *matching job* is the separate, concurrently-authored `email-case-matching` change and is explicitly out of scope here.
+- **Talk deliberation rooms.** Add `talk` to `case.linkedTypes`; register a `TalkLeafTab` (`leafTab('talk')` → `CnTalkTab`, `requiredApp: spreed`) in `src/registry.js` and a `{"type": "integration", "integrationId": "talk"}` widget on the case detail in `src/manifest.json`. Hearing schemas keep their existing URL fields (documented as legacy; see design).
+- **Forms citizen intake → case.** New optional `caseType.intakeFormRef` property binding a Nextcloud Forms form to a case type, plus a server-side `FormsIntakeService` that turns a submission into a case **through the existing intake conventions** (initial status, `intakeChannel: "forms"`, deadline calculation from `caseType.processingDeadline`) — never a raw object insert.
+- **Maps on the VTH inspection surfaces.** Add `maps` to the `linkedTypes` of `fieldInspection` (`register.d/40-mobiel-inspectie-offline.json`) and `inspectionChecklistRun`, and surface the maps leaf on their detail pages. The multi-case map overview (`CasesOnMapView`) and any leaf-side clustering/layers work stay with OpenRegister's `integration-maps` change (cross-repo stub in this repo; authoritative in ConductionNL/openregister, issue #1316) — this change adds **consumption only** and duplicates none of it.
+- **Deck coordination boards.** Add `deck` to `case.linkedTypes`; `DeckLeafTab` + `{"type": "integration", "integrationId": "deck"}` widget on the case detail. Deck cards are ad-hoc coordination aids and MUST NOT mirror or replace engine-driven `task` records (the kanban `WorkflowBoardView` remains the workflow surface).
+
+## Capabilities
+
+### New Capabilities
+
+- `leaf-integrations`: the declaration set (linkedTypes, mailObjectTemplate, manifest integration widgets, leaf tabs) that closes the email/talk/forms/maps/deck gaps.
+
+### Modified Capabilities
+
+_None._ Existing leaf consumption (calendar, forms-render, photos, maps-on-case, notes, email link tab, version-history, decidesk-decisions) is untouched.
+
+## Impact
+
+- **Schemas / registers:** `lib/Settings/procest_register.json` (`case`: +`talk`, +`deck` in `linkedTypes`, +`mailObjectTemplate`; `complaint`: +`mailObjectTemplate`; `caseType`: +`intakeFormRef` property; `inspectionChecklistRun`: +`maps` in `linkedTypes`), `lib/Settings/register.d/40-mobiel-inspectie-offline.json` (`fieldInspection`: +`configuration.linkedTypes: ["maps"]`). Register version bump so the import repair step is not a no-op.
+- **PHP:** new `lib/Service/FormsIntakeService.php` + a Forms submission listener registered in `lib/AppInfo/Application.php`; no existing service changes.
+- **Frontend:** `src/registry.js` (+`TalkLeafTab`, +`DeckLeafTab` via `leafTab()`), `src/manifest.json` (case detail: +2 integration widgets + layout entries + 2 sidebar tabs; fieldInspection/inspectionChecklistRun detail: +maps).
+- **Related changes:** `email-case-matching` (concurrent, owns the matching job — referenced, not touched), OpenRegister `integration-maps` (cross-repo, owns leaf-side maps work), `migrate-maps-to-maps-leaf` / `migrate-inspection-forms-to-forms-leaf` / `case-email-integration` (shipped precedents this change extends).
+- **Out of scope:** automatic email→case matching (`email-case-matching`); leaf-side clustering, WMS layers, or the cases-on-map overview (`integration-maps`); migrating `hearing.talkRoomUrl` / `hearingSession.videoCallUrl` data; any Deck⇄task synchronisation; portal (Portaliq) intake — ADR-046 moved the citizen portal out of Procest, and this change binds only *internal-instance* Forms.

--- a/openspec/changes/leaf-integrations/specs/leaf-integrations/spec.md
+++ b/openspec/changes/leaf-integrations/specs/leaf-integrations/spec.md
@@ -1,0 +1,99 @@
+# Leaf Integrations — email, talk, forms-intake, maps, deck (delta)
+
+## Purpose
+
+Close Procest's remaining OpenRegister leaf-integration gaps by declaration: `configuration.mailObjectTemplate` on `case` and `complaint` (create-from-email button), `talk` and `deck` on the case detail, a Forms citizen-intake path that starts the statutory clock correctly, and the maps leaf on the VTH inspection surfaces. Consumption only (ADR-022); leaf behaviour stays in OpenRegister / nextcloud-vue.
+
+## ADDED Requirements
+
+### Requirement: REQ-LEAF-101 — Create-from-email templates on case and complaint
+
+Procest MUST declare `configuration.mailObjectTemplate` on exactly two schemas in `lib/Settings/procest_register.json`: `case` (`title` → `{{subject}}`, `description` → `{{preview}}`, `intakeChannel` → `email`, `communicationChannel` → `email`, `startDate` → `{{date}}`, `initiatorDisplayName` → `{{senderName}}`) and `complaint` (`subject` → `{{subject}}`, `description` → `{{preview}}`, `receiptChannel` → `email`, `receiptDate` → `{{date}}`). Every key MUST be a real property of its schema and every value a scalar (`Schema.php::validateMailObjectTemplate` rejects the schema otherwise). The templates MUST NOT prefill any identifying field: `initiatorSourceId`, `initiatorType`, `requester` (case) and `complainant` (complaint) MUST NOT appear as template keys. This requirement covers the Mail-sidebar **button surface only**; the automatic email→case matching job is the separate `email-case-matching` change.
+
+#### Scenario: Case button appears in the Mail sidebar
+
+- **WHEN** a user with access to the Procest register opens an email in the Mail sidebar's Actions tab
+- **THEN** the `case` and `complaint` schemas SHALL be offered as create targets (`hasCreateTemplate()` returns true for both)
+- **AND** no other Procest schema SHALL be offered
+
+#### Scenario: Prefill from the email, identity left blank
+
+- **WHEN** the user clicks create-case on an email with subject "Kapotte lantaarnpaal Dorpsstraat"
+- **THEN** the create dialog SHALL open with `title` = "Kapotte lantaarnpaal Dorpsstraat", `description` = the 600-char plain-text preview, `intakeChannel` = "email", and `startDate` = the email's date
+- **AND** `initiatorSourceId` SHALL be empty (never prefilled from an email address)
+
+#### Scenario: Import accepts the templates
+
+- **WHEN** the Procest registers are imported into OpenRegister
+- **THEN** `validateMailObjectTemplate` SHALL raise no error for `case` or `complaint`
+
+### Requirement: REQ-LEAF-102 — Talk deliberation rooms on the case detail
+
+Procest MUST add `talk` to `case.configuration.linkedTypes`, register a `TalkLeafTab` in `src/registry.js` resolved via `leafTab('talk')`, and add a `{"id": "case-talk", "type": "integration", "integrationId": "talk"}` widget (plus layout entry) and the sidebar tab to the case detail page in `src/manifest.json`. The leaf owns room create/link/unlink; Procest MUST NOT add bespoke Talk API code. `hearing.talkRoomUrl` and `hearingSession.videoCallUrl` are unchanged by this change.
+
+#### Scenario: Deliberation room from the case
+
+- **WHEN** a caseworker opens a case detail with the Talk app (`spreed`) enabled
+- **THEN** the Talk integration surface SHALL render and allow creating or linking a deliberation room for this case
+
+#### Scenario: Graceful degradation without Talk
+
+- **WHEN** `spreed` is not enabled
+- **THEN** the surface SHALL show the library's "Talk not available" empty state and no error
+
+### Requirement: REQ-LEAF-103 — Forms citizen intake creates cases through the intake conventions
+
+Procest MUST add an optional `intakeFormRef` string property to the `caseType` schema, and a Forms submission listener + `FormsIntakeService` (new, `lib/Service/FormsIntakeService.php`) that, for submissions of a bound form, creates a `case` of that `caseType` with the caseType's initial status, `intakeChannel: "forms"`, and `startDate` set to the submission date — so the materialised `deadline` calculation (`dateAdd(startDate, @ref.caseType.processingDeadline)`) starts the statutory clock. The case MUST be created through `FormsIntakeService`, never by a raw `ObjectService` insert from the frontend. Submissions of forms not bound by any `caseType.intakeFormRef` MUST create nothing.
+
+#### Scenario: Bound form submission opens a case
+
+- **WHEN** a citizen submits the Forms form whose hash matches a caseType's `intakeFormRef`
+- **THEN** a case of that caseType SHALL exist with the caseType's initial status, `intakeChannel` = "forms", and a `deadline` materialised from `startDate` + `caseType.processingDeadline`
+- **AND** the submission SHALL be reachable from the case via the forms leaf
+
+#### Scenario: Unbound form submission is inert
+
+- **WHEN** a form whose hash matches no `intakeFormRef` receives a submission
+- **THEN** no case SHALL be created and no error SHALL be logged above info level
+
+#### Scenario: Forms app absent
+
+- **WHEN** the `forms` app is not enabled
+- **THEN** the listener SHALL never fire and caseType editing SHALL still accept (and simply store) `intakeFormRef`
+
+### Requirement: REQ-LEAF-104 — Maps leaf on the VTH inspection surfaces
+
+Procest MUST add `maps` to the `configuration.linkedTypes` of `fieldInspection` (`lib/Settings/register.d/40-mobiel-inspectie-offline.json` — creating the `configuration` object, which the fragment currently lacks) and of `inspectionChecklistRun` (`lib/Settings/procest_register.json`, alongside its existing `["forms", "photos"]`), and surface the maps leaf tab on both detail pages. Leaf-side behaviour (providers, layers, clustering, the multi-object overview) is owned by OpenRegister's `integration-maps` change and MUST NOT be duplicated or modified here; the existing per-case `MapsLeafTab` and the `CasesOnMapView` overview are unchanged.
+
+#### Scenario: Inspection location on the map
+
+- **WHEN** an inspector opens a `fieldInspection` detail whose `gpsLocation` is set
+- **THEN** the maps leaf SHALL render the inspection's location marker
+
+#### Scenario: No overlap with integration-maps
+
+- **WHEN** this change is fully applied
+- **THEN** no file under OpenRegister's maps provider or the nextcloud-vue maps leaf SHALL have been modified by Procest, and `CasesOnMapView` SHALL be byte-identical to before
+
+### Requirement: REQ-LEAF-105 — Deck coordination boards, decoupled from workflow tasks
+
+Procest MUST add `deck` to `case.configuration.linkedTypes` and surface a `DeckLeafTab` (`leafTab('deck')`) plus a `{"id": "case-deck", "type": "integration", "integrationId": "deck"}` widget on the case detail. Procest MUST NOT create, mirror, update, or complete Deck cards from `task` records, nor `task` records from Deck cards: `task` lifecycle belongs exclusively to `WorkflowEngineService` (`workflowStepId`, materialised `isTerminalStatus`), and the kanban `WorkflowBoardView` remains the workflow surface.
+
+#### Scenario: Ad-hoc board on a case
+
+- **WHEN** a caseworker opens a case detail with the Deck app enabled
+- **THEN** the Deck integration surface SHALL allow linking or creating a board for ad-hoc case coordination
+
+#### Scenario: Tasks are not mirrored
+
+- **WHEN** a `task` record is created or completed by the workflow engine
+- **THEN** no Deck card SHALL be created or changed by Procest code
+
+### Requirement: REQ-LEAF-106 — Every declared linkedType resolves to a registered leaf
+
+Every value Procest declares in any schema's `configuration.linkedTypes` MUST be an id registered in the integration registry (`nextcloud-vue/src/integrations/builtin/leaves.js` or a cross-app registration such as `decidesk-decisions`), because OpenRegister's `LogDanglingLinkedTypes` repair step only *logs* dangling values — a typo fails silently.
+
+#### Scenario: Repair step reports no dangling types
+
+- **WHEN** the `LogDanglingLinkedTypes` repair step runs after import on an instance with this change applied
+- **THEN** it SHALL report no Procest schema with a dangling linkedTypes value

--- a/openspec/changes/leaf-integrations/tasks.md
+++ b/openspec/changes/leaf-integrations/tasks.md
@@ -1,0 +1,37 @@
+# Tasks — leaf-integrations
+
+## 1. Create-from-email templates (REQ-LEAF-101)
+
+- [ ] 1.1 `lib/Settings/procest_register.json`: add `configuration.mailObjectTemplate` to `case` (`title`/`description`/`intakeChannel`/`communicationChannel`/`startDate`/`initiatorDisplayName` per design D1) and `complaint` (`subject`/`description`/`receiptChannel`/`receiptDate`). Scalars only; never touch `initiatorSourceId`, `initiatorType`, `requester`, `complainant`. Bump the register version so the import repair step is not a no-op. `python3 -m json.tool` after each edit.
+- [ ] 1.2 Assert every template key is a real property of its schema (cross-check against `properties`) and that no other Procest schema gains a `mailObjectTemplate`.
+
+## 2. Talk on the case detail (REQ-LEAF-102)
+
+- [ ] 2.1 `lib/Settings/procest_register.json`: add `"talk"` to `case.configuration.linkedTypes`.
+- [ ] 2.2 `src/registry.js`: register `TalkLeafTab` (`kind: 'page'`, `component: leafTab('talk')`) following the `CalendarLeafTab` precedent, with an ADR-022 `_note`.
+- [ ] 2.3 `src/manifest.json`: add the `case-talk` integration widget (`integrationId: "talk"`, icon `ChatOutline`), a layout entry, and the `TalkLeafTab` sidebar tab on the case detail page.
+
+## 3. Forms citizen intake (REQ-LEAF-103)
+
+- [ ] 3.1 `lib/Settings/procest_register.json`: add the optional `intakeFormRef` string property to `caseType` (title + description; additive — no required change).
+- [ ] 3.2 New `lib/Service/FormsIntakeService.php`: resolve the bound caseType by form hash, create the case with initial status, `intakeChannel: "forms"`, `startDate` = submission date (statutory clock via the existing `deadline` calculation), submission answers into `description`, link the submission via the forms leaf. Full PHPDoc + SPDX headers.
+- [ ] 3.3 Forms submission event listener registered in `lib/AppInfo/Application.php`; no-op when `forms` is disabled or the form is unbound. PHPUnit: bound-form creates a correctly-clocked case; unbound-form creates nothing (the guard must be shown able to say NO).
+
+## 4. Maps on the VTH surfaces (REQ-LEAF-104)
+
+- [ ] 4.1 `lib/Settings/register.d/40-mobiel-inspectie-offline.json`: add `configuration.linkedTypes: ["maps"]` to `fieldInspection` (the fragment has no `configuration` object today — create it; never drop an existing key).
+- [ ] 4.2 `lib/Settings/procest_register.json`: extend `inspectionChecklistRun.configuration.linkedTypes` to `["forms", "photos", "maps"]`.
+- [ ] 4.3 `src/manifest.json`: surface the maps leaf tab on the `fieldInspection` and `inspectionChecklistRun` detail pages. Touch nothing in OpenRegister/nextcloud-vue maps code and leave `CasesOnMapView` unchanged (owned by OpenRegister `integration-maps`).
+
+## 5. Deck on the case detail (REQ-LEAF-105)
+
+- [ ] 5.1 `lib/Settings/procest_register.json`: add `"deck"` to `case.configuration.linkedTypes`.
+- [ ] 5.2 `src/registry.js` + `src/manifest.json`: `DeckLeafTab` (`leafTab('deck')`), `case-deck` widget (`integrationId: "deck"`, icon `ViewColumnOutline`), layout entry, sidebar tab — mirroring the Talk wiring.
+- [ ] 5.3 Assert no code path links `task` records to Deck cards in either direction (grep `deck` across `lib/` — only declaration/UI wiring may match).
+
+## 6. Specs, quality, verification
+
+- [ ] 6.1 Sync the delta into `openspec/specs/leaf-integrations/spec.md` at archive time; ensure no `@spec` tag anywhere points at a change path (gate-46). `openspec validate` clean.
+- [ ] 6.2 Grep gates, with a non-zero searched-file count asserted: `mailObjectTemplate` matches exactly the `case` + `complaint` declarations; `linkedTypes` additions are exactly `talk`, `deck`, `maps` (×2); every declared linkedType id exists in `nextcloud-vue/src/integrations/builtin/leaves.js` or is `decidesk-decisions`.
+- [ ] 6.3 `php -l` on new/changed PHP; `composer check:strict` (PHPCS/PHPMD/Psalm/PHPStan) clean on touched files; `npm run build` green; run the hydra-gates suite and resolve any finding.
+- [ ] 6.4 Verify on a live instance: re-run the register import repair step, read `case`, `complaint`, `caseType`, `fieldInspection`, `inspectionChecklistRun` back **from OpenRegister** (not from the files — `case` is union-merged with `register.d/dso-omgevingsloket.json`) and assert the new `configuration` keys survived; `LogDanglingLinkedTypes` reports no dangling Procest value; Mail sidebar shows both create buttons and prefills per REQ-LEAF-101; case detail renders Talk and Deck surfaces (and their empty states with `spreed`/`deck` disabled); a bound Forms submission creates a correctly-clocked case and an unbound one creates nothing.

--- a/openspec/changes/ori-removal/design.md
+++ b/openspec/changes/ori-removal/design.md
@@ -1,0 +1,115 @@
+# Design: ori-removal
+
+Paired with decidesk `ori-adoption` (ships first). The canonical ORI → Popolo
+mapping table lives in **decidesk `ori-adoption/design.md`** — this document
+does not fork it; the summary below is for the migration runbook only.
+
+## This is a data migration, not a rename
+
+The move renames schemas, properties and enum values. A schema/property/value
+rename is a **data migration**: nothing may be "renamed" by editing JSON while
+live objects still carry the old shape. All object rewriting is done by
+decidesk's `occ decidesk:import-ori` (owned by `ori-adoption`), which is
+idempotent, tags every created object with `externalReference: ori:<uuid>`,
+supports `--dry-run` and `--rollback`, and never touches the source register.
+
+### Mapping summary (canonical table: decidesk `ori-adoption/design.md`)
+
+| ORI (procest, source) | decidesk (target) | Rename class |
+| --- | --- | --- |
+| `vergadering` | `Meeting` | schema + property renames (`name`→`title`, `startDate`→`scheduledDate`, `type`/`status` value maps incl. `afgelast`→`cancelled`) |
+| `agendapunt` | `AgendaItem` | schema + property renames (`subject`→`title`, `omschrijving`→`description`, `sortOrder`→`orderNumber`, `attachments`→`documents`) |
+| `raadsdocument` | `DigitalDocument` | schema + property renames (`title`→`name`, `contentType`→`encodingFormat`, `fileSize`→`contentSize` int→string, value map `brief`→`letter`) |
+| `stemming` | `Decision` + `VotingRound` | schema split; value maps (`aangenomen`→`adopted`, `verworpen`→`rejected`, `proposal`→`resolution`); `politicalGroupResults`→`partyResults` (aggregate preserved, never decomposed into fabricated per-person votes) |
+| `raadslid` | `Person` + `Membership`(s) | schema split; `role` value map (mayor→chair, clerk→secretary, alderman→member of executive board); `actief:false`→`endDate` = cutover date (approximation, logged) |
+| `fractie` | `GovernanceBody` (`bodyType: political-group`) | schema rename; `zetels`→`seatCount`, `coalitiepartij`/`oppositiepartij`→`coalitionRole: coalition`/`opposition` |
+
+## Migration runbook (per instance)
+
+1. **Preconditions.** decidesk release containing `ori-adoption` is installed
+   and enabled; OpenRegister up; procest still at the pre-removal version (the
+   `ori` register intact).
+2. **Dry run.** `occ decidesk:import-ori --source-register=ori --dry-run
+   --strict`. Record the per-schema source counts. Fix any reported dangling
+   references in the source data first — the importer reports them rather than
+   silently dropping them.
+3. **Live run.** Same command without `--dry-run`. Then **verify parity by
+   measuring, not by reading the command's own report**: count objects per
+   source schema in the `ori` register and count `ori:*`-tagged objects per
+   target schema in decidesk via the OpenRegister API (use `_limit`/faceting;
+   remember a bare `limit=` is a property filter). A `stemming` legitimately
+   yields two target objects (Decision + VotingRound); the parity formula in
+   the verification task accounts for that.
+4. **Verify surfaces.** decidesk feeds `/apps/decidesk/feed/ori/*.rss` return
+   the migrated content anonymously; spot-check one meeting, one vote, one
+   political group in the decidesk UI.
+5. **Upgrade procest** to the version carrying this change. The
+   `RetireOriRegister` repair step now finds the register's objects fully
+   `ori:*`-migrated (it asks decidesk / checks tags) and retires the register;
+   otherwise it warns and leaves everything in place (fail-safe: removal never
+   outruns migration).
+
+### Rollback
+
+- **Before procest upgrade:** `occ decidesk:import-ori --rollback` deletes
+  exactly the `ori:*`-tagged decidesk objects; the untouched `ori` register is
+  still the complete record. No procest data was modified.
+- **After procest upgrade but register retirement was skipped** (guard
+  triggered): nothing was deleted; downgrade procest or re-run migration.
+- **After register retirement:** the retirement step exports the register
+  (schemas + objects) to a timestamped JSON backup in the app data directory
+  before deletion; restoring = re-import of that file. The decidesk copy is
+  authoritative from this point.
+
+## Repair-step design: `RetireOriRegister`
+
+Replaces `RegisterOriRegister` in `appinfo/info.xml` (`<post-migration>`; the
+`<install>` entry is dropped entirely — fresh installs never get an ORI
+register). Behaviour:
+
+- OpenRegister absent → no-op (info line), same posture as the old step.
+- `ori` register absent → no-op (already retired / never provisioned).
+- Register present and every object is either gone or verified migrated
+  (matching `ori:*` tags in decidesk) → export backup JSON → delete register +
+  schemas.
+- Register present with unmigrated objects → **warn and keep** ("run
+  `occ decidesk:import-ori` first"); the upgrade itself still succeeds.
+  Idempotent: safe to run on every upgrade until it can retire.
+
+## Cross-app link: case ↔ decidesk Meeting
+
+procest's vergadering-backed cases are procest `case` objects (register/schema
+from procest config) and are **kept** — `VergaderingCaseService`,
+`VergaderingDeadlineJob` and their statuses continue to work on case data
+alone (the service already reads only the case register; its doc comment's
+"created in the ORI register" claim describes an ingest bridge that was never
+built and is corrected as part of this change).
+
+What changes is the *reference to the meeting record*:
+
+- The procest `case` schema gains an optional `meetingRef` property (string,
+  decidesk `Meeting` uuid) in `procest_register.json` — additive.
+- `VergaderingDetailView` (route `/besluitvorming/vergaderingen/:id`,
+  manifest `src/manifest.d/50-besluitvorming.json`) stops rendering ORI
+  agenda/vote data of its own and instead shows the case-side data plus an
+  "Open meeting in decidesk" deep link
+  (`/apps/decidesk/#/meetings/<meetingRef>`) and/or decidesk's registered
+  integration leaf, exactly the ADR-019 consume pattern proven by
+  `consume-decidesk-besluitvorming-leaf`. Route stays registered (ADR-044:
+  deep links and e2e must not break).
+- decidesk absent or `meetingRef` empty → quiet unavailable notice, never a
+  broken panel.
+
+## Removal inventory (verified against the working tree, not memory)
+
+| Surface | File(s) | Action |
+| --- | --- | --- |
+| Register definition | `lib/Settings/ori_register.json` | delete |
+| Provisioning repair | `lib/Repair/RegisterOriRegister.php`; `appinfo/info.xml` `<install>` + `<post-migration>` entries | delete; replace post-migration entry with `RetireOriRegister` |
+| Data-quality cron | `lib/Cron/OriDataQualityCheck.php`; `appinfo/info.xml` `<job>` entry | delete |
+| Public feeds | `lib/Controller/RaadsinformatieFeedController.php`; `appinfo/routes.php` lines for `/feed/ori/vergaderingen.rss`, `/feed/ori/agendapunten.rss`, `/feed/ori/documenten.rss` | delete (decidesk serves `/feed/ori/meetings.rss`, `/feed/ori/agenda-items.rss`, `/feed/ori/documents.rss`) |
+| Meeting detail page | `src/views/besluitvorming/VergaderingDetailView.vue` (+ `50-besluitvorming.json` manifest entry) | repoint to case data + decidesk link/leaf (kept, modified) |
+| Case service docs | `lib/Service/VergaderingCaseService.php` header comment | correct (no ORI ingest exists) |
+| Tests | unit/e2e touching the deleted controller/cron/repair | delete or repoint |
+
+Grep gate (task-enforced): after removal, `grep -rn "ori_register\|register: 'ori'\|RegisterOriRegister\|OriDataQualityCheck\|RaadsinformatieFeed" lib/ src/ appinfo/` returns only the new `RetireOriRegister` (which must reference the `ori` slug to retire it) — count the files, since `[OK] no matches` is also what a zero-file grep prints.

--- a/openspec/changes/ori-removal/proposal.md
+++ b/openspec/changes/ori-removal/proposal.md
@@ -1,0 +1,84 @@
+# Proposal: ori-removal
+
+Paired with decidesk change `ori-adoption` (decidesk/openspec/changes/ori-adoption/).
+**decidesk's adoption ships FIRST; this change ships SECOND** — it must not
+start until decidesk's schema deltas, `occ decidesk:import-ori` importer and
+ORI feed adapter are merged and deployed.
+
+## Summary
+
+procest drops the ORI (Open Raadsinformatie) register. Per the product-owner
+decision, raadsinformatie moves to decidesk **purely**, modelled on Popolo from
+the start (decidesk `ori-adoption`). procest removes
+`lib/Settings/ori_register.json` and every surface that provisions, checks or
+serves it; existing instances migrate their ORI objects into decidesk's
+register via decidesk's importer **before** removal; and procest cases that
+reference a council meeting (vergadering) link to the decidesk `Meeting`
+cross-app instead of a procest-owned record.
+
+## Why
+
+- **decidesk owns decision-making** (ADR-019/ADR-022; precedent:
+  `consume-decidesk-besluitvorming-leaf`, `procest-delegation-via-events`).
+  Meetings, agenda items, votes, council members and political groups are
+  decidesk's core Popolo domain; procest's ORI register is a parallel,
+  Dutch-named duplicate of it.
+- **English identifiers are a fleet contract.** The ORI register's schemas
+  (`vergadering`, `zetels`, `aangenomen`, …) violate it structurally; the
+  statutory Dutch ORI wire shape survives in decidesk's adapter layer only.
+- **One register, one record.** Every consumer (feeds, dashboards, catalogs)
+  reads one canonical dataset in decidesk instead of choosing between two.
+
+## What changes (procest)
+
+1. **Data migration first (blocking gate).** For every existing instance, the
+   objects in the OpenRegister `ori` register are migrated into decidesk by
+   running decidesk's `occ decidesk:import-ori` (dry-run, then live, then
+   verify counts). This is explicitly a **data migration**: the move renames
+   schemas, properties and enum values (`vergadering`→`Meeting`,
+   `sortOrder`→`orderNumber`, `aangenomen`→`adopted`, …) — the mapping table,
+   dry-run procedure and rollback notes live in decidesk
+   `ori-adoption/design.md` and are summarised in this change's `design.md`.
+   Removal steps are gated on verified migration parity.
+
+2. **Register removal.** Delete `lib/Settings/ori_register.json` and the
+   `RegisterOriRegister` repair step (both `<install>` and `<post-migration>`
+   entries in `appinfo/info.xml`). A new one-shot repair step retires the
+   now-orphaned `ori` OpenRegister register on upgraded instances — but only
+   when it is empty or its objects carry decidesk's `ori:*` import tags
+   (i.e. migration verified); otherwise it warns and leaves the data in place.
+
+3. **ORI surface removal.**
+   - `lib/Cron/OriDataQualityCheck.php` background job (+ its
+     `appinfo/info.xml` registration) — deleted; decidesk owns data quality
+     for its own register.
+   - `lib/Controller/RaadsinformatieFeedController.php` + the three
+     `/feed/ori/*.rss` routes in `appinfo/routes.php` — deleted; the feeds are
+     re-served by decidesk (`/apps/decidesk/feed/ori/*.rss`, same wire shape).
+   - Any remaining procest reference to the `ori` register slug or its six
+     schema slugs — removed (verified by grep gate, not by memory).
+
+4. **Cross-app link: case ↔ decidesk Meeting.** procest keeps its
+   vergadering-backed *cases* (`VergaderingCaseService`,
+   `VergaderingDeadlineJob`, the `VergaderingDetailView` page) — those are
+   procest case records, not ORI objects. Where such a case references a
+   council meeting record, it now stores a `meetingRef` (decidesk `Meeting`
+   uuid) and the UI deep-links to decidesk (or renders decidesk's integration
+   leaf, same pattern as `consume-decidesk-besluitvorming-leaf`), instead of
+   pointing at an ORI `vergadering` object. When decidesk is not installed the
+   link degrades to a quiet unavailable notice.
+
+## Out of scope / kept
+
+- decidesk-side work (schemas, importer, adapter, seed) — that is
+  `ori-adoption` in the decidesk repo.
+- procest's vergadering-backed case lifecycle (statuses, deadline job) — kept;
+  only the *meeting record* moves.
+- The besluitvorming leaf and voorstel→Decision delegation — already shipped by
+  `consume-decidesk-besluitvorming-leaf` / `procest-delegation-via-events`.
+
+## Depends on
+
+- decidesk `ori-adoption` merged, released and deployed (importer + feeds
+  available).
+- OpenRegister available on the instance (as today).

--- a/openspec/changes/ori-removal/specs/ori-removal/spec.md
+++ b/openspec/changes/ori-removal/specs/ori-removal/spec.md
@@ -1,0 +1,110 @@
+# ORI removal — procest drops the raadsinformatie registers
+
+Paired with decidesk `ori-adoption` (ships first). procest removes the ORI
+register and all surfaces over it; existing data migrates to decidesk before
+anything is deleted; cases link to decidesk meetings cross-app.
+
+## ADDED Requirements
+
+### Requirement: REQ-ORIR-001 — Removal MUST be gated on verified migration parity
+
+procest MUST NOT delete the `ori` OpenRegister register, or any object in it,
+until its objects are verifiably migrated into decidesk. The move renames
+schemas, properties and enum values, so it is a **data migration** executed by
+decidesk's `occ decidesk:import-ori` (mapping table, dry-run and rollback per
+decidesk `ori-adoption`), never by editing schema JSON in place. Parity MUST be
+verified by measuring object counts on both sides (source register counts vs
+`ori:*`-tagged target counts, accounting for the 1→2 split of `stemming` into
+Decision + VotingRound), not by trusting the import command's own report.
+
+#### Scenario: Removal blocked while unmigrated objects exist
+
+- GIVEN an upgraded procest whose `ori` register still contains objects without matching `ori:*` import tags in decidesk
+- WHEN the `RetireOriRegister` repair step runs during `occ upgrade`
+- THEN it warns, leaves the register and all its objects intact, and the upgrade still succeeds
+
+#### Scenario: Retirement after verified parity
+
+- GIVEN every object in the `ori` register has a matching `ori:*`-tagged counterpart in decidesk
+- WHEN the repair step runs
+- THEN it first writes a timestamped JSON export of the register (schemas + objects) to the app data directory, then deletes the register and its six schemas
+
+#### Scenario: Repair step is idempotent and fail-safe
+
+- GIVEN OpenRegister is unavailable, or the `ori` register was already retired
+- WHEN the repair step runs
+- THEN it is a no-op with an informational message and the upgrade succeeds
+
+### Requirement: REQ-ORIR-002 — procest MUST stop shipping and provisioning the ORI register
+
+`lib/Settings/ori_register.json` and `lib/Repair/RegisterOriRegister.php` MUST
+be deleted, together with their `appinfo/info.xml` registrations (both the
+`<install>` and `<post-migration>` entries); fresh installs MUST NOT create an
+`ori` register. The `<post-migration>` slot is taken by `RetireOriRegister`
+(REQ-ORIR-001). The `OriDataQualityCheck` background job and its `<job>`
+registration MUST be deleted. After removal, a repository-wide search for
+`ori_register`, `register: 'ori'`, `RegisterOriRegister`,
+`OriDataQualityCheck` and `RaadsinformatieFeed` MUST match only
+`RetireOriRegister` (which necessarily names the `ori` slug it retires) — and
+the check MUST count the files searched, since "no matches" over zero files is
+indistinguishable from a pass.
+
+#### Scenario: Fresh install has no ORI register
+
+- GIVEN a clean Nextcloud with OpenRegister and the new procest version
+- WHEN procest is installed and its repair steps run
+- THEN no OpenRegister register with slug `ori` exists and no ORI schemas were created
+
+#### Scenario: No dangling ORI code references
+
+- GIVEN the change is fully applied
+- WHEN the repo-wide grep gate from design.md runs over `lib/`, `src/` and `appinfo/` (file count > 0)
+- THEN the only matches are inside `RetireOriRegister` and its tests
+
+### Requirement: REQ-ORIR-003 — The public ORI feeds MUST move to decidesk
+
+`lib/Controller/RaadsinformatieFeedController.php` and the routes
+`/feed/ori/vergaderingen.rss`, `/feed/ori/agendapunten.rss` and
+`/feed/ori/documenten.rss` MUST be removed from procest. Consumers are pointed
+at decidesk's replacement feeds (`/apps/decidesk/feed/ori/meetings.rss`,
+`/feed/ori/agenda-items.rss`, `/feed/ori/documents.rss` — same ORI wire shape,
+served by decidesk's adapter). procest's release notes MUST document the URL
+change; procest MUST NOT proxy or redirect (the app may be installed without
+decidesk, and a half-alive feed is worse than a documented move).
+
+#### Scenario: procest feed routes are gone
+
+- GIVEN the new procest version
+- WHEN an anonymous client requests `/apps/procest/feed/ori/vergaderingen.rss`
+- THEN it receives a 404 (route not registered), and the routes file contains no `/feed/ori/` entries
+
+### Requirement: REQ-ORIR-004 — Cases MUST link to decidesk meetings cross-app
+
+procest's vergadering-backed cases (the `case` objects managed by
+`VergaderingCaseService` and advanced by `VergaderingDeadlineJob`) are KEPT.
+Where such a case references a council meeting record, the procest `case`
+schema MUST gain an optional additive `meetingRef` property holding the
+decidesk `Meeting` uuid, and the meeting detail surface
+(`VergaderingDetailView`, route `/besluitvorming/vergaderingen/:id`) MUST
+render case-side data plus a link into decidesk (deep link or decidesk's
+ADR-019 integration leaf) instead of reading ORI objects. The route MUST stay
+registered (deep links and e2e MUST NOT break). When decidesk is absent or
+`meetingRef` is empty the surface MUST degrade to a quiet unavailable notice.
+
+#### Scenario: Case deep-links to its decidesk meeting
+
+- GIVEN a vergadering-backed case whose `meetingRef` holds a decidesk Meeting uuid and decidesk is installed
+- WHEN the user opens `/besluitvorming/vergaderingen/:id` for that case
+- THEN the page shows the case data and an "Open meeting in decidesk" link targeting that Meeting, and no ORI register read is performed
+
+#### Scenario: Graceful degradation without decidesk
+
+- GIVEN decidesk is not installed
+- WHEN the same page renders
+- THEN the case data renders normally and the meeting panel shows an unavailable notice instead of an error
+
+#### Scenario: Case lifecycle unaffected by the removal
+
+- GIVEN vergadering-backed cases in status `gepland` with a start date in the past
+- WHEN `VergaderingDeadlineJob` runs on the new version
+- THEN the cases advance exactly as before (the job reads only case data, no ORI objects)

--- a/openspec/changes/ori-removal/tasks.md
+++ b/openspec/changes/ori-removal/tasks.md
@@ -1,0 +1,56 @@
+# Tasks: ori-removal
+
+Paired with decidesk `ori-adoption`. kind: code + data migration.
+
+**Gate T0 blocks everything below it** — do not start T2+ until decidesk's
+release carrying `ori-adoption` (schema deltas, `occ decidesk:import-ori`,
+`/feed/ori/*.rss` adapter) is merged and deployed.
+
+- [ ] **T0**: Confirm the decidesk `ori-adoption` release is deployed on the
+  target instance(s): `occ app:list` shows the decidesk version containing the
+  importer; `occ decidesk:import-ori --dry-run --strict --source-register=ori`
+  runs and reports per-schema counts. Record the counts.
+
+- [ ] **T1**: Execute the data migration per the runbook in `design.md`:
+  dry-run → live run → **measured** parity verification (source register
+  counts vs `ori:*`-tagged decidesk counts via the OpenRegister API, using
+  `_limit`; `stemming` counts double as Decision + VotingRound) → feed
+  spot-check on decidesk. On mismatch: `occ decidesk:import-ori --rollback`,
+  diagnose, re-run. Do not proceed to T2 without recorded parity.
+
+- [ ] **T2**: Delete `lib/Settings/ori_register.json` and
+  `lib/Repair/RegisterOriRegister.php`; remove their `<install>` and
+  `<post-migration>` entries from `appinfo/info.xml`. Add
+  `lib/Repair/RetireOriRegister.php` (post-migration only) implementing the
+  fail-safe retirement from `design.md`: no-op without OpenRegister or without
+  an `ori` register; warn-and-keep while unmigrated objects exist; JSON backup
+  export then delete register + schemas once parity holds. PHPUnit-cover all
+  four branches (the guard must be shown able to say NO: a test seeds one
+  unmigrated object and asserts the register survives).
+
+- [ ] **T3**: Delete `lib/Cron/OriDataQualityCheck.php` and its `<job>` entry
+  in `appinfo/info.xml`; delete
+  `lib/Controller/RaadsinformatieFeedController.php` and the three
+  `/feed/ori/*.rss` route entries in `appinfo/routes.php`. Delete or repoint
+  their tests. Document the feed URL move (procest `/apps/procest/feed/ori/*`
+  → decidesk `/apps/decidesk/feed/ori/*`) in the release notes — no proxy, no
+  redirect.
+
+- [ ] **T4**: Cross-app meeting link — add the additive optional
+  `case.meetingRef` property (decidesk Meeting uuid) to
+  `lib/Settings/procest_register.json` (bump register version so the import is
+  not a no-op); rework `src/views/besluitvorming/VergaderingDetailView.vue` to
+  render case data + "Open meeting in decidesk" deep link / ADR-019 leaf, with
+  the quiet unavailable fallback when decidesk is absent or `meetingRef` is
+  empty. Keep the `/besluitvorming/vergaderingen/:id` route registered.
+  Correct the stale "created in the ORI register" header comment in
+  `lib/Service/VergaderingCaseService.php`.
+
+- [ ] **T5**: Run the grep gate from `design.md` (`ori_register`,
+  `register: 'ori'`, `RegisterOriRegister`, `OriDataQualityCheck`,
+  `RaadsinformatieFeed` over `lib/ src/ appinfo/`) — assert matches only in
+  `RetireOriRegister` + its tests AND that the searched file count is
+  non-zero. Run `composer check:strict`, the PHPUnit suite, and the
+  besluitvorming e2e (deep-link route still renders). Verify on a dev
+  instance: `occ upgrade` retires the register only after T1 parity, and a
+  fresh install creates no `ori` register.


### PR DESCRIPTION
OpenSpec change proposals — **artifacts only**. Every task box is unticked; nothing here is wired to anything yet, and each change gets picked up by `/opsx-apply` when it is scheduled.

Opened because these were sitting **untracked in the shared dev checkout across the fleet**. An untracked directory is one file-sweep away from being swept into an unrelated commit, and one branch switch away from being gone. These carry the design reasoning, not just a title, so losing them loses the thinking.

Each proposal is a complete artifact set — `proposal.md`, `design.md`, `tasks.md` and its spec delta.
