### PR TITLE
fix(walkthrough): drop the two em-dashes from the tour copy

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -53,7 +53,7 @@
 						"sinceVersion": "0.2.17",
 						"placement": "center",
 						"title": "Welcome to Dossiq",
-						"body": "Let's take a quick spin through case handling — we'll register a case together so you can see how the pieces fit. You'll add the record yourself.",
+						"body": "Let's take a quick spin through case handling. We'll register a case together so you can see how the pieces fit, and you'll add the record yourself.",
 						"target": {
 							"kind": "page",
 							"ref": "Dashboard"
@@ -82,7 +82,7 @@
 						"sinceVersion": "0.2.17",
 						"placement": "bottom",
 						"allowManualNext": true,
-						"body": "Register your first case — give it a title and pick a case type, then save. You can add tasks, decisions and documents later.",
+						"body": "Register your first case. Give it a title, pick a case type, then save. You can add tasks, decisions and documents later.",
 						"task": "Click New and save a case",
 						"target": {
 							"kind": "element",


### PR DESCRIPTION
Reported from a running instance. Step 1 of the getting-started tour renders:

> Let's take a quick spin through case handling **—** we'll register a case together…

`voice.md` section 8 bans them outright: *"Em-dashes (—) and double-dashes (--) are AI tells. Replace with a period, a comma, or a colon."*

## The rewrite

Both became full sentences rather than a dash swapped for a comma, because in each case the clause after the dash was already a complete thought.

| | |
|---|---|
| step 1 | "…case handling. **We'll** register a case together so you can see how the pieces fit, and you'll add the record yourself." |
| step 3 | "Register your first case. **Give** it a title, pick a case type, then save." |

## Why this shipped at all

The rule was already right, and the `writing` skill's REVIEW mode literally uses a walkthrough `steps[0].body` em-dash as its worked example. But a skill is **opt-in** — it applies when an author loads it — and nothing downstream reads the prose: `check:manifest` validates this file against a JSON Schema, and JSON Schema has no opinion about writing.

So the rule lived in a document, the copy shipped past it, and the only detector was a human noticing on screen.

The fleet-wide fix is **gate-96 (`manifest-copy-style`)** in `ConductionNL/.github`, which reads every user-visible manifest string — including `manifest.d/` fragments merged at runtime — and fails on this class. A fleet sweep with it found **126 violations across 12 apps**; a walkthrough-only sweep had found 25, because the rest sit in setup-wizard steps, menu labels and widget empty states.

This app is **0 findings** against that gate now, over **390 strings** checked.