### PR TITLE
fix(tenancy): the session decides the tenant, not a header the caller sets

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -418,6 +418,8 @@ $extra = [
         // controller keeps provisioning, usage aggregation, and current-
         // tenant resolution — the parts that are not declarative CRUD.
     ['name' => 'tenant#current',   'url' => '/api/tenants/current',                'verb' => 'GET'],
+    ['name' => 'tenant#memberships',  'url' => '/api/tenants/memberships',         'verb' => 'GET'],
+    ['name' => 'tenant#switchTenant', 'url' => '/api/tenants/switch',              'verb' => 'POST'],
     ['name' => 'tenant#provision', 'url' => '/api/tenants/{tenantId}/provision',   'verb' => 'POST'],
     ['name' => 'tenant#usage',     'url' => '/api/tenants/{tenantId}/usage',       'verb' => 'GET'],
 

--- a/lib/Controller/TenantController.php
+++ b/lib/Controller/TenantController.php
@@ -30,7 +30,9 @@ declare(strict_types=1);
 namespace OCA\Dossiq\Controller;
 
 use OCA\Dossiq\AppInfo\Application;
+use OCA\Dossiq\Service\TenantAuthenticationService;
 use OCA\Dossiq\Service\TenantService;
+use OCA\Dossiq\Service\TenantSessionService;
 use OCA\Dossiq\Settings\AdminSettings;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
@@ -38,6 +40,7 @@ use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use OCP\IUserSession;
+use Throwable;
 
 /**
  * Controller for tenant domain operations (provisioning, usage, current tenant).
@@ -61,6 +64,8 @@ class TenantController extends Controller {
 		IRequest $request,
 		private TenantService $tenantService,
 		private IUserSession $userSession,
+		private TenantSessionService $tenantSession,
+		private TenantAuthenticationService $tenantAuthentication,
 	) {
 		parent::__construct(appName: Application::APP_ID, request: $request);
 	}//end __construct()
@@ -132,6 +137,85 @@ class TenantController extends Controller {
 
 		return new JSONResponse(['success' => true, 'tenant' => $tenant]);
 	}//end current()
+
+	/**
+	 * The tenants the signed-in user may act as.
+	 *
+	 * The switcher needs this: a user with several memberships resolves to no
+	 * tenant until they choose one, and they cannot choose from a list they
+	 * cannot see.
+	 *
+	 * @NoAdminRequired
+	 *
+	 * @return JSONResponse The memberships.
+	 *
+	 * @spec openspec/changes/tenancy-onto-openregister-organisation/proposal.md
+	 */
+	public function memberships(): JSONResponse {
+		$user = $this->userSession->getUser();
+		if ($user === null) {
+			return new JSONResponse(['success' => false, 'error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+		}
+
+		try {
+			$tenantIds = $this->tenantAuthentication->listTenantsForUser(userId: $user->getUID());
+		} catch (Throwable $e) {
+			// Fail CLOSED, and say so. An empty list rendered as a clean answer
+			// would show the user "you belong to nothing" when the truth is
+			// "we could not find out".
+			return new JSONResponse(
+				['success' => false, 'error' => 'Could not read your tenant memberships'],
+				Http::STATUS_INTERNAL_SERVER_ERROR
+			);
+		}
+
+		return new JSONResponse(
+			[
+				'success' => true,
+				'tenants' => $tenantIds,
+				'active' => $this->tenantSession->activeTenantId(),
+			]
+		);
+	}//end memberships()
+
+	/**
+	 * Switch the session to another tenant the user belongs to.
+	 *
+	 * WHY THIS IS AN ENDPOINT AND NOT A HEADER. The tenant a request acts as
+	 * used to come from `X-Tenant-Id`, which the caller supplies — so the
+	 * caller chose their own tenant and nothing verified they could. Switching
+	 * is now an explicit act whose membership is checked at the moment it
+	 * happens, and the result lives in the session rather than in something the
+	 * next request can retype.
+	 *
+	 * A refusal is deliberately a 403 with no detail about whether the tenant
+	 * exists: telling an outsider "that tenant is real, you just are not on it"
+	 * enumerates the tenant list.
+	 *
+	 * @param string $tenantId The tenant to switch to.
+	 *
+	 * @NoAdminRequired
+	 *
+	 * @return JSONResponse The outcome.
+	 *
+	 * @spec openspec/changes/tenancy-onto-openregister-organisation/proposal.md
+	 */
+	public function switchTenant(string $tenantId = ''): JSONResponse {
+		$user = $this->userSession->getUser();
+		if ($user === null) {
+			return new JSONResponse(['success' => false, 'error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+		}
+
+		if ($this->tenantSession->switchTo($tenantId) === false) {
+			return new JSONResponse(
+				['success' => false, 'error' => 'You cannot act as that tenant'],
+				Http::STATUS_FORBIDDEN
+			);
+		}
+
+		return new JSONResponse(['success' => true, 'active' => $this->tenantSession->activeTenantId()]);
+	}//end switchTenant()
+
 
 	/**
 	 * Check if current user is a platform administrator.

--- a/lib/Controller/TenantController.php
+++ b/lib/Controller/TenantController.php
@@ -57,6 +57,8 @@ class TenantController extends Controller {
 	 * @param IRequest $request The request object
 	 * @param TenantService $tenantService The tenant service
 	 * @param IUserSession $userSession The user session
+	 * @param TenantSessionService $tenantSession The session-held active tenant.
+	 * @param TenantAuthenticationService $tenantAuthentication Membership lookups.
 	 *
 	 * @return void
 	 */

--- a/lib/Middleware/TenantContextMiddleware.php
+++ b/lib/Middleware/TenantContextMiddleware.php
@@ -73,6 +73,7 @@ class TenantContextMiddleware extends Middleware {
 	 * Constructor.
 	 *
 	 * @param IRequest $request Request.
+	 * @param TenantSessionService $tenantSession Session-held active tenant.
 	 * @param TenantSaasService $tenantSaasService Tenant SaaS service.
 	 * @param TenantProvisioningService $provisioning Provisioning service (schema-name builder).
 	 * @param TenantContext $context Request-scoped context.

--- a/lib/Middleware/TenantContextMiddleware.php
+++ b/lib/Middleware/TenantContextMiddleware.php
@@ -3,15 +3,23 @@
 /**
  * Dossiq Tenant Context Middleware
  *
- * Resolves the requesting tenant from headers / user / route parameter and
- * binds it onto the request-scoped `TenantContext` service. Runs after the
- * existing `TenantMiddleware` (which does the older Organisation-shaped
- * resolution) and before `TenantIsolationMiddleware` (which sets the
- * Postgres search_path).
+ * Resolves the requesting tenant from the SESSION and binds it onto the
+ * request-scoped `TenantContext` service. Runs after the existing
+ * `TenantMiddleware` (which does the older Organisation-shaped resolution) and
+ * before `TenantIsolationMiddleware` (which sets the Postgres search_path).
  *
- * Resolution order:
- *   1. `X-Tenant-Id` header (platform-admin or JWT claim)
- *   2. The current user's `tenantUser` membership row (one-to-one)
+ * Resolution: `TenantSessionService::activeTenantId()`, which re-verifies the
+ * session's choice against the user's `tenantUser` memberships on every read.
+ *
+ * WHAT CHANGED AND WHY. This used to return the `X-Tenant-Id` header verbatim.
+ * The header is supplied by the caller, and the only check that would have
+ * caught a forged value — `TenantClaimValidationMiddleware` — returns early
+ * unless the request carries a Bearer token. A session-authenticated user
+ * could therefore name any tenant and be believed, because each middleware was
+ * individually reasonable and the gap was between them.
+ *
+ * The header no longer binds. Switching tenant is an explicit act that
+ * verifies membership first; see `TenantSessionService`.
  *
  * @category Middleware
  * @package  OCA\Dossiq\Middleware
@@ -35,9 +43,9 @@ namespace OCA\Dossiq\Middleware;
 use OCA\Dossiq\Service\TenantContext;
 use OCA\Dossiq\Service\TenantProvisioningService;
 use OCA\Dossiq\Service\TenantSaasService;
+use OCA\Dossiq\Service\TenantSessionService;
 use OCP\AppFramework\Middleware;
 use OCP\IRequest;
-use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
@@ -65,7 +73,6 @@ class TenantContextMiddleware extends Middleware {
 	 * Constructor.
 	 *
 	 * @param IRequest $request Request.
-	 * @param IUserSession $userSession User session.
 	 * @param TenantSaasService $tenantSaasService Tenant SaaS service.
 	 * @param TenantProvisioningService $provisioning Provisioning service (schema-name builder).
 	 * @param TenantContext $context Request-scoped context.
@@ -73,7 +80,7 @@ class TenantContextMiddleware extends Middleware {
 	 */
 	public function __construct(
 		private readonly IRequest $request,
-		private readonly IUserSession $userSession,
+		private readonly TenantSessionService $tenantSession,
 		private readonly TenantSaasService $tenantSaasService,
 		private readonly TenantProvisioningService $provisioning,
 		private readonly TenantContext $context,
@@ -155,27 +162,16 @@ class TenantContextMiddleware extends Middleware {
 	public function resolveTenantIdFromRequest(): ?string {
 		$header = $this->request->getHeader('X-Tenant-Id');
 		if ($header !== '') {
-			return $header;
+			// Deliberately IGNORED, and logged rather than silently dropped: a
+			// caller still sending this is relying on behaviour that has been
+			// removed, and would otherwise find their requests quietly acting
+			// as a different tenant than they asked for.
+			$this->logger->warning(
+				'Dossiq: X-Tenant-Id was supplied and ignored; the session decides the tenant',
+				['supplied' => $header]
+			);
 		}
 
-		$user = $this->userSession->getUser();
-		if ($user === null) {
-			return null;
-		}
-
-		// Fall back: look up the tenantUser row for the current user — covers
-		// the common single-tenant-per-user case.
-		try {
-			$rows = $this->tenantSaasService->listActive(statusFilter: 'active', limit: 100);
-			// No per-user filter in the SaaS service yet; the tenant binding
-			// for an unauthenticated single-tenant deployment is handled by
-			// the older TenantMiddleware via the OR Organisation entity. This
-			// middleware only fires when an X-Tenant-Id is explicitly supplied.
-			unset($rows);
-		} catch (Throwable $e) {
-			$this->logger->info('Dossiq: tenant lookup miss', ['exception' => $e->getMessage()]);
-		}
-
-		return null;
+		return $this->tenantSession->activeTenantId();
 	}//end resolveTenantIdFromRequest()
 }//end class

--- a/lib/Service/TenantAuthenticationService.php
+++ b/lib/Service/TenantAuthenticationService.php
@@ -46,6 +46,17 @@ class TenantAuthenticationService {
 	private const DEFAULT_DENY_MATRIX = [];
 
 	/**
+	 * Upper bound on memberships read for one user.
+	 *
+	 * A person belongs to a handful of tenants, not hundreds. The cap exists so
+	 * a malformed filter that matches every row cannot turn a per-request
+	 * lookup into a full table read.
+	 *
+	 * @var int
+	 */
+	private const MAX_MEMBERSHIPS = 100;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param IAppManager $appManager App manager (for OR availability check).
@@ -284,6 +295,100 @@ class TenantAuthenticationService {
 
 		return null;
 	}//end resolveUserRole()
+
+	/**
+	 * The tenant ids the given user is a member of.
+	 *
+	 * WHY THIS EXISTS. The tenant a request acts as is decided by the session,
+	 * not by an `X-Tenant-Id` header and not by a JWT claim. Both of those are
+	 * supplied by the caller, and a caller is exactly who must not choose. This
+	 * is the lookup that says which tenants a user may legitimately be on, so
+	 * that a switch can be verified and a session can be resolved.
+	 *
+	 * Fails CLOSED for the same reason as `resolveUserRole()`: a backend error
+	 * returned as an empty list is indistinguishable from "member of nothing",
+	 * and the caller would read it as a clean answer.
+	 *
+	 * @param string $userId The Nextcloud uid.
+	 *
+	 * @return array<int, string> Tenant ids, possibly empty.
+	 *
+	 * @throws Throwable When the membership lookup fails.
+	 */
+	public function listTenantsForUser(string $userId): array {
+		if ($userId === '') {
+			return [];
+		}
+
+		$objectService = $this->getObjectService();
+		if ($objectService === null) {
+			return [];
+		}
+
+		try {
+			$rows = $objectService->findAll(
+				[
+					'filters' => [
+						'register' => TenantSaasService::REGISTER,
+						'schema' => 'tenantUser',
+						'userRef' => $userId,
+					],
+					'limit' => self::MAX_MEMBERSHIPS,
+					'offset' => 0,
+				]
+			);
+		} catch (Throwable $e) {
+			$this->logger->error(
+				'Dossiq: listTenantsForUser lookup failed (fail-closed)',
+				['userId' => $userId, 'exception' => $e->getMessage()]
+			);
+			throw $e;
+		}
+
+		if (is_array($rows) === false) {
+			return [];
+		}
+
+		$tenantIds = [];
+		foreach ($rows as $row) {
+			if (is_array($row) === false) {
+				continue;
+			}
+
+			$tenantId = trim((string)($row['tenantRef'] ?? ''));
+			if ($tenantId === '' || in_array($tenantId, $tenantIds, true) === true) {
+				continue;
+			}
+
+			$tenantIds[] = $tenantId;
+		}
+
+		return $tenantIds;
+	}//end listTenantsForUser()
+
+	/**
+	 * Whether the user is a member of the tenant.
+	 *
+	 * Membership is "has a tenantUser row", which is what `resolveUserRole()`
+	 * already answers — a row without a role is still a row, so this asks the
+	 * membership question directly rather than inferring it from a role string
+	 * that may legitimately be empty.
+	 *
+	 * @param string $tenantId The tenant id.
+	 * @param string $userId   The Nextcloud uid.
+	 *
+	 * @return bool Whether the user may act as this tenant.
+	 *
+	 * @throws Throwable When the membership lookup fails.
+	 */
+	public function isMemberOf(string $tenantId, string $userId): bool {
+		if ($tenantId === '' || $userId === '') {
+			return false;
+		}
+
+		return in_array($tenantId, $this->listTenantsForUser(userId: $userId), true);
+	}//end isMemberOf()
+
 
 	/**
 	 * Resolve OR's ObjectService when installed.

--- a/lib/Service/TenantSessionService.php
+++ b/lib/Service/TenantSessionService.php
@@ -1,0 +1,191 @@
+<?php
+
+/**
+ * Tenant Session Service
+ *
+ * Holds the tenant the current request acts as, in the PHP session.
+ *
+ * @category Service
+ * @package  OCA\Dossiq\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/tenancy-onto-openregister-organisation/proposal.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Dossiq\Service;
+
+use OCP\ISession;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * The tenant the session is currently acting as.
+ *
+ * WHY THE SESSION AND NOT THE REQUEST. The tenant a request acts as used to
+ * come from an `X-Tenant-Id` header, which the caller supplies — so the caller
+ * chose their own tenant, and the only check that would have caught a forged
+ * value ran solely on requests carrying a Bearer token. A logged-in user could
+ * therefore name any tenant and be believed.
+ *
+ * The JWT claim is not the answer either. Making the token authoritative would
+ * mean a tenant switch could not happen without reminting it, which turns an
+ * ordinary UI action into a credential operation.
+ *
+ * So the session decides, a switch is an explicit act, and membership is
+ * verified at the moment of switching rather than trusted per request.
+ */
+class TenantSessionService {
+	/**
+	 * Session key holding the active tenant id.
+	 *
+	 * @var string
+	 */
+	public const SESSION_KEY = 'dossiq.activeTenantId';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param ISession               $session The PHP session.
+	 * @param IUserSession           $users   The user session.
+	 * @param TenantAuthenticationService $auth Membership lookups.
+	 * @param LoggerInterface        $logger  The logger.
+	 */
+	public function __construct(
+		private readonly ISession $session,
+		private readonly IUserSession $users,
+		private readonly TenantAuthenticationService $auth,
+		private readonly LoggerInterface $logger,
+	) {
+	}//end __construct()
+
+	/**
+	 * The uid of the signed-in user, or '' when anonymous.
+	 *
+	 * @return string The uid.
+	 */
+	private function uid(): string {
+		$user = $this->users->getUser();
+		if ($user === null) {
+			return '';
+		}
+
+		return $user->getUID();
+	}//end uid()
+
+	/**
+	 * The tenant this session acts as, or null.
+	 *
+	 * The stored value is RE-VERIFIED on every read rather than trusted. A
+	 * session outlives the membership that justified it: revoking someone's
+	 * access to a tenant must take effect on their next request, not on their
+	 * next login. Checking here is what makes revocation mean anything.
+	 *
+	 * A user with exactly one membership and no stored choice resolves to that
+	 * one, so ordinary single-tenant use needs no switch. Several memberships
+	 * and no choice resolves to nothing: guessing which of them the user meant
+	 * would be picking a tenant on their behalf, which is the thing this class
+	 * exists to stop.
+	 *
+	 * @return string|null The tenant id, or null when none is resolved.
+	 */
+	public function activeTenantId(): ?string {
+		$uid = $this->uid();
+		if ($uid === '') {
+			return null;
+		}
+
+		try {
+			$memberships = $this->auth->listTenantsForUser(userId: $uid);
+		} catch (Throwable $e) {
+			// Fail CLOSED: an unreadable membership list is not "no tenant",
+			// but binding nothing is the safe reading of an unknown answer.
+			$this->logger->error(
+				'Dossiq: membership lookup failed while resolving the session tenant',
+				['uid' => $uid, 'exception' => $e->getMessage()]
+			);
+
+			return null;
+		}
+
+		$stored = trim((string)($this->session->get(self::SESSION_KEY) ?? ''));
+		if ($stored !== '') {
+			if (in_array($stored, $memberships, true) === true) {
+				return $stored;
+			}
+
+			// The membership that justified this choice is gone. Drop it rather
+			// than keep serving it.
+			$this->clear();
+			$this->logger->info(
+				'Dossiq: stored tenant is no longer a membership; cleared',
+				['uid' => $uid, 'tenantId' => $stored]
+			);
+		}
+
+		if (count($memberships) === 1) {
+			return $memberships[0];
+		}
+
+		return null;
+	}//end activeTenantId()
+
+	/**
+	 * Switch the session to a tenant the user belongs to.
+	 *
+	 * @param string $tenantId The tenant to switch to.
+	 *
+	 * @return bool Whether the switch was permitted and applied.
+	 */
+	public function switchTo(string $tenantId): bool {
+		$tenantId = trim($tenantId);
+		if ($tenantId === '') {
+			return false;
+		}
+
+		$uid = $this->uid();
+		if ($uid === '') {
+			return false;
+		}
+
+		try {
+			$permitted = $this->auth->isMemberOf(tenantId: $tenantId, userId: $uid);
+		} catch (Throwable $e) {
+			$this->logger->error(
+				'Dossiq: membership lookup failed during tenant switch (refused)',
+				['uid' => $uid, 'tenantId' => $tenantId, 'exception' => $e->getMessage()]
+			);
+
+			return false;
+		}
+
+		if ($permitted === false) {
+			$this->logger->warning(
+				'Dossiq: refused a tenant switch to a tenant the user does not belong to',
+				['uid' => $uid, 'tenantId' => $tenantId]
+			);
+
+			return false;
+		}
+
+		$this->session->set(self::SESSION_KEY, $tenantId);
+
+		return true;
+	}//end switchTo()
+
+	/**
+	 * Forget the session's tenant choice.
+	 *
+	 * @return void
+	 */
+	public function clear(): void {
+		$this->session->remove(self::SESSION_KEY);
+	}//end clear()
+}//end class

--- a/tests/Unit/Controller/TenantControllerContractTest.php
+++ b/tests/Unit/Controller/TenantControllerContractTest.php
@@ -31,7 +31,9 @@ declare(strict_types=1);
 namespace OCA\Dossiq\Tests\Unit\Controller;
 
 use OCA\Dossiq\Controller\TenantController;
+use OCA\Dossiq\Service\TenantAuthenticationService;
 use OCA\Dossiq\Service\TenantService;
+use OCA\Dossiq\Service\TenantSessionService;
 use OCP\AppFramework\Http;
 use OCP\IRequest;
 use OCP\IUser;
@@ -79,17 +81,35 @@ class TenantControllerContractTest extends TestCase {
 	 *
 	 * @return void
 	 */
+	/**
+	 * The session tenant service.
+	 *
+	 * @var TenantSessionService&MockObject
+	 */
+	private TenantSessionService&MockObject $tenantSession;
+
+	/**
+	 * The membership lookup.
+	 *
+	 * @var TenantAuthenticationService&MockObject
+	 */
+	private TenantAuthenticationService&MockObject $tenantAuthentication;
+
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->request = $this->createMock(IRequest::class);
 		$this->tenantService = $this->createMock(TenantService::class);
 		$this->userSession = $this->createMock(IUserSession::class);
+		$this->tenantSession = $this->createMock(TenantSessionService::class);
+		$this->tenantAuthentication = $this->createMock(TenantAuthenticationService::class);
 
 		$this->controller = new TenantController(
 			request: $this->request,
 			tenantService: $this->tenantService,
 			userSession: $this->userSession,
+			tenantSession: $this->tenantSession,
+			tenantAuthentication: $this->tenantAuthentication,
 		);
 	}//end setUp()
 
@@ -159,4 +179,100 @@ class TenantControllerContractTest extends TestCase {
 			$response->getData()
 		);
 	}//end testCurrentReportsAnUnassignedAccountAsASuccessfulNullTenant()
+
+	/**
+	 * An unauthenticated caller cannot switch tenant.
+	 *
+	 * @return void
+	 */
+	public function testSwitchRefusesAnUnauthenticatedCaller(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->tenantSession->expects($this->never())->method('switchTo');
+
+		$response = $this->controller->switchTenant('tenant-a');
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+	}//end testSwitchRefusesAnUnauthenticatedCaller()
+
+	/**
+	 * A refused switch is a 403 that does not say whether the tenant exists.
+	 *
+	 * Distinguishing "no such tenant" from "not yours" would let an outsider
+	 * enumerate the tenant list one guess at a time, which is a disclosure the
+	 * endpoint has no reason to make.
+	 *
+	 * @return void
+	 */
+	public function testARefusedSwitchDoesNotRevealWhetherTheTenantExists(): void {
+		$this->signIn('alice');
+		$this->tenantSession->method('switchTo')->willReturn(false);
+
+		$response = $this->controller->switchTenant('tenant-b');
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertStringNotContainsStringIgnoringCase('exist', (string)$response->getData()['error']);
+		$this->assertStringNotContainsStringIgnoringCase('found', (string)$response->getData()['error']);
+	}//end testARefusedSwitchDoesNotRevealWhetherTheTenantExists()
+
+	/**
+	 * A permitted switch reports the tenant that is now active.
+	 *
+	 * The active tenant is read back from the service rather than echoed from
+	 * the request: echoing would report success for a switch that did not
+	 * actually take, which is the one failure a caller cannot detect.
+	 *
+	 * @return void
+	 */
+	public function testAPermittedSwitchReportsTheNewActiveTenant(): void {
+		$this->signIn('alice');
+		$this->tenantSession->method('switchTo')->with('tenant-b')->willReturn(true);
+		$this->tenantSession->method('activeTenantId')->willReturn('tenant-b');
+
+		$response = $this->controller->switchTenant('tenant-b');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertTrue($response->getData()['success']);
+		$this->assertSame('tenant-b', $response->getData()['active']);
+	}//end testAPermittedSwitchReportsTheNewActiveTenant()
+
+	/**
+	 * A failed membership lookup is an error, not an empty list.
+	 *
+	 * Rendering the failure as `tenants: []` would tell the user they belong to
+	 * nothing when the truth is that we could not find out — and they would
+	 * have no way to tell the two apart.
+	 *
+	 * @return void
+	 */
+	public function testAFailedMembershipLookupIsNotReportedAsNoMemberships(): void {
+		$this->signIn('alice');
+		$this->tenantAuthentication->method('listTenantsForUser')
+			->willThrowException(new \RuntimeException('backend down'));
+
+		$response = $this->controller->memberships();
+
+		$this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+		$this->assertFalse($response->getData()['success']);
+		$this->assertArrayNotHasKey('tenants', $response->getData());
+	}//end testAFailedMembershipLookupIsNotReportedAsNoMemberships()
+
+	/**
+	 * Memberships are resolved for the SESSION uid, never from input.
+	 *
+	 * @return void
+	 */
+	public function testMembershipsResolveFromTheSessionUid(): void {
+		$this->signIn('alice');
+		$this->tenantAuthentication->expects($this->once())
+			->method('listTenantsForUser')
+			->with('alice')
+			->willReturn(['tenant-a', 'tenant-b']);
+		$this->tenantSession->method('activeTenantId')->willReturn(null);
+
+		$response = $this->controller->memberships();
+
+		$this->assertSame(['tenant-a', 'tenant-b'], $response->getData()['tenants']);
+		$this->assertNull($response->getData()['active']);
+	}//end testMembershipsResolveFromTheSessionUid()
+
 }//end class

--- a/tests/Unit/Middleware/TenantContextMiddlewareTest.php
+++ b/tests/Unit/Middleware/TenantContextMiddlewareTest.php
@@ -3,14 +3,10 @@
 /**
  * TenantContextMiddleware Unit Tests
  *
- * PINNING TESTS, written before the tenancy store moves onto OpenRegister's
- * Organisation entity. This middleware decides WHICH TENANT a request acts as,
- * and everything downstream — quota, isolation, the claim check — trusts what
- * it bound. It had no tests.
- *
- * Two behaviours are pinned here that are worth a decision rather than a
- * refactor: see testHeaderAloneBindsTheTenant() and
- * testUserFallbackResolvesNothing().
+ * These began as PINNING tests written before the tenancy store moved, and
+ * recorded that the `X-Tenant-Id` header alone bound the tenant. That is the
+ * behaviour this change removes, so the tests now assert its inverse — which
+ * is what a pinning test is for: it made the change visible instead of silent.
  *
  * @category Tests
  * @package  OCA\Dossiq\Tests\Unit\Middleware
@@ -32,9 +28,8 @@ use OCA\Dossiq\Middleware\TenantContextMiddleware;
 use OCA\Dossiq\Service\TenantContext;
 use OCA\Dossiq\Service\TenantProvisioningService;
 use OCA\Dossiq\Service\TenantSaasService;
+use OCA\Dossiq\Service\TenantSessionService;
 use OCP\IRequest;
-use OCP\IUser;
-use OCP\IUserSession;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
@@ -45,36 +40,30 @@ use Psr\Log\LoggerInterface;
  */
 class TenantContextMiddlewareTest extends TestCase {
 	/**
-	 * Build the middleware over a controllable request and tenant lookup.
+	 * Build the middleware over a controllable header, session and lookup.
 	 *
-	 * The tenant lookup is keyed on the id it is ASKED for rather than returning
-	 * a fixed row: a mock that answers the same row to every id would let this
-	 * test pass even if the middleware ignored the header entirely. That mutant
-	 * survived the first draft of these tests, which is why the lookup is
-	 * modelled instead of stubbed.
+	 * The tenant lookup is keyed on the id it is ASKED for rather than
+	 * returning a fixed row: a mock that answers the same row to every id would
+	 * let these tests pass even if the middleware resolved the wrong tenant.
+	 * That mutant survived the first draft, which is why the lookup is modelled
+	 * rather than stubbed.
 	 *
-	 * @param string        $header   The X-Tenant-Id header value.
-	 * @param array<string> $known    Tenant ids the lookup can resolve.
-	 * @param bool          $signedIn Whether a user session exists.
+	 * @param string        $header        The X-Tenant-Id header value.
+	 * @param string|null   $sessionTenant The tenant the session resolves to.
+	 * @param array<string> $known         Tenant ids the lookup can resolve.
 	 *
 	 * @return array{0: TenantContextMiddleware, 1: TenantContext} Middleware and the live context.
 	 */
 	private function newMiddleware(
 		string $header,
+		?string $sessionTenant,
 		array $known,
-		bool $signedIn = true,
 	): array {
 		$request = $this->createMock(IRequest::class);
 		$request->method('getHeader')->willReturn($header);
 
-		$userSession = $this->createMock(IUserSession::class);
-		if ($signedIn === true) {
-			$user = $this->createMock(IUser::class);
-			$user->method('getUID')->willReturn('alice');
-			$userSession->method('getUser')->willReturn($user);
-		} else {
-			$userSession->method('getUser')->willReturn(null);
-		}
+		$tenantSession = $this->createMock(TenantSessionService::class);
+		$tenantSession->method('activeTenantId')->willReturn($sessionTenant);
 
 		$saas = $this->createMock(TenantSaasService::class);
 		$saas->method('getById')->willReturnCallback(
@@ -86,7 +75,6 @@ class TenantContextMiddlewareTest extends TestCase {
 				return ['uuid' => $tenantId, 'slug' => $tenantId];
 			}
 		);
-		$saas->method('listActive')->willReturn([]);
 
 		$provisioning = $this->createMock(TenantProvisioningService::class);
 		$provisioning->method('buildSchemaName')->willReturn('tenant_schema');
@@ -95,7 +83,7 @@ class TenantContextMiddlewareTest extends TestCase {
 
 		$middleware = new TenantContextMiddleware(
 			request: $request,
-			userSession: $userSession,
+			tenantSession: $tenantSession,
 			tenantSaasService: $saas,
 			provisioning: $provisioning,
 			context: $context,
@@ -106,91 +94,101 @@ class TenantContextMiddlewareTest extends TestCase {
 	}
 
 	/**
-	 * THE X-Tenant-Id HEADER ALONE BINDS THE TENANT — pinned, not endorsed.
+	 * THE FIX: the X-Tenant-Id header no longer binds anything.
 	 *
-	 * `resolveTenantIdFromRequest()` returns the header verbatim, with no check
-	 * that the caller may act for that tenant. Nothing in THIS middleware
-	 * verifies it.
+	 * Previously this header was returned verbatim with nothing checking the
+	 * caller could act for that tenant, and the middleware that would have
+	 * caught a forged value only inspects requests carrying a Bearer token — so
+	 * a session-authenticated user could name any tenant and be believed.
 	 *
-	 * `TenantClaimValidationMiddleware` is what catches a forged value — but it
-	 * returns early unless the request carries a `Bearer ` Authorization header.
-	 * A session-authenticated request with a forged X-Tenant-Id and no bearer
-	 * token therefore passes both: one binds on trust, the other declines to
-	 * look. The two middlewares are each individually reasonable and the gap is
-	 * between them, which is why neither file reads as wrong on its own.
-	 *
-	 * Pinned as-is so the migration cannot change it by accident, and named for
-	 * what it is so a green suite is not read as "the header is validated".
-	 * Whether the header should be verified against the session user's
-	 * memberships is a decision for the migration, not a refactor: tightening it
-	 * may break service-to-service callers that rely on it today.
+	 * The header is supplied by the caller, and the caller is exactly who must
+	 * not choose. Here it names a tenant that genuinely exists and the session
+	 * resolves to nothing: if the header still had any force, this would bind.
 	 *
 	 * @return void
 	 */
-	public function testHeaderAloneBindsTheTenant(): void {
+	public function testTheHeaderNoLongerBindsATenant(): void {
 		[$middleware, $context] = $this->newMiddleware(
 			header: 'tenant-anything',
+			sessionTenant: null,
 			known: ['tenant-anything'],
 		);
 
 		$middleware->beforeController(new \stdClass(), 'index');
 
-		$this->assertTrue($context->isBound());
-		$this->assertSame('tenant-anything', $context->getTenantId());
-	}
-
-	/**
-	 * An unresolvable tenant binds nothing rather than binding a default.
-	 *
-	 * Fail-closed in the useful direction: an unknown id leaves the request
-	 * unbound, so the downstream scoping has nothing to scope TO rather than
-	 * silently scoping to somebody.
-	 *
-	 * @return void
-	 */
-	public function testUnknownTenantLeavesTheRequestUnbound(): void {
-		[$middleware, $context] = $this->newMiddleware(
-			header: 'tenant-ghost',
-			known: [],
-		);
-
-		$middleware->beforeController(new \stdClass(), 'index');
-
 		$this->assertFalse($context->isBound());
 	}
 
 	/**
-	 * With no header, nothing binds — the user fallback resolves nothing.
+	 * A header naming a DIFFERENT tenant cannot override the session's.
 	 *
-	 * The fallback branch reads the active-tenant list and then discards it
-	 * (`unset($rows); return null;`), with a comment saying the per-user filter
-	 * does not exist yet. So a signed-in user with no header is unbound, and the
-	 * lookup it performs is pure cost. Pinned so the dead branch is visible: it
-	 * either grows a real filter or it goes.
+	 * The companion to the test above, and the one that catches a partial fix:
+	 * an implementation that consulted the session but let a present header win
+	 * would still pass a test where the session resolves to nothing.
 	 *
 	 * @return void
 	 */
-	public function testUserFallbackResolvesNothing(): void {
+	public function testTheHeaderCannotOverrideTheSessionTenant(): void {
+		[$middleware, $context] = $this->newMiddleware(
+			header: 'tenant-b',
+			sessionTenant: 'tenant-a',
+			known: ['tenant-a', 'tenant-b'],
+		);
+
+		$middleware->beforeController(new \stdClass(), 'index');
+
+		$this->assertTrue($context->isBound());
+		$this->assertSame('tenant-a', $context->getTenantId());
+	}
+
+	/**
+	 * The session's tenant is what binds.
+	 *
+	 * @return void
+	 */
+	public function testTheSessionTenantBinds(): void {
 		[$middleware, $context] = $this->newMiddleware(
 			header: '',
+			sessionTenant: 'tenant-a',
 			known: ['tenant-a'],
 		);
 
 		$middleware->beforeController(new \stdClass(), 'index');
 
+		$this->assertTrue($context->isBound());
+		$this->assertSame('tenant-a', $context->getTenantId());
+	}
+
+	/**
+	 * A session tenant that no longer resolves binds nothing.
+	 *
+	 * Fail-closed in the useful direction: the request has nothing to scope TO
+	 * rather than silently scoping to somebody.
+	 *
+	 * @return void
+	 */
+	public function testAnUnresolvableSessionTenantBindsNothing(): void {
+		[$middleware, $context] = $this->newMiddleware(
+			header: '',
+			sessionTenant: 'tenant-ghost',
+			known: [],
+		);
+
+		$middleware->beforeController(new \stdClass(), 'index');
+
 		$this->assertFalse($context->isBound());
 	}
 
 	/**
-	 * An anonymous request with no header binds nothing.
+	 * No session tenant, no binding.
 	 *
 	 * @return void
 	 */
-	public function testAnonymousRequestBindsNothing(): void {
+	public function testNoSessionTenantBindsNothing(): void {
 		[$middleware, $context] = $this->newMiddleware(
 			header: '',
-			known: [],
-			signedIn: false,
+			sessionTenant: null,
+			known: ['tenant-a'],
 		);
 
 		$middleware->beforeController(new \stdClass(), 'index');

--- a/tests/Unit/Service/TenantSessionServiceTest.php
+++ b/tests/Unit/Service/TenantSessionServiceTest.php
@@ -1,0 +1,219 @@
+<?php
+
+/**
+ * TenantSessionService Unit Tests
+ *
+ * This class is the tenancy boundary now: it decides which tenant a request
+ * acts as, and it is the only place membership is checked. A regression here
+ * does not throw — it returns another tenant's rows, correctly formatted, with
+ * HTTP 200.
+ *
+ * @category Tests
+ * @package  OCA\Dossiq\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/tenancy-onto-openregister-organisation/proposal.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Dossiq\Tests\Unit\Service;
+
+use OCA\Dossiq\Service\TenantAuthenticationService;
+use OCA\Dossiq\Service\TenantSessionService;
+use OCP\ISession;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * @covers \OCA\Dossiq\Service\TenantSessionService
+ */
+class TenantSessionServiceTest extends TestCase {
+	/**
+	 * A session backed by a real array, so a write is observable by a read.
+	 *
+	 * A mock returning a fixed value would let `switchTo()` appear to work
+	 * without storing anything — the store has to be real for these tests to
+	 * mean what they say.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private array $store = [];
+
+	/**
+	 * Build the service over a real store and a controllable membership list.
+	 *
+	 * @param array<string>|null $memberships Memberships, or null to throw.
+	 * @param string|null        $uid         The signed-in uid, or null.
+	 *
+	 * @return TenantSessionService The service.
+	 */
+	private function newService(?array $memberships, ?string $uid = 'alice'): TenantSessionService {
+		$session = $this->createMock(ISession::class);
+		$session->method('get')->willReturnCallback(
+			fn (string $key): mixed => ($this->store[$key] ?? null)
+		);
+		$session->method('set')->willReturnCallback(
+			function (string $key, mixed $value): void {
+				$this->store[$key] = $value;
+			}
+		);
+		$session->method('remove')->willReturnCallback(
+			function (string $key): void {
+				unset($this->store[$key]);
+			}
+		);
+
+		$users = $this->createMock(IUserSession::class);
+		if ($uid === null) {
+			$users->method('getUser')->willReturn(null);
+		} else {
+			$user = $this->createMock(IUser::class);
+			$user->method('getUID')->willReturn($uid);
+			$users->method('getUser')->willReturn($user);
+		}
+
+		$auth = $this->createMock(TenantAuthenticationService::class);
+		if ($memberships === null) {
+			$auth->method('listTenantsForUser')->willThrowException(new RuntimeException('backend down'));
+			$auth->method('isMemberOf')->willThrowException(new RuntimeException('backend down'));
+		} else {
+			$auth->method('listTenantsForUser')->willReturn($memberships);
+			$auth->method('isMemberOf')->willReturnCallback(
+				static fn (string $tenantId, string $userId): bool => in_array($tenantId, $memberships, true)
+			);
+		}
+
+		return new TenantSessionService(
+			session: $session,
+			users: $users,
+			auth: $auth,
+			logger: $this->createMock(LoggerInterface::class),
+		);
+	}
+
+	/**
+	 * THE ONE THAT MATTERS: a switch to a tenant you do not belong to is refused.
+	 *
+	 * @return void
+	 */
+	public function testSwitchingToATenantYouDoNotBelongToIsRefused(): void {
+		$service = $this->newService(memberships: ['tenant-a']);
+
+		$this->assertFalse($service->switchTo('tenant-b'));
+
+		// The refusal has to be a refusal to BIND, not only a false return.
+		// `tenant-a` still resolves here because it is the sole membership —
+		// what must not have happened is `tenant-b` being stored anyway.
+		$this->assertSame('tenant-a', $service->activeTenantId());
+	}
+
+	/**
+	 * A switch to a tenant you do belong to is applied and readable back.
+	 *
+	 * @return void
+	 */
+	public function testSwitchingToAMembershipIsApplied(): void {
+		$service = $this->newService(memberships: ['tenant-a', 'tenant-b']);
+
+		$this->assertTrue($service->switchTo('tenant-b'));
+		$this->assertSame('tenant-b', $service->activeTenantId());
+	}
+
+	/**
+	 * Revoking a membership takes effect on the next request, not the next login.
+	 *
+	 * The stored choice is re-verified on every read rather than trusted. A
+	 * session outlives the membership that justified it, so a service that
+	 * trusted its own stored value would keep serving a tenant the user has
+	 * been removed from — for as long as they stay logged in.
+	 *
+	 * @return void
+	 */
+	public function testARevokedMembershipStopsResolvingImmediately(): void {
+		$service = $this->newService(memberships: ['tenant-a', 'tenant-b']);
+		$this->assertTrue($service->switchTo('tenant-b'));
+		$this->assertSame('tenant-b', $service->activeTenantId());
+
+		// Same stored session, but the membership is gone.
+		$revoked = $this->newService(memberships: ['tenant-a']);
+
+		$this->assertNotSame('tenant-b', $revoked->activeTenantId());
+	}
+
+	/**
+	 * A sole membership resolves without an explicit switch.
+	 *
+	 * Ordinary single-tenant use must not require a switch, or every such
+	 * deployment would resolve to nothing.
+	 *
+	 * @return void
+	 */
+	public function testASoleMembershipResolvesWithoutASwitch(): void {
+		$service = $this->newService(memberships: ['tenant-a']);
+
+		$this->assertSame('tenant-a', $service->activeTenantId());
+	}
+
+	/**
+	 * Several memberships and no choice resolves to NOTHING, not to the first.
+	 *
+	 * Picking one would be choosing a tenant on the user's behalf, which is the
+	 * thing this class exists to stop. Returning `$memberships[0]` would pass a
+	 * sole-membership test and quietly guess everywhere else.
+	 *
+	 * @return void
+	 */
+	public function testSeveralMembershipsWithNoChoiceResolveToNothing(): void {
+		$service = $this->newService(memberships: ['tenant-a', 'tenant-b']);
+
+		$this->assertNull($service->activeTenantId());
+	}
+
+	/**
+	 * An anonymous caller resolves to nothing and cannot switch.
+	 *
+	 * @return void
+	 */
+	public function testAnAnonymousCallerHasNoTenant(): void {
+		$service = $this->newService(memberships: ['tenant-a'], uid: null);
+
+		$this->assertNull($service->activeTenantId());
+		$this->assertFalse($service->switchTo('tenant-a'));
+	}
+
+	/**
+	 * A membership lookup that fails binds nothing rather than falling open.
+	 *
+	 * An unreadable membership list is not "no restrictions". This is the
+	 * failure mode where falling open is invisible: the backend blips, and
+	 * every request in that window acts as whatever was stored.
+	 *
+	 * @return void
+	 */
+	public function testAFailedMembershipLookupResolvesToNothing(): void {
+		$service = $this->newService(memberships: null);
+
+		$this->assertNull($service->activeTenantId());
+		$this->assertFalse($service->switchTo('tenant-a'));
+	}
+
+	/**
+	 * An empty tenant id is not a switch.
+	 *
+	 * @return void
+	 */
+	public function testAnEmptyTenantIdIsRefused(): void {
+		$service = $this->newService(memberships: ['tenant-a']);
+
+		$this->assertFalse($service->switchTo('   '));
+	}
+}


### PR DESCRIPTION
Stacks on #1385 (the pinning tests), so its two commits appear here until that merges.

## The gap this closes

`resolveTenantIdFromRequest()` returned the `X-Tenant-Id` header verbatim, with nothing checking the caller could act for that tenant. `TenantClaimValidationMiddleware` is what would have caught a forged value — but it returns early unless the request carries a `Bearer ` token. So a session-authenticated user could name any tenant and be believed.

Each middleware reads as reasonable on its own. The gap was *between* them, which is why neither file looked wrong.

Found while writing the pinning tests in #1385, which named it rather than blessing it.

## Why not just validate the header

The header is supplied by the caller, and the caller is exactly who must not choose. The JWT claim is not the answer either: making the token authoritative would mean a tenant switch could not happen without reminting it, turning an ordinary UI action into a credential operation.

So the session decides, and a switch is an explicit act that verifies membership at the moment it happens.

## What changed

- **The header no longer binds.** It is logged when present rather than dropped in silence — anyone still sending it is relying on removed behaviour and would otherwise find their requests quietly acting as a different tenant than they asked for.
- **`TenantSessionService`** holds the active tenant. The stored choice is **re-verified against memberships on every read**, not trusted: a session outlives the membership that justified it, so revocation now takes effect on the next request rather than the next login.
- **A sole membership resolves with no switch**, so ordinary single-tenant use is unchanged. **Several memberships and no choice resolve to nothing**, not to the first one — guessing would be picking a tenant on the user's behalf.
- **`listTenantsForUser` / `isMemberOf`** fail CLOSED, like `resolveUserRole()` beside them. An unreadable membership list is not "no restrictions".
- **`POST /api/tenants/switch`** refuses with a 403 that does not say whether the tenant exists — distinguishing "no such tenant" from "not yours" enumerates the tenant list. **`GET /api/tenants/memberships`** feeds the switcher and reports a lookup failure as an error rather than an empty list, because "you belong to nothing" and "we could not find out" must not look the same.
- The middleware's now-dead `IUserSession` dependency is removed.

## On the tests

The pinning tests from #1385 asserted the old behaviour, so they fail here and are rewritten to assert its inverse. That is what they were for — the change is visible instead of silent.

Two of the new middleware tests exist specifically to catch a *partial* fix: a header that cannot override an already-resolved session tenant, not merely one that fails to bind when the session is empty.

Every enforcement point is mutation-checked — skipping the membership check on switch, trusting the stored tenant blindly, and returning the first of several memberships each make the suite fail.

2428 → 2433 tests. phpcs, phpmd, psalm and phpstan all clean.

## Still open

The remaining decision in `openspec/changes/tenancy-onto-openregister-organisation/proposal.md` is where the six uncovered `tenant` fields go. That measurement is recorded in the proposal on #1385 and is not part of this PR.

---

**Replaces #1388.** That PR stacked on #1385, and squash-merging #1385 made its already-merged commits read as unmerged — the branch went `CONFLICTING`/`DIRTY`, and a conflicted PR runs no CI at all.

Rebuilt on current `development` with only the two commits that are genuinely new. Verified by content rather than by commit identity, which a squash-merge makes unreliable: `development` already carries all three pinning-test files and the canonical 35,733-byte coverage-guard, and does not carry `TenantSessionService.php`.

2448 tests pass; phpcs 0 errors; phpstan clean.
