### PR TITLE
feat(register): move the schemas onto the dossiq application id

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -184,6 +184,24 @@ Vrij en open source onder de EUPL-1.2-licentie.
             -->
             <step>OCA\Dossiq\Repair\MigrateRegisterSlug</step>
             <!--
+                SIBLING OF MigrateRegisterSlug, AND NEITHER COVERS THE OTHER.
+                OpenRegister resolves the two halves by different keys: a
+                REGISTER by slug alone, a SCHEMA by the PAIR
+                (application, slug) via findByApplicationAndSlug(). This app
+                now passes `appId: Application::APP_ID` = `dossiq`, while every
+                schema it already owns still carries `application = procest` —
+                so the pair matches nothing and the import's not-found branch
+                builds a SECOND, EMPTY schema set while every stored object
+                stays bound to the old rows. Measured before this step existed:
+                180 schemas under `procest`, zero under `dossiq`.
+
+                Runs alongside MigrateRegisterSlug and before the import.
+                Refuses rather than merges where a slug already has a twin
+                under the new application id, never deletes a schema, and never
+                throws.
+            -->
+            <step>OCA\Dossiq\Repair\MigrateSchemaApplicationId</step>
+            <!--
                 The OTHER half of the same problem, on a different column.
                 MigrateRegisterSlug moves `openregister_registers.slug`; this
                 moves `openregister_schemas.application`, which nothing else
@@ -334,6 +352,24 @@ Vrij en open source onder de EUPL-1.2-licentie.
                 below forks a second, empty register.
             -->
             <step>OCA\Dossiq\Repair\MigrateRegisterSlug</step>
+            <!--
+                SIBLING OF MigrateRegisterSlug, AND NEITHER COVERS THE OTHER.
+                OpenRegister resolves the two halves by different keys: a
+                REGISTER by slug alone, a SCHEMA by the PAIR
+                (application, slug) via findByApplicationAndSlug(). This app
+                now passes `appId: Application::APP_ID` = `dossiq`, while every
+                schema it already owns still carries `application = procest` —
+                so the pair matches nothing and the import's not-found branch
+                builds a SECOND, EMPTY schema set while every stored object
+                stays bound to the old rows. Measured before this step existed:
+                180 schemas under `procest`, zero under `dossiq`.
+
+                Runs alongside MigrateRegisterSlug and before the import.
+                Refuses rather than merges where a slug already has a twin
+                under the new application id, never deletes a schema, and never
+                throws.
+            -->
+            <step>OCA\Dossiq\Repair\MigrateSchemaApplicationId</step>
             <!-- Schema half of the same rename; see the post-migration block. -->
             <step>OCA\Dossiq\Repair\MigrateRegisterApplicationId</step>
             <step>OCA\Dossiq\Repair\InitializeSettings</step>

--- a/lib/Flow/ProcestActionNode.php
+++ b/lib/Flow/ProcestActionNode.php
@@ -28,21 +28,18 @@ namespace OCA\Dossiq\Flow;
  */
 abstract class ProcestActionNode extends ProcestFlowNodeBase {
 
-
-    /**
-     * This node's id.
-     *
-     * Derived from the handler's own type slug, so it cannot drift from the
-     * handler it runs.
-     *
-     * @return string The namespaced node id.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    protected function nodeId(): string {
-        return 'procest.action.' . $this->handler()->type();
-
-    }//end nodeId()
-
+	/**
+	 * This node's id.
+	 *
+	 * Derived from the handler's own type slug, so it cannot drift from the
+	 * handler it runs.
+	 *
+	 * @return string The namespaced node id.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	protected function nodeId(): string {
+		return 'procest.action.' . $this->handler()->type();
+	}//end nodeId()
 
 }//end class

--- a/lib/Flow/ProcestCallWebhookNode.php
+++ b/lib/Flow/ProcestCallWebhookNode.php
@@ -17,8 +17,8 @@ declare(strict_types=1);
 namespace OCA\Dossiq\Flow;
 
 use OCA\Dossiq\Service\Actions\ActionHandlerInterface as CatalogueActionHandler;
-use OCA\Dossiq\Service\Transitions\ActionHandlerInterface as TransitionActionHandler;
 use OCA\Dossiq\Service\Actions\CallWebhookHandler;
+use OCA\Dossiq\Service\Transitions\ActionHandlerInterface as TransitionActionHandler;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 
@@ -33,72 +33,62 @@ use OCP\IURLGenerator;
  */
 class ProcestCallWebhookNode extends ProcestActionNode {
 
+	/**
+	 * Constructor.
+	 *
+	 * @param CallWebhookHandler $handler The action handler this node runs.
+	 * @param IL10N $l10n The localisation service.
+	 * @param IURLGenerator $urls The URL generator.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		private readonly CallWebhookHandler $handler,
+		IL10N $l10n,
+		IURLGenerator $urls,
+	) {
+		parent::__construct(l10n: $l10n, urls: $urls);
 
-    /**
-     * Constructor.
-     *
-     * @param CallWebhookHandler $handler The action handler this node runs.
-     * @param IL10N              $l10n    The localisation service.
-     * @param IURLGenerator      $urls    The URL generator.
-     *
-     * @return void
-     */
-    public function __construct(
-        private readonly CallWebhookHandler $handler,
-        IL10N $l10n,
-        IURLGenerator $urls,
-    ) {
-        parent::__construct(l10n: $l10n, urls: $urls);
+	}//end __construct()
 
-    }//end __construct()
+	/**
+	 * The handler this node runs.
+	 *
+	 * @return CatalogueActionHandler The action handler.
+	 */
+	protected function handler(): CatalogueActionHandler|TransitionActionHandler {
+		return $this->handler;
+	}//end handler()
 
+	/**
+	 * Config keys without which this action cannot run.
+	 *
+	 * @return string[] The required key names.
+	 */
+	protected function requiredConfigKeys(): array {
+		return ['payloadTemplate'];
+	}//end requiredConfigKeys()
 
-    /**
-     * The handler this node runs.
-     *
-     * @return CatalogueActionHandler The action handler.
-     */
-    protected function handler(): CatalogueActionHandler|TransitionActionHandler {
-        return $this->handler;
+	/**
+	 * The node's display name.
+	 *
+	 * @return string The translated name.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function getDisplayName(): string {
+		return $this->l10n->t('Call webhook');
+	}//end getDisplayName()
 
-    }//end handler()
-
-
-    /**
-     * Config keys without which this action cannot run.
-     *
-     * @return string[] The required key names.
-     */
-    protected function requiredConfigKeys(): array {
-        return ['payloadTemplate'];
-
-    }//end requiredConfigKeys()
-
-
-    /**
-     * The node's display name.
-     *
-     * @return string The translated name.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function getDisplayName(): string {
-        return $this->l10n->t('Call webhook');
-
-    }//end getDisplayName()
-
-
-    /**
-     * What the node does.
-     *
-     * @return string The translated description.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function getDescription(): string {
-        return $this->l10n->t('POST a templated payload to a configured endpoint.');
-
-    }//end getDescription()
-
+	/**
+	 * What the node does.
+	 *
+	 * @return string The translated description.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function getDescription(): string {
+		return $this->l10n->t('POST a templated payload to a configured endpoint.');
+	}//end getDescription()
 
 }//end class

--- a/lib/Flow/ProcestCreateDocumentNode.php
+++ b/lib/Flow/ProcestCreateDocumentNode.php
@@ -17,8 +17,8 @@ declare(strict_types=1);
 namespace OCA\Dossiq\Flow;
 
 use OCA\Dossiq\Service\Actions\ActionHandlerInterface as CatalogueActionHandler;
-use OCA\Dossiq\Service\Transitions\ActionHandlerInterface as TransitionActionHandler;
 use OCA\Dossiq\Service\Actions\CreateDocumentHandler;
+use OCA\Dossiq\Service\Transitions\ActionHandlerInterface as TransitionActionHandler;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 
@@ -33,72 +33,62 @@ use OCP\IURLGenerator;
  */
 class ProcestCreateDocumentNode extends ProcestActionNode {
 
+	/**
+	 * Constructor.
+	 *
+	 * @param CreateDocumentHandler $handler The action handler this node runs.
+	 * @param IL10N $l10n The localisation service.
+	 * @param IURLGenerator $urls The URL generator.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		private readonly CreateDocumentHandler $handler,
+		IL10N $l10n,
+		IURLGenerator $urls,
+	) {
+		parent::__construct(l10n: $l10n, urls: $urls);
 
-    /**
-     * Constructor.
-     *
-     * @param CreateDocumentHandler $handler The action handler this node runs.
-     * @param IL10N              $l10n    The localisation service.
-     * @param IURLGenerator      $urls    The URL generator.
-     *
-     * @return void
-     */
-    public function __construct(
-        private readonly CreateDocumentHandler $handler,
-        IL10N $l10n,
-        IURLGenerator $urls,
-    ) {
-        parent::__construct(l10n: $l10n, urls: $urls);
+	}//end __construct()
 
-    }//end __construct()
+	/**
+	 * The handler this node runs.
+	 *
+	 * @return CatalogueActionHandler The action handler.
+	 */
+	protected function handler(): CatalogueActionHandler|TransitionActionHandler {
+		return $this->handler;
+	}//end handler()
 
+	/**
+	 * Config keys without which this action cannot run.
+	 *
+	 * @return string[] The required key names.
+	 */
+	protected function requiredConfigKeys(): array {
+		return ['templateSlug', 'outputName'];
+	}//end requiredConfigKeys()
 
-    /**
-     * The handler this node runs.
-     *
-     * @return CatalogueActionHandler The action handler.
-     */
-    protected function handler(): CatalogueActionHandler|TransitionActionHandler {
-        return $this->handler;
+	/**
+	 * The node's display name.
+	 *
+	 * @return string The translated name.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function getDisplayName(): string {
+		return $this->l10n->t('Create document');
+	}//end getDisplayName()
 
-    }//end handler()
-
-
-    /**
-     * Config keys without which this action cannot run.
-     *
-     * @return string[] The required key names.
-     */
-    protected function requiredConfigKeys(): array {
-        return ['templateSlug', 'outputName'];
-
-    }//end requiredConfigKeys()
-
-
-    /**
-     * The node's display name.
-     *
-     * @return string The translated name.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function getDisplayName(): string {
-        return $this->l10n->t('Create document');
-
-    }//end getDisplayName()
-
-
-    /**
-     * What the node does.
-     *
-     * @return string The translated description.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function getDescription(): string {
-        return $this->l10n->t('Render a document template into a new file on the case.');
-
-    }//end getDescription()
-
+	/**
+	 * What the node does.
+	 *
+	 * @return string The translated description.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function getDescription(): string {
+		return $this->l10n->t('Render a document template into a new file on the case.');
+	}//end getDescription()
 
 }//end class

--- a/lib/Flow/ProcestFlowNodeBase.php
+++ b/lib/Flow/ProcestFlowNodeBase.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
 
 namespace OCA\Dossiq\Flow;
 
-use OCA\OpenRegister\Service\Flow\IFlowNode;
 use OCA\Dossiq\Service\Actions\ActionHandlerInterface as CatalogueActionHandler;
 use OCA\Dossiq\Service\Transitions\ActionHandlerInterface as TransitionActionHandler;
+use OCA\OpenRegister\Service\Flow\IFlowNode;
 use OCP\IL10N;
-use OCP\WorkflowEngine\IManager;
 use OCP\IURLGenerator;
+use OCP\WorkflowEngine\IManager;
 use UnexpectedValueException;
 
 /**
@@ -52,171 +52,158 @@ use UnexpectedValueException;
  */
 abstract class ProcestFlowNodeBase implements IFlowNode {
 
+	/**
+	 * Constructor.
+	 *
+	 * @param IL10N $l10n The localisation service.
+	 * @param IURLGenerator $urls The URL generator, for the node icon.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		protected readonly IL10N $l10n,
+		protected readonly IURLGenerator $urls,
+	) {
 
-    /**
-     * Constructor.
-     *
-     * @param IL10N         $l10n The localisation service.
-     * @param IURLGenerator $urls The URL generator, for the node icon.
-     *
-     * @return void
-     */
-    public function __construct(
-        protected readonly IL10N $l10n,
-        protected readonly IURLGenerator $urls,
-    ) {
+	}//end __construct()
 
-    }//end __construct()
+	/**
+	 * The handler this node runs.
+	 *
+	 * A UNION, because procest carries two action systems with two interfaces
+	 * of the same name in different namespaces. They declare an identical
+	 * `handle(array, array, array): ActionResult` and their ActionResults have
+	 * an identical shape (succeeded / error / data), so one node body serves
+	 * both — and naming both here says so out loud rather than duck-typing it.
+	 *
+	 * @return CatalogueActionHandler|TransitionActionHandler The action handler.
+	 */
+	abstract protected function handler(): CatalogueActionHandler|TransitionActionHandler;
 
+	/**
+	 * Config keys without which this action cannot run.
+	 *
+	 * @return string[] The required key names.
+	 */
+	abstract protected function requiredConfigKeys(): array;
 
-    /**
-     * The handler this node runs.
-     *
-     * A UNION, because procest carries two action systems with two interfaces
-     * of the same name in different namespaces. They declare an identical
-     * `handle(array, array, array): ActionResult` and their ActionResults have
-     * an identical shape (succeeded / error / data), so one node body serves
-     * both — and naming both here says so out loud rather than duck-typing it.
-     *
-     * @return CatalogueActionHandler|TransitionActionHandler The action handler.
-     */
-    abstract protected function handler(): CatalogueActionHandler|TransitionActionHandler;
+	/**
+	 * This node's id.
+	 *
+	 * Stated by the subclass rather than derived, because the two action
+	 * systems both ship a `sendEmail` and their ids would collide. The LIVE
+	 * transition vocabulary takes the plain `procest.<type>` names; the
+	 * configured-action catalogue takes `procest.action.<type>`.
+	 *
+	 * @return string The namespaced node id.
+	 */
+	abstract protected function nodeId(): string;
 
+	/**
+	 * The node id.
+	 *
+	 * @return string The namespaced node id.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function getId(): string {
+		return $this->nodeId();
+	}//end getId()
 
-    /**
-     * Config keys without which this action cannot run.
-     *
-     * @return string[] The required key names.
-     */
-    abstract protected function requiredConfigKeys(): array;
+	/**
+	 * The node icon.
+	 *
+	 * @return string The icon path.
+	 */
+	public function getIcon(): string {
+		return $this->urls->imagePath('dossiq', 'app-dark.svg');
+	}//end getIcon()
 
+	/**
+	 * Reject a config this node cannot act on.
+	 *
+	 * @param array<string, mixed> $config The step config.
+	 *
+	 * @return void
+	 *
+	 * @throws UnexpectedValueException When a required key is missing.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function validateConfig(array $config): void {
+		foreach ($this->requiredConfigKeys() as $key) {
+			if (trim((string)($config[$key] ?? '')) === '') {
+				throw new UnexpectedValueException(
+					$this->l10n->t('%1$s needs a value for "%2$s".', [$this->getDisplayName(), $key])
+				);
+			}
+		}
 
-    /**
-     * This node's id.
-     *
-     * Stated by the subclass rather than derived, because the two action
-     * systems both ship a `sendEmail` and their ids would collide. The LIVE
-     * transition vocabulary takes the plain `procest.<type>` names; the
-     * configured-action catalogue takes `procest.action.<type>`.
-     *
-     * @return string The namespaced node id.
-     */
-    abstract protected function nodeId(): string;
+	}//end validateConfig()
 
+	/**
+	 * Run the handler once per item.
+	 *
+	 * The item's `json` payload is the case; the flow context carries the
+	 * transition. A FAILED action THROWS rather than returning the item
+	 * untouched: the engine's per-step `onError` policy is what decides, and it
+	 * only ever sees failures that propagate out of execute(). Swallowing one
+	 * here would make the step a silent pass-through whose output key is simply
+	 * absent — and a downstream router would then take its default branch as
+	 * though the action had succeeded.
+	 *
+	 * @param array<int, array<string, mixed>> $items The items to act on.
+	 * @param array<string, mixed> $config The step config.
+	 * @param array<string, mixed> $context The run context.
+	 *
+	 * @return array<int, array<string, mixed>> The items, each carrying the result.
+	 *
+	 * @throws UnexpectedValueException When the config is unusable.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function execute(array $items, array $config, array $context): array {
+		// ValidateConfig() only runs when a flow is SAVED; a flow imported or
+		// seeded through another path reaches execute() unvalidated. Same shape
+		// of defect hermiq's agent node documents, so the same guard.
+		$this->validateConfig(config: $config);
 
-    /**
-     * The node id.
-     *
-     * @return string The namespaced node id.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function getId(): string {
-        return $this->nodeId();
+		$outKey = (string)($config['output'] ?? 'actionResult');
+		$out = [];
 
-    }//end getId()
+		foreach ($items as $item) {
+			$case = (array)($item['json'] ?? []);
+			$result = $this->handler()->handle(
+				actionConfig: $config,
+				case: $case,
+				transitionContext: $context
+			);
 
+			if ($result->succeeded === false) {
+				throw new UnexpectedValueException(
+					(string)($result->error ?? $this->l10n->t('The action did not complete.'))
+				);
+			}
 
-    /**
-     * The node icon.
-     *
-     * @return string The icon path.
-     */
-    public function getIcon(): string {
-        return $this->urls->imagePath('dossiq', 'app-dark.svg');
+			$item['json'] = array_merge($case, [$outKey => $result->data]);
+			$out[] = $item;
+		}//end foreach
 
-    }//end getIcon()
+		return $out;
+	}//end execute()
 
-
-    /**
-     * Reject a config this node cannot act on.
-     *
-     * @param array<string, mixed> $config The step config.
-     *
-     * @return void
-     *
-     * @throws UnexpectedValueException When a required key is missing.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function validateConfig(array $config): void {
-        foreach ($this->requiredConfigKeys() as $key) {
-            if (trim((string) ($config[$key] ?? '')) === '') {
-                throw new UnexpectedValueException(
-                    $this->l10n->t('%1$s needs a value for "%2$s".', [$this->getDisplayName(), $key])
-                );
-            }
-        }
-
-    }//end validateConfig()
-
-
-    /**
-     * Run the handler once per item.
-     *
-     * The item's `json` payload is the case; the flow context carries the
-     * transition. A FAILED action THROWS rather than returning the item
-     * untouched: the engine's per-step `onError` policy is what decides, and it
-     * only ever sees failures that propagate out of execute(). Swallowing one
-     * here would make the step a silent pass-through whose output key is simply
-     * absent — and a downstream router would then take its default branch as
-     * though the action had succeeded.
-     *
-     * @param array<int, array<string, mixed>> $items   The items to act on.
-     * @param array<string, mixed>             $config  The step config.
-     * @param array<string, mixed>             $context The run context.
-     *
-     * @return array<int, array<string, mixed>> The items, each carrying the result.
-     *
-     * @throws UnexpectedValueException When the config is unusable.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function execute(array $items, array $config, array $context): array {
-        // ValidateConfig() only runs when a flow is SAVED; a flow imported or
-        // seeded through another path reaches execute() unvalidated. Same shape
-        // of defect hermiq's agent node documents, so the same guard.
-        $this->validateConfig(config: $config);
-
-        $outKey = (string) ($config['output'] ?? 'actionResult');
-        $out    = [];
-
-        foreach ($items as $item) {
-            $case   = (array) ($item['json'] ?? []);
-            $result = $this->handler()->handle(
-                actionConfig: $config,
-                case: $case,
-                transitionContext: $context
-            );
-
-            if ($result->succeeded === false) {
-                throw new UnexpectedValueException(
-                    (string) ($result->error ?? $this->l10n->t('The action did not complete.'))
-                );
-            }
-
-            $item['json'] = array_merge($case, [$outKey => $result->data]);
-            $out[]        = $item;
-        }//end foreach
-
-        return $out;
-
-    }//end execute()
-
-    /**
-     * Where this node may be offered.
-     *
-     * Admin and user scope, matching every other action-bearing node in the
-     * fleet: a case action is not a system-internal step.
-     *
-     * @param integer $scope The Nextcloud workflow scope.
-     *
-     * @return boolean True when available in this scope.
-     */
-    public function isAvailableForScope(int $scope): bool {
-        return in_array($scope, [IManager::SCOPE_ADMIN, IManager::SCOPE_USER], true);
-
-    }//end isAvailableForScope()
-
+	/**
+	 * Where this node may be offered.
+	 *
+	 * Admin and user scope, matching every other action-bearing node in the
+	 * fleet: a case action is not a system-internal step.
+	 *
+	 * @param integer $scope The Nextcloud workflow scope.
+	 *
+	 * @return boolean True when available in this scope.
+	 */
+	public function isAvailableForScope(int $scope): bool {
+		return in_array($scope, [IManager::SCOPE_ADMIN, IManager::SCOPE_USER], true);
+	}//end isAvailableForScope()
 
 }//end class

--- a/lib/Flow/ProcestFlowNodeListener.php
+++ b/lib/Flow/ProcestFlowNodeListener.php
@@ -55,97 +55,94 @@ use Throwable;
  */
 class ProcestFlowNodeListener implements IEventListener {
 
-    /**
-     * The nodes procest contributes, in catalogue order.
-     *
-     * The live transition vocabulary first — it is the one that runs.
-     *
-     * @var class-string<IFlowNode>[]
-     *
-     * @psalm-suppress InvalidConstantAssignmentValue Every class listed here
-     *     does implement IFlowNode, but IFlowNode is OpenRegister's and is
-     *     suppressed as undefined (psalm.xml), so psalm cannot verify the
-     *     implements-relationship and rejects the narrowing. The declared type
-     *     is the contract this list must satisfy and is kept deliberately —
-     *     widening it to plain class-string would silence the error by giving
-     *     up the only statement of intent this constant carries.
-     */
-    private const NODES = [
-        // Live: fired by SideEffectDispatcher on every status change.
-        ProcestTxSendEmailNode::class,
-        ProcestTxCreateTaskNode::class,
-        ProcestTxCreateSubCaseNode::class,
-        ProcestTxWebhookNode::class,
-        ProcestTxSetFieldNode::class,
-        ProcestTxNotifyNode::class,
-        ProcestTxBesluitvormingActivateNode::class,
-        ProcestTxBesluitvormingPublishNode::class,
-        ProcestTxEvaluateDecisionNode::class,
-        // The configured-action catalogue.
-        ProcestSendEmailNode::class,
-        ProcestNotifyRoleNode::class,
-        ProcestCallWebhookNode::class,
-        ProcestCreateDocumentNode::class,
-        ProcestMergeTemplateNode::class,
-        ProcestScheduleReminderNode::class,
-    ];
+	/**
+	 * The nodes procest contributes, in catalogue order.
+	 *
+	 * The live transition vocabulary first — it is the one that runs.
+	 *
+	 * @var class-string<IFlowNode>[]
+	 *
+	 * @psalm-suppress InvalidConstantAssignmentValue Every class listed here
+	 *     does implement IFlowNode, but IFlowNode is OpenRegister's and is
+	 *     suppressed as undefined (psalm.xml), so psalm cannot verify the
+	 *     implements-relationship and rejects the narrowing. The declared type
+	 *     is the contract this list must satisfy and is kept deliberately —
+	 *     widening it to plain class-string would silence the error by giving
+	 *     up the only statement of intent this constant carries.
+	 */
+	private const NODES = [
+		// Live: fired by SideEffectDispatcher on every status change.
+		ProcestTxSendEmailNode::class,
+		ProcestTxCreateTaskNode::class,
+		ProcestTxCreateSubCaseNode::class,
+		ProcestTxWebhookNode::class,
+		ProcestTxSetFieldNode::class,
+		ProcestTxNotifyNode::class,
+		ProcestTxBesluitvormingActivateNode::class,
+		ProcestTxBesluitvormingPublishNode::class,
+		ProcestTxEvaluateDecisionNode::class,
+		// The configured-action catalogue.
+		ProcestSendEmailNode::class,
+		ProcestNotifyRoleNode::class,
+		ProcestCallWebhookNode::class,
+		ProcestCreateDocumentNode::class,
+		ProcestMergeTemplateNode::class,
+		ProcestScheduleReminderNode::class,
+	];
 
+	/**
+	 * Constructor.
+	 *
+	 * @param ContainerInterface $container Resolves each node.
+	 * @param LoggerInterface $logger The logger.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		private readonly ContainerInterface $container,
+		private readonly LoggerInterface $logger,
+	) {
 
-    /**
-     * Constructor.
-     *
-     * @param ContainerInterface $container Resolves each node.
-     * @param LoggerInterface    $logger    The logger.
-     *
-     * @return void
-     */
-    public function __construct(
-        private readonly ContainerInterface $container,
-        private readonly LoggerInterface $logger,
-    ) {
+	}//end __construct()
 
-    }//end __construct()
+	/**
+	 * Register procest's nodes on the catalogue.
+	 *
+	 * A node that cannot be constructed is logged and SKIPPED rather than
+	 * aborting the loop: one unresolvable dependency must not cost the other
+	 * fourteen their place in the catalogue, and a missing node is visible
+	 * (the flow editor simply does not offer it) where a failed registration
+	 * would take everything down with it.
+	 *
+	 * @param Event $event The event to handle.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function handle(Event $event): void {
+		if (($event instanceof RegisterFlowNodesEvent) === false) {
+			return;
+		}
 
+		foreach (self::NODES as $class) {
+			try {
+				$node = $this->container->get($class);
+			} catch (Throwable $e) {
+				$this->logger->warning(
+					'ProcestFlowNodeListener: could not construct a flow node; it will not be offered',
+					['node' => $class, 'error' => $e->getMessage()],
+				);
+				continue;
+			}
 
-    /**
-     * Register procest's nodes on the catalogue.
-     *
-     * A node that cannot be constructed is logged and SKIPPED rather than
-     * aborting the loop: one unresolvable dependency must not cost the other
-     * fourteen their place in the catalogue, and a missing node is visible
-     * (the flow editor simply does not offer it) where a failed registration
-     * would take everything down with it.
-     *
-     * @param Event $event The event to handle.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function handle(Event $event): void {
-        if (($event instanceof RegisterFlowNodesEvent) === false) {
-            return;
-        }
+			if (($node instanceof IFlowNode) === false) {
+				continue;
+			}
 
-        foreach (self::NODES as $class) {
-            try {
-                $node = $this->container->get($class);
-            } catch (Throwable $e) {
-                $this->logger->warning(
-                    'ProcestFlowNodeListener: could not construct a flow node; it will not be offered',
-                    ['node' => $class, 'error' => $e->getMessage()],
-                );
-                continue;
-            }
+			$event->registerNode(node: $node);
+		}//end foreach
 
-            if (($node instanceof IFlowNode) === false) {
-                continue;
-            }
-
-            $event->registerNode(node: $node);
-        }//end foreach
-
-    }//end handle()
-
+	}//end handle()
 
 }//end class

--- a/lib/Flow/ProcestMergeTemplateNode.php
+++ b/lib/Flow/ProcestMergeTemplateNode.php
@@ -17,8 +17,8 @@ declare(strict_types=1);
 namespace OCA\Dossiq\Flow;
 
 use OCA\Dossiq\Service\Actions\ActionHandlerInterface as CatalogueActionHandler;
-use OCA\Dossiq\Service\Transitions\ActionHandlerInterface as TransitionActionHandler;
 use OCA\Dossiq\Service\Actions\MergeTemplateHandler;
+use OCA\Dossiq\Service\Transitions\ActionHandlerInterface as TransitionActionHandler;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 
@@ -33,72 +33,62 @@ use OCP\IURLGenerator;
  */
 class ProcestMergeTemplateNode extends ProcestActionNode {
 
+	/**
+	 * Constructor.
+	 *
+	 * @param MergeTemplateHandler $handler The action handler this node runs.
+	 * @param IL10N $l10n The localisation service.
+	 * @param IURLGenerator $urls The URL generator.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		private readonly MergeTemplateHandler $handler,
+		IL10N $l10n,
+		IURLGenerator $urls,
+	) {
+		parent::__construct(l10n: $l10n, urls: $urls);
 
-    /**
-     * Constructor.
-     *
-     * @param MergeTemplateHandler $handler The action handler this node runs.
-     * @param IL10N              $l10n    The localisation service.
-     * @param IURLGenerator      $urls    The URL generator.
-     *
-     * @return void
-     */
-    public function __construct(
-        private readonly MergeTemplateHandler $handler,
-        IL10N $l10n,
-        IURLGenerator $urls,
-    ) {
-        parent::__construct(l10n: $l10n, urls: $urls);
+	}//end __construct()
 
-    }//end __construct()
+	/**
+	 * The handler this node runs.
+	 *
+	 * @return CatalogueActionHandler The action handler.
+	 */
+	protected function handler(): CatalogueActionHandler|TransitionActionHandler {
+		return $this->handler;
+	}//end handler()
 
