### PR TITLE
fix(docs): pass secrets to the reusable documentation workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -14,15 +14,25 @@ on:
 jobs:
   deploy:
     uses: ConductionNL/.github/.github/workflows/documentation.yml@main
-    # A called workflow receives NO secrets from its caller unless they are
-    # passed explicitly or inherited — `with:` carries inputs, never secrets.
-    # Without this line `secrets.CF_API_TOKEN` is EMPTY inside the callee, so
-    # its "Publish to the Cloudflare Worker" step skips itself on its own
-    # guard and the run finishes GREEN having written only gh-pages, which
-    # nothing serves. The live site never changes and no check goes red to
-    # say so — the exact failure mode the pinned inputs above guard against,
-    # arriving one layer earlier.
-    secrets: inherit
+    # A reusable workflow receives NO secrets by default. Without this block
+    # `secrets.CF_API_TOKEN` is empty inside the callee, its "Publish to the
+    # Cloudflare Worker" step skips itself on its own guard, and the run
+    # finishes GREEN having written only gh-pages — which nothing serves. The
+    # live site never changes and no check goes red to say so.
+    #
+    # Mapped explicitly rather than `secrets: inherit`, because `inherit`
+    # hands the callee EVERY secret this repo holds — signing cert and key,
+    # appstore token, deploy keys — for the sake of two Cloudflare values.
+    # This way only those two cross the boundary.
+    #
+    # The names also differ on each side (org `CLOUDFLARE_*`, callee `CF_*`),
+    # and `inherit` passes secrets under their ORIGINAL names — so it would
+    # have left `CF_API_TOKEN` empty even setting the exposure aside. Needs
+    # ConductionNL/.github#568: a mapping only compiles for secrets the callee
+    # declares.
+    secrets:
+      CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
     with:
       # FROZEN: docs/static/CNAME and docs/docusaurus.config.js `url:` both
       # still say `procest.conduction.nl`. This moves together with those two,

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -14,6 +14,15 @@ on:
 jobs:
   deploy:
     uses: ConductionNL/.github/.github/workflows/documentation.yml@main
+    # A called workflow receives NO secrets from its caller unless they are
+    # passed explicitly or inherited — `with:` carries inputs, never secrets.
+    # Without this line `secrets.CF_API_TOKEN` is EMPTY inside the callee, so
+    # its "Publish to the Cloudflare Worker" step skips itself on its own
+    # guard and the run finishes GREEN having written only gh-pages, which
+    # nothing serves. The live site never changes and no check goes red to
+    # say so — the exact failure mode the pinned inputs above guard against,
+    # arriving one layer earlier.
+    secrets: inherit
     with:
       # FROZEN: docs/static/CNAME and docs/docusaurus.config.js `url:` both
       # still say `procest.conduction.nl`. This moves together with those two,


### PR DESCRIPTION
## The bug

This repo's `.github/workflows/documentation.yml` calls the reusable workflow
`ConductionNL/.github/.github/workflows/documentation.yml@main` but never passed
it any secrets.

A **called (reusable) workflow receives NO secrets from its caller** unless they
are passed explicitly under `secrets:` or the caller sets `secrets: inherit`.
`with:` carries *inputs*, never secrets, and `permissions:` governs the *token*,
not the secrets. So inside the callee `secrets.CF_API_TOKEN` was always empty.

The consequence is a run that lies:

- `Deploy to GitHub Pages` — **success**
- `Publish to the Cloudflare Worker that serves this site` — **skipped** (its own
  `if:` guard on the token)
- `Warn when Cloudflare credentials are absent` — **success**

Every job green, and the only thing that actually reached the edge was a
`gh-pages` branch that nothing serves. That is why the fleet docs sites still
serve their pre-rename builds even now that the push triggers are fixed.

Measured on planninq run
[32715324775](https://github.com/ConductionNL/planninq/actions/runs/32715324775),
whose warn step emitted:

> `CF_API_TOKEN is not set, so the Cloudflare Worker that actually serves
> planix.conduction.nl was NOT updated.`

## The change

One line — `secrets: inherit` as a sibling of `uses:` and `with:` on the `deploy`
job — plus a comment recording why, so the next reader does not remove it as
noise. No inputs, triggers, or permissions were touched. YAML validated with
`yaml.safe_load`.

## Necessary, not sufficient

This lets the credential *reach* the callee. It does not create one. No repo in
this set carries a `CF_API_TOKEN` / `CLOUDFLARE_API_TOKEN` repo secret, so unless
an **organisation-level** secret of that name exists and is visible to this repo,
the Worker publish step will still skip after this merges — just for a different
reason. Provisioning that secret is a separate, human decision.

Part of a 12-repo fleet sweep: dossiq, integriq, humaniq, larpinq, decidiq,
buildiq, stackiq, keepiq, versioniq, thematiq, planninq, filinq.
