### PR TITLE
feat: port issue templates to GitHub Issue Forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,92 @@
+name: "🐛 Bug Report"
+description: "Iets werkt niet zoals verwacht"
+title: "[BUG] "
+labels: ["bug", "needs-triage"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Bug Report
+        Beschrijf het probleem zo concreet mogelijk zodat het reproduceerbaar is.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: "Beschrijving"
+      description: "Wat gaat er mis?"
+      placeholder: "Bij het uploaden van een PDF groter dan 10MB crasht de anonymizer."
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: "Stappen om te reproduceren"
+      value: |
+        1. Ga naar ...
+        2. Doe ...
+        3. Zie fout ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: "Verwacht gedrag"
+      placeholder: "Het document wordt anonimiseerd en gedownload."
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: "Werkelijk gedrag"
+      placeholder: "HTTP 500 na ~30 seconden, geen output."
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: "Omgeving"
+      value: |
+        - Namespace/omgeving: 
+        - Versie/image tag: 
+        - Browser (indien van toepassing): 
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: "Logs / Screenshots"
+      description: "Plak relevante logs of voeg screenshots toe"
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: "Acceptatiecriteria (fix)"
+      value: |
+        - [ ] Bug is niet meer reproduceerbaar
+        - [ ] Regressietest toegevoegd
+        - [ ] Fix getest in acceptatieomgeving
+        - [ ] Geen nieuwe security findings
+        - [ ] Code gereviewd (4-eyes)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: "Severity"
+      options:
+        - "🔴 Critical — productie ligt plat"
+        - "🟠 High — grote impact, workaround aanwezig"
+        - "🟡 Medium — beperkte impact"
+        - "🟢 Low — cosmetic / minor"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,125 @@
+name: "✨ Feature request"
+description: "Suggest a feature or improvement. Fields below feed a draft OpenSpec proposal."
+title: "[FEATURE] "
+labels: ["enhancement", "feature", "needs-triage"]
+type: "Feature"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Suggest a feature
+
+        Thanks for telling us what you need. **Triage happens within 24 hours.**
+
+        The fields below feed an OpenSpec proposal directly if the suggestion
+        is accepted. The more concrete you are, the faster it ships.
+
+        Prefer Dutch? Vul de velden in het Nederlands in — that's fine, we triage in both.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: "Problem"
+      description: "What can't you do today? What's the friction? Write it from your perspective — one or two sentences is plenty."
+      placeholder: "I want to filter contacts by last interaction date but the list view doesn't support it. I end up exporting to CSV and sorting in a spreadsheet."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: "Proposed solution"
+      description: "How would you like it to work? Sketches, links, references welcome. \"I'm not sure\" is also a valid answer — we'll figure it out together."
+      placeholder: "A date-range filter in the contacts list sidebar, defaulting to last 30 days, persisted per user."
+    validations:
+      required: true
+
+  - type: textarea
+    id: who-benefits
+    attributes:
+      label: "Who benefits"
+      description: "Which user role or workflow does this serve? Be specific."
+      placeholder: "Account managers tracking client engagement, especially before renewal conversations."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority-to-you
+    attributes:
+      label: "How important is this to you?"
+      description: "Honest self-assessment. Helps us prioritise."
+      options:
+        - "Nice to have"
+        - "Would use weekly"
+        - "Would use daily"
+        - "Blocking me right now"
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: "Anything else?"
+      description: "Edge cases, alternatives you've considered, things to avoid, related capabilities, anything that didn't fit in the boxes above."
+      placeholder: "Out of scope: per-team default filter (could be later). Avoid: hiding the filter behind a settings page — needs to be one click from the list."
+
+  - type: markdown
+    attributes:
+      value: |
+        ### Context
+
+        The fields below are auto-filled when you suggest a feature from inside
+        the app. They capture where you were when the idea hit so we can scope
+        the spec without a second round of questions.
+
+        **We show them to you here on purpose**: you can see exactly what we
+        send and edit or clear any field before you submit. Leave them blank if
+        you're filing directly from GitHub — we'll still triage it.
+
+  - type: input
+    id: app
+    attributes:
+      label: "App"
+      description: "Auto-filled by the in-product modal. The Nextcloud app you were using."
+      placeholder: "pipelinq"
+
+  - type: input
+    id: page
+    attributes:
+      label: "Page"
+      description: "Auto-filled. The manifest page id + route you were on when you opened the modal."
+      placeholder: "clients-detail (/clients/abc-123)"
+
+  - type: input
+    id: surface
+    attributes:
+      label: "Modal or widget"
+      description: "Auto-filled. Any modal, dialog, dashboard widget, or sidebar tab open at the moment the modal launched. Helps us pinpoint UI-attached suggestions."
+      placeholder: "edit-client-modal · or · dashboard widget: open-leads"
+
+  - type: input
+    id: object
+    attributes:
+      label: "Object in focus"
+      description: "Auto-filled. The OpenRegister register + schema + UUID the page was viewing, if any. Lets us trace the suggestion to a real data shape."
+      placeholder: "pipelinq · Client · 2f9d-…-abc"
+
+  - type: input
+    id: spec-ref
+    attributes:
+      label: "Related capability"
+      description: "Auto-filled if the page or widget declares a `specRef`. Connects the suggestion to the existing OpenSpec for that capability."
+      placeholder: "client-management"
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+
+        ### What happens next
+
+        1. **Within 24 hours**: a maintainer reads this and replies with one of `ready-to-build`, `needs-design`, `parking-lot`, or `wont-build` (with a reason).
+        2. **If `ready-to-build`**: an OpenSpec proposal is auto-drafted from these fields. Hydra picks it up and opens a draft PR within days.
+        3. **When it ships**: you're credited on the spec, you get a `Co-Authored-By:` trailer on the merge commit, and you appear on the app's contributors page.
+
+        Read the full flow at the [Users are the moat](https://docs.conduction.nl/strategy/users-are-the-moat) strategy doc.

--- a/.github/ISSUE_TEMPLATE/technical-task.yml
+++ b/.github/ISSUE_TEMPLATE/technical-task.yml
@@ -1,0 +1,92 @@
+name: "⚙️ Technische Taak"
+description: "Infra, refactor, technische schuld of ops-werk"
+title: "[TECH] "
+labels: ["technical", "needs-refinement"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Technische Taak
+        Gebruik dit template voor infra-wijzigingen, refactoring, technische schuld of operationeel werk zonder directe gebruikerswaarde.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: "Beschrijving"
+      description: "Wat moet er gedaan worden en waarom?"
+      placeholder: "Migreer de WOO-platform PVC's naar S3 primary storage op Fuga Cloud."
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: "Motivatie / Aanleiding"
+      description: "Welk probleem lost dit op? Waarom nu?"
+      placeholder: "Huidige lokale PVC's lopen vol en zijn niet HA. Zie ook issue #123."
+    validations:
+      required: false
+
+  - type: textarea
+    id: approach
+    attributes:
+      label: "Aanpak (globaal)"
+      description: "Hoe gaan we dit oplossen? Welke keuzes zijn al gemaakt?"
+      placeholder: |
+        1. Backup bestaande data
+        2. S3 bucket aanmaken op Fuga Cloud
+        3. Nextcloud occ storage:update uitvoeren
+        4. Smoke test per namespace
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: "Acceptatiecriteria"
+      value: |
+        - [ ] Taak uitvoerbaar via Ansible/Terraform (geen handmatige stappen)
+        - [ ] Gedocumenteerd in runbook of ADR
+        - [ ] Getest in acceptatieomgeving vóór productie
+        - [ ] Rollback-procedure beschreven
+        - [ ] Geen downtime buiten afgesproken window
+        - [ ] Gereviewd (4-eyes)
+        - [ ] Geen nieuwe security findings
+    validations:
+      required: true
+
+  - type: textarea
+    id: risks
+    attributes:
+      label: "Risico's / Afhankelijkheden"
+      placeholder: "Afhankelijk van beschikbaarheid acceptatieomgeving. Risico: dataverlies bij fout in migratiescript."
+    validations:
+      required: false
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: "Categorie"
+      options:
+        - "Infra / ops"
+        - "Refactor"
+        - "Technische schuld"
+        - "Security"
+        - "Performance"
+        - "CI/CD"
+        - "Documentatie"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: "Prioriteit"
+      options:
+        - "🔴 Critical"
+        - "🟠 High"
+        - "🟡 Medium"
+        - "🟢 Low"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/user-story.yml
+++ b/.github/ISSUE_TEMPLATE/user-story.yml
@@ -1,0 +1,74 @@
+name: "✨ User Story"
+description: "Nieuwe functionaliteit vanuit gebruikersperspectief"
+title: "Als [rol] wil ik [actie] zodat [waarde]"
+labels: ["user-story", "needs-refinement"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## User Story
+        Beschrijf de gewenste functionaliteit vanuit het perspectief van de gebruiker.
+
+  - type: textarea
+    id: story
+    attributes:
+      label: "Story"
+      description: "Als [rol] wil ik [actie] zodat [waarde]"
+      placeholder: "Als gemeentemedewerker wil ik een document kunnen anonimiseren zodat ik het veilig kan delen."
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: "Context / Achtergrond"
+      description: "Waarom is dit nodig? Wat is de aanleiding?"
+      placeholder: "WOO-verzoeken vereisen anonimisering vóór publicatie..."
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: "Acceptatiecriteria"
+      description: "Definition of Done — vink af wat van toepassing is"
+      value: |
+        - [ ] Functionaliteit werkt zoals beschreven in de story
+        - [ ] Er zijn unit tests aanwezig
+        - [ ] Er zijn integratietests aanwezig
+        - [ ] Documentatie is bijgewerkt
+        - [ ] Code is gereviewd (4-eyes)
+        - [ ] Geen nieuwe security findings (SAST/Trivy)
+        - [ ] Getest in acceptatieomgeving
+    validations:
+      required: true
+
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: "Buiten scope"
+      description: "Wat doen we expliciet NIET in dit issue?"
+      placeholder: "Geen bulk-verwerking, geen UI-wijzigingen."
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: "Prioriteit"
+      options:
+        - "🔴 Critical"
+        - "🟠 High"
+        - "🟡 Medium"
+        - "🟢 Low"
+    validations:
+      required: true
+
+  - type: input
+    id: story-points
+    attributes:
+      label: "Story points (optioneel)"
+      placeholder: "3"
+    validations:
+      required: false


### PR DESCRIPTION
## Why

This repository's **only** issue forms live under `.forgejo/issue_template/`. There is no `.github/ISSUE_TEMPLATE/`, so on GitHub — the fleet's only host — contributors get a blank issue box today.

This is a **prerequisite** for two approved fleet changes:

1. **`.forgejo/` is being removed fleet-wide.** Without this port, that removal deletes the only issue forms this repo has.
2. **`DEFAULT_FORGE` moves from `codeberg` to `github`.** The in-product "Request a feature" deep-link then targets a GitHub Issue Form named exactly `feature-request.yml`. If that file does not exist, GitHub **silently drops the pre-filled fields** rather than erroring — the app/page/surface/object/spec-ref context would be lost with no visible failure.

## What changed

Copied all four templates to `.github/ISSUE_TEMPLATE/`, filenames unchanged:

| File | Form |
| --- | --- |
| `bug-report.yml` | 🐛 Bug Report |
| `feature-request.yml` | ✨ Feature request |
| `technical-task.yml` | ⚙️ Technische Taak |
| `user-story.yml` | ✨ User Story |

**`.forgejo/` is untouched** — no file under it is modified or deleted. Its removal is a separate later change.

## Dropped in conversion: nothing

Forgejo's issue-template schema is derived from GitHub's, and every construct these files use is valid GitHub issue-form syntax. The ported files are **byte-identical** to their `.forgejo/` originals — this is a location change, not a rewrite. Specifically verified as supported:

- Block types used: `markdown`, `input`, `textarea`, `dropdown` — all with the attributes their type requires.
- `textarea` with `render: shell` (the Logs field).
- `validations.required` booleans, `labels` arrays, `assignees: []`, `title` prefixes, emoji in `name` and in dropdown options.
- Top-level `type: "Feature"` in `feature-request.yml` — **checked against the ConductionNL org issue types**, where an enabled type named `Feature` exists, so this resolves rather than breaking the form.

No `config.yml` was added: `.forgejo/issue_template/` has no equivalent, and inventing one is out of scope.

## Validation

- All four files parse as YAML (`yaml.safe_load`).
- Each has top-level `name`, `description`, `body`; every body block has a valid `type` plus the `attributes` that type requires; every `id` is unique within its file; every `validations.required` is a boolean.
- `.github/ISSUE_TEMPLATE/feature-request.yml` exists under exactly that name — the deep-link depends on it.
- `git status` shows only additions under `.github/ISSUE_TEMPLATE/`; nothing under `.forgejo/` changed.