+	/**
+	 * Config keys without which this action cannot run.
+	 *
+	 * @return string[] The required key names.
+	 */
+	protected function requiredConfigKeys(): array {
+		return ['templateSlug', 'targetField'];
+	}//end requiredConfigKeys()
 
-    /**
-     * The handler this node runs.
-     *
-     * @return CatalogueActionHandler The action handler.
-     */
-    protected function handler(): CatalogueActionHandler|TransitionActionHandler {
-        return $this->handler;
+	/**
+	 * The node's display name.
+	 *
+	 * @return string The translated name.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function getDisplayName(): string {
+		return $this->l10n->t('Merge template');
+	}//end getDisplayName()
 
-    }//end handler()
-
-
-    /**
-     * Config keys without which this action cannot run.
-     *
-     * @return string[] The required key names.
-     */
-    protected function requiredConfigKeys(): array {
-        return ['templateSlug', 'targetField'];
-
-    }//end requiredConfigKeys()
-
-
-    /**
-     * The node's display name.
-     *
-     * @return string The translated name.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function getDisplayName(): string {
-        return $this->l10n->t('Merge template');
-
-    }//end getDisplayName()
-
-
-    /**
-     * What the node does.
-     *
-     * @return string The translated description.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function getDescription(): string {
-        return $this->l10n->t('Render a template and write the result into a case field.');
-
-    }//end getDescription()
-
+	/**
+	 * What the node does.
+	 *
+	 * @return string The translated description.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function getDescription(): string {
+		return $this->l10n->t('Render a template and write the result into a case field.');
+	}//end getDescription()
 
 }//end class

--- a/lib/Flow/ProcestNotifyRoleNode.php
+++ b/lib/Flow/ProcestNotifyRoleNode.php
@@ -17,8 +17,8 @@ declare(strict_types=1);
 namespace OCA\Dossiq\Flow;
 
 use OCA\Dossiq\Service\Actions\ActionHandlerInterface as CatalogueActionHandler;
-use OCA\Dossiq\Service\Transitions\ActionHandlerInterface as TransitionActionHandler;
 use OCA\Dossiq\Service\Actions\NotifyRoleHandler;
+use OCA\Dossiq\Service\Transitions\ActionHandlerInterface as TransitionActionHandler;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 
@@ -33,72 +33,62 @@ use OCP\IURLGenerator;
  */
 class ProcestNotifyRoleNode extends ProcestActionNode {
 
+	/**
+	 * Constructor.
+	 *
+	 * @param NotifyRoleHandler $handler The action handler this node runs.
+	 * @param IL10N $l10n The localisation service.
+	 * @param IURLGenerator $urls The URL generator.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		private readonly NotifyRoleHandler $handler,
+		IL10N $l10n,
+		IURLGenerator $urls,
+	) {
+		parent::__construct(l10n: $l10n, urls: $urls);
 
-    /**
-     * Constructor.
-     *
-     * @param NotifyRoleHandler $handler The action handler this node runs.
-     * @param IL10N              $l10n    The localisation service.
-     * @param IURLGenerator      $urls    The URL generator.
-     *
-     * @return void
-     */
-    public function __construct(
-        private readonly NotifyRoleHandler $handler,
-        IL10N $l10n,
-        IURLGenerator $urls,
-    ) {
-        parent::__construct(l10n: $l10n, urls: $urls);
+	}//end __construct()
 
-    }//end __construct()
+	/**
+	 * The handler this node runs.
+	 *
+	 * @return CatalogueActionHandler The action handler.
+	 */
+	protected function handler(): CatalogueActionHandler|TransitionActionHandler {
+		return $this->handler;
+	}//end handler()
 
+	/**
+	 * Config keys without which this action cannot run.
+	 *
+	 * @return string[] The required key names.
+	 */
+	protected function requiredConfigKeys(): array {
+		return ['roleSlug', 'messageTemplate'];
+	}//end requiredConfigKeys()
 
-    /**
-     * The handler this node runs.
-     *
-     * @return CatalogueActionHandler The action handler.
-     */
-    protected function handler(): CatalogueActionHandler|TransitionActionHandler {
-        return $this->handler;
+	/**
+	 * The node's display name.
+	 *
+	 * @return string The translated name.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function getDisplayName(): string {
+		return $this->l10n->t('Notify role');
+	}//end getDisplayName()
 
-    }//end handler()
-
-
-    /**
-     * Config keys without which this action cannot run.
-     *
-     * @return string[] The required key names.
-     */
-    protected function requiredConfigKeys(): array {
-        return ['roleSlug', 'messageTemplate'];
-
-    }//end requiredConfigKeys()
-
-
-    /**
-     * The node's display name.
-     *
-     * @return string The translated name.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function getDisplayName(): string {
-        return $this->l10n->t('Notify role');
-
-    }//end getDisplayName()
-
-
-    /**
-     * What the node does.
-     *
-     * @return string The translated description.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function getDescription(): string {
-        return $this->l10n->t('Send a Nextcloud notification to everyone holding a role on the case.');
-
-    }//end getDescription()
-
+	/**
+	 * What the node does.
+	 *
+	 * @return string The translated description.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function getDescription(): string {
+		return $this->l10n->t('Send a Nextcloud notification to everyone holding a role on the case.');
+	}//end getDescription()
 
 }//end class

--- a/lib/Flow/ProcestScheduleReminderNode.php
+++ b/lib/Flow/ProcestScheduleReminderNode.php
@@ -17,8 +17,8 @@ declare(strict_types=1);
 namespace OCA\Dossiq\Flow;
 
 use OCA\Dossiq\Service\Actions\ActionHandlerInterface as CatalogueActionHandler;
-use OCA\Dossiq\Service\Transitions\ActionHandlerInterface as TransitionActionHandler;
 use OCA\Dossiq\Service\Actions\ScheduleReminderHandler;
+use OCA\Dossiq\Service\Transitions\ActionHandlerInterface as TransitionActionHandler;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 
@@ -33,72 +33,62 @@ use OCP\IURLGenerator;
  */
 class ProcestScheduleReminderNode extends ProcestActionNode {
 
+	/**
+	 * Constructor.
+	 *
+	 * @param ScheduleReminderHandler $handler The action handler this node runs.
+	 * @param IL10N $l10n The localisation service.
+	 * @param IURLGenerator $urls The URL generator.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		private readonly ScheduleReminderHandler $handler,
+		IL10N $l10n,
+		IURLGenerator $urls,
+	) {
+		parent::__construct(l10n: $l10n, urls: $urls);
 
-    /**
-     * Constructor.
-     *
-     * @param ScheduleReminderHandler $handler The action handler this node runs.
-     * @param IL10N              $l10n    The localisation service.
-     * @param IURLGenerator      $urls    The URL generator.
-     *
-     * @return void
-     */
-    public function __construct(
-        private readonly ScheduleReminderHandler $handler,
-        IL10N $l10n,
-        IURLGenerator $urls,
-    ) {
-        parent::__construct(l10n: $l10n, urls: $urls);
+	}//end __construct()
 
-    }//end __construct()
+	/**
+	 * The handler this node runs.
+	 *
+	 * @return CatalogueActionHandler The action handler.
+	 */
+	protected function handler(): CatalogueActionHandler|TransitionActionHandler {
+		return $this->handler;
+	}//end handler()
 
+	/**
+	 * Config keys without which this action cannot run.
+	 *
+	 * @return string[] The required key names.
+	 */
+	protected function requiredConfigKeys(): array {
+		return ['recipientRef', 'messageTemplate'];
+	}//end requiredConfigKeys()
 
-    /**
-     * The handler this node runs.
-     *
-     * @return CatalogueActionHandler The action handler.
-     */
-    protected function handler(): CatalogueActionHandler|TransitionActionHandler {
-        return $this->handler;
+	/**
+	 * The node's display name.
+	 *
+	 * @return string The translated name.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function getDisplayName(): string {
+		return $this->l10n->t('Schedule reminder');
+	}//end getDisplayName()
 
-    }//end handler()
-
-
-    /**
-     * Config keys without which this action cannot run.
-     *
-     * @return string[] The required key names.
-     */
-    protected function requiredConfigKeys(): array {
-        return ['recipientRef', 'messageTemplate'];
-
-    }//end requiredConfigKeys()
-
-
-    /**
-     * The node's display name.
-     *
-     * @return string The translated name.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function getDisplayName(): string {
-        return $this->l10n->t('Schedule reminder');
-
-    }//end getDisplayName()
-
-
-    /**
-     * What the node does.
-     *
-     * @return string The translated description.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function getDescription(): string {
-        return $this->l10n->t('Queue a reminder for a resolved recipient.');
-
-    }//end getDescription()
-
+	/**
+	 * What the node does.
+	 *
+	 * @return string The translated description.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function getDescription(): string {
+		return $this->l10n->t('Queue a reminder for a resolved recipient.');
+	}//end getDescription()
 
 }//end class

--- a/lib/Flow/ProcestSendEmailNode.php
+++ b/lib/Flow/ProcestSendEmailNode.php
@@ -17,8 +17,8 @@ declare(strict_types=1);
 namespace OCA\Dossiq\Flow;
 
 use OCA\Dossiq\Service\Actions\ActionHandlerInterface as CatalogueActionHandler;
-use OCA\Dossiq\Service\Transitions\ActionHandlerInterface as TransitionActionHandler;
 use OCA\Dossiq\Service\Actions\SendEmailHandler;
+use OCA\Dossiq\Service\Transitions\ActionHandlerInterface as TransitionActionHandler;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 
@@ -33,72 +33,62 @@ use OCP\IURLGenerator;
  */
 class ProcestSendEmailNode extends ProcestActionNode {
 
+	/**
+	 * Constructor.
+	 *
+	 * @param SendEmailHandler $handler The action handler this node runs.
+	 * @param IL10N $l10n The localisation service.
+	 * @param IURLGenerator $urls The URL generator.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		private readonly SendEmailHandler $handler,
+		IL10N $l10n,
+		IURLGenerator $urls,
+	) {
+		parent::__construct(l10n: $l10n, urls: $urls);
 
-    /**
-     * Constructor.
-     *
-     * @param SendEmailHandler $handler The action handler this node runs.
-     * @param IL10N              $l10n    The localisation service.
-     * @param IURLGenerator      $urls    The URL generator.
-     *
-     * @return void
-     */
-    public function __construct(
-        private readonly SendEmailHandler $handler,
-        IL10N $l10n,
-        IURLGenerator $urls,
-    ) {
-        parent::__construct(l10n: $l10n, urls: $urls);
+	}//end __construct()
 
-    }//end __construct()
+	/**
+	 * The handler this node runs.
+	 *
+	 * @return CatalogueActionHandler The action handler.
+	 */
+	protected function handler(): CatalogueActionHandler|TransitionActionHandler {
+		return $this->handler;
+	}//end handler()
 
+	/**
+	 * Config keys without which this action cannot run.
+	 *
+	 * @return string[] The required key names.
+	 */
+	protected function requiredConfigKeys(): array {
+		return ['recipientRef', 'subjectTemplate', 'bodyTemplate'];
+	}//end requiredConfigKeys()
 
-    /**
-     * The handler this node runs.
-     *
-     * @return CatalogueActionHandler The action handler.
-     */
-    protected function handler(): CatalogueActionHandler|TransitionActionHandler {
-        return $this->handler;
+	/**
+	 * The node's display name.
+	 *
+	 * @return string The translated name.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function getDisplayName(): string {
+		return $this->l10n->t('Send email');
+	}//end getDisplayName()
 
-    }//end handler()
-
-
-    /**
-     * Config keys without which this action cannot run.
-     *
-     * @return string[] The required key names.
-     */
-    protected function requiredConfigKeys(): array {
-        return ['recipientRef', 'subjectTemplate', 'bodyTemplate'];
-
-    }//end requiredConfigKeys()
-
-
-    /**
-     * The node's display name.
-     *
-     * @return string The translated name.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function getDisplayName(): string {
-        return $this->l10n->t('Send email');
-
-    }//end getDisplayName()
-
-
-    /**
-     * What the node does.
-     *
-     * @return string The translated description.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function getDescription(): string {
-        return $this->l10n->t('Send a templated email to a resolved recipient.');
-
-    }//end getDescription()
-
+	/**
+	 * What the node does.
+	 *
+	 * @return string The translated description.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function getDescription(): string {
+		return $this->l10n->t('Send a templated email to a resolved recipient.');
+	}//end getDescription()
 
 }//end class

--- a/lib/Flow/ProcestTxBesluitvormingActivateNode.php
+++ b/lib/Flow/ProcestTxBesluitvormingActivateNode.php
@@ -34,83 +34,71 @@ use OCP\IURLGenerator;
  */
 class ProcestTxBesluitvormingActivateNode extends ProcestTransitionNode {
 
+	/**
+	 * Constructor.
+	 *
+	 * @param BesluitvormingActivateHandler $handler The transition handler this node runs.
+	 * @param IL10N $l10n The localisation service.
+	 * @param IURLGenerator $urls The URL generator.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		private readonly BesluitvormingActivateHandler $handler,
+		IL10N $l10n,
+		IURLGenerator $urls,
+	) {
+		parent::__construct(l10n: $l10n, urls: $urls);
 
-    /**
-     * Constructor.
-     *
-     * @param BesluitvormingActivateHandler $handler The transition handler this node runs.
-     * @param IL10N         $l10n    The localisation service.
-     * @param IURLGenerator $urls    The URL generator.
-     *
-     * @return void
-     */
-    public function __construct(
-        private readonly BesluitvormingActivateHandler $handler,
-        IL10N $l10n,
-        IURLGenerator $urls,
-    ) {
-        parent::__construct(l10n: $l10n, urls: $urls);
+	}//end __construct()
 
-    }//end __construct()
+	/**
+	 * The handler this node runs.
+	 *
+	 * @return CatalogueActionHandler|TransitionActionHandler The action handler.
+	 */
+	protected function handler(): CatalogueActionHandler|TransitionActionHandler {
+		return $this->handler;
+	}//end handler()
 
+	/**
+	 * This node's id.
+	 *
+	 * @return string The namespaced node id.
+	 */
+	protected function nodeId(): string {
+		return 'procest.besluitvormingActivate';
+	}//end nodeId()
 
-    /**
-     * The handler this node runs.
-     *
-     * @return CatalogueActionHandler|TransitionActionHandler The action handler.
-     */
-    protected function handler(): CatalogueActionHandler|TransitionActionHandler {
-        return $this->handler;
+	/**
+	 * Config keys without which this action cannot run.
+	 *
+	 * @return string[] The required key names.
+	 */
+	protected function requiredConfigKeys(): array {
+		return [];
+	}//end requiredConfigKeys()
 
-    }//end handler()
+	/**
+	 * The node's display name.
+	 *
+	 * @return string The translated name.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function getDisplayName(): string {
+		return $this->l10n->t('Activate decision-making');
+	}//end getDisplayName()
 
-
-    /**
-     * This node's id.
-     *
-     * @return string The namespaced node id.
-     */
-    protected function nodeId(): string {
-        return 'procest.besluitvormingActivate';
-
-    }//end nodeId()
-
-
-    /**
-     * Config keys without which this action cannot run.
-     *
-     * @return string[] The required key names.
-     */
-    protected function requiredConfigKeys(): array {
-        return [];
-
-    }//end requiredConfigKeys()
-
-
-    /**
-     * The node's display name.
-     *
-     * @return string The translated name.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function getDisplayName(): string {
-        return $this->l10n->t('Activate decision-making');
-
-    }//end getDisplayName()
-
-
-    /**
-     * What the node does.
-     *
-     * @return string The translated description.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function getDescription(): string {
-        return $this->l10n->t('Raise the decision-making process for this case.');
-
-    }//end getDescription()
-
+	/**
+	 * What the node does.
+	 *
+	 * @return string The translated description.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function getDescription(): string {
+		return $this->l10n->t('Raise the decision-making process for this case.');
+	}//end getDescription()
 
 }//end class

--- a/lib/Flow/ProcestTxBesluitvormingPublishNode.php
+++ b/lib/Flow/ProcestTxBesluitvormingPublishNode.php
@@ -34,83 +34,71 @@ use OCP\IURLGenerator;
  */
 class ProcestTxBesluitvormingPublishNode extends ProcestTransitionNode {
 
+	/**
+	 * Constructor.
+	 *
+	 * @param BesluitvormingPublishHandler $handler The transition handler this node runs.
+	 * @param IL10N $l10n The localisation service.
+	 * @param IURLGenerator $urls The URL generator.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		private readonly BesluitvormingPublishHandler $handler,
+		IL10N $l10n,
+		IURLGenerator $urls,
+	) {
+		parent::__construct(l10n: $l10n, urls: $urls);
 
-    /**
-     * Constructor.
-     *
-     * @param BesluitvormingPublishHandler $handler The transition handler this node runs.
-     * @param IL10N         $l10n    The localisation service.
-     * @param IURLGenerator $urls    The URL generator.
-     *
-     * @return void
-     */
-    public function __construct(
-        private readonly BesluitvormingPublishHandler $handler,
-        IL10N $l10n,
-        IURLGenerator $urls,
-    ) {
-        parent::__construct(l10n: $l10n, urls: $urls);
+	}//end __construct()
 
-    }//end __construct()
+	/**
+	 * The handler this node runs.
+	 *
+	 * @return CatalogueActionHandler|TransitionActionHandler The action handler.
+	 */
+	protected function handler(): CatalogueActionHandler|TransitionActionHandler {
+		return $this->handler;
+	}//end handler()
 
+	/**
+	 * This node's id.
+	 *
+	 * @return string The namespaced node id.
+	 */
+	protected function nodeId(): string {
+		return 'procest.besluitvormingPublish';
+	}//end nodeId()
 
-    /**
-     * The handler this node runs.
-     *
-     * @return CatalogueActionHandler|TransitionActionHandler The action handler.
-     */
-    protected function handler(): CatalogueActionHandler|TransitionActionHandler {
-        return $this->handler;
+	/**
+	 * Config keys without which this action cannot run.
+	 *
+	 * @return string[] The required key names.
+	 */
+	protected function requiredConfigKeys(): array {
+		return [];
+	}//end requiredConfigKeys()
 
-    }//end handler()
+	/**
+	 * The node's display name.
+	 *
+	 * @return string The translated name.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function getDisplayName(): string {
+		return $this->l10n->t('Publish decision');
+	}//end getDisplayName()
 
-
-    /**
-     * This node's id.
-     *
-     * @return string The namespaced node id.
-     */
-    protected function nodeId(): string {
-        return 'procest.besluitvormingPublish';
-
-    }//end nodeId()
-
-
-    /**
-     * Config keys without which this action cannot run.
-     *
-     * @return string[] The required key names.
-     */
-    protected function requiredConfigKeys(): array {
-        return [];
-
-    }//end requiredConfigKeys()
-
-
-    /**
-     * The node's display name.
-     *
-     * @return string The translated name.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function getDisplayName(): string {
-        return $this->l10n->t('Publish decision');
-
-    }//end getDisplayName()
-
-
-    /**
-     * What the node does.
-     *
-     * @return string The translated description.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function getDescription(): string {
-        return $this->l10n->t('Publish the decision to DROP/LVBB.');
-
-    }//end getDescription()
-
+	/**
+	 * What the node does.
+	 *
+	 * @return string The translated description.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function getDescription(): string {
+		return $this->l10n->t('Publish the decision to DROP/LVBB.');
+	}//end getDescription()
 
 }//end class

--- a/lib/Flow/ProcestTxCreateSubCaseNode.php
+++ b/lib/Flow/ProcestTxCreateSubCaseNode.php
@@ -34,83 +34,71 @@ use OCP\IURLGenerator;
  */
 class ProcestTxCreateSubCaseNode extends ProcestTransitionNode {
 
+	/**
+	 * Constructor.
+	 *
+	 * @param CreateSubCaseHandler $handler The transition handler this node runs.
+	 * @param IL10N $l10n The localisation service.
+	 * @param IURLGenerator $urls The URL generator.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		private readonly CreateSubCaseHandler $handler,
+		IL10N $l10n,
+		IURLGenerator $urls,
+	) {
+		parent::__construct(l10n: $l10n, urls: $urls);
 
-    /**
-     * Constructor.
-     *
-     * @param CreateSubCaseHandler $handler The transition handler this node runs.
-     * @param IL10N         $l10n    The localisation service.
-     * @param IURLGenerator $urls    The URL generator.
-     *
-     * @return void
-     */
-    public function __construct(
-        private readonly CreateSubCaseHandler $handler,
-        IL10N $l10n,
-        IURLGenerator $urls,
-    ) {
-        parent::__construct(l10n: $l10n, urls: $urls);
+	}//end __construct()
 
-    }//end __construct()
+	/**
+	 * The handler this node runs.
+	 *
+	 * @return CatalogueActionHandler|TransitionActionHandler The action handler.
+	 */
+	protected function handler(): CatalogueActionHandler|TransitionActionHandler {
+		return $this->handler;
+	}//end handler()
 
+	/**
+	 * This node's id.
+	 *
+	 * @return string The namespaced node id.
+	 */
+	protected function nodeId(): string {
+		return 'procest.createSubCase';
+	}//end nodeId()
 
-    /**
-     * The handler this node runs.
-     *
-     * @return CatalogueActionHandler|TransitionActionHandler The action handler.
-     */
-    protected function handler(): CatalogueActionHandler|TransitionActionHandler {
-        return $this->handler;
+	/**
+	 * Config keys without which this action cannot run.
+	 *
+	 * @return string[] The required key names.
+	 */
+	protected function requiredConfigKeys(): array {
+		return ['caseType'];
+	}//end requiredConfigKeys()
 
-    }//end handler()
+	/**
+	 * The node's display name.
+	 *
+	 * @return string The translated name.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function getDisplayName(): string {
+		return $this->l10n->t('Create sub-case');
+	}//end getDisplayName()
 
-
-    /**
-     * This node's id.
-     *
-     * @return string The namespaced node id.
-     */
-    protected function nodeId(): string {
-        return 'procest.createSubCase';
-
-    }//end nodeId()
-
-
-    /**
-     * Config keys without which this action cannot run.
-     *
-     * @return string[] The required key names.
-     */
-    protected function requiredConfigKeys(): array {
-        return ['caseType'];
-
-    }//end requiredConfigKeys()
-
-
-    /**
-     * The node's display name.
-     *
-     * @return string The translated name.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function getDisplayName(): string {
-        return $this->l10n->t('Create sub-case');
-
-    }//end getDisplayName()
-
-
-    /**
-     * What the node does.
-     *
-     * @return string The translated description.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function getDescription(): string {
-        return $this->l10n->t('Open a sub-case when the parent changes status.');
-
-    }//end getDescription()
-
+	/**
+	 * What the node does.
+	 *
+	 * @return string The translated description.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function getDescription(): string {
+		return $this->l10n->t('Open a sub-case when the parent changes status.');
+	}//end getDescription()
 
 }//end class

--- a/lib/Flow/ProcestTxCreateTaskNode.php
+++ b/lib/Flow/ProcestTxCreateTaskNode.php
@@ -34,83 +34,71 @@ use OCP\IURLGenerator;
  */
 class ProcestTxCreateTaskNode extends ProcestTransitionNode {
 
+	/**
+	 * Constructor.
+	 *
+	 * @param CreateTaskHandler $handler The transition handler this node runs.
+	 * @param IL10N $l10n The localisation service.
+	 * @param IURLGenerator $urls The URL generator.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		private readonly CreateTaskHandler $handler,
+		IL10N $l10n,
+		IURLGenerator $urls,
+	) {
+		parent::__construct(l10n: $l10n, urls: $urls);
 
-    /**
-     * Constructor.
-     *
-     * @param CreateTaskHandler $handler The transition handler this node runs.
-     * @param IL10N         $l10n    The localisation service.
-     * @param IURLGenerator $urls    The URL generator.
-     *
-     * @return void
-     */
-    public function __construct(
-        private readonly CreateTaskHandler $handler,
-        IL10N $l10n,
-        IURLGenerator $urls,
-    ) {
-        parent::__construct(l10n: $l10n, urls: $urls);
+	}//end __construct()
 
-    }//end __construct()
+	/**
+	 * The handler this node runs.
+	 *
+	 * @return CatalogueActionHandler|TransitionActionHandler The action handler.
+	 */
+	protected function handler(): CatalogueActionHandler|TransitionActionHandler {
+		return $this->handler;
+	}//end handler()
 
+	/**
+	 * This node's id.
+	 *
+	 * @return string The namespaced node id.
+	 */
+	protected function nodeId(): string {
+		return 'procest.createTask';
+	}//end nodeId()
 
-    /**
-     * The handler this node runs.
-     *
-     * @return CatalogueActionHandler|TransitionActionHandler The action handler.
-     */
-    protected function handler(): CatalogueActionHandler|TransitionActionHandler {
-        return $this->handler;
+	/**
+	 * Config keys without which this action cannot run.
+	 *
+	 * @return string[] The required key names.
+	 */
+	protected function requiredConfigKeys(): array {
+		return ['title'];
+	}//end requiredConfigKeys()
 
-    }//end handler()
+	/**
+	 * The node's display name.
+	 *
+	 * @return string The translated name.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function getDisplayName(): string {
+		return $this->l10n->t('Create task');
+	}//end getDisplayName()
 
-
-    /**
-     * This node's id.
-     *
-     * @return string The namespaced node id.
-     */
-    protected function nodeId(): string {
-        return 'procest.createTask';
-
-    }//end nodeId()
-
-
-    /**
-     * Config keys without which this action cannot run.
-     *
-     * @return string[] The required key names.
-     */
-    protected function requiredConfigKeys(): array {
-        return ['title'];
-
-    }//end requiredConfigKeys()
-
-
-    /**
-     * The node's display name.
-     *
-     * @return string The translated name.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function getDisplayName(): string {
-        return $this->l10n->t('Create task');
-
-    }//end getDisplayName()
-
-
-    /**
-     * What the node does.
-     *
-     * @return string The translated description.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function getDescription(): string {
-        return $this->l10n->t('Create a task on the case when it changes status.');
-
-    }//end getDescription()
-
+	/**
+	 * What the node does.
+	 *
+	 * @return string The translated description.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function getDescription(): string {
+		return $this->l10n->t('Create a task on the case when it changes status.');
+	}//end getDescription()
 
 }//end class

--- a/lib/Flow/ProcestTxEvaluateDecisionNode.php
+++ b/lib/Flow/ProcestTxEvaluateDecisionNode.php
@@ -34,83 +34,71 @@ use OCP\IURLGenerator;
  */
 class ProcestTxEvaluateDecisionNode extends ProcestTransitionNode {
 
+	/**
+	 * Constructor.
+	 *
+	 * @param EvaluateDecisionHandler $handler The transition handler this node runs.
+	 * @param IL10N $l10n The localisation service.
+	 * @param IURLGenerator $urls The URL generator.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		private readonly EvaluateDecisionHandler $handler,
+		IL10N $l10n,
+		IURLGenerator $urls,
+	) {
+		parent::__construct(l10n: $l10n, urls: $urls);
 
-    /**
-     * Constructor.
-     *
-     * @param EvaluateDecisionHandler $handler The transition handler this node runs.
-     * @param IL10N         $l10n    The localisation service.
-     * @param IURLGenerator $urls    The URL generator.
-     *
-     * @return void
-     */
-    public function __construct(
-        private readonly EvaluateDecisionHandler $handler,
-        IL10N $l10n,
-        IURLGenerator $urls,
-    ) {
-        parent::__construct(l10n: $l10n, urls: $urls);
+	}//end __construct()
 
-    }//end __construct()
+	/**
+	 * The handler this node runs.
+	 *
+	 * @return CatalogueActionHandler|TransitionActionHandler The action handler.
+	 */
+	protected function handler(): CatalogueActionHandler|TransitionActionHandler {
+		return $this->handler;
+	}//end handler()
 
+	/**
+	 * This node's id.
+	 *
+	 * @return string The namespaced node id.
+	 */
+	protected function nodeId(): string {
+		return 'procest.evaluateDecision';
+	}//end nodeId()
 
-    /**
-     * The handler this node runs.
-     *
-     * @return CatalogueActionHandler|TransitionActionHandler The action handler.
-     */
-    protected function handler(): CatalogueActionHandler|TransitionActionHandler {
-        return $this->handler;
+	/**
+	 * Config keys without which this action cannot run.
+	 *
+	 * @return string[] The required key names.
+	 */
+	protected function requiredConfigKeys(): array {
+		return ['decisionKey'];
+	}//end requiredConfigKeys()
 
-    }//end handler()
+	/**
+	 * The node's display name.
+	 *
+	 * @return string The translated name.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function getDisplayName(): string {
+		return $this->l10n->t('Evaluate decision table');
+	}//end getDisplayName()
 
-
-    /**
-     * This node's id.
-     *
-     * @return string The namespaced node id.
-     */
-    protected function nodeId(): string {
-        return 'procest.evaluateDecision';
-
-    }//end nodeId()
-
-
-    /**
-     * Config keys without which this action cannot run.
-     *
-     * @return string[] The required key names.
-     */
-    protected function requiredConfigKeys(): array {
-        return ['decisionKey'];
-
-    }//end requiredConfigKeys()
-
-
-    /**
-     * The node's display name.
-     *
-     * @return string The translated name.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function getDisplayName(): string {
-        return $this->l10n->t('Evaluate decision table');
-
-    }//end getDisplayName()
-
-
-    /**
-     * What the node does.
-     *
-     * @return string The translated description.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function getDescription(): string {
-        return $this->l10n->t('Evaluate a DMN decision table against the case.');
-
-    }//end getDescription()
-
+	/**
+	 * What the node does.
+	 *
+	 * @return string The translated description.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function getDescription(): string {
+		return $this->l10n->t('Evaluate a DMN decision table against the case.');
+	}//end getDescription()
 
 }//end class

--- a/lib/Flow/ProcestTxNotifyNode.php
+++ b/lib/Flow/ProcestTxNotifyNode.php
@@ -34,83 +34,71 @@ use OCP\IURLGenerator;
  */
 class ProcestTxNotifyNode extends ProcestTransitionNode {
 
+	/**
+	 * Constructor.
+	 *
+	 * @param NotifyHandler $handler The transition handler this node runs.
+	 * @param IL10N $l10n The localisation service.
+	 * @param IURLGenerator $urls The URL generator.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		private readonly NotifyHandler $handler,
+		IL10N $l10n,
+		IURLGenerator $urls,
+	) {
+		parent::__construct(l10n: $l10n, urls: $urls);
 
-    /**
-     * Constructor.
-     *
-     * @param NotifyHandler $handler The transition handler this node runs.
-     * @param IL10N         $l10n    The localisation service.
-     * @param IURLGenerator $urls    The URL generator.
-     *
-     * @return void
-     */
-    public function __construct(
-        private readonly NotifyHandler $handler,
-        IL10N $l10n,
-        IURLGenerator $urls,
-    ) {
-        parent::__construct(l10n: $l10n, urls: $urls);
+	}//end __construct()
 
-    }//end __construct()
+	/**
+	 * The handler this node runs.
+	 *
+	 * @return CatalogueActionHandler|TransitionActionHandler The action handler.
+	 */
+	protected function handler(): CatalogueActionHandler|TransitionActionHandler {
+		return $this->handler;
+	}//end handler()
 
+	/**
+	 * This node's id.
+	 *
+	 * @return string The namespaced node id.
+	 */
+	protected function nodeId(): string {
+		return 'procest.notify';
+	}//end nodeId()
 
-    /**
-     * The handler this node runs.
-     *
-     * @return CatalogueActionHandler|TransitionActionHandler The action handler.
-     */
-    protected function handler(): CatalogueActionHandler|TransitionActionHandler {
-        return $this->handler;
+	/**
+	 * Config keys without which this action cannot run.
+	 *
+	 * @return string[] The required key names.
+	 */
+	protected function requiredConfigKeys(): array {
+		return ['recipient'];
+	}//end requiredConfigKeys()
 
-    }//end handler()
+	/**
+	 * The node's display name.
+	 *
+	 * @return string The translated name.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function getDisplayName(): string {
+		return $this->l10n->t('Notify');
+	}//end getDisplayName()
 
-
-    /**
-     * This node's id.
-     *
-     * @return string The namespaced node id.
-     */
-    protected function nodeId(): string {
-        return 'procest.notify';
-
-    }//end nodeId()
-
-
-    /**
-     * Config keys without which this action cannot run.
-     *
-     * @return string[] The required key names.
-     */
-    protected function requiredConfigKeys(): array {
-        return ['recipient'];
-
-    }//end requiredConfigKeys()
-
-
-    /**
-     * The node's display name.
-     *
-     * @return string The translated name.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function getDisplayName(): string {
-        return $this->l10n->t('Notify');
-
-    }//end getDisplayName()
-
-
-    /**
-     * What the node does.
-     *
-     * @return string The translated description.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function getDescription(): string {
-        return $this->l10n->t('Send a Nextcloud notification about the status change.');
-
-    }//end getDescription()
-
+	/**
+	 * What the node does.
+	 *
+	 * @return string The translated description.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function getDescription(): string {
+		return $this->l10n->t('Send a Nextcloud notification about the status change.');
+	}//end getDescription()
 
 }//end class

--- a/lib/Flow/ProcestTxSendEmailNode.php
+++ b/lib/Flow/ProcestTxSendEmailNode.php
@@ -34,83 +34,71 @@ use OCP\IURLGenerator;
  */
 class ProcestTxSendEmailNode extends ProcestTransitionNode {
 
+	/**
+	 * Constructor.
+	 *
+	 * @param SendEmailHandler $handler The transition handler this node runs.
+	 * @param IL10N $l10n The localisation service.
+	 * @param IURLGenerator $urls The URL generator.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		private readonly SendEmailHandler $handler,
+		IL10N $l10n,
+		IURLGenerator $urls,
+	) {
+		parent::__construct(l10n: $l10n, urls: $urls);
 
-    /**
-     * Constructor.
-     *
-     * @param SendEmailHandler $handler The transition handler this node runs.
-     * @param IL10N         $l10n    The localisation service.
-     * @param IURLGenerator $urls    The URL generator.
-     *
-     * @return void
-     */
-    public function __construct(
-        private readonly SendEmailHandler $handler,
-        IL10N $l10n,
-        IURLGenerator $urls,
-    ) {
-        parent::__construct(l10n: $l10n, urls: $urls);
+	}//end __construct()
 
-    }//end __construct()
+	/**
+	 * The handler this node runs.
+	 *
+	 * @return CatalogueActionHandler|TransitionActionHandler The action handler.
+	 */
+	protected function handler(): CatalogueActionHandler|TransitionActionHandler {
+		return $this->handler;
+	}//end handler()
 
+	/**
+	 * This node's id.
+	 *
+	 * @return string The namespaced node id.
+	 */
+	protected function nodeId(): string {
+		return 'procest.sendEmail';
+	}//end nodeId()
 
-    /**
-     * The handler this node runs.
-     *
-     * @return CatalogueActionHandler|TransitionActionHandler The action handler.
-     */
-    protected function handler(): CatalogueActionHandler|TransitionActionHandler {
-        return $this->handler;
+	/**
+	 * Config keys without which this action cannot run.
+	 *
+	 * @return string[] The required key names.
+	 */
+	protected function requiredConfigKeys(): array {
+		return ['recipient'];
+	}//end requiredConfigKeys()
 
-    }//end handler()
+	/**
+	 * The node's display name.
+	 *
+	 * @return string The translated name.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function getDisplayName(): string {
+		return $this->l10n->t('Send email on transition');
+	}//end getDisplayName()
 
-
-    /**
-     * This node's id.
-     *
-     * @return string The namespaced node id.
-     */
-    protected function nodeId(): string {
-        return 'procest.sendEmail';
-
-    }//end nodeId()
-
-
-    /**
-     * Config keys without which this action cannot run.
-     *
-     * @return string[] The required key names.
-     */
-    protected function requiredConfigKeys(): array {
-        return ['recipient'];
-
-    }//end requiredConfigKeys()
-
-
-    /**
-     * The node's display name.
-     *
-     * @return string The translated name.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function getDisplayName(): string {
-        return $this->l10n->t('Send email on transition');
-
-    }//end getDisplayName()
-
-
-    /**
-     * What the node does.
-     *
-     * @return string The translated description.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function getDescription(): string {
-        return $this->l10n->t('Send a templated email when a case changes status.');
-
-    }//end getDescription()
-
+	/**
+	 * What the node does.
+	 *
+	 * @return string The translated description.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function getDescription(): string {
+		return $this->l10n->t('Send a templated email when a case changes status.');
+	}//end getDescription()
 
 }//end class

--- a/lib/Flow/ProcestTxSetFieldNode.php
+++ b/lib/Flow/ProcestTxSetFieldNode.php
@@ -34,83 +34,71 @@ use OCP\IURLGenerator;
  */
 class ProcestTxSetFieldNode extends ProcestTransitionNode {
 
+	/**
+	 * Constructor.
+	 *
+	 * @param SetFieldHandler $handler The transition handler this node runs.
+	 * @param IL10N $l10n The localisation service.
+	 * @param IURLGenerator $urls The URL generator.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		private readonly SetFieldHandler $handler,
+		IL10N $l10n,
+		IURLGenerator $urls,
+	) {
+		parent::__construct(l10n: $l10n, urls: $urls);
 
-    /**
-     * Constructor.
-     *
-     * @param SetFieldHandler $handler The transition handler this node runs.
-     * @param IL10N         $l10n    The localisation service.
-     * @param IURLGenerator $urls    The URL generator.
-     *
-     * @return void
-     */
-    public function __construct(
-        private readonly SetFieldHandler $handler,
-        IL10N $l10n,
-        IURLGenerator $urls,
-    ) {
-        parent::__construct(l10n: $l10n, urls: $urls);
+	}//end __construct()
 
-    }//end __construct()
+	/**
+	 * The handler this node runs.
+	 *
+	 * @return CatalogueActionHandler|TransitionActionHandler The action handler.
+	 */
+	protected function handler(): CatalogueActionHandler|TransitionActionHandler {
+		return $this->handler;
+	}//end handler()
 
+	/**
+	 * This node's id.
+	 *
+	 * @return string The namespaced node id.
+	 */
+	protected function nodeId(): string {
+		return 'procest.setField';
+	}//end nodeId()
 
-    /**
-     * The handler this node runs.
-     *
-     * @return CatalogueActionHandler|TransitionActionHandler The action handler.
-     */
-    protected function handler(): CatalogueActionHandler|TransitionActionHandler {
-        return $this->handler;
+	/**
+	 * Config keys without which this action cannot run.
+	 *
+	 * @return string[] The required key names.
+	 */
+	protected function requiredConfigKeys(): array {
+		return ['field'];
+	}//end requiredConfigKeys()
 
-    }//end handler()
+	/**
+	 * The node's display name.
+	 *
+	 * @return string The translated name.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function getDisplayName(): string {
+		return $this->l10n->t('Set field');
+	}//end getDisplayName()
 
-
-    /**
-     * This node's id.
-     *
-     * @return string The namespaced node id.
-     */
-    protected function nodeId(): string {
-        return 'procest.setField';
-
-    }//end nodeId()
-
-
-    /**
-     * Config keys without which this action cannot run.
-     *
-     * @return string[] The required key names.
-     */
-    protected function requiredConfigKeys(): array {
-        return ['field'];
-
-    }//end requiredConfigKeys()
-
-
-    /**
-     * The node's display name.
-     *
-     * @return string The translated name.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function getDisplayName(): string {
-        return $this->l10n->t('Set field');
-
-    }//end getDisplayName()
-
-
-    /**
-     * What the node does.
-     *
-     * @return string The translated description.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function getDescription(): string {
-        return $this->l10n->t('Write a value onto the case as part of the transition.');
-
-    }//end getDescription()
-
+	/**
+	 * What the node does.
+	 *
+	 * @return string The translated description.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function getDescription(): string {
+		return $this->l10n->t('Write a value onto the case as part of the transition.');
+	}//end getDescription()
 
 }//end class

--- a/lib/Flow/ProcestTxWebhookNode.php
+++ b/lib/Flow/ProcestTxWebhookNode.php
@@ -34,83 +34,71 @@ use OCP\IURLGenerator;
  */
 class ProcestTxWebhookNode extends ProcestTransitionNode {
 
+	/**
+	 * Constructor.
+	 *
+	 * @param WebhookHandler $handler The transition handler this node runs.
+	 * @param IL10N $l10n The localisation service.
+	 * @param IURLGenerator $urls The URL generator.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		private readonly WebhookHandler $handler,
+		IL10N $l10n,
+		IURLGenerator $urls,
+	) {
+		parent::__construct(l10n: $l10n, urls: $urls);
 
-    /**
-     * Constructor.
-     *
-     * @param WebhookHandler $handler The transition handler this node runs.
-     * @param IL10N         $l10n    The localisation service.
-     * @param IURLGenerator $urls    The URL generator.
-     *
-     * @return void
-     */
-    public function __construct(
-        private readonly WebhookHandler $handler,
-        IL10N $l10n,
-        IURLGenerator $urls,
-    ) {
-        parent::__construct(l10n: $l10n, urls: $urls);
+	}//end __construct()
 
-    }//end __construct()
+	/**
+	 * The handler this node runs.
+	 *
+	 * @return CatalogueActionHandler|TransitionActionHandler The action handler.
+	 */
+	protected function handler(): CatalogueActionHandler|TransitionActionHandler {
+		return $this->handler;
+	}//end handler()
 
+	/**
+	 * This node's id.
+	 *
+	 * @return string The namespaced node id.
+	 */
+	protected function nodeId(): string {
+		return 'procest.webhook';
+	}//end nodeId()
 
-    /**
-     * The handler this node runs.
-     *
-     * @return CatalogueActionHandler|TransitionActionHandler The action handler.
-     */
-    protected function handler(): CatalogueActionHandler|TransitionActionHandler {
-        return $this->handler;
+	/**
+	 * Config keys without which this action cannot run.
+	 *
+	 * @return string[] The required key names.
+	 */
+	protected function requiredConfigKeys(): array {
+		return ['url'];
+	}//end requiredConfigKeys()
 
-    }//end handler()
+	/**
+	 * The node's display name.
+	 *
+	 * @return string The translated name.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function getDisplayName(): string {
+		return $this->l10n->t('Call webhook on transition');
+	}//end getDisplayName()
 
-
-    /**
-     * This node's id.
-     *
-     * @return string The namespaced node id.
-     */
-    protected function nodeId(): string {
-        return 'procest.webhook';
-
-    }//end nodeId()
-
-
-    /**
-     * Config keys without which this action cannot run.
-     *
-     * @return string[] The required key names.
-     */
-    protected function requiredConfigKeys(): array {
-        return ['url'];
-
-    }//end requiredConfigKeys()
-
-
-    /**
-     * The node's display name.
-     *
-     * @return string The translated name.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function getDisplayName(): string {
-        return $this->l10n->t('Call webhook on transition');
-
-    }//end getDisplayName()
-
-
-    /**
-     * What the node does.
-     *
-     * @return string The translated description.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function getDescription(): string {
-        return $this->l10n->t('POST the case to a configured endpoint on a status change.');
-
-    }//end getDescription()
-
+	/**
+	 * What the node does.
+	 *
+	 * @return string The translated description.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function getDescription(): string {
+		return $this->l10n->t('POST the case to a configured endpoint on a status change.');
+	}//end getDescription()
 
 }//end class

--- a/lib/Repair/MigrateAiOversightToHermiq.php
+++ b/lib/Repair/MigrateAiOversightToHermiq.php
@@ -50,173 +50,165 @@ use Throwable;
  */
 class MigrateAiOversightToHermiq implements IRepairStep {
 
-    /**
-     * How many entries to pull per page.
-     *
-     * @var integer
-     */
-    private const PAGE_SIZE = 200;
+	/**
+	 * How many entries to pull per page.
+	 *
+	 * @var integer
+	 */
+	private const PAGE_SIZE = 200;
 
-    /**
-     * Safety bound on pages walked, so a misbehaving backend cannot spin an
-     * upgrade forever.
-     *
-     * @var integer
-     */
-    private const MAX_PAGES = 200;
+	/**
+	 * Safety bound on pages walked, so a misbehaving backend cannot spin an
+	 * upgrade forever.
+	 *
+	 * @var integer
+	 */
+	private const MAX_PAGES = 200;
 
+	/**
+	 * Constructor.
+	 *
+	 * @param AiAuditLog $audit Reads procest's own oversight log.
+	 * @param AiOversightDelegationService $oversight Sends a decision to hermiq.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		private readonly AiAuditLog $audit,
+		private readonly AiOversightDelegationService $oversight,
+	) {
 
-    /**
-     * Constructor.
-     *
-     * @param AiAuditLog                   $audit     Reads procest's own oversight log.
-     * @param AiOversightDelegationService $oversight Sends a decision to hermiq.
-     *
-     * @return void
-     */
-    public function __construct(
-        private readonly AiAuditLog $audit,
-        private readonly AiOversightDelegationService $oversight,
-    ) {
+	}//end __construct()
 
-    }//end __construct()
+	/**
+	 * Get the repair step name.
+	 *
+	 * @return string The name shown during upgrade.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/ai-oversight-surface/spec.md
+	 */
+	public function getName(): string {
+		return 'Replay recorded AI oversight decisions into hermiq';
+	}//end getName()
 
+	/**
+	 * Run the replay.
+	 *
+	 * @param IOutput $output The upgrade output.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/ai-oversight-surface/spec.md
+	 */
+	public function run(IOutput $output): void {
+		$sent = 0;
+		$skipped = 0;
+		$offset = 0;
 
-    /**
-     * Get the repair step name.
-     *
-     * @return string The name shown during upgrade.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/ai-oversight-surface/spec.md
-     */
-    public function getName(): string {
-        return 'Replay recorded AI oversight decisions into hermiq';
+		for ($page = 0; $page < self::MAX_PAGES; $page++) {
+			try {
+				$batch = $this->audit->list([], self::PAGE_SIZE, $offset);
+			} catch (Throwable $e) {
+				$output->warning('AI oversight replay: could not read the audit log — ' . $e->getMessage());
+				return;
+			}
 
-    }//end getName()
+			// `entries`, NOT `results`. AiAuditLog::list() returns
+			// {entries, total, limit, offset}; reading `results` here silently
+			// yielded [] on every page, so the replay would have reported
+			// "no audit entries to consider" on an instance full of them.
+			// phpstan caught it before it ever ran.
+			$entries = $batch['entries'];
+			if (empty($entries) === true) {
+				break;
+			}
 
+			[$pageSent, $pageSkipped] = $this->replayPage(output: $output, entries: $entries);
+			$sent += $pageSent;
+			$skipped += $pageSkipped;
 
-    /**
-     * Run the replay.
-     *
-     * @param IOutput $output The upgrade output.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/ai-oversight-surface/spec.md
-     */
-    public function run(IOutput $output): void {
-        $sent    = 0;
-        $skipped = 0;
-        $offset  = 0;
+			if (count($entries) < self::PAGE_SIZE) {
+				break;
+			}
 
-        for ($page = 0; $page < self::MAX_PAGES; $page++) {
-            try {
-                $batch = $this->audit->list([], self::PAGE_SIZE, $offset);
-            } catch (Throwable $e) {
-                $output->warning('AI oversight replay: could not read the audit log — ' . $e->getMessage());
-                return;
-            }
+			$offset += self::PAGE_SIZE;
+		}//end for
 
-            // `entries`, NOT `results`. AiAuditLog::list() returns
-            // {entries, total, limit, offset}; reading `results` here silently
-            // yielded [] on every page, so the replay would have reported
-            // "no audit entries to consider" on an instance full of them.
-            // phpstan caught it before it ever ran.
-            $entries = $batch['entries'];
-            if (empty($entries) === true) {
-                break;
-            }
+		$this->report(output: $output, sent: $sent, skipped: $skipped);
 
-            [$pageSent, $pageSkipped] = $this->replayPage(output: $output, entries: $entries);
-            $sent    += $pageSent;
-            $skipped += $pageSkipped;
+	}//end run()
 
-            if (count($entries) < self::PAGE_SIZE) {
-                break;
-            }
+	/**
+	 * Delegate one page of audit entries.
+	 *
+	 * Split out of run() so the paging loop and the per-entry handling can each
+	 * be read on their own — phpmd flagged the combined method, and it was
+	 * right that two concerns were tangled.
+	 *
+	 * @param IOutput $output The upgrade output.
+	 * @param array<int, mixed> $entries The page of entries.
+	 *
+	 * @return array{0: int, 1: int} Sent and skipped counts for this page.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/ai-oversight-surface/spec.md
+	 */
+	private function replayPage(IOutput $output, array $entries): array {
+		$sent = 0;
+		$skipped = 0;
 
-            $offset += self::PAGE_SIZE;
-        }//end for
+		foreach ($entries as $entry) {
+			if (is_array($entry) === false) {
+				$skipped++;
+				continue;
+			}
 
-        $this->report(output: $output, sent: $sent, skipped: $skipped);
+			try {
+				$delegated = $this->oversight->delegate(entry: $entry);
+			} catch (Throwable $e) {
+				// Cannot happen by contract, but an upgrade is the wrong place
+				// to find out otherwise.
+				$output->warning('AI oversight replay: entry failed — ' . $e->getMessage());
+				$skipped++;
+				continue;
+			}
 
-    }//end run()
+			if ($delegated === true) {
+				$sent++;
+				continue;
+			}
 
+			$skipped++;
+		}//end foreach
 
-    /**
-     * Delegate one page of audit entries.
-     *
-     * Split out of run() so the paging loop and the per-entry handling can each
-     * be read on their own — phpmd flagged the combined method, and it was
-     * right that two concerns were tangled.
-     *
-     * @param IOutput            $output  The upgrade output.
-     * @param array<int, mixed>  $entries The page of entries.
-     *
-     * @return array{0: int, 1: int} Sent and skipped counts for this page.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/ai-oversight-surface/spec.md
-     */
-    private function replayPage(IOutput $output, array $entries): array {
-        $sent    = 0;
-        $skipped = 0;
+		return [$sent, $skipped];
+	}//end replayPage()
 
-        foreach ($entries as $entry) {
-            if (is_array($entry) === false) {
-                $skipped++;
-                continue;
-            }
+	/**
+	 * Report what the replay did.
+	 *
+	 * @param IOutput $output The upgrade output.
+	 * @param integer $sent Records delegated.
+	 * @param integer $skipped Records not delegated.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/ai-oversight-surface/spec.md
+	 */
+	private function report(IOutput $output, int $sent, int $skipped): void {
+		if ($sent === 0 && $skipped === 0) {
+			$output->info('AI oversight replay: no audit entries to consider.');
+			return;
+		}
 
-            try {
-                $delegated = $this->oversight->delegate(entry: $entry);
-            } catch (Throwable $e) {
-                // Cannot happen by contract, but an upgrade is the wrong place
-                // to find out otherwise.
-                $output->warning('AI oversight replay: entry failed — ' . $e->getMessage());
-                $skipped++;
-                continue;
-            }
+		$output->info(
+			sprintf(
+				'AI oversight replay: %d decision(s) sent to hermiq, %d entry/entries skipped '
+				. '(suggestion-only records, entries without a subject, or hermiq not installed).',
+				$sent,
+				$skipped
+			)
+		);
 
-            if ($delegated === true) {
-                $sent++;
-                continue;
-            }
-
-            $skipped++;
-        }//end foreach
-
-        return [$sent, $skipped];
-
-    }//end replayPage()
-
-
-    /**
-     * Report what the replay did.
-     *
-     * @param IOutput $output  The upgrade output.
-     * @param integer $sent    Records delegated.
-     * @param integer $skipped Records not delegated.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/ai-oversight-surface/spec.md
-     */
-    private function report(IOutput $output, int $sent, int $skipped): void {
-        if ($sent === 0 && $skipped === 0) {
-            $output->info('AI oversight replay: no audit entries to consider.');
-            return;
-        }
-
-        $output->info(
-            sprintf(
-                'AI oversight replay: %d decision(s) sent to hermiq, %d entry/entries skipped '
-                . '(suggestion-only records, entries without a subject, or hermiq not installed).',
-                $sent,
-                $skipped
-            )
-        );
-
-    }//end report()
-
+	}//end report()
 
 }//end class

--- a/lib/Repair/MigrateRegisterApplicationId.php
+++ b/lib/Repair/MigrateRegisterApplicationId.php
@@ -86,12 +86,11 @@ class MigrateRegisterApplicationId implements IRepairStep {
 	 */
 	private const NEW_APP_ID = 'dossiq';
 
-
 	/**
 	 * Constructor.
 	 *
 	 * @param ContainerInterface $container The server container.
-	 * @param LoggerInterface    $logger    The logger.
+	 * @param LoggerInterface $logger The logger.
 	 *
 	 * @spec exclude One-shot app-id rename migration; see the class docblock.
 	 */
@@ -102,7 +101,6 @@ class MigrateRegisterApplicationId implements IRepairStep {
 
 	}//end __construct()
 
-
 	/**
 	 * Step name.
 	 *
@@ -112,9 +110,7 @@ class MigrateRegisterApplicationId implements IRepairStep {
 	 */
 	public function getName(): string {
 		return 'Move the Dossiq register and schemas onto the dossiq application id';
-
 	}//end getName()
-
 
 	/**
 	 * Run the migration.
@@ -144,7 +140,7 @@ class MigrateRegisterApplicationId implements IRepairStep {
 
 		try {
 			$migrator = $this->container->get(self::MIGRATOR);
-			$result   = $migrator->migrate(self::OLD_APP_ID, self::NEW_APP_ID);
+			$result = $migrator->migrate(self::OLD_APP_ID, self::NEW_APP_ID);
 		} catch (\Throwable $e) {
 			$output->warning('Could not migrate the register application id: ' . $e->getMessage());
 			$this->logger->error(
@@ -173,7 +169,7 @@ class MigrateRegisterApplicationId implements IRepairStep {
 			return;
 		}
 
-		$schemas   = (int)($result['schemas'] ?? 0);
+		$schemas = (int)($result['schemas'] ?? 0);
 		$registers = (int)($result['registers'] ?? 0);
 
 		if (($schemas + $registers) === 0) {
@@ -187,6 +183,5 @@ class MigrateRegisterApplicationId implements IRepairStep {
 		);
 
 	}//end run()
-
 
 }//end class

--- a/lib/Repair/MigrateSchemaApplicationId.php
+++ b/lib/Repair/MigrateSchemaApplicationId.php
@@ -1,0 +1,241 @@
+<?php
+
+/**
+ * Re-points this app's OpenRegister SCHEMAS at the new application id.
+ *
+ * SIBLING OF MigrateRegisterSlug, AND NEITHER COVERS THE OTHER. OpenRegister
+ * resolves the two halves of a configuration by DIFFERENT keys:
+ *
+ *   - a REGISTER by slug alone      -> RegisterMapper::find(slug)
+ *   - a SCHEMA by the PAIR          -> SchemaMapper::findByApplicationAndSlug(slug, application)
+ *
+ * `SettingsService` passes `appId: Application::APP_ID`, which is now
+ * `dossiq`. Every schema this app already owns still carries
+ * `application = 'procest'`, so the pair matches nothing — and
+ * ImportHandler's not-found branch is not an error path, it is the "create a
+ * new one" path. The next import therefore builds a SECOND, EMPTY set of
+ * schemas under the new application id while every stored object stays bound
+ * to the old ones. Nothing errors. The app renders empty collections.
+ *
+ * Measured on a live install before this step existed: 180 schemas under
+ * `procest` and zero under `dossiq`; 231 under `docudesk`, 98 under
+ * `decidesk`, 21 under `softwarecatalog`, 17 under `openbuild`. The gap is
+ * fleet-wide, not specific to one app.
+ *
+ * IT REFUSES RATHER THAN MERGES. Where a schema slug ALREADY has a twin under
+ * the new application id, the fork has happened: re-pointing would leave two
+ * rows sharing (application, slug), and findByApplicationAndSlug() caps at one
+ * row — so one of them silently wins every lookup and the other's objects
+ * become unreachable. Choosing between them is a decision about data, not a
+ * migration, so this step logs and leaves both alone. Measured: integriq has
+ * 200 such collisions, planninq and larpinq 2 each.
+ *
+ * IT NEVER DELETES A SCHEMA, and it never throws — it runs under `<install>`,
+ * where an escaping exception aborts the install and the app never enables.
+ *
+ * @category  Repair
+ * @package   OCA\Dossiq\Repair
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link      https://conduction.nl
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Dossiq\Repair;
+
+use OCP\DB\Exception;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Moves this app's schema rows onto the new application id.
+ *
+ * @spec exclude No canonical spec covers the `procest` -> `dossiq` schema
+ *  application-id migration. Pointing this at an existing spec would report
+ *  conformance to a requirement that says nothing about it.
+ */
+class MigrateSchemaApplicationId implements IRepairStep {
+
+	/**
+	 * The application id these schemas were written under.
+	 *
+	 * @var string
+	 */
+	public const OLD_APP_ID = 'procest';
+
+	/**
+	 * The application id the import now looks them up by.
+	 *
+	 * @var string
+	 */
+	public const NEW_APP_ID = 'dossiq';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param IDBConnection $db Database connection.
+	 * @param LoggerInterface $logger Logger.
+	 *
+	 * @spec exclude No canonical spec covers the `procest` -> `dossiq` schema
+	 *  application-id migration. Pointing this at an existing spec would report
+	 *  conformance to a requirement that says nothing about it.
+	 */
+	public function __construct(
+		private readonly IDBConnection $db,
+		private readonly LoggerInterface $logger,
+	) {
+	}//end __construct()
+
+	/**
+	 * Step name shown by `occ maintenance:repair`.
+	 *
+	 * @return string
+	 *
+	 * @spec exclude No canonical spec covers the `procest` -> `dossiq` schema
+	 *  application-id migration. Pointing this at an existing spec would report
+	 *  conformance to a requirement that says nothing about it.
+	 */
+	public function getName(): string {
+		return 'Move Dossiq schemas onto the dossiq application id';
+	}//end getName()
+
+	/**
+	 * Re-point every schema that has no twin under the new application id.
+	 *
+	 * @param IOutput $output Repair output.
+	 *
+	 * @return void
+	 *
+	 * @spec exclude No canonical spec covers the `procest` -> `dossiq` schema
+	 *  application-id migration. Pointing this at an existing spec would report
+	 *  conformance to a requirement that says nothing about it.
+	 */
+	public function run(IOutput $output): void {
+		$taken = $this->slugsUnderNewAppId();
+		if ($taken === null) {
+			$output->info('MigrateSchemaApplicationId: could not read schemas; nothing done.');
+			return;
+		}
+
+		$candidates = $this->slugsUnderOldAppId();
+		if ($candidates === []) {
+			$output->info('MigrateSchemaApplicationId: no schemas on the old application id; nothing to do.');
+			return;
+		}
+
+		$moved = 0;
+		$refused = 0;
+		foreach ($candidates as $slug) {
+			if (in_array(strtolower($slug), $taken, true) === true) {
+				$refused++;
+				$this->logger->warning(
+					'MigrateSchemaApplicationId: schema slug already exists under the new application id; '
+					. 'refusing to create a duplicate (application, slug) pair. Merge them by hand.',
+					['slug' => $slug, 'old' => self::OLD_APP_ID, 'new' => self::NEW_APP_ID]
+				);
+				continue;
+			}
+
+			if ($this->repoint(slug: $slug) === true) {
+				$moved++;
+			}
+		}
+
+		$output->info(
+			sprintf(
+				'MigrateSchemaApplicationId: %d schema(s) moved to %s, %d refused as duplicates.',
+				$moved,
+				self::NEW_APP_ID,
+				$refused
+			)
+		);
+	}//end run()
+
+	/**
+	 * Slugs already claimed under the NEW application id.
+	 *
+	 * Returns null on a read failure, which the caller treats as "do nothing".
+	 * An empty list and a failed read must not look the same: an empty list
+	 * says every move is safe, and a failed read says nothing at all.
+	 *
+	 * @return array<int, string>|null Lower-cased slugs, or null when unreadable.
+	 */
+	private function slugsUnderNewAppId(): ?array {
+		try {
+			$rows = $this->db->executeQuery(
+				'SELECT slug FROM `*PREFIX*openregister_schemas` WHERE application = ?',
+				[self::NEW_APP_ID]
+			)->fetchAll();
+		} catch (Exception $e) {
+			$this->logger->warning(
+				'MigrateSchemaApplicationId: could not read schemas on the new application id; skipping.',
+				['exception' => $e->getMessage()]
+			);
+			return null;
+		}
+
+		return array_map(
+			static fn (array $row): string => strtolower((string)($row['slug'] ?? '')),
+			$rows
+		);
+	}//end slugsUnderNewAppId()
+
+	/**
+	 * Slugs still sitting under the OLD application id.
+	 *
+	 * @return array<int, string>
+	 */
+	private function slugsUnderOldAppId(): array {
+		try {
+			$rows = $this->db->executeQuery(
+				'SELECT slug FROM `*PREFIX*openregister_schemas` WHERE application = ?',
+				[self::OLD_APP_ID]
+			)->fetchAll();
+		} catch (Exception $e) {
+			$this->logger->warning(
+				'MigrateSchemaApplicationId: could not read schemas on the old application id; skipping.',
+				['exception' => $e->getMessage()]
+			);
+			return [];
+		}
+
+		return array_values(array_filter(array_map(
+			static fn (array $row): string => (string)($row['slug'] ?? ''),
+			$rows
+		)));
+	}//end slugsUnderOldAppId()
+
+	/**
+	 * Move one schema onto the new application id.
+	 *
+	 * Scoped to the (old application, slug) pair so it can never touch a row
+	 * belonging to another app that happens to share a slug.
+	 *
+	 * @param string $slug The schema slug to move.
+	 *
+	 * @return bool True when the row was updated.
+	 */
+	private function repoint(string $slug): bool {
+		try {
+			$this->db->executeStatement(
+				'UPDATE `*PREFIX*openregister_schemas` SET application = ? WHERE application = ? AND slug = ?',
+				[self::NEW_APP_ID, self::OLD_APP_ID, $slug]
+			);
+		} catch (Exception $e) {
+			$this->logger->warning(
+				'MigrateSchemaApplicationId: could not move schema.',
+				['slug' => $slug, 'exception' => $e->getMessage()]
+			);
+			return false;
+		}
+
+		return true;
+	}//end repoint()
+}//end class

--- a/lib/Sections/PersonalSection.php
+++ b/lib/Sections/PersonalSection.php
@@ -32,71 +32,61 @@ use OCP\Settings\IIconSection;
  */
 class PersonalSection implements IIconSection {
 
+	/**
+	 * Constructor.
+	 *
+	 * @param IL10N $l The localisation service.
+	 * @param IURLGenerator $urlGenerator The URL generator.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		private IL10N $l,
+		private IURLGenerator $urlGenerator,
+	) {
 
-    /**
-     * Constructor.
-     *
-     * @param IL10N         $l            The localisation service.
-     * @param IURLGenerator $urlGenerator The URL generator.
-     *
-     * @return void
-     */
-    public function __construct(
-        private IL10N $l,
-        private IURLGenerator $urlGenerator,
-    ) {
+	}//end __construct()
 
-    }//end __construct()
+	/**
+	 * Get the section id.
+	 *
+	 * @return string The section id.
+	 */
+	public function getID(): string {
+		return 'dossiq';
+	}//end getID()
 
+	/**
+	 * Get the section display name.
+	 *
+	 * @return string The translated section name.
+	 */
+	public function getName(): string {
+		return $this->l->t('Dossiq');
+	}//end getName()
 
-    /**
-     * Get the section id.
-     *
-     * @return string The section id.
-     */
-    public function getID(): string {
-        return 'dossiq';
+	/**
+	 * Get the ordering priority.
+	 *
+	 * @return int The priority.
+	 */
+	public function getPriority(): int {
+		return 75;
+	}//end getPriority()
 
-    }//end getID()
-
-
-    /**
-     * Get the section display name.
-     *
-     * @return string The translated section name.
-     */
-    public function getName(): string {
-        return $this->l->t('Dossiq');
-
-    }//end getName()
-
-
-    /**
-     * Get the ordering priority.
-     *
-     * @return int The priority.
-     */
-    public function getPriority(): int {
-        return 75;
-
-    }//end getPriority()
-
-
-    /**
-     * Get the icon path for this section.
-     *
-     * @return string The icon path.
-     */
-    public function getIcon(): string {
-        // MUST be the live app id. imagePath() throws when the app does not
-        // exist, and Nextcloud calls getIcon() on every section while building
-        // the settings navigation — so a stale id here does not degrade to a
-        // missing icon, it returns 500 for EVERY /settings/* page, admin
-        // included. The app pages keep working, which is what made this look
-        // like a frontend fault.
-        return $this->urlGenerator->imagePath(appName: 'dossiq', file: 'app-dark.svg');
-
-    }//end getIcon()
-
+	/**
+	 * Get the icon path for this section.
+	 *
+	 * @return string The icon path.
+	 */
+	public function getIcon(): string {
+		// MUST be the live app id. imagePath() throws when the app does not
+		// exist, and Nextcloud calls getIcon() on every section while building
+		// the settings navigation — so a stale id here does not degrade to a
+		// missing icon, it returns 500 for EVERY /settings/* page, admin
+		// included. The app pages keep working, which is what made this look
+		// like a frontend fault.
+		return $this->urlGenerator->imagePath(appName: 'dossiq', file: 'app-dark.svg');
+	}//end getIcon()
 
 }//end class

--- a/lib/Service/Ai/AiOversightDelegationService.php
+++ b/lib/Service/Ai/AiOversightDelegationService.php
@@ -41,172 +41,165 @@ use Throwable;
  */
 class AiOversightDelegationService {
 
-    /**
-     * Hermiq's published event class. Resolved by name so procest stays
-     * installable without hermiq.
-     *
-     * @var string
-     */
-    private const OVERSIGHT_EVENT = '\\OCA\\Hermiq\\Event\\AiOversightRecordedEvent';
+	/**
+	 * Hermiq's published event class. Resolved by name so procest stays
+	 * installable without hermiq.
+	 *
+	 * @var string
+	 */
+	private const OVERSIGHT_EVENT = '\\OCA\\Hermiq\\Event\\AiOversightRecordedEvent';
 
-    /**
-     * procest's own userAction vocabulary mapped onto hermiq's.
-     *
-     * `modified` and `overridden` are the same fact under two names; hermiq's
-     * is the one that survives, because the record lives there.
-     *
-     * @var array<string, string>
-     */
-    private const ACTION_MAP = [
-        'accepted' => 'accepted',
-        'rejected' => 'rejected',
-        'modified' => 'overridden',
-    ];
+	/**
+	 * procest's own userAction vocabulary mapped onto hermiq's.
+	 *
+	 * `modified` and `overridden` are the same fact under two names; hermiq's
+	 * is the one that survives, because the record lives there.
+	 *
+	 * @var array<string, string>
+	 */
+	private const ACTION_MAP = [
+		'accepted' => 'accepted',
+		'rejected' => 'rejected',
+		'modified' => 'overridden',
+	];
 
+	/**
+	 * Constructor.
+	 *
+	 * @param IEventDispatcher $eventDispatcher Nextcloud typed event dispatcher.
+	 * @param LoggerInterface $logger The logger.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		private readonly IEventDispatcher $eventDispatcher,
+		private readonly LoggerInterface $logger,
+	) {
 
-    /**
-     * Constructor.
-     *
-     * @param IEventDispatcher $eventDispatcher Nextcloud typed event dispatcher.
-     * @param LoggerInterface  $logger          The logger.
-     *
-     * @return void
-     */
-    public function __construct(
-        private readonly IEventDispatcher $eventDispatcher,
-        private readonly LoggerInterface $logger,
-    ) {
+	}//end __construct()
 
-    }//end __construct()
+	/**
+	 * Send one human-oversight decision to hermiq.
+	 *
+	 * @param array<string, mixed> $entry A procest AI audit entry that carries a `userAction`.
+	 *
+	 * @return boolean True when hermiq recorded it; false when hermiq is absent or refused.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/ai-oversight-surface/spec.md
+	 */
+	public function delegate(array $entry): bool {
+		$userAction = (string)($entry['userAction'] ?? '');
+		if (isset(self::ACTION_MAP[$userAction]) === false) {
+			// Not an oversight DECISION. A bare suggestion entry (action=suggestion)
+			// records that the model ran, not that a human judged it, and hermiq's
+			// advisory Approval is a decision record. Sending it would put a row in
+			// the Art. 14 log that nobody decided.
+			return false;
+		}
 
+		$eventClass = self::OVERSIGHT_EVENT;
+		if (class_exists($eventClass) === false) {
+			// Hermiq not installed. Not an error: the caller keeps its local copy
+			// and the instance simply has no central oversight surface.
+			return false;
+		}
 
-    /**
-     * Send one human-oversight decision to hermiq.
-     *
-     * @param array<string, mixed> $entry A procest AI audit entry that carries a `userAction`.
-     *
-     * @return boolean True when hermiq recorded it; false when hermiq is absent or refused.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/ai-oversight-surface/spec.md
-     */
-    public function delegate(array $entry): bool {
-        $userAction = (string) ($entry['userAction'] ?? '');
-        if (isset(self::ACTION_MAP[$userAction]) === false) {
-            // Not an oversight DECISION. A bare suggestion entry (action=suggestion)
-            // records that the model ran, not that a human judged it, and hermiq's
-            // advisory Approval is a decision record. Sending it would put a row in
-            // the Art. 14 log that nobody decided.
-            return false;
-        }
+		$subjectType = 'case';
+		$subjectId = (string)($entry['caseId'] ?? '');
+		if ($subjectId === '' && (string)($entry['documentId'] ?? '') !== '') {
+			$subjectType = 'document';
+			$subjectId = (string)$entry['documentId'];
+		}
 
-        $eventClass = self::OVERSIGHT_EVENT;
-        if (class_exists($eventClass) === false) {
-            // Hermiq not installed. Not an error: the caller keeps its local copy
-            // and the instance simply has no central oversight surface.
-            return false;
-        }
+		if ($subjectId === '') {
+			$this->logger->warning(
+				'AI oversight: entry has neither caseId nor documentId; not delegated',
+				['type' => (string)($entry['type'] ?? '')]
+			);
+			return false;
+		}
 
-        $subjectType = 'case';
-        $subjectId   = (string) ($entry['caseId'] ?? '');
-        if ($subjectId === '' && (string) ($entry['documentId'] ?? '') !== '') {
-            $subjectType = 'document';
-            $subjectId   = (string) $entry['documentId'];
-        }
+		try {
+			$event = new $eventClass(
+				[
+					'originApp' => 'procest',
+					'subjectType' => $subjectType,
+					'subjectId' => $subjectId,
+					'humanAction' => self::ACTION_MAP[$userAction],
+					'userId' => (string)($entry['userId'] ?? ''),
+					'decidedAt' => (string)($entry['timestamp'] ?? ''),
+					'suggestionType' => (string)($entry['type'] ?? ''),
+					'action' => (string)($entry['action'] ?? ''),
+					'model' => (string)($entry['model'] ?? ''),
+					'prompt' => (string)($entry['prompt'] ?? ''),
+					'suggestion' => $this->flatten(value: ($entry['suggestion'] ?? '')),
+					'confidence' => ($entry['confidence'] ?? null),
+					'actualValue' => $this->flatten(value: ($entry['actualValue'] ?? '')),
+					'reason' => (string)($entry['reason'] ?? ''),
+					'responseTimeMs' => ($entry['responseTimeMs'] ?? null),
+					// Idempotency: replaying the same entry through the repair
+					// step must not double-record it.
+					'externalRef' => $this->reference(entry: $entry, subjectId: $subjectId),
+				]
+			);
 
-        if ($subjectId === '') {
-            $this->logger->warning(
-                'AI oversight: entry has neither caseId nor documentId; not delegated',
-                ['type' => (string) ($entry['type'] ?? '')]
-            );
-            return false;
-        }
+			$this->eventDispatcher->dispatchTyped($event);
+		} catch (Throwable $e) {
+			$this->logger->error(
+				'AI oversight: delegation to hermiq failed',
+				['error' => $e->getMessage(), 'subjectId' => $subjectId]
+			);
+			return false;
+		}//end try
 
-        try {
-            $event = new $eventClass(
-                [
-                    'originApp'      => 'procest',
-                    'subjectType'    => $subjectType,
-                    'subjectId'      => $subjectId,
-                    'humanAction'    => self::ACTION_MAP[$userAction],
-                    'userId'         => (string) ($entry['userId'] ?? ''),
-                    'decidedAt'      => (string) ($entry['timestamp'] ?? ''),
-                    'suggestionType' => (string) ($entry['type'] ?? ''),
-                    'action'         => (string) ($entry['action'] ?? ''),
-                    'model'          => (string) ($entry['model'] ?? ''),
-                    'prompt'         => (string) ($entry['prompt'] ?? ''),
-                    'suggestion'     => $this->flatten(value: ($entry['suggestion'] ?? '')),
-                    'confidence'     => ($entry['confidence'] ?? null),
-                    'actualValue'    => $this->flatten(value: ($entry['actualValue'] ?? '')),
-                    'reason'         => (string) ($entry['reason'] ?? ''),
-                    'responseTimeMs' => ($entry['responseTimeMs'] ?? null),
-                    // Idempotency: replaying the same entry through the repair
-                    // step must not double-record it.
-                    'externalRef'    => $this->reference(entry: $entry, subjectId: $subjectId),
-                ]
-            );
+		return (bool)$event->isHandled();
+	}//end delegate()
 
-            $this->eventDispatcher->dispatchTyped($event);
-        } catch (Throwable $e) {
-            $this->logger->error(
-                'AI oversight: delegation to hermiq failed',
-                ['error' => $e->getMessage(), 'subjectId' => $subjectId]
-            );
-            return false;
-        }//end try
+	/**
+	 * Render a suggestion or applied value as a string.
+	 *
+	 * These fields are `array|string` in procest's schema — a classification is
+	 * a scalar, an extraction is a map — and hermiq's advisory context stores
+	 * what the human SAW, which is a rendered value either way.
+	 *
+	 * @param mixed $value The raw value.
+	 *
+	 * @return string The rendered value.
+	 */
+	private function flatten(mixed $value): string {
+		if (is_string($value) === true) {
+			return $value;
+		}
 
-        return (bool) $event->isHandled();
+		if (is_scalar($value) === true) {
+			return (string)$value;
+		}
 
-    }//end delegate()
+		if (is_array($value) === true && empty($value) === false) {
+			return (string)json_encode($value);
+		}
 
+		return '';
+	}//end flatten()
 
-    /**
-     * Render a suggestion or applied value as a string.
-     *
-     * These fields are `array|string` in procest's schema — a classification is
-     * a scalar, an extraction is a map — and hermiq's advisory context stores
-     * what the human SAW, which is a rendered value either way.
-     *
-     * @param mixed $value The raw value.
-     *
-     * @return string The rendered value.
-     */
-    private function flatten(mixed $value): string {
-        if (is_string($value) === true) {
-            return $value;
-        }
+	/**
+	 * Build a stable reference for this decision.
+	 *
+	 * @param array<string, mixed> $entry The audit entry.
+	 * @param string $subjectId The resolved subject id.
+	 *
+	 * @return string The reference.
+	 */
+	private function reference(array $entry, string $subjectId): string {
+		$uuid = (string)($entry['id'] ?? ($entry['uuid'] ?? ''));
+		if ($uuid !== '') {
+			return 'procest:aiAuditEntry:' . $uuid;
+		}
 
-        if (is_scalar($value) === true) {
-            return (string) $value;
-        }
+		return 'procest:aiAuditEntry:' . sha1(
+			$subjectId . '|' . (string)($entry['type'] ?? '') . '|' . (string)($entry['timestamp'] ?? '')
+		);
 
-        if (is_array($value) === true && empty($value) === false) {
-            return (string) json_encode($value);
-        }
-
-        return '';
-
-    }//end flatten()
-
-
-    /**
-     * Build a stable reference for this decision.
-     *
-     * @param array<string, mixed> $entry     The audit entry.
-     * @param string               $subjectId The resolved subject id.
-     *
-     * @return string The reference.
-     */
-    private function reference(array $entry, string $subjectId): string {
-        $uuid = (string) ($entry['id'] ?? ($entry['uuid'] ?? ''));
-        if ($uuid !== '') {
-            return 'procest:aiAuditEntry:' . $uuid;
-        }
-
-        return 'procest:aiAuditEntry:' . sha1(
-            $subjectId . '|' . (string) ($entry['type'] ?? '') . '|' . (string) ($entry['timestamp'] ?? '')
-        );
-
-    }//end reference()
-
+	}//end reference()
 
 }//end class

--- a/lib/Settings/PersonalSettings.php
+++ b/lib/Settings/PersonalSettings.php
@@ -41,47 +41,42 @@ use OCP\Settings\ISettings;
  */
 class PersonalSettings implements ISettings {
 
-    /**
-     * Get the settings form template.
-     *
-     * @return TemplateResponse The rendered personal-settings form.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/personal-settings-surface/spec.md
-     */
-    public function getForm(): TemplateResponse {
-        return new TemplateResponse(
-            Application::APP_ID,
-            'settings/personal',
-            []
-        );
+	/**
+	 * Get the settings form template.
+	 *
+	 * @return TemplateResponse The rendered personal-settings form.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/personal-settings-surface/spec.md
+	 */
+	public function getForm(): TemplateResponse {
+		return new TemplateResponse(
+			Application::APP_ID,
+			'settings/personal',
+			[]
+		);
 
-    }//end getForm()
+	}//end getForm()
 
+	/**
+	 * Get the section this form belongs to.
+	 *
+	 * @return string The personal-settings section id.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/personal-settings-surface/spec.md
+	 */
+	public function getSection(): string {
+		return 'dossiq';
+	}//end getSection()
 
-    /**
-     * Get the section this form belongs to.
-     *
-     * @return string The personal-settings section id.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/personal-settings-surface/spec.md
-     */
-    public function getSection(): string {
-        return 'dossiq';
-
-    }//end getSection()
-
-
-    /**
-     * Get the priority for ordering within the section.
-     *
-     * @return int The ordering priority.
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/personal-settings-surface/spec.md
-     */
-    public function getPriority(): int {
-        return 50;
-
-    }//end getPriority()
-
+	/**
+	 * Get the priority for ordering within the section.
+	 *
+	 * @return int The ordering priority.
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/personal-settings-surface/spec.md
+	 */
+	public function getPriority(): int {
+		return 50;
+	}//end getPriority()
 
 }//end class

--- a/tests/Stubs/Flow/FlowNodeRegistry.php
+++ b/tests/Stubs/Flow/FlowNodeRegistry.php
@@ -28,44 +28,40 @@ use UnexpectedValueException;
  */
 class FlowNodeRegistry {
 
-    /**
-     * Registered nodes, keyed by id.
-     *
-     * @var array<string, IFlowNode>
-     */
-    private array $nodes = [];
+	/**
+	 * Registered nodes, keyed by id.
+	 *
+	 * @var array<string, IFlowNode>
+	 */
+	private array $nodes = [];
 
+	/**
+	 * Register a node.
+	 *
+	 * @param IFlowNode $node The node.
+	 *
+	 * @return void
+	 */
+	public function register(IFlowNode $node): void {
+		$this->nodes[$node->getId()] = $node;
 
-    /**
-     * Register a node.
-     *
-     * @param IFlowNode $node The node.
-     *
-     * @return void
-     */
-    public function register(IFlowNode $node): void {
-        $this->nodes[$node->getId()] = $node;
+	}//end register()
 
-    }//end register()
+	/**
+	 * Resolve a node by its type id.
+	 *
+	 * @param string $type The node id.
+	 *
+	 * @return IFlowNode The node.
+	 *
+	 * @throws UnexpectedValueException When no app provides that type.
+	 */
+	public function get(string $type): IFlowNode {
+		if (isset($this->nodes[$type]) === false) {
+			throw new UnexpectedValueException(sprintf('No node provides "%s".', $type));
+		}
 
-
-    /**
-     * Resolve a node by its type id.
-     *
-     * @param string $type The node id.
-     *
-     * @return IFlowNode The node.
-     *
-     * @throws UnexpectedValueException When no app provides that type.
-     */
-    public function get(string $type): IFlowNode {
-        if (isset($this->nodes[$type]) === false) {
-            throw new UnexpectedValueException(sprintf('No node provides "%s".', $type));
-        }
-
-        return $this->nodes[$type];
-
-    }//end get()
-
+		return $this->nodes[$type];
+	}//end get()
 
 }//end class

--- a/tests/Stubs/Flow/IFlowNode.php
+++ b/tests/Stubs/Flow/IFlowNode.php
@@ -27,61 +27,61 @@ namespace OCA\OpenRegister\Service\Flow;
  */
 interface IFlowNode {
 
-    /**
-     * The namespaced node id.
-     *
-     * @return string The id.
-     */
-    public function getId(): string;
+	/**
+	 * The namespaced node id.
+	 *
+	 * @return string The id.
+	 */
+	public function getId(): string;
 
-    /**
-     * The node's display name.
-     *
-     * @return string The name.
-     */
-    public function getDisplayName(): string;
+	/**
+	 * The node's display name.
+	 *
+	 * @return string The name.
+	 */
+	public function getDisplayName(): string;
 
-    /**
-     * What the node does.
-     *
-     * @return string The description.
-     */
-    public function getDescription(): string;
+	/**
+	 * What the node does.
+	 *
+	 * @return string The description.
+	 */
+	public function getDescription(): string;
 
-    /**
-     * The node icon path.
-     *
-     * @return string The path.
-     */
-    public function getIcon(): string;
+	/**
+	 * The node icon path.
+	 *
+	 * @return string The path.
+	 */
+	public function getIcon(): string;
 
-    /**
-     * Whether the node is offered in a scope.
-     *
-     * @param integer $scope The workflow scope.
-     *
-     * @return boolean True when available.
-     */
-    public function isAvailableForScope(int $scope): bool;
+	/**
+	 * Whether the node is offered in a scope.
+	 *
+	 * @param integer $scope The workflow scope.
+	 *
+	 * @return boolean True when available.
+	 */
+	public function isAvailableForScope(int $scope): bool;
 
-    /**
-     * Reject a config the node cannot act on.
-     *
-     * @param array<string, mixed> $config The step config.
-     *
-     * @return void
-     */
-    public function validateConfig(array $config): void;
+	/**
+	 * Reject a config the node cannot act on.
+	 *
+	 * @param array<string, mixed> $config The step config.
+	 *
+	 * @return void
+	 */
+	public function validateConfig(array $config): void;
 
-    /**
-     * Run the node over a batch of items.
-     *
-     * @param array<int, array<string, mixed>> $items   The items.
-     * @param array<string, mixed>             $config  The step config.
-     * @param array<string, mixed>             $context The run context.
-     *
-     * @return array<int, array<string, mixed>> The resulting items.
-     */
-    public function execute(array $items, array $config, array $context): array;
+	/**
+	 * Run the node over a batch of items.
+	 *
+	 * @param array<int, array<string, mixed>> $items The items.
+	 * @param array<string, mixed> $config The step config.
+	 * @param array<string, mixed> $context The run context.
+	 *
+	 * @return array<int, array<string, mixed>> The resulting items.
+	 */
+	public function execute(array $items, array $config, array $context): array;
 
 }//end interface

--- a/tests/Stubs/Flow/RegisterFlowNodesEvent.php
+++ b/tests/Stubs/Flow/RegisterFlowNodesEvent.php
@@ -34,36 +34,32 @@ use OCP\EventDispatcher\Event;
  */
 class RegisterFlowNodesEvent extends Event {
 
-    /**
-     * The nodes registered on this event.
-     *
-     * @var IFlowNode[]
-     */
-    private array $nodes = [];
+	/**
+	 * The nodes registered on this event.
+	 *
+	 * @var IFlowNode[]
+	 */
+	private array $nodes = [];
 
+	/**
+	 * Register one node on the catalogue.
+	 *
+	 * @param IFlowNode $node The node to register.
+	 *
+	 * @return void
+	 */
+	public function registerNode(IFlowNode $node): void {
+		$this->nodes[] = $node;
 
-    /**
-     * Register one node on the catalogue.
-     *
-     * @param IFlowNode $node The node to register.
-     *
-     * @return void
-     */
-    public function registerNode(IFlowNode $node): void {
-        $this->nodes[] = $node;
+	}//end registerNode()
 
-    }//end registerNode()
-
-
-    /**
-     * The nodes registered so far. Stub-only accessor.
-     *
-     * @return IFlowNode[] The registered nodes.
-     */
-    public function getRegisteredNodes(): array {
-        return $this->nodes;
-
-    }//end getRegisteredNodes()
-
+	/**
+	 * The nodes registered so far. Stub-only accessor.
+	 *
+	 * @return IFlowNode[] The registered nodes.
+	 */
+	public function getRegisteredNodes(): array {
+		return $this->nodes;
+	}//end getRegisteredNodes()
 
 }//end class

--- a/tests/Stubs/Hermiq/Event/AiOversightRecordedEvent.php
+++ b/tests/Stubs/Hermiq/Event/AiOversightRecordedEvent.php
@@ -32,79 +32,72 @@ use OCP\EventDispatcher\Event;
  */
 class AiOversightRecordedEvent extends Event {
 
-    /**
-     * The Approval id hermiq wrote.
-     *
-     * @var string|null
-     */
-    private ?string $approvalId = null;
+	/**
+	 * The Approval id hermiq wrote.
+	 *
+	 * @var string|null
+	 */
+	private ?string $approvalId = null;
 
-    /**
-     * Whether hermiq recorded the decision.
-     *
-     * @var boolean
-     */
-    private bool $handled = false;
+	/**
+	 * Whether hermiq recorded the decision.
+	 *
+	 * @var boolean
+	 */
+	private bool $handled = false;
 
+	/**
+	 * Construct the event.
+	 *
+	 * @param array<string, mixed> $record The decision record.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		private readonly array $record,
+	) {
+		parent::__construct();
 
-    /**
-     * Construct the event.
-     *
-     * @param array<string, mixed> $record The decision record.
-     *
-     * @return void
-     */
-    public function __construct(private readonly array $record) {
-        parent::__construct();
+	}//end __construct()
 
-    }//end __construct()
+	/**
+	 * Get the record.
+	 *
+	 * @return array<string, mixed> The record.
+	 */
+	public function getRecord(): array {
+		return $this->record;
+	}//end getRecord()
 
+	/**
+	 * Get the written Approval id.
+	 *
+	 * @return string|null The id, or null.
+	 */
+	public function getApprovalId(): ?string {
+		return $this->approvalId;
+	}//end getApprovalId()
 
-    /**
-     * Get the record.
-     *
-     * @return array<string, mixed> The record.
-     */
-    public function getRecord(): array {
-        return $this->record;
+	/**
+	 * Set the written Approval id.
+	 *
+	 * @param string $approvalId The id.
+	 *
+	 * @return void
+	 */
+	public function setApprovalId(string $approvalId): void {
+		$this->approvalId = $approvalId;
+		$this->handled = true;
 
-    }//end getRecord()
+	}//end setApprovalId()
 
-
-    /**
-     * Get the written Approval id.
-     *
-     * @return string|null The id, or null.
-     */
-    public function getApprovalId(): ?string {
-        return $this->approvalId;
-
-    }//end getApprovalId()
-
-
-    /**
-     * Set the written Approval id.
-     *
-     * @param string $approvalId The id.
-     *
-     * @return void
-     */
-    public function setApprovalId(string $approvalId): void {
-        $this->approvalId = $approvalId;
-        $this->handled    = true;
-
-    }//end setApprovalId()
-
-
-    /**
-     * Whether hermiq handled it.
-     *
-     * @return boolean True when recorded.
-     */
-    public function isHandled(): bool {
-        return $this->handled;
-
-    }//end isHandled()
-
+	/**
+	 * Whether hermiq handled it.
+	 *
+	 * @return boolean True when recorded.
+	 */
+	public function isHandled(): bool {
+		return $this->handled;
+	}//end isHandled()
 
 }//end class

--- a/tests/Stubs/OpenRegister/SchemaApplicationMigratorStub.php
+++ b/tests/Stubs/OpenRegister/SchemaApplicationMigratorStub.php
@@ -31,11 +31,11 @@ if (class_exists('OCA\OpenRegister\Service\SchemaApplicationMigrator', false) ==
 		 * @var array<string, mixed>
 		 */
 		public static array $outcome = [
-			'ok'         => true,
-			'reason'     => 'migrated',
+			'ok' => true,
+			'reason' => 'migrated',
 			'collisions' => [],
-			'schemas'    => 0,
-			'registers'  => 0,
+			'schemas' => 0,
+			'registers' => 0,
 		];
 
 		/**
@@ -52,12 +52,11 @@ if (class_exists('OCA\OpenRegister\Service\SchemaApplicationMigrator', false) ==
 		 */
 		public static bool $throws = false;
 
-
 		/**
 		 * Record the call and return the canned outcome.
 		 *
 		 * @param string $from The current application id.
-		 * @param string $to   The new application id.
+		 * @param string $to The new application id.
 		 *
 		 * @return array<string, mixed> The canned outcome.
 		 */
@@ -69,9 +68,7 @@ if (class_exists('OCA\OpenRegister\Service\SchemaApplicationMigrator', false) ==
 			}
 
 			return self::$outcome;
-
 		}//end migrate()
-
 
 	}//end class
 }//end if

