### PR TITLE
fix(docs): publish from development, to the worker that actually serves this site

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,18 +1,42 @@
 name: Documentation
 
 on:
+  # `development` is where the work lands. This used to trigger on a
+  # `documentation` branch that exists but nobody updates — so the workflow
+  # was green and idle while the live site aged. Measured today:
+  # procest.conduction.nl and dossiq.conduction.nl both still serve the
+  # pre-rename "Procest" title while docs/docusaurus.config.js says 'Dossiq'.
   push:
-    branches: [documentation]
+    branches: [development]
   pull_request:
-    branches: [documentation]
+    branches: [development]
 
 jobs:
   deploy:
     uses: ConductionNL/.github/.github/workflows/documentation.yml@main
     with:
-      # FROZEN: the docs subdomain is pinned to a live DNS record that moves in
-      # a separate pass. procest.conduction.nl resolves (HTTP 200);
-      # dossiq.conduction.nl does not exist yet, so renaming this here would
-      # publish the docs to a host nobody can reach. Must stay in step with
-      # docs/static/CNAME.
+      # FROZEN: docs/static/CNAME and docs/docusaurus.config.js `url:` both
+      # still say `procest.conduction.nl`. This moves together with those two,
+      # not before — the callee's live-site check fetches this host.
       cname: procest.conduction.nl
+
+      # EVERY host this site answers on, in FULL. This was MISSING, and that
+      # was not a cosmetic gap: `docs-hosts` defaults to `cname` alone, and
+      # wrangler reconciles the worker's triggers against what it is given —
+      # so the first successful deploy would have REMOVED
+      # `dossiq.conduction.nl` from the worker and taken it down. It was
+      # attached as a second custom domain on 2026-08-23 and answers 200.
+      docs-hosts: procest.conduction.nl,dossiq.conduction.nl
+
+      # The worker that holds both custom domains. It happens to match what
+      # the callee would derive from `cname` today, which is exactly why it is
+      # pinned here: the moment `cname` moves to `dossiq.conduction.nl` the
+      # derived name silently becomes `dossiq-docs`, a worker that does not
+      # exist, and the deploy forks off a second one while both custom domains
+      # keep routing to this one — green, and reaching nobody.
+      #
+      # `docs/wrangler.jsonc` used to claim exactly that wrong name. It has
+      # been removed: the callee GENERATES a wrangler.toml from these inputs,
+      # and wrangler prefers .jsonc over .toml, so the checked-in file would
+      # have won and both inputs above would have been decorative.
+      worker-name: procest-docs

--- a/docs/wrangler.jsonc
+++ b/docs/wrangler.jsonc
@@ -1,8 +1,0 @@
-{
-  "name": "dossiq-docs",
-  "compatibility_date": "2025-06-01",
-  "assets": {
-    "directory": "./build",
-    "not_found_handling": "404-page"
-  }
-}


### PR DESCRIPTION
## Three silent failures, any one of which was enough

Measured today:

```
procest.conduction.nl  [200] <title>Procest, case management and BPMN workflows for Nextcloud | Procest
dossiq.conduction.nl   [200] <title>Procest, case management and BPMN workflows for Nextcloud | Procest
docs/docusaurus.config.js:   title: 'Dossiq'
```

Both hosts answer. Both serve a pre-rename build. Nothing has carried bytes to the edge.

### 1. The trigger pointed at a branch nobody updates

`push: branches: [documentation]`. The branch exists, so the workflow looked configured; it just never fired. Now `development`.

### 2. `docs-hosts` was missing — and that is worse than it looks

It defaults to `cname` alone, and wrangler **reconciles** a worker's triggers against what it is given rather than appending. So the first *successful* deploy would have **removed `dossiq.conduction.nl` from the worker and taken it down**. That host was attached as a second custom domain on 2026-08-23 and answers 200 today. Fixing the trigger without this would have turned a stale site into a dark one.

### 3. `docs/wrangler.jsonc` named a worker that does not exist

```json
{ "name": "dossiq-docs", ... }
```

There is no `dossiq-docs`. Both custom domains live on **`procest-docs`**.

And it would have won: the reusable workflow **generates** a `wrangler.toml` from its inputs, and wrangler prefers `.jsonc` over `.toml`. The checked-in file would have overridden the generated one, making `docs-hosts` and `worker-name` decorative — two sources of truth where the runtime silently reads only the wrong one. It also declared no `routes` at all, so the deploy would have created a bare `dossiq-docs` worker with no custom domains and left the real site untouched.

Removed. The workflow inputs are now the single source of truth, with `worker-name: procest-docs` stated explicitly rather than derived.

## What is deliberately *not* changed

`cname` stays `procest.conduction.nl`. `docs/static/CNAME` and the config's `url:` still say the same thing, and the callee's live-site verification fetches this host. All three move together, in one change, once the subdomain flip is wanted.

No Cloudflare changes were made by hand — this PR only makes the workflow correct.
