### PR TITLE
chore(deps): take hydra-gates v1.8.1 — the contract v1.8.0 shipped broken

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -516,16 +516,16 @@
         },
         {
             "name": "conduction/hydra-gates",
-            "version": "v1.8.0",
+            "version": "v1.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ConductionNL/.github.git",
-                "reference": "9fc64ab93f7a20b69f6b5912745ef9fc456c1cee"
+                "reference": "8e0e9857e54d6c680e157939e78a468e58d3751a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/9fc64ab93f7a20b69f6b5912745ef9fc456c1cee",
-                "reference": "9fc64ab93f7a20b69f6b5912745ef9fc456c1cee",
+                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/8e0e9857e54d6c680e157939e78a468e58d3751a",
+                "reference": "8e0e9857e54d6c680e157939e78a468e58d3751a",
                 "shasum": ""
             },
             "require": {
@@ -569,9 +569,9 @@
             "support": {
                 "docs": "https://github.com/ConductionNL/.github/blob/main/hydra-gates/README.md",
                 "issues": "https://github.com/ConductionNL/.github/issues",
-                "source": "https://github.com/ConductionNL/.github/tree/v1.8.0"
+                "source": "https://github.com/ConductionNL/.github/tree/v1.8.1"
             },
-            "time": "2026-08-15T06:24:48+00:00"
+            "time": "2026-08-20T05:07:22+00:00"
         },
         {
             "name": "consolidation/annotated-command",
@@ -8002,9 +8002,9 @@
         "php": "^8.3",
         "ext-zip": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.3"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
v1.8.0 shipped an `ObjectServiceInterface` **without `patchObject()`** and with `updateObject()` still summarised as "Apply a partial update to an existing object" — the exact wording that sent a consumer down the erasing path. The correction landed on `main` in `f8cad2f0`, two days after v1.8.0 was tagged; every app has been pinned to the broken copy ever since. v1.8.1 publishes it.

**Why every app and not just openregister.** `hydra-gates/composer.json` claims the app's own namespace:

```json
"psr-4": { "OCA\\OpenRegister\\Contract\\": "hydra-gates/contracts/" }
```

That is a *longer* prefix than openregister's own `OCA\OpenRegister\` → `lib/`, so the gate package wins. Nine repos vendor it, so under `OC_App::loadApps()` whichever app registers first defines the contract for the whole instance. Measured on a running instance:

```
WINNER: custom_apps/softwarecatalog/vendor/conduction/hydra-gates/.../ObjectServiceInterface.php
patchObject: NO
```

**softwarecatalog's** vendor directory was defining openregister's contract — and updating openregister alone did **not** change the winner. Verified empirically before opening these PRs.

v1.8.1 also carries everything else merged on `main` since v1.8.0 (63 commits), including gate-behaviour changes: phpcs errors fail the gate (#483), gate-8 judges how the caller consumes the null (#506), coverage-guard ignores deletions (#480), and the release step now bumps `openapi.json` alongside `appinfo/info.xml` (#515).

Lockfile only — the `^1.0` constraint already allowed this.