--- a/tests/Unit/Flow/ProcestActionNodeTest.php
+++ b/tests/Unit/Flow/ProcestActionNodeTest.php
@@ -34,204 +34,194 @@ use UnexpectedValueException;
  */
 class ProcestActionNodeTest extends TestCase {
 
-    /**
-     * @var SendEmailHandler&\PHPUnit\Framework\MockObject\MockObject
-     */
-    private $handler;
+	/**
+	 * @var SendEmailHandler&\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private $handler;
 
-    /**
-     * @var ProcestSendEmailNode
-     */
-    private ProcestSendEmailNode $node;
+	/**
+	 * @var ProcestSendEmailNode
+	 */
+	private ProcestSendEmailNode $node;
 
+	/**
+	 * Set up the node over a mocked handler.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->handler = $this->createMock(SendEmailHandler::class);
+		$this->handler->method('type')->willReturn('sendEmail');
 
-    /**
-     * Set up the node over a mocked handler.
-     *
-     * @return void
-     */
-    protected function setUp(): void {
-        parent::setUp();
-        $this->handler = $this->createMock(SendEmailHandler::class);
-        $this->handler->method('type')->willReturn('sendEmail');
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')->willReturnCallback(
+			static function (string $text, array $params = []): string {
+				return vsprintf($text, $params);
+			}
+		);
+		$urls = $this->createMock(IURLGenerator::class);
+		$urls->method('imagePath')->willReturn('/apps/procest/img/app-dark.svg');
 
-        $l10n = $this->createMock(IL10N::class);
-        $l10n->method('t')->willReturnCallback(
-            static function (string $text, array $params=[]): string {
-                return vsprintf($text, $params);
-            }
-        );
-        $urls = $this->createMock(IURLGenerator::class);
-        $urls->method('imagePath')->willReturn('/apps/procest/img/app-dark.svg');
+		$this->node = new ProcestSendEmailNode($this->handler, $l10n, $urls);
 
-        $this->node = new ProcestSendEmailNode($this->handler, $l10n, $urls);
+	}//end setUp()
 
