### PR TITLE
fix(transitions): create tasks with a status the schema allows

### DIFF
--- a/lib/Service/Transitions/CreateTaskHandler.php
+++ b/lib/Service/Transitions/CreateTaskHandler.php
@@ -74,7 +74,10 @@ class CreateTaskHandler implements ActionHandlerInterface {
 			$task = [
 				'title' => (string)($actionConfig['title'] ?? sprintf('Taak na transitie %s', $transitionContext['transitionLabel'] ?? '')),
 				'case' => $caseId,
-				'status' => 'open',
+				// The task schema's lifecycle starts at 'available' (enum:
+				// available|active|completed|terminated|disabled). Writing 'open'
+				// produced an object no transition could advance.
+				'status' => 'available',
 				'assignee' => (string)($actionConfig['assignee'] ?? ''),
 			];
 

--- a/tests/Unit/Service/Transitions/CreateTaskHandlerTest.php
+++ b/tests/Unit/Service/Transitions/CreateTaskHandlerTest.php
@@ -130,7 +130,15 @@ class CreateTaskHandlerTest extends TestCase {
 		self::assertSame('Review docs', $recorded['object']['title']);
 		self::assertSame('case-9', $recorded['object']['case']);
 		self::assertSame('alice', $recorded['object']['assignee']);
-		self::assertSame('open', $recorded['object']['status']);
+		// The task schema declares enum available|active|completed|terminated|disabled
+		// with initial state 'available'. A status outside that enum yields a task no
+		// lifecycle transition can advance, so assert the declared initial state.
+		self::assertSame('available', $recorded['object']['status']);
+		self::assertContains(
+			$recorded['object']['status'],
+			['available', 'active', 'completed', 'terminated', 'disabled'],
+			'CreateTaskHandler must write a status the task schema allows'
+		);
 		self::assertSame('reg-1', $recorded['register']);
 		self::assertSame('task-schema', $recorded['schema']);
 	}//end testCreatesTaskWithCaseLinkAndAssigneeOnSuccess()


### PR DESCRIPTION
Closes #1325

## Problem

`CreateTaskHandler` wrote `'status' => 'open'`, but the `task` schema declares:

- `enum`: `available | active | completed | terminated | disabled`
- `default` / lifecycle `initial`: `available`

`open` is in neither the enum nor any transition. Every task created by a workflow `createTask` action — reachable from any published `workflowTemplate` — was persisted in a state **no lifecycle transition could advance**, and consumers filtering on the declared enum skipped it without error.

## Fix

Write `available`, the declared initial state.

## The test was part of the problem

`CreateTaskHandlerTest` asserted `self::assertSame('open', ...)` — it locked the defect in place, so the suite stayed green while the behaviour was wrong. It now asserts the initial state **and** that the written value is a member of the schema enum, so a future drift fails loudly rather than being ratified.

## Verification

```
OK (4 tests, 15 assertions)
```

## Context

Found during the ADR-098 fleet task inventory (ConductionNL/hydra#609), which will migrate `task` onto a fleet-generic task entity. Fixing it before migration means the migration does not have to carry an out-of-enum value.