### PR TITLE
chore(deps): refresh the shared Conduction locks

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -53,20 +53,20 @@ Vrij en open source onder de EUPL-1.2-licentie.
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>Procest</namespace>
     <documentation>
-        <user>https://codeberg.org/Conduction/procest</user>
-        <admin>https://codeberg.org/Conduction/procest</admin>
-        <developer>https://codeberg.org/Conduction/procest</developer>
+        <user>https://github.com/ConductionNL/dossiq</user>
+        <admin>https://github.com/ConductionNL/dossiq</admin>
+        <developer>https://github.com/ConductionNL/dossiq</developer>
     </documentation>
     <category>organization</category>
     <category>tools</category>
     <category>workflow</category>
-    <website>https://codeberg.org/Conduction/procest</website>
-    <bugs>https://codeberg.org/Conduction/procest/issues</bugs>
-    <repository>https://codeberg.org/Conduction/procest</repository>
+    <website>https://github.com/ConductionNL/dossiq</website>
+    <bugs>https://github.com/ConductionNL/dossiq/issues</bugs>
+    <repository>https://github.com/ConductionNL/dossiq</repository>
 
-    <screenshot>https://codeberg.org/Conduction/procest/raw/branch/main/img/screenshot-dashboard.png</screenshot>
-    <screenshot>https://codeberg.org/Conduction/procest/raw/branch/main/img/screenshot-cases.png</screenshot>
-    <screenshot>https://codeberg.org/Conduction/procest/raw/branch/main/img/screenshot-admin.png</screenshot>
+    <screenshot>https://raw.githubusercontent.com/ConductionNL/dossiq/main/img/screenshot-dashboard.png</screenshot>
+    <screenshot>https://raw.githubusercontent.com/ConductionNL/dossiq/main/img/screenshot-cases.png</screenshot>
+    <screenshot>https://raw.githubusercontent.com/ConductionNL/dossiq/main/img/screenshot-admin.png</screenshot>
 
     <dependencies>
         <php min-version="8.3"/>

--- a/composer.lock
+++ b/composer.lock
@@ -516,16 +516,16 @@
         },
         {
             "name": "conduction/hydra-gates",
-            "version": "v1.8.2",
+            "version": "v1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ConductionNL/.github.git",
-                "reference": "3dfcd1e56d27bd06eaa98a9a66e377e7e14fe491"
+                "reference": "9801ffdbff17d05f0934742190742d733ac912b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/3dfcd1e56d27bd06eaa98a9a66e377e7e14fe491",
-                "reference": "3dfcd1e56d27bd06eaa98a9a66e377e7e14fe491",
+                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/9801ffdbff17d05f0934742190742d733ac912b4",
+                "reference": "9801ffdbff17d05f0934742190742d733ac912b4",
                 "shasum": ""
             },
             "require": {
@@ -540,11 +540,6 @@
                     "runner": "hydra-gates/scripts/run-hydra-gates.sh",
                     "helpers": "hydra-gates/scripts/lib",
                     "schemas": "hydra-gates/scripts/schemas"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "OCA\\OpenRegister\\Contract\\": "hydra-gates/contracts/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -569,9 +564,9 @@
             "support": {
                 "docs": "https://github.com/ConductionNL/.github/blob/main/hydra-gates/README.md",
                 "issues": "https://github.com/ConductionNL/.github/issues",
-                "source": "https://github.com/ConductionNL/.github/tree/v1.8.2"
+                "source": "https://github.com/ConductionNL/.github/tree/v1.9.0"
             },
-            "time": "2026-08-20T09:37:12+00:00"
+            "time": "2026-08-22T00:30:18+00:00"
         },
         {
             "name": "consolidation/annotated-command",

--- a/package-lock.json
+++ b/package-lock.json
@@ -587,9 +587,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "2.10.1",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.10.1.tgz",
-			"integrity": "sha512-4S2X+Bv6mGzQMfxZW8XJheJ8iFis+iJdrl3+hlchYl50qQ77TDWy2xsp9Dog+ggfOikfngzmJseF5kz2MHZt4A==",
+			"version": "2.11.1",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.11.1.tgz",
+			"integrity": "sha512-E5oB7KUXL2JO68nMItsmL8kepmx6omI6SqDnKm04U7y81ipRASeyyh9bIB9ViT8/yHsqjBIF2VkwnvIwcuTfFQ==",
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@ckpack/vue-color": "^1.6.0",


### PR DESCRIPTION
Weekly refresh of the two shared Conduction packages. **Lock-only** - both are
already declared with caret ranges that permit these versions, so what this app
*accepts* is unchanged; only what it currently resolves to moves.

| package | was | now |
|---|---|---|
| conduction/hydra-gates | v1.8.2 | v1.9.0 |
| @conduction/nextcloud-vue | 2.10.1 | 2.11.1 |

**Why this is automated.** Nothing here was ever pinned on purpose. The caret
always allowed the newer release; the lockfile is what froze it, and nobody
re-resolves a lock unless they happen to be touching dependencies. Measured
across the fleet on 2026-08-20: every app sat on hydra-gates v1.8.0 while
v1.8.1 was out, and fourteen sat below nc-vue 2.7.0 - twelve of them on 2.3.0.
Neither number was a decision.

**Why it is a PR and not a push.** Because a shared bump is not always safe and
this repository's suite is what knows. Taking hydra-gates v1.8.1 added
patchObject() to a published interface, which is a load-time fatal for any
concrete test double implementing it without the method - the suite dies before
a single test runs. Two apps needed stub updates first.

**If this PR is red, fix it on this branch.** While it stays open the weekly run
skips this app entirely and will not touch your commits - it never force-pushes
and never reuses a branch.

Opened by fleet-shared-dep-bump.yml in ConductionNL/.github.
