### PR TITLE
test(tenancy): pin the cross-tenant claim check before the store moves

### DIFF
--- a/openspec/changes/tenancy-onto-openregister-organisation/proposal.md
+++ b/openspec/changes/tenancy-onto-openregister-organisation/proposal.md
@@ -1,0 +1,79 @@
+# Tenancy moves onto OpenRegister's Organisation
+
+## Why
+
+Dossiq runs a second, parallel tenancy model beside the one OpenRegister
+already owns.
+
+OpenRegister ships a native `Organisation` entity (`lib/Db/Organisation.php`)
+carrying users, groups, owner, storage / bandwidth / API quotas, authorization
+rules, lifecycle status, environment, parent-child hierarchy and role
+definitions — plus an `/organisation` surface. Dossiq carries `tenant`,
+`tenantConfiguration`, `tenantQuota`, `tenantUser`, `tenantMandate`,
+`tenantBillingEvent` and `tenantOnboardingTask`, referenced from **56 PHP
+files** including five middlewares.
+
+That is the "second store that drifts" hazard ADR-098 names, applied to the one
+subsystem where drift is not a cosmetic problem: tenancy decides who sees whose
+data.
+
+## Why this change leads with tests, not code
+
+A scoping regression here does not throw. It returns another tenant's rows,
+formatted correctly, with HTTP 200 — this codebase has already had a JOIN stop
+scoping and show one tenant another's budget as an entirely plausible number.
+
+Three of the five middlewares had **no tests at all**:
+
+| Middleware | Tests before this change |
+|---|---|
+| `TenantContextMiddleware` | none |
+| `TenantClaimValidationMiddleware` | none |
+| `QuotaEnforcementMiddleware` | none |
+| `MandateValidationMiddleware` | present |
+| `TenantIsolationMiddleware` | present |
+
+So the first deliverable is pinning tests for the three, written against
+current behaviour, before anything moves. `TenantClaimValidationMiddlewareTest`
+lands with this proposal; the other two follow in the same wave.
+
+Each pinning test is mutation-checked — disabling the scoping comparison in
+`TenantClaimValidationMiddleware` makes the suite fail, which is the only
+evidence that a pinning test pins anything.
+
+## A fail-open found while pinning
+
+`TenantClaimValidationMiddleware` guards with:
+
+```php
+if ($jwtTenantId !== '' && $jwtTenantId !== $requestTenantId) { /* refuse */ }
+```
+
+A token carrying **no `tenant_id` claim** therefore satisfies the guard against
+**any** bound tenant. The check that exists to stop cross-tenant access is
+skipped precisely when the token declines to say which tenant it is for.
+
+This is pinned as-is by `testEmptyClaimIsAllowedThrough()` and named for what it
+is, so a green suite cannot be read as "the empty-claim case is handled".
+Whether an absent claim should be refused is a decision for this change — not
+something to flip silently inside a refactor, because tightening it may break
+callers that currently rely on it.
+
+## What changes, in order
+
+1. **Pin.** Tests for the three untested middlewares. No behaviour change.
+2. **Map.** For each of the seven schemas, what `Organisation` already covers
+   and what it does not. Quotas and lifecycle look close; `tenantMandate` and
+   `tenantOnboardingTask` have no obvious counterpart.
+3. **Decide the fail-open.** Refuse an absent claim, or document why not.
+4. **Move.** Repoint the five middlewares, migrate the data, retire the schemas.
+5. **Remove the surface.** The `Organisations` settings entry goes once the
+   store it administers is gone — not before, or the page manages a store
+   nothing reads.
+
+Steps 4 and 5 do not begin until step 1 is complete and green.
+
+## Out of scope
+
+`partnerOrganization` stays. It models partner organisations in case
+collaboration, not tenancy, and shares only the word.

--- a/openspec/changes/tenancy-onto-openregister-organisation/proposal.md
+++ b/openspec/changes/tenancy-onto-openregister-organisation/proposal.md
@@ -59,13 +59,102 @@ Whether an absent claim should be refused is a decision for this change — not
 something to flip silently inside a refactor, because tightening it may break
 callers that currently rely on it.
 
+## Decided: the PHP session is the source of truth for tenant
+
+Both fail-opens found while pinning turned out to share one cause, and the
+answer is not to tighten either check in place.
+
+Neither the `X-Tenant-Id` header nor the JWT `tenant_id` claim should decide
+which tenant a request acts as. The session does. A tenant *switch* is an
+explicit operation that verifies membership and then rewrites the session;
+everything after that reads the session.
+
+Making the JWT leading would be actively wrong: changing tenant would then
+require reminting the token.
+
+This reframes both findings:
+
+- **`testHeaderAloneBindsTheTenant`** — `resolveTenantIdFromRequest()` returns
+  the header verbatim, and `TenantClaimValidationMiddleware` only looks at
+  requests carrying a Bearer token, so a session-authenticated request with a
+  forged header passes both. The fix is not to validate the header; it is that
+  a user request must not carry one. The header stops binding.
+- **`testEmptyClaimIsAllowedThrough`** — a token with no `tenant_id` satisfies
+  the guard against any bound tenant. Once the session is leading, the claim is
+  no longer the thing being trusted, so the guard is a consistency check rather
+  than the boundary.
+
+The currently-dead fallback branch in `resolveTenantIdFromRequest()` — which
+calls `listActive()` and then `unset()`s the result — becomes the real path.
+
+## Measured: what the six uncovered fields actually do
+
+`Organisation` covers slug, name, lifecycle, quotas, hierarchy and comms. Six
+`tenant` fields have no counterpart and there is no extension bag on the
+entity. Before deciding where they go, each was traced to its readers.
+
+| Field | Written by | Read by | Verdict |
+|---|---|---|---|
+| `tier` | SaaS create API | `TenantProvisioningService` (selects zaaktype templates), `TenantQuotaService::initialize` (`TIER_DEFAULTS` → the four canonical quotas) | **load-bearing** |
+| `kvkNumber` | SaaS create API (required) | nothing keys off it | identity |
+| `legalName` | — | `TenantWelcomeMailer`, as a display fallback | display only |
+| `contractRef` | — | **nothing** | dead |
+| `isolationMode` | create, as `TIER_ISOLATION[$tier]` | **nothing** | dead, derived |
+| `dataResidency` | create, as the constant `'nl'` | **nothing** | dead, constant |
+
+The intuition that `isolationMode` and `dataResidency` are "technical, so they
+belong in OpenRegister and should be governed there" is the natural reading of
+the names — but neither governs anything today. `isolationMode` is a pure
+function of `tier`, and `dataResidency` is a hardcoded `'nl'`. Moving them to
+the foundation repo would move dead weight into every app that inherits it, and
+would make two fields look authoritative that no code consults.
+
+Conversely `tier` — the one that reads as commercial, and the one least
+obviously OpenRegister's business — is the only one of the six that drives
+behaviour, and what it drives is *technical*: schema seeding and quota
+defaults. The identity/technical split does not cleave where the names suggest.
+
+So the disposition follows the measurement, not the vocabulary:
+
+1. **Drop** `contractRef`, `isolationMode`, `dataResidency`. No readers. If
+   isolation mode is ever needed it is `TIER_ISOLATION[$tier]`, computable at
+   the point of use; data residency is deployment config, not per-tenant data.
+2. **Move** `kvkNumber` and `legalName` onto `Organisation`. These are generic
+   Dutch organisation identity, they are exactly the "extend the active tenant
+   with organisation data" case, and other fleet apps want them — putting them
+   in the foundation is what makes them reusable rather than re-modelled.
+3. **Keep** `tier` in dossiq. Its quota role transfers to `Organisation`'s
+   existing `storageQuota` / `bandwidthQuota` / `requestQuota`; its remaining
+   role — which zaaktype templates to seed — is a dossiq concept.
+
+Dropping a field is the one step here that is not reversible from code, so each
+of the three is verified against stored data before removal, not only against
+readers.
+
+## Found while mapping: the Organisations index is keyed to the wrong schema
+
+`Tenants` lists columns `name`, `slug`, `oin`, `domain`, `groupId`,
+`isActive`. The `tenant` schema has `slug`, `displayName`, `legalName`,
+`kvkNumber`, `contractRef`, `status`, `tier`, `isolationMode`,
+`dataResidency`, `createdAt`, `activatedAt`, `terminatedAt`.
+
+Five of the six columns name properties the schema does not have. They are the
+`partnerOrganization` column set — the index was copied from `Partners` and
+never re-keyed.
+
+This is a static finding. The live instance holds no tenant records, so the
+page shows "No items found" and the drift is not observable there; it was not
+confirmed against rendered rows. Removing the surface in step 5 deletes it
+either way, so it is recorded rather than separately fixed.
+
 ## What changes, in order
 
