### PR TITLE
chore(deps): refresh the shared Conduction locks

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -516,16 +516,16 @@
         },
         {
             "name": "conduction/hydra-gates",
-            "version": "v1.8.1",
+            "version": "v1.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ConductionNL/.github.git",
-                "reference": "8e0e9857e54d6c680e157939e78a468e58d3751a"
+                "reference": "3dfcd1e56d27bd06eaa98a9a66e377e7e14fe491"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/8e0e9857e54d6c680e157939e78a468e58d3751a",
-                "reference": "8e0e9857e54d6c680e157939e78a468e58d3751a",
+                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/3dfcd1e56d27bd06eaa98a9a66e377e7e14fe491",
+                "reference": "3dfcd1e56d27bd06eaa98a9a66e377e7e14fe491",
                 "shasum": ""
             },
             "require": {
@@ -569,9 +569,9 @@
             "support": {
                 "docs": "https://github.com/ConductionNL/.github/blob/main/hydra-gates/README.md",
                 "issues": "https://github.com/ConductionNL/.github/issues",
-                "source": "https://github.com/ConductionNL/.github/tree/v1.8.1"
+                "source": "https://github.com/ConductionNL/.github/tree/v1.8.2"
             },
-            "time": "2026-08-20T05:07:22+00:00"
+            "time": "2026-08-20T09:37:12+00:00"
         },
         {
             "name": "consolidation/annotated-command",

--- a/package-lock.json
+++ b/package-lock.json
@@ -587,9 +587,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "2.8.2",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.8.2.tgz",
-			"integrity": "sha512-kqzqQ2uFyzpHUL6VxzNsfJ5iDOsy/S1iQ9UVn7W0w3CdlVb4RxWz5AFym/onB1eKewF2WtF+9vzBM5CHWsaHTQ==",
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.9.2.tgz",
+			"integrity": "sha512-79AFgzsNiTU9ltg4bEquumR0CFm7b4ed/jW5qEncPPSPWO82HEDwIIe0zm6x38oOegE2ESADiRDn02TW/qXeIQ==",
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@ckpack/vue-color": "^1.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -587,9 +587,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "2.9.2",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.9.2.tgz",
-			"integrity": "sha512-79AFgzsNiTU9ltg4bEquumR0CFm7b4ed/jW5qEncPPSPWO82HEDwIIe0zm6x38oOegE2ESADiRDn02TW/qXeIQ==",
+			"version": "2.10.1",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.10.1.tgz",
+			"integrity": "sha512-4S2X+Bv6mGzQMfxZW8XJheJ8iFis+iJdrl3+hlchYl50qQ77TDWy2xsp9Dog+ggfOikfngzmJseF5kz2MHZt4A==",
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@ckpack/vue-color": "^1.6.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -28,6 +28,24 @@ parameters:
         DataResponseType: 'array|int|float|string|bool|object|null|\stdClass|\JsonSerializable'
 
     ignoreErrors:
+        # ApprovalStepNotificationListener dispatches on ANOTHER APP's event classes.
+        #
+        # It compares get_class($event) against
+        # 'OCA\OpenRegister\Event\ApprovalStepApprovedEvent' / ...RejectedEvent,
+        # held as string constants precisely so Procest carries no hard dependency
+        # on OpenRegister. Those classes therefore do not exist in this app's
+        # vendor tree, so the analyser types get_class($event) as
+        # class-string<Event>, decides neither comparison can ever match, and
+        # reports both as always-false. At runtime OpenRegister is installed and
+        # dispatches them.
+        #
+        # Surfaced by hydra-gates v1.8.2's `treatPhpDocTypesAsCertain: false`.
+        # Scoped to the one file: an always-false class comparison anywhere else
+        # is still a real finding.
+        -
+            message: '#Strict comparison using === between class-string#'
+            path: lib/Listener/ApprovalStepNotificationListener.php
+
         # registerJob exists on server; not yet in nextcloud/ocp stub used for analysis
         - '#Call to an undefined method OCP\\AppFramework\\Bootstrap\\IRegistrationContext::registerJob#'
         # registerEventListener accepts the listener FQCN string at runtime; the


### PR DESCRIPTION
Weekly refresh of the two shared Conduction packages. **Lock-only** - both are
already declared with caret ranges that permit these versions, so what this app
*accepts* is unchanged; only what it currently resolves to moves.

| package | was | now |
|---|---|---|
| conduction/hydra-gates | v1.8.1 | v1.8.2 |
| @conduction/nextcloud-vue | 2.8.2 | 2.9.2 |

**Why this is automated.** Nothing here was ever pinned on purpose. The caret
always allowed the newer release; the lockfile is what froze it, and nobody
re-resolves a lock unless they happen to be touching dependencies. Measured
across the fleet on 2026-08-20: every app sat on hydra-gates v1.8.0 while
v1.8.1 was out, and fourteen sat below nc-vue 2.7.0 - twelve of them on 2.3.0.
Neither number was a decision.

**Why it is a PR and not a push.** Because a shared bump is not always safe and
this repository's suite is what knows. Taking hydra-gates v1.8.1 added
patchObject() to a published interface, which is a load-time fatal for any
concrete test double implementing it without the method - the suite dies before
a single test runs. Two apps needed stub updates first.

**If this PR is red, fix it on this branch.** While it stays open the weekly run
skips this app entirely and will not touch your commits - it never force-pushes
and never reuses a branch.

Opened by fleet-shared-dep-bump.yml in ConductionNL/.github.
