### PR TITLE
feat(cases): implement the Sub-cases section the spec requires

### DIFF
--- a/openspec/specs/deelzaak-support/spec.md
+++ b/openspec/specs/deelzaak-support/spec.md
@@ -6,7 +6,26 @@ status: done
 
 Provide deelzaak (sub-case) support in Dossiq: creating sub-cases from a parent case, listing them on the parent detail, parent breadcrumb navigation, progress roll-up, case-list count badges, and deletion protection. Maps to the ZGW `hoofdzaak` / `deelzaken` relations on the Zaak resource.
 
-The deelzaak UI panel, sub-case create flow, parent breadcrumb, count badge, and orphan-deletion protection are all built (manifest Sub-cases tab → DeelzaakList/DeelzaakDetail, the `subCaseCount` column formatter, and DeelzaakDeleteWarningModal). UI scenarios are exercised by `tests/e2e/spec-coverage/deelzaak-support.spec.ts`; the ZGW `hoofdzaak`/`deelzaken` API response shape is verified at the integration tier (Newman ZGW collection), not via Playwright.
+The deelzaak UI panel, sub-case create flow, parent breadcrumb, count badge, and orphan-deletion protection are all built: the `case-sub-cases` **object-list widget on `CaseDetail`** (the "Sub-cases section" the requirement below mandates), the parent-scoped `DeelzaakList` / `DeelzaakDetail` pages at `/cases/:id/deelzaken`, the `subCaseCount` column formatter, and `DeelzaakDeleteWarningModal`. UI scenarios are exercised by `tests/e2e/spec-coverage/deelzaak-support.spec.ts`; the ZGW `hoofdzaak`/`deelzaken` API response shape is verified at the integration tier (Newman ZGW collection), not via Playwright.
+
+> **Corrected 2026-08-24.** This paragraph previously read "manifest Sub-cases
+> **tab** → DeelzaakList/DeelzaakDetail". No such tab has ever existed: the
+> manifest declares `DeelzaakList` as a `type: "custom"` **page** bound to
+> `/cases/:id/deelzaken` (its `_note` explains why — a standard list type
+> cannot express the parent-route binding plus the parent-context header), and
+> `CaseDetail` carried only the `case-kpis-sub-cases` **count**, never a
+> listing. So the normative requirement below — "the case detail view SHALL
+> display a 'Sub-cases' section" — was **not implemented**, while this
+> paragraph asserted it was.
+>
+> The e2e suite inherited the error: `deelzaak-support.spec.ts` hunts for
+> `getByRole('tab', { name: /Sub-cases|Deelzaken/i })` and, on not finding one,
+> skipped all five of its tests with *"Sub-cases tab not present in the
+> deployed build (deploy mismatch)"* — a deployment excuse for a surface no
+> build ever had. Three artefacts, three different stories.
+>
+> Resolved by implementing the requirement (`case-sub-cases` on `CaseDetail`)
+> rather than by weakening it.
 
 ## Requirements
 
@@ -62,6 +81,21 @@ The case detail view SHALL display a "Sub-cases" section
 
 - **WHEN** user views a case whose case type has an empty `subCaseTypes` array
 - **THEN** the "Sub-cases" section MUST NOT be rendered
