### PR TITLE
chore: ignore agent/test scratch and untrack generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,8 @@ tests/e2e/.auth/
 /coverage-vitest/
 /coverage/
 composer.phar
+
+# Agent/test scratch and tool caches — generated, never source.
+# Added by the 2026-08-25 fleet hygiene sweep (ADR-100 Decision 2).
+.stale/
+/.e2e-state/


### PR DESCRIPTION
Part of the 2026-08-25 fleet structure audit — **ADR-100 Decision 2** (the repository root is a closed set; generated files are never tracked).

**Ignore rules added:** `.stale/`,`/.e2e-state/`

`.stale/` was missing from **all 19** fleet repos. It is the one that matters most operationally: agent scratch accumulating there filled the dev disk once already.

Every rule was verified to actually take effect by exit code (`git check-ignore -q`), not by reading `check-ignore -v` output — a `!`-negation prints as a match while doing the opposite, which is how one repo in this sweep looked covered and was not.

Refs `ConductionNL/hydra` ADR-100.
