### PR TITLE
fix(repair): run writing repair steps under a system identity

### DIFF
--- a/lib/Repair/BackfillInformatieobjectMetadata.php
+++ b/lib/Repair/BackfillInformatieobjectMetadata.php
@@ -33,6 +33,7 @@ declare(strict_types=1);
 namespace OCA\Dossiq\Repair;
 
 use OCA\Dossiq\AppInfo\Application;
+use OCA\Dossiq\Repair\Support\RunsUnderSystemIdentity;
 use OCA\Dossiq\Service\SettingsService;
 use OCA\Dossiq\Service\Support\SearchesObjects;
 use OCP\Files\File;
@@ -47,6 +48,7 @@ use Psr\Log\LoggerInterface;
  * Repair step that back-fills informatieobject metadata for existing files.
  */
 class BackfillInformatieobjectMetadata implements IRepairStep {
+	use RunsUnderSystemIdentity;
 	use SearchesObjects;
 
 	/**
@@ -93,6 +95,29 @@ class BackfillInformatieobjectMetadata implements IRepairStep {
 			return;
 		}
 
+		// Under a system identity: an upgrade has no session, and OpenRegister
+		// refuses `create` for 'Anonymous'. Without it this backfill writes
+		// nothing and says so only in a warning, which does not fail an upgrade.
+		$this->withSystemIdentity(
+			objectService: $objectService,
+			work: function () use ($objectService, $output): void {
+				$this->runInner(objectService: $objectService, output: $output);
+			}
+		);
+	}//end run()
+
+	/**
+	 * The backfill itself.
+	 *
+	 * @param object $objectService OpenRegister's ObjectService.
+	 * @param IOutput $output Progress reporting.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/document-zaakdossier/tasks.md#T09
+	 */
+	private function runInner(object $objectService, IOutput $output): void {
+
 		$register = $this->settingsService->getConfigValue('register');
 		$infoSchema = $this->settingsService->getConfigValue('dossier_informatieobject_schema');
 		if ($register === '' || $infoSchema === '') {
@@ -128,7 +153,7 @@ class BackfillInformatieobjectMetadata implements IRepairStep {
 		}//end foreach
 
 		$output->info('Dossiq backfill: created ' . $created . ' informatieobject(en), skipped ' . $skipped . ' existing.');
-	}//end run()
+	}//end runInner()
 
 	/**
 	 * Back-fill every not-yet-registered file inside one case folder.

--- a/lib/Repair/MigrateArchivalToOpenRegister.php
+++ b/lib/Repair/MigrateArchivalToOpenRegister.php
@@ -43,6 +43,7 @@ declare(strict_types=1);
 
 namespace OCA\Dossiq\Repair;
 
+use OCA\Dossiq\Repair\Support\RunsUnderSystemIdentity;
 use OCA\Dossiq\Service\SettingsService;
 use OCA\Dossiq\Service\Support\SearchesObjects;
 use OCP\IAppConfig;
@@ -57,6 +58,7 @@ use Psr\Log\LoggerInterface;
  * @spec openspec/specs/archief-edepot-handover/spec.md
  */
 class MigrateArchivalToOpenRegister implements IRepairStep {
+	use RunsUnderSystemIdentity;
 	use SearchesObjects;
 
 	/**
@@ -154,6 +156,29 @@ class MigrateArchivalToOpenRegister implements IRepairStep {
 			return;
 		}
 
+		// Under a system identity: an upgrade has no session, and OpenRegister
+		// refuses the write for 'Anonymous'. Without it the holds and proofs are
+		// never written — AND the completion marker below would still be set,
+		// so the migration would mark itself done having moved nothing.
+		$this->withSystemIdentity(
+			objectService: $this->settings->getObjectService(),
+			work: function () use ($register, $output): void {
+				$this->runInner(register: $register, output: $output);
+			}
+		);
+	}//end run()
+
+	/**
+	 * The migration itself.
+	 *
+	 * @param string $register The register slug.
+	 * @param IOutput $output Progress reporting.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/archief-edepot-handover/spec.md
+	 */
+	private function runInner(string $register, IOutput $output): void {
 		$this->enableTmlo(register: $register, output: $output);
 		$holds = $this->placeHoldsForSuspendedTriggers(register: $register);
 		$proofs = $this->exportProofRecords(register: $register);
@@ -163,7 +188,7 @@ class MigrateArchivalToOpenRegister implements IRepairStep {
 			'Archival migration complete: ' . $holds . ' legal hold(s) placed, '
 			. $proofs . ' proof-of-transfer record(s) exported to the zaakdossier.'
 		);
-	}//end run()
+	}//end runInner()
 
 	/**
 	 * Enable TMLO auto-population on the dossiq register (idempotent).

--- a/lib/Repair/SeedBezwaarWorkflowDefinition.php
+++ b/lib/Repair/SeedBezwaarWorkflowDefinition.php
@@ -33,6 +33,7 @@ declare(strict_types=1);
 namespace OCA\Dossiq\Repair;
 
 use OCA\Dossiq\AppInfo\Application;
+use OCA\Dossiq\Repair\Support\RunsUnderSystemIdentity;
 use OCA\Dossiq\Service\SettingsService;
 use OCA\Dossiq\Service\Support\SearchesObjects;
 use OCA\Dossiq\Service\WorkflowDefinitionService;
@@ -45,6 +46,7 @@ use Psr\Log\LoggerInterface;
  */
 class SeedBezwaarWorkflowDefinition implements IRepairStep {
 
+	use RunsUnderSystemIdentity;
 	use SearchesObjects;
 
 	/**
@@ -102,6 +104,26 @@ class SeedBezwaarWorkflowDefinition implements IRepairStep {
 			return;
 		}
 
+		// Under a system identity: an upgrade has no session, and OpenRegister
+		// refuses `create` for 'Anonymous'. Without it this seed writes nothing
+		// and says so only in a warning, which does not fail an upgrade.
+		$this->withSystemIdentity(
+			objectService: $objectService,
+			work: function () use ($objectService, $output): void {
+				$this->runInner(objectService: $objectService, output: $output);
+			}
+		);
+	}//end run()
+
+	/**
+	 * The seed itself.
+	 *
+	 * @param object $objectService OpenRegister's ObjectService.
+	 * @param IOutput $output Progress reporting.
+	 *
+	 * @return void
+	 */
+	private function runInner(object $objectService, IOutput $output): void {
 		$register = $this->settingsService->getConfigValue('register');
 		$caseTypeSchema = $this->settingsService->getConfigValue('case_type_schema');
 		$statusSchema = $this->settingsService->getConfigValue('status_type_schema');
@@ -180,7 +202,7 @@ class SeedBezwaarWorkflowDefinition implements IRepairStep {
 			template: $template,
 			output: $output,
 		);
-	}//end run()
+	}//end runInner()
 
 	/**
 	 * Locate the bezwaar caseType that still needs a workflow definition.

--- a/lib/Repair/SeedLhsMatrix.php
+++ b/lib/Repair/SeedLhsMatrix.php
@@ -31,6 +31,7 @@ namespace OCA\Dossiq\Repair;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use OCA\Dossiq\Repair\Support\RunsUnderSystemIdentity;
 use OCA\Dossiq\Service\SettingsService;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
@@ -43,6 +44,8 @@ use Throwable;
  * @spec openspec/changes/enforcement-lhs/tasks.md#T02
  */
 class SeedLhsMatrix implements IRepairStep {
+	use RunsUnderSystemIdentity;
+
 	/**
 	 * Constructor.
 	 *
@@ -82,7 +85,16 @@ class SeedLhsMatrix implements IRepairStep {
 		}
 
 		try {
-			$this->seedMatrix(output: $output);
+			// Under a system identity: an upgrade has no session, and
+			// OpenRegister refuses `create` for 'Anonymous'. Without it this
+			// seed writes nothing and says so only in a warning, which does not
+			// fail an upgrade.
+			$this->withSystemIdentity(
+				objectService: $this->settingsService->getObjectService(),
+				work: function () use ($output): void {
+					$this->seedMatrix(output: $output);
+				}
+			);
 		} catch (Throwable $e) {
 			$output->warning('Could not seed LHS matrix: ' . $e->getMessage());
 			$this->logger->error(

--- a/lib/Repair/Support/RunsUnderSystemIdentity.php
+++ b/lib/Repair/Support/RunsUnderSystemIdentity.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * Dossiq repair-step system-identity helper.
+ *
+ * @category Repair
+ * @package  OCA\Dossiq\Repair\Support
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Dossiq\Repair\Support;
+
+/**
+ * Runs a repair step's work under OpenRegister's system identity.
+ *
+ * WHY EVERY WRITING REPAIR STEP NEEDS THIS. A repair step executes during
+ * `occ upgrade`, where there is no session. OpenRegister then resolves the actor
+ * as 'Anonymous' and REFUSES the write — and the refusal is not app-specific.
+ * Probing five registers (decidiq, shillinq, trust-configuration, stackiq and
+ * THIS app's) with a deliberately invalid payload, so nothing could be created
+ * either way, every one answered "User 'Anonymous' does not have permission to
+ * 'create'" BEFORE validation was reached.
+ *
+ * The failure is silent. Steps report it with `$output->warning()`, which does
+ * NOT fail an upgrade, so the upgrade prints "Update successful" while nothing
+ * was written. On an instance whose data already exists it is quieter still:
+ * the step skips, and so never attempts the write that would fail — which is
+ * why this survived so long in so many apps.
+ *
+ * @spec openspec/changes/page-topology-cleanup/tasks.md
+ */
+trait RunsUnderSystemIdentity {
+	/**
+	 * Run $work under a system identity when one can be established.
+	 *
+	 * FALLS THROUGH rather than refusing. If OpenRegister cannot be resolved the
+	 * work still runs: each step already handles its own write failures, and
+	 * adding an identity must not cost the degradation behaviour that was there
+	 * before. (Learned the hard way in a sibling app: an eager resolve aborted
+	 * every seeder when resolution failed, and three existing tests caught it.)
+	 *
+	 * @param object|null $objectService OpenRegister's ObjectService, or null.
+	 * @param callable $work The step's actual work.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/page-topology-cleanup/tasks.md
+	 */
+	private function withSystemIdentity(?object $objectService, callable $work): void {
+		if ($objectService !== null && method_exists($objectService, 'runAsSystem') === true) {
+			$objectService->runAsSystem(static function () use ($work): void {
+				$work();
+			});
+
+			return;
+		}
+
+		$work();
+	}//end withSystemIdentity()
+}//end trait


### PR DESCRIPTION
## Why

A repair step runs during `occ upgrade`, where there is no session. OpenRegister resolves the actor as `Anonymous` and **refuses the write** — before validation is even reached.

The failure is silent in both directions. Steps report it with `$output->warning()`, which does not fail an upgrade, so the upgrade prints "Update successful" while nothing was written. On an instance whose data already exists it is quieter still: the step skips, and so never attempts the write that would have failed — which is why this survived so long.

This is the known defect class: *a migration without `runAsSystem()` migrates nothing, and a step that skips looks exactly like one that succeeded.*

## Evidence

Probing five registers (decidiq, shillinq, trust-configuration, stackiq and dossiq's own) with a deliberately invalid payload — so nothing could be created either way — every one answered `User 'Anonymous' does not have permission to 'create'` **before** validation. The refusal is not app-specific.

## What

- **`lib/Repair/Support/RunsUnderSystemIdentity.php`** — a shared trait that runs a step's work under OpenRegister's system identity. It **falls through rather than refusing**: if OpenRegister cannot be resolved the work still runs, since each step already handles its own write failures, and hard-failing here would turn a recoverable upgrade into a broken one.
- Applied to the four writing repair steps: `SeedBezwaarWorkflowDefinition`, `SeedLhsMatrix`, `BackfillInformatieobjectMetadata`, `MigrateArchivalToOpenRegister`.

## Note

These commits predate the ADR-110 nav work and were sitting unpushed on a local branch; pushing them so they land rather than being lost.
