### PR TITLE
fix(walkthrough): end the tour on a call to action that opens the docs

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -116,11 +116,12 @@
 						"id": "done",
 						"sinceVersion": "0.2.17",
 						"placement": "center",
-						"title": "You're all set",
-						"body": "Nicely done — your first case is on the board. Head back to the Dashboard to track progress, and reopen this tour anytime from the … menu.",
+						"title": "Your first case is on the board",
+						"body": "The Dashboard tracks progress as cases move through it. The documentation covers the rest.",
+						"task": "Open the documentation to keep going",
 						"target": {
-							"kind": "page",
-							"ref": "Dashboard"
+							"kind": "nav-item",
+							"ref": "Documentation"
 						},
 						"advanceOn": {
 							"type": "manual"


### PR DESCRIPTION
Replaces #1346, which was closed because its branch deleted `src/manifest.json` entirely (`+0/-4714`) instead of making the intended edit. That branch was created in a git worktree on a **submodule with a broken `core.worktree`**, where git resolves the working tree to the gitdir and silently records phantom deletions. This one is from a clean clone: **+5/-4**.

I caught it by diffing every PR in the sweep rather than trusting that a successful push meant a correct commit.

---

The guided tour's final step had **no `task`**, so it stopped without telling the user where to go next. It now closes on the documentation, per the fleet rule that a walkthrough's last step points somewhere.

The CTA targets the `Documentation` nav item **that already exists in this app's menu**, and I confirmed the URL resolves (HTTP 200) before pointing users at it.

### The same step carried voice defects

| Was | Why it fails |
|---|---|
| `Nicely done` | praise, not voice |
| `—` | em-dash, stripped fleet-wide |
| `reopen this tour anytime from the … menu` | housekeeping in the one line a user is most likely to act on |

Measured against the shared `writing` skill (ConductionNL/hydra#610). No em-dashes, every sentence under 16 words, the task starts with a verb.

Part of a fleet sweep across the 9 apps that ship a walkthrough.