+
+> **NOT YET IMPLEMENTED, and recorded here rather than quietly dropped.** The
+> two scenarios above are satisfied by the `case-sub-cases` object-list widget
+> added to `CaseDetail`; this third one is not. A manifest widget has no
+> conditional-visibility key — there is no `visibleWhen` / `showWhen` /
+> `condition` anywhere in this app's manifest, and the renderer offers none —
+> so a declarative widget cannot hide itself based on the parent case type's
+> `subCaseTypes`. What a reader sees instead is the widget's empty state
+> ("No sub-cases yet") on a case type that can never have sub-cases.
+>
+> Closing this needs one of: a conditional-visibility capability in the shared
+> manifest renderer (the general fix, useful well beyond deelzaken), a bespoke
+> `type: "custom"` widget for this one section, or an amendment agreeing that
+> an empty state is acceptable here. That is a product call, not something to
+> settle by editing the requirement to match what shipped.
 
 ### Requirement: Parent case breadcrumb navigation
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1717,6 +1717,16 @@
 						"showTitle": true
 					},
 					{
+						"_note": "A widget declared in `widgets` but absent from `layout` never renders — this grid is explicit, not inferred. Adding case-sub-cases to `widgets` alone produced no section at all, and the e2e failed on exactly that. Appended below the last row (cmmn-case-plan ends at y=47) rather than placed beside the sub-case KPI: these coordinates are absolute, so a mid-page insert would mean re-flowing every widget beneath it — a layout change this requirement does not ask for.",
+						"id": "23",
+						"widgetId": "case-sub-cases",
+						"gridX": 0,
+						"gridY": 47,
+						"gridWidth": 12,
+						"gridHeight": 4,
+						"showTitle": true
+					},
+					{
 						"id": "22",
 						"widgetId": "case-kpis-hours",
 						"gridX": 0,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1263,6 +1263,45 @@
 						"_note": "Initiator (indiener) display — brp-kvk register sets. Resolved via page slots (widget-initiator -> InitiatorSection); self-fetches the case from the route id and renders nothing when no initiator is set."
 					},
 					{
+						"id": "case-sub-cases",
+						"type": "object-list",
+						"title": "Sub-cases",
+						"icon": "FileTreeOutline",
+						"_note": "deelzaak-support REQ 'Sub-cases section on parent case detail': 'The case detail view SHALL display a \"Sub-cases\" section ... listing all cases whose parentCase references the current case. The section MUST show each sub-case's title, status, assignee, and deadline.' Only the stats-block COUNT (case-kpis-sub-cases) existed; the listing lived on a separate route (/cases/:id/deelzaken, DeelzaakList), so the detail view had no such section and the requirement was unimplemented. The count widget already proves the filter shape works. Rows deep-link to CaseDetail because a sub-case IS a case.",
+						"content": {
+							"register": "dossiq",
+							"schema": "case",
+							"filter": {
+								"parentCase": "@objectId"
+							},
+							"sort": {
+								"field": "deadline",
+								"dir": "asc"
+							},
+							"limit": 25,
+							"columns": [
+								{
+									"key": "title",
+									"label": "Title"
+								},
+								{
+									"key": "status",
+									"label": "Status"
+								},
+								{
+									"key": "assignee",
+									"label": "Assignee"
+								},
+								{
+									"key": "deadline",
+									"label": "Deadline"
+								}
+							],
+							"rowRoute": "CaseDetail",
+							"emptyText": "No sub-cases yet"
+						}
+					},
+					{
 						"id": "case-tasks",
 						"type": "object-list",
 						"title": "Tasks",

--- a/tests/e2e/spec-coverage/deelzaak-support.spec.ts
+++ b/tests/e2e/spec-coverage/deelzaak-support.spec.ts
@@ -42,27 +42,48 @@ async function openCasesListOrSkip(page) {
 	return true
 }
 
-/** Open the first case detail and switch to its Sub-cases tab, or skip. */
-async function openSubCasesTabOrSkip(page) {
+/**
+ * Open the first case detail and reveal its Sub-cases SECTION, or skip.
+ *
+ * There is no Sub-cases TAB, and there never was. This helper used to look for
+ * `getByRole('tab', { name: /Sub-cases|Deelzaken/i })` and, on finding none,
+ * skip every test in this file with "Sub-cases tab not present in the deployed
+ * build (deploy mismatch)" — a deployment excuse for a surface no build has
+ * ever shipped. The manifest declares `DeelzaakList` as a `type: "custom"`
+ * PAGE at `/cases/:id/deelzaken`, and `CaseDetail` carried only the
+ * `case-kpis-sub-cases` COUNT.
+ *
+ * The spec is the authority and it says section, not tab:
+ *
+ *   "The case detail view SHALL display a 'Sub-cases' section ... listing all
+ *    cases whose parentCase references the current case. The section MUST show
+ *    each sub-case's title, status, assignee, and deadline."
+ *
+ * So the requirement was simply unimplemented. It is now implemented as the
+ * `case-sub-cases` object-list widget on `CaseDetail`, and this helper asserts
+ * that section on the detail page rather than clicking a tab.
+ */
+async function openSubCasesSectionOrSkip(page) {
 	const opened = await openCasesListOrSkip(page)
 	if (!opened) return false
 	const row = page
 		.locator('.viewTableRow, tr[role="row"], .list-item, table tbody tr')
 		.first()
 	await row.click().catch(() => {})
-	await page.waitForTimeout(1000)
-	const subCasesTab = page
-		.getByRole('tab', { name: /Sub-cases|Deelzaken/i })
+
+	// Retrying assertion rather than a fixed pause: the detail page mounts its
+	// widgets asynchronously, and a `waitForTimeout` either wastes time or
+	// races, depending on the runner's load.
+	const section = page
+		.locator('.cn-widget-wrapper, section, [class*="widget"]')
+		.filter({ hasText: /Sub-cases/i })
 		.first()
-	if ((await subCasesTab.count()) === 0) {
-		test.skip(
-			true,
-			'Sub-cases tab not present in the deployed build (deploy mismatch).',
-		)
-		return false
-	}
-	await subCasesTab.click()
-	await page.waitForTimeout(800)
+	await expect(
+		section,
+		'CaseDetail must render the "Sub-cases" section (deelzaak-support: '
+			+ '"Sub-cases section on parent case detail")',
+	).toBeVisible({ timeout: 15_000 })
+
 	await expect(page.locator('body')).not.toContainText('Internal Server Error')
 	return true
 }
@@ -118,7 +139,7 @@ test.describe('Sub-case orphan deletion (deelzaak-support REQ — deletion prote
 	test('the sub-cases page delete control warns about orphans for a parent with sub-cases', async ({
 		page,
 	}) => {
-		const opened = await openSubCasesTabOrSkip(page)
+		const opened = await openSubCasesSectionOrSkip(page)
 		if (!opened) return
 
 		const deleteBtn = page
@@ -162,7 +183,7 @@ test.describe('Sub-cases list + create (deelzaak-support REQ — section / creat
 	test('the Sub-cases tab renders either a list or an empty state without error', async ({
 		page,
 	}) => {
-		const opened = await openSubCasesTabOrSkip(page)
+		const opened = await openSubCasesSectionOrSkip(page)
 		if (!opened) return
 
 		// Either the sub-cases table OR the "No sub-cases yet" empty state must
@@ -184,7 +205,7 @@ test.describe('Sub-cases list + create (deelzaak-support REQ — section / creat
 	test('the Create sub-case control opens a filtered dialog when allowed, and is hidden otherwise', async ({
 		page,
 	}) => {
-		const opened = await openSubCasesTabOrSkip(page)
+		const opened = await openSubCasesSectionOrSkip(page)
 		if (!opened) return
 
 		const createBtn = page
@@ -232,7 +253,7 @@ test.describe('Sub-case breadcrumb + roll-up (deelzaak-support REQ — navigatio
 	test('opening a sub-case shows the parent breadcrumb and the list shows a completion roll-up', async ({
 		page,
 	}) => {
-		const opened = await openSubCasesTabOrSkip(page)
+		const opened = await openSubCasesSectionOrSkip(page)
 		if (!opened) return
 
 		// The DeelzaakList header carries the "(X/Y completed)" roll-up when a

--- a/tests/e2e/spec-coverage/deelzaak-support.spec.ts
+++ b/tests/e2e/spec-coverage/deelzaak-support.spec.ts
@@ -23,21 +23,49 @@
 import { test, expect } from '@playwright/test'
 import { navTo, dismissSupportDialog } from '../helpers/nav'
 
+/** OpenRegister's object API for this app's own register. */
+const CASES_API = '/index.php/apps/openregister/api/objects/dossiq/case'
+
+/**
+ * Resolve the id of a case to work with, or skip when the register is empty.
+ *
+ * Asks the API rather than clicking a row. The previous approach —
+ * `.locator('.viewTableRow, tr[role="row"], .list-item, table tbody tr').first()`
+ * followed by `.click().catch(() => {})` — had two faults that cancelled each
+ * other out into a silent no-op: `tr[role="row"]` matches the table HEADER row,
+ * so `.first()` selected a header, and the swallowed catch meant a click that
+ * navigated nowhere looked exactly like a click that worked.
+ *
+ * The result was that every test carried on believing it was on a case detail
+ * while the snapshot shows `heading "Cases"` — the list page — and then failed
+ * on an assertion about a page it had never opened.
+ */
+async function firstCaseIdOrSkip(page): Promise<string | null> {
+	const resp = await page.request.get(`${CASES_API}?_limit=1`, {
+		headers: { Accept: 'application/json' },
+	})
+	if (!resp.ok()) {
+		test.skip(true, `cases API not reachable (HTTP ${resp.status()})`)
+		return null
+	}
+	const body = await resp.json()
+	const first = (body.results ?? body.items ?? [])[0]
+	if (!first) {
+		test.skip(
+			true,
+			'No cases in the seeded register — this suite is data-dependent.',
+		)
+		return null
+	}
+	return first.id ?? first['@self']?.id ?? null
+}
+
 /** Open the Cases list, or skip when it does not render. */
 async function openCasesListOrSkip(page) {
 	await navTo(page, 'Cases').catch(() => {})
 	await dismissSupportDialog(page).catch(() => {})
-	await page.waitForTimeout(1000)
-	const row = page
-		.locator('.viewTableRow, tr[role="row"], .list-item, table tbody tr')
-		.first()
-	if ((await row.count()) === 0) {
-		test.skip(
-			true,
-			'No cases in the deployed/seeded register — case list is data-dependent.',
-		)
-		return false
-	}
+	const caseId = await firstCaseIdOrSkip(page)
+	if (!caseId) return false
 	await expect(page.locator('body')).not.toContainText('Internal Server Error')
 	return true
 }
@@ -64,12 +92,16 @@ async function openCasesListOrSkip(page) {
  * that section on the detail page rather than clicking a tab.
  */
 async function openSubCasesSectionOrSkip(page) {
-	const opened = await openCasesListOrSkip(page)
-	if (!opened) return false
-	const row = page
-		.locator('.viewTableRow, tr[role="row"], .list-item, table tbody tr')
-		.first()
-	await row.click().catch(() => {})
+	const caseId = await firstCaseIdOrSkip(page)
+	if (!caseId) return false
+
+	// Navigate by URL. dossiq is history-mode
+	// (`createWebHistory(generateUrl('/apps/dossiq'))`) and its detail route is
+	// `/cases/:id`, the same form the visual and workflow suites already drive.
+	await page.goto(`/index.php/apps/dossiq/cases/${caseId}`, {
+		waitUntil: 'domcontentloaded',
+	})
+	await dismissSupportDialog(page).catch(() => {})
 
 	// Retrying assertion rather than a fixed pause: the detail page mounts its
 	// widgets asynchronously, and a `waitForTimeout` either wastes time or

--- a/tests/e2e/spec-coverage/deelzaak-support.spec.ts
+++ b/tests/e2e/spec-coverage/deelzaak-support.spec.ts
@@ -20,27 +20,42 @@
  * navigate there and skip cleanly when the surface is not present.
  */
 
-import { test, expect } from '@playwright/test'
+import { test, expect, request, type APIRequestContext } from '@playwright/test'
 import { navTo, dismissSupportDialog } from '../helpers/nav'
+import { STORAGE_STATE } from '../helpers/auth'
+import {
+	getRequestToken,
+	ensureCaseType,
+	seedCase,
+	objectId,
+} from '../helpers/fixtures'
 
 /** OpenRegister's object API for this app's own register. */
 const CASES_API = '/index.php/apps/openregister/api/objects/dossiq/case'
 
 /**
- * Resolve the id of a case to work with, or skip when the register is empty.
+ * Resolve a case to work with, seeding one when the register has none.
  *
- * Asks the API rather than clicking a row. The previous approach —
- * `.locator('.viewTableRow, tr[role="row"], .list-item, table tbody tr').first()`
- * followed by `.click().catch(() => {})` — had two faults that cancelled each
- * other out into a silent no-op: `tr[role="row"]` matches the table HEADER row,
- * so `.first()` selected a header, and the swallowed catch meant a click that
- * navigated nowhere looked exactly like a click that worked.
+ * TWO THINGS THIS REPLACED.
  *
- * The result was that every test carried on believing it was on a case detail
- * while the snapshot shows `heading "Cases"` — the list page — and then failed
- * on an assertion about a page it had never opened.
+ * 1. It asks the API instead of clicking a row. The previous approach —
+ *    `.locator('.viewTableRow, tr[role="row"], .list-item, table tbody tr')
+ *    .first()` followed by `.click().catch(() => {})` — had two faults that
+ *    cancelled into a silent no-op: `tr[role="row"]` matches the table HEADER,
+ *    so `.first()` selected a header, and the swallowed catch made a click that
+ *    navigated nowhere look exactly like one that worked. Every test then
+ *    asserted against the Cases LIST believing it was on a case detail.
+ *
+ * 2. It SEEDS rather than standing down. Asking the API first turned the old
+ *    false skip into an honest one — "No cases in the seeded register" — which
+ *    was true, and still left this requirement unverified in CI. dossiq's own
+ *    fixture helpers already seed a caseType and a case for the visual suite,
+ *    so the data this needs is one call away and there is no reason to skip for
+ *    the want of it.
+ *
+ * Only a genuinely unreachable API skips now, and it names its status code.
  */
-async function firstCaseIdOrSkip(page): Promise<string | null> {
+async function ensureCaseId(page): Promise<string | null> {
 	const resp = await page.request.get(`${CASES_API}?_limit=1`, {
 		headers: { Accept: 'application/json' },
 	})
@@ -50,21 +65,30 @@ async function firstCaseIdOrSkip(page): Promise<string | null> {
 	}
 	const body = await resp.json()
 	const first = (body.results ?? body.items ?? [])[0]
-	if (!first) {
-		test.skip(
-			true,
-			'No cases in the seeded register — this suite is data-dependent.',
-		)
-		return null
+	if (first) return first.id ?? first['@self']?.id ?? null
+
+	// Empty register — seed the minimum the schema requires (title + caseType).
+	let api: APIRequestContext | null = null
+	try {
+		api = await request.newContext({ storageState: STORAGE_STATE })
+		const token = await getRequestToken(api)
+		const caseType = await ensureCaseType(api, token)
+		const kase = await seedCase(api, token, {
+			title: 'E2E deelzaak parent case',
+			caseType: caseType.id,
+			description: 'Seeded by deelzaak-support.spec.ts.',
+		})
+		return objectId(kase)
+	} finally {
+		await api?.dispose()
 	}
-	return first.id ?? first['@self']?.id ?? null
 }
 
 /** Open the Cases list, or skip when it does not render. */
 async function openCasesListOrSkip(page) {
 	await navTo(page, 'Cases').catch(() => {})
 	await dismissSupportDialog(page).catch(() => {})
-	const caseId = await firstCaseIdOrSkip(page)
+	const caseId = await ensureCaseId(page)
 	if (!caseId) return false
 	await expect(page.locator('body')).not.toContainText('Internal Server Error')
 	return true
@@ -92,7 +116,7 @@ async function openCasesListOrSkip(page) {
  * that section on the detail page rather than clicking a tab.
  */
 async function openSubCasesSectionOrSkip(page) {
-	const caseId = await firstCaseIdOrSkip(page)
+	const caseId = await ensureCaseId(page)
 	if (!caseId) return false
 
 	// Navigate by URL. dossiq is history-mode


### PR DESCRIPTION
## An unimplemented `SHALL`, sitting green behind a deployment excuse

`deelzaak-support`, *Sub-cases section on parent case detail*:

> The case detail view **SHALL** display a "Sub-cases" section … listing all
> cases whose `parentCase` references the current case. The section MUST show
> each sub-case's **title, status, assignee, and deadline**.

`CaseDetail` carried the `case-kpis-sub-cases` **count** and nothing else. The
listing lived on a separate page — `DeelzaakList`, `type: "custom"`, bound to
`/cases/:id/deelzaken`. The detail view had no such section.

### Three artefacts, three different stories

| artefact | what it says |
|---|---|
| spec (normative) | a "Sub-cases" **section** on the case detail view |
| spec (prose, line 9) | "manifest Sub-cases **tab** → DeelzaakList/DeelzaakDetail" |
| manifest | a **page** at `/cases/:id/deelzaken`, plus a count widget |
| e2e | `getByRole('tab', { name: /Sub-cases\|Deelzaken/i })` |

**No tab has ever existed in any build.** So the e2e found none and skipped all
five of its tests with:

```
Sub-cases tab not present in the deployed build (deploy mismatch).
```

A deployment excuse for a surface nothing ever shipped — which reads as an
environment problem, and is exactly why an unimplemented `SHALL` sat green.

## What this changes

**`case-sub-cases`** — an object-list widget on `CaseDetail`: `register:
dossiq`, `schema: case`, `filter: { parentCase: "@objectId" }`, columns
title / status / assignee / deadline **exactly as the requirement enumerates**,
rows deep-linking to `CaseDetail` (a sub-case *is* a case), empty state
"No sub-cases yet" as the second scenario words it. The filter shape isn't a
guess — the existing count widget already uses it.

**The spec's line 9 corrected**, with a note recording what it claimed versus
what was there. Resolved by *implementing* the requirement, not by rewording it
to match what shipped.

**The e2e helper** renamed `openSubCasesTabOrSkip` → `openSubCasesSectionOrSkip`
and asserts the section on the detail page. Its fixed `waitForTimeout` pauses
give way to a retrying assertion, which neither wastes time nor races.

## Not implemented — and said so in the spec

The third scenario, *"Case without sub-case type support hides section"*, cannot
be expressed declaratively: there is no `visibleWhen` / `showWhen` / `condition`
anywhere in this manifest and the renderer offers none, so a manifest widget
cannot hide itself based on the parent case type's `subCaseTypes`. A reader gets
the empty state instead.

Closing it needs a renderer capability, a bespoke custom widget, or an agreed
amendment — a product call, recorded in the spec rather than quietly dropped.

## Verification

| | |
|---|---|
| `node tests/validate-manifest.js` | **Ajv PASS**, 0 errors (48 pages, schema 2.15.0) |
| `npm run test:unit` | **343 tests / 33 files green** |
| `node tests/l10n/check-l10n.js` | OK; en/nl key sets match ("No sub-cases yet" already present) |

`manifest.json` is not in CI's prettier glob (`**/*.{js,ts,vue,css,scss}`) and
fails it before this change too, so it is left unreformatted rather than buried
in an unrelated diff.

Surfaced by the e2e skip-discipline gate, ConductionNL/.github#559.
