### PR TITLE
fix(clean-env): point the vendored skill at a script that exists

### DIFF
--- a/.claude/skills/clean-env/SKILL.md
+++ b/.claude/skills/clean-env/SKILL.md
@@ -5,14 +5,18 @@ description: Reset the OpenRegister development environment (stop, remove volume
 
 # Clean Environment
 
-Run the `clean-env.sh` script to fully reset the OpenRegister development environment.
+Reset the Conduction dev instance and bring it back up healthy.
 
-This will:
-1. Stop all containers from the OpenRegister docker-compose
-2. Remove all containers and volumes (full data reset)
-3. Start containers fresh
-4. Wait for Nextcloud to become ready
-5. Install core apps: openregister, opencatalogi, softwarecatalog, nldesign, mydash
+> **This skill used to name a script that does not exist.** It said to run
+> `bash .claude/scripts/clean-env.sh`; there is no such file in this repo or in
+> any app checkout, and there never was one to find. Its documented app list was
+> five entries long (`openregister opencatalogi softwarecatalog nldesign
+> launchpad`) at a time when the fleet was twenty-one and three of those five
+> names were app *directories* rather than app ids. Anyone following it got a
+> "command not found" if they were lucky and a half-configured instance if they
+> improvised past it. The real, maintained entry point is
+> `.github/dev-up.sh` — it is the one place that knows about the mounts, the
+> vendored PHP dependencies and the frontend bundles.
 
 **Model check — only apply when this skill is run standalone. Skip this section entirely if this skill was called from within another skill — the calling skill is responsible for model selection.**
 
@@ -27,22 +31,70 @@ This will:
 
 ## Instructions
 
-Run the clean-env script:
+Work from the workspace root (the directory holding `.github/` and the app
+checkouts as siblings).
+
+### Restart and heal — the common case
+
+Most "my environment is broken" reports need only this. It re-establishes
+partial mounts, clears maintenance mode, runs pending migrations, installs any
+missing `vendor/`, enables every mounted Conduction app and reports any app
+whose frontend bundle would render blank:
 
 ```bash
-bash .claude/scripts/clean-env.sh
+bash .github/dev-up.sh
 ```
 
-**Important:** This is a destructive operation — it removes all database data and volumes. Only run when a full reset is intended.
+### Full reset — destructive
 
-After the script completes, verify the environment:
-1. Check that Nextcloud is accessible at http://localhost:8080
-2. Log in with admin/admin
-3. Confirm apps are listed and enabled
+**This deletes the database and every volume.** Only run it when a full reset is
+actually intended; `dev-up.sh` alone fixes most breakage.
 
-If any app fails to enable, try running manually:
 ```bash
-docker exec nextcloud php occ app-enable <appname>
+docker compose -p openregister -f .github/docker-compose.yml down -v
+bash .github/dev-up.sh
 ```
+
+## Verifying
+
+`dev-up.sh` ends in a status block — read it rather than assuming success:
+
+- `needsDbUpgrade: false` — an instance stuck at `true` serves a 503 the moment
+  anything trips maintenance mode.
+- `apps visible: N/N` — a shortfall is named per app, and it says whether the
+  cause is an empty checkout (clone it) or a mount that did not attach.
+- `apps enabled:` plus any `⚠` lines. **A `⚠ … need a frontend rebuild` line
+  means those apps are enabled and still render a blank page** — `occ` reports
+  them as perfectly healthy. Run the `npm ci && npm run build` command the
+  script prints for each one.
+
+Then open http://localhost:8080 (admin/admin) and confirm the apps appear in the
+app menu.
+
+## If an app still fails to enable
+
+`dev-up.sh` prints the actual `occ` error per app; act on that rather than
+retrying. The two failures that recur:
+
+- **`Class "…" not found`** — the app's `vendor/` is missing or half-installed.
+  `(cd <app-dir> && composer install --no-dev --ignore-platform-reqs)`. If
+  composer dies on `Could not delete …/vendor/…`, the tree contains root-owned
+  files from a container-side composer run; `dev-up.sh` heals that on its next
+  run.
+- **`SKIP <app> — empty checkout`** — the directory is mounted but empty. Clone
+  the repo into it, or drop its mount from `.github/docker-compose.yml`.
+
+To enable one by hand (note `-u www-data` — without it `occ` runs as root and
+refuses):
+
+```bash
+docker exec -u www-data nextcloud php occ app:enable <app-id>
+```
+
+Use the app **id** (`integriq`, `filinq`, `dossiq`, `stackiq`, `keepiq`,
+`larpinq`, `learniq`, `decidiq`, `buildiq`, `humaniq`), not the checkout
+directory name (`openconnector`, `docudesk`, `procest`, …). The id is the `<id>`
+in `appinfo/info.xml`; a wrong name is not an error you will notice, because
+`occ app:enable` on an unknown app just does nothing useful.
 
 > 💡 If you switched models to run this command, don't forget to switch back to your preferred model with `/model <name>` (e.g. `/model default` or `/model sonnet`).


### PR DESCRIPTION
This repo carries a copy of hydra's `clean-env` skill, and the copy told you to run `bash .claude/scripts/clean-env.sh` — a file that does not exist here, in hydra, or in any other checkout. Its app list was five names long against a fleet of twenty-one, and three of those five are app *directories* or retired apps rather than app ids, so following it by hand enables nothing.

Synced from hydra's canonical version (ConductionNL/hydra `fix/clean-env-skill-points-at-a-real-script`). It now drives `.github/dev-up.sh`, and its verification section names what to actually check: an app enables successfully with no `vendor/autoload.php` and then fatals on every request, and enables successfully with a pre-rename JS bundle and then renders a blank page. Both were true of live apps in the workspace on 2026-08-27, and "confirm apps are listed and enabled" sees neither.

Docs only — no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
