### PR TITLE
fix(register): point x-openregister.app at the new app id, and migrate the schemas it orphans

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -172,6 +172,20 @@ Vrij en open source onder de EUPL-1.2-licentie.
                 Ahead of the import trigger, InitializeSettings.
             -->
             <step>OCA\Dossiq\Repair\RenameDutchSchemaSlugs</step>
+            <!--
+                Same ordering argument as the slug rename above, one field over.
+                The descriptor now declares x-openregister.app = dossiq, but the
+                existing schemas still carry application = procest, and
+                ImportHandler matches a schema on the PAIR
+                (findByApplicationAndSlug, lower(slug)). Left alone, the import
+                would miss every one of them, take its "not found, will create
+                new one" branch, and fork a second EMPTY set under dossiq while
+                the originals and their objects stay behind — again presenting
+                as an app with no records rather than as an error. Re-pointing
+                the application id first makes the import recognise them.
+                Ahead of the import trigger, InitializeSettings.
+            -->
+            <step>OCA\Dossiq\Repair\MigrateRegisterApplicationId</step>
             <step>OCA\Dossiq\Repair\InitializeSettings</step>
             <step>OCA\Dossiq\Repair\LoadDefaultZgwMappings</step>
             <step>OCA\Dossiq\Repair\SeedBezwaarBeroepData</step>
@@ -275,6 +289,16 @@ Vrij en open source onder de EUPL-1.2-licentie.
             -->
             <step>OCA\Dossiq\Repair\MigrateAppConfigKeys</step>
             <step>OCA\Dossiq\Repair\MigrateUserPreferences</step>
+            <!--
+                Declared here for exactly the reason the block comment above
+                gives, and this step depends on it more than most: the instances
+                that need the procest -> dossiq application migration are
+                precisely the ones where Nextcloud sees `dossiq` as a NEW app
+                and fires <install> only. Declared solely in post-migration it
+                would never run where it matters. Idempotent, so the duplicate
+                declaration is free.
+            -->
+            <step>OCA\Dossiq\Repair\MigrateRegisterApplicationId</step>
             <step>OCA\Dossiq\Repair\InitializeSettings</step>
             <step>OCA\Dossiq\Repair\LoadDefaultZgwMappings</step>
             <step>OCA\Dossiq\Repair\SeedBezwaarBeroepData</step>