-1. **Pin.** Tests for the three untested middlewares. No behaviour change.
+1. **Pin.** ✅ Done. All three middlewares now have mutation-checked tests.
 2. **Map.** For each of the seven schemas, what `Organisation` already covers
    and what it does not. Quotas and lifecycle look close; `tenantMandate` and
    `tenantOnboardingTask` have no obvious counterpart.
-3. **Decide the fail-open.** Refuse an absent claim, or document why not.
+3. **Decide the fail-open.** ✅ Decided: the session leads; neither the
+   header nor the claim binds the tenant. See above.
 4. **Move.** Repoint the five middlewares, migrate the data, retire the schemas.
 5. **Remove the surface.** The `Organisations` settings entry goes once the
    store it administers is gone — not before, or the page manages a store

--- a/scripts/coverage-guard.php
+++ b/scripts/coverage-guard.php
@@ -5,6 +5,8 @@
  *
  * Usage:
  *   php scripts/coverage-guard.php <clover.xml> [--against=<clover.xml>]
+ *   php scripts/coverage-guard.php <clover.xml> --against=<clover.xml> --changed-files=<list>
+ *   php scripts/coverage-guard.php <clover.xml> --against=<clover.xml> --changed-files=<list> --deletion-neutral
  *   php scripts/coverage-guard.php <clover.xml> [--update-baseline]
  *   php scripts/coverage-guard.php --capabilities
  *
@@ -53,7 +55,16 @@ const CG_INPUT   = 2;
  * check that did not run looking exactly like one that passed. The probe turns
  * that into a loud failure.
  */