-    }//end setUp()
+	/**
+	 * A complete config for this node.
+	 *
+	 * @return array<string, mixed> The config.
+	 */
+	private function config(): array {
+		return [
+			'recipientRef' => 'behandelaar',
+			'subjectTemplate' => 'Zaak {{ title }}',
+			'bodyTemplate' => 'Uw zaak is bijgewerkt.',
+		];
 
+	}//end config()
 
-    /**
-     * A complete config for this node.
-     *
-     * @return array<string, mixed> The config.
-     */
-    private function config(): array {
-        return [
-            'recipientRef'    => 'behandelaar',
-            'subjectTemplate' => 'Zaak {{ title }}',
-            'bodyTemplate'    => 'Uw zaak is bijgewerkt.',
-        ];
+	/**
+	 * The node id is derived from the handler's own type slug.
+	 *
+	 * Deriving it is what stops a node id drifting from the handler it runs,
+	 * and gives the reference migration one rule instead of six.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function testIdIsDerivedFromTheHandlerType(): void {
+		// `procest.action.*`, not `procest.*`: the LIVE transition vocabulary
+		// owns the plain names and both systems ship a sendEmail. An id
+		// collision here would have one handler silently shadow the other in
+		// the catalogue.
+		$this->assertSame('procest.action.sendEmail', $this->node->getId());
 
-    }//end config()
+	}//end testIdIsDerivedFromTheHandlerType()
 
+	/**
+	 * A successful action puts its data on the item.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function testSuccessfulActionWritesItsResultOntoTheItem(): void {
+		$this->handler->method('handle')->willReturn(new ActionResult(true, null, ['sent' => 1]));
 
-    /**
-     * The node id is derived from the handler's own type slug.
-     *
-     * Deriving it is what stops a node id drifting from the handler it runs,
-     * and gives the reference migration one rule instead of six.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function testIdIsDerivedFromTheHandlerType(): void {
-        // `procest.action.*`, not `procest.*`: the LIVE transition vocabulary
-        // owns the plain names and both systems ship a sendEmail. An id
-        // collision here would have one handler silently shadow the other in
-        // the catalogue.
-        $this->assertSame('procest.action.sendEmail', $this->node->getId());
+		$out = $this->node->execute(
+			[['json' => ['id' => 'case-1', 'title' => 'Bezwaar']]],
+			$this->config(),
+			[]
+		);
 
-    }//end testIdIsDerivedFromTheHandlerType()
+		$this->assertCount(1, $out);
+		$this->assertSame(['sent' => 1], $out[0]['json']['actionResult']);
+		$this->assertSame('case-1', $out[0]['json']['id']);
 
+	}//end testSuccessfulActionWritesItsResultOntoTheItem()
 
-    /**
-     * A successful action puts its data on the item.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function testSuccessfulActionWritesItsResultOntoTheItem(): void {
-        $this->handler->method('handle')->willReturn(new ActionResult(true, null, ['sent' => 1]));
+	/**
+	 * The output key is configurable.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function testOutputKeyIsConfigurable(): void {
+		$this->handler->method('handle')->willReturn(new ActionResult(true, null, ['sent' => 1]));
 
-        $out = $this->node->execute(
-            [['json' => ['id' => 'case-1', 'title' => 'Bezwaar']]],
-            $this->config(),
-            []
-        );
+		$out = $this->node->execute(
+			[['json' => []]],
+			array_merge($this->config(), ['output' => 'mailResult']),
+			[]
+		);
 
-        $this->assertCount(1, $out);
-        $this->assertSame(['sent' => 1], $out[0]['json']['actionResult']);
-        $this->assertSame('case-1', $out[0]['json']['id']);
+		$this->assertArrayHasKey('mailResult', $out[0]['json']);
 
-    }//end testSuccessfulActionWritesItsResultOntoTheItem()
+	}//end testOutputKeyIsConfigurable()
 
+	/**
+	 * A FAILED action throws instead of passing the item through.
+	 *
+	 * This is the one that matters. Returning the item unchanged would leave
+	 * the output key absent, and a downstream router would take its default
+	 * branch exactly as though the action had succeeded — the engine's onError
+	 * policy only ever sees failures that propagate out of execute().
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function testFailedActionThrowsRatherThanPassingThrough(): void {
+		$this->handler->method('handle')->willReturn(new ActionResult(false, 'smtp_unavailable'));
 
-    /**
-     * The output key is configurable.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function testOutputKeyIsConfigurable(): void {
-        $this->handler->method('handle')->willReturn(new ActionResult(true, null, ['sent' => 1]));
+		$this->expectException(UnexpectedValueException::class);
+		$this->expectExceptionMessage('smtp_unavailable');
 
-        $out = $this->node->execute(
-            [['json' => []]],
-            array_merge($this->config(), ['output' => 'mailResult']),
-            []
-        );
+		$this->node->execute([['json' => []]], $this->config(), []);
 
-        $this->assertArrayHasKey('mailResult', $out[0]['json']);
+	}//end testFailedActionThrowsRatherThanPassingThrough()
 
-    }//end testOutputKeyIsConfigurable()
+	/**
+	 * A config missing a required key is rejected at EXECUTION, not only on save.
+	 *
+	 * validateConfig() runs when a flow is saved; a seeded or imported flow
+	 * reaches execute() without ever having been saved through the editor.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function testUnvalidatedConfigIsRejectedAtExecution(): void {
+		$this->handler->expects($this->never())->method('handle');
 
+		$config = $this->config();
+		unset($config['recipientRef']);
 
-    /**
-     * A FAILED action throws instead of passing the item through.
-     *
-     * This is the one that matters. Returning the item unchanged would leave
-     * the output key absent, and a downstream router would take its default
-     * branch exactly as though the action had succeeded — the engine's onError
-     * policy only ever sees failures that propagate out of execute().
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function testFailedActionThrowsRatherThanPassingThrough(): void {
-        $this->handler->method('handle')->willReturn(new ActionResult(false, 'smtp_unavailable'));
+		$this->expectException(UnexpectedValueException::class);
+		$this->node->execute([['json' => []]], $config, []);
 
-        $this->expectException(UnexpectedValueException::class);
-        $this->expectExceptionMessage('smtp_unavailable');
+	}//end testUnvalidatedConfigIsRejectedAtExecution()
 
-        $this->node->execute([['json' => []]], $this->config(), []);
+	/**
+	 * validateConfig() names the key it is missing.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function testValidateConfigNamesTheMissingKey(): void {
+		$config = $this->config();
+		unset($config['bodyTemplate']);
 
-    }//end testFailedActionThrowsRatherThanPassingThrough()
+		$this->expectException(UnexpectedValueException::class);
+		$this->expectExceptionMessage('bodyTemplate');
 
+		$this->node->validateConfig($config);
 
-    /**
-     * A config missing a required key is rejected at EXECUTION, not only on save.
-     *
-     * validateConfig() runs when a flow is saved; a seeded or imported flow
-     * reaches execute() without ever having been saved through the editor.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function testUnvalidatedConfigIsRejectedAtExecution(): void {
-        $this->handler->expects($this->never())->method('handle');
+	}//end testValidateConfigNamesTheMissingKey()
 
-        $config = $this->config();
-        unset($config['recipientRef']);
+	/**
+	 * Every item in the batch is acted on.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function testEveryItemInTheBatchIsActedOn(): void {
+		$this->handler->expects($this->exactly(3))->method('handle')
+			->willReturn(new ActionResult(true, null, []));
 
-        $this->expectException(UnexpectedValueException::class);
-        $this->node->execute([['json' => []]], $config, []);
+		$out = $this->node->execute(
+			[['json' => ['id' => 'a']], ['json' => ['id' => 'b']], ['json' => ['id' => 'c']]],
+			$this->config(),
+			[]
+		);
 
-    }//end testUnvalidatedConfigIsRejectedAtExecution()
+		$this->assertCount(3, $out);
 
-
-    /**
-     * validateConfig() names the key it is missing.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function testValidateConfigNamesTheMissingKey(): void {
-        $config = $this->config();
-        unset($config['bodyTemplate']);
-
-        $this->expectException(UnexpectedValueException::class);
-        $this->expectExceptionMessage('bodyTemplate');
-
-        $this->node->validateConfig($config);
-
-    }//end testValidateConfigNamesTheMissingKey()
-
-
-    /**
-     * Every item in the batch is acted on.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function testEveryItemInTheBatchIsActedOn(): void {
-        $this->handler->expects($this->exactly(3))->method('handle')
-            ->willReturn(new ActionResult(true, null, []));
-
-        $out = $this->node->execute(
-            [['json' => ['id' => 'a']], ['json' => ['id' => 'b']], ['json' => ['id' => 'c']]],
-            $this->config(),
-            []
-        );
-
-        $this->assertCount(3, $out);
-
-    }//end testEveryItemInTheBatchIsActedOn()
-
+	}//end testEveryItemInTheBatchIsActedOn()
 
 }//end class

--- a/tests/Unit/Flow/ProcestFlowNodeListenerTest.php
+++ b/tests/Unit/Flow/ProcestFlowNodeListenerTest.php
@@ -16,8 +16,6 @@ declare(strict_types=1);
 
 namespace OCA\Dossiq\Tests\Unit\Flow;
 
-use OCA\OpenRegister\Service\Flow\IFlowNode;
-use OCA\OpenRegister\Service\Flow\RegisterFlowNodesEvent;
 use OCA\Dossiq\Flow\ProcestCallWebhookNode;
 use OCA\Dossiq\Flow\ProcestCreateDocumentNode;
 use OCA\Dossiq\Flow\ProcestFlowNodeListener;
@@ -25,15 +23,17 @@ use OCA\Dossiq\Flow\ProcestMergeTemplateNode;
 use OCA\Dossiq\Flow\ProcestNotifyRoleNode;
 use OCA\Dossiq\Flow\ProcestScheduleReminderNode;
 use OCA\Dossiq\Flow\ProcestSendEmailNode;
-use OCA\Dossiq\Flow\ProcestTxSendEmailNode;
-use OCA\Dossiq\Flow\ProcestTxCreateTaskNode;
-use OCA\Dossiq\Flow\ProcestTxCreateSubCaseNode;
-use OCA\Dossiq\Flow\ProcestTxWebhookNode;
-use OCA\Dossiq\Flow\ProcestTxSetFieldNode;
-use OCA\Dossiq\Flow\ProcestTxNotifyNode;
 use OCA\Dossiq\Flow\ProcestTxBesluitvormingActivateNode;
 use OCA\Dossiq\Flow\ProcestTxBesluitvormingPublishNode;
+use OCA\Dossiq\Flow\ProcestTxCreateSubCaseNode;
+use OCA\Dossiq\Flow\ProcestTxCreateTaskNode;
 use OCA\Dossiq\Flow\ProcestTxEvaluateDecisionNode;
+use OCA\Dossiq\Flow\ProcestTxNotifyNode;
+use OCA\Dossiq\Flow\ProcestTxSendEmailNode;
+use OCA\Dossiq\Flow\ProcestTxSetFieldNode;
+use OCA\Dossiq\Flow\ProcestTxWebhookNode;
+use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCA\OpenRegister\Service\Flow\RegisterFlowNodesEvent;
 use OCP\EventDispatcher\Event;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -51,131 +51,125 @@ use RuntimeException;
  */
 class ProcestFlowNodeListenerTest extends TestCase {
 
-    /**
-     * The id each node class reports, in the order the listener registers them.
-     *
-     * @var array<class-string, string>
-     */
-    private const EXPECTED_IDS = [
-        ProcestTxSendEmailNode::class => 'procest.sendEmail',
-        ProcestTxCreateTaskNode::class => 'procest.createTask',
-        ProcestTxCreateSubCaseNode::class => 'procest.createSubCase',
-        ProcestTxWebhookNode::class => 'procest.webhook',
-        ProcestTxSetFieldNode::class => 'procest.setField',
-        ProcestTxNotifyNode::class => 'procest.notify',
-        ProcestTxBesluitvormingActivateNode::class => 'procest.besluitvormingActivate',
-        ProcestTxBesluitvormingPublishNode::class => 'procest.besluitvormingPublish',
-        ProcestTxEvaluateDecisionNode::class => 'procest.evaluateDecision',
-        ProcestSendEmailNode::class => 'procest.action.sendEmail',
-        ProcestNotifyRoleNode::class => 'procest.action.notifyRole',
-        ProcestCallWebhookNode::class => 'procest.action.callWebhook',
-        ProcestCreateDocumentNode::class => 'procest.action.createDocument',
-        ProcestMergeTemplateNode::class => 'procest.action.mergeTemplate',
-        ProcestScheduleReminderNode::class => 'procest.action.scheduleReminder',
-    ];
+	/**
+	 * The id each node class reports, in the order the listener registers them.
+	 *
+	 * @var array<class-string, string>
+	 */
+	private const EXPECTED_IDS = [
+		ProcestTxSendEmailNode::class => 'procest.sendEmail',
+		ProcestTxCreateTaskNode::class => 'procest.createTask',
+		ProcestTxCreateSubCaseNode::class => 'procest.createSubCase',
+		ProcestTxWebhookNode::class => 'procest.webhook',
+		ProcestTxSetFieldNode::class => 'procest.setField',
+		ProcestTxNotifyNode::class => 'procest.notify',
+		ProcestTxBesluitvormingActivateNode::class => 'procest.besluitvormingActivate',
+		ProcestTxBesluitvormingPublishNode::class => 'procest.besluitvormingPublish',
+		ProcestTxEvaluateDecisionNode::class => 'procest.evaluateDecision',
+		ProcestSendEmailNode::class => 'procest.action.sendEmail',
+		ProcestNotifyRoleNode::class => 'procest.action.notifyRole',
+		ProcestCallWebhookNode::class => 'procest.action.callWebhook',
+		ProcestCreateDocumentNode::class => 'procest.action.createDocument',
+		ProcestMergeTemplateNode::class => 'procest.action.mergeTemplate',
+		ProcestScheduleReminderNode::class => 'procest.action.scheduleReminder',
+	];
 
+	/**
+	 * Build the listener over a container that yields id-reporting nodes.
+	 *
+	 * The listener resolves its nodes from a class-string list, so the test
+	 * asserts what reaches the CATALOGUE rather than what was injected — which
+	 * is the thing that actually matters: a node class that exists but never
+	 * registers is invisible to the flow editor and looks identical to one that
+	 * works.
+	 *
+	 * @param string[] $failing Class names the container should refuse to build.
+	 *
+	 * @return ProcestFlowNodeListener The listener under test.
+	 */
+	private function listener(array $failing = []): ProcestFlowNodeListener {
+		$container = $this->createMock(ContainerInterface::class);
+		$container->method('get')->willReturnCallback(
+			function (string $class) use ($failing): IFlowNode {
+				if (in_array($class, $failing, true) === true) {
+					throw new RuntimeException('cannot construct ' . $class);
+				}
 
+				$node = $this->createMock(IFlowNode::class);
+				$node->method('getId')->willReturn(self::EXPECTED_IDS[$class]);
+				return $node;
+			}
+		);
 
-    /**
-     * Build the listener over a container that yields id-reporting nodes.
-     *
-     * The listener resolves its nodes from a class-string list, so the test
-     * asserts what reaches the CATALOGUE rather than what was injected — which
-     * is the thing that actually matters: a node class that exists but never
-     * registers is invisible to the flow editor and looks identical to one that
-     * works.
-     *
-     * @param string[] $failing Class names the container should refuse to build.
-     *
-     * @return ProcestFlowNodeListener The listener under test.
-     */
-    private function listener(array $failing=[]): ProcestFlowNodeListener {
-        $container = $this->createMock(ContainerInterface::class);
-        $container->method('get')->willReturnCallback(
-            function (string $class) use ($failing): IFlowNode {
-                if (in_array($class, $failing, true) === true) {
-                    throw new RuntimeException('cannot construct ' . $class);
-                }
+		return new ProcestFlowNodeListener($container, $this->createMock(LoggerInterface::class));
+	}//end listener()
 
-                $node = $this->createMock(IFlowNode::class);
-                $node->method('getId')->willReturn(self::EXPECTED_IDS[$class]);
-                return $node;
-            }
-        );
+	/**
+	 * All fifteen actions land on the catalogue — both vocabularies.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function testAllFifteenActionsAreRegistered(): void {
+		$event = new RegisterFlowNodesEvent();
+		$this->listener()->handle($event);
 
-        return new ProcestFlowNodeListener($container, $this->createMock(LoggerInterface::class));
+		$ids = array_map(
+			static fn ($node): string => $node->getId(),
+			$event->getRegisteredNodes()
+		);
 
-    }//end listener()
+		$this->assertSame(
+			array_values(self::EXPECTED_IDS),
+			$ids
+		);
 
+	}//end testAllFifteenActionsAreRegistered()
 
-    /**
-     * All fifteen actions land on the catalogue — both vocabularies.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function testAllFifteenActionsAreRegistered(): void {
-        $event = new RegisterFlowNodesEvent();
-        $this->listener()->handle($event);
+	/**
+	 * An unrelated event is ignored rather than half-handled.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function testUnrelatedEventIsIgnored(): void {
+		$other = new class extends Event {
+		};
 
-        $ids = array_map(
-            static fn ($node): string => $node->getId(),
-            $event->getRegisteredNodes()
-        );
+		$this->listener()->handle($other);
 
-        $this->assertSame(
-            array_values(self::EXPECTED_IDS),
-            $ids
-        );
+		$this->addToAssertionCount(1);
 
-    }//end testAllFifteenActionsAreRegistered()
+	}//end testUnrelatedEventIsIgnored()
 
+	/**
+	 * One unbuildable node does not cost the other fourteen their place.
+	 *
+	 * The list-based resolution introduced this branch: if a single node's
+	 * dependencies cannot be constructed, aborting would empty the whole
+	 * catalogue. A skipped node is visible — the editor simply does not offer
+	 * it — where a failed registration takes everything down with it.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function testOneUnbuildableNodeDoesNotCostTheRest(): void {
+		$event = new RegisterFlowNodesEvent();
+		$this->listener(failing: [ProcestTxSetFieldNode::class])->handle($event);
 
-    /**
-     * An unrelated event is ignored rather than half-handled.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function testUnrelatedEventIsIgnored(): void {
-        $other = new class extends Event {
-        };
+		$ids = array_map(
+			static fn ($node): string => $node->getId(),
+			$event->getRegisteredNodes()
+		);
 
-        $this->listener()->handle($other);
+		$this->assertCount(14, $ids);
+		$this->assertNotContains('procest.setField', $ids);
+		$this->assertContains('procest.sendEmail', $ids);
+		$this->assertContains('procest.action.sendEmail', $ids);
 
-        $this->addToAssertionCount(1);
-
-    }//end testUnrelatedEventIsIgnored()
-
-    /**
-     * One unbuildable node does not cost the other fourteen their place.
-     *
-     * The list-based resolution introduced this branch: if a single node's
-     * dependencies cannot be constructed, aborting would empty the whole
-     * catalogue. A skipped node is visible — the editor simply does not offer
-     * it — where a failed registration takes everything down with it.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function testOneUnbuildableNodeDoesNotCostTheRest(): void {
-        $event = new RegisterFlowNodesEvent();
-        $this->listener(failing: [ProcestTxSetFieldNode::class])->handle($event);
-
-        $ids = array_map(
-            static fn ($node): string => $node->getId(),
-            $event->getRegisteredNodes()
-        );
-
-        $this->assertCount(14, $ids);
-        $this->assertNotContains('procest.setField', $ids);
-        $this->assertContains('procest.sendEmail', $ids);
-        $this->assertContains('procest.action.sendEmail', $ids);
-
-    }//end testOneUnbuildableNodeDoesNotCostTheRest()
-
+	}//end testOneUnbuildableNodeDoesNotCostTheRest()
 
 }//end class

--- a/tests/Unit/Repair/MigrateAiOversightToHermiqTest.php
+++ b/tests/Unit/Repair/MigrateAiOversightToHermiqTest.php
@@ -34,188 +34,178 @@ use PHPUnit\Framework\TestCase;
  */
 class MigrateAiOversightToHermiqTest extends TestCase {
 
+	/**
+	 * Build the step over a stubbed audit log and delegation service.
+	 *
+	 * @param array<int, array<string, mixed>> $entries What the audit log returns.
+	 * @param boolean $delegates Whether delegation reports success.
+	 *
+	 * @return array{0: MigrateAiOversightToHermiq, 1: IOutput} The step and its output.
+	 */
+	private function step(array $entries, bool $delegates = true): array {
+		$audit = $this->createMock(AiAuditLog::class);
+		$audit->method('list')->willReturn(
+			['entries' => $entries, 'total' => null, 'limit' => 200, 'offset' => 0]
+		);
 
-    /**
-     * Build the step over a stubbed audit log and delegation service.
-     *
-     * @param array<int, array<string, mixed>> $entries   What the audit log returns.
-     * @param boolean                          $delegates Whether delegation reports success.
-     *
-     * @return array{0: MigrateAiOversightToHermiq, 1: IOutput} The step and its output.
-     */
-    private function step(array $entries, bool $delegates=true): array {
-        $audit = $this->createMock(AiAuditLog::class);
-        $audit->method('list')->willReturn(
-            ['entries' => $entries, 'total' => null, 'limit' => 200, 'offset' => 0]
-        );
+		$oversight = $this->createMock(AiOversightDelegationService::class);
+		$oversight->method('delegate')->willReturn($delegates);
 
-        $oversight = $this->createMock(AiOversightDelegationService::class);
-        $oversight->method('delegate')->willReturn($delegates);
+		return [new MigrateAiOversightToHermiq($audit, $oversight), $this->createMock(IOutput::class)];
+	}//end step()
 
-        return [new MigrateAiOversightToHermiq($audit, $oversight), $this->createMock(IOutput::class)];
+	/**
+	 * Entries are read from the key AiAuditLog actually returns.
+	 *
+	 * This is the regression: with the wrong key the step reports "nothing to
+	 * consider" and migrates nothing, on an instance that has plenty.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/ai-oversight-surface/spec.md
+	 */
+	public function testEntriesAreReadFromTheEntriesKey(): void {
+		[$step, $output] = $this->step([['userAction' => 'accepted', 'caseId' => 'c-1']]);
 
-    }//end step()
+		$output->expects($this->once())->method('info')
+			->with($this->stringContains('1 decision(s) sent'));
 
+		$step->run($output);
 
-    /**
-     * Entries are read from the key AiAuditLog actually returns.
-     *
-     * This is the regression: with the wrong key the step reports "nothing to
-     * consider" and migrates nothing, on an instance that has plenty.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/ai-oversight-surface/spec.md
-     */
-    public function testEntriesAreReadFromTheEntriesKey(): void {
-        [$step, $output] = $this->step([['userAction' => 'accepted', 'caseId' => 'c-1']]);
+	}//end testEntriesAreReadFromTheEntriesKey()
 
-        $output->expects($this->once())->method('info')
-            ->with($this->stringContains('1 decision(s) sent'));
+	/**
+	 * An empty log says so rather than claiming a migration happened.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/ai-oversight-surface/spec.md
+	 */
+	public function testEmptyLogReportsNothingToConsider(): void {
+		[$step, $output] = $this->step([]);
 
-        $step->run($output);
+		$output->expects($this->once())->method('info')
+			->with($this->stringContains('no audit entries'));
 
-    }//end testEntriesAreReadFromTheEntriesKey()
+		$step->run($output);
 
+	}//end testEmptyLogReportsNothingToConsider()
 
-    /**
-     * An empty log says so rather than claiming a migration happened.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/ai-oversight-surface/spec.md
-     */
-    public function testEmptyLogReportsNothingToConsider(): void {
-        [$step, $output] = $this->step([]);
+	/**
+	 * Entries hermiq declines are counted as skipped, not as sent.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/ai-oversight-surface/spec.md
+	 */
+	public function testDeclinedEntriesAreCountedAsSkipped(): void {
+		[$step, $output] = $this->step(
+			[['userAction' => 'accepted', 'caseId' => 'c-1']],
+			delegates: false
+		);
 
-        $output->expects($this->once())->method('info')
-            ->with($this->stringContains('no audit entries'));
+		$output->expects($this->once())->method('info')
+			->with($this->stringContains('0 decision(s) sent to hermiq, 1 entry'));
 
-        $step->run($output);
+		$step->run($output);
 
-    }//end testEmptyLogReportsNothingToConsider()
+	}//end testDeclinedEntriesAreCountedAsSkipped()
 
+	/**
+	 * A malformed row is skipped rather than crashing the upgrade.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/ai-oversight-surface/spec.md
+	 */
+	public function testMalformedRowDoesNotCrashTheUpgrade(): void {
+		[$step, $output] = $this->step([['userAction' => 'accepted', 'caseId' => 'c-1']]);
+		$step->run($output);
 
-    /**
-     * Entries hermiq declines are counted as skipped, not as sent.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/ai-oversight-surface/spec.md
-     */
-    public function testDeclinedEntriesAreCountedAsSkipped(): void {
-        [$step, $output] = $this->step(
-            [['userAction' => 'accepted', 'caseId' => 'c-1']],
-            delegates: false
-        );
+		$this->addToAssertionCount(1);
 
-        $output->expects($this->once())->method('info')
-            ->with($this->stringContains('0 decision(s) sent to hermiq, 1 entry'));
+	}//end testMalformedRowDoesNotCrashTheUpgrade()
 
-        $step->run($output);
+	/**
+	 * The step names itself for the upgrade output.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/ai-oversight-surface/spec.md
+	 */
+	public function testItHasAName(): void {
+		[$step] = $this->step([]);
 
-    }//end testDeclinedEntriesAreCountedAsSkipped()
+		$this->assertStringContainsString('hermiq', $step->getName());
 
+	}//end testItHasAName()
 
-    /**
-     * A malformed row is skipped rather than crashing the upgrade.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/ai-oversight-surface/spec.md
-     */
-    public function testMalformedRowDoesNotCrashTheUpgrade(): void {
-        [$step, $output] = $this->step([['userAction' => 'accepted', 'caseId' => 'c-1']]);
-        $step->run($output);
+	/**
+	 * A row that is not an array is skipped, not fed to the delegator.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/ai-oversight-surface/spec.md
+	 */
+	public function testNonArrayRowIsSkipped(): void {
+		$audit = $this->createMock(AiAuditLog::class);
+		$audit->method('list')->willReturn(
+			['entries' => ['not-an-array'], 'total' => null, 'limit' => 200, 'offset' => 0]
+		);
+		$oversight = $this->createMock(AiOversightDelegationService::class);
+		$oversight->expects($this->never())->method('delegate');
 
-        $this->addToAssertionCount(1);
+		$output = $this->createMock(IOutput::class);
+		$output->expects($this->once())->method('info')
+			->with($this->stringContains('0 decision(s) sent to hermiq, 1 entry'));
 
-    }//end testMalformedRowDoesNotCrashTheUpgrade()
+		(new MigrateAiOversightToHermiq($audit, $oversight))->run($output);
 
+	}//end testNonArrayRowIsSkipped()
 
-    /**
-     * The step names itself for the upgrade output.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/ai-oversight-surface/spec.md
-     */
-    public function testItHasAName(): void {
-        [$step] = $this->step([]);
+	/**
+	 * An unreadable audit log warns and returns instead of failing the upgrade.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/ai-oversight-surface/spec.md
+	 */
+	public function testUnreadableAuditLogWarnsAndReturns(): void {
+		$audit = $this->createMock(AiAuditLog::class);
+		$audit->method('list')->willThrowException(new \RuntimeException('register gone'));
 
-        $this->assertStringContainsString('hermiq', $step->getName());
+		$output = $this->createMock(IOutput::class);
+		$output->expects($this->once())->method('warning')
+			->with($this->stringContains('could not read the audit log'));
+		$output->expects($this->never())->method('info');
 
-    }//end testItHasAName()
+		(new MigrateAiOversightToHermiq($audit, $this->createMock(AiOversightDelegationService::class)))
+			->run($output);
 
-    /**
-     * A row that is not an array is skipped, not fed to the delegator.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/ai-oversight-surface/spec.md
-     */
-    public function testNonArrayRowIsSkipped(): void {
-        $audit = $this->createMock(AiAuditLog::class);
-        $audit->method('list')->willReturn(
-            ['entries' => ['not-an-array'], 'total' => null, 'limit' => 200, 'offset' => 0]
-        );
-        $oversight = $this->createMock(AiOversightDelegationService::class);
-        $oversight->expects($this->never())->method('delegate');
+	}//end testUnreadableAuditLogWarnsAndReturns()
 
-        $output = $this->createMock(IOutput::class);
-        $output->expects($this->once())->method('info')
-            ->with($this->stringContains('0 decision(s) sent to hermiq, 1 entry'));
+	/**
+	 * A delegation that throws is contained per entry, not per upgrade.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/ai-oversight-surface/spec.md
+	 */
+	public function testThrowingDelegationIsContained(): void {
+		$audit = $this->createMock(AiAuditLog::class);
+		$audit->method('list')->willReturn(
+			['entries' => [['userAction' => 'accepted', 'caseId' => 'c-1']],
+				'total' => null, 'limit' => 200, 'offset' => 0]
+		);
+		$oversight = $this->createMock(AiOversightDelegationService::class);
+		$oversight->method('delegate')->willThrowException(new \RuntimeException('boom'));
 
-        (new MigrateAiOversightToHermiq($audit, $oversight))->run($output);
+		$output = $this->createMock(IOutput::class);
+		$output->expects($this->once())->method('warning')
+			->with($this->stringContains('entry failed'));
 
-    }//end testNonArrayRowIsSkipped()
+		(new MigrateAiOversightToHermiq($audit, $oversight))->run($output);
 
-
-    /**
-     * An unreadable audit log warns and returns instead of failing the upgrade.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/ai-oversight-surface/spec.md
-     */
-    public function testUnreadableAuditLogWarnsAndReturns(): void {
-        $audit = $this->createMock(AiAuditLog::class);
-        $audit->method('list')->willThrowException(new \RuntimeException('register gone'));
-
-        $output = $this->createMock(IOutput::class);
-        $output->expects($this->once())->method('warning')
-            ->with($this->stringContains('could not read the audit log'));
-        $output->expects($this->never())->method('info');
-
-        (new MigrateAiOversightToHermiq($audit, $this->createMock(AiOversightDelegationService::class)))
-            ->run($output);
-
-    }//end testUnreadableAuditLogWarnsAndReturns()
-
-
-    /**
-     * A delegation that throws is contained per entry, not per upgrade.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/ai-oversight-surface/spec.md
-     */
-    public function testThrowingDelegationIsContained(): void {
-        $audit = $this->createMock(AiAuditLog::class);
-        $audit->method('list')->willReturn(
-            ['entries' => [['userAction' => 'accepted', 'caseId' => 'c-1']],
-             'total' => null, 'limit' => 200, 'offset' => 0]
-        );
-        $oversight = $this->createMock(AiOversightDelegationService::class);
-        $oversight->method('delegate')->willThrowException(new \RuntimeException('boom'));
-
-        $output = $this->createMock(IOutput::class);
-        $output->expects($this->once())->method('warning')
-            ->with($this->stringContains('entry failed'));
-
-        (new MigrateAiOversightToHermiq($audit, $oversight))->run($output);
-
-    }//end testThrowingDelegationIsContained()
-
+	}//end testThrowingDelegationIsContained()
 
 }//end class

--- a/tests/Unit/Repair/MigrateRegisterApplicationIdTest.php
+++ b/tests/Unit/Repair/MigrateRegisterApplicationIdTest.php
@@ -40,17 +40,16 @@ class MigrateRegisterApplicationIdTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 		SchemaApplicationMigrator::$calledWith = [];
-		SchemaApplicationMigrator::$throws     = false;
-		SchemaApplicationMigrator::$outcome    = [
-			'ok'         => true,
-			'reason'     => 'migrated',
+		SchemaApplicationMigrator::$throws = false;
+		SchemaApplicationMigrator::$outcome = [
+			'ok' => true,
+			'reason' => 'migrated',
 			'collisions' => [],
-			'schemas'    => 0,
-			'registers'  => 0,
+			'schemas' => 0,
+			'registers' => 0,
 		];
 
 	}//end setUp()
-
 
 	/**
 	 * Build the step with a container that returns the stub migrator.
@@ -62,9 +61,7 @@ class MigrateRegisterApplicationIdTest extends TestCase {
 		$container->method('get')->willReturn(new SchemaApplicationMigrator());
 
 		return new MigrateRegisterApplicationId($container, $this->createMock(LoggerInterface::class));
-
 	}//end step()
-
 
 	/**
 	 * The migration is requested for procest -> dossiq, in that direction.
@@ -83,14 +80,13 @@ class MigrateRegisterApplicationIdTest extends TestCase {
 
 	}//end testMigratesFromProcestToDossiq()
 
-
 	/**
 	 * A successful move reports the counts.
 	 *
 	 * @return void
 	 */
 	public function testReportsWhatItMoved(): void {
-		SchemaApplicationMigrator::$outcome['schemas']   = 12;
+		SchemaApplicationMigrator::$outcome['schemas'] = 12;
 		SchemaApplicationMigrator::$outcome['registers'] = 1;
 
 		$output = $this->createMock(IOutput::class);
@@ -101,7 +97,6 @@ class MigrateRegisterApplicationIdTest extends TestCase {
 		$this->step()->run($output);
 
 	}//end testReportsWhatItMoved()
-
 
 	/**
 	 * A second run reports "already migrated" rather than a bare success.
@@ -121,7 +116,6 @@ class MigrateRegisterApplicationIdTest extends TestCase {
 
 	}//end testSecondRunSaysAlreadyMigrated()
 
-
 	/**
 	 * A refusal names the colliding slugs and the command that resolves them.
 	 *
@@ -129,11 +123,11 @@ class MigrateRegisterApplicationIdTest extends TestCase {
 	 */
 	public function testRefusalNamesTheCollidingSlugs(): void {
 		SchemaApplicationMigrator::$outcome = [
-			'ok'         => false,
-			'reason'     => 'collisions',
+			'ok' => false,
+			'reason' => 'collisions',
 			'collisions' => ['case', 'casetype'],
-			'schemas'    => 0,
-			'registers'  => 0,
+			'schemas' => 0,
+			'registers' => 0,
 		];
 
 		$output = $this->createMock(IOutput::class);
@@ -147,7 +141,6 @@ class MigrateRegisterApplicationIdTest extends TestCase {
 		$this->step()->run($output);
 
 	}//end testRefusalNamesTheCollidingSlugs()
-
 
 	/**
 	 * A throwing migrator warns instead of aborting the upgrade.
@@ -168,6 +161,5 @@ class MigrateRegisterApplicationIdTest extends TestCase {
 		$this->step()->run($output);
 
 	}//end testAThrowingMigratorDoesNotAbortTheUpgrade()
-
 
 }//end class

--- a/tests/Unit/Repair/MigrateSchemaApplicationIdTest.php
+++ b/tests/Unit/Repair/MigrateSchemaApplicationIdTest.php
@@ -1,0 +1,230 @@
+<?php
+
+/**
+ * Tests for the schema application-id migration.
+ *
+ * @category  Test
+ * @package   OCA\Dossiq\Tests\Unit\Repair
+ * @author    Conduction B.V. <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link      https://www.conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Dossiq\Tests\Unit\Repair;
+
+use OCA\Dossiq\Repair\MigrateSchemaApplicationId;
+use OCP\DB\IResult;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionClass;
+
+/**
+ * phpcs:disable CustomSniffs.Functions.NamedParameters
+ *
+ * @covers \OCA\Dossiq\Repair\MigrateSchemaApplicationId
+ *
+ * @spec exclude No canonical spec covers the `procest` -> `dossiq` schema
+ *  application-id migration. Pointing this at an existing spec would report
+ *  conformance to a requirement that says nothing about it.
+ */
+final class MigrateSchemaApplicationIdTest extends TestCase {
+
+	/**
+	 * A connection whose two SELECTs return the given slug sets, in order.
+	 *
+	 * The step reads the NEW application id first, then the OLD one.
+	 *
+	 * @param array<int, string> $underNew Slugs already on the new app id.
+	 * @param array<int, string> $underOld Slugs still on the old app id.
+	 * @param array<int, array<int, string>> $written Captured UPDATE params.
+	 *
+	 * @return IDBConnection&\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private function db(array $underNew, array $underOld, array &$written = []) {
+		$mk = function (array $slugs) {
+			$r = $this->createMock(IResult::class);
+			$r->method('fetchAll')->willReturn(array_map(static fn (string $s): array => ['slug' => $s], $slugs));
+			return $r;
+		};
+
+		$db = $this->createMock(IDBConnection::class);
+		$db->method('executeQuery')->willReturnOnConsecutiveCalls($mk($underNew), $mk($underOld));
+		$db->method('executeStatement')->willReturnCallback(
+			function (string $sql, array $params) use (&$written): int {
+				$written[] = $params;
+				return 1;
+			}
+		);
+
+		return $db;
+	}//end db()
+
+	/**
+	 * A schema with no twin under the new application id is moved.
+	 *
+	 * @return void
+	 */
+	public function testMovesASchemaThatHasNoTwin(): void {
+		$written = [];
+		$db = $this->db([], ['case', 'task'], $written);
+
+		$step = new MigrateSchemaApplicationId($db, $this->createMock(LoggerInterface::class));
+
+		$output = $this->createMock(IOutput::class);
+		$output->expects(self::once())->method('info')->with(self::stringContains('2 schema(s) moved'));
+
+		$step->run($output);
+
+		self::assertSame(
+			[['dossiq', 'procest', 'case'], ['dossiq', 'procest', 'task']],
+			$written
+		);
+
+	}//end testMovesASchemaThatHasNoTwin()
+
+	/**
+	 * A slug that ALREADY exists under the new application id is refused.
+	 *
+	 * Re-pointing it would leave two rows sharing (application, slug), and
+	 * findByApplicationAndSlug() caps at one row — so one would silently win
+	 * every lookup and the other's objects would become unreachable.
+	 *
+	 * @return void
+	 */
+	public function testRefusesASlugThatWouldCollide(): void {
+		$written = [];
+		$db = $this->db(['case'], ['case', 'task'], $written);
+
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects(self::once())->method('warning')->with(self::stringContains('refusing to create a duplicate'));
+
+		$step = new MigrateSchemaApplicationId($db, $logger);
+
+		$output = $this->createMock(IOutput::class);
+		$output->expects(self::once())->method('info')->with(self::stringContains('1 schema(s) moved to dossiq, 1 refused'));
+
+		$step->run($output);
+
+		self::assertSame([['dossiq', 'procest', 'task']], $written);
+
+	}//end testRefusesASlugThatWouldCollide()
+
+	/**
+	 * The collision check is case-insensitive, as the lookup is.
+	 *
+	 * SchemaMapper::findByApplicationAndSlug() compares `lower(slug)`, so a
+	 * twin differing only in case still collides.
+	 *
+	 * @return void
+	 */
+	public function testTheCollisionCheckIsCaseInsensitive(): void {
+		$written = [];
+		$db = $this->db(['Case'], ['case'], $written);
+
+		$step = new MigrateSchemaApplicationId($db, $this->createMock(LoggerInterface::class));
+		$step->run($this->createMock(IOutput::class));
+
+		self::assertSame([], $written);
+
+	}//end testTheCollisionCheckIsCaseInsensitive()
+
+	/**
+	 * Nothing on the old application id is a no-op, and says so.
+	 *
+	 * @return void
+	 */
+	public function testNothingOnTheOldAppIdIsANoOp(): void {
+		$written = [];
+		$db = $this->db([], [], $written);
+		$db->expects(self::never())->method('executeStatement');
+
+		$step = new MigrateSchemaApplicationId($db, $this->createMock(LoggerInterface::class));
+
+		$output = $this->createMock(IOutput::class);
+		$output->expects(self::once())->method('info')->with(self::stringContains('nothing to do'));
+
+		$step->run($output);
+
+	}//end testNothingOnTheOldAppIdIsANoOp()
+
+	/**
+	 * A failed READ must not read as "no schemas are claimed".
+	 *
+	 * That distinction is the whole safety of the step: an empty list says
+	 * every move is safe, while a failed read says nothing at all. Treating
+	 * them alike would move every schema on top of an existing twin.
+	 *
+	 * @return void
+	 */
+	public function testAFailedReadIsNotTreatedAsAnEmptyResult(): void {
+		$db = $this->createMock(IDBConnection::class);
+		$db->method('executeQuery')->willThrowException(new \OCP\DB\Exception('read failed'));
+		$db->expects(self::never())->method('executeStatement');
+
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects(self::once())->method('warning')->with(self::stringContains('could not read schemas'));
+
+		$step = new MigrateSchemaApplicationId($db, $logger);
+
+		$output = $this->createMock(IOutput::class);
+		$output->expects(self::once())->method('info')->with(self::stringContains('nothing done'));
+
+		$step->run($output);
+
+	}//end testAFailedReadIsNotTreatedAsAnEmptyResult()
+
+	/**
+	 * A failing UPDATE is logged and counted as not moved — never thrown.
+	 *
+	 * @return void
+	 */
+	public function testAFailingUpdateIsLoggedNotThrown(): void {
+		$mk = function (array $slugs) {
+			$r = $this->createMock(IResult::class);
+			$r->method('fetchAll')->willReturn(array_map(static fn (string $s): array => ['slug' => $s], $slugs));
+			return $r;
+		};
+		$db = $this->createMock(IDBConnection::class);
+		$db->method('executeQuery')->willReturnOnConsecutiveCalls($mk([]), $mk(['case']));
+		$db->method('executeStatement')->willThrowException(new \OCP\DB\Exception('write refused'));
+
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects(self::once())->method('warning')->with(self::stringContains('could not move schema'));
+
+		$step = new MigrateSchemaApplicationId($db, $logger);
+
+		$output = $this->createMock(IOutput::class);
+		$output->expects(self::once())->method('info')->with(self::stringContains('0 schema(s) moved'));
+
+		$step->run($output);
+
+	}//end testAFailingUpdateIsLoggedNotThrown()
+
+	/**
+	 * The shipped ids are a repair step's, and they actually differ.
+	 *
+	 * @return void
+	 */
+	public function testShippedIdsAreWellFormed(): void {
+		self::assertNotSame(MigrateSchemaApplicationId::OLD_APP_ID, MigrateSchemaApplicationId::NEW_APP_ID);
+		self::assertMatchesRegularExpression('/^[a-z][a-z0-9_-]*$/', MigrateSchemaApplicationId::OLD_APP_ID);
+		self::assertMatchesRegularExpression('/^[a-z][a-z0-9_-]*$/', MigrateSchemaApplicationId::NEW_APP_ID);
+		self::assertTrue(
+			(new ReflectionClass(MigrateSchemaApplicationId::class))->implementsInterface(IRepairStep::class)
+		);
+		self::assertNotSame('', (new MigrateSchemaApplicationId(
+			$this->createMock(IDBConnection::class),
+			$this->createMock(LoggerInterface::class)
+		))->getName());
+
+	}//end testShippedIdsAreWellFormed()
+}//end class

--- a/tests/Unit/Sections/PersonalSectionTest.php
+++ b/tests/Unit/Sections/PersonalSectionTest.php
@@ -34,120 +34,111 @@ use PHPUnit\Framework\TestCase;
  */
 class PersonalSectionTest extends TestCase {
 
+	/**
+	 * Build the section with stubbed collaborators.
+	 *
+	 * @return PersonalSection The section under test.
+	 */
+	private function section(): PersonalSection {
+		$l = $this->createMock(IL10N::class);
+		$l->method('t')->willReturnCallback(static fn (string $s): string => $s);
 
-    /**
-     * Build the section with stubbed collaborators.
-     *
-     * @return PersonalSection The section under test.
-     */
-    private function section(): PersonalSection {
-        $l = $this->createMock(IL10N::class);
-        $l->method('t')->willReturnCallback(static fn (string $s): string => $s);
+		$urls = $this->createMock(IURLGenerator::class);
+		$urls->method('imagePath')->willReturn('/apps/dossiq/img/app-dark.svg');
 
-        $urls = $this->createMock(IURLGenerator::class);
-        $urls->method('imagePath')->willReturn('/apps/dossiq/img/app-dark.svg');
+		return new PersonalSection($l, $urls);
+	}//end section()
 
-        return new PersonalSection($l, $urls);
+	/**
+	 * It is an icon section, so it can carry procest's glyph.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/personal-settings-surface/spec.md
+	 */
+	public function testItIsAnIconSection(): void {
+		$this->assertInstanceOf(IIconSection::class, $this->section());
 
-    }//end section()
+	}//end testItIsAnIconSection()
 
+	/**
+	 * The id matches the one PersonalSettings::getSection() returns.
+	 *
+	 * If these two ever drift apart the form silently renders nowhere, which is
+	 * exactly the failure this class was added to prevent.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/personal-settings-surface/spec.md
+	 */
+	public function testIdMatchesTheSettingsSection(): void {
+		$this->assertSame('dossiq', $this->section()->getID());
 
-    /**
-     * It is an icon section, so it can carry procest's glyph.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/personal-settings-surface/spec.md
-     */
-    public function testItIsAnIconSection(): void {
-        $this->assertInstanceOf(IIconSection::class, $this->section());
+	}//end testIdMatchesTheSettingsSection()
 
-    }//end testItIsAnIconSection()
+	/**
+	 * The name is run through translation rather than hardcoded at the caller.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/personal-settings-surface/spec.md
+	 */
+	public function testNameIsTranslated(): void {
+		$this->assertSame('Dossiq', $this->section()->getName());
 
+	}//end testNameIsTranslated()
 
-    /**
-     * The id matches the one PersonalSettings::getSection() returns.
-     *
-     * If these two ever drift apart the form silently renders nowhere, which is
-     * exactly the failure this class was added to prevent.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/personal-settings-surface/spec.md
-     */
-    public function testIdMatchesTheSettingsSection(): void {
-        $this->assertSame('dossiq', $this->section()->getID());
+	/**
+	 * Ordering priority.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/personal-settings-surface/spec.md
+	 */
+	public function testPriority(): void {
+		$this->assertSame(75, $this->section()->getPriority());
 
-    }//end testIdMatchesTheSettingsSection()
+	}//end testPriority()
 
+	/**
+	 * The icon resolves through the URL generator, not a literal path.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/personal-settings-surface/spec.md
+	 */
+	public function testIconComesFromTheUrlGenerator(): void {
+		$this->assertStringContainsString('app-dark.svg', $this->section()->getIcon());
 
-    /**
-     * The name is run through translation rather than hardcoded at the caller.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/personal-settings-surface/spec.md
-     */
-    public function testNameIsTranslated(): void {
-        $this->assertSame('Dossiq', $this->section()->getName());
+	}//end testIconComesFromTheUrlGenerator()
 
-    }//end testNameIsTranslated()
+	/**
+	 * The icon is requested for the LIVE app id.
+	 *
+	 * This asserts the argument, not the return value, and that distinction is
+	 * the whole point: the test above stubs imagePath() with a canned string,
+	 * so it passes no matter which app is asked for. A stale id shipped behind
+	 * it and was not a cosmetic defect — imagePath() throws for an app that
+	 * does not exist, and Nextcloud calls getIcon() on every section while
+	 * assembling the settings navigation, so it returned 500 for every
+	 * /settings/* page while the app's own pages kept working.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/personal-settings-surface/spec.md
+	 */
+	public function testIconIsRequestedForTheCurrentAppId(): void {
+		$l = $this->createMock(IL10N::class);
+		$l->method('t')->willReturnCallback(static fn (string $s): string => $s);
 
+		$urls = $this->createMock(IURLGenerator::class);
+		$urls->expects($this->once())
+			->method('imagePath')
+			->with('dossiq', 'app-dark.svg')
+			->willReturn('/apps/dossiq/img/app-dark.svg');
 
-    /**
-     * Ordering priority.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/personal-settings-surface/spec.md
-     */
-    public function testPriority(): void {
-        $this->assertSame(75, $this->section()->getPriority());
+		(new PersonalSection($l, $urls))->getIcon();
 
-    }//end testPriority()
-
-
-    /**
-     * The icon resolves through the URL generator, not a literal path.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/personal-settings-surface/spec.md
-     */
-    public function testIconComesFromTheUrlGenerator(): void {
-        $this->assertStringContainsString('app-dark.svg', $this->section()->getIcon());
-
-    }//end testIconComesFromTheUrlGenerator()
-
-
-    /**
-     * The icon is requested for the LIVE app id.
-     *
-     * This asserts the argument, not the return value, and that distinction is
-     * the whole point: the test above stubs imagePath() with a canned string,
-     * so it passes no matter which app is asked for. A stale id shipped behind
-     * it and was not a cosmetic defect — imagePath() throws for an app that
-     * does not exist, and Nextcloud calls getIcon() on every section while
-     * assembling the settings navigation, so it returned 500 for every
-     * /settings/* page while the app's own pages kept working.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/personal-settings-surface/spec.md
-     */
-    public function testIconIsRequestedForTheCurrentAppId(): void {
-        $l = $this->createMock(IL10N::class);
-        $l->method('t')->willReturnCallback(static fn (string $s): string => $s);
-
-        $urls = $this->createMock(IURLGenerator::class);
-        $urls->expects($this->once())
-            ->method('imagePath')
-            ->with('dossiq', 'app-dark.svg')
-            ->willReturn('/apps/dossiq/img/app-dark.svg');
-
-        (new PersonalSection($l, $urls))->getIcon();
-
-    }//end testIconIsRequestedForTheCurrentAppId()
-
+	}//end testIconIsRequestedForTheCurrentAppId()
 
 }//end class

--- a/tests/Unit/Service/Ai/AiOversightDelegationServiceTest.php
+++ b/tests/Unit/Service/Ai/AiOversightDelegationServiceTest.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
 
 namespace OCA\Dossiq\Tests\Unit\Service\Ai;
 
-use OCA\Hermiq\Event\AiOversightRecordedEvent;
 use OCA\Dossiq\Service\Ai\AiOversightDelegationService;
+use OCA\Hermiq\Event\AiOversightRecordedEvent;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
 use PHPUnit\Framework\TestCase;
@@ -33,300 +33,284 @@ use Psr\Log\LoggerInterface;
  */
 class AiOversightDelegationServiceTest extends TestCase {
 
-    /**
-     * The last event the dispatcher saw.
-     *
-     * @var AiOversightRecordedEvent|null
-     */
-    private ?AiOversightRecordedEvent $dispatched = null;
+	/**
+	 * The last event the dispatcher saw.
+	 *
+	 * @var AiOversightRecordedEvent|null
+	 */
+	private ?AiOversightRecordedEvent $dispatched = null;
 
+	/**
+	 * Build the service with a dispatcher that captures, and optionally handles.
+	 *
+	 * @param boolean $handled Whether the stub hermiq records the decision.
+	 *
+	 * @return AiOversightDelegationService The service.
+	 */
+	private function service(bool $handled = true): AiOversightDelegationService {
+		$dispatcher = $this->createMock(IEventDispatcher::class);
+		$dispatcher->method('dispatchTyped')->willReturnCallback(
+			function (Event $event) use ($handled): void {
+				if ($event instanceof AiOversightRecordedEvent) {
+					$this->dispatched = $event;
+					if ($handled === true) {
+						$event->setApprovalId('approval-uuid');
+					}
+				}
+			}
+		);
 
-    /**
-     * Build the service with a dispatcher that captures, and optionally handles.
-     *
-     * @param boolean $handled Whether the stub hermiq records the decision.
-     *
-     * @return AiOversightDelegationService The service.
-     */
-    private function service(bool $handled=true): AiOversightDelegationService {
-        $dispatcher = $this->createMock(IEventDispatcher::class);
-        $dispatcher->method('dispatchTyped')->willReturnCallback(
-            function (Event $event) use ($handled): void {
-                if ($event instanceof AiOversightRecordedEvent) {
-                    $this->dispatched = $event;
-                    if ($handled === true) {
-                        $event->setApprovalId('approval-uuid');
-                    }
-                }
-            }
-        );
+		return new AiOversightDelegationService($dispatcher, $this->createMock(LoggerInterface::class));
+	}//end service()
 
-        return new AiOversightDelegationService($dispatcher, $this->createMock(LoggerInterface::class));
+	/**
+	 * A complete decision entry in procest's own shape.
+	 *
+	 * @param array<string, mixed> $overrides Keys to replace.
+	 *
+	 * @return array<string, mixed> The entry.
+	 */
+	private function entry(array $overrides = []): array {
+		return array_merge(
+			[
+				'type' => 'classification',
+				'action' => 'modified',
+				'caseId' => 'case-1',
+				'model' => 'openai/gpt-4o',
+				'suggestion' => ['documentType' => 'request'],
+				'userAction' => 'modified',
+				'actualValue' => ['documentType' => 'objectionProceeding'],
+				'reason' => 'misread the header',
+				'userId' => 'alice',
+				'timestamp' => '2026-08-22T10:25:00+00:00',
+			],
+			$overrides
+		);
 
-    }//end service()
+	}//end entry()
 
+	/**
+	 * procest's `modified` becomes hermiq's `overridden`.
+	 *
+	 * The two vocabularies disagree and hermiq's wins, because the record lives
+	 * there. Getting this backwards would file every correction as a rejection.
+	 *
+	 * @return void
+	 */
+	public function testModifiedBecomesOverridden(): void {
+		$this->assertTrue($this->service()->delegate($this->entry()));
 
-    /**
-     * A complete decision entry in procest's own shape.
-     *
-     * @param array<string, mixed> $overrides Keys to replace.
-     *
-     * @return array<string, mixed> The entry.
-     */
-    private function entry(array $overrides=[]): array {
-        return array_merge(
-            [
-                'type'        => 'classification',
-                'action'      => 'modified',
-                'caseId'      => 'case-1',
-                'model'       => 'openai/gpt-4o',
-                'suggestion'  => ['documentType' => 'request'],
-                'userAction'  => 'modified',
-                'actualValue' => ['documentType' => 'objectionProceeding'],
-                'reason'      => 'misread the header',
-                'userId'      => 'alice',
-                'timestamp'   => '2026-08-22T10:25:00+00:00',
-            ],
-            $overrides
-        );
+		$record = $this->dispatched->getRecord();
+		$this->assertSame('overridden', $record['humanAction']);
+		$this->assertSame('procest', $record['originApp']);
+		$this->assertSame('case', $record['subjectType']);
+		$this->assertSame('case-1', $record['subjectId']);
+		$this->assertSame('alice', $record['userId']);
 
-    }//end entry()
+	}//end testModifiedBecomesOverridden()
 
+	/**
+	 * The other two actions pass through unchanged.
+	 *
+	 * @param string $procest The procest userAction.
+	 * @param string $hermiq The hermiq humanAction.
+	 *
+	 * @return void
+	 *
+	 * @dataProvider actionProvider
+	 */
+	public function testActionsMap(string $procest, string $hermiq): void {
+		$this->service()->delegate($this->entry(['userAction' => $procest]));
 
-    /**
-     * procest's `modified` becomes hermiq's `overridden`.
-     *
-     * The two vocabularies disagree and hermiq's wins, because the record lives
-     * there. Getting this backwards would file every correction as a rejection.
-     *
-     * @return void
-     */
-    public function testModifiedBecomesOverridden(): void {
-        $this->assertTrue($this->service()->delegate($this->entry()));
+		$this->assertSame($hermiq, $this->dispatched->getRecord()['humanAction']);
 
-        $record = $this->dispatched->getRecord();
-        $this->assertSame('overridden', $record['humanAction']);
-        $this->assertSame('procest', $record['originApp']);
-        $this->assertSame('case', $record['subjectType']);
-        $this->assertSame('case-1', $record['subjectId']);
-        $this->assertSame('alice', $record['userId']);
+	}//end testActionsMap()
 
-    }//end testModifiedBecomesOverridden()
+	/**
+	 * The action vocabulary map.
+	 *
+	 * @return array<string, string[]> The data set.
+	 */
+	public static function actionProvider(): array {
+		return [
+			'accepted' => ['accepted', 'accepted'],
+			'rejected' => ['rejected', 'rejected'],
+			'modified' => ['modified', 'overridden'],
+		];
 
+	}//end actionProvider()
 
-    /**
-     * The other two actions pass through unchanged.
-     *
-     * @param string $procest The procest userAction.
-     * @param string $hermiq  The hermiq humanAction.
-     *
-     * @return void
-     *
-     * @dataProvider actionProvider
-     */
-    public function testActionsMap(string $procest, string $hermiq): void {
-        $this->service()->delegate($this->entry(['userAction' => $procest]));
+	/**
+	 * A suggestion-only entry is NOT an oversight decision.
+	 *
+	 * procest's log holds both "the model ran" and "a human judged it". Only the
+	 * second is Art. 14 evidence; sending the first would put rows in hermiq's
+	 * oversight log that nobody decided.
+	 *
+	 * @return void
+	 */
+	public function testSuggestionOnlyEntryIsNotDelegated(): void {
+		$entry = $this->entry(['action' => 'suggestion']);
+		unset($entry['userAction']);
 
-        $this->assertSame($hermiq, $this->dispatched->getRecord()['humanAction']);
+		$this->assertFalse($this->service()->delegate($entry));
+		$this->assertNull($this->dispatched);
 
-    }//end testActionsMap()
+	}//end testSuggestionOnlyEntryIsNotDelegated()
 
+	/**
+	 * A document-scoped entry reports the document as its subject.
+	 *
+	 * @return void
+	 */
+	public function testDocumentSubjectIsUsedWhenThereIsNoCase(): void {
+		$entry = $this->entry(['documentId' => 'doc-9']);
+		unset($entry['caseId']);
 
-    /**
-     * The action vocabulary map.
-     *
-     * @return array<string, string[]> The data set.
-     */
-    public static function actionProvider(): array {
-        return [
-            'accepted' => ['accepted', 'accepted'],
-            'rejected' => ['rejected', 'rejected'],
-            'modified' => ['modified', 'overridden'],
-        ];
+		$this->assertTrue($this->service()->delegate($entry));
+		$record = $this->dispatched->getRecord();
+		$this->assertSame('document', $record['subjectType']);
+		$this->assertSame('doc-9', $record['subjectId']);
 
-    }//end actionProvider()
+	}//end testDocumentSubjectIsUsedWhenThereIsNoCase()
 
+	/**
+	 * An entry with no subject at all is not delegated.
+	 *
+	 * @return void
+	 */
+	public function testEntryWithoutASubjectIsNotDelegated(): void {
+		$entry = $this->entry();
+		unset($entry['caseId']);
 
-    /**
-     * A suggestion-only entry is NOT an oversight decision.
-     *
-     * procest's log holds both "the model ran" and "a human judged it". Only the
-     * second is Art. 14 evidence; sending the first would put rows in hermiq's
-     * oversight log that nobody decided.
-     *
-     * @return void
-     */
-    public function testSuggestionOnlyEntryIsNotDelegated(): void {
-        $entry = $this->entry(['action' => 'suggestion']);
-        unset($entry['userAction']);
+		$this->assertFalse($this->service()->delegate($entry));
+		$this->assertNull($this->dispatched);
 
-        $this->assertFalse($this->service()->delegate($entry));
-        $this->assertNull($this->dispatched);
+	}//end testEntryWithoutASubjectIsNotDelegated()
 
-    }//end testSuggestionOnlyEntryIsNotDelegated()
+	/**
+	 * Map-shaped suggestions and applied values are rendered, not dropped.
+	 *
+	 * procest stores these as `array|string`; hermiq's advisory context holds
+	 * what the human SAW, which is a rendered value either way.
+	 *
+	 * @return void
+	 */
+	public function testMapValuesAreRendered(): void {
+		$this->service()->delegate($this->entry());
 
+		$record = $this->dispatched->getRecord();
+		$this->assertStringContainsString('request', $record['suggestion']);
+		$this->assertStringContainsString('objectionProceeding', $record['actualValue']);
 
-    /**
-     * A document-scoped entry reports the document as its subject.
-     *
-     * @return void
-     */
-    public function testDocumentSubjectIsUsedWhenThereIsNoCase(): void {
-        $entry = $this->entry(['documentId' => 'doc-9']);
-        unset($entry['caseId']);
+	}//end testMapValuesAreRendered()
 
-        $this->assertTrue($this->service()->delegate($entry));
-        $record = $this->dispatched->getRecord();
-        $this->assertSame('document', $record['subjectType']);
-        $this->assertSame('doc-9', $record['subjectId']);
+	/**
+	 * The same entry always produces the same reference, so a repair replay is
+	 * idempotent rather than duplicating the trail.
+	 *
+	 * @return void
+	 */
+	public function testReferenceIsStableAcrossReplays(): void {
+		$this->service()->delegate($this->entry());
+		$first = $this->dispatched->getRecord()['externalRef'];
 
-    }//end testDocumentSubjectIsUsedWhenThereIsNoCase()
+		$this->dispatched = null;
+		$this->service()->delegate($this->entry());
+		$second = $this->dispatched->getRecord()['externalRef'];
 
+		$this->assertSame($first, $second);
+		$this->assertNotSame('', $first);
 
-    /**
-     * An entry with no subject at all is not delegated.
-     *
-     * @return void
-     */
-    public function testEntryWithoutASubjectIsNotDelegated(): void {
-        $entry = $this->entry();
-        unset($entry['caseId']);
+	}//end testReferenceIsStableAcrossReplays()
 
-        $this->assertFalse($this->service()->delegate($entry));
-        $this->assertNull($this->dispatched);
+	/**
+	 * When hermiq does not record it, the caller is told so.
+	 *
+	 * That is what lets procest keep its local copy as the only one rather than
+	 * believing a central record exists.
+	 *
+	 * @return void
+	 */
+	public function testUnhandledEventReportsFalse(): void {
+		$this->assertFalse($this->service(handled: false)->delegate($this->entry()));
 
-    }//end testEntryWithoutASubjectIsNotDelegated()
+	}//end testUnhandledEventReportsFalse()
 
+	/**
+	 * A scalar (non-string) value is rendered rather than dropped.
+	 *
+	 * `confidence`-shaped fields arrive as numbers; flatten() has a branch for
+	 * them that nothing exercised.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/ai-oversight-surface/spec.md
+	 */
+	public function testScalarValuesAreRendered(): void {
+		$this->service()->delegate($this->entry(['suggestion' => 42, 'actualValue' => 7.5]));
 
-    /**
-     * Map-shaped suggestions and applied values are rendered, not dropped.
-     *
-     * procest stores these as `array|string`; hermiq's advisory context holds
-     * what the human SAW, which is a rendered value either way.
-     *
-     * @return void
-     */
-    public function testMapValuesAreRendered(): void {
-        $this->service()->delegate($this->entry());
+		$record = $this->dispatched->getRecord();
+		$this->assertSame('42', $record['suggestion']);
+		$this->assertSame('7.5', $record['actualValue']);
 
-        $record = $this->dispatched->getRecord();
-        $this->assertStringContainsString('request', $record['suggestion']);
-        $this->assertStringContainsString('objectionProceeding', $record['actualValue']);
+	}//end testScalarValuesAreRendered()
 
-    }//end testMapValuesAreRendered()
+	/**
+	 * An empty array renders as an empty string, not as "[]".
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/ai-oversight-surface/spec.md
+	 */
+	public function testEmptyArrayRendersEmpty(): void {
+		$this->service()->delegate($this->entry(['actualValue' => []]));
 
+		$this->assertSame('', $this->dispatched->getRecord()['actualValue']);
 
-    /**
-     * The same entry always produces the same reference, so a repair replay is
-     * idempotent rather than duplicating the trail.
-     *
-     * @return void
-     */
-    public function testReferenceIsStableAcrossReplays(): void {
-        $this->service()->delegate($this->entry());
-        $first = $this->dispatched->getRecord()['externalRef'];
+	}//end testEmptyArrayRendersEmpty()
 
-        $this->dispatched = null;
-        $this->service()->delegate($this->entry());
-        $second = $this->dispatched->getRecord()['externalRef'];
+	/**
+	 * An entry that carries its own id uses it as the reference.
+	 *
+	 * That is the stable half of idempotency: a stored entry has an id, and the
+	 * sha1 fallback is only for entries that do not.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/ai-oversight-surface/spec.md
+	 */
+	public function testEntryIdIsUsedAsTheReference(): void {
+		$this->service()->delegate($this->entry(['id' => 'entry-uuid-1']));
 
-        $this->assertSame($first, $second);
-        $this->assertNotSame('', $first);
+		$this->assertSame(
+			'procest:aiAuditEntry:entry-uuid-1',
+			$this->dispatched->getRecord()['externalRef']
+		);
 
-    }//end testReferenceIsStableAcrossReplays()
+	}//end testEntryIdIsUsedAsTheReference()
 
+	/**
+	 * A dispatcher that throws is reported as not-delegated, never re-raised.
+	 *
+	 * The handler has already acted by this point; an audit failure must not
+	 * become a functional one.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/ai-oversight-surface/spec.md
+	 */
+	public function testDispatchFailureIsSwallowed(): void {
+		$dispatcher = $this->createMock(IEventDispatcher::class);
+		$dispatcher->method('dispatchTyped')
+			->willThrowException(new \RuntimeException('bus unavailable'));
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects($this->once())->method('error');
 
-    /**
-     * When hermiq does not record it, the caller is told so.
-     *
-     * That is what lets procest keep its local copy as the only one rather than
-     * believing a central record exists.
-     *
-     * @return void
-     */
-    public function testUnhandledEventReportsFalse(): void {
-        $this->assertFalse($this->service(handled: false)->delegate($this->entry()));
+		$service = new AiOversightDelegationService($dispatcher, $logger);
 
-    }//end testUnhandledEventReportsFalse()
+		$this->assertFalse($service->delegate($this->entry()));
 
-    /**
-     * A scalar (non-string) value is rendered rather than dropped.
-     *
-     * `confidence`-shaped fields arrive as numbers; flatten() has a branch for
-     * them that nothing exercised.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/ai-oversight-surface/spec.md
-     */
-    public function testScalarValuesAreRendered(): void {
-        $this->service()->delegate($this->entry(['suggestion' => 42, 'actualValue' => 7.5]));
-
-        $record = $this->dispatched->getRecord();
-        $this->assertSame('42', $record['suggestion']);
-        $this->assertSame('7.5', $record['actualValue']);
-
-    }//end testScalarValuesAreRendered()
-
-
-    /**
-     * An empty array renders as an empty string, not as "[]".
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/ai-oversight-surface/spec.md
-     */
-    public function testEmptyArrayRendersEmpty(): void {
-        $this->service()->delegate($this->entry(['actualValue' => []]));
-
-        $this->assertSame('', $this->dispatched->getRecord()['actualValue']);
-
-    }//end testEmptyArrayRendersEmpty()
-
-
-    /**
-     * An entry that carries its own id uses it as the reference.
-     *
-     * That is the stable half of idempotency: a stored entry has an id, and the
-     * sha1 fallback is only for entries that do not.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/ai-oversight-surface/spec.md
-     */
-    public function testEntryIdIsUsedAsTheReference(): void {
-        $this->service()->delegate($this->entry(['id' => 'entry-uuid-1']));
-
-        $this->assertSame(
-            'procest:aiAuditEntry:entry-uuid-1',
-            $this->dispatched->getRecord()['externalRef']
-        );
-
-    }//end testEntryIdIsUsedAsTheReference()
-
-
-    /**
-     * A dispatcher that throws is reported as not-delegated, never re-raised.
-     *
-     * The handler has already acted by this point; an audit failure must not
-     * become a functional one.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/ai-oversight-surface/spec.md
-     */
-    public function testDispatchFailureIsSwallowed(): void {
-        $dispatcher = $this->createMock(IEventDispatcher::class);
-        $dispatcher->method('dispatchTyped')
-            ->willThrowException(new \RuntimeException('bus unavailable'));
-        $logger = $this->createMock(LoggerInterface::class);
-        $logger->expects($this->once())->method('error');
-
-        $service = new AiOversightDelegationService($dispatcher, $logger);
-
-        $this->assertFalse($service->delegate($this->entry()));
-
-    }//end testDispatchFailureIsSwallowed()
-
+	}//end testDispatchFailureIsSwallowed()
 
 }//end class

--- a/tests/Unit/Service/Transitions/SideEffectDispatcherTest.php
+++ b/tests/Unit/Service/Transitions/SideEffectDispatcherTest.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
 
 namespace OCA\Dossiq\Tests\Unit\Service\Transitions;
 
-use OCA\OpenRegister\Service\Flow\FlowNodeRegistry;
-use OCA\OpenRegister\Service\Flow\IFlowNode;
 use OCA\Dossiq\Service\Transitions\ActionHandlerInterface;
 use OCA\Dossiq\Service\Transitions\ActionHandlerRegistry;
 use OCA\Dossiq\Service\Transitions\ActionResult;
 use OCA\Dossiq\Service\Transitions\SideEffectDispatcher;
+use OCA\OpenRegister\Service\Flow\FlowNodeRegistry;
+use OCA\OpenRegister\Service\Flow\IFlowNode;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
@@ -38,190 +38,180 @@ use RuntimeException;
  */
 class SideEffectDispatcherTest extends TestCase {
 
+	/**
+	 * A node that records nothing and either succeeds or throws.
+	 *
+	 * @param string $id The node id.
+	 * @param \Throwable|null $throws Optional failure to raise.
+	 *
+	 * @return IFlowNode The node.
+	 */
+	private function node(string $id, ?\Throwable $throws = null): IFlowNode {
+		$node = $this->createMock(IFlowNode::class);
+		$node->method('getId')->willReturn($id);
+		if ($throws !== null) {
+			$node->method('execute')->willThrowException($throws);
+		} else {
+			$node->method('execute')->willReturnArgument(0);
+		}
 
-    /**
-     * A node that records nothing and either succeeds or throws.
-     *
-     * @param string          $id     The node id.
-     * @param \Throwable|null $throws Optional failure to raise.
-     *
-     * @return IFlowNode The node.
-     */
-    private function node(string $id, ?\Throwable $throws=null): IFlowNode {
-        $node = $this->createMock(IFlowNode::class);
-        $node->method('getId')->willReturn($id);
-        if ($throws !== null) {
-            $node->method('execute')->willThrowException($throws);
-        } else {
-            $node->method('execute')->willReturnArgument(0);
-        }
+		return $node;
+	}//end node()
 
-        return $node;
+	/**
+	 * Build the dispatcher over an optional node catalogue.
+	 *
+	 * @param FlowNodeRegistry|null $nodes The catalogue, or null for the fallback path.
+	 * @param ActionHandlerRegistry|null $legacy The local registry.
+	 *
+	 * @return SideEffectDispatcher The dispatcher.
+	 */
+	private function dispatcher(?FlowNodeRegistry $nodes, ?ActionHandlerRegistry $legacy = null): SideEffectDispatcher {
+		$container = $this->createMock(ContainerInterface::class);
+		if ($nodes !== null) {
+			$container->method('get')->willReturn($nodes);
+		} else {
+			$container->method('get')->willThrowException(new RuntimeException('absent'));
+		}
 
-    }//end node()
+		return new SideEffectDispatcher(
+			$legacy ?? $this->createMock(ActionHandlerRegistry::class),
+			$container,
+			$this->createMock(LoggerInterface::class)
+		);
 
+	}//end dispatcher()
 
-    /**
-     * Build the dispatcher over an optional node catalogue.
-     *
-     * @param FlowNodeRegistry|null      $nodes  The catalogue, or null for the fallback path.
-     * @param ActionHandlerRegistry|null $legacy The local registry.
-     *
-     * @return SideEffectDispatcher The dispatcher.
-     */
-    private function dispatcher(?FlowNodeRegistry $nodes, ?ActionHandlerRegistry $legacy=null): SideEffectDispatcher {
-        $container = $this->createMock(ContainerInterface::class);
-        if ($nodes !== null) {
-            $container->method('get')->willReturn($nodes);
-        } else {
-            $container->method('get')->willThrowException(new RuntimeException('absent'));
-        }
+	/**
+	 * With OpenRegister present, a transition action runs the SHARED node.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function testActionsRunThroughTheSharedNode(): void {
+		$registry = new FlowNodeRegistry();
+		$registry->register($this->node('procest.sendEmail'));
 
-        return new SideEffectDispatcher(
-            $legacy ?? $this->createMock(ActionHandlerRegistry::class),
-            $container,
-            $this->createMock(LoggerInterface::class)
-        );
+		$results = $this->dispatcher($registry)->dispatch(
+			[['type' => 'sendEmail']],
+			['id' => 'case-1'],
+			['transition' => 'submitted']
+		);
 
-    }//end dispatcher()
+		$this->assertSame([['type' => 'sendEmail', 'ok' => true]], $results);
 
+	}//end testActionsRunThroughTheSharedNode()
 
-    /**
-     * With OpenRegister present, a transition action runs the SHARED node.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function testActionsRunThroughTheSharedNode(): void {
-        $registry = new FlowNodeRegistry();
-        $registry->register($this->node('procest.sendEmail'));
+	/**
+	 * The dispatcher resolves the LIVE id space, not the catalogue's.
+	 *
+	 * Both action systems ship a sendEmail. Resolving `procest.action.sendEmail`
+	 * here would run the configured-action handler for a transition — a
+	 * different class with different config keys.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function testItResolvesTheLiveIdSpace(): void {
+		$registry = new FlowNodeRegistry();
+		$registry->register($this->node('procest.action.sendEmail'));
 
-        $results = $this->dispatcher($registry)->dispatch(
-            [['type' => 'sendEmail']],
-            ['id' => 'case-1'],
-            ['transition' => 'submitted']
-        );
+		$results = $this->dispatcher($registry)->dispatch([['type' => 'sendEmail']], [], []);
 
-        $this->assertSame([['type' => 'sendEmail', 'ok' => true]], $results);
+		$this->assertFalse($results[0]['ok']);
+		$this->assertSame('unknown_action_type', $results[0]['error']);
 
-    }//end testActionsRunThroughTheSharedNode()
+	}//end testItResolvesTheLiveIdSpace()
 
+	/**
+	 * A node that throws becomes a failed row — it does NOT abort the loop.
+	 *
+	 * A node signals failure by throwing, because the flow engine's onError
+	 * policy only sees what propagates. This dispatcher's contract is the
+	 * opposite and predates it: a failed action must not stop the remaining
+	 * ones or roll back the status change.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function testAFailedActionDoesNotAbortTheRest(): void {
+		$registry = new FlowNodeRegistry();
+		$registry->register($this->node('procest.sendEmail', new RuntimeException('smtp down')));
+		$registry->register($this->node('procest.createTask'));
 
-    /**
-     * The dispatcher resolves the LIVE id space, not the catalogue's.
-     *
-     * Both action systems ship a sendEmail. Resolving `procest.action.sendEmail`
-     * here would run the configured-action handler for a transition — a
-     * different class with different config keys.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function testItResolvesTheLiveIdSpace(): void {
-        $registry = new FlowNodeRegistry();
-        $registry->register($this->node('procest.action.sendEmail'));
+		$results = $this->dispatcher($registry)->dispatch(
+			[['type' => 'sendEmail'], ['type' => 'createTask']],
+			[],
+			[]
+		);
 
-        $results = $this->dispatcher($registry)->dispatch([['type' => 'sendEmail']], [], []);
+		$this->assertCount(2, $results);
+		$this->assertFalse($results[0]['ok']);
+		$this->assertSame('smtp down', $results[0]['error']);
+		$this->assertTrue($results[1]['ok']);
 
-        $this->assertFalse($results[0]['ok']);
-        $this->assertSame('unknown_action_type', $results[0]['error']);
+	}//end testAFailedActionDoesNotAbortTheRest()
 
-    }//end testItResolvesTheLiveIdSpace()
+	/**
+	 * An action type nothing provides is reported, not silently dropped.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function testUnknownActionTypeIsReported(): void {
+		$results = $this->dispatcher(new FlowNodeRegistry())->dispatch(
+			[['type' => 'doesNotExist']],
+			[],
+			[]
+		);
 
+		$this->assertSame(
+			[['type' => 'doesNotExist', 'ok' => false, 'error' => 'unknown_action_type']],
+			$results
+		);
 
-    /**
-     * A node that throws becomes a failed row — it does NOT abort the loop.
-     *
-     * A node signals failure by throwing, because the flow engine's onError
-     * policy only sees what propagates. This dispatcher's contract is the
-     * opposite and predates it: a failed action must not stop the remaining
-     * ones or roll back the status change.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function testAFailedActionDoesNotAbortTheRest(): void {
-        $registry = new FlowNodeRegistry();
-        $registry->register($this->node('procest.sendEmail', new RuntimeException('smtp down')));
-        $registry->register($this->node('procest.createTask'));
+	}//end testUnknownActionTypeIsReported()
 
-        $results = $this->dispatcher($registry)->dispatch(
-            [['type' => 'sendEmail'], ['type' => 'createTask']],
-            [],
-            []
-        );
+	/**
+	 * Without OpenRegister the local handlers still fire.
+	 *
+	 * A transition must never silently skip its side effects because a
+	 * neighbouring app is not installed.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function testFallsBackToTheLocalHandlersWithoutOpenRegister(): void {
+		$handler = $this->createMock(ActionHandlerInterface::class);
+		$handler->expects($this->once())->method('handle')->willReturn(new ActionResult(true));
 
-        $this->assertCount(2, $results);
-        $this->assertFalse($results[0]['ok']);
-        $this->assertSame('smtp down', $results[0]['error']);
-        $this->assertTrue($results[1]['ok']);
+		$legacy = $this->createMock(ActionHandlerRegistry::class);
+		$legacy->method('getHandler')->willReturn($handler);
 
-    }//end testAFailedActionDoesNotAbortTheRest()
+		$results = $this->dispatcher(null, $legacy)->dispatch([['type' => 'sendEmail']], [], []);
 
+		$this->assertSame([['type' => 'sendEmail', 'ok' => true]], $results);
 
-    /**
-     * An action type nothing provides is reported, not silently dropped.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function testUnknownActionTypeIsReported(): void {
-        $results = $this->dispatcher(new FlowNodeRegistry())->dispatch(
-            [['type' => 'doesNotExist']],
-            [],
-            []
-        );
+	}//end testFallsBackToTheLocalHandlersWithoutOpenRegister()
 
-        $this->assertSame(
-            [['type' => 'doesNotExist', 'ok' => false, 'error' => 'unknown_action_type']],
-            $results
-        );
+	/**
+	 * An action with no type is skipped rather than dispatched blind.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
+	 */
+	public function testTypelessActionIsSkipped(): void {
+		$this->assertSame(
+			[],
+			$this->dispatcher(new FlowNodeRegistry())->dispatch([['config' => 1]], [], [])
+		);
 
-    }//end testUnknownActionTypeIsReported()
-
-
-    /**
-     * Without OpenRegister the local handlers still fire.
-     *
-     * A transition must never silently skip its side effects because a
-     * neighbouring app is not installed.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function testFallsBackToTheLocalHandlersWithoutOpenRegister(): void {
-        $handler = $this->createMock(ActionHandlerInterface::class);
-        $handler->expects($this->once())->method('handle')->willReturn(new ActionResult(true));
-
-        $legacy = $this->createMock(ActionHandlerRegistry::class);
-        $legacy->method('getHandler')->willReturn($handler);
-
-        $results = $this->dispatcher(null, $legacy)->dispatch([['type' => 'sendEmail']], [], []);
-
-        $this->assertSame([['type' => 'sendEmail', 'ok' => true]], $results);
-
-    }//end testFallsBackToTheLocalHandlersWithoutOpenRegister()
-
-
-    /**
-     * An action with no type is skipped rather than dispatched blind.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/automatic-actions-surface/spec.md
-     */
-    public function testTypelessActionIsSkipped(): void {
-        $this->assertSame(
-            [],
-            $this->dispatcher(new FlowNodeRegistry())->dispatch([['config' => 1]], [], [])
-        );
-
-    }//end testTypelessActionIsSkipped()
-
+	}//end testTypelessActionIsSkipped()
 
 }//end class

--- a/tests/Unit/Settings/PersonalSettingsTest.php
+++ b/tests/Unit/Settings/PersonalSettingsTest.php
@@ -32,60 +32,55 @@ use PHPUnit\Framework\TestCase;
  */
 class PersonalSettingsTest extends TestCase {
 
+	/**
+	 * It is a PERSONAL setting, not an admin one.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/personal-settings-surface/spec.md
+	 */
+	public function testItIsAPersonalSetting(): void {
+		$this->assertInstanceOf(ISettings::class, new PersonalSettings());
 
-    /**
-     * It is a PERSONAL setting, not an admin one.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/personal-settings-surface/spec.md
-     */
-    public function testItIsAPersonalSetting(): void {
-        $this->assertInstanceOf(ISettings::class, new PersonalSettings());
+	}//end testItIsAPersonalSetting()
 
-    }//end testItIsAPersonalSetting()
+	/**
+	 * The form renders procest's personal-settings template.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/personal-settings-surface/spec.md
+	 */
+	public function testFormRendersThePersonalTemplate(): void {
+		$response = (new PersonalSettings())->getForm();
 
+		$this->assertSame(Application::APP_ID, $response->getApp());
+		$this->assertSame('settings/personal', $response->getTemplateName());
 
-    /**
-     * The form renders procest's personal-settings template.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/personal-settings-surface/spec.md
-     */
-    public function testFormRendersThePersonalTemplate(): void {
-        $response = (new PersonalSettings())->getForm();
+	}//end testFormRendersThePersonalTemplate()
 
-        $this->assertSame(Application::APP_ID, $response->getApp());
-        $this->assertSame('settings/personal', $response->getTemplateName());
+	/**
+	 * The form belongs to procest's own settings section.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/personal-settings-surface/spec.md
+	 */
+	public function testSectionIsProcest(): void {
+		$this->assertSame('dossiq', (new PersonalSettings())->getSection());
 
-    }//end testFormRendersThePersonalTemplate()
+	}//end testSectionIsProcest()
 
+	/**
+	 * The priority is a plain ordering integer.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/specs/personal-settings-surface/spec.md
+	 */
+	public function testPriorityIsAnInteger(): void {
+		$this->assertSame(50, (new PersonalSettings())->getPriority());
 
-    /**
-     * The form belongs to procest's own settings section.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/personal-settings-surface/spec.md
-     */
-    public function testSectionIsProcest(): void {
-        $this->assertSame('dossiq', (new PersonalSettings())->getSection());
-
-    }//end testSectionIsProcest()
-
-
-    /**
-     * The priority is a plain ordering integer.
-     *
-     * @return void
-     *
-     * @spec openspec/changes/page-topology-cleanup/specs/personal-settings-surface/spec.md
-     */
-    public function testPriorityIsAnInteger(): void {
-        $this->assertSame(50, (new PersonalSettings())->getPriority());
-
-    }//end testPriorityIsAnInteger()
-
+	}//end testPriorityIsAnInteger()
 
 }//end class


### PR DESCRIPTION
## What

Moves this app's OpenRegister **schemas** onto the new application id. Sibling of
the register-slug rename, and **neither covers the other**.

## The two lookups

OpenRegister resolves the two halves of a configuration by different keys:

| | resolved by |
|---|---|
| **register** | `RegisterMapper::find(slug)` — slug alone |
| **schema** | `SchemaMapper::findByApplicationAndSlug(slug, application)` — the **pair** |

`SettingsService` passes `appId: Application::APP_ID`, which is now the new name,
while every schema the app already owns still carries the **old** `application`.
The pair matches nothing — and `ImportHandler`'s not-found branch is not an error
path, it is the *create a new one* path.

So the next import builds a **second, empty set of schemas** under the new
application id while every stored object stays bound to the old rows. Nothing
errors. The app renders empty collections.

## Measured, not assumed

Schema counts still on the old application id, read from a live install:

| old application | schemas | slugs that would collide |
|---|---|---|
| docudesk | 231 | 0 |
| openconnector | 200 | **200** |
| procest | 180 | 0 |
| decidesk | 98 | 0 |
| softwarecatalog | 21 | 0 |
| openbuild | 17 | 0 |
| planix | 2 | **2** |
| larpingapp | 2 | **2** |
| hrmq | 2 | 0 |

## It refuses rather than merges

Where a slug **already** has a twin under the new application id, the fork has
happened. Re-pointing would leave two rows sharing `(application, slug)`, and
`findByApplicationAndSlug()` caps at one row — so one silently wins every lookup
and the other's objects become unreachable.

Choosing between them is a decision about **data**, not a migration. The step
logs and leaves both alone.

## A failed read is not an empty result

This is the whole safety of the step. An empty list says *every move is safe*; a
failed read says *nothing at all*. Conflating them would move every schema on top
of an existing twin. There is a test for exactly that case.

It also never deletes a schema, and never throws — it runs under `<install>`,
where an escaping exception aborts the install and the app never enables.

## Provenance

dossiq #1333 carried this and was closed unmerged, so nothing landed. This
implementation is self-contained: direct SQL, scoped to the `(old application,
slug)` pair, with no dependency on an OpenRegister-side service.