--- a/lib/Repair/MigrateRegisterApplicationId.php
+++ b/lib/Repair/MigrateRegisterApplicationId.php
@@ -53,6 +53,12 @@ use Psr\Log\LoggerInterface;
 
 /**
  * Move the register and its schemas onto the `dossiq` application id.
+ *
+ * @spec exclude No canonical spec covers the procest-to-dossiq application
+ *  migration — it is a one-shot consequence of the app-id rename, not a
+ *  capability. Pointing this at an existing spec would report conformance to a
+ *  requirement that says nothing about it, which is the same reasoning the
+ *  sibling RenameDutchSchemaSlugs records for the slug half of the problem.
  */
 class MigrateRegisterApplicationId implements IRepairStep {
 	/**
@@ -86,6 +92,8 @@ class MigrateRegisterApplicationId implements IRepairStep {
 	 *
 	 * @param ContainerInterface $container The server container.
 	 * @param LoggerInterface    $logger    The logger.
+	 *
+	 * @spec exclude One-shot app-id rename migration; see the class docblock.
 	 */
 	public function __construct(
 		private readonly ContainerInterface $container,
@@ -99,6 +107,8 @@ class MigrateRegisterApplicationId implements IRepairStep {
 	 * Step name.
 	 *
 	 * @return string The human-readable step name.
+	 *
+	 * @spec exclude One-shot app-id rename migration; see the class docblock.
 	 */
 	public function getName(): string {
 		return 'Move the Dossiq register and schemas onto the dossiq application id';
@@ -116,6 +126,8 @@ class MigrateRegisterApplicationId implements IRepairStep {
 	 * @param IOutput $output The migration output.
 	 *
 	 * @return void
+	 *
+	 * @spec exclude One-shot app-id rename migration; see the class docblock.
 	 */
 	public function run(IOutput $output): void {
 		if (class_exists(self::MIGRATOR) === false) {

--- a/lib/Repair/MigrateRegisterApplicationId.php
+++ b/lib/Repair/MigrateRegisterApplicationId.php
@@ -1,0 +1,180 @@
+<?php
+
+/**
+ * Dossiq register-application migration repair step
+ *
+ * Re-points the register and its schemas from the `procest` application id to
+ * `dossiq` before the register import runs.
+ *
+ * WHY THIS IS NEEDED, AND WHY IT MUST RUN FIRST. The register descriptor's
+ * `x-openregister.app` names the owning application. OpenRegister's
+ * ImportHandler resolves the two halves by different keys: a register is
+ * matched by SLUG alone and then has setApplication() applied, so it follows a
+ * rename by itself, while a schema is matched by findByApplicationAndSlug() —
+ * the PAIR, on lower(slug).
+ *
+ * So once `x-openregister.app` says `dossiq`, every schema lookup misses the
+ * schemas that still say `procest`. The import does not fail and does not warn:
+ * it takes the "not found, will create new one" branch and builds a second,
+ * EMPTY set of schemas under `dossiq`, while the originals and every object
+ * stored against them stay behind under `procest`. The UI then renders empty
+ * collections and the API 404s for `procest-<schema>` — a rename that silently
+ * half-happened, presented to the user as missing data.
+ *
+ * Running BEFORE InitializeSettings means the schemas already carry the new
+ * application id when the import looks for them, so the import updates the
+ * originals instead of forking them.
+ *
+ * NOT THE REGISTER SLUG. The register keeps its slug `procest` — that is an
+ * identifier written into stored data and referenced by 77 manifest pages, and
+ * it does not move with the app id. Only the `application` column changes here.
+ *
+ * @category Repair
+ * @package  OCA\Dossiq\Repair
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.conduction.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Dossiq\Repair;
+
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Move the register and its schemas onto the `dossiq` application id.
+ */
+class MigrateRegisterApplicationId implements IRepairStep {
+	/**
+	 * OpenRegister's migration service, resolved by name at runtime.
+	 *
+	 * A string rather than an import: dossiq must install and boot on an
+	 * instance without OpenRegister, so this is a duck-typed lookup guarded by
+	 * class_exists() — the same shape MigrateArchivalToOpenRegister uses.
+	 *
+	 * @var string
+	 */
+	private const MIGRATOR = 'OCA\OpenRegister\Service\SchemaApplicationMigrator';
+
+	/**
+	 * The application id this app used to be published under.
+	 *
+	 * @var string
+	 */
+	private const OLD_APP_ID = 'procest';
+
+	/**
+	 * The application id this app is published under now.
+	 *
+	 * @var string
+	 */
+	private const NEW_APP_ID = 'dossiq';
+
+
+	/**
+	 * Constructor.
+	 *
+	 * @param ContainerInterface $container The server container.
+	 * @param LoggerInterface    $logger    The logger.
+	 */
+	public function __construct(
+		private readonly ContainerInterface $container,
+		private readonly LoggerInterface $logger,
+	) {
+
+	}//end __construct()
+
+
+	/**
+	 * Step name.
+	 *
+	 * @return string The human-readable step name.
+	 */
+	public function getName(): string {
+		return 'Move the Dossiq register and schemas onto the dossiq application id';
+
+	}//end getName()
+
+
+	/**
+	 * Run the migration.
+	 *
+	 * Never throws into the upgrade: a failure here leaves the estate exactly as
+	 * it was (the old ids still own everything), which the next run retries.
+	 * Aborting the whole app upgrade would be a worse outcome than a warning.
+	 *
+	 * @param IOutput $output The migration output.
+	 *
+	 * @return void
+	 */
+	public function run(IOutput $output): void {
+		if (class_exists(self::MIGRATOR) === false) {
+			// Either OpenRegister is absent, or it predates the migrator. Both
+			// are legitimate; say which is being skipped rather than passing
+			// silently, because a silent skip here looks identical to a
+			// migration that ran and found nothing.
+			$output->info(
+				'OpenRegister\'s SchemaApplicationMigrator is not available; '
+				. 'skipping the ' . self::OLD_APP_ID . ' -> ' . self::NEW_APP_ID . ' application migration.'
+			);
+			return;
+		}
+
+		try {
+			$migrator = $this->container->get(self::MIGRATOR);
+			$result   = $migrator->migrate(self::OLD_APP_ID, self::NEW_APP_ID);
+		} catch (\Throwable $e) {
+			$output->warning('Could not migrate the register application id: ' . $e->getMessage());
+			$this->logger->error(
+				'Dossiq: register application migration failed',
+				['exception' => $e->getMessage()]
+			);
+			return;
+		}
+
+		if (($result['ok'] ?? false) === false) {
+			$reason = (string)($result['reason'] ?? 'unknown');
+			if ($reason === 'collisions') {
+				$slugs = implode(', ', (array)($result['collisions'] ?? []));
+				$output->warning(
+					'Refused: these schema slugs already exist under "' . self::NEW_APP_ID . '": ' . $slugs
+					. '. An import has already forked them; run occ openregister:schemas:dedup, then re-run the upgrade.'
+				);
+				$this->logger->warning(
+					'Dossiq: register application migration refused, forked schemas present',
+					['collisions' => $slugs]
+				);
+				return;
+			}
+
+			$output->warning('Register application migration did not run: ' . $reason);
+			return;
+		}
+
+		$schemas   = (int)($result['schemas'] ?? 0);
+		$registers = (int)($result['registers'] ?? 0);
+
+		if (($schemas + $registers) === 0) {
+			$output->info('Register application id already migrated; nothing to move.');
+			return;
+		}
+
+		$output->info(
+			'Moved ' . $schemas . ' schema(s) and ' . $registers . ' register(s) from "'
+			. self::OLD_APP_ID . '" to "' . self::NEW_APP_ID . '".'
+		);
+
+	}//end run()
+
+
+}//end class

--- a/lib/Settings/dossiq_register.json
+++ b/lib/Settings/dossiq_register.json
@@ -7,7 +7,7 @@
     },
     "x-openregister": {
         "type": "application",
-        "app": "procest",
+        "app": "dossiq",
         "openregister": "^v0.2.10",
         "description": "Case management (zaakgericht werken) for Nextcloud"
     },

--- a/tests/Stubs/OpenRegister/SchemaApplicationMigratorStub.php
+++ b/tests/Stubs/OpenRegister/SchemaApplicationMigratorStub.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * Test stub for OpenRegister's SchemaApplicationMigrator.
+ *
+ * MigrateRegisterApplicationId resolves this class BY NAME (dossiq must boot on
+ * an instance without OpenRegister, so there is no import to point at). A stub
+ * declared under the real FQN is therefore the only way to exercise the
+ * repair step's branches; without it class_exists() is false and every test
+ * would take the "not available" path and prove nothing about the rest.
+ *
+ * Guarded by class_exists so a real OpenRegister on the include path always
+ * wins over this.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service;
+
+if (class_exists('OCA\OpenRegister\Service\SchemaApplicationMigrator', false) === false) {
+	/**
+	 * Minimal stand-in for the real migrator.
+	 */
+	class SchemaApplicationMigrator {
+		/**
+		 * The canned outcome returned by migrate().
+		 *
+		 * @var array<string, mixed>
+		 */
+		public static array $outcome = [
+			'ok'         => true,
+			'reason'     => 'migrated',
+			'collisions' => [],
+			'schemas'    => 0,
+			'registers'  => 0,
+		];
+
+		/**
+		 * Arguments the step passed, for assertion.
+		 *
+		 * @var array<int, string>
+		 */
+		public static array $calledWith = [];
+
+		/**
+		 * Whether migrate() should throw.
+		 *
+		 * @var bool
+		 */
+		public static bool $throws = false;
+
+
+		/**
+		 * Record the call and return the canned outcome.
+		 *
+		 * @param string $from The current application id.
+		 * @param string $to   The new application id.
+		 *
+		 * @return array<string, mixed> The canned outcome.
+		 */
+		public function migrate(string $from, string $to): array {
+			self::$calledWith = [$from, $to];
+
+			if (self::$throws === true) {
+				throw new \RuntimeException('database is on fire');
+			}
+
+			return self::$outcome;
+
+		}//end migrate()
+
+
+	}//end class
+}//end if

--- a/tests/Unit/Repair/MigrateRegisterApplicationIdTest.php
+++ b/tests/Unit/Repair/MigrateRegisterApplicationIdTest.php
@@ -1,0 +1,173 @@
+<?php
+
+/**
+ * MigrateRegisterApplicationId unit tests
+ *
+ * @category Test
+ * @package  OCA\Dossiq\Tests\Unit\Repair
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Dossiq\Tests\Unit\Repair;
+
+use OCA\Dossiq\Repair\MigrateRegisterApplicationId;
+use OCA\OpenRegister\Service\SchemaApplicationMigrator;
+use OCP\Migration\IOutput;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+require_once __DIR__ . '/../../Stubs/OpenRegister/SchemaApplicationMigratorStub.php';
+
+/**
+ * Covers the repair step that re-points the register onto the dossiq app id.
+ */
+class MigrateRegisterApplicationIdTest extends TestCase {
+
+	/**
+	 * Reset the stub between tests.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		SchemaApplicationMigrator::$calledWith = [];
+		SchemaApplicationMigrator::$throws     = false;
+		SchemaApplicationMigrator::$outcome    = [
+			'ok'         => true,
+			'reason'     => 'migrated',
+			'collisions' => [],
+			'schemas'    => 0,
+			'registers'  => 0,
+		];
+
+	}//end setUp()
+
+
+	/**
+	 * Build the step with a container that returns the stub migrator.
+	 *
+	 * @return MigrateRegisterApplicationId The step under test.
+	 */
+	private function step(): MigrateRegisterApplicationId {
+		$container = $this->createMock(ContainerInterface::class);
+		$container->method('get')->willReturn(new SchemaApplicationMigrator());
+
+		return new MigrateRegisterApplicationId($container, $this->createMock(LoggerInterface::class));
+
+	}//end step()
+
+
+	/**
+	 * The migration is requested for procest -> dossiq, in that direction.
+	 *
+	 * The direction is the whole point: reversed, it would move a correctly
+	 * migrated estate back onto the retired id.
+	 *
+	 * @return void
+	 */
+	public function testMigratesFromProcestToDossiq(): void {
+		SchemaApplicationMigrator::$outcome['schemas'] = 12;
+
+		$this->step()->run($this->createMock(IOutput::class));
+
+		$this->assertSame(['procest', 'dossiq'], SchemaApplicationMigrator::$calledWith);
+
+	}//end testMigratesFromProcestToDossiq()
+
+
+	/**
+	 * A successful move reports the counts.
+	 *
+	 * @return void
+	 */
+	public function testReportsWhatItMoved(): void {
+		SchemaApplicationMigrator::$outcome['schemas']   = 12;
+		SchemaApplicationMigrator::$outcome['registers'] = 1;
+
+		$output = $this->createMock(IOutput::class);
+		$output->expects($this->once())
+			->method('info')
+			->with($this->stringContains('Moved 12 schema(s) and 1 register(s)'));
+
+		$this->step()->run($output);
+
+	}//end testReportsWhatItMoved()
+
+
+	/**
+	 * A second run reports "already migrated" rather than a bare success.
+	 *
+	 * Zero moved rows is the idempotent case, and saying so is what keeps it
+	 * distinguishable from a run that did work.
+	 *
+	 * @return void
+	 */
+	public function testSecondRunSaysAlreadyMigrated(): void {
+		$output = $this->createMock(IOutput::class);
+		$output->expects($this->once())
+			->method('info')
+			->with($this->stringContains('already migrated'));
+
+		$this->step()->run($output);
+
+	}//end testSecondRunSaysAlreadyMigrated()
+
+
+	/**
+	 * A refusal names the colliding slugs and the command that resolves them.
+	 *
+	 * @return void
+	 */
+	public function testRefusalNamesTheCollidingSlugs(): void {
+		SchemaApplicationMigrator::$outcome = [
+			'ok'         => false,
+			'reason'     => 'collisions',
+			'collisions' => ['case', 'casetype'],
+			'schemas'    => 0,
+			'registers'  => 0,
+		];
+
+		$output = $this->createMock(IOutput::class);
+		$output->expects($this->once())
+			->method('warning')
+			->with($this->logicalAnd(
+				$this->stringContains('case, casetype'),
+				$this->stringContains('openregister:schemas:dedup')
+			));
+
+		$this->step()->run($output);
+
+	}//end testRefusalNamesTheCollidingSlugs()
+
+
+	/**
+	 * A throwing migrator warns instead of aborting the upgrade.
+	 *
+	 * Letting this bubble would fail the whole app upgrade over a migration
+	 * that the next run can simply retry — the estate is untouched either way.
+	 *
+	 * @return void
+	 */
+	public function testAThrowingMigratorDoesNotAbortTheUpgrade(): void {
+		SchemaApplicationMigrator::$throws = true;
+
+		$output = $this->createMock(IOutput::class);
+		$output->expects($this->once())
+			->method('warning')
+			->with($this->stringContains('database is on fire'));
+
+		$this->step()->run($output);
+
+	}//end testAThrowingMigratorDoesNotAbortTheUpgrade()
+
+
+}//end class


### PR DESCRIPTION
Points `x-openregister.app` at `dossiq`, **and adds the migration without which that one line is actively harmful**.

## Why the one-line change could not ship alone

The first CI run on this branch went red: the Bezwaar page 404'd on `procest-bezwaaradviescommissie`.

OpenRegister's `ImportHandler` resolves an app's register and its schemas by **different keys**:

| | matched by | follows a rename? |
|---|---|---|
| register | `registerMapper->find($data['slug'])`, then `setApplication($appId)` | **yes, by itself** |
| schema | `findByApplicationAndSlug($slug, $appId)` — the *pair*, on `lower(slug)` | **no** |

So the moment the descriptor says `dossiq`, every schema lookup misses the schemas that still say `procest`. The import neither fails nor warns — it takes its `"not found, will create new one"` branch and builds a second, **empty** set of schemas under `dossiq`, while the originals and every object stored against them stay behind. The user sees an app with no records, not an error.

## What was added

`MigrateRegisterApplicationId`, a repair step that re-points them **before** `InitializeSettings` triggers the import. It delegates to OpenRegister's `SchemaApplicationMigrator` (ConductionNL/openregister#2811) rather than carrying a second copy of the rule — a migration rule with two implementations drifts, and the copy that drifts is the one nobody runs interactively.

**Declared in both repair blocks, and that is load-bearing.** To Nextcloud, `dossiq` is a *brand-new app*, so on exactly the instances that need this migration it fires `<install>` and never `<post-migration>`. Declared only in the latter, it would run everywhere except where it matters.

## What deliberately does NOT move

The register keeps its slug `procest` — and so do the 77 manifest `"register"` references, `fixtures.ts`'s `REGISTER`, and `ci-seed.sh`'s `objects/procest/<schema>` paths. That identifier is written into stored data; only the `application` column changes here. Two different identifiers that happen to share a spelling, and renaming the wrong one points the app at a register holding nothing.

## Failure behaviour

- Migrator absent (no OpenRegister, or an older one) → says **which** situation it is, because a silent skip is indistinguishable from a migration that ran and found nothing.
- Migrator throws → warns, does not abort the upgrade. The estate is untouched either way and the next run retries.
- Slug already forked under the new id → refuses, names the slugs, points at `openregister:schemas:dedup`.

## Verification

Tests cover the direction (reversed, it would move a healthy estate back onto the retired id), the counts, the idempotent second run, the refusal, and the throw.

```
phpunit  OK (5 tests, 5 assertions)
phpcs    clean
phpmd    exit 0
psalm    0 errors
info.xml validates against the appstore schema
```

**Depends on ConductionNL/openregister#2811** — merge that first, or the repair step logs "migrator not available" and skips.