### PR TITLE
ci(quality): give every event its own concurrency lane

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -91,7 +91,25 @@ concurrency:
   # This is hermiq's form, already live there. Pull requests keep the bare
   # group (so a PR still supersedes its own earlier run); push, dispatch and
   # schedule each get their own lane.
-  group: quality-${{ github.head_ref || github.ref_name }}${{ (github.event_name != 'pull_request' && (github.ref_name == 'main' || github.ref_name == 'development')) && format('-{0}', github.event_name) || '' }}
+  #
+  # THE BRANCH RESTRICTION IS GONE, because it contradicted the sentence above.
+  #
+  # The suffix used to apply only when `ref_name` was `main` or `development`,
+  # so on every OTHER branch push and pull_request computed the SAME group —
+  # and `cancel-in-progress` made them kill each other. That became reachable
+  # when the push allow-list widened on 2026-08-14 to include `feat/**`,
+  # `fix/**`, `perf/**`, `refactor/**` and `chore/**`: those branches now get
+  # both a push run and a pull_request run for one commit.
+  #
+  # `quality / Quality Report` is a `needs:`-gated aggregator and reports
+  # FAILURE when its dependencies are CANCELLED, so the collision shows up as a
+  # red gate on a PR that was never actually evaluated — and re-running collides
+  # the same way. Measured on openregister#2821: a push run left queued and a
+  # pull_request run cancelled, 18 seconds apart, on one commit.
+  #
+  # A branch name is not a unique lane when two event types can each produce a
+  # run for it, so the event is now always part of the key.
+  group: quality-${{ github.head_ref || github.ref_name }}${{ github.event_name != 'pull_request' && format('-{0}', github.event_name) || '' }}
   cancel-in-progress: true
 
 # Permission CEILING for the called quality pipeline. GitHub statically


### PR DESCRIPTION
Applies the concurrency fix already live on openregister, integriq and pipelinq, where cancellations went to zero.

## What was wrong

The event suffix applied **only** when `ref_name` was `main` or `development`:

```yaml
group: quality-${{ github.head_ref || github.ref_name }}${{ (github.event_name != 'pull_request' && (github.ref_name == 'main' || github.ref_name == 'development')) && format('-{0}', github.event_name) || '' }}
```

So on every other branch, a **push** run and a **pull_request** run for the same commit computed the *same* group, and `cancel-in-progress: true` made them kill each other. That contradicts the comment directly above it, which already states that push, dispatch and schedule each get their own lane.

It became reachable when the push allow-list widened on 2026-08-14 to include `feat/**`, `fix/**`, `perf/**`, `refactor/**` and `chore/**` — those branches now produce both event types for one commit.

## Why it matters beyond wasted minutes

`quality / Quality Report` is a `needs:`-gated aggregator, and it reports **FAILURE** when its dependencies are **CANCELLED**. So the collision surfaces as a red gate on a PR that was never actually evaluated — and re-running collides the same way, which is what made it look persistent rather than flaky.

Measured on openregister#2821, one commit, 18 seconds apart:

```
07:51:57  event=push          queued      <- never started
07:52:15  event=pull_request  cancelled
```

I hit this repeatedly today and initially reported it as a fleet-wide outage before working out that most of the "failures" were supersession rather than code.

## The change

Suffix by event unconditionally. A branch name is not a unique lane when two event types can each produce a run for it. Pull requests keep the bare group, so a PR still supersedes its own earlier run; push, dispatch and schedule each get their own — exactly what the existing comment says should happen.

Tracked in ConductionNL/.github#563.