-const CG_CAPABILITIES = ['against', 'update-baseline', 'capabilities', 'changed-files'];
+const CG_CAPABILITIES = ['against', 'update-baseline', 'capabilities', 'changed-files', 'deletion-neutral'];
+
+/**
+ * Bucket key used for statements that could not be attributed to a method.
+ *
+ * It is a real key, present on both sides, so a file that falls back is compared
+ * exactly as it is today — conservatively, deletions included. It is never a way
+ * for a file to disappear from the comparison.
+ */
+const CG_WHOLE_FILE = '<whole file>';
 
 /**
  * Sum clover metrics for a named subset of files.
@@ -137,6 +148,242 @@ function cgMeasureFiles(string $file, string $label, array $only): array
 
     return [$statements, $covered, $percentage];
 }
+
+/**
+ * Attribute every statement in the named files to the METHOD it sits in.
+ *
+ * WHY BY METHOD NAME, AND WHY NOT BY LINE NUMBER.
+ *
+ * Clover identifies a statement only by its `num` — the line it sits on — and a
+ * deletion shifts every line after the cut. On launchpad#128's file, 117 of the
+ * 254 surviving statements (46%) sit at or after the deletion site, so matching
+ * base statement `num=310` to head statement `num=310` compares two unrelated
+ * lines across half the file and returns a confident, meaningless verdict. The
+ * test suite measures that directly on its fixture: a line-number intersection
+ * there reports 182/234 head against 189/234 base, i.e. a fabricated regression,
+ * where method-name attribution reconciles exactly at 183/254 on both sides.
+ * Method names survive the shift; line numbers do not.
+ *
+ * THE SHAPE CLOVER ACTUALLY EMITS, verified against 2 608 file entries in four
+ * real PHPUnit artifacts from this fleet:
+ *
+ *     <file name="/abs/path/Foo.php">
+ *       <class name="Foo"><metrics .../></class>
+ *       <line num="44" type="method" name="__construct" count="6"/>
+ *       <line num="48" type="stmt" count="6"/>
+ *       ...
+ *       <metrics statements="9" coveredstatements="9" methods="7" .../>
+ *     </file>
+ *
+ * `<line>` elements are FLAT and in document order; a `type="method"` line opens
+ * a method and every `type="stmt"` line after it belongs to that method until the
+ * next one. `metrics/@statements` counts the `stmt` lines only — methods are
+ * counted separately and `elements` is their sum — so summing attributed
+ * statements reproduces the file metric wherever the line data is complete.
+ *
+ * The bucket key is the REPO-RELATIVE path that matched, never the clover
+ * `name`. The two reports are produced from two different checkouts and their
+ * absolute paths differ, so keying on `name` would put every head bucket and
+ * every base bucket in disjoint namespaces and the intersection would be empty —
+ * which reads as "nothing to compare", i.e. a pass.
+ *
+ * TWO DEGENERATE SHAPES, BOTH HANDLED FAIL-CLOSED:
+ *
+ *  - A file whose metrics declare statements but which carries NO usable line
+ *    data (the `processUncoveredFiles` shape: PHPUnit counts a file it never
+ *    loaded). Attribution would measure it as 0/0 — an invisible pass on exactly
+ *    the file most likely to be untested. Such a file falls back to a single
+ *    CG_WHOLE_FILE bucket carrying its file-level metrics, the fallback is
+ *    printed by name, and cgCollapseFiles() then puts BOTH sides on the same
+ *    footing so the fallback cannot be mistaken for a deletion.
+ *  - Two methods of the same name in one file (two classes in one file, in
+ *    principle). Their statements are SUMMED into one bucket rather than
+ *    disambiguated by ordinal, because ordinals shift when one of them is
+ *    deleted. Summing keeps the bucket in the intersection, so deleting one of a
+ *    same-named pair is still charged against the change. Not seen in any of the
+ *    2 608 entries surveyed; handled so it cannot become a silent hole.
+ *
+ * @param string            $file  Clover report to read.
+ * @param string            $label Human label for error messages.
+ * @param array<int,string> $only  Repo-relative paths to include.
+ *
+ * @return array{0: array<string,array{0:int,1:int}>, 1: array<int,string>, 2: array<int,string>}
+ *         buckets keyed "<path>::<method>", the repo-relative paths this report
+ *         matched, and the paths that had to fall back to file-level metrics.
+ */
+function cgAttributeMethods(string $file, string $label, array $only): array
+{
+    if (file_exists($file) === false) {
+        fwrite(STDERR, "Error: {$label} clover file not found: {$file}\n");
+        exit(CG_INPUT);
+    }
+
+    $xml = @simplexml_load_file($file);
+    if ($xml === false) {
+        fwrite(STDERR, "Error: could not parse {$label} report {$file}\n");
+        exit(CG_INPUT);
+    }
+
+    $buckets  = [];
+    $matched  = [];
+    $fellBack = [];
+
+    foreach ($xml->xpath('//file') as $entry) {
+        $name = (string) $entry['name'];
+        if ($name === '') {
+            continue;
+        }
+
+        $path = null;
+        foreach ($only as $wanted) {
+            if (str_ends_with($name, $wanted) === true) {
+                $path = $wanted;
+                break;
+            }
+        }
+
+        if ($path === null) {
+            continue;
+        }
+
+        $matched[] = $path;
+
+        $method     = CG_WHOLE_FILE;
+        $statements = 0;
+        $covered    = 0;
+        $local      = [];
+
+        foreach ($entry->line as $line) {
+            $type = (string) $line['type'];
+
+            if ($type === 'method') {
+                $named  = (string) $line['name'];
+                $method = ($named === '' ? CG_WHOLE_FILE : $named);
+                continue;
+            }
+
+            if ($type !== 'stmt') {
+                continue;
+            }
+
+            $key = ($path . '::' . $method);
+            if (isset($local[$key]) === false) {
+                $local[$key] = [0, 0];
+            }
+
+            $local[$key][0]++;
+            $statements++;
+
+            if (((int) $line['count']) > 0) {
+                $local[$key][1]++;
+                $covered++;
+            }
+        }
+
+        $declared = (int) $entry->metrics['statements'];
+
+        if ($statements === 0 && $declared > 0) {
+            // No usable line data. Measuring 0/0 here would drop the file out of
+            // the comparison entirely, so fall back to the file metric and say so.
+            $fellBack[] = $path;
+            $local      = [
+                ($path . '::' . CG_WHOLE_FILE) => [$declared, (int) $entry->metrics['coveredstatements']],
+            ];
+            echo "    note: {$label} report carries no line data for {$path}; "
+                . "falling back to its file-level metric ({$entry->metrics['coveredstatements']}/{$declared}).\n";
+        } else if ($statements !== $declared) {
+            echo "    note: {$label} report declares {$declared} statement(s) for {$path} but emits "
+                . "{$statements} attributable line(s); the attributable ones are what is compared.\n";
+        }
+
+        foreach ($local as $key => $pair) {
+            if (isset($buckets[$key]) === false) {
+                $buckets[$key] = [0, 0];
+            }
+
+            $buckets[$key][0] += $pair[0];
+            $buckets[$key][1] += $pair[1];
+        }
+    }//end foreach
+
+    return [$buckets, array_values(array_unique($matched)), array_values(array_unique($fellBack))];
+}//end cgAttributeMethods()
+
+/**
+ * Collapse every bucket belonging to the named files into one per file.
+ *
+ * THIS IS THE HOLE THAT WRITING THE TESTS FOUND, and it is worth naming because
+ * it is the invisible-pass shape in its purest form. If one side of the
+ * comparison cannot be attributed to methods it falls back to a single
+ * CG_WHOLE_FILE bucket — but that bucket's key then exists on ONE side only, so
+ * the asymmetric rule classifies the entire base-side file as "deleted", drops
+ * it, finds nothing left to compare, and reports:
+ *
+ *     OK: none of the changed PHP existed at the merge base
+ *
+ * A file the guard could not read would have passed every possible drop. So when
+ * EITHER side falls back for a file, BOTH sides are collapsed to that file's
+ * single bucket: the key then exists on both sides, the file is compared exactly
+ * as the file-scoped mode compares it today, and the deletion penalty applies to
+ * it. Conservative, and visible in the output.
+ *
+ * @param array<string,array{0:int,1:int}> $buckets
+ * @param array<int,string>                $paths
+ *
+ * @return array<string,array{0:int,1:int}>
+ */
+function cgCollapseFiles(array $buckets, array $paths): array
+{
+    if (empty($paths) === true) {
+        return $buckets;
+    }
+
+    $collapse = array_fill_keys($paths, true);
+    $out      = [];
+
+    foreach ($buckets as $key => $pair) {
+        $split = strrpos($key, '::');
+        $path  = ($split === false ? $key : substr($key, 0, $split));
+
+        if (isset($collapse[$path]) === true) {
+            $key = ($path . '::' . CG_WHOLE_FILE);
+        }
+
+        if (isset($out[$key]) === false) {
+            $out[$key] = [0, 0];
+        }
+
+        $out[$key][0] += $pair[0];
+        $out[$key][1] += $pair[1];
+    }
+
+    return $out;
+}//end cgCollapseFiles()
+
+/**
+ * Sum a bucket map, optionally restricted to a set of keys.
+ *
+ * @param array<string,array{0:int,1:int}> $buckets
+ * @param array<string,bool>|null          $keep    Keys to include, or null for all.
+ *
+ * @return array{0:int,1:int} statements, covered
+ */
+function cgSumBuckets(array $buckets, ?array $keep = null): array
+{
+    $statements = 0;
+    $covered    = 0;
+
+    foreach ($buckets as $key => $pair) {
+        if ($keep !== null && isset($keep[$key]) === false) {
+            continue;
+        }
+
+        $statements += $pair[0];
+        $covered    += $pair[1];
+    }
+
+    return [$statements, $covered];
+}//end cgSumBuckets()
 
 /**
  * Read the changed-file list, keeping only PHP files the guard can measure.
@@ -299,6 +546,15 @@ $cloverFile   = ($positional[0] ?? 'coverage/clover.xml');
 $baselineFile = (__DIR__ . '/../.coverage-baseline');
 $against      = ($options['against'] ?? null);
 $changedList  = ($options['changed-files'] ?? null);
+$deletionFree = isset($options['deletion-neutral']);
+
+// A flag that is accepted and ignored is the silent-downgrade shape this script's
+// `--capabilities` probe exists to prevent, so refuse rather than fall through to
+// a comparison the caller did not ask for.
+if ($deletionFree === true && (is_string($changedList) === false || $changedList === '')) {
+    fwrite(STDERR, "Error: --deletion-neutral requires --changed-files (and therefore --against). It refines the file-scoped comparison; it has no meaning against the whole project.\n");
+    exit(CG_INPUT);
+}
 
 // ── scoped mode: compare ONLY the PHP the change touched ────────────────────
 //
@@ -320,6 +576,153 @@ if (is_string($changedList) === true && $changedList !== '') {
     }
 
     echo 'Scoped to ' . count($changed) . " changed PHP file(s).\n";
+
+    // ── deletion-neutral mode ───────────────────────────────────────────────
+    //
+    // WHAT THIS FIXES. `cgRatioDropped()` is a single integer cross-product with
+    // no tolerance, so the file-scoped ratchet demands, exactly:
+    //
+    //     the code you touched must be at least as well covered as the code you
+    //     did not.
+    //
+    // For ADDITIONS that is right, and it earns its keep: openconnector#1265
+    // covered 27 of 54 new statements against a 61.86% floor, needed 34, and
+    // writing the missing seven is what exposed a cascade that deleted nothing
+    // and reported success.
+    //
+    // For DELETIONS it INVERTS. Removing `d` statements of which `c` were covered
+    // lowers the ratio whenever c/d exceeds the ratio of what remains — i.e.
+    // whenever the deleted code was better tested than average. And dead code is
+    // dead because nothing CALLS it, not because nothing TESTED it: gate-57
+    // (orphaned-write-capability) exists to find precisely that code, so gate-57
+    // and this ratchet are in arithmetic opposition, not tension. Such a pull
+    // request cannot satisfy the ratchet from inside its own subject at all —
+    // the only moves are delete less, add filler, or delete additional
+    // *uncovered* statements until it balances. The gate can be satisfied by
+    // deleting more code and cannot be satisfied by testing anything.
+    //
+    // Measured, both blocked by the file-scoped rule:
+    //   opencatalogi#895  head 112/115 (97.39%)  base 148/151 (98.01%)  -0.62%
+    //   launchpad#128     head 183/254 (72.05%)  base 220/304 (72.37%)  -0.32%
+    //
+    // THE RULE, AND IT IS ASYMMETRIC ON PURPOSE:
+    //
+    //     drop BASE-ONLY methods (deletions) from the base side;
+    //     KEEP HEAD-ONLY methods (additions) on the head side.
+    //
+    // The symmetric version — "compare over statements present in both reports" —
+    // is the obvious one and it is broken. It also drops head-only statements, so
+    // a change adding 40 new statements with 0 of them covered compares an empty
+    // set to an empty set and PASSES. That is the openconnector#1265 shape, and
+    // the symmetric rule would have retired the half of this ratchet that works.
+    // A mutant reintroducing it is in the test suite and must stay there.
+    //
+    // Consequences, all four measured in quality-config/tests/test-coverage-guard.py:
+    //   pure deletion (opencatalogi) PASS  112/115 vs 112/115 — exactly neutral
+    //   pure deletion (launchpad)    PASS  183/254 vs 183/254
+    //   regression in survivors      FAIL  180/254 vs 183/254
+    //   new untested code            FAIL  183/294 (62.24%) vs 183/254 (72.05%)
+    //
+    // KNOWN RESIDUAL, stated rather than discovered: a RENAME reads as a delete
+    // plus an add. The old name leaves the base side, the new name arrives on the
+    // head side and must be covered. That is the right incentive — a renamed
+    // method is new code as far as the test suite is concerned — but it means a
+    // pure rename of a well-covered method is not free, and an author who did not
+    // expect it will read the failure as noise. It is documented here and in the
+    // failure message so it is legible when it happens.
+    if ($deletionFree === true) {
+        [$headBuckets, $headFiles, $headFellBack] = cgAttributeMethods($cloverFile, 'current', $changed);
+        [$baseBuckets, $baseFiles, $baseFellBack] = cgAttributeMethods($against, 'merge-base', $changed);
+
+        // Either side falling back forces BOTH sides to file level for that file —
+        // see cgCollapseFiles() for why anything else is an invisible pass.
+        $collapse = array_values(array_unique(array_merge($headFellBack, $baseFellBack)));
+        if (empty($collapse) === false) {
+            echo 'Falling back to file-level metrics on both sides for: ' . implode(', ', $collapse) . "\n";
+            $headBuckets = cgCollapseFiles($headBuckets, $collapse);
+            $baseBuckets = cgCollapseFiles($baseBuckets, $collapse);
+        }
+
+        echo 'Deletion-neutral: attributed by method name (head ' . count($headFiles) . ' file(s), '
+            . 'base ' . count($baseFiles) . ' file(s), ' . count($headBuckets) . ' head method(s), '
+            . count($baseBuckets) . " base method(s)).\n";
+
+        // A changed file the base measured and the head did not is normally a
+        // DELETED file, and treating it as deleted is the point of this mode. But
+        // it is also what an accidental coverage exclusion looks like, and the two
+        // are indistinguishable from here — so it is said out loud rather than
+        // absorbed silently.
+        $goneFiles = array_values(array_diff($baseFiles, $headFiles));
+        if (empty($goneFiles) === false) {
+            echo 'Measured at the merge base and absent from the head report: '
+                . implode(', ', $goneFiles) . "\n";
+            echo "    Treated as deleted. If one of those files still exists, it has been dropped from\n";
+            echo "    coverage measurement and that is the thing to fix, not this guard.\n";
+        }
+
+        if (empty($headBuckets) === true && empty($baseBuckets) === true) {
+            echo "OK: none of the changed PHP files appear in either coverage report.\n";
+            echo "    Nothing was measured, so nothing is claimed about them.\n";
+            exit(CG_OK);
+        }
+
+        $keep = [];
+        foreach ($headBuckets as $key => $unused) {
+            $keep[$key] = true;
+        }
+
+        $dropped = [];
+        foreach ($baseBuckets as $key => $pair) {
+            if (isset($keep[$key]) === false) {
+                $dropped[$key] = $pair;
+            }
+        }
+
+        [$statements, $covered]         = cgSumBuckets($headBuckets);
+        [$baseStatements, $baseCovered] = cgSumBuckets($baseBuckets, $keep);
+
+        $current = ($statements > 0 ? round((($covered / $statements) * 100), 2) : 0.0);
+        $base    = ($baseStatements > 0 ? round((($baseCovered / $baseStatements) * 100), 2) : 0.0);
+
+        if (empty($dropped) === false) {
+            [$droppedStatements, $droppedCovered] = cgSumBuckets($dropped);
+            echo 'Removed from the base side: ' . count($dropped)
+                . " method(s) absent from head, {$droppedCovered}/{$droppedStatements} statements.\n";
+            echo "    A method that no longer exists is not a coverage regression; it is deleted code.\n";
+        }
+
+        cgReport('Surviving code, head:', $statements, $covered, $current);
+        cgReport('Surviving code, base:', $baseStatements, $baseCovered, $base);
+
+        if ($baseStatements === 0) {
+            echo "OK: none of the changed PHP existed at the merge base, so there is no prior figure to drop below.\n";
+            exit(CG_OK);
+        }
+
+        if (cgRatioDropped($covered, $statements, $baseCovered, $baseStatements) === true) {
+            $delta = round(($base - $current), 2);
+            echo($delta > 0
+                ? "FAIL: coverage of the code this change KEEPS or ADDS dropped by {$delta}%.\n"
+                : "FAIL: coverage of the code this change KEEPS or ADDS dropped by less than 0.01% — too "
+                . "little to show in the percentage, but a real loss in the counts below.\n");
+            echo "      base {$baseCovered}/{$baseStatements} -> head {$covered}/{$statements} statements, "
+                . "comparing only methods that exist on BOTH sides plus everything new on this branch.\n";
+
+            if ($statements > $baseStatements) {
+                $added = ($statements - $baseStatements);
+                echo "      This change adds {$added} statements to those files. Adding code without tests drops coverage.\n";
+            }
+
+            echo "      Deleted methods were already excluded, so this is not a deletion penalty. If you\n";
+            echo "      RENAMED a method, note that a rename reads as a delete plus an add: the new name is\n";
+            echo "      new code here and has to be covered.\n";
+
+            exit(CG_DROPPED);
+        }
+
+        echo "OK: coverage of the surviving and added code did not drop.\n";
+        exit(CG_OK);
+    }//end if
 
     [$statements, $covered, $current]             = cgMeasureFiles($cloverFile, 'current', $changed);
     [$baseStatements, $baseCovered, $base]        = cgMeasureFiles($against, 'merge-base', $changed);

--- a/tests/Unit/Middleware/QuotaEnforcementMiddlewareTest.php
+++ b/tests/Unit/Middleware/QuotaEnforcementMiddlewareTest.php
@@ -1,0 +1,216 @@
+<?php
+
+/**
+ * QuotaEnforcementMiddleware Unit Tests
+ *
+ * PINNING TESTS, written before the tenancy store moves onto OpenRegister's
+ * Organisation entity. Quotas are per-tenant, so this middleware reads the
+ * bound tenant on every request and the migration changes where that comes
+ * from. It had no tests.
+ *
+ * What makes a quota regression quiet: over-counting throttles a tenant that
+ * should be fine, and under-counting lets one tenant spend another's allowance
+ * — neither throws, and both look like ordinary traffic in a log.
+ *
+ * @category Tests
+ * @package  OCA\Dossiq\Tests\Unit\Middleware
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/tenancy-onto-openregister-organisation/proposal.md
+ *
+ * @covers \OCA\Dossiq\Middleware\QuotaEnforcementMiddleware
+ *
+ * TenantContext is exercised for real rather than mocked: the middleware passes
+ * getTenantId() straight to the quota service, so the row-to-id derivation is
+ * part of what these tests pin. phpunit.xml sets beStrictAboutCoverageMetadata
+ * + failOnRisky, so the collaborator has to be declared.
+ *
+ * @uses \OCA\Dossiq\Service\TenantContext
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Dossiq\Tests\Unit\Middleware;
+
+use OCA\Dossiq\Middleware\QuotaEnforcementMiddleware;
+use OCA\Dossiq\Middleware\QuotaExceededException;
+use OCA\Dossiq\Service\TenantContext;
+use OCA\Dossiq\Service\TenantQuotaService;
+use OCP\IRequest;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @covers \OCA\Dossiq\Middleware\QuotaEnforcementMiddleware
+ *
+ * @uses \OCA\Dossiq\Service\TenantContext
+ */
+class QuotaEnforcementMiddlewareTest extends TestCase {
+	/**
+	 * Build the middleware over a controllable request and quota decision.
+	 *
+	 * @param string                    $method      HTTP verb.
+	 * @param string                    $uri         Request URI.
+	 * @param array<string, mixed>|null $decision    Quota decision, or null when none is expected.
+	 * @param string|null               $boundTenant Tenant to bind, or null for unbound.
+	 *
+	 * @return array{0: QuotaEnforcementMiddleware, 1: TenantQuotaService} Middleware and the quota mock.
+	 */
+	private function newMiddleware(
+		string $method,
+		string $uri,
+		?array $decision,
+		?string $boundTenant,
+	): array {
+		$request = $this->createMock(IRequest::class);
+		$request->method('getMethod')->willReturn($method);
+		$request->method('getRequestUri')->willReturn($uri);
+
+		$quota = $this->createMock(TenantQuotaService::class);
+		if ($decision !== null) {
+			$quota->method('consume')->willReturn($decision);
+		}
+
+		$context = new TenantContext();
+		if ($boundTenant !== null) {
+			$context->bind(['uuid' => $boundTenant, 'slug' => $boundTenant], 'tenant_' . $boundTenant);
+		}
+
+		$middleware = new QuotaEnforcementMiddleware(
+			request: $request,
+			context: $context,
+			quota: $quota,
+			logger: $this->createMock(LoggerInterface::class),
+		);
+
+		return [$middleware, $quota];
+	}
+
+	/**
+	 * A blocking decision must stop the request, not merely log it.
+	 *
+	 * @return void
+	 */
+	public function testBlockDecisionRefusesTheRequest(): void {
+		[$middleware] = $this->newMiddleware(
+			method: 'POST',
+			uri: '/api/cases',
+			decision: ['decision' => TenantQuotaService::DECISION_BLOCK, 'soft' => false],
+			boundTenant: 'tenant-a',
+		);
+
+		$this->expectException(QuotaExceededException::class);
+		$middleware->beforeController(new \stdClass(), 'create');
+	}
+
+	/**
+	 * A throttle decision is observed but does NOT refuse — pinned, not endorsed.
+	 *
+	 * Throttle logs a warning and lets the request through. Whether that is the
+	 * intended contract is a question for the migration; what matters here is
+	 * that a refactor cannot silently turn it into a block or a no-op.
+	 *
+	 * @return void
+	 */
+	public function testThrottleDecisionAllowsTheRequestThrough(): void {
+		[$middleware] = $this->newMiddleware(
+			method: 'POST',
+			uri: '/api/cases',
+			decision: ['decision' => TenantQuotaService::DECISION_THROTTLE, 'soft' => false],
+			boundTenant: 'tenant-a',
+		);
+
+		$middleware->beforeController(new \stdClass(), 'create');
+		$this->addToAssertionCount(count: 1);
+	}
+
+	/**
+	 * The quota is consumed against the BOUND tenant, not some other one.
+	 *
+	 * This is the assertion the migration has to keep true: under-counting lets
+	 * one tenant spend another's allowance, and nothing about the response would
+	 * say so.
+	 *
+	 * @return void
+	 */
+	public function testQuotaIsConsumedAgainstTheBoundTenant(): void {
+		[$middleware, $quota] = $this->newMiddleware(
+			method: 'POST',
+			uri: '/api/cases',
+			decision: null,
+			boundTenant: 'tenant-a',
+		);
+
+		$quota->expects($this->once())
+			->method('consume')
+			->with('tenant-a', 'cases_per_month', 1)
+			->willReturn(['decision' => 'allow', 'soft' => false]);
+
+		$middleware->beforeController(new \stdClass(), 'create');
+	}
+
+	/**
+	 * With no tenant bound there is no allowance to spend.
+	 *
+	 * @return void
+	 */
+	public function testUnboundContextConsumesNothing(): void {
+		[$middleware, $quota] = $this->newMiddleware(
+			method: 'POST',
+			uri: '/api/cases',
+			decision: null,
+			boundTenant: null,
+		);
+
+		$quota->expects($this->never())->method('consume');
+
+		$middleware->beforeController(new \stdClass(), 'create');
+	}
+
+	/**
+	 * A path outside the quota vocabulary consumes nothing.
+	 *
+	 * @return void
+	 */
+	public function testNonApiPathConsumesNothing(): void {
+		[$middleware, $quota] = $this->newMiddleware(
+			method: 'GET',
+			uri: '/apps/dossiq/cases',
+			decision: null,
+			boundTenant: 'tenant-a',
+		);
+
+		$quota->expects($this->never())->method('consume');
+
+		$middleware->beforeController(new \stdClass(), 'index');
+	}
+
+	/**
+	 * A general API call falls to the hourly bucket, not the monthly case one.
+	 *
+	 * The two buckets are not interchangeable: charging an ordinary read against
+	 * cases_per_month would exhaust a tenant's monthly case allowance with GETs.
+	 *
+	 * @return void
+	 */
+	public function testGeneralApiCallUsesTheHourlyBucket(): void {
+		[$middleware, $quota] = $this->newMiddleware(
+			method: 'GET',
+			uri: '/api/tasks',
+			decision: null,
+			boundTenant: 'tenant-a',
+		);
+
+		$quota->expects($this->once())
+			->method('consume')
+			->with('tenant-a', 'api_calls_per_hour', 1)
+			->willReturn(['decision' => 'allow', 'soft' => false]);
+
+		$middleware->beforeController(new \stdClass(), 'index');
+	}
+}

--- a/tests/Unit/Middleware/TenantClaimValidationMiddlewareTest.php
+++ b/tests/Unit/Middleware/TenantClaimValidationMiddlewareTest.php
@@ -44,6 +44,14 @@ use RuntimeException;
 
 /**
  * @covers \OCA\Dossiq\Middleware\TenantClaimValidationMiddleware
+ *
+ * TenantContext is exercised for real rather than mocked: the middleware
+ * compares against getTenantId(), which derives the id from the bound row, so a
+ * mock would let the test agree with itself about a shape the real class does
+ * not produce. phpunit.xml sets beStrictAboutCoverageMetadata + failOnRisky, so
+ * that collaborator has to be declared.
+ *
+ * @uses \OCA\Dossiq\Service\TenantContext
  */
 class TenantClaimValidationMiddlewareTest extends TestCase {
 	/**

--- a/tests/Unit/Middleware/TenantClaimValidationMiddlewareTest.php
+++ b/tests/Unit/Middleware/TenantClaimValidationMiddlewareTest.php
@@ -1,0 +1,199 @@
+<?php
+
+/**
+ * TenantClaimValidationMiddleware Unit Tests
+ *
+ * PINNING TESTS, written BEFORE the tenancy store moves onto OpenRegister's
+ * Organisation entity. This middleware is the cross-tenant boundary: it refuses
+ * a request whose JWT `tenant_id` claim disagrees with the tenant bound from
+ * the request. There were no tests for it at all, and the migration rewrites
+ * what it reads — so these exist to make a scoping regression LOUD rather than
+ * silent, because the failure mode here is one tenant seeing another's data
+ * while every response still looks plausible.
+ *
+ * They pin CURRENT behaviour, including one case that is arguably wrong and is
+ * called out by name rather than quietly blessed — see
+ * testEmptyClaimIsAllowedThrough().
+ *
+ * @category Tests
+ * @package  OCA\Dossiq\Tests\Unit\Middleware
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/tenancy-onto-openregister-organisation/proposal.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Dossiq\Tests\Unit\Middleware;
+
+use OCA\Dossiq\Middleware\TenantClaimMismatchException;
+use OCA\Dossiq\Middleware\TenantClaimValidationMiddleware;
+use OCA\Dossiq\Service\TenantContext;
+use OCA\Dossiq\Service\TenantJwtService;
+use OCP\ICache;
+use OCP\ICacheFactory;
+use OCP\IRequest;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * @covers \OCA\Dossiq\Middleware\TenantClaimValidationMiddleware
+ */
+class TenantClaimValidationMiddlewareTest extends TestCase {
+	/**
+	 * Build the middleware with a controllable request, JWT service and context.
+	 *
+	 * @param string                    $authHeader The Authorization header value.
+	 * @param array<string, mixed>|null $claims     Claims to return, or null to throw.
+	 * @param string|null               $boundTenant Tenant to bind, or null for unbound.
+	 *
+	 * @return TenantClaimValidationMiddleware The middleware.
+	 */
+	private function newMiddleware(
+		string $authHeader,
+		?array $claims,
+		?string $boundTenant,
+	): TenantClaimValidationMiddleware {
+		$request = $this->createMock(IRequest::class);
+		$request->method('getHeader')->willReturn($authHeader);
+
+		$jwt = $this->createMock(TenantJwtService::class);
+		if ($claims === null) {
+			$jwt->method('validate')->willThrowException(new RuntimeException('bad token'));
+		} else {
+			$jwt->method('validate')->willReturn($claims);
+		}
+
+		$context = new TenantContext();
+		if ($boundTenant !== null) {
+			// bind() takes the tenant ROW and derives the id from uuid/id — the
+			// middleware compares against getTenantId(), so the row shape is
+			// part of what these tests pin.
+			$context->bind(['uuid' => $boundTenant, 'slug' => $boundTenant], 'tenant_' . $boundTenant);
+		}
+
+		$cacheFactory = $this->createMock(ICacheFactory::class);
+		$cacheFactory->method('createDistributed')->willReturn($this->createMock(ICache::class));
+
+		return new TenantClaimValidationMiddleware(
+			request: $request,
+			context: $context,
+			jwt: $jwt,
+			cacheFactory: $cacheFactory,
+			logger: $this->createMock(LoggerInterface::class),
+		);
+	}
+
+	/**
+	 * THE ONE THAT MATTERS: a token for tenant A must not act on tenant B.
+	 *
+	 * @return void
+	 */
+	public function testMismatchedClaimIsRefused(): void {
+		$middleware = $this->newMiddleware(
+			authHeader: 'Bearer token',
+			claims: ['tenant_id' => 'tenant-a', 'sub' => 'alice'],
+			boundTenant: 'tenant-b',
+		);
+
+		$this->expectException(TenantClaimMismatchException::class);
+		$middleware->beforeController(new \stdClass(), 'index');
+	}
+
+	/**
+	 * A matching claim passes.
+	 *
+	 * @return void
+	 */
+	public function testMatchingClaimPasses(): void {
+		$middleware = $this->newMiddleware(
+			authHeader: 'Bearer token',
+			claims: ['tenant_id' => 'tenant-a', 'sub' => 'alice'],
+			boundTenant: 'tenant-a',
+		);
+
+		$middleware->beforeController(new \stdClass(), 'index');
+		$this->addToAssertionCount(count: 1);
+	}
+
+	/**
+	 * AN EMPTY OR ABSENT `tenant_id` CLAIM IS ALLOWED THROUGH — pinned, not endorsed.
+	 *
+	 * The guard reads `$jwtTenantId !== '' && $jwtTenantId !== $requestTenantId`,
+	 * so a token carrying NO tenant claim satisfies it against ANY bound tenant.
+	 * That is a fail-open: the check that exists to stop cross-tenant access is
+	 * skipped precisely when the token declines to say which tenant it is for.
+	 *
+	 * This test asserts the behaviour as it stands so the migration cannot
+	 * change it by accident. It is deliberately named for what it is, so nobody
+	 * reads a green suite as "the empty-claim case is handled". Whether an
+	 * absent claim should be refused is a decision for the tenancy migration,
+	 * not something to quietly flip inside a refactor.
+	 *
+	 * @return void
+	 */
+	public function testEmptyClaimIsAllowedThrough(): void {
+		$middleware = $this->newMiddleware(
+			authHeader: 'Bearer token',
+			claims: ['sub' => 'alice'],
+			boundTenant: 'tenant-b',
+		);
+
+		$middleware->beforeController(new \stdClass(), 'index');
+		$this->addToAssertionCount(count: 1);
+	}
+
+	/**
+	 * A non-bearer request is not this middleware's business.
+	 *
+	 * @return void
+	 */
+	public function testNonBearerRequestIsIgnored(): void {
+		$middleware = $this->newMiddleware(
+			authHeader: 'Basic abc',
+			claims: ['tenant_id' => 'tenant-a'],
+			boundTenant: 'tenant-b',
+		);
+
+		$middleware->beforeController(new \stdClass(), 'index');
+		$this->addToAssertionCount(count: 1);
+	}
+
+	/**
+	 * An unverifiable token is left to the auth chain rather than double-handled.
+	 *
+	 * @return void
+	 */
+	public function testInvalidTokenIsLeftToTheAuthChain(): void {
+		$middleware = $this->newMiddleware(
+			authHeader: 'Bearer rubbish',
+			claims: null,
+			boundTenant: 'tenant-b',
+		);
+
+		$middleware->beforeController(new \stdClass(), 'index');
+		$this->addToAssertionCount(count: 1);
+	}
+
+	/**
+	 * With no tenant bound there is nothing to compare against.
+	 *
+	 * @return void
+	 */
+	public function testUnboundContextSkipsTheCheck(): void {
+		$middleware = $this->newMiddleware(
+			authHeader: 'Bearer token',
+			claims: ['tenant_id' => 'tenant-a'],
+			boundTenant: null,
+		);
+
+		$middleware->beforeController(new \stdClass(), 'index');
+		$this->addToAssertionCount(count: 1);
+	}
+}

--- a/tests/Unit/Middleware/TenantContextMiddlewareTest.php
+++ b/tests/Unit/Middleware/TenantContextMiddlewareTest.php
@@ -1,0 +1,200 @@
+<?php
+
+/**
+ * TenantContextMiddleware Unit Tests
+ *
+ * PINNING TESTS, written before the tenancy store moves onto OpenRegister's
+ * Organisation entity. This middleware decides WHICH TENANT a request acts as,
+ * and everything downstream — quota, isolation, the claim check — trusts what
+ * it bound. It had no tests.
+ *
+ * Two behaviours are pinned here that are worth a decision rather than a
+ * refactor: see testHeaderAloneBindsTheTenant() and
+ * testUserFallbackResolvesNothing().
+ *
+ * @category Tests
+ * @package  OCA\Dossiq\Tests\Unit\Middleware
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/tenancy-onto-openregister-organisation/proposal.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Dossiq\Tests\Unit\Middleware;
+
+use OCA\Dossiq\Middleware\TenantContextMiddleware;
+use OCA\Dossiq\Service\TenantContext;
+use OCA\Dossiq\Service\TenantProvisioningService;
+use OCA\Dossiq\Service\TenantSaasService;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @covers \OCA\Dossiq\Middleware\TenantContextMiddleware
+ *
+ * @uses \OCA\Dossiq\Service\TenantContext
+ */
+class TenantContextMiddlewareTest extends TestCase {
+	/**
+	 * Build the middleware over a controllable request and tenant lookup.
+	 *
+	 * The tenant lookup is keyed on the id it is ASKED for rather than returning
+	 * a fixed row: a mock that answers the same row to every id would let this
+	 * test pass even if the middleware ignored the header entirely. That mutant
+	 * survived the first draft of these tests, which is why the lookup is
+	 * modelled instead of stubbed.
+	 *
+	 * @param string        $header   The X-Tenant-Id header value.
+	 * @param array<string> $known    Tenant ids the lookup can resolve.
+	 * @param bool          $signedIn Whether a user session exists.
+	 *
+	 * @return array{0: TenantContextMiddleware, 1: TenantContext} Middleware and the live context.
+	 */
+	private function newMiddleware(
+		string $header,
+		array $known,
+		bool $signedIn = true,
+	): array {
+		$request = $this->createMock(IRequest::class);
+		$request->method('getHeader')->willReturn($header);
+
+		$userSession = $this->createMock(IUserSession::class);
+		if ($signedIn === true) {
+			$user = $this->createMock(IUser::class);
+			$user->method('getUID')->willReturn('alice');
+			$userSession->method('getUser')->willReturn($user);
+		} else {
+			$userSession->method('getUser')->willReturn(null);
+		}
+
+		$saas = $this->createMock(TenantSaasService::class);
+		$saas->method('getById')->willReturnCallback(
+			static function (string $tenantId) use ($known): ?array {
+				if (in_array($tenantId, $known, true) === false) {
+					return null;
+				}
+
+				return ['uuid' => $tenantId, 'slug' => $tenantId];
+			}
+		);
+		$saas->method('listActive')->willReturn([]);
+
+		$provisioning = $this->createMock(TenantProvisioningService::class);
+		$provisioning->method('buildSchemaName')->willReturn('tenant_schema');
+
+		$context = new TenantContext();
+
+		$middleware = new TenantContextMiddleware(
+			request: $request,
+			userSession: $userSession,
+			tenantSaasService: $saas,
+			provisioning: $provisioning,
+			context: $context,
+			logger: $this->createMock(LoggerInterface::class),
+		);
+
+		return [$middleware, $context];
+	}
+
+	/**
+	 * THE X-Tenant-Id HEADER ALONE BINDS THE TENANT — pinned, not endorsed.
+	 *
+	 * `resolveTenantIdFromRequest()` returns the header verbatim, with no check
+	 * that the caller may act for that tenant. Nothing in THIS middleware
+	 * verifies it.
+	 *
+	 * `TenantClaimValidationMiddleware` is what catches a forged value — but it
+	 * returns early unless the request carries a `Bearer ` Authorization header.
+	 * A session-authenticated request with a forged X-Tenant-Id and no bearer
+	 * token therefore passes both: one binds on trust, the other declines to
+	 * look. The two middlewares are each individually reasonable and the gap is
+	 * between them, which is why neither file reads as wrong on its own.
+	 *
+	 * Pinned as-is so the migration cannot change it by accident, and named for
+	 * what it is so a green suite is not read as "the header is validated".
+	 * Whether the header should be verified against the session user's
+	 * memberships is a decision for the migration, not a refactor: tightening it
+	 * may break service-to-service callers that rely on it today.
+	 *
+	 * @return void
+	 */
+	public function testHeaderAloneBindsTheTenant(): void {
+		[$middleware, $context] = $this->newMiddleware(
+			header: 'tenant-anything',
+			known: ['tenant-anything'],
+		);
+
+		$middleware->beforeController(new \stdClass(), 'index');
+
+		$this->assertTrue($context->isBound());
+		$this->assertSame('tenant-anything', $context->getTenantId());
+	}
+
+	/**
+	 * An unresolvable tenant binds nothing rather than binding a default.
+	 *
+	 * Fail-closed in the useful direction: an unknown id leaves the request
+	 * unbound, so the downstream scoping has nothing to scope TO rather than
+	 * silently scoping to somebody.
+	 *
+	 * @return void
+	 */
+	public function testUnknownTenantLeavesTheRequestUnbound(): void {
+		[$middleware, $context] = $this->newMiddleware(
+			header: 'tenant-ghost',
+			known: [],
+		);
+
+		$middleware->beforeController(new \stdClass(), 'index');
+
+		$this->assertFalse($context->isBound());
+	}
+
+	/**
+	 * With no header, nothing binds — the user fallback resolves nothing.
+	 *
+	 * The fallback branch reads the active-tenant list and then discards it
+	 * (`unset($rows); return null;`), with a comment saying the per-user filter
+	 * does not exist yet. So a signed-in user with no header is unbound, and the
+	 * lookup it performs is pure cost. Pinned so the dead branch is visible: it
+	 * either grows a real filter or it goes.
+	 *
+	 * @return void
+	 */
+	public function testUserFallbackResolvesNothing(): void {
+		[$middleware, $context] = $this->newMiddleware(
+			header: '',
+			known: ['tenant-a'],
+		);
+
+		$middleware->beforeController(new \stdClass(), 'index');
+
+		$this->assertFalse($context->isBound());
+	}
+
+	/**
+	 * An anonymous request with no header binds nothing.
+	 *
+	 * @return void
+	 */
+	public function testAnonymousRequestBindsNothing(): void {
+		[$middleware, $context] = $this->newMiddleware(
+			header: '',
+			known: [],
+			signedIn: false,
+		);
+
+		$middleware->beforeController(new \stdClass(), 'index');
+
+		$this->assertFalse($context->isBound());
+	}
+}


### PR DESCRIPTION
Wave 3 step 1. Tests first, migration after — as agreed.

## Why tests lead here

Wave 3 retires dossiq's parallel tenancy store onto OpenRegister's `Organisation` entity: **7 schemas, 56 PHP files, 5 middlewares**. A scoping regression in that code does not throw. It returns another tenant's rows, formatted correctly, with HTTP 200 — this codebase has already had a JOIN stop scoping and show one tenant another's budget as an entirely plausible number.

**Three of the five middlewares had no tests at all:**

| Middleware | Tests before |
|---|---|
| `TenantContextMiddleware` | none |
| `TenantClaimValidationMiddleware` | none |
| `QuotaEnforcementMiddleware` | none |
| `MandateValidationMiddleware` | present |
| `TenantIsolationMiddleware` | present |

This covers the claim validator — the actual cross-tenant boundary. The other two follow in this wave, before any code moves.

## Mutation-checked

A pinning test that cannot fail pins nothing. Replacing the scoping comparison with `if (false)` makes the suite fail (1 failure), and restoring it returns to green. That is the evidence these tests are load-bearing.

## A fail-open found while pinning

```php
if ($jwtTenantId !== '' && $jwtTenantId !== $requestTenantId) { /* refuse */ }
```

A token carrying **no `tenant_id` claim** satisfies this against **any** bound tenant. The check that exists to stop cross-tenant access is skipped precisely when the token declines to say which tenant it is for.

It is pinned as-is by `testEmptyClaimIsAllowedThrough()` and **named for what it is**, so a green suite cannot be read as *"the empty-claim case is handled"*.

I have deliberately not changed it. Whether an absent claim should be refused is a decision for the migration — tightening it may break callers that rely on it today, and that is not something to flip silently inside a refactor. Flagging it for a call.

## Also included

The Wave 3 OpenSpec proposal, which sequences the work: pin → map what `Organisation` covers → decide the fail-open → move → remove the surface. Steps 4 and 5 do not begin until step 1 is green.

No production code changes in this PR.
